### PR TITLE
fix(#91): wire college_review_end through ranking detail (BE + FE)

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -525,7 +525,9 @@ async def get_ranking(
                 "sub_type_metadata": list(sub_type_metadata_map.values()),
                 "items": items,
                 "created_at": ranking.created_at.isoformat(),
-                "college_review_end": config.college_review_end.isoformat() if config and config.college_review_end else None,
+                "college_review_end": (
+                    config.college_review_end.isoformat() if config and config.college_review_end else None
+                ),
             },
         )
 

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -293,22 +293,22 @@ async def get_ranking(
 
         normalized_ranking_semester = normalize_semester_value(ranking.semester)
 
-        if user_college_code:
-            config_stmt = select(ScholarshipConfiguration).where(
-                and_(
-                    ScholarshipConfiguration.scholarship_type_id == ranking.scholarship_type_id,
-                    ScholarshipConfiguration.academic_year == ranking.academic_year,
-                    ScholarshipConfiguration.is_active.is_(True),
-                )
+        # Fetch scholarship config once — used for quota calculation AND deadline banner (#91)
+        _cfg_stmt = select(ScholarshipConfiguration).where(
+            and_(
+                ScholarshipConfiguration.scholarship_type_id == ranking.scholarship_type_id,
+                ScholarshipConfiguration.academic_year == ranking.academic_year,
+                ScholarshipConfiguration.is_active.is_(True),
             )
-            if normalized_ranking_semester:
-                config_stmt = config_stmt.where(ScholarshipConfiguration.semester == normalized_ranking_semester)
-            else:
-                config_stmt = config_stmt.where(ScholarshipConfiguration.semester.is_(None))
+        )
+        if normalized_ranking_semester:
+            _cfg_stmt = _cfg_stmt.where(ScholarshipConfiguration.semester == normalized_ranking_semester)
+        else:
+            _cfg_stmt = _cfg_stmt.where(ScholarshipConfiguration.semester.is_(None))
+        _cfg_result = await db.execute(_cfg_stmt)
+        config = _cfg_result.scalar_one_or_none()
 
-            config_result = await db.execute(config_stmt)
-            config = config_result.scalar_one_or_none()
-
+        if user_college_code:
             if config and config.has_college_quota and isinstance(config.quotas, dict):
 
                 def _record_quota(sub_type_code: str, quota_value: Any) -> None:
@@ -525,6 +525,7 @@ async def get_ranking(
                 "sub_type_metadata": list(sub_type_metadata_map.values()),
                 "items": items,
                 "created_at": ranking.created_at.isoformat(),
+                "college_review_end": config.college_review_end.isoformat() if config and config.college_review_end else None,
             },
         )
 

--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -121,6 +121,9 @@ export function RankingManagementPanel({
     fetchRankings,
   } = useCollegeManagement();
 
+  // #91 fix: store the college_review_end fetched for the active ranking's config.
+  const [activeConfigDeadline, setActiveConfigDeadline] = useState<string | null>(null);
+
   const fetchRankingDetails = useCallback(
     async (rankingId: number) => {
       setIsRankingLoading(true);
@@ -160,6 +163,9 @@ export function RankingManagementPanel({
             })
           );
 
+          // #91: college_review_end is now returned directly by the ranking detail endpoint
+          setActiveConfigDeadline((response.data as any).college_review_end ?? null);
+
           setRankingData({
             applications: transformedApplications,
             totalQuota: response.data.total_quota || 0,
@@ -186,7 +192,7 @@ export function RankingManagementPanel({
         setIsRankingLoading(false);
       }
     },
-    [setIsRankingLoading, setRankingData]
+    [setIsRankingLoading, setRankingData, setActiveConfigDeadline]
   );
 
   // Auto-refresh when switching to ranking tab or when data version changes
@@ -538,6 +544,7 @@ export function RankingManagementPanel({
         if (selectedRanking === rankingToDelete.id) {
           setSelectedRanking(null);
           setRankingData(null);
+          setActiveConfigDeadline(null);
         }
         await fetchRankings();
         incrementDataVersion();
@@ -617,9 +624,7 @@ export function RankingManagementPanel({
     const id = setInterval(() => setNow(Date.now()), 60_000);
     return () => clearInterval(id);
   }, []);
-  const deadlineISO =
-    (scholarshipConfig as { college_review_end?: string | null } | undefined)
-      ?.college_review_end ?? null;
+  const deadlineISO = activeConfigDeadline;
   const deadlineInfo = useMemo(
     () => computeDeadlineInfo(deadlineISO),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `now` triggers re-eval


### PR DESCRIPTION
## Summary

End-to-end fix for issue #91 (deadline banner on the college ranking page reads stale data):

**Backend** (`ranking_management.py`)
- Embed `college_review_end` in the ranking detail response — fetch the active `ScholarshipConfiguration` once and reuse it for both quota calculation and the deadline banner.

**Frontend** (`RankingManagementPanel.tsx`)
- Read `college_review_end` from the ranking detail response into component state.
- Drive the deadline banner from that state (instead of stale `scholarshipConfig`).
- Reset on ranking switch / delete.

This is the last code-only piece of the original PR #95 that hadn't yet landed via the parallel split-PRs (#97 / #99 / #100). Companion evidence is on branch [`evidence/2026-05-07`](https://github.com/anud18/scholarship-system/tree/evidence/2026-05-07) — see the `03-ranking-page` flow.

Supersedes (and closes) PR #98, which mixed these BE commits with stale email-table changes that have since merged via PR #97.

## Test plan

- [x] TypeScript hoist fix included (TS2448 from `audit/monitoring-stack-phase1`)
- [x] Manual verification on staging during 2026-05-07 revalidation — deadline banner renders correct timestamp and live-updates per minute (see `evidence/2026-05-07/03-ranking-page/REPORT.md`)
- [ ] CI green on this branch (backend black + frontend type-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)