### PR TITLE
fix: make local dev setup work on a fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,39 +34,69 @@ help: ## Show this help message
 # Setup Commands
 install: ## Setup - Install all dependencies (backend + frontend)
 	@echo "$(GREEN)Installing dependencies...$(NC)"
-	@echo "$(CYAN)Installing backend dependencies with uv...$(NC)"
-	cd backend && uv pip install -r pyproject.toml --extra dev
+	@if ! command -v uv >/dev/null 2>&1; then \
+		echo "$(RED)❌ uv not found. Install: https://github.com/astral-sh/uv$(NC)"; \
+		exit 1; \
+	fi
+	@if ! command -v bun >/dev/null 2>&1; then \
+		echo "$(RED)❌ bun not found. Install: https://bun.sh$(NC)"; \
+		exit 1; \
+	fi
+	@if [ "$$(uname)" = "Darwin" ] && ! brew list libmagic >/dev/null 2>&1; then \
+		echo "$(YELLOW)⚠️  libmagic not installed (required by python-magic).$(NC)"; \
+		echo "$(YELLOW)   Run: brew install libmagic$(NC)"; \
+	fi
+	@echo "$(CYAN)Creating backend venv at backend/.venv...$(NC)"
+	cd backend && uv venv --python 3.12 .venv
+	@echo "$(CYAN)Installing backend deps (runtime + dev)...$(NC)"
+	cd backend && uv pip install --python .venv/bin/python -r requirements.txt -r requirements-dev.txt
 	@echo "$(CYAN)Installing frontend dependencies with bun...$(NC)"
 	cd frontend && bun install
 	@echo "$(GREEN)✅ Dependencies installed successfully!$(NC)"
+	@echo "$(YELLOW)Activate the backend venv before 'make dev':$(NC)"
+	@echo "  source backend/.venv/bin/activate"
 
 setup: install ## Setup - Complete project setup (install deps + setup env)
 	@echo "$(GREEN)Setting up development environment...$(NC)"
 	@if [ ! -f backend/.env ]; then \
-		echo "$(YELLOW)Creating backend .env file...$(NC)"; \
-		cp backend/.env.example backend/.env 2>/dev/null || echo "DATABASE_URL=sqlite+aiosqlite:///./scholarship.db\nSECRET_KEY=dev-secret-key" > backend/.env; \
+		echo "$(YELLOW)Writing backend/.env (local-dev defaults that match docker-compose.dev.yml)...$(NC)"; \
+		./scripts/write_dev_env.sh backend; \
+	else \
+		echo "$(CYAN)backend/.env already exists, skipping$(NC)"; \
 	fi
 	@if [ ! -f frontend/.env.local ]; then \
-		echo "$(YELLOW)Creating frontend .env.local file...$(NC)"; \
-		cp frontend/.env.example frontend/.env.local 2>/dev/null || echo "NEXT_PUBLIC_API_URL=http://localhost:8000" > frontend/.env.local; \
+		echo "$(YELLOW)Writing frontend/.env.local (local-dev defaults)...$(NC)"; \
+		./scripts/write_dev_env.sh frontend; \
+	else \
+		echo "$(CYAN)frontend/.env.local already exists, skipping$(NC)"; \
 	fi
 	@echo "$(GREEN)✅ Development environment setup complete!$(NC)"
 	@echo "$(CYAN)Next steps:$(NC)"
-	@echo "  1. Run 'make dev' to start development servers"
-	@echo "  2. Run 'make test' to run tests"
-	@echo "  3. Run 'make docker-up' to start with Docker"
+	@echo "  1. Start infra services:  docker compose -f docker-compose.dev.yml up -d postgres redis minio mock-student-api"
+	@echo "  2. Activate venv:         source backend/.venv/bin/activate"
+	@echo "  3. Run migrations:        make db-migrate"
+	@echo "  4. Seed test data:        make db-seed"
+	@echo "  5. Start dev servers:     make dev"
+	@echo "  ─ or, for full Docker dev: make init-all"
+
+# Resolve uvicorn from the venv if it exists; otherwise rely on PATH.
+UVICORN := $(shell test -x backend/.venv/bin/uvicorn && echo backend/.venv/bin/uvicorn || echo uvicorn)
 
 # Development Commands
 dev: ## Development - Start both backend and frontend in development mode
 	@echo "$(GREEN)Starting development servers...$(NC)"
+	@if [ ! -f backend/.env ]; then \
+		echo "$(RED)❌ backend/.env missing. Run 'make setup' first.$(NC)"; \
+		exit 1; \
+	fi
 	@trap 'kill 0' SIGINT; \
-	(cd backend && echo "$(CYAN)Starting backend on http://localhost:8000$(NC)" && uvicorn app.main:app --reload --host 0.0.0.0 --port 8000) & \
+	(cd backend && echo "$(CYAN)Starting backend on http://localhost:8000$(NC)" && $(abspath $(UVICORN)) app.main:app --reload --host 0.0.0.0 --port 8000) & \
 	(cd frontend && echo "$(CYAN)Starting frontend on http://localhost:3000$(NC)" && bun run dev) & \
 	wait
 
 dev-backend: ## Development - Start only backend server
 	@echo "$(GREEN)Starting backend server...$(NC)"
-	cd backend && uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+	cd backend && $(abspath $(UVICORN)) app.main:app --reload --host 0.0.0.0 --port 8000
 
 dev-frontend: ## Development - Start only frontend server
 	@echo "$(GREEN)Starting frontend server...$(NC)"
@@ -311,6 +341,19 @@ init-all: ## Initialize complete development environment (Docker + DB + Test Dat
 	@echo "$(GREEN)✅ Directories created$(NC)"
 	@echo ""
 	@$(MAKE) docker-up
+	@echo "$(CYAN)⏳ Waiting for backend container to become healthy...$(NC)"
+	@for i in $$(seq 1 60); do \
+		if docker inspect --format '{{.State.Health.Status}}' scholarship_backend_dev 2>/dev/null | grep -q healthy; then \
+			echo "$(GREEN)✅ Backend healthy$(NC)"; break; \
+		fi; \
+		if [ $$i -eq 60 ]; then \
+			echo "$(RED)❌ Backend never became healthy. Check 'docker compose -f docker-compose.dev.yml logs backend'$(NC)"; \
+			exit 1; \
+		fi; \
+		printf "."; sleep 2; \
+	done
+	@echo "$(CYAN)🗄️  Running database migrations (alembic upgrade head)...$(NC)"
+	@docker exec scholarship_backend_dev alembic upgrade head
 	@echo "$(CYAN)🚀 Running database seed...$(NC)"
 	@docker exec scholarship_backend_dev python -m app.seed
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ scholarship-system/
 - **Python 3.12+** and **uv** (if running backend locally) - [Install uv](https://github.com/astral-sh/uv)
 - **Bun** (if running frontend locally) - [Install Bun](https://bun.sh)
 - **Make** (optional, for Makefile commands)
+- **libmagic** & **tesseract** system libraries (only when running the backend on host, not in Docker):
+  - macOS: `brew install libmagic tesseract`
+  - Debian/Ubuntu: `sudo apt-get install libmagic-dev tesseract-ocr`
 
 > **New in this version:** We've upgraded to **Bun** for frontend development (replacing npm) and **uv** for backend (replacing pip) for significantly faster dependency installation and better developer experience. See [DEV_SETUP.md](DEV_SETUP.md) for detailed setup instructions.
 

--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -44,8 +44,7 @@ def _serialize_result(result):
     try:
         mapper = sa_inspect(type(result))
         return {
-            c.key: (v.value if isinstance(v := getattr(result, c.key), enum.Enum) else v)
-            for c in mapper.column_attrs
+            c.key: (v.value if isinstance(v := getattr(result, c.key), enum.Enum) else v) for c in mapper.column_attrs
         }
     except Exception as exc:
         raise TypeError(f"Cannot serialize {type(result).__name__}: {exc}") from exc
@@ -199,7 +198,11 @@ async def create_application(
                         "status": existing_status_str,
                         "scholarship_type_id": existing_application.scholarship_type_id,
                         "academic_year": existing_application.academic_year,
-                        "semester": existing_application.semester.value if hasattr(existing_application.semester, "value") else existing_application.semester,
+                        "semester": (
+                            existing_application.semester.value
+                            if hasattr(existing_application.semester, "value")
+                            else existing_application.semester
+                        ),
                     },
                 }
 

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -62,9 +62,7 @@ async def get_admin_available_combinations(
 ):
     """Get all active scholarship types and configurations for admin distribution."""
     try:
-        scholarship_result = await db.execute(
-            select(ScholarshipType).where(ScholarshipType.status == "active")
-        )
+        scholarship_result = await db.execute(select(ScholarshipType).where(ScholarshipType.status == "active"))
         scholarship_types_objs = scholarship_result.scalars().all()
 
         scholarship_types = [
@@ -77,9 +75,7 @@ async def get_admin_available_combinations(
             for st in scholarship_types_objs
         ]
 
-        config_result = await db.execute(
-            select(ScholarshipConfiguration).where(ScholarshipConfiguration.is_active)
-        )
+        config_result = await db.execute(select(ScholarshipConfiguration).where(ScholarshipConfiguration.is_active))
         configs = config_result.scalars().all()
 
         academic_years_set = set()
@@ -131,9 +127,7 @@ async def get_students_for_distribution(
 ):
     """Get ranked students with allocation status for manual distribution."""
     service = ManualDistributionService(db)
-    students = await service.get_students_for_distribution(
-        scholarship_type_id, academic_year, semester, college_code
-    )
+    students = await service.get_students_for_distribution(scholarship_type_id, academic_year, semester, college_code)
     return {
         "success": True,
         "message": "Students retrieved successfully",
@@ -151,9 +145,7 @@ async def get_quota_status(
 ):
     """Get real-time quota status per sub-type per college."""
     service = ManualDistributionService(db)
-    quota_status = await service.get_quota_status(
-        scholarship_type_id, academic_year, semester
-    )
+    quota_status = await service.get_quota_status(scholarship_type_id, academic_year, semester)
     return {
         "success": True,
         "message": "Quota status retrieved successfully",
@@ -406,25 +398,29 @@ async def get_distribution_summary(
             for item in items:
                 app = item.application
                 sd = (app.student_data or {}) if app else {}
-                students.append({
-                    "ranking_item_id": item.id,
-                    "application_id": item.application_id,
-                    "student_name": sd.get("std_cname", ""),
-                    "student_id": sd.get("std_stdcode", ""),
-                    "college_code": sd.get("std_academyno") or sd.get("trm_academyno", ""),
-                    "college_name": sd.get("trm_academyname", ""),
-                    "department_name": sd.get("trm_depname", ""),
-                    "rank_position": item.rank_position,
-                    "is_renewal": app.is_renewal if app else False,
-                    "renewal_year": app.renewal_year if app else None,
-                })
+                students.append(
+                    {
+                        "ranking_item_id": item.id,
+                        "application_id": item.application_id,
+                        "student_name": sd.get("std_cname", ""),
+                        "student_id": sd.get("std_stdcode", ""),
+                        "college_code": sd.get("std_academyno") or sd.get("trm_academyno", ""),
+                        "college_name": sd.get("trm_academyname", ""),
+                        "department_name": sd.get("trm_depname", ""),
+                        "rank_position": item.rank_position,
+                        "is_renewal": app.is_renewal if app else False,
+                        "renewal_year": app.renewal_year if app else None,
+                    }
+                )
             total_allocated += len(students)
-            group_data.append({
-                "sub_type": sub_type,
-                "allocation_year": alloc_year,
-                "count": len(students),
-                "students": students,
-            })
+            group_data.append(
+                {
+                    "sub_type": sub_type,
+                    "allocation_year": alloc_year,
+                    "count": len(students),
+                    "students": students,
+                }
+            )
 
         return {
             "success": True,

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -530,6 +530,7 @@ async def preview_roster_students(
 
         # 查詢分發資訊：從同學年度排名中取得各 application 的分配結果
         from app.models.college_review import CollegeRankingItem
+
         app_ids = [a.id for a in applications]
         allocation_map: dict = {}
         if app_ids:
@@ -843,19 +844,23 @@ async def get_roster_cycle_status(
                             "period_end_date": period_dates["end_date"].isoformat(),
                         }
                         if roster.status in [RosterStatus.COMPLETED, RosterStatus.LOCKED]:
-                            entry.update({
-                                "status": "completed",
-                                "completed_at": roster.completed_at.isoformat() if roster.completed_at else None,
-                                "total_amount": float(roster.total_amount) if roster.total_amount else 0,
-                                "qualified_count": roster.qualified_count,
-                            })
+                            entry.update(
+                                {
+                                    "status": "completed",
+                                    "completed_at": roster.completed_at.isoformat() if roster.completed_at else None,
+                                    "total_amount": float(roster.total_amount) if roster.total_amount else 0,
+                                    "qualified_count": roster.qualified_count,
+                                }
+                            )
                         elif roster.status == RosterStatus.FAILED:
-                            entry.update({
-                                "status": "failed",
-                                "error_message": roster.notes,
-                                "total_amount": float(roster.total_amount) if roster.total_amount else 0,
-                                "qualified_count": roster.qualified_count,
-                            })
+                            entry.update(
+                                {
+                                    "status": "failed",
+                                    "error_message": roster.notes,
+                                    "total_amount": float(roster.total_amount) if roster.total_amount else 0,
+                                    "qualified_count": roster.qualified_count,
+                                }
+                            )
                         elif roster.status == RosterStatus.PROCESSING:
                             entry["status"] = "processing"
                         else:
@@ -903,19 +908,23 @@ async def get_roster_cycle_status(
                             "period_end_date": period_dates["end_date"].isoformat(),
                         }
                         if roster.status in [RosterStatus.COMPLETED, RosterStatus.LOCKED]:
-                            entry.update({
-                                "status": "completed",
-                                "completed_at": roster.completed_at.isoformat() if roster.completed_at else None,
-                                "total_amount": float(roster.total_amount) if roster.total_amount else 0,
-                                "qualified_count": roster.qualified_count,
-                            })
+                            entry.update(
+                                {
+                                    "status": "completed",
+                                    "completed_at": roster.completed_at.isoformat() if roster.completed_at else None,
+                                    "total_amount": float(roster.total_amount) if roster.total_amount else 0,
+                                    "qualified_count": roster.qualified_count,
+                                }
+                            )
                         elif roster.status == RosterStatus.FAILED:
-                            entry.update({
-                                "status": "failed",
-                                "error_message": roster.notes,
-                                "total_amount": float(roster.total_amount) if roster.total_amount else 0,
-                                "qualified_count": roster.qualified_count,
-                            })
+                            entry.update(
+                                {
+                                    "status": "failed",
+                                    "error_message": roster.notes,
+                                    "total_amount": float(roster.total_amount) if roster.total_amount else 0,
+                                    "qualified_count": roster.qualified_count,
+                                }
+                            )
                         elif roster.status == RosterStatus.PROCESSING:
                             entry["status"] = "processing"
                         else:
@@ -960,19 +969,23 @@ async def get_roster_cycle_status(
                         "period_end_date": period_dates["end_date"].isoformat(),
                     }
                     if roster.status in [RosterStatus.COMPLETED, RosterStatus.LOCKED]:
-                        entry.update({
-                            "status": "completed",
-                            "completed_at": roster.completed_at.isoformat() if roster.completed_at else None,
-                            "total_amount": float(roster.total_amount) if roster.total_amount else 0,
-                            "qualified_count": roster.qualified_count,
-                        })
+                        entry.update(
+                            {
+                                "status": "completed",
+                                "completed_at": roster.completed_at.isoformat() if roster.completed_at else None,
+                                "total_amount": float(roster.total_amount) if roster.total_amount else 0,
+                                "qualified_count": roster.qualified_count,
+                            }
+                        )
                     elif roster.status == RosterStatus.FAILED:
-                        entry.update({
-                            "status": "failed",
-                            "error_message": roster.notes,
-                            "total_amount": float(roster.total_amount) if roster.total_amount else 0,
-                            "qualified_count": roster.qualified_count,
-                        })
+                        entry.update(
+                            {
+                                "status": "failed",
+                                "error_message": roster.notes,
+                                "total_amount": float(roster.total_amount) if roster.total_amount else 0,
+                                "qualified_count": roster.qualified_count,
+                            }
+                        )
                     elif roster.status == RosterStatus.PROCESSING:
                         entry["status"] = "processing"
                     else:
@@ -1006,19 +1019,23 @@ async def get_roster_cycle_status(
                         "project_number": roster.project_number,
                     }
                     if roster.status in [RosterStatus.COMPLETED, RosterStatus.LOCKED]:
-                        entry.update({
-                            "status": "completed",
-                            "completed_at": roster.completed_at.isoformat() if roster.completed_at else None,
-                            "total_amount": float(roster.total_amount) if roster.total_amount else 0,
-                            "qualified_count": roster.qualified_count,
-                        })
+                        entry.update(
+                            {
+                                "status": "completed",
+                                "completed_at": roster.completed_at.isoformat() if roster.completed_at else None,
+                                "total_amount": float(roster.total_amount) if roster.total_amount else 0,
+                                "qualified_count": roster.qualified_count,
+                            }
+                        )
                     elif roster.status == RosterStatus.FAILED:
-                        entry.update({
-                            "status": "failed",
-                            "error_message": roster.notes,
-                            "total_amount": float(roster.total_amount) if roster.total_amount else 0,
-                            "qualified_count": roster.qualified_count,
-                        })
+                        entry.update(
+                            {
+                                "status": "failed",
+                                "error_message": roster.notes,
+                                "total_amount": float(roster.total_amount) if roster.total_amount else 0,
+                                "qualified_count": roster.qualified_count,
+                            }
+                        )
                     elif roster.status == RosterStatus.PROCESSING:
                         entry["status"] = "processing"
                     else:

--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -110,8 +110,6 @@ async def get_professor_review(
                     sub_type_code=item.sub_type_code,
                     recommendation=item.recommendation,
                     comments=item.comments,
-
-
                 )
                 for item in review.items
             ],
@@ -188,8 +186,6 @@ async def submit_professor_review(
                     sub_type_code=item.sub_type_code,
                     recommendation=item.recommendation,
                     comments=item.comments,
-
-
                 )
                 for item in review.items
             ],
@@ -268,8 +264,6 @@ async def update_professor_review(
                     sub_type_code=item.sub_type_code,
                     recommendation=item.recommendation,
                     comments=item.comments,
-
-
                 )
                 for item in review.items
             ],

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -1010,6 +1010,7 @@ async def update_scholarship_configuration(
             # Frontend textarea may send as string; parse to dict
             if isinstance(pqy, str):
                 import json as _json
+
                 try:
                     pqy = _json.loads(pqy)
                 except (ValueError, TypeError):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -227,6 +227,7 @@ class Settings(BaseSettings):
     def create_upload_directory(cls, v: str) -> str:
         """Ensure upload directory exists"""
         import sys
+
         # Skip directory creation during Alembic migrations or when directory is not writable
         try:
             if "alembic" not in sys.argv:

--- a/backend/app/models/college_review.py
+++ b/backend/app/models/college_review.py
@@ -152,7 +152,9 @@ class CollegeRankingItem(Base):
 
     # Matrix distribution fields
     allocated_sub_type = Column(String(50), nullable=True)  # Sub-type code allocated to (e.g., 'nstc', 'moe_1w')
-    allocation_year = Column(Integer, nullable=True)  # Which academic year's quota was used (e.g., 113 for prior-year supplement)
+    allocation_year = Column(
+        Integer, nullable=True
+    )  # Which academic year's quota was used (e.g., 113 for prior-year supplement)
     backup_position = Column(Integer, nullable=True)  # Backup position (NULL for admitted, 1, 2, 3... for backup)
     backup_allocations = Column(
         JSONB, nullable=True
@@ -272,7 +274,9 @@ class ManualDistributionHistory(Base):
     user = relationship("User", lazy="select", foreign_keys=[created_by])
 
     def __repr__(self):
-        return f"<ManualDistributionHistory(id={self.id}, type_id={self.scholarship_type_id}, year={self.academic_year})>"
+        return (
+            f"<ManualDistributionHistory(id={self.id}, type_id={self.scholarship_type_id}, year={self.academic_year})>"
+        )
 
 
 # PostgreSQL-optimized indexes for college ranking tables

--- a/backend/app/models/scholarship.py
+++ b/backend/app/models/scholarship.py
@@ -598,9 +598,7 @@ class ScholarshipConfiguration(Base):
     )  # 計畫編號，依子類型及學年度 {"nstc": {"115": "115RXXXXXXX", "114": "114RXXXXXXX"}, "moe_1w": {"115": "115CXXXXXX"}}
 
     # 各子類型可使用的前年度配額
-    prior_quota_years = Column(
-        JSON, nullable=True
-    )  # {"nstc": [113, 112], "moe_1w": []}
+    prior_quota_years = Column(JSON, nullable=True)  # {"nstc": [113, 112], "moe_1w": []}
 
     # 金額設定 (從 ScholarshipType 移至此處)
     amount = Column(Integer, nullable=False)  # 獎學金金額（整數）

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -194,9 +194,7 @@ class ApplicationCreate(BaseModel):
         subtype_list = self.scholarship_subtype_list
         if prefs and subtype_list:
             if set(prefs) != set(subtype_list):
-                raise ValueError(
-                    "sub_type_preferences must be a permutation of scholarship_subtype_list"
-                )
+                raise ValueError("sub_type_preferences must be a permutation of scholarship_subtype_list")
         return self
 
     model_config = ConfigDict(

--- a/backend/app/schemas/college_review.py
+++ b/backend/app/schemas/college_review.py
@@ -139,7 +139,9 @@ class RankingImportItem(BaseModel):
 
     student_id: str = Field(..., description="Student ID (學號)")
     student_name: str = Field(..., description="Student name (姓名)")
-    rank_position: Union[int, Literal["N"]] = Field(..., description="Ranking position (排名): positive integer or 'N' for rejected")
+    rank_position: Union[int, Literal["N"]] = Field(
+        ..., description="Ranking position (排名): positive integer or 'N' for rejected"
+    )
 
     @field_validator("rank_position", mode="before")
     @classmethod

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -196,12 +196,8 @@ class ScholarshipAnalyticsService:
                     if sub_apps:
                         type_stats[type_id]["sub_types"][sub_type_value] = {
                             "total": len(sub_apps),
-                            "approved": len(
-                                [app for app in sub_apps if app.status == ApplicationStatus.approved]
-                            ),
-                            "approval_rate": len(
-                                [app for app in sub_apps if app.status == ApplicationStatus.approved]
-                            )
+                            "approved": len([app for app in sub_apps if app.status == ApplicationStatus.approved]),
+                            "approval_rate": len([app for app in sub_apps if app.status == ApplicationStatus.approved])
                             / len(sub_apps)
                             * 100,
                         }

--- a/backend/app/services/application_audit_service.py
+++ b/backend/app/services/application_audit_service.py
@@ -579,7 +579,9 @@ class ApplicationAuditService:
                 if application:
                     app_id = application.app_id
                     app_scholarship_id = application.scholarship_type_id
-                    student_name = (application.student_data or {}).get("std_cname") if application.student_data else None
+                    student_name = (
+                        (application.student_data or {}).get("std_cname") if application.student_data else None
+                    )
                     application_id = application.id
                 else:
                     # Application has been hard-deleted; rely on snapshot stored in meta_data.

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -218,12 +218,8 @@ class CollegeReviewService:
             select(Application)
             .options(
                 selectinload(Application.scholarship_type_ref),
-                selectinload(Application.reviews).selectinload(
-                    ApplicationReview.reviewer
-                ),
-                selectinload(Application.reviews).selectinload(
-                    ApplicationReview.items
-                ),
+                selectinload(Application.reviews).selectinload(ApplicationReview.reviewer),
+                selectinload(Application.reviews).selectinload(ApplicationReview.items),
                 selectinload(Application.files),
                 selectinload(Application.student),  # Load student information
             )
@@ -323,8 +319,7 @@ class CollegeReviewService:
                 "is_renewal": app.is_renewal,
                 # Professor review details
                 "professor_review_completed": any(
-                    self._role_matches(review.reviewer.role, "professor")
-                    for review in app.reviews if review.reviewer
+                    self._role_matches(review.reviewer.role, "professor") for review in app.reviews if review.reviewer
                 ),
                 "professor_review_items": [
                     {
@@ -646,9 +641,7 @@ class CollegeReviewService:
             max_renewal_pos = max(renewal_positions)
             min_new_pos = min(new_positions)
             if max_renewal_pos > min_new_pos:
-                raise InvalidRankingDataError(
-                    "續領學生的排名必須在所有新申請學生之前"
-                )
+                raise InvalidRankingDataError("續領學生的排名必須在所有新申請學生之前")
 
         # Update rank positions
         updated_count = 0

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -9,7 +9,12 @@ import asyncio
 import io
 import logging
 import re
-from xml.sax.saxutils import escape as xml_escape
+
+# `escape` is a pure string-escaping helper (replaces `<` → `&lt;` etc.) used
+# for sanitising values before they are placed inside reportlab Paragraph
+# markup. It does not parse untrusted XML, so the B406 warning is a false
+# positive here — defusedxml does not provide an equivalent escape function.
+from xml.sax.saxutils import escape as xml_escape  # nosec B406
 import zipfile
 from collections import Counter, defaultdict
 from datetime import datetime
@@ -91,9 +96,7 @@ class ExportPackageService:
         scholarship_name = await self._get_scholarship_name(scholarship_type_id)
 
         # 2. Query applications with files
-        applications = await self._query_applications(
-            scholarship_type_id, academic_year, semester, college_code
-        )
+        applications = await self._query_applications(scholarship_type_id, academic_year, semester, college_code)
 
         if not applications:
             raise ValueError("無申請資料可匯出")
@@ -124,9 +127,7 @@ class ExportPackageService:
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
             for dept_folder, apps in sorted(dept_groups.items()):
                 for app in apps:
-                    await self._add_application_to_zip(
-                        zf, dept_folder, app, scholarship_name, academic_year, semester
-                    )
+                    await self._add_application_to_zip(zf, dept_folder, app, scholarship_name, academic_year, semester)
 
         buf.seek(0)
 
@@ -178,7 +179,8 @@ class ExportPackageService:
         # Filter by college_code using student_data
         if college_code:
             applications = [
-                app for app in applications
+                app
+                for app in applications
                 if app.student_data and app.student_data.get("std_academyno") == college_code
             ]
 
@@ -270,24 +272,37 @@ class ExportPackageService:
         s_normal = ParagraphStyle("CJK", fontName="WQY", fontSize=10, leading=14)
         s_title = ParagraphStyle("CJKTitle", fontName="WQY", fontSize=16, leading=20, alignment=1)
         s_section = ParagraphStyle(
-            "CJKSection", fontName="WQY", fontSize=12, leading=16,
+            "CJKSection",
+            fontName="WQY",
+            fontSize=12,
+            leading=16,
             backColor=colors.Color(0.94, 0.94, 0.94),
         )
         s_header = ParagraphStyle(
-            "CJKHeader", fontName="WQY", fontSize=9, leading=12,
-            alignment=1, textColor=colors.Color(0.4, 0.4, 0.4),
+            "CJKHeader",
+            fontName="WQY",
+            fontSize=9,
+            leading=12,
+            alignment=1,
+            textColor=colors.Color(0.4, 0.4, 0.4),
         )
         s_footer = ParagraphStyle(
-            "CJKFooter", fontName="WQY", fontSize=8, leading=10,
-            alignment=1, textColor=colors.Color(0.6, 0.6, 0.6),
+            "CJKFooter",
+            fontName="WQY",
+            fontSize=8,
+            leading=10,
+            alignment=1,
+            textColor=colors.Color(0.6, 0.6, 0.6),
         )
 
-        table_style = TableStyle([
-            ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
-            ("BACKGROUND", (0, 0), (0, -1), colors.Color(0.96, 0.96, 0.96)),
-            ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("LEFTPADDING", (0, 0), (-1, -1), 6),
-        ])
+        table_style = TableStyle(
+            [
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("BACKGROUND", (0, 0), (0, -1), colors.Color(0.96, 0.96, 0.96)),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
 
         elements = []
 
@@ -370,7 +385,9 @@ class ExportPackageService:
     @staticmethod
     def _build_table(rows: List[Tuple[str, str]], style: ParagraphStyle, table_style: TableStyle) -> Table:
         """Build a two-column label-value table."""
-        data = [[Paragraph(xml_escape(label), style), Paragraph(xml_escape(str(value)), style)] for label, value in rows]
+        data = [
+            [Paragraph(xml_escape(label), style), Paragraph(xml_escape(str(value)), style)] for label, value in rows
+        ]
         t = Table(data, colWidths=[50 * mm, 120 * mm])
         t.setStyle(table_style)
         return t

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -113,11 +113,13 @@ def _compute_suggestions(
         # College-rejected students default to no allocation. Admin can still
         # override manually if needed.
         if getattr(item, "college_rejected", False):
-            results.append({
-                "ranking_item_id": item.id,
-                "sub_type_code": None,
-                "allocation_year": None,
-            })
+            results.append(
+                {
+                    "ranking_item_id": item.id,
+                    "sub_type_code": None,
+                    "allocation_year": None,
+                }
+            )
             continue
 
         app = item.application
@@ -139,8 +141,7 @@ def _compute_suggestions(
         raw_prefs: list[str] = app.sub_type_preferences or applied or default_prefs
         applied_set = set(applied)
         preferences: list[str] = [
-            p for p in raw_prefs
-            if (p in applied_set if applied_set else True) and p not in rejected
+            p for p in raw_prefs if (p in applied_set if applied_set else True) and p not in rejected
         ]
 
         allocated_sub_type: Optional[str] = None
@@ -180,11 +181,13 @@ def _compute_suggestions(
                     allocated_year = academic_year
                     break
 
-        results.append({
-            "ranking_item_id": item.id,
-            "sub_type_code": allocated_sub_type,
-            "allocation_year": allocated_year,
-        })
+        results.append(
+            {
+                "ranking_item_id": item.id,
+                "sub_type_code": allocated_sub_type,
+                "allocation_year": allocated_year,
+            }
+        )
 
     return results
 
@@ -248,9 +251,7 @@ class ManualDistributionService:
         if not student_ids:
             return {}
 
-        return await calculate_received_months_bulk_async(
-            self.db, student_ids, config_id
-        )
+        return await calculate_received_months_bulk_async(self.db, student_ids, config_id)
 
     async def get_students_for_distribution(
         self,
@@ -297,9 +298,7 @@ class ManualDistributionService:
         # Bulk-compute system received_months for all students in one query.
         # Admin-imported overrides (source="imported") take precedence over
         # system values — see docs/received-months-calculation.md.
-        system_months = await self._bulk_system_received_months(
-            items, scholarship_type_id, academic_year, semester
-        )
+        system_months = await self._bulk_system_received_months(items, scholarship_type_id, academic_year, semester)
 
         students = []
         for item in items:
@@ -336,31 +335,33 @@ class ManualDistributionService:
                 rm_value = system_months.get(student_id_value) if student_id_value else None
                 rm_source = "system" if rm_value is not None else None
 
-            students.append({
-                "ranking_item_id": item.id,
-                "application_id": app.id,
-                "rank_position": item.rank_position,
-                "applied_sub_types": app.scholarship_subtype_list or [],
-                "rejected_sub_types": list(rejected_map.get(app.id, set())),
-                "allocated_sub_type": item.allocated_sub_type,
-                "allocation_year": item.allocation_year,
-                "status": item.status,
-                "college_rejected": item.college_rejected,
-                "college_code": student_college,
-                "college_name": student_data.get("trm_academyname", ""),
-                "department_name": student_data.get("trm_depname", ""),
-                "term_count": term_count,
-                "student_name": student_data.get("std_cname", ""),
-                "nationality": student_data.get("std_nation", ""),
-                "enrollment_date": enrollment_date,
-                "student_id": student_data.get("std_stdcode", ""),
-                "application_identity": identity,
-                "is_renewal": app.is_renewal,
-                "renewal_year": app.renewal_year,
-                "renewal_sub_type": self._get_renewal_sub_type(app),
-                "received_months": rm_value,
-                "received_months_source": rm_source,
-            })
+            students.append(
+                {
+                    "ranking_item_id": item.id,
+                    "application_id": app.id,
+                    "rank_position": item.rank_position,
+                    "applied_sub_types": app.scholarship_subtype_list or [],
+                    "rejected_sub_types": list(rejected_map.get(app.id, set())),
+                    "allocated_sub_type": item.allocated_sub_type,
+                    "allocation_year": item.allocation_year,
+                    "status": item.status,
+                    "college_rejected": item.college_rejected,
+                    "college_code": student_college,
+                    "college_name": student_data.get("trm_academyname", ""),
+                    "department_name": student_data.get("trm_depname", ""),
+                    "term_count": term_count,
+                    "student_name": student_data.get("std_cname", ""),
+                    "nationality": student_data.get("std_nation", ""),
+                    "enrollment_date": enrollment_date,
+                    "student_id": student_data.get("std_stdcode", ""),
+                    "application_identity": identity,
+                    "is_renewal": app.is_renewal,
+                    "renewal_year": app.renewal_year,
+                    "renewal_sub_type": self._get_renewal_sub_type(app),
+                    "received_months": rm_value,
+                    "received_months_source": rm_source,
+                }
+            )
 
         # Sort by college_code, then rank_position
         students.sort(key=lambda s: (s["college_code"], s["rank_position"]))
@@ -395,9 +396,7 @@ class ManualDistributionService:
         }
         """
         # 1. Load current year's config to get prior_quota_years
-        current_config = await self._load_config(
-            scholarship_type_id, academic_year, semester
-        )
+        current_config = await self._load_config(scholarship_type_id, academic_year, semester)
 
         prior_years_map: dict[str, list[int]] = {}
         if current_config and current_config.prior_quota_years:
@@ -598,9 +597,7 @@ class ManualDistributionService:
         sub_type_code=None means unallocate.
         """
         # Validate quota limits first
-        await self._validate_allocations(
-            scholarship_type_id, academic_year, semester, allocations
-        )
+        await self._validate_allocations(scholarship_type_id, academic_year, semester, allocations)
 
         updated_count = 0
         for alloc in allocations:
@@ -608,9 +605,7 @@ class ManualDistributionService:
             sub_type = alloc.get("sub_type_code")
             alloc_year = alloc.get("allocation_year") or (academic_year if sub_type else None)
 
-            item_query = select(CollegeRankingItem).where(
-                CollegeRankingItem.id == item_id
-            )
+            item_query = select(CollegeRankingItem).where(CollegeRankingItem.id == item_id)
             result = await self.db.execute(item_query)
             item = result.scalar_one_or_none()
             if not item:
@@ -649,9 +644,7 @@ class ManualDistributionService:
 
             if ranking_ids:
                 # Get current allocations
-                items_query = select(CollegeRankingItem).where(
-                    CollegeRankingItem.ranking_id.in_(ranking_ids)
-                )
+                items_query = select(CollegeRankingItem).where(CollegeRankingItem.ranking_id.in_(ranking_ids))
                 result = await self.db.execute(items_query)
                 items = result.scalars().all()
 
@@ -814,9 +807,7 @@ class ManualDistributionService:
 
         if ranking_ids:
             # Clear all allocations
-            items_query = select(CollegeRankingItem).where(
-                CollegeRankingItem.ranking_id.in_(ranking_ids)
-            )
+            items_query = select(CollegeRankingItem).where(CollegeRankingItem.ranking_id.in_(ranking_ids))
             result = await self.db.execute(items_query)
             items = result.scalars().all()
 
@@ -832,9 +823,7 @@ class ManualDistributionService:
         for item_id_str, alloc_data in allocations_snapshot.items():
             try:
                 item_id = int(item_id_str)
-                item_query = select(CollegeRankingItem).where(
-                    CollegeRankingItem.id == item_id
-                )
+                item_query = select(CollegeRankingItem).where(CollegeRankingItem.id == item_id)
                 result = await self.db.execute(item_query)
                 item = result.scalar_one_or_none()
 
@@ -956,9 +945,7 @@ class ManualDistributionService:
         result = await self.db.execute(stmt)
         return [row.sub_type_code for row in result.scalars().all()]
 
-    async def _batch_load_previous_allocation_years(
-        self, previous_app_ids: list[int]
-    ) -> dict[int, int]:
+    async def _batch_load_previous_allocation_years(self, previous_app_ids: list[int]) -> dict[int, int]:
         """
         For renewal students, find the allocation_year from their previous application's
         CollegeRankingItem.
@@ -1036,11 +1023,7 @@ class ManualDistributionService:
         seen_app_ids: set[int] = set()
         unique_items = []
         for item in all_items:
-            if (
-                item.application
-                and item.application.deleted_at is None
-                and item.application.id not in seen_app_ids
-            ):
+            if item.application and item.application.deleted_at is None and item.application.id not in seen_app_ids:
                 seen_app_ids.add(item.application.id)
                 unique_items.append(item)
 

--- a/backend/app/services/plugins/phd_eligibility_plugin.py
+++ b/backend/app/services/plugins/phd_eligibility_plugin.py
@@ -174,8 +174,7 @@ def _calculate_received_months(db: Session, student_nycu_id: str, scholarship_co
     try:
         months = calculate_received_months(db, student_nycu_id, scholarship_config.id)
         logger.info(
-            f"Student {student_nycu_id} has received {months} months "
-            f"for scholarship_config {scholarship_config.id}"
+            f"Student {student_nycu_id} has received {months} months " f"for scholarship_config {scholarship_config.id}"
         )
         return months
     except Exception as e:

--- a/backend/app/services/received_months_service.py
+++ b/backend/app/services/received_months_service.py
@@ -72,9 +72,7 @@ def _bulk_stmt(student_nycu_ids: list[str], scholarship_config_id: int) -> Selec
     )
 
 
-def calculate_received_months(
-    db: Session, student_nycu_id: str, scholarship_config_id: int
-) -> int:
+def calculate_received_months(db: Session, student_nycu_id: str, scholarship_config_id: int) -> int:
     """
     Total months a single student has received under the given scholarship config.
 

--- a/backend/app/services/roster_scheduler_service.py
+++ b/backend/app/services/roster_scheduler_service.py
@@ -37,6 +37,7 @@ class RosterSchedulerService:
         # 設定Redis作為Job Store
         # Parse REDIS_URL: redis://:password@host:port/db
         from urllib.parse import urlparse
+
         parsed = urlparse(settings.redis_url)
         redis_password = parsed.password if parsed.password else None
         redis_host = parsed.hostname if parsed.hostname else "redis"

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -1443,8 +1443,7 @@ class RosterService:
 
         if not scholarship_config:
             raise ValueError(
-                f"找不到對應的獎學金配置：scholarship_type_id={scholarship_type_id}, "
-                f"academic_year={academic_year}"
+                f"找不到對應的獎學金配置：scholarship_type_id={scholarship_type_id}, " f"academic_year={academic_year}"
             )
 
         # 3. 取得所有已分配的 ranking items，並按 (allocation_year, allocated_sub_type) 分組
@@ -1460,9 +1459,7 @@ class RosterService:
         )
 
         if not allocated_items:
-            raise ValueError(
-                f"排名 {ranking_ids} 沒有已分配的學生。請確認已完成手動分發並確認分發。"
-            )
+            raise ValueError(f"排名 {ranking_ids} 沒有已分配的學生。請確認已完成手動分發並確認分發。")
 
         # 分組：{(allocation_year, sub_type): [ranking_item, ...]}
         groups: Dict[tuple, List] = {}
@@ -1533,9 +1530,7 @@ class RosterService:
             project_number = sub_type_projects.get(str(allocation_year))
 
         # 產生造冊代碼（包含 sub_type 和 allocation_year 以確保唯一性）
-        roster_code = (
-            f"ROSTER-{academic_year}-{sub_type}-{allocation_year}-{scholarship_config.config_code}"
-        )
+        roster_code = f"ROSTER-{academic_year}-{sub_type}-{allocation_year}-{scholarship_config.config_code}"
 
         # 檢查是否已存在
         existing_roster = (
@@ -1676,6 +1671,7 @@ class RosterService:
 
         # 產生 Excel 並上傳至 MinIO（在 sync 環境中執行，避免 greenlet 問題）
         from app.services.excel_export_service import ExcelExportService
+
         try:
             export_service = ExcelExportService()
             export_service.export_roster_to_excel(

--- a/backend/app/tests/test_admin_endpoints.py
+++ b/backend/app/tests/test_admin_endpoints.py
@@ -673,15 +673,11 @@ class TestAdminEndpoints:
         # Row must be gone.
         get_db_override = fastapi_app.dependency_overrides[get_db]
         db = await get_db_override().__anext__()
-        still_there = (
-            await db.execute(select(Application).where(Application.id == target.id))
-        ).scalar_one_or_none()
+        still_there = (await db.execute(select(Application).where(Application.id == target.id))).scalar_one_or_none()
         assert still_there is None
 
     @pytest.mark.asyncio
-    async def test_delete_application_success_submitted_records_audit_log(
-        self, admin_client, deletable_applications
-    ):
+    async def test_delete_application_success_submitted_records_audit_log(self, admin_client, deletable_applications):
         """Deleting a submitted app writes an AuditLog with the reason and scholarship snapshot."""
         from sqlalchemy import select
 

--- a/backend/app/tests/test_received_months_service.py
+++ b/backend/app/tests/test_received_months_service.py
@@ -277,9 +277,7 @@ class TestCalculateReceivedMonthsBulk:
         _make_item(db, roster_id=roster.id, student_nycu_id="S001", application_id=1)
         _make_item(db, roster_id=roster.id, student_nycu_id="S002", application_id=2)
 
-        result = calculate_received_months_bulk(
-            db, ["S001", "S002", "S999"], scholarship_config_id=1
-        )
+        result = calculate_received_months_bulk(db, ["S001", "S002", "S999"], scholarship_config_id=1)
         assert result == {"S001": 1, "S002": 1, "S999": 0}
 
     def test_empty_list_returns_empty_dict(self, db):

--- a/backend/app/tests/unit/conftest.py
+++ b/backend/app/tests/unit/conftest.py
@@ -2,4 +2,5 @@
 Minimal conftest for unit tests that don't require database access.
 These tests run without the full app stack.
 """
+
 # No imports needed - override the parent conftest

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -119,6 +119,7 @@ dependencies = [
     "alembic==1.17.2",
     "asyncpg==0.30.0",
     "psycopg2-binary==2.9.11",
+    "greenlet>=3.0,<4",  # Required by SQLAlchemy sync engine
     
     # Authentication and Security
     "PyJWT[crypto]==2.9.0",
@@ -174,20 +175,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    "pytest==8.3.7",
-    "pytest-asyncio==0.26.3",
-    "pytest-cov==6.0.0",
-    "pytest-mock==3.16.0",
-    "httpx==0.28.1",
-    "faker==34.0.2",
-    "black==26.3.1",
-    "flake8==7.1.1",
-    "isort==6.1.0",
-    "mypy==1.18.2",
-    "pylint==3.4.3",
-    "bandit==1.8.4",
-]
+# Dev dependencies are managed in requirements-dev.txt to keep one source of truth.
+# Install with: uv pip install -r requirements.txt -r requirements-dev.txt
+# (or `make install`)
+dev = []
 
 [build-system]
 requires = ["hatchling"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ sqlalchemy==2.0.44  # Updated for Python 3.13 compatibility
 alembic==1.17.2  # Updated for Python 3.13 compatibility
 asyncpg==0.30.0  # Updated for Python 3.13 compatibility
 psycopg2-binary==2.9.11  # Updated for Python 3.13 compatibility
+greenlet>=3.0,<4  # Required by SQLAlchemy sync engine (used by health check + APScheduler)
 
 # Authentication and Security
 PyJWT[crypto]==2.9.0  # Replaced python-jose (unmaintained, has CVE-2024-33663)
@@ -54,6 +55,9 @@ minio==7.2.18  # Updated for Python 3.13 compatibility
 # Excel processing
 pandas==2.3.3  # Updated for Python 3.13 compatibility
 openpyxl==3.1.2
+
+# PDF generation
+reportlab==4.4.10  # Used by export_package_service
 
 # Logging and monitoring
 structlog==24.4.0  # Updated for Python 3.13 compatibility

--- a/backend/tests/test_auto_allocate_preview.py
+++ b/backend/tests/test_auto_allocate_preview.py
@@ -89,6 +89,7 @@ def _compute_suggestions():
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_app(
     app_id: int,
     college: str = "A",
@@ -149,10 +150,12 @@ class TestNewApplicantsAllocatedToCurrentYearNstcFirst:
         academic_year = 114
         default_prefs = ["nstc", "moe_1w"]
         prior_years_map = {"nstc": [113], "moe_1w": []}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 5,
-            ("moe_1w", 114, "A"): 3,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 5,
+                ("moe_1w", 114, "A"): 3,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         app1 = _make_app(1, college="A", sub_type_preferences=["nstc", "moe_1w"])
@@ -182,10 +185,12 @@ class TestRenewalStudentsSortedBeforeNew:
         default_prefs = ["nstc", "moe_1w"]
         prior_years_map = {"nstc": [113], "moe_1w": []}
         # Only 1 slot for nstc in college A
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 1,
-            ("moe_1w", 114, "A"): 5,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 1,
+                ("moe_1w", 114, "A"): 5,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         renewal_app = _make_app(1, college="A", is_renewal=True)
@@ -218,11 +223,13 @@ class TestRenewalTargetsPreviousAllocationYear:
         academic_year = 114
         default_prefs = ["nstc", "moe_1w"]
         prior_years_map = {"nstc": [113], "moe_1w": []}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 113, "A"): 2,  # Prior year quota available
-            ("nstc", 114, "A"): 5,
-            ("moe_1w", 114, "A"): 3,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 113, "A"): 2,  # Prior year quota available
+                ("nstc", 114, "A"): 5,
+                ("moe_1w", 114, "A"): 3,
+            }
+        )
         # Renewal student's previous app (id=99) was allocated to year 113
         prev_alloc_years = {99: 113}
 
@@ -249,11 +256,13 @@ class TestRenewalFallbackToCurrentYearWhenPriorExhausted:
         academic_year = 114
         default_prefs = ["nstc", "moe_1w"]
         prior_years_map = {"nstc": [113], "moe_1w": []}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 113, "A"): 0,  # Prior year exhausted
-            ("nstc", 114, "A"): 5,  # Current year available
-            ("moe_1w", 114, "A"): 3,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 113, "A"): 0,  # Prior year exhausted
+                ("nstc", 114, "A"): 5,  # Current year available
+                ("moe_1w", 114, "A"): 3,
+            }
+        )
         prev_alloc_years = {99: 113}
 
         renewal_app = _make_app(1, college="A", is_renewal=True, prev_app_id=99)
@@ -280,10 +289,12 @@ class TestQuotaExhaustedFallsToNextPreference:
         academic_year = 114
         default_prefs = ["nstc", "moe_1w"]
         prior_years_map = {"nstc": [113], "moe_1w": []}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 0,  # Exhausted
-            ("moe_1w", 114, "A"): 3,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 0,  # Exhausted
+                ("moe_1w", 114, "A"): 3,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         app = _make_app(1, college="A", sub_type_preferences=["nstc", "moe_1w"])
@@ -309,10 +320,12 @@ class TestAllQuotasExhaustedReturnsNull:
         academic_year = 114
         default_prefs = ["nstc", "moe_1w"]
         prior_years_map = {"nstc": [113], "moe_1w": []}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 0,
-            ("moe_1w", 114, "A"): 0,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 0,
+                ("moe_1w", 114, "A"): 0,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         app = _make_app(1, college="A", sub_type_preferences=["nstc", "moe_1w"])
@@ -338,10 +351,12 @@ class TestNullPreferencesUsesConfigDefaults:
         academic_year = 114
         default_prefs = ["nstc", "moe_1w"]  # Config-driven defaults
         prior_years_map = {"nstc": [113], "moe_1w": []}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 0,  # nstc exhausted
-            ("moe_1w", 114, "A"): 5,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 0,  # nstc exhausted
+                ("moe_1w", 114, "A"): 5,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         app = _make_app(1, college="A", sub_type_preferences=None)  # No preferences set
@@ -368,16 +383,20 @@ class TestAlreadyAllocatedStudentsSkipped:
         academic_year = 114
         default_prefs = ["nstc", "moe_1w"]
         prior_years_map = {"nstc": [113], "moe_1w": []}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 5,
-            ("moe_1w", 114, "A"): 3,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 5,
+                ("moe_1w", 114, "A"): 3,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         app = _make_app(1, college="A")
         # Item already has an allocation
         item = _make_item(
-            101, rank_position=1, app=app,
+            101,
+            rank_position=1,
+            app=app,
             is_allocated=True,
             allocated_sub_type="nstc",
             allocation_year=114,
@@ -406,10 +425,12 @@ class TestPerCollegeQuotaRespected:
         academic_year = 114
         default_prefs = ["nstc", "moe_1w"]
         prior_years_map = {"nstc": [113], "moe_1w": []}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 1,   # Only 1 slot for college A
-            ("moe_1w", 114, "A"): 0,  # No moe_1w for college A either
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 1,  # Only 1 slot for college A
+                ("moe_1w", 114, "A"): 0,  # No moe_1w for college A either
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         app1 = _make_app(1, college="A", sub_type_preferences=["nstc", "moe_1w"])
@@ -444,10 +465,12 @@ class TestRenewalWithPriorYearNotConfigured:
         academic_year = 114
         default_prefs = ["nstc"]
         prior_years_map = {"nstc": [113]}  # Only 113, not 112
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 3,  # Current year available
-            ("nstc", 113, "A"): 2,  # 113 available but not target
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 3,  # Current year available
+                ("nstc", 113, "A"): 2,  # 113 available but not target
+            }
+        )
         prev_alloc_years = {99: 112}  # Previous year was 112
 
         renewal_app = _make_app(1, college="A", is_renewal=True, prev_app_id=99)
@@ -474,9 +497,11 @@ class TestNoDedupInComputeSuggestions:
         academic_year = 114
         default_prefs = ["nstc"]
         prior_years_map = {"nstc": [113]}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 5,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 5,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         app = _make_app(1, college="A")
@@ -521,9 +546,11 @@ class TestRenewalWithNoPreviousApplicationId:
         academic_year = 114
         default_prefs = ["nstc"]
         prior_years_map = {"nstc": [113]}
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 5,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 5,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         # is_renewal=True but prev_app_id=None
@@ -551,9 +578,11 @@ class TestUnknownCollegeGetsNoAllocation:
         default_prefs = ["nstc"]
         prior_years_map = {}
         # Only college A has quota
-        quota_tracker = _build_quota_tracker({
-            ("nstc", 114, "A"): 5,
-        })
+        quota_tracker = _build_quota_tracker(
+            {
+                ("nstc", 114, "A"): 5,
+            }
+        )
         prev_alloc_years: dict[int, int] = {}
 
         app = _make_app(1, college="B")  # College B not in tracker
@@ -617,7 +646,6 @@ class TestPreferenceOrderRespected:
 
         results = _compute_suggestions(
             unique_items=[item],
-
             default_prefs=["nstc", "moe_1w"],
             prev_alloc_years={},
             prior_years_map={},
@@ -643,7 +671,6 @@ class TestPreferenceOrderRespected:
 
         results = _compute_suggestions(
             unique_items=[item],
-
             default_prefs=["nstc", "moe_1w"],
             prev_alloc_years={},
             prior_years_map={},

--- a/backend/tests/test_phd_sub_type_selection.py
+++ b/backend/tests/test_phd_sub_type_selection.py
@@ -89,6 +89,6 @@ class TestPhdSubTypeSelectionMode:
         """Confirm hierarchical mode would reject MOE-only (the old behavior we're removing)."""
         sub_type_list = ["nstc", "moe_1w"]
         selected = ["moe_1w"]
-        expected = sub_type_list[:len(selected)]
+        expected = sub_type_list[: len(selected)]
         # hierarchical: selected must match prefix of sub_type_list
         assert selected != expected, "Hierarchical should reject ['moe_1w'] alone"

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4574,10 +4574,11 @@ export interface paths {
         put?: never;
         /**
          * Import Ranking From Excel
-         * @description Import ranking data from Excel
+         * @description Import ranking data from Excel.
          *
-         *     Expected Excel columns: 學號, 姓名, 排名
-         *     This endpoint updates the rank_position of existing ranking items based on student IDs
+         *     Expected columns: 學號, 姓名, 排名
+         *     rank_position accepts positive integers (1-based, consecutive, no duplicates) or "N" (rejected).
+         *     Student IDs must exactly match the ranking's application set.
          */
         post: operations["import_ranking_from_excel_api_v1_college_review_rankings__ranking_id__import_excel_post"];
         delete?: never;
@@ -8561,9 +8562,9 @@ export interface components {
             student_name: string;
             /**
              * Rank Position
-             * @description Ranking position (排名)
+             * @description Ranking position (排名): positive integer or 'N' for rejected
              */
-            rank_position: number;
+            rank_position: number | "N";
         };
         /**
          * RankingOrderUpdate

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -153,6 +153,7 @@ export interface DistributionSummaryStudent {
   college_name: string;
   department_name: string;
   rank_position: number;
+  college_rejected?: boolean;
 }
 
 export interface DistributionSummaryGroup {

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -1273,6 +1273,7 @@ export interface ScholarshipConfigurationFormData {
   quota_management_mode?: string;
   total_quota?: number;
   quotas?: Record<string, any> | string;
+  prior_quota_years?: Record<string, any> | string;
   whitelist_student_ids?: Record<string, number[]> | string;
   renewal_application_start_date?: string;
   renewal_application_end_date?: string;

--- a/scripts/write_dev_env.sh
+++ b/scripts/write_dev_env.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Write local-dev .env files for `make dev`. Values mirror
+# docker-compose.dev.yml so the host-run backend can talk to the
+# Dockerised postgres / redis / minio / mock-student-api.
+#
+# Usage: ./scripts/write_dev_env.sh {backend|frontend}
+#
+# These are NOT secrets — they're the same dev defaults already in
+# docker-compose.dev.yml. They MUST NOT be used outside local dev.
+
+set -euo pipefail
+
+case "${1:-}" in
+  backend)
+    cat > backend/.env <<'EOF'
+# Local-dev defaults written by scripts/write_dev_env.sh.
+# Replace each value with your own for staging/prod, e.g.:
+#   SECRET_KEY=your-generated-key  (run: openssl rand -hex 32)
+
+ENVIRONMENT=development
+DEBUG=true
+
+DATABASE_URL=postgresql+asyncpg://scholarship_user:scholarship_pass@localhost:5432/scholarship_db  # pragma: allowlist secret
+DATABASE_URL_SYNC=postgresql://scholarship_user:scholarship_pass@localhost:5432/scholarship_db  # pragma: allowlist secret
+REDIS_URL=redis://localhost:6379/0
+
+SECRET_KEY=dev-secret-key-for-development-only
+
+CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+
+MINIO_ENDPOINT=localhost:9000
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin123
+MINIO_BUCKET=scholarship-documents
+MINIO_SECURE=false
+
+ENABLE_MOCK_SSO=true
+MOCK_SSO_DOMAIN=dev.university.edu
+PORTAL_SSO_ENABLED=false
+
+STUDENT_API_ENABLED=true
+STUDENT_API_BASE_URL=http://localhost:8080
+STUDENT_API_ACCOUNT=scholarship
+STUDENT_API_HMAC_KEY=4d6f636b4b657946726f6d48657841424344454647484a4b4c4d4e4f505152535455565758595a
+STUDENT_API_TIMEOUT=10.0
+STUDENT_API_ENCODE_TYPE=UTF-8
+
+FRONTEND_URL=http://localhost:3000
+FRONTEND_INTERNAL_URL=http://localhost:3000
+EOF
+    echo "  ✓ wrote backend/.env"
+    ;;
+
+  frontend)
+    cat > frontend/.env.local <<'EOF'
+# Local-dev defaults written by scripts/write_dev_env.sh.
+
+NEXT_PUBLIC_API_URL=http://localhost:8000
+INTERNAL_API_URL=http://localhost:8000
+MOCK_STUDENT_API_URL=http://localhost:8080
+NEXT_TELEMETRY_DISABLED=1
+EOF
+    echo "  ✓ wrote frontend/.env.local"
+    ;;
+
+  *)
+    echo "usage: $0 {backend|frontend}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- `make dev` / `make install` were broken for new contributors and `make init-all` left the database without a schema. This PR makes the documented onboarding flow work end-to-end on a fresh clone.

## What was broken
- `pyproject.toml`'s `[project.optional-dependencies] dev` block pinned versions that don't exist on PyPI (`pytest==8.3.7`, `pytest-asyncio==0.26.3`, `pytest-mock==3.16.0`, `mypy==1.18.2`), so `make install` failed at resolve time.
- `requirements.txt` was missing `reportlab` (imported by `export_package_service`) and `greenlet` (required by SQLAlchemy's sync engine — used by the health check and APScheduler).
- `make init-all` ran `python -m app.seed` against a tableless DB because `alembic upgrade head` was never invoked, leaving `/dev-login` returning 500.
- `make setup` referenced `.env.example` files that didn't exist; the fallback wrote a minimal `.env` missing required Settings fields (`MINIO_ACCESS_KEY`, etc.).
- macOS `libmagic` system dep wasn't documented; backend imports fail on `import magic` without it.

## Changes
**Dependencies**
- Add `reportlab==4.4.10` and `greenlet>=3.0,<4` to both `requirements.txt` and `pyproject.toml` runtime deps.
- Drop the broken `[project.optional-dependencies] dev` pins; `requirements-dev.txt` is the working source of truth and the dev extra is now a no-op pointer to it.

**Makefile**
- `install`: create `backend/.venv`, install via `requirements.txt + requirements-dev.txt`, with pre-flight checks for `uv` / `bun` / `libmagic` (macOS).
- `dev` / `dev-backend`: auto-resolve `backend/.venv/bin/uvicorn` when present so the venv doesn't have to be activated first.
- `init-all`: wait for the backend container to become healthy, then run `alembic upgrade head` before seeding.
- `setup`: delegate env-file creation to `scripts/write_dev_env.sh`.

**scripts/write_dev_env.sh** (new)
- Writes `backend/.env` and `frontend/.env.local` with the same defaults already in `docker-compose.dev.yml`, so the host-run backend connects to the Dockerised infra. Inline `# pragma: allowlist secret` keeps the dev DB URL out of `detect-secrets` results.

**README**
- Add macOS / Debian system-package prereqs (`libmagic`, `tesseract`) for host-based backend dev.

## Test plan
- [ ] `make setup` succeeds on a clean clone and writes `backend/.env` + `frontend/.env.local`
- [ ] `source backend/.venv/bin/activate && make dev` boots both services without hand-editing
- [ ] `make init-all` against an empty DB volume produces a working `/dev-login` (admin/admin123 logs in)
- [ ] `docker compose -f docker-compose.dev.yml build backend` still succeeds (pyproject path unchanged for Docker)
- [ ] `make help` renders without errors
- [ ] `pre-commit run --all-files` passes (detect-secrets + custom hardcoded-creds checks both clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)