### PR TITLE
fix(monitoring): close the last 8 staging No-data panels

### DIFF
--- a/monitoring/config/grafana/provisioning/dashboards/application/nginx-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/application/nginx-monitoring.json
@@ -185,8 +185,8 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(nginx_http_request_duration_seconds_bucket{environment=\"$environment\"}[5m])) by (le))",
-          "legendFormat": "P50",
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{environment=\"$environment\", job=\"backend\"}[5m])) by (le))",
+          "legendFormat": "p50",
           "refId": "A"
         },
         {
@@ -194,8 +194,8 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(nginx_http_request_duration_seconds_bucket{environment=\"$environment\"}[5m])) by (le))",
-          "legendFormat": "P95",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{environment=\"$environment\", job=\"backend\"}[5m])) by (le))",
+          "legendFormat": "p95",
           "refId": "B"
         },
         {
@@ -203,8 +203,8 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(nginx_http_request_duration_seconds_bucket{environment=\"$environment\"}[5m])) by (le))",
-          "legendFormat": "P99",
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{environment=\"$environment\", job=\"backend\"}[5m])) by (le))",
+          "legendFormat": "p99",
           "refId": "C"
         }
       ],
@@ -356,7 +356,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "100 * sum(rate(nginx_http_requests_total{environment=\"$environment\",status=~\"5..\"}[5m])) / sum(rate(nginx_http_requests_total{environment=\"$environment\"}[5m]))",
+          "expr": "100 * (sum(rate(http_requests_total{environment=\"$environment\", job=\"backend\", status=~\"5..\"}[5m])) or vector(0)) / sum(rate(http_requests_total{environment=\"$environment\", job=\"backend\"}[5m]))",
           "legendFormat": "5xx Error Rate",
           "refId": "A"
         },
@@ -365,7 +365,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "100 * sum(rate(nginx_http_requests_total{environment=\"$environment\",status=~\"4..\"}[5m])) / sum(rate(nginx_http_requests_total{environment=\"$environment\"}[5m]))",
+          "expr": "100 * (sum(rate(http_requests_total{environment=\"$environment\", job=\"backend\", status=~\"4..\"}[5m])) or vector(0)) / sum(rate(http_requests_total{environment=\"$environment\", job=\"backend\"}[5m]))",
           "legendFormat": "4xx Error Rate",
           "refId": "B"
         }

--- a/monitoring/config/grafana/provisioning/dashboards/database/postgresql-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/database/postgresql-monitoring.json
@@ -265,7 +265,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decbytes"
         },
         "overrides": []
       },
@@ -297,7 +297,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "sum(pg_stat_database_tup_fetched{environment=\"$environment\", vm=\"db-vm\", datname=\"$database\"})",
+          "expr": "sum(pg_database_size_bytes{environment=\"$environment\", vm=\"db-vm\", datname=\"$database\"})",
           "legendFormat": "Total Size",
           "refId": "A"
         }

--- a/monitoring/config/grafana/provisioning/dashboards/default/scholarship-system-overview.json
+++ b/monitoring/config/grafana/provisioning/dashboards/default/scholarship-system-overview.json
@@ -604,7 +604,7 @@
             "type": "prometheus",
             "uid": "prometheus-uid"
           },
-          "expr": "((sum(rate(http_requests_total{environment=\"$environment\", vm=~\"$vm\", job=\"backend\", status=~\"5..\"}[5m])) / sum(rate(http_requests_total{environment=\"$environment\", vm=~\"$vm\", job=\"backend\"}[5m]))) * 100)",
+          "expr": "(((sum(rate(http_requests_total{environment=\"$environment\", vm=~\"$vm\", job=\"backend\", status=~\"5..\"}[5m])) or vector(0)) / sum(rate(http_requests_total{environment=\"$environment\", vm=~\"$vm\", job=\"backend\"}[5m]))) * 100)",
           "refId": "A"
         }
       ],

--- a/monitoring/config/grafana/provisioning/dashboards/logs/application-logs.json
+++ b/monitoring/config/grafana/provisioning/dashboards/logs/application-logs.json
@@ -213,7 +213,7 @@
             "uid": "loki-staging-uid"
           },
           "editorMode": "code",
-          "expr": "count_over_time({container=~\".*backend.*\", environment=\"$environment\", vm=\"$vm\"} |~ \"ERROR\"[$__auto])",
+          "expr": "sum(count_over_time({container=~\".*backend.*\", environment=\"$environment\", vm=\"$vm\"} |~ \"ERROR\"[$__auto])) or vector(0)",
           "legendFormat": "Errors",
           "queryType": "range",
           "refId": "A"
@@ -283,7 +283,7 @@
             "uid": "loki-staging-uid"
           },
           "editorMode": "code",
-          "expr": "count_over_time({container=~\".*backend.*\", environment=\"$environment\", vm=\"$vm\"} |~ \"WARNING\"[$__auto])",
+          "expr": "sum(count_over_time({container=~\".*backend.*\", environment=\"$environment\", vm=\"$vm\"} |~ \"WARNING\"[$__auto])) or vector(0)",
           "legendFormat": "Warnings",
           "queryType": "range",
           "refId": "A"


### PR DESCRIPTION
Final follow-up on top of #110 + #113. Each of the 8 remaining No-data panels gets a targeted fix:

- **Postgres Database Size** → `pg_database_size_bytes` (was using a tuple counter)
- **App Logs Backend Errors / Warnings** → `or vector(0)` so 0-errors renders as 0
- **Overview Backend Error Rate** → same `or vector(0)` pattern
- **Nginx Request Latency + HTTP Error Rate** → reuse backend's `http_request_duration_seconds_bucket` and `http_requests_total{status=...}` since stock nginx-exporter doesn't expose either (would need VTS module)

Expected: `inspect.js` reports 0 no-data across all 8 dashboards after merge + auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)