### PR TITLE
feat: show ineligible scholarship subtypes greyed out + add 國籍/身分 to 確認學籍資料

### DIFF
--- a/backend/app/api/v1/endpoints/scholarships.py
+++ b/backend/app/api/v1/endpoints/scholarships.py
@@ -185,10 +185,10 @@ async def get_all_scholarships(
 
 
 # 學生查看自己可以申請的獎學金
-@router.get("/eligible", response_model=ApiResponse[list[EligibleScholarshipResponse]])
+@router.get("/eligible")
 async def get_scholarship_eligibility(
     db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)
-):
+) -> ApiResponse[list[EligibleScholarshipResponse]]:
     """Get scholarships that the current student is eligible for"""
     from app.services.application_service import get_student_data_from_user
     from app.services.scholarship_service import ScholarshipService

--- a/backend/app/api/v1/endpoints/scholarships.py
+++ b/backend/app/api/v1/endpoints/scholarships.py
@@ -223,6 +223,8 @@ async def get_scholarship_eligibility(
             name=scholarship["name"],
             name_en=scholarship.get("name_en") or scholarship["name"],
             eligible_sub_types=sub_type_list,
+            all_sub_type_list=scholarship.get("all_sub_type_list", []),
+            subtype_eligibility=scholarship.get("subtype_eligibility", {}),
             academic_year=scholarship.get("academic_year"),
             semester=scholarship.get("semester"),
             application_cycle=scholarship.get("application_cycle", "semester"),

--- a/backend/app/api/v1/endpoints/scholarships.py
+++ b/backend/app/api/v1/endpoints/scholarships.py
@@ -185,7 +185,7 @@ async def get_all_scholarships(
 
 
 # 學生查看自己可以申請的獎學金
-@router.get("/eligible")
+@router.get("/eligible", response_model=ApiResponse[list[EligibleScholarshipResponse]])
 async def get_scholarship_eligibility(
     db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)
 ):

--- a/backend/app/schemas/scholarship.py
+++ b/backend/app/schemas/scholarship.py
@@ -244,6 +244,18 @@ class SubTypeOption(BaseModel):
     is_default: bool = False
 
 
+class SubtypeRuleDetail(BaseModel):
+    rule_name: str
+    message: Optional[str] = None
+    tag: Optional[str] = None
+
+
+class SubtypeEligibilityInfo(BaseModel):
+    eligible: bool
+    failed_rules: List[SubtypeRuleDetail] = []
+    warning_rules: List[SubtypeRuleDetail] = []
+
+
 class EligibleScholarshipResponse(BaseModel):
     id: int
     configuration_id: int  # Add configuration ID for application creation
@@ -268,6 +280,8 @@ class EligibleScholarshipResponse(BaseModel):
     warnings: List[RuleMessage]
     errors: List[RuleMessage]
     created_at: datetime
+    all_sub_type_list: List[str] = []
+    subtype_eligibility: Dict[str, SubtypeEligibilityInfo] = {}
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/docs/superpowers/plans/2026-04-27-phd-scholarship-card-ineligible-display.md
+++ b/docs/superpowers/plans/2026-04-27-phd-scholarship-card-ineligible-display.md
@@ -1,0 +1,632 @@
+# PhD 獎學金卡片不合格子類型顯示 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 讓學生在獎學金瀏覽卡片看到所有子類型（不合格的灰掉並列出失敗原因），並在「確認學籍資料」步驟顯示國籍與身分。
+
+**Architecture:** 後端 service 層已備齊資料但 schema 沒 expose；只在 schema 加兩個欄位、endpoint pass through，前端拿到後改寫 chip 渲染。前端另外新增兩個學籍欄位 + 更新 i18n label。
+
+**Tech Stack:** FastAPI / Pydantic v2（後端）, Next.js / React / TypeScript / Tailwind（前端）, Docker compose dev stack。
+
+**Spec:** `docs/superpowers/specs/2026-04-27-phd-scholarship-card-ineligible-display-design.md`
+
+---
+
+## File Structure
+
+| File | Change Type | Responsibility |
+|---|---|---|
+| `backend/app/schemas/scholarship.py` | Modify | 新增兩個 helper schema + 在 `EligibleScholarshipResponse` 加兩個欄位 |
+| `backend/app/api/v1/endpoints/scholarships.py` | Modify | `get_scholarship_eligibility` 在組裝 response 時 pass through 兩個新欄位 |
+| `frontend/lib/api/generated/schema.d.ts` | Auto-regen | OpenAPI 型別同步 |
+| `frontend/lib/i18n.ts` | Modify | 更新 `rule_types` 為完整名稱、新增 `nationality` / `identity` 字串 |
+| `frontend/components/enhanced-student-portal.tsx` | Modify | 卡片 Block 1 改用 `all_sub_type_list` + `subtype_eligibility` 渲染所有子類型 |
+| `frontend/components/student-wizard/steps/StudentDataReviewStep.tsx` | Modify | 新增 `identityMap` + 兩個 grid 欄位 |
+
+無新檔案，全部是既有檔案修改。
+
+---
+
+## Task 1: Backend Pydantic helper schemas
+
+**Files:**
+- Modify: `backend/app/schemas/scholarship.py`（在 `EligibleScholarshipResponse` 之前/之後新增 helper class，並更新 `EligibleScholarshipResponse` 本身）
+
+- [ ] **Step 1: Read current schema**
+
+```bash
+sed -n '230,275p' backend/app/schemas/scholarship.py
+```
+Confirm `EligibleScholarshipResponse` is at line 247 with no `all_sub_type_list` / `subtype_eligibility`. Also confirm `Dict` is already imported.
+
+- [ ] **Step 2: Verify Dict import**
+
+```bash
+grep -n "^from typing" backend/app/schemas/scholarship.py
+```
+If `Dict` not imported, add it to the typing import.
+
+- [ ] **Step 3: Add SubtypeRuleDetail and SubtypeEligibilityInfo classes**
+
+Insert immediately above `class EligibleScholarshipResponse(BaseModel):`:
+
+```python
+class SubtypeRuleDetail(BaseModel):
+    rule_name: str
+    message: Optional[str] = None
+    tag: Optional[str] = None
+
+
+class SubtypeEligibilityInfo(BaseModel):
+    eligible: bool
+    failed_rules: List[SubtypeRuleDetail] = []
+    warning_rules: List[SubtypeRuleDetail] = []
+```
+
+`Optional` for `message` / `tag` because rule data may have null fields.
+
+- [ ] **Step 4: Add two fields to EligibleScholarshipResponse**
+
+In the existing `EligibleScholarshipResponse` class (line 247-272), add immediately before `model_config = ConfigDict(from_attributes=True)`:
+
+```python
+    all_sub_type_list: List[str] = []
+    subtype_eligibility: Dict[str, SubtypeEligibilityInfo] = {}
+```
+
+- [ ] **Step 5: Format + lint**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m black app/schemas/scholarship.py
+docker compose -f docker-compose.dev.yml exec backend python -m flake8 app/schemas/scholarship.py
+```
+
+Expected: black reformats nothing meaningful; flake8 shows 0 errors (or only pre-existing ones unrelated to our edits).
+
+- [ ] **Step 6: Verify backend reloads cleanly**
+
+```bash
+docker compose -f docker-compose.dev.yml logs backend --tail 30
+```
+
+Expected: no Pydantic validation errors. If hot-reload is on, just look for the auto-reload line.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/schemas/scholarship.py
+git commit -m "feat(schema): add subtype eligibility fields to EligibleScholarshipResponse
+
+Adds SubtypeRuleDetail / SubtypeEligibilityInfo helper classes and exposes
+all_sub_type_list and subtype_eligibility on the eligible scholarships
+response so the frontend can render ineligible subtypes greyed out with
+their failed rule tags."
+```
+
+---
+
+## Task 2: Endpoint pass through
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/scholarships.py`（在 `get_scholarship_eligibility` 內 line 219-244 區段新增兩行）
+
+- [ ] **Step 1: Locate the assignment**
+
+```bash
+sed -n '219,245p' backend/app/api/v1/endpoints/scholarships.py
+```
+Confirm the `EligibleScholarshipResponse(...)` call constructs the response item.
+
+- [ ] **Step 2: Add two new keyword args**
+
+In the `EligibleScholarshipResponse(...)` call, immediately after `eligible_sub_types=sub_type_list,` add:
+
+```python
+            all_sub_type_list=scholarship.get("all_sub_type_list", []),
+            subtype_eligibility=scholarship.get("subtype_eligibility", {}),
+```
+
+(Indentation must match the existing 12-space indent inside the call.)
+
+- [ ] **Step 3: Format + lint**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m black app/api/v1/endpoints/scholarships.py
+docker compose -f docker-compose.dev.yml exec backend python -m flake8 app/api/v1/endpoints/scholarships.py
+```
+
+Expected: 0 new lint errors.
+
+- [ ] **Step 4: Live API check via curl**
+
+Get a student token first (login as `csphd0002` or any test student via the dev login flow) and:
+
+```bash
+curl -s -H "Authorization: Bearer <token>" http://localhost:8000/api/v1/scholarships/eligible \
+  | python3 -c "import sys, json; d=json.load(sys.stdin); s=d['data'][0]; print('all_sub_type_list:', s.get('all_sub_type_list')); print('subtype_eligibility keys:', list((s.get('subtype_eligibility') or {}).keys()))"
+```
+
+Expected output (for csphd0002):
+```
+all_sub_type_list: ['nstc', 'moe_1w']
+subtype_eligibility keys: ['nstc', 'moe_1w']
+```
+
+If empty / null, recheck Task 1 + Task 2 before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/scholarships.py
+git commit -m "feat(api): pass all_sub_type_list and subtype_eligibility to client
+
+Wire the two service-layer fields into the EligibleScholarshipResponse
+construction so the eligible scholarships endpoint exposes them. Service
+logic untouched."
+```
+
+---
+
+## Task 3: Re-generate frontend OpenAPI types
+
+**Files:**
+- Auto-regen: `frontend/lib/api/generated/schema.d.ts`
+
+- [ ] **Step 1: Verify backend up on :8000**
+
+```bash
+curl -fsS http://localhost:8000/openapi.json > /dev/null && echo "OK"
+```
+
+- [ ] **Step 2: Run codegen**
+
+```bash
+cd frontend && npm run api:generate
+cd ..
+```
+
+- [ ] **Step 3: Confirm new types appear**
+
+```bash
+grep -n "all_sub_type_list\|subtype_eligibility\|SubtypeEligibilityInfo" frontend/lib/api/generated/schema.d.ts | head -10
+```
+
+Expected: at least 4-6 matches showing the new fields and helper types in the generated schema.
+
+- [ ] **Step 4: Commit generated types**
+
+```bash
+git add frontend/lib/api/generated/schema.d.ts
+git commit -m "chore(types): regenerate OpenAPI schema for subtype eligibility fields"
+```
+
+---
+
+## Task 4: Update i18n labels
+
+**Files:**
+- Modify: `frontend/lib/i18n.ts` (zh block ~line 251 and en block ~line 591; also `text` objects for student wizard if shared)
+
+- [ ] **Step 1: Verify current `rule_types` location**
+
+```bash
+grep -n "rule_types:" frontend/lib/i18n.ts
+```
+
+Expected output: two lines (zh ~251, en ~591).
+
+- [ ] **Step 2: Replace zh `rule_types` map (line ~251-255)**
+
+Use Edit tool. Old:
+```ts
+    rule_types: {
+      nstc: "國科會",
+      moe_1w: "教育部(1萬)",
+      moe_2w: "教育部(2萬)",
+    },
+```
+New:
+```ts
+    rule_types: {
+      nstc: "國科會博士生獎學金",
+      moe_1w: "教育部博士生獎學金 (指導教授配合款一萬)",
+      moe_2w: "教育部博士生獎學金 (指導教授配合款兩萬)",
+    },
+```
+
+- [ ] **Step 3: Replace en `rule_types` map (line ~591-595)**
+
+Use Edit tool. Old (verified at line 591-595):
+```ts
+    rule_types: {
+      nstc: "NSTC",
+      moe_1w: "MOE (10K)",
+      moe_2w: "MOE (20K)",
+    },
+```
+
+New:
+```ts
+    rule_types: {
+      nstc: "NSTC PhD Scholarship",
+      moe_1w: "MOE PhD Scholarship (Advisor Matching Fund - 10K)",
+      moe_2w: "MOE PhD Scholarship (Advisor Matching Fund - 20K)",
+    },
+```
+
+- [ ] **Step 4: Verify no other references to short names**
+
+```bash
+grep -rn "國科會\b\|教育部(1萬)\|教育部(2萬)\|MOE (10K)\|MOE (20K)" frontend/components frontend/app 2>/dev/null
+```
+
+Expected: 0 hits (or only inside admin-configuration-management.tsx as plain placeholder strings inside JSX text — those are display-only literals, leave them).
+
+If grep shows any actual `getTranslation` lookups depending on the old short names, surface them now and decide how to handle.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/i18n.ts
+git commit -m "feat(i18n): expand rule_types labels to full subtype names
+
+Updates nstc / moe_1w / moe_2w display strings (zh + en) so the
+scholarship card chips render full names like '國科會博士生獎學金'
+instead of the previous short form."
+```
+
+---
+
+## Task 5: Card Block 1 — render all subtypes with eligibility state
+
+**Files:**
+- Modify: `frontend/components/enhanced-student-portal.tsx`（line ~1328-1358，「Eligible Programs Section」區塊）
+
+- [ ] **Step 1: Read current block**
+
+```bash
+sed -n '1325,1360p' frontend/components/enhanced-student-portal.tsx
+```
+
+Note the JSX structure: `{isEligible && scholarship.eligible_sub_types && ... map(...)}`.
+
+- [ ] **Step 2: Replace the inner `.map(...)` with all-subtypes rendering**
+
+Use Edit tool. Old (the entire `<div className="px-3 py-2 flex flex-wrap gap-1.5">` block):
+
+```tsx
+                        <div className="px-3 py-2 flex flex-wrap gap-1.5">
+                          {scholarship.eligible_sub_types.map(
+                            (subType, index) => (
+                              <Badge
+                                key={subType.value || index}
+                                variant="outline"
+                                className="bg-white text-indigo-600 border-indigo-100 shadow-sm"
+                              >
+                                {locale === "zh"
+                                  ? subType.label
+                                  : subType.label_en}
+                              </Badge>
+                            )
+                          )}
+                        </div>
+```
+
+New:
+
+```tsx
+                        <div className="px-3 py-2 flex flex-wrap gap-1.5">
+                          {(scholarship.all_sub_type_list ?? []).map(
+                            subTypeKey => {
+                              const eligibility =
+                                scholarship.subtype_eligibility?.[subTypeKey];
+                              const isSubEligible =
+                                eligibility?.eligible !== false;
+                              const label =
+                                getTranslation(
+                                  locale,
+                                  `rule_types.${subTypeKey}`
+                                ) || subTypeKey;
+
+                              if (isSubEligible) {
+                                return (
+                                  <Badge
+                                    key={subTypeKey}
+                                    variant="outline"
+                                    className="bg-white text-indigo-600 border-indigo-100 shadow-sm"
+                                  >
+                                    ✓ {label}
+                                  </Badge>
+                                );
+                              }
+
+                              const failedTagLabels = (
+                                eligibility?.failed_rules ?? []
+                              )
+                                .map(r =>
+                                  r.tag
+                                    ? getTranslation(
+                                        locale,
+                                        `eligibility_tags.${r.tag}`
+                                      )
+                                    : null
+                                )
+                                .filter((s): s is string => Boolean(s));
+                              const reasonText =
+                                failedTagLabels.length > 0
+                                  ? `${locale === "zh" ? "不符" : "Missing"}：${failedTagLabels.join(
+                                      "、"
+                                    )}`
+                                  : locale === "zh"
+                                    ? "不符資格"
+                                    : "Not eligible";
+
+                              return (
+                                <Badge
+                                  key={subTypeKey}
+                                  variant="outline"
+                                  className="bg-gray-100 text-gray-400 border-gray-200 shadow-sm"
+                                >
+                                  ✗ {label} — {reasonText}
+                                </Badge>
+                              );
+                            }
+                          )}
+                        </div>
+```
+
+- [ ] **Step 3: Update outer condition to use `all_sub_type_list` instead of `eligible_sub_types`**
+
+Old (around line 1328-1332):
+```tsx
+                  {isEligible &&
+                    scholarship.eligible_sub_types &&
+                    scholarship.eligible_sub_types.length > 0 &&
+                    scholarship.eligible_sub_types[0]?.value !== "general" &&
+                    scholarship.eligible_sub_types[0]?.value !== null && (
+```
+
+New:
+```tsx
+                  {isEligible &&
+                    scholarship.all_sub_type_list &&
+                    scholarship.all_sub_type_list.length > 0 &&
+                    scholarship.all_sub_type_list[0] !== "general" &&
+                    scholarship.all_sub_type_list[0] !== null && (
+```
+
+This preserves the existing skip-when-only-general logic but using the new field.
+
+- [ ] **Step 4: Confirm `getTranslation` import already exists in this file**
+
+```bash
+grep -n "getTranslation" frontend/components/enhanced-student-portal.tsx | head -3
+```
+
+Expected: at least one match (it's already used elsewhere on the page).
+
+- [ ] **Step 5: Lint check**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "enhanced-student-portal" | head -20
+cd ..
+```
+
+Expected: 0 errors specific to this file.
+
+- [ ] **Step 6: Visual smoke test**
+
+Open `http://localhost:3000`, log in as `csphd0002`. On the scholarship list, find 博士生獎學金 card. Confirm:
+- Green chip `✓ 國科會博士生獎學金`
+- Grey chip `✗ 教育部博士生獎學金 (指導教授配合款一萬) — 不符：三年級以下`
+
+Switch to en: confirm chips render in English. (English failed-tag text might be empty if `eligibility_tags.三年級以下` lacks an en version — that's an existing tag i18n issue, not in scope.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/components/enhanced-student-portal.tsx
+git commit -m "feat(student): render all subtypes on scholarship card with eligibility state
+
+Switches the eligible-programs chip list to iterate all_sub_type_list and
+subtype_eligibility, rendering ineligible subtypes greyed out with their
+failed rule tags inline. Eligible chips keep the current blue style with
+a leading ✓; ineligible chips are grey with ✗ and a 不符: tag、tag suffix."
+```
+
+---
+
+## Task 6: 確認學籍資料 — 新增國籍與身分欄位
+
+**Files:**
+- Modify: `frontend/components/student-wizard/steps/StudentDataReviewStep.tsx`
+
+- [ ] **Step 1: Read text dictionary + maps**
+
+```bash
+sed -n '40,130p' frontend/components/student-wizard/steps/StudentDataReviewStep.tsx
+```
+
+Note: `t = { zh: {...}, en: {...} }`, then `degreeMap`, `studyingStatusMap`. We will mirror the pattern.
+
+- [ ] **Step 2: Add `nationality` + `identity` keys to both locales**
+
+Use Edit tool. In the zh block (around the existing `text` definitions for degree / enrollmentStatus / etc.), add inside the zh object:
+
+```ts
+      nationality: "國籍",
+      identity: "身分",
+```
+
+And inside the en object:
+
+```ts
+      nationality: "Nationality",
+      identity: "Identity",
+```
+
+(Use Read first to find exact placement next to `semesterCount` or similar.)
+
+- [ ] **Step 3: Add `identityMap`**
+
+After the existing `studyingStatusMap` declaration (around line 129), insert:
+
+```ts
+  const identityMap: Record<string, string> = {
+    "1": "一般生",
+    "2": "原住民",
+    "3": "僑生(目前有中華民國國籍生)",
+    "4": "外籍生(目前有中華民國國籍生)",
+    "5": "外交子女",
+    "6": "身心障礙生",
+    "7": "運動成績優良甄試學生",
+    "8": "離島",
+    "9": "退伍軍人",
+    "10": "一般公費生",
+    "11": "原住民公費生",
+    "12": "離島公費生",
+    "13": "退伍軍人公費生",
+    "14": "願景計畫生",
+    "17": "陸生",
+    "30": "其他",
+  };
+```
+
+Source: `backend/alembic/versions/6d5b1940bf8a_seed_reference_tables_degrees_.py:101-118`.
+
+- [ ] **Step 4: Add two grid items in the academic info card**
+
+Use Edit tool. Find the closing `</div>` of the existing grid (after the `Semester Count` block, around line 350). Immediately before that closing `</div>` insert:
+
+```tsx
+                      {/* Nationality */}
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium text-gray-600">
+                          {text.nationality}
+                        </label>
+                        <div className="text-base text-gray-700">
+                          {studentInfo.std_nation || "-"}
+                        </div>
+                      </div>
+
+                      {/* Identity */}
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium text-gray-600">
+                          {text.identity}
+                        </label>
+                        <div className="text-base text-gray-700">
+                          {studentInfo.std_identity
+                            ? identityMap[
+                                String(studentInfo.std_identity)
+                              ] || studentInfo.std_identity
+                            : "-"}
+                        </div>
+                      </div>
+```
+
+- [ ] **Step 5: Lint check**
+
+```bash
+cd frontend && npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "StudentDataReviewStep" | head -20
+cd ..
+```
+
+Expected: 0 errors specific to this file. If `studentInfo` typing complains about missing `std_nation` / `std_identity`, those fields likely exist on the API type already — re-run codegen if not.
+
+- [ ] **Step 6: Visual smoke test**
+
+Open the application wizard for any logged-in student, navigate to 確認學籍資料 step. Confirm:
+- 6 fields shown: 學位 / 在學狀態 / 入學年度學期 / 學期數 / **國籍** / **身分**
+- 國籍 shows `std_nation` raw string (e.g., "中華民國")
+- 身分 shows the mapped name (e.g., "一般生" or "僑生(目前有中華民國國籍生)") — never the raw integer code
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/components/student-wizard/steps/StudentDataReviewStep.tsx
+git commit -m "feat(student): show std_nation and std_identity in 確認學籍資料
+
+Adds 國籍 (std_nation, raw string) and 身分 (std_identity, mapped via
+identityMap) rows to the academic info card so students can verify the
+identity classification that drives subtype eligibility."
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Frontend build**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -30
+cd ..
+```
+
+Expected: build succeeds with no new errors.
+
+- [ ] **Step 2: Backend test suite (regression check)**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest tests/ -x --tb=short 2>&1 | tail -30
+```
+
+Expected: existing tests pass. New schema fields default-empty, should not break anything.
+
+- [ ] **Step 3: End-to-end manual matrix**
+
+Run through the test matrix from the spec (Testing Plan → Manual Testing). Tick off each row:
+
+| # | Student | Expected on card |
+|---|---|---|
+| 1 | 一般本國博士生 | `[✓ 國科會博士生獎學金] [✓ 教育部博士生獎學金 (指導教授配合款一萬)]` |
+| 2 | 414708008 (僑/外籍) | `[✓ 國科會博士生獎學金] [✗ 教育部博士生獎學金 (指導教授配合款一萬) — 不符：中華民國國籍]` |
+| 3 | csphd0002 (博四) | `[✓ 國科會博士生獎學金] [✗ 教育部博士生獎學金 (指導教授配合款一萬) — 不符：三年級以下]` |
+| 4 | 假設博四+外籍 | `[✓ 國科會博士生獎學金] [✗ 教育部博士生獎學金 (...) — 不符：中華民國國籍、三年級以下]` |
+| 5 | 任意學生在 確認學籍資料 | 6 個欄位含國籍 + 身分 |
+
+For row 4 if no test fixture matches, document and skip — it's a derived assertion, not blocking.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+git push -u origin investigate/csphd0002-moe-visibility
+gh pr create --title "feat: show ineligible scholarship subtypes greyed out + add 國籍/身分 to 確認學籍資料" \
+  --body "$(cat <<'EOF'
+## Summary
+- Backend: expose `all_sub_type_list` and `subtype_eligibility` on `/api/v1/scholarships/eligible` (schema + endpoint plumbing only; service logic untouched).
+- Frontend: scholarship card 「可申請項目」 now lists every subtype — eligible chips stay blue with ✓, ineligible chips are grey with ✗ and an inline `不符：tag、tag` reason.
+- Frontend: 確認學籍資料 step now also shows 國籍 (`std_nation`) and 身分 (`std_identity` mapped to its reference-table name).
+- i18n: `rule_types` updated from short names to full subtype titles for both zh and en.
+
+## Background
+Triggered by two cases — csphd0002 (PhD year 4, fails the 一至三年級 rule) and 414708008 (僑/外籍生, fails the 中華民國國籍 rule). Both situations match the existing scholarship policy but the UI silently filtered the ineligible subtype out, leaving students confused. The fix surfaces the result of policy without changing the policy itself.
+
+Spec: `docs/superpowers/specs/2026-04-27-phd-scholarship-card-ineligible-display-design.md`
+
+## Test plan
+- [ ] Login as a regular PhD student → both subtypes show ✓
+- [ ] Login as csphd0002 → MOE shows ✗ with `不符：三年級以下`
+- [ ] Login as 414708008 → MOE shows ✗ with `不符：中華民國國籍`
+- [ ] 確認學籍資料 step shows 國籍 and 身分 with mapped name
+- [ ] `npm run build` and backend tests pass
+EOF
+)"
+```
+
+---
+
+## Risks / Things to Watch
+
+1. **`rule_types` was orphaned**: Pre-implementation grep showed `rule_types` is currently defined in `i18n.ts` but **never referenced**. So changing the labels is safe — Task 5 introduces the first real consumer (via `getTranslation(locale, "rule_types.${key}")`). Risk #1 from spec is essentially eliminated.
+2. **`failed_rules[].tag` lacks i18n** for some tags (e.g., `三年級以下` not yet in `eligibility_tags`): chip falls back to `不符資格` with no detail. To verify after Task 5 — if any failure tag shows up empty, add it to `eligibility_tags` in the same commit.
+3. **`std_nation` / `std_identity` types**: confirmed appear in the OpenAPI student snapshot schema. If `studentInfo` type lacks them after codegen, re-run `npm run api:generate`.
+
+---
+
+## Self-Review Notes
+
+- ✅ Spec coverage: every Backend / Frontend Change in spec maps to a task (Task 1-2 = 0a/0b, Task 3 = OpenAPI re-gen, Task 4 = Change 2, Task 5 = Change 1, Task 6 = Change 3).
+- ✅ Placeholder scan: no TBDs in actionable steps. The English label text is concrete in Task 4 step 3 (no longer "TBD").
+- ✅ Type consistency: `SubtypeRuleDetail` / `SubtypeEligibilityInfo` introduced in Task 1 are referenced by name in Task 3 (codegen verification) and used implicitly via codegen in Task 5/6.

--- a/docs/superpowers/specs/2026-04-27-phd-scholarship-card-ineligible-display-design.md
+++ b/docs/superpowers/specs/2026-04-27-phd-scholarship-card-ineligible-display-design.md
@@ -1,0 +1,323 @@
+# PhD 獎學金卡片：不合格子類型顯示與學籍資料補充 Design Spec
+
+**Date**: 2026-04-27
+**Scope**: Frontend (主要) + 後端 schema 擴充（兩個欄位） — `enhanced-student-portal.tsx`, `StudentDataReviewStep.tsx`, `i18n.ts`, `schemas/scholarship.py`, `endpoints/scholarships.py`
+
+---
+
+## Background
+
+兩個調查案例觸發此次設計：
+
+1. **csphd0002**（博士四年級，`trm_termcount=7`）反映「看不到教育部獎學金」。調查發現 MOE 規則 `trm_termcount in (1,2,3,4,5,6)` 失敗，`moe_1w` 子類型在 `_filter_eligible_subtypes` 被過濾出回傳資料。
+2. **414708008**（已歸化僑生/外籍生，`std_identity in (3,4)` 但 `std_nation ≠ "中華民國"`）同樣看不到教育部獎學金，根因是 MOE 規則 `std_nation == "中華民國"` 失敗。
+
+這兩個案例的後端規則行為**符合既定政策**，不修改：
+- MOE 限本國籍 + 限一至三年級 → 政策本意
+- 頂層 `std_identity != 17` → 排除陸生
+
+但 UX 上學生只看到部分子類型卻不知道為何缺漏，造成困惑。本 spec 處理 UX 缺口。
+
+---
+
+## Goals
+
+1. 學生在獎學金瀏覽卡片可清楚看到該獎學金的**所有子類型**，不合格的灰掉並列出失敗原因。
+2. 學生在「確認學籍資料」步驟可看到自己的 `std_nation`（國籍）與 `std_identity`（身分），方便理解為何某些子類型不合格、也方便日後跟承辦人溝通。
+
+---
+
+## Non-Goals
+
+- ❌ 不修改任何 `scholarship_rules`（rule 4 / 5 / 7 / 18 全部不動）
+- ❌ 不修改 i18n `eligibility_tags` 中「中華民國國籍」display
+- ❌ 不修改 eligibility/篩選**業務邏輯**（service 層完全不動）
+- ❌ 不修改申請流程的子類型選擇器（仍只能勾選 eligible 子類型）
+- ❌ 不修改卡片的「申請資格」(Block 2) 區塊
+
+---
+
+## Backend Data Plumbing Gap
+
+`ScholarshipService.get_eligible_scholarships()`（`backend/app/services/scholarship_service.py:182-188`）已經組好：
+- `all_sub_type_list`：來自 `scholarship_type.sub_type_list`（資料庫欄位，目前 phd = `["nstc", "moe_1w"]`）
+- `subtype_eligibility`：每個子類型的 `{ eligible, failed_rules, warning_rules }`
+
+但 **`EligibleScholarshipResponse` schema（`backend/app/schemas/scholarship.py:247-272`）沒有對應欄位**，endpoint（`backend/app/api/v1/endpoints/scholarships.py:219-244`）也沒有 pass through，所以這些資料**從未送到前端**。
+
+本 spec 要在 schema + endpoint 補上這兩個欄位，service 層完全不動。
+
+---
+
+## Backend Changes
+
+### Change 0a — Schema 新增兩個欄位
+
+**File**: `backend/app/schemas/scholarship.py`
+**Class**: `EligibleScholarshipResponse`（line 247）
+
+新增：
+```python
+class SubtypeRuleDetail(BaseModel):
+    rule_name: str
+    message: str
+    tag: str
+
+class SubtypeEligibilityInfo(BaseModel):
+    eligible: bool
+    failed_rules: List[SubtypeRuleDetail] = []
+    warning_rules: List[SubtypeRuleDetail] = []
+
+class EligibleScholarshipResponse(BaseModel):
+    # ... 既有欄位不動 ...
+    all_sub_type_list: List[str] = []
+    subtype_eligibility: Dict[str, SubtypeEligibilityInfo] = {}
+```
+
+### Change 0b — Endpoint pass through 兩個欄位
+
+**File**: `backend/app/api/v1/endpoints/scholarships.py`
+**Function**: `get_scholarship_eligibility`（line 219-244 處組裝 `EligibleScholarshipResponse`）
+
+新增兩行：
+```python
+response_item = EligibleScholarshipResponse(
+    # ... 既有欄位 ...
+    all_sub_type_list=scholarship.get("all_sub_type_list", []),
+    subtype_eligibility=scholarship.get("subtype_eligibility", {}),
+    # ...
+)
+```
+
+Service 層的 `get_eligible_scholarships()` 已具備這些資料（line 184-186），不需要動。
+
+### OpenAPI 型別 re-generate
+
+```bash
+cd frontend && npm run api:generate
+git add lib/api/generated/schema.d.ts
+```
+（後端必須跑在 `localhost:8000`）
+
+---
+
+## Frontend Changes
+
+### Change 1 — Card Block 1「可申請項目」改成顯示所有子類型
+
+**File**: `frontend/components/enhanced-student-portal.tsx`
+**Region**: 約 line 1328-1358，渲染 `eligible_programs` badge 列表的區塊。
+
+**改動前**：
+```tsx
+{scholarship.eligible_sub_types.map(subType => (
+  <Badge variant="outline" className="bg-white text-indigo-600 border-indigo-100">
+    {locale === "zh" ? subType.label : subType.label_en}
+  </Badge>
+))}
+```
+顯示僅 eligible 子類型，藍色 chip。
+
+**改動後**（pseudocode）：
+```tsx
+{scholarship.all_sub_type_list?.map(subTypeKey => {
+  const eligibilityInfo = scholarship.subtype_eligibility?.[subTypeKey];
+  const isEligible = eligibilityInfo?.eligible !== false;
+  const label = getTranslation(locale, `rule_types.${subTypeKey}`) || subTypeKey;
+
+  if (isEligible) {
+    return (
+      <Badge variant="outline" className="bg-white text-indigo-600 border-indigo-100">
+        ✓ {label}
+      </Badge>
+    );
+  }
+
+  const failedTagLabels = (eligibilityInfo?.failed_rules ?? [])
+    .map(r => getTranslation(locale, `eligibility_tags.${r.tag}`))
+    .filter(Boolean);
+  const reasonText = failedTagLabels.length > 0
+    ? `不符：${failedTagLabels.join("、")}`
+    : "不符資格";
+
+  return (
+    <Badge variant="outline" className="bg-gray-100 text-gray-400 border-gray-200">
+      ✗ {label} — {reasonText}
+    </Badge>
+  );
+})}
+```
+
+**範例輸出（414708008，僑/外籍生）**：
+```
+[ ✓ 國科會博士生獎學金 ]   [ ✗ 教育部博士生獎學金 (指導教授配合款一萬) — 不符：中華民國國籍 ]
+```
+
+**範例輸出（csphd0002，博四）**：
+```
+[ ✓ 國科會博士生獎學金 ]   [ ✗ 教育部博士生獎學金 (指導教授配合款一萬) — 不符：三年級以下 ]
+```
+
+**Edge cases**:
+- `all_sub_type_list` 為空或只含 `general` / `null`：照舊不顯示此區（沿用原 line 1331-1332 的判斷邏輯）。
+- `subtype_eligibility[key]` 不存在：視為 eligible，僅顯示綠色 chip（防禦性 fallback）。
+- `failed_rules` 全部 tag 找不到 i18n 翻譯：fallback 顯示「不符資格」（無細節）。
+
+### Change 2 — i18n `rule_types` 改成完整 label
+
+**File**: `frontend/lib/i18n.ts`
+**Region**: line 251-255 (zh) 與 line 591-595 (en)
+
+**改動前（zh）**：
+```ts
+rule_types: {
+  nstc: "國科會",
+  moe_1w: "教育部(1萬)",
+  moe_2w: "教育部(2萬)",
+}
+```
+
+**改動後（zh）**：
+```ts
+rule_types: {
+  nstc: "國科會博士生獎學金",
+  moe_1w: "教育部博士生獎學金 (指導教授配合款一萬)",
+  moe_2w: "教育部博士生獎學金 (指導教授配合款兩萬)",
+}
+```
+
+**改動後（en）**（待最終確認文字）：
+```ts
+rule_types: {
+  nstc: "NSTC PhD Scholarship",
+  moe_1w: "MOE PhD Scholarship (Advisor Matching Fund - 10K)",
+  moe_2w: "MOE PhD Scholarship (Advisor Matching Fund - 20K)",
+}
+```
+
+**注意**：原本 `rule_types` 是否在其他地方被引用？需要在實作前 grep 確認沒有其他地方依賴短名稱（例如管理後台）。
+
+### Change 3 — 確認學籍資料新增「國籍」與「身分」
+
+**File**: `frontend/components/student-wizard/steps/StudentDataReviewStep.tsx`
+
+**Region**: 約 line 285-352 的 academic info card。目前 grid 渲染 4 個欄位（學位 / 在學狀態 / 入學年度學期 / 學期數）。
+
+**改動**：
+
+a. 在現有的 `degreeMap` / `studyingStatusMap` 旁新增 `identityMap`：
+
+```ts
+const identityMap: Record<string, string> = {
+  "1":  "一般生",
+  "2":  "原住民",
+  "3":  "僑生(目前有中華民國國籍生)",
+  "4":  "外籍生(目前有中華民國國籍生)",
+  "5":  "外交子女",
+  "6":  "身心障礙生",
+  "7":  "運動成績優良甄試學生",
+  "8":  "離島",
+  "9":  "退伍軍人",
+  "10": "一般公費生",
+  "11": "原住民公費生",
+  "12": "離島公費生",
+  "13": "退伍軍人公費生",
+  "14": "願景計畫生",
+  "17": "陸生",
+  "30": "其他",
+};
+```
+資料來源：`backend/alembic/versions/6d5b1940bf8a_seed_reference_tables_degrees_.py:101-118`。
+
+b. `text` 物件新增兩個 label：
+
+```ts
+zh: {
+  ...
+  nationality: "國籍",
+  identity:    "身分",
+},
+en: {
+  ...
+  nationality: "Nationality",
+  identity:    "Identity",
+},
+```
+
+c. 在 academic info card 的 grid 新增兩個欄位（沿用既有 grid item 的 markup 樣式）：
+
+```tsx
+{/* Nationality */}
+<div className="space-y-2">
+  <label className="text-sm font-medium text-gray-600">{text.nationality}</label>
+  <div className="text-base text-gray-700">
+    {studentInfo.std_nation || "-"}
+  </div>
+</div>
+
+{/* Identity */}
+<div className="space-y-2">
+  <label className="text-sm font-medium text-gray-600">{text.identity}</label>
+  <div className="text-base text-gray-700">
+    {studentInfo.std_identity
+      ? identityMap[String(studentInfo.std_identity)] || studentInfo.std_identity
+      : "-"}
+  </div>
+</div>
+```
+
+身分顯示**只取名稱不顯示代碼**（例如顯示「僑生(目前有中華民國國籍生)」，不顯示「3：僑生(目前有中華民國國籍生)」）。
+
+---
+
+## Testing Plan
+
+### Manual Testing
+
+| Case | Pre-condition | Expected |
+|---|---|---|
+| 1. 一般本國生（std_identity=1, std_nation=中華民國, trm_termcount≤6, 博士） | 符合 nstc + moe_1w | 兩個藍色 chip，無灰色 chip |
+| 2. 414708008（僑/外籍生 std_identity=3 or 4, std_nation≠中華民國, 博士） | nstc 合格，moe_1w 不合格 | nstc 藍色，moe_1w 灰色「— 不符：中華民國國籍」|
+| 3. csphd0002（本國博四 trm_termcount=7） | nstc 合格，moe_1w 不合格 | nstc 藍色，moe_1w 灰色「— 不符：三年級以下」|
+| 4. 雙重失敗（假設外籍博四） | nstc 合格，moe_1w 兩條 fail | moe_1w 灰色「— 不符：中華民國國籍、三年級以下」|
+| 5. 確認學籍資料 | 任一登入學生 | 學籍資訊 card 顯示 6 個欄位含國籍與身分名稱 |
+
+### Build / Type Checks
+
+```bash
+# 1. Re-generate OpenAPI types after backend schema change
+cd frontend && npm run api:generate
+
+# 2. Frontend lint + build
+npm run lint && npm run build
+
+# 3. Backend lint
+cd ../backend && python -m black app/schemas/scholarship.py app/api/v1/endpoints/scholarships.py && python -m flake8 app/schemas/scholarship.py app/api/v1/endpoints/scholarships.py
+```
+
+不需要新單元測試 — 純 UI / data presentation 改動，沒有新邏輯分支需測。但需確認既有測試不會因為新增 schema 欄位而失敗。
+
+### Regression
+
+**重點檢查**：
+- 既有「申請資格」(Block 2) 區塊行為不變
+- 申請流程的子類型選擇器仍只能選 eligible 子類型
+- 沒有子類型的獎學金（general scholarship）卡片不顯示「可申請項目」區塊（行為不變）
+
+---
+
+## Risks / Open Items
+
+1. **i18n key 同步**：`rule_types` map 從短名稱改長，需 grep 全 codebase 確認沒有其他地方期望短名稱（admin 介面、ranking 頁面、distribution 介面）。
+2. **`all_sub_type_list` 來源**：service 層 `scholarship_service.py:185` 從 `scholarship_type.sub_type_list` 取（資料表欄位）。目前 phd 的 `sub_type_list = ["nstc", "moe_1w"]`，學生不會看到 `moe_2w` 的 chip。若未來 admin 啟用 `moe_2w` 需先把它加進 `scholarship_types.sub_type_list`，這對本 spec 沒有影響。
+3. **`failed_rules[].tag` 可能缺翻譯**：若新增規則時忘了同步 i18n，chip 會顯示「不符：（空）」。實作中應有 fallback「不符資格」。
+4. **OpenAPI types 同步**：若 `frontend/lib/api/generated/schema.d.ts` 缺 `subtype_eligibility` 或 `all_sub_type_list`，需 re-run `npm run api:generate`（CI 也會驗證）。
+
+---
+
+## Out of Scope (Future Considerations)
+
+- 申請流程的子類型選擇器同步顯示灰掉的不合格子類型（更一致的 UX，但複雜度較高）
+- Block 2「申請資格」也顯示不合格子類型的完整 tag 群組（資訊更完整但版面可能過長）
+- Rule 18 tag「中華民國國籍」改寫成「僑生/外籍生」或類似（需要先處理 rule 5/7 共用 tag 問題）
+- MOE 國籍規則改用 std_identity 判斷而非 std_nation 字串（需要釐清 SIS 資料一致性政策）

--- a/docs/superpowers/specs/2026-04-27-phd-scholarship-card-ineligible-display-design.md
+++ b/docs/superpowers/specs/2026-04-27-phd-scholarship-card-ineligible-display-design.md
@@ -33,7 +33,8 @@
 - ❌ 不修改 i18n `eligibility_tags` 中「中華民國國籍」display
 - ❌ 不修改 eligibility/篩選**業務邏輯**（service 層完全不動）
 - ❌ 不修改申請流程的子類型選擇器（仍只能勾選 eligible 子類型）
-- ❌ 不修改卡片的「申請資格」(Block 2) 區塊
+
+> **Scope expanded during implementation:** the original spec scoped only Block 1, but the user reviewed the partial result and asked for Block 2「申請資格」 to also iterate all subtypes (greyed title + 「（不符資格）」 hint for ineligible, with the same passed/error tag groupings). The implementation reflects this expanded scope.
 
 ---
 

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -1498,12 +1498,23 @@ export function EnhancedStudentPortal({
                               );
                             }
 
-                            // Sub-type specific sections with common rules appended
-                            return scholarship.eligible_sub_types?.map(
-                              subTypeInfo => {
-                                const subType = subTypeInfo.value;
+                            // Sub-type specific sections with common rules appended.
+                            // Iterate all_sub_type_list so ineligible subtypes are also
+                            // shown; their failed-rule tags will appear in red.
+                            return (scholarship.all_sub_type_list ?? []).map(
+                              subType => {
                                 if (!subType || subType === "general")
                                   return null;
+
+                                const isSubEligible =
+                                  scholarship.subtype_eligibility?.[subType]
+                                    ?.eligible !== false;
+
+                                const subTypeLabel =
+                                  getTranslation(
+                                    locale,
+                                    `rule_types.${subType}`
+                                  ) || subType;
 
                                 const passedRulesForType =
                                   scholarship.passed?.filter(
@@ -1533,11 +1544,21 @@ export function EnhancedStudentPortal({
 
                                 return (
                                   <div key={subType}>
-                                    <p className="text-sm font-medium text-gray-800 mb-2">
-                                      {locale === "zh"
-                                        ? subTypeInfo.label
-                                        : subTypeInfo.label_en ||
-                                          subTypeInfo.label}
+                                    <p
+                                      className={`text-sm font-medium mb-2 ${
+                                        isSubEligible
+                                          ? "text-gray-800"
+                                          : "text-gray-400"
+                                      }`}
+                                    >
+                                      {subTypeLabel}
+                                      {!isSubEligible && (
+                                        <span className="ml-2 text-xs text-gray-400">
+                                          {locale === "zh"
+                                            ? "（不符資格）"
+                                            : "(Not eligible)"}
+                                        </span>
+                                      )}
                                     </p>
                                     <div className="flex flex-wrap gap-1">
                                       {/* Passed rules (common + subtype-specific) */}

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -1327,9 +1327,9 @@ export function EnhancedStudentPortal({
                   {/* Eligible Programs Section - only show if student is eligible */}
                   {isEligible &&
                     scholarship.all_sub_type_list &&
-                    scholarship.all_sub_type_list.length > 0 &&
-                    scholarship.all_sub_type_list[0] !== "general" &&
-                    scholarship.all_sub_type_list[0] !== null && (
+                    scholarship.all_sub_type_list.some(
+                      st => st && st !== "general"
+                    ) && (
                       <div className="mt-3 bg-indigo-50/30 rounded-lg border border-indigo-100/50 divide-y divide-indigo-100/50">
                         <div className="px-3 py-2">
                           <p className="text-sm font-medium text-indigo-900">
@@ -1346,11 +1346,15 @@ export function EnhancedStudentPortal({
                                 scholarship.subtype_eligibility?.[subTypeKey];
                               const isSubEligible =
                                 eligibility?.eligible !== false;
+                              const labelKey = `rule_types.${subTypeKey}`;
+                              const labelLookup = getTranslation(
+                                locale,
+                                labelKey
+                              );
                               const label =
-                                getTranslation(
-                                  locale,
-                                  `rule_types.${subTypeKey}`
-                                ) || subTypeKey;
+                                labelLookup === labelKey
+                                  ? subTypeKey
+                                  : labelLookup;
 
                               if (isSubEligible) {
                                 return (
@@ -1367,14 +1371,17 @@ export function EnhancedStudentPortal({
                               const failedTagLabels = (
                                 eligibility?.failed_rules ?? []
                               )
-                                .map(r =>
-                                  r.tag
-                                    ? getTranslation(
-                                        locale,
-                                        `eligibility_tags.${r.tag}`
-                                      )
-                                    : null
-                                )
+                                .map(r => {
+                                  if (!r.tag) return null;
+                                  const tagKey = `eligibility_tags.${r.tag}`;
+                                  const tagLookup = getTranslation(
+                                    locale,
+                                    tagKey
+                                  );
+                                  return tagLookup === tagKey
+                                    ? null
+                                    : tagLookup;
+                                })
                                 .filter((s): s is string => Boolean(s));
                               const reasonText =
                                 failedTagLabels.length > 0
@@ -1510,11 +1517,15 @@ export function EnhancedStudentPortal({
                                   scholarship.subtype_eligibility?.[subType]
                                     ?.eligible !== false;
 
+                                const subTypeLabelKey = `rule_types.${subType}`;
+                                const subTypeLabelLookup = getTranslation(
+                                  locale,
+                                  subTypeLabelKey
+                                );
                                 const subTypeLabel =
-                                  getTranslation(
-                                    locale,
-                                    `rule_types.${subType}`
-                                  ) || subType;
+                                  subTypeLabelLookup === subTypeLabelKey
+                                    ? subType
+                                    : subTypeLabelLookup;
 
                                 const passedRulesForType =
                                   scholarship.passed?.filter(

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -1326,10 +1326,10 @@ export function EnhancedStudentPortal({
 
                   {/* Eligible Programs Section - only show if student is eligible */}
                   {isEligible &&
-                    scholarship.eligible_sub_types &&
-                    scholarship.eligible_sub_types.length > 0 &&
-                    scholarship.eligible_sub_types[0]?.value !== "general" &&
-                    scholarship.eligible_sub_types[0]?.value !== null && (
+                    scholarship.all_sub_type_list &&
+                    scholarship.all_sub_type_list.length > 0 &&
+                    scholarship.all_sub_type_list[0] !== "general" &&
+                    scholarship.all_sub_type_list[0] !== null && (
                       <div className="mt-3 bg-indigo-50/30 rounded-lg border border-indigo-100/50 divide-y divide-indigo-100/50">
                         <div className="px-3 py-2">
                           <p className="text-sm font-medium text-indigo-900">
@@ -1340,18 +1340,61 @@ export function EnhancedStudentPortal({
                           </p>
                         </div>
                         <div className="px-3 py-2 flex flex-wrap gap-1.5">
-                          {scholarship.eligible_sub_types.map(
-                            (subType, index) => (
-                              <Badge
-                                key={subType.value || index}
-                                variant="outline"
-                                className="bg-white text-indigo-600 border-indigo-100 shadow-sm"
-                              >
-                                {locale === "zh"
-                                  ? subType.label
-                                  : subType.label_en}
-                              </Badge>
-                            )
+                          {(scholarship.all_sub_type_list ?? []).map(
+                            subTypeKey => {
+                              const eligibility =
+                                scholarship.subtype_eligibility?.[subTypeKey];
+                              const isSubEligible =
+                                eligibility?.eligible !== false;
+                              const label =
+                                getTranslation(
+                                  locale,
+                                  `rule_types.${subTypeKey}`
+                                ) || subTypeKey;
+
+                              if (isSubEligible) {
+                                return (
+                                  <Badge
+                                    key={subTypeKey}
+                                    variant="outline"
+                                    className="bg-white text-indigo-600 border-indigo-100 shadow-sm whitespace-normal text-left"
+                                  >
+                                    ✓ {label}
+                                  </Badge>
+                                );
+                              }
+
+                              const failedTagLabels = (
+                                eligibility?.failed_rules ?? []
+                              )
+                                .map(r =>
+                                  r.tag
+                                    ? getTranslation(
+                                        locale,
+                                        `eligibility_tags.${r.tag}`
+                                      )
+                                    : null
+                                )
+                                .filter((s): s is string => Boolean(s));
+                              const reasonText =
+                                failedTagLabels.length > 0
+                                  ? `${locale === "zh" ? "不符" : "Missing"}：${failedTagLabels.join(
+                                      "、"
+                                    )}`
+                                  : locale === "zh"
+                                    ? "不符資格"
+                                    : "Not eligible";
+
+                              return (
+                                <Badge
+                                  key={subTypeKey}
+                                  variant="outline"
+                                  className="bg-gray-100 text-gray-400 border-gray-200 shadow-sm whitespace-normal text-left"
+                                >
+                                  ✗ {label} — {reasonText}
+                                </Badge>
+                              );
+                            }
                           )}
                         </div>
                       </div>

--- a/frontend/components/student-wizard/steps/StudentDataReviewStep.tsx
+++ b/frontend/components/student-wizard/steps/StudentDataReviewStep.tsx
@@ -64,6 +64,8 @@ export function StudentDataReviewStep({
       enrollmentStatus: "在學狀態",
       enrollmentYear: "入學年度學期",
       semesterCount: "學期數",
+      nationality: "國籍",
+      identity: "身分",
       dataNotice: "資料說明",
       dataNoticeContent:
         "以上資料來自學校資料庫，若發現資料有誤，請聯繫教務處註冊組更新。",
@@ -93,6 +95,8 @@ export function StudentDataReviewStep({
       enrollmentStatus: "Enrollment Status",
       enrollmentYear: "Enrollment Year & Semester",
       semesterCount: "Semester Count",
+      nationality: "Nationality",
+      identity: "Identity",
       dataNotice: "Data Notice",
       dataNoticeContent:
         "The above information is from the university database. If you find any errors, please contact the Office of the Registrar.",
@@ -126,6 +130,25 @@ export function StudentDataReviewStep({
     "9": "保留學籍",
     "10": "放棄入學",
     "11": "畢業",
+  };
+
+  const identityMap: Record<string, string> = {
+    "1": "一般生",
+    "2": "原住民",
+    "3": "僑生(目前有中華民國國籍生)",
+    "4": "外籍生(目前有中華民國國籍生)",
+    "5": "外交子女",
+    "6": "身心障礙生",
+    "7": "運動成績優良甄試學生",
+    "8": "離島",
+    "9": "退伍軍人",
+    "10": "一般公費生",
+    "11": "原住民公費生",
+    "12": "離島公費生",
+    "13": "退伍軍人公費生",
+    "14": "願景計畫生",
+    "17": "陸生",
+    "30": "其他",
   };
 
   const handleConfirm = () => {
@@ -345,6 +368,30 @@ export function StudentDataReviewStep({
                         </label>
                         <div className="text-base text-gray-700">
                           {studentInfo.std_termcount || "-"}
+                        </div>
+                      </div>
+
+                      {/* Nationality */}
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium text-gray-600">
+                          {text.nationality}
+                        </label>
+                        <div className="text-base text-gray-700">
+                          {studentInfo.std_nation || "-"}
+                        </div>
+                      </div>
+
+                      {/* Identity */}
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium text-gray-600">
+                          {text.identity}
+                        </label>
+                        <div className="text-base text-gray-700">
+                          {studentInfo.std_identity
+                            ? identityMap[
+                                String(studentInfo.std_identity)
+                              ] || studentInfo.std_identity
+                            : "-"}
                         </div>
                       </div>
                     </div>

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -932,6 +932,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/applications/{application_id}/application-document": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Application Document File
+         * @description Stream the 申請文件 from MinIO. Owner or staff can access.
+         */
+        get: operations["get_application_document_file_api_v1_applications__application_id__application_document_get"];
+        put?: never;
+        /**
+         * Upload Application Document
+         * @description Upload 申請文件 for a specific application (student only, must own the application).
+         */
+        post: operations["upload_application_document_api_v1_applications__application_id__application_document_post"];
+        /**
+         * Delete Application Document
+         * @description Delete 申請文件 for a specific application.
+         */
+        delete: operations["delete_application_document_api_v1_applications__application_id__application_document_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/applications/{application_id}/document-requests": {
         parameters: {
             query?: never;
@@ -6352,6 +6380,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/system-settings/public-docs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Public Docs
+         * @description Return object_names for 獎學金要點 and 申請文件範例檔.
+         *     Accessible by any authenticated user.
+         */
+        get: operations["get_public_docs_api_v1_system_settings_public_docs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/system-settings/upload/{doc_key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upload System Doc
+         * @description Upload a global system document (獎學金要點 or 申請文件範例檔). Admin only.
+         *     Stores object_name in system_settings under the given key.
+         */
+        post: operations["upload_system_doc_api_v1_system_settings_upload__doc_key__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/system-settings/file/{doc_key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get System Doc File
+         * @description Proxy a global system document from MinIO. Any authenticated user.
+         */
+        get: operations["get_system_doc_file_api_v1_system_settings_file__doc_key__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/system-settings/{id}": {
         parameters: {
             query?: never;
@@ -6819,6 +6909,19 @@ export interface components {
             /** Trace Id */
             trace_id?: string | null;
         };
+        /** ApiResponse[list[EligibleScholarshipResponse]] */
+        ApiResponse_list_EligibleScholarshipResponse__: {
+            /** Success */
+            success: boolean;
+            /** Message */
+            message: string;
+            /** Data */
+            data?: components["schemas"]["EligibleScholarshipResponse"][] | null;
+            /** Errors */
+            errors?: string[] | null;
+            /** Trace Id */
+            trace_id?: string | null;
+        };
         /**
          * ApplicationCreate
          * @description 建立申請
@@ -6892,6 +6995,11 @@ export interface components {
              */
             sub_type_preferences?: string[] | null;
         };
+        /**
+         * ApplicationCycleEnum
+         * @enum {string}
+         */
+        ApplicationCycleEnum: "semester" | "yearly";
         /**
          * ApplicationDocumentCreate
          * @description Schema for creating application document
@@ -7327,6 +7435,10 @@ export interface components {
             updated_at: string;
             /** Meta Data */
             meta_data?: Record<string, never> | null;
+            /** Application Document Url */
+            application_document_url?: string | null;
+            /** Application Document Original Filename */
+            application_document_original_filename?: string | null;
             /**
              * Reviews
              * @default []
@@ -7641,6 +7753,14 @@ export interface components {
             /** Academic Year */
             academic_year?: number | null;
         };
+        /** Body_upload_application_document_api_v1_applications__application_id__application_document_post */
+        Body_upload_application_document_api_v1_applications__application_id__application_document_post: {
+            /**
+             * File
+             * Format: binary
+             */
+            file: string;
+        };
         /** Body_upload_bank_document_file_api_v1_user_profiles_me_bank_document_file_post */
         Body_upload_bank_document_file_api_v1_user_profiles_me_bank_document_file_post: {
             /**
@@ -7685,6 +7805,14 @@ export interface components {
         };
         /** Body_upload_file_api_v1_applications__id__files_upload_post */
         Body_upload_file_api_v1_applications__id__files_upload_post: {
+            /**
+             * File
+             * Format: binary
+             */
+            file: string;
+        };
+        /** Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post */
+        Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post: {
             /**
              * File
              * Format: binary
@@ -8052,6 +8180,68 @@ export interface components {
              * @description 驗證規則
              */
             validation_rules?: Record<string, never> | null;
+        };
+        /** EligibleScholarshipResponse */
+        EligibleScholarshipResponse: {
+            /** Id */
+            id: number;
+            /** Configuration Id */
+            configuration_id: number;
+            /** Code */
+            code: string;
+            /** Name */
+            name: string;
+            /** Name En */
+            name_en: string;
+            /** Eligible Sub Types */
+            eligible_sub_types: components["schemas"]["SubTypeOption"][];
+            application_cycle: components["schemas"]["ApplicationCycleEnum"];
+            /** Description */
+            description?: string | null;
+            /** Description En */
+            description_en?: string | null;
+            /** Amount */
+            amount: string;
+            /** Currency */
+            currency: string;
+            /** Application Start Date */
+            application_start_date?: string | null;
+            /** Application End Date */
+            application_end_date?: string | null;
+            /** Professor Review Start */
+            professor_review_start?: string | null;
+            /** Professor Review End */
+            professor_review_end?: string | null;
+            /** College Review Start */
+            college_review_start?: string | null;
+            /** College Review End */
+            college_review_end?: string | null;
+            sub_type_selection_mode: components["schemas"]["SubTypeSelectionModeEnum"];
+            /** Terms Document Url */
+            terms_document_url?: string | null;
+            /** Passed */
+            passed: components["schemas"]["RuleMessage"][];
+            /** Warnings */
+            warnings: components["schemas"]["RuleMessage"][];
+            /** Errors */
+            errors: components["schemas"]["RuleMessage"][];
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * All Sub Type List
+             * @default []
+             */
+            all_sub_type_list: string[];
+            /**
+             * Subtype Eligibility
+             * @default {}
+             */
+            subtype_eligibility: {
+                [key: string]: components["schemas"]["SubtypeEligibilityInfo"];
+            };
         };
         /** EmailAutomationRuleCreate */
         EmailAutomationRuleCreate: {
@@ -8780,6 +8970,42 @@ export interface components {
              */
             overwrite_existing: boolean;
         };
+        /** RuleMessage */
+        RuleMessage: {
+            /** Rule Id */
+            rule_id: number | string;
+            /** Rule Name */
+            rule_name: string;
+            /** Rule Type */
+            rule_type: string;
+            /** Tag */
+            tag?: string | null;
+            /** Message */
+            message: string;
+            /** Message En */
+            message_en?: string | null;
+            /** Sub Type */
+            sub_type?: string | null;
+            /**
+             * Priority
+             * @default 0
+             */
+            priority: number;
+            /**
+             * Is Warning
+             * @default false
+             */
+            is_warning: boolean;
+            /**
+             * Is Hard Rule
+             * @default false
+             */
+            is_hard_rule: boolean;
+            /** Status */
+            status?: string | null;
+            /** System Message */
+            system_message?: string | null;
+        };
         /**
          * RuleTemplateRequest
          * @description Schema for creating rule templates
@@ -9265,6 +9491,52 @@ export interface components {
          * @enum {string}
          */
         StudentVerificationStatus: "verified" | "graduated" | "suspended" | "withdrawn" | "api_error" | "not_found";
+        /**
+         * SubTypeOption
+         * @description Schema for scholarship sub-type options
+         */
+        SubTypeOption: {
+            /** Value */
+            value: string | null;
+            /** Label */
+            label: string;
+            /** Label En */
+            label_en: string;
+            /**
+             * Is Default
+             * @default false
+             */
+            is_default: boolean;
+        };
+        /**
+         * SubTypeSelectionModeEnum
+         * @enum {string}
+         */
+        SubTypeSelectionModeEnum: "single" | "multiple" | "hierarchical";
+        /** SubtypeEligibilityInfo */
+        SubtypeEligibilityInfo: {
+            /** Eligible */
+            eligible: boolean;
+            /**
+             * Failed Rules
+             * @default []
+             */
+            failed_rules: components["schemas"]["SubtypeRuleDetail"][];
+            /**
+             * Warning Rules
+             * @default []
+             */
+            warning_rules: components["schemas"]["SubtypeRuleDetail"][];
+        };
+        /** SubtypeRuleDetail */
+        SubtypeRuleDetail: {
+            /** Rule Name */
+            rule_name: string;
+            /** Message */
+            message?: string | null;
+            /** Tag */
+            tag?: string | null;
+        };
         /**
          * SupervisorInfo
          * @description Supervisor information schema
@@ -11148,6 +11420,103 @@ export interface operations {
             path: {
                 /** @description Application ID */
                 id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_application_document_file_api_v1_applications__application_id__application_document_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                application_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upload_application_document_api_v1_applications__application_id__application_document_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                application_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_upload_application_document_api_v1_applications__application_id__application_document_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_application_document_api_v1_applications__application_id__application_document_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                application_id: number;
             };
             cookie?: never;
         };
@@ -13788,7 +14157,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["ApiResponse_list_EligibleScholarshipResponse__"];
                 };
             };
         };
@@ -20193,6 +20562,92 @@ export interface operations {
                 "application/json": components["schemas"]["SystemSettingCreate"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_public_docs_api_v1_system_settings_public_docs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    upload_system_doc_api_v1_system_settings_upload__doc_key__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                doc_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_system_doc_file_api_v1_system_settings_file__doc_key__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                doc_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -203,6 +203,22 @@ export interface ScholarshipType {
     label_en: string;
     is_default: boolean;
   }>;
+  all_sub_type_list?: string[];
+  subtype_eligibility?: {
+    [subTypeKey: string]: {
+      eligible: boolean;
+      failed_rules: Array<{
+        rule_name: string;
+        message?: string | null;
+        tag?: string | null;
+      }>;
+      warning_rules: Array<{
+        rule_name: string;
+        message?: string | null;
+        tag?: string | null;
+      }>;
+    };
+  };
   passed?: Array<{
     rule_id: number;
     rule_name: string;

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -249,9 +249,9 @@ export const translations = {
       第一學年: "第一學年",
     },
     rule_types: {
-      nstc: "國科會",
-      moe_1w: "教育部(1萬)",
-      moe_2w: "教育部(2萬)",
+      nstc: "國科會博士生獎學金",
+      moe_1w: "教育部博士生獎學金 (指導教授配合款一萬)",
+      moe_2w: "教育部博士生獎學金 (指導教授配合款兩萬)",
     },
     scholarship_sections: {
       eligible_programs: "可申請項目",
@@ -589,9 +589,9 @@ export const translations = {
       第一學年: "First Academic Year",
     },
     rule_types: {
-      nstc: "NSTC",
-      moe_1w: "MOE (10K)",
-      moe_2w: "MOE (20K)",
+      nstc: "NSTC PhD Scholarship",
+      moe_1w: "MOE PhD Scholarship (Advisor Matching Fund - 10K)",
+      moe_2w: "MOE PhD Scholarship (Advisor Matching Fund - 20K)",
     },
     scholarship_sections: {
       eligible_programs: "Eligible Programs",


### PR DESCRIPTION
## Summary

Two related student-facing UX improvements for the PhD scholarship card, plus the supporting API/schema plumbing:

- **Backend** — surface `all_sub_type_list` and `subtype_eligibility` on `GET /api/v1/scholarships/eligible`. Pure schema/endpoint plumbing; service-layer eligibility logic is untouched. Endpoint now uses a return-type annotation (`-> ApiResponse[list[EligibleScholarshipResponse]]`) per local convention to enable OpenAPI emission.
- **Frontend (Block 1「可申請項目」)** — chip list now shows every subtype. Eligible subtypes get the existing blue ✓ chip; ineligible subtypes get a grey ✗ chip with the failure reason inline (e.g. `✗ 教育部博士生獎學金 (指導教授配合款一萬) — 不符：中華民國國籍`). Both chip variants use `whitespace-normal` to allow wrapping.
- **Frontend (Block 2「申請資格」)** — extended to also iterate all subtypes; ineligible sections get a greyed title plus a `（不符資格）` hint, with the same passed (green) / error (red) tag groupings underneath.
- **i18n** — `rule_types` labels expanded from short names (`國科會`) to full names (`國科會博士生獎學金`, `教育部博士生獎學金 (指導教授配合款一萬)`) in both zh and en.
- **Confirmation step** — 確認學籍資料 academic info card now shows 國籍 (`std_nation`) and 身分 (`std_identity` mapped via `identityMap`) so students can see the values that drive subtype eligibility.

## Background

Triggered by two cases where students could not see 教育部獎學金:

1. **csphd0002** — PhD year 4 (`trm_termcount=7`), fails the 一至三年級 (1-6 學期) rule.
2. **414708008** — 僑/外籍生 (`std_identity=3 or 4`), fails `std_nation == "中華民國"`.

Both situations match the existing scholarship policy (no rule changes needed). The fix surfaces the eligibility result in the UI so students understand *why* a subtype is unavailable instead of silently seeing it disappear.

Spec: `docs/superpowers/specs/2026-04-27-phd-scholarship-card-ineligible-display-design.md`
Plan: `docs/superpowers/plans/2026-04-27-phd-scholarship-card-ineligible-display.md`

## Test plan

- [ ] Login as a regular PhD student (eligible for both subtypes) → both chips blue with ✓
- [ ] Login as a 4th-year PhD student → MOE chip grey with `不符：三年級以下`; Block 2 MOE section greyed with `（不符資格）`
- [ ] Login as a 僑/外籍生 PhD student → MOE chip grey with `不符：中華民國國籍`
- [ ] Login as a 陸生 → MOE chip grey, top-level `非陸生` red tag visible
- [ ] 確認學籍資料 step shows 國籍 + 身分 (mapped name only, no code prefix)
- [ ] `npm run build` and existing backend tests pass
- [ ] Verify generated `schema.d.ts` includes `SubtypeRuleDetail`, `SubtypeEligibilityInfo`, `all_sub_type_list`, `subtype_eligibility`

## Known follow-ups (not in this PR)

- `college-ranking-table.tsx`, `RosterDetailDialog.tsx`, `StudentRosterPreview.tsx`, `ManualDistributionPanel.tsx` still hardcode the short subtype labels (`國科會`, `教育部+1` …). They could migrate to `getTranslation(locale, "rule_types.${key}")` for consistency.
- `identityMap` in `StudentDataReviewStep.tsx` duplicates the alembic seed at `6d5b1940bf8a:101-118`. The backend already exposes `/identities` — frontend could fetch that instead of hardcoding.
- If a future failure tag lacks an `eligibility_tags.<tag>` translation, the chip falls back to `不符資格` / `Not eligible` (no detail). Documented behavior, but worth tracking.