### PR TITLE
fix(monitoring): new uid for application-logs to bypass stuck Grafana resource manager

### DIFF
--- a/monitoring/config/grafana/provisioning/dashboards/logs/application-logs.json
+++ b/monitoring/config/grafana/provisioning/dashboards/logs/application-logs.json
@@ -474,7 +474,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Application Logs",
-  "uid": "application-logs",
-  "version": 7,
+  "uid": "application-logs-v2",
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Grafana 12's 'Cannot change resource manager' error has the dashboard locked with editable=true. New UID = fresh dashboard, no resource-manager conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)