### PR TITLE
fix(#106): catch ReviewPermissionError → 403 instead of 500

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/application_review.py
+++ b/backend/app/api/v1/endpoints/college_review/application_review.py
@@ -61,18 +61,21 @@ async def get_applications_for_review(
         if not semester or semester not in ["first", "second", "annual"]:
             semester = None
 
-    # Granular authorization checks
-    if not current_user.is_college() and not current_user.is_admin() and not current_user.is_super_admin():
-        raise ReviewPermissionError("College role required for application review access")
-
-    # Additional checks for specific operations
-    if scholarship_type_id and not await _check_scholarship_permission(current_user, scholarship_type_id, db):
-        raise ReviewPermissionError(f"User {current_user.id} not authorized for scholarship type {scholarship_type_id}")
-
-    if academic_year and not await _check_academic_year_permission(current_user, academic_year, db):
-        raise ReviewPermissionError(f"User {current_user.id} not authorized for academic year {academic_year}")
-
     try:
+        # Granular authorization checks (must be inside try so ReviewPermissionError
+        # is caught by the handler below and returned as 403, not propagated as 500).
+        if not current_user.is_college() and not current_user.is_admin() and not current_user.is_super_admin():
+            raise ReviewPermissionError("College role required for application review access")
+
+        # Additional checks for specific operations
+        if scholarship_type_id and not await _check_scholarship_permission(current_user, scholarship_type_id, db):
+            raise ReviewPermissionError(
+                f"User {current_user.id} not authorized for scholarship type {scholarship_type_id}"
+            )
+
+        if academic_year and not await _check_academic_year_permission(current_user, academic_year, db):
+            raise ReviewPermissionError(f"User {current_user.id} not authorized for academic year {academic_year}")
+
         # Get college code for filtering (None for super_admin to see all)
         college_code = current_user.college_code if current_user.role == UserRole.college else None
 


### PR DESCRIPTION
## Summary

Fixes #106. Three permission-check raises in `GET /api/v1/college-review/applications` sat outside the `try` block, so the `except ReviewPermissionError → 403` handler never reached them. They propagated through Starlette middleware as unhandled 500s.

## Change

`backend/app/api/v1/endpoints/college_review/application_review.py` — move lines 64–73 (the three permission checks) inside the `try` block. No behavior change for valid requests; only changes how unauthorized requests fail (500 → 403).

## Test plan

- [x] Local: `curl -H "Authorization: Bearer $cs_college_token" 'http://localhost:8000/api/v1/college-review/applications?academic_year=999'` → returns **HTTP 403** with body `{"success": false, "message": "User 13 not authorized for academic year 999", "trace_id": "..."}`
- [x] Backend log shows only `WARNING - Permission denied` — no `ERROR` or `Traceback`
- [ ] Staging (after deploy): same `academic_year=115` request that produced the original 500 should now return 403; monitoring should stop showing `Unhandled exception - ... ReviewPermissionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)