### PR TITLE
refactor: revert prettier noise from soft-delete commit

### DIFF
--- a/frontend/components/admin-scholarship-dashboard.tsx
+++ b/frontend/components/admin-scholarship-dashboard.tsx
@@ -201,14 +201,9 @@ const transformApplicationData = (app: any): DashboardApplication => {
     submitted_form_data: submittedFormData, // Use the enhanced version
     student_data: app.student_data,
     // Map student information using helper functions with fallbacks
-    student_name:
-      app.student_name || getStudentName(app.student_data) || "未知",
+    student_name: app.student_name || getStudentName(app.student_data) || "未知",
     student_no: app.student_no || getStudentId(app.student_data) || "N/A",
-    student_email:
-      app.student_email ||
-      getStudentEmail(app.student_data) ||
-      app.user?.email ||
-      "N/A",
+    student_email: app.student_email || getStudentEmail(app.student_data) || app.user?.email || "N/A",
     user: app.user || {
       email: getStudentEmail(app.student_data) || "N/A",
     },
@@ -285,8 +280,7 @@ export function AdminScholarshipDashboard({
   const [showApplicationDetail, setShowApplicationDetail] = useState(false);
   const [selectedApplicationForDetail, setSelectedApplicationForDetail] =
     useState<Application | null>(null);
-  const [loadingApplicationDetail, setLoadingApplicationDetail] =
-    useState(false);
+  const [loadingApplicationDetail, setLoadingApplicationDetail] = useState(false);
   const [bankVerificationLoading, setBankVerificationLoading] = useState<
     Record<number, boolean>
   >({});
@@ -295,9 +289,7 @@ export function AdminScholarshipDashboard({
   const [selectedApplicationsForBatch, setSelectedApplicationsForBatch] =
     useState<number[]>([]);
   const [bankReviewDialogOpen, setBankReviewDialogOpen] = useState(false);
-  const [currentBankVerification, setCurrentBankVerification] = useState<
-    any | null
-  >(null);
+  const [currentBankVerification, setCurrentBankVerification] = useState<any | null>(null);
   // 學期選擇相關狀態
   const [selectedAcademicYear, setSelectedAcademicYear] = useState<number>();
   const [selectedSemester, setSelectedSemester] = useState<string>();
@@ -416,10 +408,7 @@ export function AdminScholarshipDashboard({
   // 獲取子類型顯示名稱（從後端獲取）
   const getSubTypeDisplayName = (subType: string, lang: string = locale) => {
     // Type-safe access to translations
-    const currentLangDict =
-      lang === "zh" || lang === "en"
-        ? subTypeTranslations[lang]
-        : subTypeTranslations.zh;
+    const currentLangDict = lang === "zh" || lang === "en" ? subTypeTranslations[lang] : subTypeTranslations.zh;
 
     // 使用後端翻譯
     if (currentLangDict && currentLangDict[subType]) {
@@ -427,11 +416,7 @@ export function AdminScholarshipDashboard({
     }
 
     // 如果當前語言沒有翻譯，嘗試使用中文
-    if (
-      lang !== "zh" &&
-      subTypeTranslations.zh &&
-      subTypeTranslations.zh[subType]
-    ) {
+    if (lang !== "zh" && subTypeTranslations.zh && subTypeTranslations.zh[subType]) {
       return subTypeTranslations.zh[subType];
     }
 
@@ -450,9 +435,7 @@ export function AdminScholarshipDashboard({
       console.log("Status update result:", result);
 
       // 檢查是否成功（即使拋出錯誤，實際上也可能成功了）
-      toast.success(
-        `申請狀態已更新為${newStatus === "approved" ? "已核准" : newStatus === "rejected" ? "已駁回" : newStatus}`
-      );
+      toast.success(`申請狀態已更新為${newStatus === "approved" ? "已核准" : newStatus === "rejected" ? "已駁回" : newStatus}`);
 
       // 重新載入數據
       refetch();
@@ -470,9 +453,7 @@ export function AdminScholarshipDashboard({
   const handleViewApplication = async (dashboardApp: DashboardApplication) => {
     setLoadingApplicationDetail(true);
     try {
-      const response = await apiClient.applications.getApplicationById(
-        dashboardApp.id
-      );
+      const response = await apiClient.applications.getApplicationById(dashboardApp.id);
       if (response.success && response.data) {
         setSelectedApplicationForDetail(response.data);
         setShowApplicationDetail(true);
@@ -541,8 +522,7 @@ export function AdminScholarshipDashboard({
     setBankVerificationLoading(prev => ({ ...prev, [applicationId]: true }));
     try {
       // 執行 OCR 驗證（與自動驗證使用相同 API）
-      const response =
-        await apiClient.bankVerification.verifyBankAccount(applicationId);
+      const response = await apiClient.bankVerification.verifyBankAccount(applicationId);
 
       if (response.success && response.data) {
         // 不管驗證結果如何，都開啟人工檢閱 dialog
@@ -575,9 +555,7 @@ export function AdminScholarshipDashboard({
         selectedApplicationsForBatch
       );
       if (response.success) {
-        toast.success(
-          `已完成 ${selectedApplicationsForBatch.length} 個申請案件的郵局帳戶驗證`
-        );
+        toast.success(`已完成 ${selectedApplicationsForBatch.length} 個申請案件的郵局帳戶驗證`);
         setSelectedApplicationsForBatch([]);
         refetch(); // 重新載入數據
       } else {
@@ -632,11 +610,8 @@ export function AdminScholarshipDashboard({
 
     // 如果有分開狀態，判斷整體驗證狀態
     if (accountNumberStatus || accountHolderStatus) {
-      const allVerified =
-        accountNumberStatus === "verified" &&
-        accountHolderStatus === "verified";
-      const anyFailed =
-        accountNumberStatus === "failed" || accountHolderStatus === "failed";
+      const allVerified = accountNumberStatus === "verified" && accountHolderStatus === "verified";
+      const anyFailed = accountNumberStatus === "failed" || accountHolderStatus === "failed";
 
       if (allVerified) {
         return <ShieldCheck className="h-5 w-5 text-green-600" />;
@@ -691,8 +666,7 @@ export function AdminScholarshipDashboard({
     setAuditLoading(true);
     try {
       // 使用新的獎學金稽核軌跡端點，一次性獲取所有日誌（包含已刪除申請）
-      const response =
-        await apiClient.admin.getScholarshipAuditTrail(activeTab);
+      const response = await apiClient.admin.getScholarshipAuditTrail(activeTab);
 
       if (response.success && response.data) {
         setAuditLogs(response.data);
@@ -974,7 +948,7 @@ export function AdminScholarshipDashboard({
                               <div className="flex items-center justify-between gap-2 p-2 bg-green-50 border border-green-200 rounded-md">
                                 <div className="flex items-center gap-1">
                                   <CheckCircle className="h-4 w-4 text-green-600" />
-                                  <span className="text-sm font-medium text-green-800 whitespace-nowrap">
+                                    <span className="text-sm font-medium text-green-800 whitespace-nowrap">
                                     {(() => {
                                       console.log(
                                         "🎯 Display logic - App:",
@@ -1117,9 +1091,7 @@ export function AdminScholarshipDashboard({
                         // 不需要教授推薦的獎學金
                         <div className="flex items-center gap-2 p-2 bg-gray-50 border border-gray-200 rounded-md">
                           <Minus className="h-4 w-4 text-gray-500" />
-                          <span className="text-sm text-gray-600 whitespace-nowrap">
-                            不需要
-                          </span>
+                          <span className="text-sm text-gray-600 whitespace-nowrap">不需要</span>
                         </div>
                       )}
                     </TableCell>
@@ -1129,11 +1101,8 @@ export function AdminScholarshipDashboard({
                           const statusInfo = getDisplayStatusInfo(app, "zh");
                           return (
                             <>
-                              {app.status === "partial_approved" ? (
-                                <Badge
-                                  variant="outline"
-                                  className="bg-blue-100 text-blue-700 border-blue-300"
-                                >
+                              {app.status === 'partial_approved' ? (
+                                <Badge variant="outline" className="bg-blue-100 text-blue-700 border-blue-300">
                                   <Circle className="w-3 h-3 mr-1 fill-blue-700" />
                                   {statusInfo.statusLabel}
                                 </Badge>
@@ -1142,12 +1111,11 @@ export function AdminScholarshipDashboard({
                                   {statusInfo.statusLabel}
                                 </Badge>
                               )}
-                              {statusInfo.showStage &&
-                                statusInfo.stageLabel && (
-                                  <Badge variant={statusInfo.stageVariant}>
-                                    {statusInfo.stageLabel}
-                                  </Badge>
-                                )}
+                              {statusInfo.showStage && statusInfo.stageLabel && (
+                                <Badge variant={statusInfo.stageVariant}>
+                                  {statusInfo.stageLabel}
+                                </Badge>
+                              )}
                             </>
                           );
                         })()}
@@ -1180,8 +1148,7 @@ export function AdminScholarshipDashboard({
                         </Button>
 
                         {/* 刪除按鈕 */}
-                        {(app.status === "draft" ||
-                          app.status === "submitted") && (
+                        {(app.status === "draft" || app.status === "submitted") && (
                           <Button
                             variant="outline"
                             size="sm"
@@ -1198,23 +1165,15 @@ export function AdminScholarshipDashboard({
                         {/* 退件按鈕 */}
                         <button
                           onClick={async () => {
-                            const reason = window
-                              .prompt("請輸入退件理由：")
-                              ?.trim();
+                            const reason = window.prompt("請輸入退件理由：")?.trim();
                             if (!reason) return;
                             try {
-                              const result =
-                                await apiClient.admin.softDeleteApplication(
-                                  app.id,
-                                  reason
-                                );
+                              const result = await apiClient.admin.softDeleteApplication(app.id, reason);
                               if (result.success) {
                                 toast.success("退件成功");
                                 refetch();
                               } else {
-                                toast.error(
-                                  result.message || "退件失敗，請稍後再試"
-                                );
+                                toast.error(result.message || "退件失敗，請稍後再試");
                               }
                             } catch (error) {
                               console.error("Failed to soft-delete:", error);
@@ -1443,7 +1402,9 @@ export function AdminScholarshipDashboard({
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-2xl font-bold">獎學金申請管理</h2>
-            <p className="text-muted-foreground">載入獎學金資料中...</p>
+            <p className="text-muted-foreground">
+              載入獎學金資料中...
+            </p>
           </div>
           <div className="flex gap-2">
             <Skeleton className="h-10 w-28" /> {/* 操作紀錄按鈕 */}
@@ -1665,7 +1626,7 @@ export function AdminScholarshipDashboard({
         application={selectedApplicationForDetail}
         role="admin"
         open={showApplicationDetail}
-        onOpenChange={open => {
+        onOpenChange={(open) => {
           setShowApplicationDetail(open);
           if (!open) {
             setSelectedApplicationForDetail(null);
@@ -1704,9 +1665,7 @@ export function AdminScholarshipDashboard({
                   {auditLogs.map((log, index) => (
                     <TableRow key={index}>
                       <TableCell className="text-sm">
-                        {new Date(
-                          log.created_at || log.timestamp
-                        ).toLocaleString("zh-TW")}
+                        {new Date(log.created_at || log.timestamp).toLocaleString("zh-TW")}
                       </TableCell>
                       <TableCell className="text-sm">
                         {log.user_name || log.user?.name || "系統"}
@@ -1744,14 +1703,14 @@ export function AdminScholarshipDashboard({
       {applicationToDelete && (
         <DeleteApplicationDialog
           open={showDeleteDialog}
-          onOpenChange={open => {
+          onOpenChange={(open) => {
             setShowDeleteDialog(open);
             if (!open) {
               setApplicationToDelete(null);
             }
           }}
           applicationId={applicationToDelete.id}
-          applicationName={`${applicationToDelete.app_id || "N/A"} - ${applicationToDelete.student_name || "未知"}`}
+          applicationName={`${applicationToDelete.app_id || 'N/A'} - ${applicationToDelete.student_name || '未知'}`}
           onSuccess={handleDeleteSuccess}
           locale="zh"
           requireReason={true}

--- a/frontend/lib/api/modules/admin.ts
+++ b/frontend/lib/api/modules/admin.ts
@@ -15,9 +15,9 @@
  * Now using openapi-fetch for full type safety from backend OpenAPI schema
  */
 
-import { typedClient } from "../typed-client";
-import { toApiResponse } from "../compat";
-import type { ApiResponse } from "../types";
+import { typedClient } from '../typed-client';
+import { toApiResponse } from '../compat';
+import type { ApiResponse } from '../types';
 
 export function createAdminApi() {
   return {
@@ -28,9 +28,7 @@ export function createAdminApi() {
      * Type-safe: Response type inferred from OpenAPI
      */
     getDashboardStats: async (): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/dashboard/stats"
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/dashboard/stats');
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -38,15 +36,10 @@ export function createAdminApi() {
      * Get recent applications
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getRecentApplications: async (
-      limit?: number
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/recent-applications",
-        {
-          params: { query: { limit } },
-        }
-      );
+    getRecentApplications: async (limit?: number): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/recent-applications', {
+        params: { query: { limit } },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -54,15 +47,10 @@ export function createAdminApi() {
      * Get system announcements
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getSystemAnnouncements: async (
-      limit?: number
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/system-announcements",
-        {
-          params: { query: { limit } },
-        }
-      );
+    getSystemAnnouncements: async (limit?: number): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/system-announcements', {
+        params: { query: { limit } },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -71,9 +59,7 @@ export function createAdminApi() {
      * Type-safe: Response type inferred from OpenAPI
      */
     getSystemStats: async (): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/dashboard/stats"
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/dashboard/stats');
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -87,10 +73,8 @@ export function createAdminApi() {
       page?: number,
       size?: number,
       status?: string
-    ): Promise<
-      ApiResponse<{ items: any[]; total: number; page: number; size: number }>
-    > => {
-      const response = await typedClient.raw.GET("/api/v1/admin/applications", {
+    ): Promise<ApiResponse<{ items: any[]; total: number; page: number; size: number }>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/applications', {
         params: {
           query: {
             page,
@@ -106,25 +90,20 @@ export function createAdminApi() {
      * Get historical applications with filters
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getHistoricalApplications: async (
-      filters?: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/applications/history",
-        {
-          params: {
-            query: {
-              page: filters?.page,
-              size: filters?.size,
-              status: filters?.status,
-              scholarship_type: filters?.scholarship_type,
-              academic_year: filters?.academic_year,
-              semester: filters?.semester,
-              search: filters?.search,
-            },
+    getHistoricalApplications: async (filters?: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/applications/history', {
+        params: {
+          query: {
+            page: filters?.page,
+            size: filters?.size,
+            status: filters?.status,
+            scholarship_type: filters?.scholarship_type,
+            academic_year: filters?.academic_year,
+            semester: filters?.semester,
+            search: filters?.search,
           },
-        }
-      );
+        },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -137,13 +116,10 @@ export function createAdminApi() {
       status: string,
       reviewNotes?: string
     ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PATCH(
-        "/api/v1/admin/applications/{id}/status",
-        {
-          params: { path: { id: applicationId } },
-          body: { status, review_notes: reviewNotes } as any,
-        }
-      );
+      const response = await typedClient.raw.PATCH('/api/v1/admin/applications/{id}/status', {
+        params: { path: { id: applicationId } },
+        body: { status, review_notes: reviewNotes } as any,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -154,12 +130,9 @@ export function createAdminApi() {
      * Type-safe: Query parameters validated against OpenAPI
      */
     getEmailTemplate: async (key: string): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/email-template",
-        {
-          params: { query: { key } },
-        }
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/email-template', {
+        params: { query: { key } },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -168,12 +141,9 @@ export function createAdminApi() {
      * Type-safe: Request body validated against OpenAPI
      */
     updateEmailTemplate: async (template: any): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/admin/email-template",
-        {
-          body: template,
-        }
-      );
+      const response = await typedClient.raw.PUT('/api/v1/admin/email-template', {
+        body: template,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -181,15 +151,10 @@ export function createAdminApi() {
      * Get email templates by sending type
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getEmailTemplatesBySendingType: async (
-      sendingType?: string
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/email-templates",
-        {
-          params: { query: { sending_type: sendingType } },
-        }
-      );
+    getEmailTemplatesBySendingType: async (sendingType?: string): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/email-templates', {
+        params: { query: { sending_type: sendingType } },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -201,16 +166,10 @@ export function createAdminApi() {
     getScholarshipEmailTemplates: async (
       scholarshipTypeId: number
     ): Promise<ApiResponse<{ items: any[]; total: number }>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarship-email-templates/{scholarship_type_id}",
-        {
-          params: { path: { scholarship_type_id: scholarshipTypeId } },
-        }
-      );
-      return toApiResponse(response) as ApiResponse<{
-        items: any[];
-        total: number;
-      }>;
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarship-email-templates/{scholarship_type_id}', {
+        params: { path: { scholarship_type_id: scholarshipTypeId } },
+      });
+      return toApiResponse(response) as ApiResponse<{ items: any[]; total: number }>;
     },
 
     /**
@@ -221,17 +180,9 @@ export function createAdminApi() {
       scholarshipTypeId: number,
       templateKey: string
     ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/{template_key}",
-        {
-          params: {
-            path: {
-              scholarship_type_id: scholarshipTypeId,
-              template_key: templateKey,
-            },
-          },
-        }
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/{template_key}', {
+        params: { path: { scholarship_type_id: scholarshipTypeId, template_key: templateKey } },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -239,15 +190,10 @@ export function createAdminApi() {
      * Create scholarship email template
      * Type-safe: Request body validated against OpenAPI
      */
-    createScholarshipEmailTemplate: async (
-      templateData: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/scholarship-email-templates",
-        {
-          body: templateData,
-        }
-      );
+    createScholarshipEmailTemplate: async (templateData: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/scholarship-email-templates', {
+        body: templateData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -260,18 +206,10 @@ export function createAdminApi() {
       templateKey: string,
       templateData: any
     ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/{template_key}",
-        {
-          params: {
-            path: {
-              scholarship_type_id: scholarshipTypeId,
-              template_key: templateKey,
-            },
-          },
-          body: templateData,
-        }
-      );
+      const response = await typedClient.raw.PUT('/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/{template_key}', {
+        params: { path: { scholarship_type_id: scholarshipTypeId, template_key: templateKey } },
+        body: templateData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -283,17 +221,9 @@ export function createAdminApi() {
       scholarshipTypeId: number,
       templateKey: string
     ): Promise<ApiResponse<boolean>> => {
-      const response = await typedClient.raw.DELETE(
-        "/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/{template_key}",
-        {
-          params: {
-            path: {
-              scholarship_type_id: scholarshipTypeId,
-              template_key: templateKey,
-            },
-          },
-        }
-      );
+      const response = await typedClient.raw.DELETE('/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/{template_key}', {
+        params: { path: { scholarship_type_id: scholarshipTypeId, template_key: templateKey } },
+      });
       return toApiResponse(response) as ApiResponse<boolean>;
     },
 
@@ -304,17 +234,11 @@ export function createAdminApi() {
     bulkCreateScholarshipEmailTemplates: async (
       scholarshipTypeId: number
     ): Promise<ApiResponse<{ items: any[]; total: number }>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/bulk-create",
-        {
-          params: { path: { scholarship_type_id: scholarshipTypeId } },
-          body: {} as any,
-        }
-      );
-      return toApiResponse(response) as ApiResponse<{
-        items: any[];
-        total: number;
-      }>;
+      const response = await typedClient.raw.POST('/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/bulk-create', {
+        params: { path: { scholarship_type_id: scholarshipTypeId } },
+        body: {} as any,
+      });
+      return toApiResponse(response) as ApiResponse<{ items: any[]; total: number }>;
     },
 
     /**
@@ -324,12 +248,9 @@ export function createAdminApi() {
     getAvailableScholarshipEmailTemplates: async (
       scholarshipTypeId: number
     ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/available",
-        {
-          params: { path: { scholarship_type_id: scholarshipTypeId } },
-        }
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarship-email-templates/{scholarship_type_id}/available', {
+        params: { path: { scholarship_type_id: scholarshipTypeId } },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -340,12 +261,9 @@ export function createAdminApi() {
      * Type-safe: Query parameters validated against OpenAPI
      */
     getSystemSetting: async (key: string): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/system-setting",
-        {
-          params: { query: { key } },
-        }
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/system-setting', {
+        params: { query: { key } },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -354,12 +272,9 @@ export function createAdminApi() {
      * Type-safe: Request body validated against OpenAPI
      */
     updateSystemSetting: async (setting: any): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/admin/system-setting",
-        {
-          body: setting,
-        }
-      );
+      const response = await typedClient.raw.PUT('/api/v1/admin/system-setting', {
+        body: setting,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -374,22 +289,17 @@ export function createAdminApi() {
       size?: number,
       notificationType?: string,
       priority?: string
-    ): Promise<
-      ApiResponse<{ items: any[]; total: number; page: number; size: number }>
-    > => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/announcements",
-        {
-          params: {
-            query: {
-              page,
-              size,
-              notification_type: notificationType,
-              priority,
-            },
+    ): Promise<ApiResponse<{ items: any[]; total: number; page: number; size: number }>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/announcements', {
+        params: {
+          query: {
+            page,
+            size,
+            notification_type: notificationType,
+            priority,
           },
-        }
-      );
+        },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -398,12 +308,9 @@ export function createAdminApi() {
      * Type-safe: Path parameter validated against OpenAPI
      */
     getAnnouncement: async (id: number): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/announcements/{id}",
-        {
-          params: { path: { id } },
-        }
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/announcements/{id}', {
+        params: { path: { id } },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -411,15 +318,10 @@ export function createAdminApi() {
      * Create announcement
      * Type-safe: Request body validated against OpenAPI
      */
-    createAnnouncement: async (
-      announcementData: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/announcements",
-        {
-          body: announcementData,
-        }
-      );
+    createAnnouncement: async (announcementData: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/announcements', {
+        body: announcementData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -427,17 +329,11 @@ export function createAdminApi() {
      * Update announcement
      * Type-safe: Path parameter and request body validated against OpenAPI
      */
-    updateAnnouncement: async (
-      id: number,
-      announcementData: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/admin/announcements/{id}",
-        {
-          params: { path: { id } },
-          body: announcementData,
-        }
-      );
+    updateAnnouncement: async (id: number, announcementData: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.PUT('/api/v1/admin/announcements/{id}', {
+        params: { path: { id } },
+        body: announcementData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -445,15 +341,10 @@ export function createAdminApi() {
      * Delete announcement
      * Type-safe: Path parameter validated against OpenAPI
      */
-    deleteAnnouncement: async (
-      id: number
-    ): Promise<ApiResponse<{ message: string }>> => {
-      const response = await typedClient.raw.DELETE(
-        "/api/v1/admin/announcements/{id}",
-        {
-          params: { path: { id } },
-        }
-      );
+    deleteAnnouncement: async (id: number): Promise<ApiResponse<{ message: string }>> => {
+      const response = await typedClient.raw.DELETE('/api/v1/admin/announcements/{id}', {
+        params: { path: { id } },
+      });
       return toApiResponse(response) as ApiResponse<{ message: string }>;
     },
 
@@ -463,12 +354,8 @@ export function createAdminApi() {
      * Get scholarship statistics
      * Type-safe: Response type inferred from OpenAPI
      */
-    getScholarshipStats: async (): Promise<
-      ApiResponse<Record<string, any>>
-    > => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarships/stats"
-      );
+    getScholarshipStats: async (): Promise<ApiResponse<Record<string, any>>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarships/stats');
       return toApiResponse(response) as ApiResponse<Record<string, any>>;
     },
 
@@ -481,18 +368,15 @@ export function createAdminApi() {
       subType?: string,
       status?: string
     ): Promise<ApiResponse<any[]>> => {
-      const response = await (typedClient.raw.GET as any)(
-        "/api/v1/admin/scholarships/{scholarship_code}/applications",
-        {
-          params: {
-            path: { scholarship_code: scholarshipCode },
-            query: {
-              sub_type: subType,
-              status,
-            },
+      const response = await (typedClient.raw.GET as any)('/api/v1/admin/scholarships/{scholarship_code}/applications', {
+        params: {
+          path: { scholarship_code: scholarshipCode },
+          query: {
+            sub_type: subType,
+            status,
           },
-        }
-      );
+        },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -500,15 +384,10 @@ export function createAdminApi() {
      * Get scholarship sub-types
      * Type-safe: Path parameter validated against OpenAPI
      */
-    getScholarshipSubTypes: async (
-      scholarshipCode: string
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarships/{scholarship_code}/sub-types",
-        {
-          params: { path: { scholarship_code: scholarshipCode } },
-        }
-      );
+    getScholarshipSubTypes: async (scholarshipCode: string): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarships/{scholarship_code}/sub-types', {
+        params: { path: { scholarship_code: scholarshipCode } },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -516,15 +395,9 @@ export function createAdminApi() {
      * Get sub-type translations
      * Type-safe: Response type inferred from OpenAPI
      */
-    getSubTypeTranslations: async (): Promise<
-      ApiResponse<Record<string, Record<string, string>>>
-    > => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarships/sub-type-translations"
-      );
-      return toApiResponse(response) as ApiResponse<
-        Record<string, Record<string, string>>
-      >;
+    getSubTypeTranslations: async (): Promise<ApiResponse<Record<string, Record<string, string>>>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarships/sub-type-translations');
+      return toApiResponse(response) as ApiResponse<Record<string, Record<string, string>>>;
     },
 
     /**
@@ -538,18 +411,15 @@ export function createAdminApi() {
       limit?: number,
       offset?: number
     ): Promise<ApiResponse<any[]>> => {
-      const response = await (typedClient.raw.GET as any)(
-        `/api/v1/admin/scholarships/${scholarshipIdentifier}/audit-trail`,
-        {
-          params: {
-            query: {
-              action_filter: actionFilter,
-              limit,
-              offset,
-            },
+      const response = await (typedClient.raw.GET as any)(`/api/v1/admin/scholarships/${scholarshipIdentifier}/audit-trail`, {
+        params: {
+          query: {
+            action_filter: actionFilter,
+            limit,
+            offset,
           },
-        }
-      );
+        },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -570,19 +440,14 @@ export function createAdminApi() {
       });
     },
 
-    updateWorkflow: async (
-      id: string,
-      workflow: any
-    ): Promise<ApiResponse<any>> => {
+    updateWorkflow: async (id: string, workflow: any): Promise<ApiResponse<any>> => {
       return Promise.resolve({
         success: false,
         message: "Workflows feature not implemented yet",
       });
     },
 
-    deleteWorkflow: async (
-      id: string
-    ): Promise<ApiResponse<{ message: string }>> => {
+    deleteWorkflow: async (id: string): Promise<ApiResponse<{ message: string }>> => {
       return Promise.resolve({
         success: false,
         message: "Workflows feature not implemented yet",
@@ -596,12 +461,9 @@ export function createAdminApi() {
      * Type-safe: Query parameters validated against OpenAPI
      */
     getScholarshipRules: async (filters?: any): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarship-rules",
-        {
-          params: { query: filters },
-        }
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarship-rules', {
+        params: { query: filters },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -610,12 +472,9 @@ export function createAdminApi() {
      * Type-safe: Path parameter validated against OpenAPI
      */
     getScholarshipRule: async (id: number): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarship-rules/{id}",
-        {
-          params: { path: { id } },
-        }
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarship-rules/{id}', {
+        params: { path: { id } },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -624,12 +483,9 @@ export function createAdminApi() {
      * Type-safe: Request body validated against OpenAPI
      */
     createScholarshipRule: async (rule: any): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/scholarship-rules",
-        {
-          body: rule,
-        }
-      );
+      const response = await typedClient.raw.POST('/api/v1/admin/scholarship-rules', {
+        body: rule,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -637,17 +493,11 @@ export function createAdminApi() {
      * Update scholarship rule
      * Type-safe: Path parameter and request body validated against OpenAPI
      */
-    updateScholarshipRule: async (
-      id: number,
-      rule: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/admin/scholarship-rules/{id}",
-        {
-          params: { path: { id } },
-          body: rule,
-        }
-      );
+    updateScholarshipRule: async (id: number, rule: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.PUT('/api/v1/admin/scholarship-rules/{id}', {
+        params: { path: { id } },
+        body: rule,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -655,15 +505,10 @@ export function createAdminApi() {
      * Delete scholarship rule
      * Type-safe: Path parameter validated against OpenAPI
      */
-    deleteScholarshipRule: async (
-      id: number
-    ): Promise<ApiResponse<{ message: string }>> => {
-      const response = await typedClient.raw.DELETE(
-        "/api/v1/admin/scholarship-rules/{id}",
-        {
-          params: { path: { id } },
-        }
-      );
+    deleteScholarshipRule: async (id: number): Promise<ApiResponse<{ message: string }>> => {
+      const response = await typedClient.raw.DELETE('/api/v1/admin/scholarship-rules/{id}', {
+        params: { path: { id } },
+      });
       return toApiResponse(response) as ApiResponse<{ message: string }>;
     },
 
@@ -671,15 +516,10 @@ export function createAdminApi() {
      * Copy rules between periods
      * Type-safe: Request body validated against OpenAPI
      */
-    copyRulesBetweenPeriods: async (
-      copyRequest: any
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/scholarship-rules/copy",
-        {
-          body: copyRequest,
-        }
-      );
+    copyRulesBetweenPeriods: async (copyRequest: any): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/scholarship-rules/copy', {
+        body: copyRequest,
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -688,12 +528,9 @@ export function createAdminApi() {
      * Type-safe: Request body validated against OpenAPI
      */
     bulkRuleOperation: async (operation: any): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/scholarship-rules/bulk-operation",
-        {
-          body: operation,
-        }
-      );
+      const response = await typedClient.raw.POST('/api/v1/admin/scholarship-rules/bulk-operation', {
+        body: operation,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -701,15 +538,10 @@ export function createAdminApi() {
      * Get rule templates
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getRuleTemplates: async (
-      scholarship_type_id?: number
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarship-rules/templates",
-        {
-          params: { query: { scholarship_type_id } },
-        }
-      );
+    getRuleTemplates: async (scholarship_type_id?: number): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarship-rules/templates', {
+        params: { query: { scholarship_type_id } },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -717,15 +549,10 @@ export function createAdminApi() {
      * Create rule template
      * Type-safe: Request body validated against OpenAPI
      */
-    createRuleTemplate: async (
-      templateRequest: any
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/scholarship-rules/create-template",
-        {
-          body: templateRequest,
-        }
-      );
+    createRuleTemplate: async (templateRequest: any): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/scholarship-rules/create-template', {
+        body: templateRequest,
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -733,15 +560,10 @@ export function createAdminApi() {
      * Apply rule template
      * Type-safe: Request body validated against OpenAPI
      */
-    applyRuleTemplate: async (
-      templateRequest: any
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/scholarship-rules/apply-template",
-        {
-          body: templateRequest,
-        }
-      );
+    applyRuleTemplate: async (templateRequest: any): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/scholarship-rules/apply-template', {
+        body: templateRequest,
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -753,15 +575,12 @@ export function createAdminApi() {
       templateName: string,
       scholarshipTypeId: number
     ): Promise<ApiResponse<{ message: string }>> => {
-      const response = await typedClient.raw.DELETE(
-        "/api/v1/admin/scholarship-rules/templates/{template_name}",
-        {
-          params: {
-            path: { template_name: templateName },
-            query: { scholarship_type_id: scholarshipTypeId },
-          },
-        }
-      );
+      const response = await typedClient.raw.DELETE('/api/v1/admin/scholarship-rules/templates/{template_name}', {
+        params: {
+          path: { template_name: templateName },
+          query: { scholarship_type_id: scholarshipTypeId },
+        },
+      });
       return toApiResponse(response) as ApiResponse<{ message: string }>;
     },
 
@@ -769,15 +588,10 @@ export function createAdminApi() {
      * Get scholarship rule sub-types
      * Type-safe: Path parameter validated against OpenAPI
      */
-    getScholarshipRuleSubTypes: async (
-      scholarshipTypeId: number
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/scholarship-rules/scholarship-types/{scholarship_type_id}/sub-types",
-        {
-          params: { path: { scholarship_type_id: scholarshipTypeId } },
-        }
-      );
+    getScholarshipRuleSubTypes: async (scholarshipTypeId: number): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/scholarship-rules/scholarship-types/{scholarship_type_id}/sub-types', {
+        params: { path: { scholarship_type_id: scholarshipTypeId } },
+      });
       return toApiResponse(response) as unknown as ApiResponse<any[]>;
     },
 
@@ -787,15 +601,10 @@ export function createAdminApi() {
      * Get scholarship permissions
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getScholarshipPermissions: async (
-      userId?: number
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarship-permissions",
-        {
-          params: { query: { user_id: userId } },
-        }
-      );
+    getScholarshipPermissions: async (userId?: number): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarship-permissions', {
+        params: { query: { user_id: userId } },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -803,12 +612,8 @@ export function createAdminApi() {
      * Get current user scholarship permissions
      * Type-safe: Response type inferred from OpenAPI
      */
-    getCurrentUserScholarshipPermissions: async (): Promise<
-      ApiResponse<any[]>
-    > => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarship-permissions/current-user"
-      );
+    getCurrentUserScholarshipPermissions: async (): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarship-permissions/current-user');
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -816,15 +621,10 @@ export function createAdminApi() {
      * Create scholarship permission
      * Type-safe: Request body validated against OpenAPI
      */
-    createScholarshipPermission: async (
-      permission: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/scholarship-permissions",
-        {
-          body: permission,
-        }
-      );
+    createScholarshipPermission: async (permission: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/scholarship-permissions', {
+        body: permission,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -832,17 +632,11 @@ export function createAdminApi() {
      * Update scholarship permission
      * Type-safe: Path parameter and request body validated against OpenAPI
      */
-    updateScholarshipPermission: async (
-      id: number,
-      permission: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/admin/scholarship-permissions/{id}",
-        {
-          params: { path: { id } },
-          body: permission,
-        }
-      );
+    updateScholarshipPermission: async (id: number, permission: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.PUT('/api/v1/admin/scholarship-permissions/{id}', {
+        params: { path: { id } },
+        body: permission,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -850,15 +644,10 @@ export function createAdminApi() {
      * Delete scholarship permission
      * Type-safe: Path parameter validated against OpenAPI
      */
-    deleteScholarshipPermission: async (
-      id: number
-    ): Promise<ApiResponse<{ message: string }>> => {
-      const response = await typedClient.raw.DELETE(
-        "/api/v1/admin/scholarship-permissions/{id}",
-        {
-          params: { path: { id } },
-        }
-      );
+    deleteScholarshipPermission: async (id: number): Promise<ApiResponse<{ message: string }>> => {
+      const response = await typedClient.raw.DELETE('/api/v1/admin/scholarship-permissions/{id}', {
+        params: { path: { id } },
+      });
       return toApiResponse(response) as ApiResponse<{ message: string }>;
     },
 
@@ -867,9 +656,7 @@ export function createAdminApi() {
      * Type-safe: Response type inferred from OpenAPI
      */
     getAllScholarshipsForPermissions: async (): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarships/all-for-permissions"
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarships/all-for-permissions');
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -878,9 +665,7 @@ export function createAdminApi() {
      * Type-safe: Response type inferred from OpenAPI
      */
     getMyScholarships: async (): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarships/my-scholarships"
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarships/my-scholarships');
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -888,15 +673,10 @@ export function createAdminApi() {
      * Get available semesters
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getAvailableSemesters: async (
-      scholarshipCode?: string
-    ): Promise<ApiResponse<string[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/scholarship-configurations/available-semesters",
-        {
-          params: { query: { scholarship_code: scholarshipCode } },
-        }
-      );
+    getAvailableSemesters: async (scholarshipCode?: string): Promise<ApiResponse<string[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/scholarship-configurations/available-semesters', {
+        params: { query: { scholarship_code: scholarshipCode } },
+      });
       return toApiResponse(response) as unknown as ApiResponse<string[]>;
     },
 
@@ -905,9 +685,7 @@ export function createAdminApi() {
      * Type-safe: Response type inferred from OpenAPI
      */
     getAvailableYears: async (): Promise<ApiResponse<number[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/scholarships/available-years"
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/scholarships/available-years');
       return toApiResponse(response) as ApiResponse<number[]>;
     },
 
@@ -918,9 +696,7 @@ export function createAdminApi() {
      * Type-safe: Response type inferred from OpenAPI
      */
     getScholarshipConfigTypes: async (): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/scholarship-configurations/scholarship-types"
-      );
+      const response = await typedClient.raw.GET('/api/v1/scholarship-configurations/scholarship-types');
       return toApiResponse(response) as unknown as ApiResponse<any[]>;
     },
 
@@ -928,22 +704,17 @@ export function createAdminApi() {
      * Get scholarship configurations with filters
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getScholarshipConfigurations: async (
-      params?: any
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/scholarship-configurations/configurations",
-        {
-          params: {
-            query: {
-              scholarship_type_id: params?.scholarship_type_id,
-              academic_year: params?.academic_year,
-              semester: params?.semester,
-              is_active: params?.is_active,
-            },
+    getScholarshipConfigurations: async (params?: any): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/scholarship-configurations/configurations', {
+        params: {
+          query: {
+            scholarship_type_id: params?.scholarship_type_id,
+            academic_year: params?.academic_year,
+            semester: params?.semester,
+            is_active: params?.is_active,
           },
-        }
-      );
+        },
+      });
       return toApiResponse(response) as unknown as ApiResponse<any[]>;
     },
 
@@ -951,15 +722,10 @@ export function createAdminApi() {
      * Get scholarship configuration by ID
      * Type-safe: Path parameter validated against OpenAPI
      */
-    getScholarshipConfiguration: async (
-      id: number
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/scholarship-configurations/configurations/{id}",
-        {
-          params: { path: { id } },
-        }
-      );
+    getScholarshipConfiguration: async (id: number): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.GET('/api/v1/scholarship-configurations/configurations/{id}', {
+        params: { path: { id } },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -967,15 +733,10 @@ export function createAdminApi() {
      * Create scholarship configuration
      * Type-safe: Request body validated against OpenAPI
      */
-    createScholarshipConfiguration: async (
-      configData: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/scholarship-configurations/configurations",
-        {
-          body: configData,
-        }
-      );
+    createScholarshipConfiguration: async (configData: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.POST('/api/v1/scholarship-configurations/configurations', {
+        body: configData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -983,17 +744,11 @@ export function createAdminApi() {
      * Update scholarship configuration
      * Type-safe: Path parameter and request body validated against OpenAPI
      */
-    updateScholarshipConfiguration: async (
-      id: number,
-      configData: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/scholarship-configurations/configurations/{id}",
-        {
-          params: { path: { id } },
-          body: configData,
-        }
-      );
+    updateScholarshipConfiguration: async (id: number, configData: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.PUT('/api/v1/scholarship-configurations/configurations/{id}', {
+        params: { path: { id } },
+        body: configData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1001,15 +756,10 @@ export function createAdminApi() {
      * Delete scholarship configuration
      * Type-safe: Path parameter validated against OpenAPI
      */
-    deleteScholarshipConfiguration: async (
-      id: number
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.DELETE(
-        "/api/v1/scholarship-configurations/configurations/{id}",
-        {
-          params: { path: { id } },
-        }
-      );
+    deleteScholarshipConfiguration: async (id: number): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.DELETE('/api/v1/scholarship-configurations/configurations/{id}', {
+        params: { path: { id } },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1021,13 +771,10 @@ export function createAdminApi() {
       id: number,
       targetData: any
     ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/scholarship-configurations/configurations/{id}/duplicate",
-        {
-          params: { path: { id } },
-          body: targetData,
-        }
-      );
+      const response = await typedClient.raw.POST('/api/v1/scholarship-configurations/configurations/{id}/duplicate', {
+        params: { path: { id } },
+        body: targetData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1038,7 +785,7 @@ export function createAdminApi() {
      * Type-safe: Query parameters validated against OpenAPI
      */
     getProfessors: async (search?: string): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET("/api/v1/admin/professors", {
+      const response = await typedClient.raw.GET('/api/v1/admin/professors', {
         params: { query: { search } },
       });
       return toApiResponse(response) as ApiResponse<any[]>;
@@ -1048,17 +795,11 @@ export function createAdminApi() {
      * Assign professor to application
      * Type-safe: Path parameter and request body validated against OpenAPI
      */
-    assignProfessor: async (
-      applicationId: number,
-      professorNycuId: string
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/admin/applications/{id}/assign-professor",
-        {
-          params: { path: { id: applicationId } },
-          body: { professor_nycu_id: professorNycuId } as any,
-        }
-      );
+    assignProfessor: async (applicationId: number, professorNycuId: string): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.PUT('/api/v1/admin/applications/{id}/assign-professor', {
+        params: { path: { id: applicationId } },
+        body: { professor_nycu_id: professorNycuId } as any,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1066,10 +807,8 @@ export function createAdminApi() {
      * Get available professors (alias for getProfessors)
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getAvailableProfessors: async (
-      search?: string
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET("/api/v1/admin/professors", {
+    getAvailableProfessors: async (search?: string): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/professors', {
         params: { query: { search } },
       });
       return toApiResponse(response) as ApiResponse<any[]>;
@@ -1082,9 +821,7 @@ export function createAdminApi() {
      * Type-safe: Response type inferred from OpenAPI
      */
     getConfigurations: async (): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/configurations"
-      );
+      const response = await typedClient.raw.GET('/api/v1/admin/configurations');
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -1093,12 +830,9 @@ export function createAdminApi() {
      * Type-safe: Request body validated against OpenAPI
      */
     createConfiguration: async (configData: any): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/configurations",
-        {
-          body: configData,
-        }
-      );
+      const response = await typedClient.raw.POST('/api/v1/admin/configurations', {
+        body: configData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1110,15 +844,12 @@ export function createAdminApi() {
       configurations: any[],
       changeReason?: string
     ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.PUT(
-        "/api/v1/admin/configurations/bulk",
-        {
-          body: {
-            updates: configurations,
-            ...(changeReason && { change_reason: changeReason }),
-          },
-        }
-      );
+      const response = await typedClient.raw.PUT('/api/v1/admin/configurations/bulk', {
+        body: {
+          updates: configurations,
+          ...(changeReason && { change_reason: changeReason }),
+        },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -1126,15 +857,10 @@ export function createAdminApi() {
      * Validate configuration
      * Type-safe: Request body validated against OpenAPI
      */
-    validateConfiguration: async (
-      configData: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/configurations/validate",
-        {
-          body: configData,
-        }
-      );
+    validateConfiguration: async (configData: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/configurations/validate', {
+        body: configData,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1143,12 +869,9 @@ export function createAdminApi() {
      * Type-safe: Path parameter validated against OpenAPI
      */
     deleteConfiguration: async (key: string): Promise<ApiResponse<string>> => {
-      const response = await typedClient.raw.DELETE(
-        "/api/v1/admin/configurations/{key}",
-        {
-          params: { path: { key } },
-        }
-      );
+      const response = await typedClient.raw.DELETE('/api/v1/admin/configurations/{key}', {
+        params: { path: { key } },
+      });
       return toApiResponse(response) as ApiResponse<string>;
     },
 
@@ -1158,15 +881,10 @@ export function createAdminApi() {
      * Verify bank account (admin duplicate of bank-verification module)
      * Type-safe: Request body validated against OpenAPI
      */
-    verifyBankAccount: async (
-      applicationId: number
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/bank-verification",
-        {
-          body: { application_id: applicationId } as any,
-        }
-      );
+    verifyBankAccount: async (applicationId: number): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/bank-verification', {
+        body: { application_id: applicationId } as any,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1174,15 +892,10 @@ export function createAdminApi() {
      * Verify bank accounts in batch (admin duplicate of bank-verification module)
      * Type-safe: Request body validated against OpenAPI
      */
-    verifyBankAccountsBatch: async (
-      applicationIds: number[]
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/bank-verification/batch",
-        {
-          body: { application_ids: applicationIds } as any,
-        }
-      );
+    verifyBankAccountsBatch: async (applicationIds: number[]): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/bank-verification/batch', {
+        body: { application_ids: applicationIds } as any,
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1192,20 +905,15 @@ export function createAdminApi() {
      * Get professor-student relationships with filters
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getProfessorStudentRelationships: async (
-      params?: any
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/professor-student-relationships",
-        {
-          params: {
-            query: {
-              page: params?.page,
-              size: params?.size,
-            },
+    getProfessorStudentRelationships: async (params?: any): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/professor-student-relationships', {
+        params: {
+          query: {
+            page: params?.page,
+            size: params?.size,
           },
-        }
-      );
+        },
+      });
       return toApiResponse(response) as ApiResponse<any[]>;
     },
 
@@ -1213,15 +921,10 @@ export function createAdminApi() {
      * Create professor-student relationship
      * Type-safe: Request body validated against OpenAPI
      */
-    createProfessorStudentRelationship: async (
-      relationshipData: any
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/admin/professor-student-relationships",
-        {
-          params: { query: { relationship_data: relationshipData } },
-        }
-      );
+    createProfessorStudentRelationship: async (relationshipData: any): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/professor-student-relationships', {
+        params: { query: { relationship_data: relationshipData } },
+      });
       return toApiResponse(response) as ApiResponse<any>;
     },
 
@@ -1232,15 +935,10 @@ export function createAdminApi() {
      * Uses multi-role review API - supports professor, college, and admin roles.
      * Type-safe: Path parameter validated against OpenAPI
      */
-    getReviewableSubTypes: async (
-      applicationId: number
-    ): Promise<ApiResponse<any[]>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/reviews/applications/{application_id}/sub-types" as any,
-        {
-          params: { path: { application_id: applicationId } },
-        }
-      );
+    getReviewableSubTypes: async (applicationId: number): Promise<ApiResponse<any[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/reviews/applications/{application_id}/sub-types' as any, {
+        params: { path: { application_id: applicationId } },
+      });
       return toApiResponse<any[]>(response);
     },
 
@@ -1248,15 +946,10 @@ export function createAdminApi() {
      * Get current admin user's review for an application
      * Type-safe: Path parameter validated against OpenAPI
      */
-    getApplicationReview: async (
-      applicationId: number
-    ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.GET(
-        "/api/v1/reviews/applications/{application_id}/review" as any,
-        {
-          params: { path: { application_id: applicationId } },
-        }
-      );
+    getApplicationReview: async (applicationId: number): Promise<ApiResponse<any>> => {
+      const response = await typedClient.raw.GET('/api/v1/reviews/applications/{application_id}/review' as any, {
+        params: { path: { application_id: applicationId } },
+      });
       return toApiResponse<any>(response);
     },
 
@@ -1269,18 +962,15 @@ export function createAdminApi() {
       reviewData: {
         items: Array<{
           sub_type_code: string;
-          recommendation: "approve" | "reject";
+          recommendation: 'approve' | 'reject';
           comments?: string;
         }>;
       }
     ): Promise<ApiResponse<any>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/reviews/applications/{application_id}/review" as any,
-        {
-          params: { path: { application_id: applicationId } },
-          body: reviewData,
-        }
-      );
+      const response = await typedClient.raw.POST('/api/v1/reviews/applications/{application_id}/review' as any, {
+        params: { path: { application_id: applicationId } },
+        body: reviewData,
+      });
       return toApiResponse<any>(response);
     },
 
@@ -1290,21 +980,12 @@ export function createAdminApi() {
     softDeleteApplication: async (
       id: number,
       reason: string
-    ): Promise<
-      ApiResponse<{ id: number; app_id: string; deleted_at: string }>
-    > => {
-      const response = await typedClient.raw.PATCH(
-        "/api/v1/admin/applications/{id}/soft-delete",
-        {
-          params: { path: { id } },
-          body: { reason },
-        }
-      );
-      return toApiResponse(response) as ApiResponse<{
-        id: number;
-        app_id: string;
-        deleted_at: string;
-      }>;
+    ): Promise<ApiResponse<{ id: number; app_id: string; deleted_at: string }>> => {
+      const response = await typedClient.raw.PATCH('/api/v1/admin/applications/{id}/soft-delete', {
+        params: { path: { id } },
+        body: { reason },
+      });
+      return toApiResponse(response) as ApiResponse<{ id: number; app_id: string; deleted_at: string }>;
     },
   };
 }


### PR DESCRIPTION
## Summary

Commit `1fa9729` ran prettier across `admin.ts` and `admin-scholarship-dashboard.tsx` while adding the soft-delete feature, converting ~660 lines from single to double quotes and re-wrapping long lines. This obscured the two small functional additions (~37 lines) inside a 1000+ line diff, making review hard and creating merge-conflict risk with unrelated work on those files.

This PR restores both files to their pre-`1fa9729` formatting and re-applies only the functional additions on top.

## Changes

- `frontend/lib/api/modules/admin.ts` — kept `softDeleteApplication()` using templated OpenAPI path, reverted all quote-style and line-wrap noise
- `frontend/components/admin-scholarship-dashboard.tsx` — kept the 退件 button (with prompt + `result.success` / `result.message` handling), reverted all quote-style and line-wrap noise

## Stats

- Before: `1fa9729` + `b107dd1` + `e551987` had net +300 lines on these two files
- After: -360 net lines, functional surface identical

## Why target `feat/admin-ui-enhancements`?

Stacked on PR #38 so the cleanup lands with the feature. Can be squash-merged into the PR or cherry-picked to main — either way the final commit is a clean diff.

## Test plan

- [x] `bun run tsc --noEmit` — no new TypeScript errors on modified files
- [ ] Smoke test 退件 button on admin dashboard (same behavior as before)
- [ ] Smoke test `softDeleteApplication` API call returns expected shape