### PR TITLE
fix(monitoring): editable=false on all dashboards (fixes Cannot change resource manager)

### DIFF
--- a/monitoring/config/grafana/provisioning/dashboards/application/container-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/application/container-monitoring.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
@@ -858,6 +858,6 @@
   "timezone": "browser",
   "title": "Container Monitoring (cAdvisor)",
   "uid": "container-monitoring",
-  "version": 1,
+  "version": 6,
   "weekStart": ""
 }

--- a/monitoring/config/grafana/provisioning/dashboards/application/nginx-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/application/nginx-monitoring.json
@@ -2,7 +2,7 @@
   "annotations": {
     "list": []
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
@@ -421,6 +421,6 @@
   "timezone": "browser",
   "title": "Nginx Monitoring",
   "uid": "nginx-monitoring",
-  "version": 2,
+  "version": 7,
   "weekStart": ""
 }

--- a/monitoring/config/grafana/provisioning/dashboards/database/minio-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/database/minio-monitoring.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
@@ -770,6 +770,6 @@
   "timezone": "browser",
   "title": "MinIO Monitoring",
   "uid": "minio-monitoring",
-  "version": 2,
+  "version": 7,
   "weekStart": ""
 }

--- a/monitoring/config/grafana/provisioning/dashboards/database/postgresql-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/database/postgresql-monitoring.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
@@ -964,6 +964,6 @@
   "timezone": "browser",
   "title": "PostgreSQL Monitoring",
   "uid": "postgresql-monitoring",
-  "version": 2,
+  "version": 7,
   "weekStart": ""
 }

--- a/monitoring/config/grafana/provisioning/dashboards/database/redis-monitoring.json
+++ b/monitoring/config/grafana/provisioning/dashboards/database/redis-monitoring.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
@@ -1026,6 +1026,6 @@
   "timezone": "browser",
   "title": "Redis Monitoring",
   "uid": "redis-monitoring",
-  "version": 1,
+  "version": 6,
   "weekStart": ""
 }

--- a/monitoring/config/grafana/provisioning/dashboards/default/scholarship-system-overview.json
+++ b/monitoring/config/grafana/provisioning/dashboards/default/scholarship-system-overview.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
@@ -1141,6 +1141,6 @@
   "timezone": "browser",
   "title": "Scholarship System Overview",
   "uid": "scholarship-overview",
-  "version": 3,
+  "version": 8,
   "weekStart": ""
 }

--- a/monitoring/config/grafana/provisioning/dashboards/logs/application-logs.json
+++ b/monitoring/config/grafana/provisioning/dashboards/logs/application-logs.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
@@ -475,6 +475,6 @@
   "timezone": "",
   "title": "Application Logs",
   "uid": "application-logs",
-  "version": 2,
+  "version": 7,
   "weekStart": ""
 }

--- a/monitoring/config/grafana/provisioning/dashboards/system/node-exporter-system.json
+++ b/monitoring/config/grafana/provisioning/dashboards/system/node-exporter-system.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
@@ -637,6 +637,6 @@
   "timezone": "browser",
   "title": "System Monitoring (Node Exporter)",
   "uid": "node-exporter-system",
-  "version": 1,
+  "version": 6,
   "weekStart": ""
 }


### PR DESCRIPTION
Root cause of why application-logs Backend Errors / Warnings panels still showed "No data" after #117 + #118: dashboards had `editable: true` which Grafana 12 unified storage treats as "UI-manager owned." File-provisioner couldn't take ownership and produced `Cannot change resource manager` errors every 30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)