### PR TITLE
fix(monitoring): remaining No-data panels (MinIO bucket/node + postgres datname)

### DIFF
--- a/monitoring/config/alloy/staging-db-vm.alloy
+++ b/monitoring/config/alloy/staging-db-vm.alloy
@@ -110,6 +110,28 @@ prometheus.scrape "minio" {
   metrics_path = "/minio/v2/metrics/cluster"
 }
 
+// Bucket-level metrics live behind a separate endpoint. Without this,
+// minio_bucket_usage_total_bytes / minio_bucket_usage_object_total stay
+// missing and the dashboard's Total Storage / Total Objects / Total
+// Buckets / Bucket Usage panels show "No data".
+prometheus.scrape "minio_bucket" {
+  targets    = [{ __address__ = "minio:9000" }]
+  forward_to = [prometheus.relabel.add_labels.receiver]
+  job_name   = "minio"
+  scrape_interval = "30s"
+  metrics_path = "/minio/v2/metrics/bucket"
+}
+
+// Per-node metrics — S3 request rates + traffic counters. Required by
+// the "S3 API Requests" / "S3 API Errors" / "Network Traffic" panels.
+prometheus.scrape "minio_node" {
+  targets    = [{ __address__ = "minio:9000" }]
+  forward_to = [prometheus.relabel.add_labels.receiver]
+  job_name   = "minio"
+  scrape_interval = "15s"
+  metrics_path = "/minio/v2/metrics/node"
+}
+
 prometheus.relabel "add_labels" {
   forward_to = [prometheus.remote_write.default.receiver]
   rule {

--- a/monitoring/config/grafana/provisioning/dashboards/database/minio-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/database/minio-monitoring.json
@@ -94,7 +94,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "minio_bucket_usage_total_bytes{environment=\"$environment\", vm=\"ap-vm\"}",
+          "expr": "minio_bucket_usage_total_bytes{environment=\"$environment\", vm=\"db-vm\"}",
           "legendFormat": "{{bucket}}",
           "refId": "A"
         }
@@ -154,7 +154,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "sum(minio_bucket_usage_object_total{environment=\"$environment\", vm=\"ap-vm\"})",
+          "expr": "sum(minio_bucket_usage_object_total{environment=\"$environment\", vm=\"db-vm\"})",
           "legendFormat": "Total Objects",
           "refId": "A"
         }
@@ -214,7 +214,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "count(minio_bucket_usage_total_bytes{environment=\"$environment\", vm=\"ap-vm\"})",
+          "expr": "count(minio_bucket_usage_total_bytes{environment=\"$environment\", vm=\"db-vm\"})",
           "legendFormat": "Buckets",
           "refId": "A"
         }
@@ -289,7 +289,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "minio_cluster_health_status{environment=\"$environment\", vm=\"ap-vm\"}",
+          "expr": "minio_cluster_health_status{environment=\"$environment\", vm=\"db-vm\"}",
           "legendFormat": "Status",
           "refId": "A"
         }
@@ -392,7 +392,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "rate(minio_s3_requests_total{environment=\"$environment\", vm=\"ap-vm\"}[5m])",
+          "expr": "rate(minio_s3_requests_total{environment=\"$environment\", vm=\"db-vm\"}[5m])",
           "legendFormat": "{{api}}",
           "refId": "A"
         }
@@ -498,7 +498,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "rate(minio_s3_requests_errors_total{environment=\"$environment\", vm=\"ap-vm\"}[5m])",
+          "expr": "rate(minio_s3_requests_errors_total{environment=\"$environment\", vm=\"db-vm\"}[5m])",
           "legendFormat": "{{api}} - errors",
           "refId": "A"
         }
@@ -615,7 +615,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "rate(minio_s3_traffic_received_bytes{environment=\"$environment\", vm=\"ap-vm\"}[5m])",
+          "expr": "rate(minio_s3_traffic_received_bytes{environment=\"$environment\", vm=\"db-vm\"}[5m])",
           "legendFormat": "Received",
           "refId": "A"
         },
@@ -624,7 +624,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "rate(minio_s3_traffic_sent_bytes{environment=\"$environment\", vm=\"ap-vm\"}[5m])",
+          "expr": "rate(minio_s3_traffic_sent_bytes{environment=\"$environment\", vm=\"db-vm\"}[5m])",
           "legendFormat": "Sent",
           "refId": "B"
         }
@@ -713,7 +713,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "minio_bucket_usage_total_bytes{environment=\"$environment\", vm=\"ap-vm\"}",
+          "expr": "minio_bucket_usage_total_bytes{environment=\"$environment\", vm=\"db-vm\"}",
           "legendFormat": "{{bucket}}",
           "refId": "A"
         }

--- a/monitoring/config/grafana/provisioning/dashboards/database/postgresql-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/database/postgresql-monitoring.json
@@ -936,7 +936,7 @@
           "type": "prometheus",
           "uid": "prometheus-uid"
         },
-        "definition": "label_values(pg_up{environment=\"$environment\", vm=\"db-vm\"}, datname)",
+        "definition": "label_values(pg_stat_database_xact_commit{environment=\"$environment\", vm=\"db-vm\"}, datname)",
         "hide": 0,
         "includeAll": true,
         "label": "Database",
@@ -944,7 +944,7 @@
         "name": "database",
         "options": [],
         "query": {
-          "query": "label_values(pg_up{environment=\"$environment\", vm=\"db-vm\"}, datname)",
+          "query": "label_values(pg_stat_database_xact_commit{environment=\"$environment\", vm=\"db-vm\"}, datname)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
Follow-up to #110. Closes the rest of the staging dashboard No-data panels:

| Dashboard | After #110 | After this PR |
|---|---|---|
| MinIO Monitoring | 8/16 no-data | ~0 |
| PostgreSQL Monitoring | 3/16 no-data | ~0 |

Three changes:
1. MinIO dashboard `vm="ap-vm"` → `"db-vm"` (9 panels)
2. Add MinIO `/minio/v2/metrics/bucket` + `/node` scrapes (cluster endpoint alone is too narrow)
3. Postgres `$database` template var: query a per-DB metric instead of pg_up (no datname label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)