### PR TITLE
fix(ci): use repository_owner for ghcr image namespace in main pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.13'
   REGISTRY: ghcr.io
-  USER: ${{ github.actor }}
+  USER: ${{ github.repository_owner }}
   IMAGE_NAME: ${{ github.repository }}
   CI: true
 


### PR DESCRIPTION
## Summary

Follow-up to #51. That PR fixed `deploy-pipeline.yml`, but the failing run (https://github.com/anud18/scholarship-system/actions/runs/25213014128/job/73927724671) is from `ci.yml` ("Main CI/CD Pipeline"), which has the same bug:

```yaml
# .github/workflows/ci.yml:14
env:
  USER: ${{ github.actor }}      # ← namespace owner, not authenticator
```

`env.USER` is then used as the GHCR namespace at lines 381, 398, 399, 412, 413. When a contributor outside the owner namespace triggers the pipeline, `GITHUB_TOKEN` (or `GH_PAT`) lacks `packages: write` for that user's namespace and the push fails with `denied: permission_denied: write_package` (e.g. `ghcr.io/jotpalch/scholarship-system-backend:latest`).

This PR changes line 14 only:

```diff
- USER: ${{ github.actor }}
+ USER: ${{ github.repository_owner }}
```

The `username: ${{ github.actor }}` on `docker/login-action` (line 374) stays — that identifies who is authenticating, not where the package goes.

## Test plan

- [ ] Re-run "Main CI/CD Pipeline" on this branch and verify the build & push targets `ghcr.io/anud18/...`
- [ ] Confirm `ghcr.io/anud18/scholarship-system-backend:latest` and `:<sha>` are published under https://github.com/anud18?tab=packages


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFmR46GGJYsE1ukSTjAd7K)_