### PR TITLE
feat(professor-review): inline error banner for non-lock submit failures (#92)

### DIFF
--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -800,6 +800,14 @@ function ProfessorReviewComponentInner({
                 </div>
               )}
 
+              {/* Inline error from submit/update (e.g. 403 lock) — issue #92 */}
+              {error && !isLocked && (
+                <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900 flex items-start gap-2">
+                  <span className="flex-1">{error}</span>
+                  <button onClick={() => setError(null)} className="shrink-0 text-red-700 hover:text-red-900">✕</button>
+                </div>
+              )}
+
               {/* Application Info */}
               <Card>
                 <CardHeader>


### PR DESCRIPTION
## Summary

The professor review modal already shows a banner when the application
has hit a locked review stage (#64 work). Other submit/update failures
— 403 from the backend lock guard, network errors, validation errors
from `ReviewService` — were silently dropped: only the disabled submit
button indicated something had happened.

This PR adds a complementary inline error banner that appears whenever
\`error\` state is set and the application is NOT in a locked stage
(the existing locked banner already covers that path). The new banner
includes a dismiss button so the operator can clear and retry.

## Diff

`frontend/components/professor-review-component.tsx` (+8 lines, no deletions)

```tsx
{/* Inline error from submit/update (e.g. 403 lock) — issue #92 */}
{error && !isLocked && (
  <div className="rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900 flex items-start gap-2">
    <span className="flex-1">{error}</span>
    <button onClick={() => setError(null)} className="shrink-0 text-red-700 hover:text-red-900">✕</button>
  </div>
)}
```

Reuses the existing \`error\` and \`isLocked\` state already managed by
the modal's submit / update flows — no new state, no behaviour changes.

## Test plan

- [ ] Trigger a submit failure (e.g., disconnect backend mid-submit, or
      submit a review for an application that was just moved to a locked
      stage between modal open and submit). The red banner appears.
- [ ] Click the ✕ to dismiss; banner disappears.
- [ ] Open a review for an already-locked application: only the amber
      locked banner shows (no duplicate red banner).

## Related

- Branched off main at `aba10e2`. No conflict with PR #98.
- Sibling PR (PR-C): backend cleanup for `professor_student.py` and
  `application_service.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)