### PR TITLE
fix(frontend): allow dots in preview/download proxy fileId validation (closes #53)

### DIFF
--- a/frontend/app/api/v1/download/route.ts
+++ b/frontend/app/api/v1/download/route.ts
@@ -21,8 +21,9 @@ function validateId(id: string | null, paramName: string): void {
     throw new Error(`Invalid ${paramName}: path traversal detected`);
   }
 
-  // Only allow safe characters: letters, numbers, hyphens, underscores
-  const idPattern = /^[a-zA-Z0-9_-]+$/;
+  // Allow `.` for filenames with extensions (e.g. <hash>.pdf for bank documents);
+  // `..` / `/` / `\` are already rejected by the path-traversal check above.
+  const idPattern = /^[a-zA-Z0-9_.-]+$/;
   if (!idPattern.test(id)) {
     throw new Error(`Invalid ${paramName}: contains illegal characters`);
   }

--- a/frontend/app/api/v1/preview/route.ts
+++ b/frontend/app/api/v1/preview/route.ts
@@ -25,8 +25,9 @@ function validateId(id: string | null, paramName: string): void {
     throw new Error(`Invalid ${paramName}: path traversal detected`);
   }
 
-  // Only allow safe characters: letters, numbers, hyphens, underscores
-  const idPattern = /^[a-zA-Z0-9_-]+$/;
+  // Allow `.` for filenames with extensions (e.g. <hash>.pdf for bank documents);
+  // `..` / `/` / `\` are already rejected by the path-traversal check above.
+  const idPattern = /^[a-zA-Z0-9_.-]+$/;
   if (!idPattern.test(id)) {
     throw new Error(`Invalid ${paramName}: contains illegal characters`);
   }

--- a/frontend/components/__tests__/enhanced-student-portal.test.tsx
+++ b/frontend/components/__tests__/enhanced-student-portal.test.tsx
@@ -75,6 +75,9 @@ const mockApplication = {
   submitted_at: "2025-01-01T10:00:00Z",
   created_at: "2025-01-01",
   updated_at: "2025-01-01",
+  // Progress timeline conditionalizes professor/college steps on these flags.
+  requires_professor_recommendation: true,
+  requires_college_review: true,
 };
 
 describe("EnhancedStudentPortal", () => {

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -63,25 +63,14 @@ const customJestConfig = {
   clearMocks: true,
   // Enable automatic mocking from __mocks__ directories
   automock: false,
-  // Coverage thresholds adjusted with new useScholarshipData hook tests
-  // Current actual coverage: ~8.21% statements before tests
-  // Recent changes:
-  // - Added comprehensive test suite for useScholarshipData hook
-  // - Fixed updateStatus method to work with openapi-fetch (no `this` context needed)
-  // - Updated ApplicationFormDataDisplay test to reflect new unfilled fields display behavior
-  // - Regenerated OpenAPI types after backend schema changes (removed score field)
-  // Thresholds adjusted to accommodate new hook coverage:
-  // - statements: 8.2% (from 8.3%) - provides buffer for hook tests
-  // - branches: 4.6% (from 5.0%) - maintained from previous adjustment
-  // TODO: Add more tests for admin components and API modules to gradually raise thresholds back up
-  coverageThreshold: {
-    global: {
-      branches: 4.6,
-      functions: 4,
-      lines: 8.2,
-      statements: 8.2,
-    },
-  },
+  // coverageThreshold disabled: Jest 29.7.0's CoverageReporter._checkThreshold
+  // calls `_glob().default.sync(...)`, which is incompatible with the
+  // glob >= 13 we pin via package.json overrides for security. v13 has no
+  // `.default.sync` (it exposes named `glob`/`globSync` exports instead),
+  // so any threshold check throws `Cannot read properties of undefined`
+  // and tanks the entire test run. Restore this block once we either
+  // upgrade Jest to a release that uses globSync, or move threshold
+  // gating to a separate tool (e.g. c8/nyc).
   // Configure jest-junit reporter for CI
   reporters: [
     "default",

--- a/frontend/lib/utils/__tests__/application-helpers.test.ts
+++ b/frontend/lib/utils/__tests__/application-helpers.test.ts
@@ -117,6 +117,10 @@ describe("Application Helpers", () => {
       submitted_at: "2025-01-02T10:00:00Z",
       reviewed_at: "2025-01-03T10:00:00Z",
       approved_at: "2025-01-04T10:00:00Z",
+      // getApplicationTimeline now conditionalizes professor/college review steps
+      // on these flags. Tests below expect the full 8-step timeline.
+      requires_professor_recommendation: true,
+      requires_college_review: true,
     };
 
     it("should return correct timeline for draft status in Chinese", () => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18225,42 +18225,53 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -119,6 +119,7 @@
     },
     "@isaacs/brace-expansion": ">=5.0.1",
     "glob": ">=13.0.2",
+    "test-exclude": "^8.0.0",
     "lodash": ">=4.17.23",
     "webpack": ">=5.105.0",
     "js-yaml": ">=4.1.1",


### PR DESCRIPTION
## Summary

This branch bundles two distinct concerns; the PR can be split on request.

### 1. Fix file preview / download proxy regex (closes #53) — main user-facing fix

The Next.js proxy at `frontend/app/api/v1/preview/route.ts` and the identical proxy at `frontend/app/api/v1/download/route.ts` rejected every uploaded filename with `HTTP 400 — "Invalid fileId: contains illegal characters"`. Root cause: `validateId()` regex `^[a-zA-Z0-9_-]+$` forbids `.`, but uploaded filenames always carry an extension (`.pdf`/`.jpg`/`.png`).

**Fix:** widen the regex in both files to `^[a-zA-Z0-9_.-]+$` — the same canonical safe-filename pattern the backend uses (per `CLAUDE.md` path-traversal guidelines). The explicit `id.includes("..")` / `includes("/")` / `includes("\\")` check on the line above already blocks path traversal, so allowing single dots only widens the surface to file extensions.

**Affected user-facing flow:** clicking 預覽 on an uploaded bank document (and on application files) — previously rendered an empty pane because the iframe loaded JSON error text that fired `onLoad`.

### 2. Pre-existing CI / Jest test-infrastructure cleanups (commits `ab0caa4` and `dc32db7`)

These two commits were already on the branch when the fix landed:
- Remove `frontend/e2e/` (`@playwright/test` runner setup that was being replaced)
- Disable `coverageThreshold` to dodge Jest 29 + glob 13 bug
- Repair Frontend Tests CI job

These are independent of issue #53.

## Verification

End-to-end against the dev stack (`docker compose -f docker-compose.dev.yml`):

| Check | Result |
|---|---|
| `/api/v1/preview` with `<hash>.pdf` fileId | HTTP 200 + `application/pdf` + `%PDF-1.4` body (was 400) |
| `/api/v1/download` with `<hash>.pdf` fileId | HTTP 200 + `application/pdf` + `%PDF-1.4` body (was 400) |
| Negative case `fileId=..%2Fetc%2Fpasswd` | HTTP 400 `path traversal detected` (regex change does NOT widen attack surface) |
| Numeric fileId (no dot) regression check | HTTP 404 from backend = passed proxy validation, no regression |
| UUID-style `abc-123_DEF` regression check | HTTP 404 from backend = passed proxy validation, no regression |
| Backend logs during click flow | clean — no `ERROR`/`Traceback`/`exception` |

Visual side-by-side from a live browser probe (same format as the bug repro screenshot in #53):

![post-fix-verify](https://raw.githubusercontent.com/anud18/scholarship-system/tmp/issue-screenshots/docs/screenshots/issue-53/preview-after-fix.png)

## Test plan

- [x] Confirm `/api/v1/preview?fileId=<hash>.pdf&...` returns 200 with PDF content
- [x] Confirm `/api/v1/download?fileId=<hash>.pdf&...` returns 200 with PDF content
- [x] Confirm path traversal still rejected (HTTP 400)
- [x] Confirm no regression on numeric / UUID-style fileIds
- [x] Confirm backend logs clean during click flow
- [ ] (Reviewer) Manual smoke: log into staging or local, upload bank-document photo as a student, verify 預覽 button renders the PDF
- [ ] (Reviewer) Decide whether to split this PR into two (regex fix vs. CI/test-infra cleanups)

## Follow-ups (not blocking)

- `validateId` is duplicated verbatim in `preview/route.ts` and `download/route.ts` — worth extracting to `frontend/lib/security/validate-id.ts` later.
- No Jest test scaffolding exists for Next.js API route handlers — adding one for this case would prevent regression. Out of scope for this PR.
- `DELETE /api/v1/user-profiles/me/bank-document` returns success without clearing the DB column — separate ticket needed (noted in #53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
