### PR TITLE
fix(college-ranking) + feat(email-mgmt): two standalone post-PR87 commits

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -525,7 +525,9 @@ async def get_ranking(
                 "sub_type_metadata": list(sub_type_metadata_map.values()),
                 "items": items,
                 "created_at": ranking.created_at.isoformat(),
-                "college_review_end": config.college_review_end.isoformat() if config and config.college_review_end else None,
+                "college_review_end": (
+                    config.college_review_end.isoformat() if config and config.college_review_end else None
+                ),
             },
         )
 

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -293,22 +293,22 @@ async def get_ranking(
 
         normalized_ranking_semester = normalize_semester_value(ranking.semester)
 
-        if user_college_code:
-            config_stmt = select(ScholarshipConfiguration).where(
-                and_(
-                    ScholarshipConfiguration.scholarship_type_id == ranking.scholarship_type_id,
-                    ScholarshipConfiguration.academic_year == ranking.academic_year,
-                    ScholarshipConfiguration.is_active.is_(True),
-                )
+        # Fetch scholarship config once — used for quota calculation AND deadline banner (#91)
+        _cfg_stmt = select(ScholarshipConfiguration).where(
+            and_(
+                ScholarshipConfiguration.scholarship_type_id == ranking.scholarship_type_id,
+                ScholarshipConfiguration.academic_year == ranking.academic_year,
+                ScholarshipConfiguration.is_active.is_(True),
             )
-            if normalized_ranking_semester:
-                config_stmt = config_stmt.where(ScholarshipConfiguration.semester == normalized_ranking_semester)
-            else:
-                config_stmt = config_stmt.where(ScholarshipConfiguration.semester.is_(None))
+        )
+        if normalized_ranking_semester:
+            _cfg_stmt = _cfg_stmt.where(ScholarshipConfiguration.semester == normalized_ranking_semester)
+        else:
+            _cfg_stmt = _cfg_stmt.where(ScholarshipConfiguration.semester.is_(None))
+        _cfg_result = await db.execute(_cfg_stmt)
+        config = _cfg_result.scalar_one_or_none()
 
-            config_result = await db.execute(config_stmt)
-            config = config_result.scalar_one_or_none()
-
+        if user_college_code:
             if config and config.has_college_quota and isinstance(config.quotas, dict):
 
                 def _record_quota(sub_type_code: str, quota_value: Any) -> None:
@@ -525,6 +525,7 @@ async def get_ranking(
                 "sub_type_metadata": list(sub_type_metadata_map.values()),
                 "items": items,
                 "created_at": ranking.created_at.isoformat(),
+                "college_review_end": config.college_review_end.isoformat() if config and config.college_review_end else None,
             },
         )
 

--- a/frontend/components/email-history-table.tsx
+++ b/frontend/components/email-history-table.tsx
@@ -62,6 +62,16 @@ interface EmailHistoryFilters {
   date_to: string;
 }
 
+function isHtmlContent(body: string): boolean {
+  if (!body) return false;
+  const trimmed = body.trim();
+  return (
+    /^<!doctype/i.test(trimmed) ||
+    /^<html/i.test(trimmed) ||
+    /<(table|div|p|span|br|h[1-6]|ul|ol|li|a\s|img)\b/i.test(trimmed)
+  );
+}
+
 export function EmailHistoryTable({ className }: EmailHistoryTableProps) {
   const [emailHistory, setEmailHistory] = useState<EmailHistoryItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -476,11 +486,23 @@ export function EmailHistoryTable({ className }: EmailHistoryTableProps) {
                                   <Label className="text-sm font-medium text-gray-700">
                                     郵件內容
                                   </Label>
-                                  <div className="bg-gray-50 p-4 rounded-md border max-h-96 overflow-y-auto">
-                                    <pre className="whitespace-pre-wrap text-sm leading-relaxed text-gray-900">
-                                      {selectedEmail.body}
-                                    </pre>
-                                  </div>
+                                  {isHtmlContent(selectedEmail.body) ? (
+                                    <div className="border rounded-md overflow-hidden">
+                                      <iframe
+                                        srcDoc={selectedEmail.body}
+                                        className="w-full"
+                                        style={{ height: "480px", border: "none" }}
+                                        sandbox="allow-same-origin"
+                                        title="郵件內容預覽"
+                                      />
+                                    </div>
+                                  ) : (
+                                    <div className="bg-gray-50 p-4 rounded-md border max-h-96 overflow-y-auto">
+                                      <pre className="whitespace-pre-wrap text-sm leading-relaxed text-gray-900">
+                                        {selectedEmail.body}
+                                      </pre>
+                                    </div>
+                                  )}
                                 </div>
                               </div>
                             )}

--- a/frontend/components/scheduled-emails-table.tsx
+++ b/frontend/components/scheduled-emails-table.tsx
@@ -225,6 +225,16 @@ export function ScheduledEmailsTable({
     return "default";
   };
 
+  const isHtmlContent = (body: string): boolean => {
+    if (!body) return false;
+    const trimmed = body.trim();
+    return (
+      /^<!doctype/i.test(trimmed) ||
+      /^<html/i.test(trimmed) ||
+      /<(table|div|p|span|br|h[1-6]|ul|ol|li|a\s|img)\b/i.test(trimmed)
+    );
+  };
+
   const renderTemplateVariables = (content: string) => {
     if (!content) return content;
 
@@ -697,6 +707,16 @@ export function ScheduledEmailsTable({
                                       className="min-h-64 text-sm"
                                       placeholder="請輸入郵件內容"
                                     />
+                                  ) : isHtmlContent(selectedEmail.body) ? (
+                                    <div className="border rounded-md overflow-hidden">
+                                      <iframe
+                                        srcDoc={selectedEmail.body}
+                                        className="w-full"
+                                        style={{ height: "480px", border: "none" }}
+                                        sandbox="allow-same-origin"
+                                        title="郵件內容預覽"
+                                      />
+                                    </div>
                                   ) : (
                                     <div className="bg-gray-50 p-4 rounded-md border max-h-96 overflow-y-auto">
                                       <div className="whitespace-pre-wrap text-sm leading-relaxed text-gray-900">


### PR DESCRIPTION
## Summary

Two unrelated focused commits that landed locally on \`fix/professor-review-empty-subtypes\` after PR #87 merged. Bundling them into one PR for review velocity since each is small and independently reviewable.

## Commits

### \`098d31b\` — fix(#91): embed college_review_end in ranking detail response

The \`GET /api/v1/college-review/rankings/{id}\` endpoint now returns
\`college_review_end\` alongside the existing ranking data. The config
fetch was moved outside the \`if user_college_code:\` block so it runs
for both college and admin callers and serves both the quota
calculation and the new field. Resolves issue #91.

\`backend/app/api/v1/endpoints/college_review/ranking_management.py\`
(+15 / −14)

### \`43f89b8\` — feat(email-mgmt): render HTML body in 查看內容 / 查看模板 dialogs

Both the Email History and Scheduled Emails tables were displaying
email body as raw text inside \`<pre>\`/\`<div>\` blocks. Since outgoing
emails are HTML, this showed unreadable markup instead of the rendered
message. Switches the dialogs to render the body as sandboxed HTML so
operators see what the recipient sees.

\`frontend/components/email-history-table.tsx\`,
\`frontend/components/scheduled-emails-table.tsx\` (+47 / −5)

## Test plan

- [ ] Open a ranking detail page as a college reviewer; verify the
      response now includes \`college_review_end\` (network tab).
- [ ] Same as admin role; same field present.
- [ ] Open Email History → 查看內容 on any sent email; verify HTML
      renders (not raw \`<table>\` markup).
- [ ] Open Scheduled Emails → 查看模板; verify HTML renders.

## Related

Two more PRs follow this one to clean up the rest of the post-PR87
work: \`pr/b-professor-lock-and-rate-limit\` (security) and
\`pr/c-post-pr87-batch\` (i18n + roster + sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)