### PR TITLE
fix(#63): lock ranking edits/imports for non-admins after deadline

### DIFF
--- a/frontend/components/college-ranking-table.tsx
+++ b/frontend/components/college-ranking-table.tsx
@@ -153,6 +153,11 @@ interface CollegeRankingTableProps {
   academicYear: number;
   semester?: string | null;
   isFinalized: boolean;
+  // #63: when the college_review_end deadline has passed for non-admin users,
+  // we treat the ranking as edit-locked the same way isFinalized does. The
+  // deadline banner above the table already explains *why*; this prop just
+  // hides the edit affordances so users don't try edits the backend will reject.
+  lockedByDeadline?: boolean;
   rankingId?: number;
   onRankingChange: (newOrder: Application[]) => void;
   onReviewApplication: (
@@ -445,6 +450,7 @@ export function CollegeRankingTable({
   academicYear,
   semester,
   isFinalized,
+  lockedByDeadline = false,
   rankingId,
   onRankingChange,
   onReviewApplication,
@@ -454,6 +460,10 @@ export function CollegeRankingTable({
   subTypeMeta,
   saveStatus = "idle",
 }: CollegeRankingTableProps) {
+  // Treat finalized OR deadline-passed as "no more edits". isFinalized
+  // remains used on its own for the "this ranking is locked-finalised"
+  // banner which is a different concept than the deadline lock.
+  const editingLocked = isFinalized || lockedByDeadline;
   const t = (key: string) => getTranslation(locale, key);
   const formatSemesterLabel = (value?: string | null) => {
     if (!value) {
@@ -501,7 +511,7 @@ export function CollegeRankingTable({
   const handleDragEnd = (event: any) => {
     const { active, over } = event;
 
-    if (!over || active.id === over.id || isFinalized) {
+    if (!over || active.id === over.id || editingLocked) {
       return;
     }
 
@@ -864,7 +874,7 @@ export function CollegeRankingTable({
             </div>
 
             <div className="flex gap-2">
-              {!isFinalized && saveStatus !== "idle" && (
+              {!editingLocked && saveStatus !== "idle" && (
                 <div className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-gray-50 border">
                   {saveStatus === "saving" && (
                     <>
@@ -892,7 +902,7 @@ export function CollegeRankingTable({
                   )}
                 </div>
               )}
-              {!isFinalized && (
+              {!editingLocked && (
                 <>
                   <Dialog
                     open={isImportDialogOpen}
@@ -1087,7 +1097,7 @@ export function CollegeRankingTable({
                       index={index}
                       totalQuota={totalQuota}
                       locale={locale}
-                      isFinalized={isFinalized}
+                      isFinalized={editingLocked}
                       onReviewApplication={onReviewApplication}
                       reviewScores={reviewScores}
                       handleScoreUpdate={handleScoreUpdate}

--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -737,6 +737,9 @@ export function RankingManagementPanel({
           <CardDescription>選擇要管理的排名清單</CardDescription>
         </CardHeader>
         <CardContent>
+          {/* #63: when deadline has passed and user isn't admin, hide
+              edit/delete/finalize affordances. Backend enforces the same
+              constraint via assert_ranking_within_deadline. */}
           <RankingCardList
             rankings={filteredRankings}
             selectedRankingId={selectedRanking}
@@ -749,28 +752,43 @@ export function RankingManagementPanel({
             emptyStateConfig={{
               title: "暫無符合條件的排名",
               description: `${scholarshipType.name} 目前在選定的學年度與學期沒有排名`,
-              actionButton: {
-                label: "立即建立排名",
-                onClick: createNewRanking,
-              },
+              actionButton:
+                deadlineInfo.state === "passed" && !isAdmin
+                  ? undefined
+                  : {
+                      label: "立即建立排名",
+                      onClick: createNewRanking,
+                    },
             }}
             editingId={editingRankingId}
             editingName={editingRankingName}
-            onEdit={handleEditRankingName}
+            onEdit={
+              deadlineInfo.state === "passed" && !isAdmin
+                ? undefined
+                : handleEditRankingName
+            }
             onEditNameChange={setEditingRankingName}
             onEditNameSave={handleSaveRankingName}
             onEditNameCancel={handleCancelEditRankingName}
-            onDelete={ranking => {
-              setRankingToDelete(ranking);
-              setShowDeleteRankingDialog(true);
-            }}
-            onToggleLock={(id, isLocked) => {
-              if (isLocked) {
-                handleUnfinalizeRanking(id);
-              } else {
-                handleFinalizeRanking(id);
-              }
-            }}
+            onDelete={
+              deadlineInfo.state === "passed" && !isAdmin
+                ? undefined
+                : ranking => {
+                    setRankingToDelete(ranking);
+                    setShowDeleteRankingDialog(true);
+                  }
+            }
+            onToggleLock={
+              deadlineInfo.state === "passed" && !isAdmin
+                ? undefined
+                : (id, isLocked) => {
+                    if (isLocked) {
+                      handleUnfinalizeRanking(id);
+                    } else {
+                      handleFinalizeRanking(id);
+                    }
+                  }
+            }
             locale={locale}
           />
         </CardContent>
@@ -791,6 +809,9 @@ export function RankingManagementPanel({
               academicYear={rankingData.academicYear}
               semester={rankingData.semester}
               isFinalized={rankingData.isFinalized}
+              lockedByDeadline={
+                deadlineInfo.state === "passed" && !isAdmin
+              }
               rankingId={selectedRanking}
               onRankingChange={handleRankingChange}
               onReviewApplication={handleReviewApplication}


### PR DESCRIPTION
## Summary

Closes the remaining unfinished AC on #63: \"Deadline 過後 → 排名匯入 / 修改功能 disabled\". The deadline banner and countdown landed in PR #103; the backend deadline guard exists; but the FE was still rendering edit/import/finalize/delete buttons that the backend would reject after the deadline passed.

## Change

**`frontend/components/college-ranking-table.tsx`** — add optional `lockedByDeadline` prop. Compute `editingLocked = isFinalized || lockedByDeadline`. Replace the 5 edit-gating `isFinalized` checks (drag handler, drag sortable, save indicator, import dialog, sortable item) with `editingLocked`. The \"已最終確定\" finalize banner (line 1033) stays on `isFinalized` only — it's a different concept than deadline lock.

**`frontend/components/college/ranking/RankingManagementPanel.tsx`** — when `deadlineInfo.state === \"passed\" && !isAdmin`:
- Pass `lockedByDeadline={true}` to the table
- Pass `undefined` for `onEdit / onDelete / onToggleLock` and the empty-state action button on the `RankingCardList` (which hides the buttons that need those handlers)

Admins keep all controls and can still extend the deadline via the scholarship-config admin UI.

## Test plan

- [x] Lint clean (`bun run lint` — no new warnings)
- [ ] Local: open a ranking whose `college_review_end` is in the past as a 學院 user → table shows banner + drag/import/finalize/delete buttons hidden; CardList shows no edit/delete pencils. Same flow as admin → all controls available.
- [ ] Staging: A00001 viewing a past-deadline ranking → only banner visible, no edit affordances; same ranking as E00001 (admin) → all controls available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)