### PR TITLE
fix: correct application submission enum comparison bugs

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -2,10 +2,12 @@
 Application management API endpoints
 """
 
+import enum
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Body, Depends, File, HTTPException, Path, Query, Request, UploadFile, status
+from fastapi import APIRouter, Body, Depends, File, HTTPException, Path, Query, Request, Response, UploadFile, status
+from sqlalchemy import inspect as sa_inspect
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,6 +32,25 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+def _serialize_result(result):
+    """Serialize a Pydantic model, dict, or SQLAlchemy model to dict."""
+    if isinstance(result, dict):
+        return result
+    if hasattr(result, "model_dump"):
+        return result.model_dump()
+    if hasattr(result, "dict"):
+        return result.dict()
+    # SQLAlchemy model fallback — extract column values only (no relationship loading)
+    try:
+        mapper = sa_inspect(type(result))
+        return {
+            c.key: (v.value if isinstance(v := getattr(result, c.key), enum.Enum) else v)
+            for c in mapper.column_attrs
+        }
+    except Exception as exc:
+        raise TypeError(f"Cannot serialize {type(result).__name__}: {exc}") from exc
+
+
 @router.post("", status_code=status.HTTP_201_CREATED)
 async def create_application(
     application_data: ApplicationCreate,
@@ -37,6 +58,7 @@ async def create_application(
     current_user: User = Depends(require_student),
     db: AsyncSession = Depends(get_db),
     request: Request = None,
+    response: Response = None,  # Injected by FastAPI
 ):
     """Create a new scholarship application (draft or submitted)"""
     logger.debug(f"Received application creation request from user: {current_user.id}, is_draft: {is_draft}")
@@ -137,10 +159,10 @@ async def create_application(
 
         # 排除已撤回/拒絕/取消/刪除的申請
         excluded_statuses = [
-            ApplicationStatus.withdrawn.value,
-            ApplicationStatus.rejected.value,
-            ApplicationStatus.cancelled.value,
-            ApplicationStatus.deleted.value,  # 允許刪除後重新申請
+            ApplicationStatus.withdrawn,
+            ApplicationStatus.rejected,
+            ApplicationStatus.cancelled,
+            ApplicationStatus.deleted,
         ]
 
         # 查詢是否已有申請 - using values from scholarship configuration
@@ -157,11 +179,34 @@ async def create_application(
         existing_application = duplicate_result.scalar_one_or_none()
 
         if existing_application:
+            existing_status = existing_application.status
+            existing_status_str = existing_status.value if hasattr(existing_status, "value") else existing_status
+
+            # If existing application is a draft, return it so frontend can continue
+            if existing_status == ApplicationStatus.draft:
+                logger.info(
+                    f"Returning existing draft application: user_id={current_user.id}, "
+                    f"app_id={existing_application.app_id}"
+                )
+                response.status_code = 200
+                return {
+                    "success": True,
+                    "message": "已返回現有草稿",
+                    "data": {
+                        "id": existing_application.id,
+                        "app_id": existing_application.app_id,
+                        "status": existing_status_str,
+                        "scholarship_type_id": existing_application.scholarship_type_id,
+                        "academic_year": existing_application.academic_year,
+                        "semester": existing_application.semester.value if hasattr(existing_application.semester, "value") else existing_application.semester,
+                    },
+                }
+
             logger.warning(
                 f"Duplicate application detected: user_id={current_user.id}, "
                 f"scholarship_type_id={scholarship_config.scholarship_type_id}, "
                 f"existing_app_id={existing_application.app_id}, "
-                f"status={existing_application.status}"
+                f"status={existing_status}"
             )
             return {
                 "success": False,
@@ -170,7 +215,7 @@ async def create_application(
                     "error_code": "DUPLICATE_APPLICATION",
                     "existing_application_id": existing_application.id,
                     "existing_app_id": existing_application.app_id,
-                    "existing_status": existing_application.status,
+                    "existing_status": existing_status_str,
                     "scholarship_name": existing_application.scholarship_name,
                 },
             }
@@ -273,7 +318,7 @@ async def get_my_applications(
     return {
         "success": True,
         "message": "查詢成功",
-        "data": [item.dict() if hasattr(item, "dict") else item.model_dump() for item in result],
+        "data": [_serialize_result(item) for item in result],
     }
 
 
@@ -285,7 +330,7 @@ async def get_dashboard_stats(current_user: User = Depends(require_student), db:
     return {
         "success": True,
         "message": "查詢成功",
-        "data": result.dict() if hasattr(result, "dict") else result.model_dump(),
+        "data": _serialize_result(result),
     }
 
 
@@ -312,7 +357,7 @@ async def get_application(
     return {
         "success": True,
         "message": "查詢成功",
-        "data": result.dict() if hasattr(result, "dict") else result.model_dump(),
+        "data": _serialize_result(result),
     }
 
 
@@ -347,7 +392,7 @@ async def update_application(
     return {
         "success": True,
         "message": "更新成功",
-        "data": result.dict() if hasattr(result, "dict") else result.model_dump(),
+        "data": _serialize_result(result),
     }
 
 
@@ -374,7 +419,7 @@ async def submit_application(
     return {
         "success": True,
         "message": "申請已提交",
-        "data": result.dict() if hasattr(result, "dict") else result.model_dump(),
+        "data": _serialize_result(result),
     }
 
 
@@ -452,7 +497,7 @@ async def withdraw_application(
     return {
         "success": True,
         "message": "申請已撤回",
-        "data": result.dict() if hasattr(result, "dict") else result.model_dump(),
+        "data": _serialize_result(result),
     }
 
 
@@ -612,7 +657,7 @@ async def get_applications_for_review(
     return {
         "success": True,
         "message": "查詢成功",
-        "data": [item.dict() if hasattr(item, "dict") else item.model_dump() for item in result],
+        "data": [_serialize_result(item) for item in result],
     }
 
 
@@ -701,7 +746,7 @@ async def submit_professor_review(
     return {
         "success": True,
         "message": "審查已提交",
-        "data": result.dict() if hasattr(result, "dict") else result.model_dump(),
+        "data": _serialize_result(result),
     }
 
 
@@ -731,7 +776,7 @@ async def get_college_applications_for_review(
     return {
         "success": True,
         "message": "查詢成功",
-        "data": [item.dict() if hasattr(item, "dict") else item.model_dump() for item in result],
+        "data": [_serialize_result(item) for item in result],
     }
 
 

--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -58,7 +58,7 @@ async def create_application(
     current_user: User = Depends(require_student),
     db: AsyncSession = Depends(get_db),
     request: Request = None,
-    response: Response = None,  # Injected by FastAPI
+    response: Response = None,
 ):
     """Create a new scholarship application (draft or submitted)"""
     logger.debug(f"Received application creation request from user: {current_user.id}, is_draft: {is_draft}")
@@ -188,7 +188,8 @@ async def create_application(
                     f"Returning existing draft application: user_id={current_user.id}, "
                     f"app_id={existing_application.app_id}"
                 )
-                response.status_code = 200
+                if response:
+                    response.status_code = 200
                 return {
                     "success": True,
                     "message": "已返回現有草稿",

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -214,12 +214,12 @@ class Application(Base):
     @property
     def is_editable(self) -> bool:
         """Check if application can be edited"""
-        return bool(self.status in [ApplicationStatus.draft.value, ApplicationStatus.returned.value])
+        return bool(self.status in [ApplicationStatus.draft, ApplicationStatus.returned])
 
     @property
     def is_submitted(self) -> bool:
         """Check if application is submitted"""
-        return bool(self.status != ApplicationStatus.draft.value)
+        return bool(self.status != ApplicationStatus.draft)
 
     @property
     def can_be_reviewed(self) -> bool:
@@ -227,8 +227,8 @@ class Application(Base):
         return bool(
             self.status
             in [
-                ApplicationStatus.submitted.value,
-                ApplicationStatus.under_review.value,
+                ApplicationStatus.submitted,
+                ApplicationStatus.under_review,
             ]
         )
 
@@ -274,14 +274,14 @@ class Application(Base):
     def get_review_stage(self) -> Optional[str]:
         """Get current review stage based on application type and status"""
         if self.is_renewal:
-            if self.status == ApplicationStatus.submitted.value:
+            if self.status == ApplicationStatus.submitted:
                 return "renewal_professor"
-            elif self.status == ApplicationStatus.under_review.value:
+            elif self.status == ApplicationStatus.under_review:
                 return "renewal_college"
         else:
-            if self.status == ApplicationStatus.submitted.value:
+            if self.status == ApplicationStatus.submitted:
                 return "general_professor"
-            elif self.status == ApplicationStatus.under_review.value:
+            elif self.status == ApplicationStatus.under_review:
                 return "general_college"
         return None
 

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -85,16 +85,16 @@ class ScholarshipAnalyticsService:
             }
 
         # Status counts
-        approved = len([app for app in applications if app.status == ApplicationStatus.approved.value])
-        rejected = len([app for app in applications if app.status == ApplicationStatus.rejected.value])
+        approved = len([app for app in applications if app.status == ApplicationStatus.approved])
+        rejected = len([app for app in applications if app.status == ApplicationStatus.rejected])
         pending = len(
             [
                 app
                 for app in applications
                 if app.status
                 in [
-                    ApplicationStatus.submitted.value,
-                    ApplicationStatus.under_review.value,
+                    ApplicationStatus.submitted,
+                    ApplicationStatus.under_review,
                 ]
             ]
         )
@@ -126,7 +126,7 @@ class ScholarshipAnalyticsService:
 
         status_counts = {}
         for status in ApplicationStatus:
-            count = len([app for app in applications if app.status == status.value])
+            count = len([app for app in applications if app.status == status])
             if count > 0:
                 status_counts[status.value] = {
                     "count": count,
@@ -146,8 +146,8 @@ class ScholarshipAnalyticsService:
                         for app in applications
                         if app.status
                         in [
-                            ApplicationStatus.approved.value,
-                            ApplicationStatus.rejected.value,
+                            ApplicationStatus.approved,
+                            ApplicationStatus.rejected,
                         ]
                     ]
                 )
@@ -181,8 +181,8 @@ class ScholarshipAnalyticsService:
                     "scholarship_type_id": type_id,
                     "scholarship_type_name": type_name,
                     "total_applications": len(type_apps),
-                    "approved": len([app for app in type_apps if app.status == ApplicationStatus.approved.value]),
-                    "approval_rate": len([app for app in type_apps if app.status == ApplicationStatus.approved.value])
+                    "approved": len([app for app in type_apps if app.status == ApplicationStatus.approved]),
+                    "approval_rate": len([app for app in type_apps if app.status == ApplicationStatus.approved])
                     / len(type_apps)
                     * 100,
                     "sub_types": {},
@@ -197,10 +197,10 @@ class ScholarshipAnalyticsService:
                         type_stats[type_id]["sub_types"][sub_type_value] = {
                             "total": len(sub_apps),
                             "approved": len(
-                                [app for app in sub_apps if app.status == ApplicationStatus.approved.value]
+                                [app for app in sub_apps if app.status == ApplicationStatus.approved]
                             ),
                             "approval_rate": len(
-                                [app for app in sub_apps if app.status == ApplicationStatus.approved.value]
+                                [app for app in sub_apps if app.status == ApplicationStatus.approved]
                             )
                             / len(sub_apps)
                             * 100,
@@ -237,7 +237,7 @@ class ScholarshipAnalyticsService:
                 if month_key not in monthly_submissions:
                     monthly_submissions[month_key] = {"total": 0, "approved": 0}
                 monthly_submissions[month_key]["total"] += 1
-                if app.status == ApplicationStatus.approved.value:
+                if app.status == ApplicationStatus.approved:
                     monthly_submissions[month_key]["approved"] += 1
 
         # Day of week patterns
@@ -289,11 +289,11 @@ class ScholarshipAnalyticsService:
 
         # Renewal success rates
         if renewal_apps:
-            renewal_approved = len([app for app in renewal_apps if app.status == ApplicationStatus.approved.value])
+            renewal_approved = len([app for app in renewal_apps if app.status == ApplicationStatus.approved])
             renewal_analysis["renewal_approval_rate"] = renewal_approved / len(renewal_apps) * 100
 
         if new_apps:
-            new_approved = len([app for app in new_apps if app.status == ApplicationStatus.approved.value])
+            new_approved = len([app for app in new_apps if app.status == ApplicationStatus.approved])
             renewal_analysis["new_application_approval_rate"] = new_approved / len(new_apps) * 100
 
         # Note: Priority score comparison removed (priority_score field removed from Application model)
@@ -312,8 +312,8 @@ class ScholarshipAnalyticsService:
                 and app.review_deadline < datetime.now(timezone.utc)
                 and app.status
                 in [
-                    ApplicationStatus.submitted.value,
-                    ApplicationStatus.under_review.value,
+                    ApplicationStatus.submitted,
+                    ApplicationStatus.under_review,
                 ]
             ]
         )
@@ -342,8 +342,8 @@ class ScholarshipAnalyticsService:
     def _analyze_success_factors(self, applications: List[Application]) -> Dict[str, Any]:
         """Analyze factors that correlate with successful applications"""
 
-        approved_apps = [app for app in applications if app.status == ApplicationStatus.approved.value]
-        rejected_apps = [app for app in applications if app.status == ApplicationStatus.rejected.value]
+        approved_apps = [app for app in applications if app.status == ApplicationStatus.approved]
+        rejected_apps = [app for app in applications if app.status == ApplicationStatus.rejected]
 
         success_factors = {}
 

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1130,11 +1130,9 @@ class ApplicationService:
             raise NotFoundError(f"Application {application_id} not found")
 
         if not application.is_editable:
-            from app.models.enums import ApplicationStatus
-
             allowed_statuses = [ApplicationStatus.draft.value, ApplicationStatus.returned.value]
             raise ValidationError(
-                f"Application cannot be submitted in current status '{application.status}'. "
+                f"Application cannot be submitted in current status '{application.status.value}'. "
                 f"Only applications with status {', '.join(repr(s) for s in allowed_statuses)} can be submitted."
             )
 
@@ -1828,7 +1826,7 @@ class ApplicationService:
             raise NotFoundError("Application", application_id)
 
         # Check if already deleted
-        if application.status == ApplicationStatus.deleted.value:
+        if application.status == ApplicationStatus.deleted:
             raise ValidationError("Application is already deleted")
 
         # Check if user has permission to delete this application
@@ -1836,7 +1834,7 @@ class ApplicationService:
             if application.user_id != current_user.id:
                 raise AuthorizationError("You can only delete your own applications")
             # Students can only delete draft applications
-            if application.status != ApplicationStatus.draft.value:
+            if application.status != ApplicationStatus.draft:
                 raise ValidationError("Only draft applications can be deleted by students")
         elif current_user.role in [UserRole.professor, UserRole.college, UserRole.admin, UserRole.super_admin]:
             # Staff can delete any application but must provide a reason
@@ -1846,7 +1844,7 @@ class ApplicationService:
             raise AuthorizationError("You don't have permission to delete applications")
 
         # Determine deletion type based on application status
-        is_draft = application.status == ApplicationStatus.draft.value
+        is_draft = application.status == ApplicationStatus.draft
 
         if is_draft:
             # Hard delete for draft applications
@@ -1918,7 +1916,7 @@ class ApplicationService:
             raise NotFoundError("Application", application_id)
 
         # Check if already deleted
-        if application.status != ApplicationStatus.deleted.value:
+        if application.status != ApplicationStatus.deleted:
             raise ValidationError("Only deleted applications can be restored")
 
         # Check if user has permission to restore this application

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1145,7 +1145,7 @@ class ApplicationService:
         # 更新狀態為已提交
         from app.utils.i18n import ScholarshipI18n
 
-        application.status = ApplicationStatus.submitted.value
+        application.status = ApplicationStatus.submitted
         application.status_name = ScholarshipI18n.get_application_status_text(ApplicationStatus.submitted.value)
         application.submitted_at = datetime.now(timezone.utc)
         application.updated_at = datetime.now(timezone.utc)
@@ -1875,7 +1875,7 @@ class ApplicationService:
             # Soft delete for submitted applications
             logger.info(f"Performing soft delete for submitted application {application.app_id}")
 
-            application.status = ApplicationStatus.deleted.value
+            application.status = ApplicationStatus.deleted
             application.deleted_at = datetime.now(timezone.utc)
             application.deleted_by_id = current_user.id
             application.deletion_reason = reason or "Application deleted"
@@ -1931,10 +1931,10 @@ class ApplicationService:
         # so it will appear in the college review list
         if application.submitted_at:
             # Application was previously submitted - restore to under_review
-            application.status = ApplicationStatus.under_review.value
+            application.status = ApplicationStatus.under_review
         else:
             # Application was never submitted - restore to draft
-            application.status = ApplicationStatus.draft.value
+            application.status = ApplicationStatus.draft
 
         # Clear deletion metadata
         application.deleted_at = None
@@ -2535,7 +2535,7 @@ class ApplicationService:
                 from app.utils.i18n import ScholarshipI18n
 
                 logger.info("Step 6: Setting status to under_review")
-                application.status = ApplicationStatus.under_review.value
+                application.status = ApplicationStatus.under_review
                 application.status_name = ScholarshipI18n.get_application_status_text(
                     ApplicationStatus.under_review.value
                 )

--- a/scripts/clear_applications.sh
+++ b/scripts/clear_applications.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Clear all application data and related records.
+# Usage: ./scripts/clear_applications.sh
+
+set -e
+
+DB_CONTAINER="scholarship_postgres_dev"
+DB_USER="scholarship_user"
+DB_NAME="scholarship_db"
+
+echo "🗑  Clearing all application data..."
+
+docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "
+BEGIN;
+
+-- Related data (foreign key references to applications)
+TRUNCATE payment_roster_items CASCADE;
+TRUNCATE college_ranking_items CASCADE;
+TRUNCATE college_ranking_items_backup CASCADE;
+TRUNCATE document_requests CASCADE;
+TRUNCATE scheduled_emails CASCADE;
+DELETE FROM email_history WHERE application_id IS NOT NULL;
+
+-- Application direct children
+TRUNCATE application_reviews CASCADE;
+TRUNCATE application_review_items CASCADE;
+TRUNCATE application_files CASCADE;
+
+-- Applications
+TRUNCATE applications CASCADE;
+
+-- Sequence counters
+TRUNCATE application_sequences CASCADE;
+
+COMMIT;
+"
+
+echo "✅ All application data cleared."

--- a/scripts/clear_applications.sh
+++ b/scripts/clear_applications.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 # Clear all application data and related records.
-# Usage: ./scripts/clear_applications.sh
+# Usage: ./scripts/clear_applications.sh [--force]
 
 set -e
 
 DB_CONTAINER="scholarship_postgres_dev"
 DB_USER="scholarship_user"
 DB_NAME="scholarship_db"
+
+if [ "$1" != "--force" ]; then
+    read -p "⚠️  This will delete ALL application data. Continue? [y/N] " confirm
+    if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
 
 echo "🗑  Clearing all application data..."
 

--- a/scripts/seed_csphd001_draft.py
+++ b/scripts/seed_csphd001_draft.py
@@ -143,7 +143,7 @@ async def seed(nycu_id: str):
             status_name="草稿",
             review_stage=ReviewStage.student_draft,
             academic_year=config.academic_year,
-            semester=config.semester or "yearly",
+            semester=config.semester,
             is_renewal=False,
             agree_terms=True,
             student_data=student_data,

--- a/scripts/seed_csphd001_draft.py
+++ b/scripts/seed_csphd001_draft.py
@@ -1,0 +1,165 @@
+"""
+Seed a ready-to-submit draft PhD scholarship application for a given student.
+Fetches student data from mock SIS API via the existing StudentService.
+
+Usage:
+  python seed_csphd001_draft.py <nycu_id>
+  python seed_csphd001_draft.py csphd0001
+  python seed_csphd001_draft.py csphd0002
+"""
+import argparse
+import asyncio
+from datetime import datetime, timezone
+
+from sqlalchemy import select, text
+from app.db.session import AsyncSessionLocal
+from app.models.application import Application
+from app.models.user_profile import UserProfile
+from app.models.enums import ApplicationStatus, ReviewStage, SubTypeSelectionMode
+from app.services.student_service import StudentService
+
+
+async def seed(nycu_id: str):
+    async with AsyncSessionLocal() as session:
+        # 1. Get user
+        user_result = await session.execute(
+            text("SELECT id, nycu_id, name FROM users WHERE nycu_id = :nid"),
+            {"nid": nycu_id},
+        )
+        user = user_result.fetchone()
+        if not user:
+            print(f"❌ User {nycu_id} not found in database")
+            return
+
+        # 2. Get PhD scholarship config for year 114
+        config_result = await session.execute(
+            text("""
+                SELECT sc.id, sc.scholarship_type_id, sc.academic_year, sc.semester,
+                       st.code, st.name
+                FROM scholarship_configurations sc
+                JOIN scholarship_types st ON st.id = sc.scholarship_type_id
+                WHERE st.code = 'phd' AND sc.academic_year = 114
+            """)
+        )
+        config = config_result.fetchone()
+        if not config:
+            print("❌ PhD scholarship configuration for year 114 not found")
+            return
+
+        print(f"👤 User: {user.name} ({user.nycu_id}), id={user.id}")
+        print(f"🎓 Scholarship: {config.name}, config_id={config.id}")
+
+        # 3. Create or update user_profile (fixed fields)
+        profile_result = await session.execute(
+            select(UserProfile).where(UserProfile.user_id == user.id)
+        )
+        profile = profile_result.scalar_one_or_none()
+        if not profile:
+            profile = UserProfile(
+                user_id=user.id,
+                account_number="0011234-5678901",
+                advisor_name="張教授",
+                advisor_email="professor@nycu.edu.tw",
+                advisor_nycu_id="T001",
+            )
+            session.add(profile)
+            print("  ✓ User profile created")
+        else:
+            profile.account_number = profile.account_number or "0011234-5678901"
+            profile.advisor_name = profile.advisor_name or "張教授"
+            profile.advisor_email = profile.advisor_email or "professor@nycu.edu.tw"
+            profile.advisor_nycu_id = profile.advisor_nycu_id or "T001"
+            print("  ✓ User profile updated")
+
+        # 4. Check existing application
+        existing = await session.execute(
+            select(Application).where(
+                Application.user_id == user.id,
+                Application.scholarship_type_id == config.scholarship_type_id,
+                Application.academic_year == config.academic_year,
+            )
+        )
+        if existing.scalar_one_or_none():
+            print("⚠️  Application already exists, skipping")
+            await session.commit()
+            return
+
+        # 5. Fetch student data via StudentService (uses mock API with auth)
+        print("  📡 Fetching student data from SIS API...")
+        student_service = StudentService()
+        try:
+            student_data = await student_service.get_student_snapshot(
+                nycu_id, academic_year=str(config.academic_year), semester=config.semester
+            )
+            print(f"  ✓ Student data: {student_data.get('std_cname', nycu_id)}")
+        except Exception as e:
+            print(f"  ⚠️  API fetch failed ({e}), using minimal snapshot")
+            student_data = {
+                "std_stdcode": nycu_id,
+                "std_cname": user.name,
+                "com_email": f"{nycu_id}@nycu.edu.tw",
+                "_api_fetched_at": datetime.now(timezone.utc).isoformat(),
+                "_term_data_status": "fallback",
+            }
+
+        # 6. Build submitted_form_data
+        submitted_form_data = {
+            "fields": {
+                "master_school_info": {
+                    "field_id": "master_school_info",
+                    "field_type": "text",
+                    "value": f"{student_data.get('std_highestschname', '國立陽明交通大學')} 資訊工程研究所",
+                    "required": True,
+                },
+            },
+            "documents": [],
+        }
+
+        # 7. Generate app_id
+        seq_result = await session.execute(
+            text("""
+                INSERT INTO application_sequences (academic_year, semester, last_sequence)
+                VALUES (:year, :semester, 1)
+                ON CONFLICT (academic_year, semester)
+                DO UPDATE SET last_sequence = application_sequences.last_sequence + 1
+                RETURNING last_sequence
+            """),
+            {"year": config.academic_year, "semester": config.semester or "yearly"},
+        )
+        seq = seq_result.scalar()
+        app_id = f"APP-{config.academic_year}-0-{seq:05d}"
+
+        # 8. Create draft application
+        application = Application(
+            app_id=app_id,
+            user_id=user.id,
+            scholarship_type_id=config.scholarship_type_id,
+            scholarship_configuration_id=config.id,
+            scholarship_name=config.name,
+            scholarship_subtype_list=["nstc"],
+            sub_type_selection_mode=SubTypeSelectionMode.multiple,
+            sub_scholarship_type="nstc",
+            status=ApplicationStatus.draft,
+            status_name="草稿",
+            review_stage=ReviewStage.student_draft,
+            academic_year=config.academic_year,
+            semester=config.semester or "yearly",
+            is_renewal=False,
+            agree_terms=True,
+            student_data=student_data,
+            submitted_form_data=submitted_form_data,
+        )
+        session.add(application)
+        await session.commit()
+
+        print(f"\n✅ Draft application created: {app_id}")
+        print(f"   Student: {user.name} ({nycu_id})")
+        print(f"   Scholarship: {config.name} (nstc)")
+        print(f"   Ready to submit via UI")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Seed a draft PhD application")
+    parser.add_argument("nycu_id", help="Student NYCU ID (e.g. csphd0001)")
+    args = parser.parse_args()
+    asyncio.run(seed(args.nycu_id))

--- a/scripts/seed_test_draft.sh
+++ b/scripts/seed_test_draft.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Seed a ready-to-submit draft PhD scholarship application.
+# Usage:
+#   ./scripts/seed_test_draft.sh <nycu_id>           # Seed for specific student
+#   ./scripts/seed_test_draft.sh --clean <nycu_id>   # Clear all applications first
+#
+# Examples:
+#   ./scripts/seed_test_draft.sh csphd0001
+#   ./scripts/seed_test_draft.sh --clean csphd0002
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTAINER="scholarship_backend_dev"
+
+# Parse args
+CLEAN=false
+NYCU_ID=""
+
+for arg in "$@"; do
+    if [ "$arg" = "--clean" ]; then
+        CLEAN=true
+    else
+        NYCU_ID="$arg"
+    fi
+done
+
+if [ -z "$NYCU_ID" ]; then
+    echo "Usage: $0 [--clean] <nycu_id>"
+    echo "Example: $0 csphd0001"
+    exit 1
+fi
+
+if [ "$CLEAN" = true ]; then
+    "$SCRIPT_DIR/clear_applications.sh"
+fi
+
+echo "🌱 Seeding draft application for $NYCU_ID..."
+docker cp "$SCRIPT_DIR/seed_csphd001_draft.py" "$CONTAINER":/tmp/seed_csphd001_draft.py
+docker exec -e PYTHONPATH=/app -u root "$CONTAINER" python /tmp/seed_csphd001_draft.py "$NYCU_ID"

--- a/scripts/seed_test_draft.sh
+++ b/scripts/seed_test_draft.sh
@@ -32,7 +32,7 @@ if [ -z "$NYCU_ID" ]; then
 fi
 
 if [ "$CLEAN" = true ]; then
-    "$SCRIPT_DIR/clear_applications.sh"
+    "$SCRIPT_DIR/clear_applications.sh" --force
 fi
 
 echo "🌱 Seeding draft application for $NYCU_ID..."


### PR DESCRIPTION
## Summary

- Fix enum member vs string value comparisons that broke application submit, delete, and restore flows
- Add `_serialize_result()` helper to handle Pydantic/SQLAlchemy/dict serialization consistently
- Return existing draft on duplicate check instead of blocking (supports frontend create-then-submit retry)
- Add test scripts for seeding draft applications and clearing application data

## Root Cause

SQLAlchemy `Enum` columns with `values_callable` return **enum members** (e.g. `ApplicationStatus.draft`), not strings (`"draft"`). All instance-level comparisons used `.value`, which always evaluated to `False`:

```python
# BEFORE (broken): always False
application.status == ApplicationStatus.draft.value

# AFTER (correct): proper enum comparison
application.status == ApplicationStatus.draft
```

This caused:
1. `is_editable` always returning `False` → submit blocked with contradictory error
2. Delete/restore status checks silently failing
3. Analytics status counts always zero

## Changes

### Bug fixes
- `application.py`: Fix `is_editable`, `is_submitted`, `can_be_reviewed`, `get_review_stage` properties
- `application_service.py`: Fix delete/restore status checks, remove shadowing import causing `UnboundLocalError`
- `analytics_service.py`: Fix all instance-level status comparisons

### Improvements
- `applications.py`: Add `_serialize_result()` with enum-safe SQLAlchemy model fallback
- `applications.py`: Return existing draft instead of duplicate error (HTTP 200 vs 201)
- `applications.py`: Use enum members in `notin_` query for consistency

### Scripts
- `scripts/seed_test_draft.sh`: Seed draft application for any student ID
- `scripts/clear_applications.sh`: Truncate all application-related tables

## Test plan

- [ ] Login as csphd0001, create new PhD scholarship application → submit succeeds
- [ ] Re-submit same scholarship → returns existing draft, not duplicate error
- [ ] Delete a draft application → works correctly
- [ ] Restore a deleted application → works correctly
- [ ] Admin dashboard analytics → status counts show correct values
- [ ] `./scripts/seed_test_draft.sh --clean csphd0001` → seeds draft successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)