### PR TITLE
fix: correct stale OCR test assertion for raw_response field (#79)

### DIFF
--- a/backend/app/tests/test_ocr_service.py
+++ b/backend/app/tests/test_ocr_service.py
@@ -248,7 +248,7 @@ class TestOCRService:
         assert result["success"] is False
         assert "Invalid response format" in result["error"]
         assert result["confidence"] == 0.0
-        assert result["raw_response"] == "invalid json response"
+        assert "raw_response" not in result
 
     @pytest.mark.asyncio
     @patch("app.services.ocr_service.settings")


### PR DESCRIPTION
Closes #79

## Summary

- `test_ocr_service.py:251` asserted `result["raw_response"] == "invalid json response"`, but `ocr_service.py` intentionally omits `raw_response` from the return value to prevent leaking raw Gemini API responses (security patch).
- Changed the assertion to `assert "raw_response" not in result`, which matches the current service behaviour and keeps CI green.

> Auto-fix by scheduled agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_016oTz7raMw6efFEMBpJwoF3)_