### PR TITLE
fix(#93): rename status param shadow in POST/PUT professor-student endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/professor_student.py
+++ b/backend/app/api/v1/endpoints/professor_student.py
@@ -113,7 +113,7 @@ async def create_professor_student_relationship(
     professor_id: int,
     student_id: int,
     relationship_type: str,
-    status: Optional[str] = "active",
+    active_status: Optional[str] = Query("active", alias="status", description="active|inactive"),
     start_date: Optional[str] = None,
     notes: Optional[str] = None,
     current_user: User = Depends(require_admin),
@@ -163,7 +163,7 @@ async def create_professor_student_relationship(
             professor_id=professor_id,
             student_id=student_id,
             relationship_type=relationship_type,
-            is_active=(status == "active"),
+            is_active=(active_status == "active"),
             notes=notes,
             created_by=current_user.id,
         )
@@ -203,7 +203,7 @@ async def create_professor_student_relationship(
 async def update_professor_student_relationship(
     id: int = Path(..., description="Relationship ID"),
     relationship_type: Optional[str] = None,
-    status: Optional[str] = None,
+    active_status: Optional[str] = Query(None, alias="status", description="active|inactive"),
     end_date: Optional[str] = None,
     notes: Optional[str] = None,
     current_user: User = Depends(require_admin),
@@ -229,8 +229,8 @@ async def update_professor_student_relationship(
         if relationship_type is not None:
             relationship.relationship_type = relationship_type
 
-        if status is not None:
-            relationship.is_active = status == "active"
+        if active_status is not None:
+            relationship.is_active = active_status == "active"
 
         if notes is not None:
             relationship.notes = notes

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -17545,6 +17545,7 @@ export interface operations {
                 professor_id: number;
                 student_id: number;
                 relationship_type: string;
+                /** @description active|inactive */
                 status?: string | null;
                 start_date?: string | null;
                 notes?: string | null;
@@ -17579,6 +17580,7 @@ export interface operations {
         parameters: {
             query?: {
                 relationship_type?: string | null;
+                /** @description active|inactive */
                 status?: string | null;
                 end_date?: string | null;
                 notes?: string | null;


### PR DESCRIPTION
## Summary

Closes #93. PR #100 fixed the GET endpoint by renaming `status` → `active_status` with `alias=\"status\"`. The POST and PUT endpoints in the same file (`professor_student.py` lines 116 and 206) still have the same shadow bug — caught while doing import-chain verification on this file.

## Why it matters

Both POST and PUT have parameters named `status: Optional[str]` that shadow the imported `status` module. Every error path uses `status.HTTP_*`, which fails with `AttributeError: 'str' object has no attribute 'HTTP_400_BAD_REQUEST'` (or similar) and surfaces as a generic 500 instead of the intended 400/404/409.

Admin-only endpoints, so impact is small (only admins hit this), but the error responses are wrong and noisy in logs.

## Change

- POST `/api/v1/professor-student`: rename param `status` → `active_status` with `alias=\"status\"`, update body reference (line 166)
- PUT `/api/v1/professor-student/{id}`: same rename, update both references (lines 232–233)
- API contract preserved — clients still send `?status=active`

## Test plan

- [x] `python -m py_compile` clean
- [x] `black` clean
- [ ] Local: `curl -X POST 'http://localhost:8000/api/v1/professor-student' \`<br/>`-H \"Authorization: Bearer <admin>\" \`<br/>`-d '{...invalid prof_id...}'` → returns 400, not 500
- [ ] Staging: same after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)