### PR TITLE
feat(frontend): update UI text for student application and professor review

### DIFF
--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -135,12 +135,7 @@ function ProfessorReviewComponentInner({
 
   // Ensure reviewData.items is always initialized when subTypes change
   useEffect(() => {
-    console.log("SubTypes changed, checking reviewData initialization");
-    console.log("SubTypes:", subTypes);
-    console.log("Current reviewData.items:", reviewData.items);
-
     if (subTypes.length > 0 && reviewData.items.length === 0) {
-      console.log("Initializing reviewData.items from subTypes effect");
       const initialItems = subTypes.map(subType => ({
         sub_type_code: subType.value,
         recommendation: 'pending' as const,
@@ -151,8 +146,6 @@ function ProfessorReviewComponentInner({
         ...prev,
         items: initialItems,
       }));
-
-      console.log("ReviewData.items initialized:", initialItems);
     }
   }, [subTypes, reviewData.items.length]);
 
@@ -187,25 +180,19 @@ function ProfessorReviewComponentInner({
     setError(null);
 
     try {
-      console.log("=== OPENING REVIEW MODAL ===");
-      console.log("Application ID:", application.id);
-
       // Get available sub-types
       const subTypesResponse = await apiClient.professor.getSubTypes(
         application.id
       );
-      console.log("Sub-types response:", subTypesResponse);
 
       let availableSubTypes: SubTypeOption[] = [];
       if (subTypesResponse.success && subTypesResponse.data) {
         availableSubTypes = subTypesResponse.data;
         setSubTypes(availableSubTypes);
-        console.log("Set sub-types:", availableSubTypes);
       }
 
       // Always initialize items based on available sub-types
       const initializeItems = (subTypes: SubTypeOption[]) => {
-        console.log("Initializing items for sub-types:", subTypes);
         return subTypes.map(subType => ({
           sub_type_code: subType.value,
           recommendation: 'pending' as const,
@@ -215,13 +202,11 @@ function ProfessorReviewComponentInner({
 
       // Get existing review if any
       const initialItems = initializeItems(availableSubTypes);
-      console.log("Initial items created:", initialItems);
 
       try {
         const reviewResponse = await apiClient.professor.getReview(
           application.id
         );
-        console.log("Existing review response:", reviewResponse);
 
         // Check if this is an actual existing review (id > 0) or a new review (id = 0)
         if (
@@ -230,8 +215,6 @@ function ProfessorReviewComponentInner({
           reviewResponse.data.id &&
           reviewResponse.data.id > 0
         ) {
-          console.log("Found existing review with ID:", reviewResponse.data.id);
-          console.log("Existing review items:", reviewResponse.data.items);
           setExistingReview(reviewResponse.data);
 
           // Merge existing review items with all available sub-types
@@ -249,14 +232,12 @@ function ProfessorReviewComponentInner({
             );
           });
 
-          console.log("Merged items with existing review:", mergedItems);
           setReviewData({
             recommendation: reviewResponse.data.recommendation || "",
             items: mergedItems,
           });
         } else {
           // No existing review (id = 0 or no data), use initial items
-          console.log("No existing review found, using initial items");
           setExistingReview(null);
           setReviewData({
             recommendation: "",
@@ -265,21 +246,12 @@ function ProfessorReviewComponentInner({
         }
       } catch (e) {
         // No existing review, use initial items
-        console.log("Error getting existing review, using initial items:", e);
         setExistingReview(null);
         setReviewData({
           recommendation: "",
           items: initialItems,
         });
       }
-
-      // Final verification
-      setTimeout(() => {
-        console.log("=== FINAL STATE VERIFICATION ===");
-        console.log("SubTypes length:", availableSubTypes.length);
-        console.log("ReviewData items length:", initialItems.length);
-        console.log("ReviewData items:", initialItems);
-      }, 100);
 
       setReviewModalOpen(true);
     } catch (e: any) {
@@ -311,6 +283,13 @@ function ProfessorReviewComponentInner({
           recommendation: item.recommendation as 'approve' | 'reject',
           comments: item.comments
         }));
+
+      // Validate that at least one item has been evaluated
+      if (filteredItems.length === 0) {
+        setError('請至少對一個獎學金申請項目進行評估（選擇同意或不同意）');
+        setLoading(false);
+        return;
+      }
 
       // Validate that all rejected items have comments
       const rejectedWithoutComments = filteredItems.filter(
@@ -362,35 +341,17 @@ function ProfessorReviewComponentInner({
 
   // Update review item
   const updateReviewItem = (subTypeCode: string, field: string, value: any) => {
-    console.log("=== updateReviewItem START ===");
-    console.log("Parameters:", { subTypeCode, field, value });
-    console.log(
-      "Current reviewData before update:",
-      JSON.stringify(reviewData, null, 2)
-    );
-
     setReviewData(prev => {
-      console.log("Previous state in setter:", JSON.stringify(prev, null, 2));
-
-      const itemFound = prev.items.find(
-        item => item.sub_type_code === subTypeCode
-      );
-      console.log("Item found for subTypeCode:", subTypeCode, "=", itemFound);
-
       const newData = {
         ...prev,
         items: prev.items.map(item => {
           if (item.sub_type_code === subTypeCode) {
-            const updatedItem = { ...item, [field]: value };
-            console.log("Updating item from:", item, "to:", updatedItem);
-            return updatedItem;
+            return { ...item, [field]: value };
           }
           return item;
         }),
       };
 
-      console.log("New reviewData:", JSON.stringify(newData, null, 2));
-      console.log("=== updateReviewItem END ===");
       return newData;
     });
   };
@@ -696,12 +657,6 @@ function ProfessorReviewComponentInner({
                                   id={`agree-${subType.value}`}
                                   checked={reviewItem?.recommendation === 'approve'}
                                   onCheckedChange={checked => {
-                                    console.log(
-                                      "Agree checkbox changed:",
-                                      subType.value,
-                                      "to:",
-                                      checked
-                                    );
                                     updateReviewItem(
                                       subType.value,
                                       "recommendation",
@@ -721,12 +676,6 @@ function ProfessorReviewComponentInner({
                                   id={`disagree-${subType.value}`}
                                   checked={reviewItem?.recommendation === 'reject'}
                                   onCheckedChange={checked => {
-                                    console.log(
-                                      "Disagree checkbox changed:",
-                                      subType.value,
-                                      "to:",
-                                      checked
-                                    );
                                     updateReviewItem(
                                       subType.value,
                                       "recommendation",
@@ -761,10 +710,6 @@ function ProfessorReviewComponentInner({
                               placeholder={`請說明您對「${subType.label}」的評估意見...`}
                               value={reviewItem?.comments || ""}
                               onChange={e => {
-                                console.log(
-                                  "Comments updated for:",
-                                  subType.value
-                                );
                                 updateReviewItem(
                                   subType.value,
                                   "comments",
@@ -784,25 +729,6 @@ function ProfessorReviewComponentInner({
                       );
                     })}
 
-                    {/* Debug Info */}
-                    <div className="bg-yellow-50 border border-yellow-200 rounded p-3 text-sm">
-                      <p className="font-medium">Debug Info:</p>
-                      <p>Sub-types count: {subTypes.length}</p>
-                      <p>Review items count: {reviewData.items.length}</p>
-                      <p>
-                        Recommended count:{" "}
-                        {
-                          reviewData.items.filter(item => item.recommendation === 'approve')
-                            .length
-                        }
-                      </p>
-                      <div className="mt-2">
-                        <p>Current review data:</p>
-                        <pre className="text-xs bg-white p-2 rounded mt-1">
-                          {JSON.stringify(reviewData.items, null, 2)}
-                        </pre>
-                      </div>
-                    </div>
                   </CardContent>
                 </Card>
               )}

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -807,26 +807,6 @@ function ProfessorReviewComponentInner({
                 </Card>
               )}
 
-              {/* Overall Recommendation */}
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">整體推薦意見</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <Textarea
-                    placeholder="請提供對此申請的整體推薦意見..."
-                    value={reviewData.recommendation || ""}
-                    onChange={e =>
-                      setReviewData(prev => ({
-                        ...prev,
-                        recommendation: e.target.value,
-                      }))
-                    }
-                    rows={4}
-                  />
-                </CardContent>
-              </Card>
-
               {/* Actions */}
               <div className="flex justify-end gap-2">
                 <Button

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -312,6 +312,17 @@ function ProfessorReviewComponentInner({
           comments: item.comments
         }));
 
+      // Validate that all rejected items have comments
+      const rejectedWithoutComments = filteredItems.filter(
+        item => item.recommendation === 'reject' && (!item.comments || item.comments.trim() === '')
+      );
+
+      if (rejectedWithoutComments.length > 0) {
+        setError('當選擇「不同意」時必須填寫評估意見');
+        setLoading(false);
+        return;
+      }
+
       const submissionData = {
         items: filteredItems
       };
@@ -647,10 +658,10 @@ function ProfessorReviewComponentInner({
                   <CardHeader>
                     <CardTitle className="text-lg flex items-center gap-2">
                       <CheckCircle className="h-5 w-5 text-blue-600" />
-                      子類型推薦評估
+                      是否同意學生申請
                     </CardTitle>
                     <p className="text-sm text-muted-foreground">
-                      請針對每個獎學金子類型進行評估，並提供您的推薦意見
+                      請針對每個獎學金申請進行評估，並提供您的推薦意見
                     </p>
                   </CardHeader>
                   <CardContent className="space-y-4">
@@ -665,96 +676,86 @@ function ProfessorReviewComponentInner({
                           key={subType.value}
                           className="border rounded-lg p-4 space-y-4"
                         >
-                          {/* Simple checkbox approach */}
-                          <div className="flex items-start gap-4">
-                            <div className="flex items-center space-x-2 pt-1">
-                              <Checkbox
-                                id={`recommend-${subType.value}`}
-                                checked={isRecommended}
-                                onCheckedChange={checked => {
-                                  console.log(
-                                    "Checkbox changed:",
-                                    subType.value,
-                                    "to:",
-                                    checked
-                                  );
-                                  updateReviewItem(
-                                    subType.value,
-                                    "recommendation",
-                                    checked ? 'approve' : 'reject'
-                                  );
-                                }}
-                              />
-                              <label
-                                htmlFor={`recommend-${subType.value}`}
-                                className="text-sm font-medium cursor-pointer"
-                              >
-                                推薦
-                              </label>
-                            </div>
-                            <div className="flex-1">
-                              <h3 className="font-semibold text-lg mb-1">
-                                {subType.label}
-                              </h3>
-                              {subType.label_en && (
-                                <p className="text-sm text-muted-foreground mb-2">
-                                  {subType.label_en}
-                                </p>
-                              )}
-                              <Badge
-                                variant={
-                                  isRecommended ? "default" : "secondary"
-                                }
-                              >
-                                {isRecommended ? "✓ 推薦" : "未推薦"}
-                              </Badge>
-                            </div>
+                          {/* Sub-type Title */}
+                          <div>
+                            <h3 className="font-semibold text-lg mb-1">
+                              {subType.label}
+                            </h3>
+                            {subType.label_en && (
+                              <p className="text-sm text-muted-foreground mb-2">
+                                {subType.label_en}
+                              </p>
+                            )}
                           </div>
 
-                          {/* Alternative buttons */}
-                          <div className="flex gap-2">
-                            <Button
-                              type="button"
-                              variant={isRecommended ? "default" : "outline"}
-                              size="sm"
-                              onClick={() => {
-                                console.log(
-                                  "Direct recommend button clicked:",
-                                  subType.value
-                                );
-                                updateReviewItem(
-                                  subType.value,
-                                  "recommendation",
-                                  'approve'
-                                );
-                              }}
-                            >
-                              推薦此項目
-                            </Button>
-                            <Button
-                              type="button"
-                              variant={!isRecommended ? "secondary" : "outline"}
-                              size="sm"
-                              onClick={() => {
-                                console.log(
-                                  "Direct not recommend button clicked:",
-                                  subType.value
-                                );
-                                updateReviewItem(
-                                  subType.value,
-                                  "recommendation",
-                                  'reject'
-                                );
-                              }}
-                            >
-                              不推薦
-                            </Button>
+                          {/* Checkbox options */}
+                          <div className="space-y-3">
+                            <div className="flex items-center gap-4">
+                              <div className="flex items-center space-x-2">
+                                <Checkbox
+                                  id={`agree-${subType.value}`}
+                                  checked={reviewItem?.recommendation === 'approve'}
+                                  onCheckedChange={checked => {
+                                    console.log(
+                                      "Agree checkbox changed:",
+                                      subType.value,
+                                      "to:",
+                                      checked
+                                    );
+                                    updateReviewItem(
+                                      subType.value,
+                                      "recommendation",
+                                      checked ? 'approve' : 'pending'
+                                    );
+                                  }}
+                                />
+                                <label
+                                  htmlFor={`agree-${subType.value}`}
+                                  className="text-sm font-medium cursor-pointer"
+                                >
+                                  同意
+                                </label>
+                              </div>
+                              <div className="flex items-center space-x-2">
+                                <Checkbox
+                                  id={`disagree-${subType.value}`}
+                                  checked={reviewItem?.recommendation === 'reject'}
+                                  onCheckedChange={checked => {
+                                    console.log(
+                                      "Disagree checkbox changed:",
+                                      subType.value,
+                                      "to:",
+                                      checked
+                                    );
+                                    updateReviewItem(
+                                      subType.value,
+                                      "recommendation",
+                                      checked ? 'reject' : 'pending'
+                                    );
+                                  }}
+                                />
+                                <label
+                                  htmlFor={`disagree-${subType.value}`}
+                                  className="text-sm font-medium cursor-pointer"
+                                >
+                                  不同意
+                                </label>
+                              </div>
+                            </div>
+                            {reviewItem?.recommendation && reviewItem.recommendation !== 'pending' && (
+                              <Badge
+                                variant={reviewItem.recommendation === 'approve' ? 'default' : 'destructive'}
+                                className="w-fit"
+                              >
+                                {reviewItem.recommendation === 'approve' ? '✓ 同意' : '✗ 不同意'}
+                              </Badge>
+                            )}
                           </div>
 
                           {/* Comments Section */}
                           <div>
                             <label className="text-sm font-medium mb-2 block">
-                              評估意見 (可選)
+                              評估意見 {reviewItem?.recommendation === 'reject' && <span className="text-red-500">*</span>} (當選擇「不同意」時為必填)
                             </label>
                             <Textarea
                               placeholder={`請說明您對「${subType.label}」的評估意見...`}
@@ -771,7 +772,13 @@ function ProfessorReviewComponentInner({
                                 );
                               }}
                               rows={3}
+                              className={reviewItem?.recommendation === 'reject' && (!reviewItem?.comments || reviewItem.comments.trim() === '') ? 'border-red-500' : ''}
                             />
+                            {reviewItem?.recommendation === 'reject' && (!reviewItem?.comments || reviewItem.comments.trim() === '') && (
+                              <p className="text-sm text-red-600 mt-1">
+                                當選擇「不同意」時必須填寫評估意見
+                              </p>
+                            )}
                           </div>
                         </div>
                       );
@@ -829,7 +836,12 @@ function ProfessorReviewComponentInner({
                 >
                   取消
                 </Button>
-                <Button onClick={submitReview} disabled={loading}>
+                <Button
+                  onClick={submitReview}
+                  disabled={loading || reviewData.items.some(
+                    item => item.recommendation === 'reject' && (!item.comments || item.comments.trim() === '')
+                  )}
+                >
                   {loading
                     ? "提交中..."
                     : existingReview

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -818,9 +818,15 @@ function ProfessorReviewComponentInner({
                 </Button>
                 <Button
                   onClick={submitReview}
-                  disabled={loading || reviewData.items.some(
-                    item => item.recommendation === 'reject' && (!item.comments || item.comments.trim() === '')
-                  )}
+                  disabled={
+                    loading ||
+                    !reviewData.items.some(
+                      item => item.recommendation === "approve" || item.recommendation === "reject"
+                    ) ||
+                    reviewData.items.some(
+                      item => item.recommendation === "reject" && (!item.comments || item.comments.trim() === "")
+                    )
+                  }
                 >
                   {loading
                     ? "提交中..."

--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -158,7 +158,7 @@ export function ScholarshipApplicationStep({
       advisorId: "指導教授本校人事編號",
       advisorIdPlaceholder: "請輸入指導教授本校人事編號",
       bankInfo: "郵局帳號資訊",
-      accountNumber: "郵局局號加帳號共 14 碼",
+      accountNumber: "郵局局號加帳號共 14 碼(限本人)",
       accountNumberPlaceholder: "請輸入 14 碼郵局帳號",
       bankDocument: "存摺封面照片",
       documentUploaded: "已上傳文件",
@@ -883,7 +883,7 @@ export function ScholarshipApplicationStep({
               </CardTitle>
               <CardDescription>
                 {locale === "zh"
-                  ? "請填寫指導教授資訊與郵局帳號資料"
+                  ? "請填寫指導教授資訊與學生本人郵局帳號資料"
                   : "Please provide advisor information and bank account details"}
               </CardDescription>
             </div>

--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -878,7 +878,12 @@ export function ScholarshipApplicationStep({
               <User className="h-6 w-6 text-violet-600" />
             </div>
             <div>
-              <CardDescription>
+              <CardTitle className="text-xl font-bold">
+                {locale === "zh"
+                  ? "指導教授資訊與本人郵局帳號資料"
+                  : "Advisor & Bank Account Information"}
+              </CardTitle>
+              <CardDescription className="mt-1">
                 {locale === "zh"
                   ? "請填寫指導教授資訊與學生本人郵局帳號資料"
                   : "Please provide advisor information and bank account details"}

--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -878,9 +878,6 @@ export function ScholarshipApplicationStep({
               <User className="h-6 w-6 text-violet-600" />
             </div>
             <div>
-              <CardTitle className="text-2xl">
-                {text.personalInfoTitle}
-              </CardTitle>
               <CardDescription>
                 {locale === "zh"
                   ? "請填寫指導教授資訊與學生本人郵局帳號資料"


### PR DESCRIPTION
## Summary
- Updated student application form: clarify bank account ownership with '學生本人' and add '(限本人)' hint
- Renamed professor review section: '子類型推薦評估' → '是否同意學生申請'
- Replaced recommendation buttons with dual checkboxes (同意/不同意)
- Added conditional validation: comments required when selecting '不同意'

## Test Plan
- [ ] Navigate to student scholarship application form and verify updated text labels
- [ ] Verify account number field shows '(限本人)' hint
- [ ] Navigate to professor review interface and verify checkbox UI
- [ ] Test that selecting '同意' allows optional comments
- [ ] Test that selecting '不同意' requires comments with error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)