### PR TITLE
ci(claude-review): skip review for dependabot[bot] PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- `claude-code-action@beta` blocks non-human actors by default
- Dependabot PRs (like #90) were failing the `claude-review` job with: `Workflow initiated by non-human actor: dependabot (type: Bot)`
- Added `if: github.actor != 'dependabot[bot]'` at the job level to skip review for automated dependency bumps

## Test plan

- [ ] Merge this to main first; then re-trigger or wait for the next dependabot PR — `claude-review` should be skipped (`neutral`) rather than failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)