### PR TITLE
fix: update staging image owner from jotpalch to anud18

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -17,7 +17,7 @@ services:
 
   # FastAPI Backend
   backend:
-    image: ghcr.io/jotpalch/scholarship-system-backend:${TAG:-latest}
+    image: ghcr.io/anud18/scholarship-system-backend:${TAG:-latest}
     container_name: scholarship_backend_staging
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000
     ports:
@@ -87,7 +87,7 @@ services:
 
   # Next.js Frontend
   frontend:
-    image: ghcr.io/jotpalch/scholarship-system-frontend:${TAG:-latest}
+    image: ghcr.io/anud18/scholarship-system-frontend:${TAG:-latest}
     container_name: scholarship_frontend_staging
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
- Update `docker-compose.staging.yml` image references from `ghcr.io/jotpalch/` to `ghcr.io/anud18/`

## Test plan
- [ ] Verify staging deployment pulls images from `ghcr.io/anud18/`