### PR TITLE
fix(ci): use repository_owner for ghcr image namespace

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -104,7 +104,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.actor }}/scholarship-system-${{ matrix.component }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-${{ matrix.component }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -159,8 +159,8 @@ jobs:
       - name: Pull latest images
         run: |
           echo "Pulling Docker images..."
-          docker pull ${{ env.REGISTRY }}/${{ github.actor }}/scholarship-system-backend:${{ needs.pre-deployment.outputs.version }}
-          docker pull ${{ env.REGISTRY }}/${{ github.actor }}/scholarship-system-frontend:${{ needs.pre-deployment.outputs.version }}
+          docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-backend:${{ needs.pre-deployment.outputs.version }}
+          docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-frontend:${{ needs.pre-deployment.outputs.version }}
 
       - name: Create deployment directory
         run: |
@@ -278,7 +278,7 @@ jobs:
           echo "Cleaning up old Docker images (keeping latest 3 versions)..."
 
           # Cleanup old backend images (sorted by creation time, newest first)
-          docker images ghcr.io/${{ github.actor }}/scholarship-system-backend \
+          docker images ghcr.io/${{ github.repository_owner }}/scholarship-system-backend \
             --format "{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}" | \
             sort -r | \
             grep -v latest | \
@@ -287,7 +287,7 @@ jobs:
             xargs -r docker rmi -f || true
 
           # Cleanup old frontend images (sorted by creation time, newest first)
-          docker images ghcr.io/${{ github.actor }}/scholarship-system-frontend \
+          docker images ghcr.io/${{ github.repository_owner }}/scholarship-system-frontend \
             --format "{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}" | \
             sort -r | \
             grep -v latest | \


### PR DESCRIPTION
## Summary

The deploy pipeline pushed images to `ghcr.io/${{ github.actor }}/scholarship-system-*`, where `github.actor` is the user who triggered the workflow run. When a contributor outside the repo owner's namespace triggers the pipeline, `GITHUB_TOKEN` has no write access to that user's personal package namespace and the push fails with `denied: permission_denied: write_package` (e.g. https://github.com/anud18/scholarship-system/actions/runs/25212715214/job/73926515346 — pushed to `ghcr.io/jotpalch/scholarship-system-backend`).

Switch the five image-path references to `${{ github.repository_owner }}` so packages always land under the repo's namespace, regardless of who triggered the run.

The two `username: ${{ github.actor }}` lines on `docker/login-action` are intentionally kept — those identify who is authenticating, not where the package goes.

## Test plan

- [ ] Re-run the deploy pipeline on this branch (or on `main` after merge) and verify the build & push step targets `ghcr.io/anud18/...`
- [ ] Verify the package shows up under https://github.com/anud18?tab=packages


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFmR46GGJYsE1ukSTjAd7K)_