### PR TITLE
feat(email-mgmt): render HTML body in 查看內容 / 查看模板 dialogs

### DIFF
--- a/frontend/components/email-history-table.tsx
+++ b/frontend/components/email-history-table.tsx
@@ -62,6 +62,16 @@ interface EmailHistoryFilters {
   date_to: string;
 }
 
+function isHtmlContent(body: string): boolean {
+  if (!body) return false;
+  const trimmed = body.trim();
+  return (
+    /^<!doctype/i.test(trimmed) ||
+    /^<html/i.test(trimmed) ||
+    /<(table|div|p|span|br|h[1-6]|ul|ol|li|a\s|img)\b/i.test(trimmed)
+  );
+}
+
 export function EmailHistoryTable({ className }: EmailHistoryTableProps) {
   const [emailHistory, setEmailHistory] = useState<EmailHistoryItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -476,11 +486,23 @@ export function EmailHistoryTable({ className }: EmailHistoryTableProps) {
                                   <Label className="text-sm font-medium text-gray-700">
                                     郵件內容
                                   </Label>
-                                  <div className="bg-gray-50 p-4 rounded-md border max-h-96 overflow-y-auto">
-                                    <pre className="whitespace-pre-wrap text-sm leading-relaxed text-gray-900">
-                                      {selectedEmail.body}
-                                    </pre>
-                                  </div>
+                                  {isHtmlContent(selectedEmail.body) ? (
+                                    <div className="border rounded-md overflow-hidden">
+                                      <iframe
+                                        srcDoc={selectedEmail.body}
+                                        className="w-full"
+                                        style={{ height: "480px", border: "none" }}
+                                        sandbox="allow-same-origin"
+                                        title="郵件內容預覽"
+                                      />
+                                    </div>
+                                  ) : (
+                                    <div className="bg-gray-50 p-4 rounded-md border max-h-96 overflow-y-auto">
+                                      <pre className="whitespace-pre-wrap text-sm leading-relaxed text-gray-900">
+                                        {selectedEmail.body}
+                                      </pre>
+                                    </div>
+                                  )}
                                 </div>
                               </div>
                             )}

--- a/frontend/components/scheduled-emails-table.tsx
+++ b/frontend/components/scheduled-emails-table.tsx
@@ -225,6 +225,16 @@ export function ScheduledEmailsTable({
     return "default";
   };
 
+  const isHtmlContent = (body: string): boolean => {
+    if (!body) return false;
+    const trimmed = body.trim();
+    return (
+      /^<!doctype/i.test(trimmed) ||
+      /^<html/i.test(trimmed) ||
+      /<(table|div|p|span|br|h[1-6]|ul|ol|li|a\s|img)\b/i.test(trimmed)
+    );
+  };
+
   const renderTemplateVariables = (content: string) => {
     if (!content) return content;
 
@@ -697,6 +707,16 @@ export function ScheduledEmailsTable({
                                       className="min-h-64 text-sm"
                                       placeholder="請輸入郵件內容"
                                     />
+                                  ) : isHtmlContent(selectedEmail.body) ? (
+                                    <div className="border rounded-md overflow-hidden">
+                                      <iframe
+                                        srcDoc={selectedEmail.body}
+                                        className="w-full"
+                                        style={{ height: "480px", border: "none" }}
+                                        sandbox="allow-same-origin"
+                                        title="郵件內容預覽"
+                                      />
+                                    </div>
                                   ) : (
                                     <div className="bg-gray-50 p-4 rounded-md border max-h-96 overflow-y-auto">
                                       <div className="whitespace-pre-wrap text-sm leading-relaxed text-gray-900">


### PR DESCRIPTION
## Summary

- Email History 的「查看內容」與 Scheduled Emails 的「查看模板」對話框，過去直接以 `<pre>` 顯示 HTML 原始碼，導致看到一堆 HTML 標籤而非實際郵件排版
- 本 PR 加入 HTML 偵測（`<!doctype` / `<html` / 常見 inline 標籤），若為 HTML 則以沙箱 `<iframe srcDoc=... sandbox="allow-same-origin">` 渲染；純文字仍維持原本呈現方式
- 排程郵件在「編輯模式」下仍使用 Textarea（不影響編輯流程）

## Test plan

- [ ] CI passes (TypeScript + Frontend Tests)
- [ ] 歷史紀錄「查看內容」→ HTML 郵件正確渲染樣式
- [ ] 排程郵件「查看模板」→ HTML 郵件正確渲染樣式
- [ ] 純文字郵件 fallback 正常顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)