### PR TITLE
feat(#68): add nationality and identity columns to admin list and college ranking export

### DIFF
--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -362,6 +362,7 @@ class ApplicationResponse(BaseModel):
     term_count: Optional[int] = None  # std_termcount / trm_termcount
 
     # === Identity & Status ===
+    student_nationality: Optional[str] = None  # std_nation
     student_identity: Optional[int] = None  # std_identity
     school_identity: Optional[int] = None  # std_schoolid
     gender: Optional[int] = None  # std_sex
@@ -484,6 +485,7 @@ class ApplicationStatusUpdateResponse(BaseModel):
     term_count: Optional[int] = None
 
     # === Identity & Status ===
+    student_nationality: Optional[str] = None
     student_identity: Optional[int] = None
     school_identity: Optional[int] = None
     gender: Optional[int] = None
@@ -574,6 +576,7 @@ class ApplicationListResponse(BaseModel):
     term_count: Optional[int] = None  # std_termcount / trm_termcount
 
     # === Identity & Status ===
+    student_nationality: Optional[str] = None  # std_nation
     student_identity: Optional[int] = None  # std_identity
     school_identity: Optional[int] = None  # std_schoolid
     gender: Optional[int] = None  # std_sex

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -126,6 +126,7 @@ class ApplicationService:
             "enroll_type": student_data.get("std_enrolltype"),
             "term_count": student_data.get("trm_termcount") or student_data.get("std_termcount"),
             # Identity
+            "student_nationality": student_data.get("std_nation"),
             "student_identity": student_data.get("std_identity"),
             "school_identity": student_data.get("std_schoolid"),
             "gender": student_data.get("std_sex"),

--- a/frontend/components/admin-management-interface.tsx
+++ b/frontend/components/admin-management-interface.tsx
@@ -2452,6 +2452,7 @@ export function AdminManagementInterface({
                               <TableRow>
                                 <TableHead>申請編號</TableHead>
                                 <TableHead>學生資訊</TableHead>
+                                <TableHead>國籍/身分</TableHead>
                                 <TableHead>獎學金類型</TableHead>
                                 <TableHead>學年度/學期</TableHead>
                                 <TableHead>狀態</TableHead>
@@ -2463,7 +2464,7 @@ export function AdminManagementInterface({
                               {historicalApplications.length === 0 ? (
                                 <TableRow>
                                   <TableCell
-                                    colSpan={7}
+                                    colSpan={8}
                                     className="text-center py-8 text-gray-500"
                                   >
                                     沒有找到符合條件的申請記錄
@@ -2489,6 +2490,16 @@ export function AdminManagementInterface({
                                           </div>
                                         )}
                                       </div>
+                                    </TableCell>
+                                    <TableCell>
+                                      <div className="text-sm">
+                                        {application.student_nationality || "-"}
+                                      </div>
+                                      {application.student_identity != null && (
+                                        <div className="text-xs text-gray-500">
+                                          身分 {application.student_identity}
+                                        </div>
+                                      )}
                                     </TableCell>
                                     <TableCell>
                                       <div>
@@ -2770,6 +2781,7 @@ export function AdminManagementInterface({
                               <TableRow>
                                 <TableHead>申請編號</TableHead>
                                 <TableHead>學生資訊</TableHead>
+                                <TableHead>國籍/身分</TableHead>
                                 <TableHead>學年度/學期</TableHead>
                                 <TableHead>狀態</TableHead>
                                 <TableHead>申請時間</TableHead>
@@ -2781,7 +2793,7 @@ export function AdminManagementInterface({
                                 .length === 0 ? (
                                 <TableRow>
                                   <TableCell
-                                    colSpan={6}
+                                    colSpan={7}
                                     className="text-center py-8 text-gray-500"
                                   >
                                     沒有找到 {scholarshipType} 的申請記錄
@@ -2809,6 +2821,16 @@ export function AdminManagementInterface({
                                           </div>
                                         )}
                                       </div>
+                                    </TableCell>
+                                    <TableCell>
+                                      <div className="text-sm">
+                                        {application.student_nationality || "-"}
+                                      </div>
+                                      {application.student_identity != null && (
+                                        <div className="text-xs text-gray-500">
+                                          身分 {application.student_identity}
+                                        </div>
+                                      )}
                                     </TableCell>
                                     <TableCell>
                                       <div className="text-sm">

--- a/frontend/components/college-ranking-table.tsx
+++ b/frontend/components/college-ranking-table.tsx
@@ -764,6 +764,8 @@ export function CollegeRankingTable({
           排名: app.rank_position,
           學號: app.student_id || "",
           姓名: app.student_name || "",
+          國籍: app.student_data?.std_nation || "-",
+          身分別: formatIdentityLabel(app.student_data?.std_identity ?? null, "zh"),
           學院: app.academy_name || "-",
           系所: app.department_name || "-",
           獎學金類別: eligibleSubtypes,
@@ -779,6 +781,8 @@ export function CollegeRankingTable({
         { wch: 8 }, // 排名
         { wch: 15 }, // 學號
         { wch: 20 }, // 姓名
+        { wch: 15 }, // 國籍
+        { wch: 15 }, // 身分別
         { wch: 20 }, // 學院
         { wch: 25 }, // 系所
         { wch: 30 }, // 獎學金類別


### PR DESCRIPTION
## Summary

Closes #68

- Add `student_nationality` field to `ApplicationResponse`, `ApplicationStatusUpdateResponse`, and `ApplicationListResponse` backend schemas, extracted from `student_data.std_nation`
- Add `std_nation` extraction to `_extract_student_fields` in `ApplicationService` alongside existing `std_identity`
- Add **國籍/身分** columns to both admin historical application tables (paginated list view and grouped-by-scholarship view)
- Add **國籍** and **身分別** columns to the college ranking Excel export

## Test plan

- [ ] Admin → 歷史申請 → paginated list: 國籍/身分 column visible for each application row
- [ ] Admin → 歷史申請 → by scholarship type tabs: 國籍/身分 column visible
- [ ] College → 排名 → 匯出 XLSX: downloaded file includes 國籍 and 身分別 columns between 姓名 and 學院

🤖 Generated with [Claude Code](https://claude.com/claude-code)