### PR TITLE
refactor: migrate to Bun and uv for faster development

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,23 @@
 
 Please use English for git commit messages.
 
+## Development Environment
+
+**Use `docker compose -f docker-compose.dev.yml` for all local development.**
+
+```bash
+# Start all services
+docker compose -f docker-compose.dev.yml up
+
+# View logs
+docker compose -f docker-compose.dev.yml logs -f
+
+# Restart a specific service
+docker compose -f docker-compose.dev.yml restart backend
+```
+
+This spins up the full stack (backend, frontend, database, MinIO, mock student API) with hot-reload enabled.
+
 ## Core Development Principles
 
 ### 1. Error Handling Standards


### PR DESCRIPTION
## Summary

Migrate package managers for faster development iteration:

- **Frontend**: npm → Bun (dependency installation only; Next.js dev server still runs on Node.js for stability)
- **Backend**: pip → uv (10-100× faster installs)
- **Mock API**: pip → uv

## Changes

### Backend / Mock API
- Replace \`pip\` with \`uv\` in Dockerfiles and CI
- Migrate deps from \`requirements.txt\` to \`pyproject.toml\` (both \`backend/\` and \`mock-student-api/\`)
- Keep \`requirements.txt\` as a thin fallback shim

### Frontend
- Migrate from npm to Bun for dependency installation
- Use Bun image (\`oven/bun:1-alpine\`) with Node.js added for Next.js runtime
- Enable Next.js Turbo mode and \`optimizePackageImports\`
- Regenerate \`package-lock.json\` with Bun

### Dev tooling
- Update \`Makefile\` with uv/Bun-aware install targets
- Update \`README.md\`
- Add \`.worktrees/\` to \`.gitignore\`

## Test Plan
- [x] Backend builds successfully with uv
- [x] Mock API builds successfully with uv
- [x] Frontend installs dependencies with Bun
- [x] Full stack starts via \`docker compose -f docker-compose.dev.yml up\`
- [x] Seed runs cleanly after migrations