### PR TITLE
feat(monitoring): webhook-bridge sidecar (FastAPI + uv) for Grafana → GitHub /dispatches

### DIFF
--- a/monitoring/config/grafana/provisioning/alerting/contact-points.yml
+++ b/monitoring/config/grafana/provisioning/alerting/contact-points.yml
@@ -7,32 +7,12 @@ contactPoints:
         type: webhook
         disableResolveMessage: false
         settings:
-          url: https://api.github.com/repos/anud18/scholarship-system/dispatches
+          # Forward through our webhook-bridge sidecar (see
+          # docker-compose.monitoring.yml `webhook-bridge`). Grafana's
+          # webhook contact-point only lets us customize the message
+          # text inside its standard Alertmanager-style envelope, but
+          # GitHub /dispatches strictly requires `{event_type,
+          # client_payload}`. The bridge accepts Grafana's envelope and
+          # re-POSTs to GitHub in the right shape.
+          url: http://monitoring_webhook_bridge:8080/grafana
           httpMethod: POST
-          authorization_scheme: token
-          # GH_PAT mounted as a file at runtime; Grafana reads via $__file{...}
-          authorization_credentials: $__file{/etc/grafana/secrets/gh_pat}
-          # Override default webhook body so GitHub's dispatches API accepts
-          # it (event_type + client_payload wrapper required by
-          # repository_dispatch). Use `printf "%q"` for every interpolated
-          # value so quotes, newlines, and control chars in annotations get
-          # JSON-escaped — without this GitHub returns 422 Unprocessable
-          # Entity on alerts whose summary / description happen to contain
-          # double quotes (which is most of them once template expansion
-          # injects `{{ $value | humanize }}` output).
-          message: |-
-            {
-              "event_type": "monitoring-alert",
-              "client_payload": {
-                "alertname": {{ printf "%q" (index .Alerts 0).Labels.alertname }},
-                "severity": {{ printf "%q" (or (index .Alerts 0).Labels.severity "info") }},
-                "status": {{ printf "%q" .Status }},
-                "summary": {{ printf "%q" (or (index .Alerts 0).Annotations.summary "(no summary)") }},
-                "description": {{ printf "%q" (or (index .Alerts 0).Annotations.description "(no description)") }},
-                "instance": {{ printf "%q" (or (index .Alerts 0).Labels.instance "") }},
-                "environment": {{ printf "%q" (or (index .Alerts 0).Labels.environment "") }},
-                "value": {{ printf "%q" (or (index .Alerts 0).ValueString "") }},
-                "fired_at": "(see grafana_url)",
-                "grafana_url": {{ printf "%q" .ExternalURL }}
-              }
-            }

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -143,6 +143,42 @@ services:
   # =========================================================================
   # If you need alerting, uncomment and configure AlertManager service here
 
+  # =========================================================================
+  # WEBHOOK BRIDGE - Grafana → GitHub /dispatches
+  # =========================================================================
+  # Grafana's webhook contact-point only customises the message *inside*
+  # an Alertmanager-style envelope; GitHub /dispatches strictly requires
+  # `{event_type, client_payload}` and rejects everything else with 422.
+  # This sidecar receives Grafana's envelope on POST /grafana, reformats
+  # it, and forwards to GitHub. The GH_PAT file is shared via a read-only
+  # bind mount.
+  webhook-bridge:
+    build: ./webhook-bridge
+    image: scholarship/webhook-bridge:latest
+    container_name: monitoring_webhook_bridge
+    expose:
+      - "8080"
+    environment:
+      GH_REPO: ${GH_REPO:-anud18/scholarship-system}
+      GH_EVENT_TYPE: ${GH_EVENT_TYPE:-monitoring-alert}
+      GH_PAT_FILE: /etc/webhook-bridge/gh_pat
+    volumes:
+      - /opt/scholarship/secrets/gh_pat:/etc/webhook-bridge/gh_pat:ro
+    networks:
+      - monitoring_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8080/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "5m"
+        max-file: "3"
+
 volumes:
   grafana_data:
     driver: local

--- a/monitoring/webhook-bridge/Dockerfile
+++ b/monitoring/webhook-bridge/Dockerfile
@@ -1,0 +1,19 @@
+# Grafana → GitHub /dispatches webhook bridge.
+# FastAPI + uvicorn, deps installed via uv.
+FROM ghcr.io/astral-sh/uv:python3.12-alpine
+
+# Install deps system-wide so we don't have to deal with venv ownership
+# when we drop privileges below.
+RUN uv pip install --system --no-cache \
+    "fastapi>=0.115" \
+    "uvicorn>=0.32" \
+    "httpx>=0.27"
+
+# Run as non-root.
+RUN adduser -D -u 1100 bridge
+WORKDIR /app
+COPY bridge.py pyproject.toml ./
+
+USER bridge
+EXPOSE 8080
+ENTRYPOINT ["python", "bridge.py"]

--- a/monitoring/webhook-bridge/bridge.py
+++ b/monitoring/webhook-bridge/bridge.py
@@ -1,0 +1,152 @@
+"""
+Tiny Grafana → GitHub repository_dispatch webhook bridge.
+
+Why this exists:
+    Grafana webhook contact-points only let you customize the `message`
+    field *inside* their standard Alertmanager-style envelope. They
+    can't send a raw JSON body. GitHub's /repos/{owner}/{repo}/dispatches
+    endpoint strictly requires `{event_type, client_payload}` and
+    rejects everything else with HTTP 422.
+
+    This bridge listens on :8080, accepts Grafana's standard envelope
+    on POST /grafana, extracts the first alert's fields, and reposts
+    to GitHub /dispatches in the right shape.
+
+Configuration (env):
+    GH_PAT_FILE       path to file containing the GitHub PAT
+                      (default /etc/webhook-bridge/gh_pat)
+    GH_REPO           owner/repo to dispatch to (required)
+    GH_EVENT_TYPE     event_type for repository_dispatch
+                      (default monitoring-alert)
+    LISTEN_HOST       default 0.0.0.0
+    LISTEN_PORT       default 8080
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request, Response, status
+
+GH_PAT_FILE = os.environ.get("GH_PAT_FILE", "/etc/webhook-bridge/gh_pat")
+GH_REPO = os.environ.get("GH_REPO", "").strip()
+GH_EVENT_TYPE = os.environ.get("GH_EVENT_TYPE", "monitoring-alert")
+LISTEN_HOST = os.environ.get("LISTEN_HOST", "0.0.0.0")
+LISTEN_PORT = int(os.environ.get("LISTEN_PORT", "8080"))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("webhook-bridge")
+
+app = FastAPI(title="grafana-github-webhook-bridge", version="1.0")
+
+
+def read_pat() -> str:
+    """Read the PAT from disk on every request so token rotation doesn't
+    require a container restart."""
+    with open(GH_PAT_FILE, "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
+def transform(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Pick the first alert from Grafana's webhook envelope and produce
+    a GitHub-/dispatches-shaped payload (max 10 client_payload keys)."""
+    alerts = envelope.get("alerts") or []
+    a = (alerts[0] if alerts else {}) or {}
+    labels = a.get("labels") or {}
+    annotations = a.get("annotations") or {}
+    return {
+        "event_type": GH_EVENT_TYPE,
+        "client_payload": {
+            "alertname": labels.get("alertname") or "(unknown)",
+            "severity": labels.get("severity") or "info",
+            "status": envelope.get("status") or a.get("status") or "firing",
+            "summary": annotations.get("summary") or "(no summary)",
+            "description": annotations.get("description") or "(no description)",
+            "instance": labels.get("instance") or "",
+            "environment": labels.get("environment") or "",
+            "value": str(a.get("valueString") or ""),
+            "fired_at": str(a.get("startsAt") or ""),
+            "grafana_url": envelope.get("externalURL") or "",
+        },
+    }
+
+
+@app.get("/")
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+
+@app.post("/grafana")
+async def grafana(request: Request):
+    if not GH_REPO:
+        log.error("GH_REPO env var not set")
+        raise HTTPException(500, "GH_REPO env var not set")
+
+    try:
+        envelope = await request.json()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("invalid JSON from grafana: %s", exc)
+        raise HTTPException(400, f"invalid json: {exc}") from exc
+
+    if not envelope.get("alerts"):
+        log.info("no alerts in envelope; ignoring")
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    try:
+        pat = read_pat()
+    except OSError as exc:
+        log.error("failed to read PAT file: %s", exc)
+        raise HTTPException(500, f"failed to read PAT file: {exc}") from exc
+
+    payload = transform(envelope)
+    cp = payload["client_payload"]
+    log.info(
+        "forwarding alertname=%s severity=%s status=%s",
+        cp["alertname"], cp["severity"], cp["status"],
+    )
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            r = await client.post(
+                f"https://api.github.com/repos/{GH_REPO}/dispatches",
+                json=payload,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {pat}",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    "User-Agent": "grafana-github-webhook-bridge/1.0",
+                },
+            )
+        except httpx.HTTPError as exc:
+            log.error("upstream connection failed: %s", exc)
+            raise HTTPException(502, f"upstream connection failed: {exc}") from exc
+
+    if 200 <= r.status_code < 300:
+        log.info("github accepted: %s", r.status_code)
+        return {"status": "ok", "github_status": r.status_code}
+    log.warning("github rejected: %s body=%s", r.status_code, r.text[:200])
+    raise HTTPException(502, f"upstream {r.status_code}: {r.text[:200]}")
+
+
+def main():
+    if not GH_REPO:
+        log.error("GH_REPO env var must be set (e.g. owner/repo)")
+        sys.exit(2)
+    log.info(
+        "listening on %s:%s repo=%s event_type=%s",
+        LISTEN_HOST, LISTEN_PORT, GH_REPO, GH_EVENT_TYPE,
+    )
+    uvicorn.run(app, host=LISTEN_HOST, port=LISTEN_PORT, log_config=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring/webhook-bridge/pyproject.toml
+++ b/monitoring/webhook-bridge/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "webhook-bridge"
+version = "1.0.0"
+description = "Grafana → GitHub repository_dispatch webhook bridge"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn>=0.32",
+    "httpx>=0.27",
+]


### PR DESCRIPTION
Grafana webhook can't customize the outer envelope; GitHub /dispatches strictly requires `{event_type, client_payload}`. The bridge translates Grafana's standard Alertmanager-style envelope into the right shape and forwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)