### PR TITLE
test(#124): pure-unit coverage for roster eligibility operators + cron parsing

### DIFF
--- a/backend/app/tests/test_roster_eligibility_operators.py
+++ b/backend/app/tests/test_roster_eligibility_operators.py
@@ -1,0 +1,166 @@
+"""
+Pure-unit tests for `RosterService._evaluate_condition`.
+
+This is the inner loop of eligibility checking — every scholarship rule
+condition runs through one of the 10 operators below, so a regression here
+disqualifies real students or sneaks unqualified ones into the roster Excel.
+The method is dependency-free (no DB / no IO), so we instantiate the service
+with a `MagicMock` session and call the bound method directly.
+
+Covers issue #124 § 1 (rule-eval unit tests).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.roster_service import RosterService
+
+
+@pytest.fixture
+def evaluator():
+    # _evaluate_condition does not touch the db; the session is only stored
+    # for other methods on the service. A MagicMock keeps the constructor happy.
+    return RosterService(db=MagicMock())._evaluate_condition
+
+
+# ---------------------------------------------------------------------------
+# None-handling: every operator must short-circuit to False on None inputs,
+# never raise. A real-world trigger is a transfer student whose GPA hasn't
+# been imported yet.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "operator,expected_value",
+    [
+        (">=", "3.0"),
+        ("<=", "3.0"),
+        (">", "3.0"),
+        ("<", "3.0"),
+        ("==", "foo"),
+        ("!=", "foo"),
+        ("in", "a,b,c"),
+        ("not_in", "a,b,c"),
+        ("contains", "foo"),
+        ("not_contains", "foo"),
+    ],
+)
+def test_none_actual_value_returns_false(evaluator, operator, expected_value):
+    assert evaluator(None, operator, expected_value) is False
+
+
+# ---------------------------------------------------------------------------
+# Numeric comparisons (>=, <=, >, <)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "actual,op,expected,result",
+    [
+        # GPA threshold
+        (3.5, ">=", "3.0", True),
+        (3.0, ">=", "3.0", True),  # boundary
+        (2.9, ">=", "3.0", False),
+        (3.0, "<=", "3.0", True),  # boundary
+        (3.0, ">", "3.0", False),  # strict
+        (3.0, "<", "3.0", False),  # strict
+        # Stringified numerics: scholarship rules sometimes ship as strings
+        ("3.5", ">=", "3.0", True),
+        # Integer comparison
+        (5, ">", "4", True),
+    ],
+)
+def test_numeric_comparison(evaluator, actual, op, expected, result):
+    assert evaluator(actual, op, expected) is result
+
+
+def test_numeric_comparison_with_garbage_expected_value_logs_and_returns_false(evaluator, caplog):
+    # A typo in the rule config (e.g. expected_value="three") used to crash
+    # the whole roster generation. The handler swallows the ValueError and
+    # logs it instead.
+    assert evaluator(3.5, ">=", "three") is False
+
+
+# ---------------------------------------------------------------------------
+# Equality (==, !=) — string-stripped, never numeric
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "actual,op,expected,result",
+    [
+        ("active", "==", "active", True),
+        ("active", "==", "inactive", False),
+        ("active", "!=", "inactive", True),
+        # Whitespace gets stripped from BOTH sides (real bug we hit when the
+        # spreadsheet import had trailing spaces in expected_value).
+        ("  active  ", "==", "active", True),
+        ("active", "==", "  active  ", True),
+        # Mixed numeric / string is compared as strings — important to know
+        # because rule configs are JSON and TS-side may stringify numbers.
+        (3, "==", "3", True),
+        (3, "==", "3.0", False),  # string-equality, not numeric
+    ],
+)
+def test_equality_operators(evaluator, actual, op, expected, result):
+    assert evaluator(actual, op, expected) is result
+
+
+# ---------------------------------------------------------------------------
+# Membership (in, not_in) — comma-split list, whitespace-stripped per element
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "actual,op,expected,result",
+    [
+        ("CS", "in", "CS,EE,ME", True),
+        ("CS", "in", "EE,ME", False),
+        ("CS", "not_in", "EE,ME", True),
+        ("CS", "not_in", "CS,EE", False),
+        # Whitespace inside the comma list — common HackMD copy-paste artifact.
+        ("CS", "in", " CS , EE , ME ", True),
+        # Whitespace on the actual value too.
+        ("  CS  ", "in", "CS,EE", True),
+        # Empty list (degenerate config) — nothing matches.
+        ("CS", "in", "", False),
+        ("CS", "not_in", "", True),
+    ],
+)
+def test_membership_operators(evaluator, actual, op, expected, result):
+    assert evaluator(actual, op, expected) is result
+
+
+# ---------------------------------------------------------------------------
+# Substring (contains, not_contains)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "actual,op,expected,result",
+    [
+        ("國科會獎學金", "contains", "國科會", True),
+        ("國科會獎學金", "contains", "教育部", False),
+        ("國科會獎學金", "not_contains", "教育部", True),
+        ("國科會獎學金", "not_contains", "國科會", False),
+        # Empty needle is technically a substring of anything; document the
+        # current behavior so future refactors don't quietly flip it.
+        ("anything", "contains", "", True),
+        ("anything", "not_contains", "", False),
+    ],
+)
+def test_substring_operators(evaluator, actual, op, expected, result):
+    assert evaluator(actual, op, expected) is result
+
+
+# ---------------------------------------------------------------------------
+# Unknown operator — must return False (and log a warning), never raise.
+# This guards against typos in scholarship-rule configs proliferating into
+# crashes during the once-a-month roster generation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("operator", ["===", "like", "regex", "GREATER_THAN", ""])
+def test_unknown_operator_returns_false(evaluator, operator):
+    assert evaluator("anything", operator, "anything") is False

--- a/backend/app/tests/test_roster_scheduler_cron.py
+++ b/backend/app/tests/test_roster_scheduler_cron.py
@@ -1,0 +1,132 @@
+"""
+Pure-unit tests for `RosterSchedulerService._parse_cron_expression`.
+
+Schedules drive the once-a-month payment roster fire — a parser regression
+silently shifts the fire window or refuses to schedule. The method itself is
+DB-free; we just instantiate the service.
+
+Covers issue #124 § 6a (cron parsing, pure unit).
+"""
+
+import pytest
+
+from app.services.roster_scheduler_service import RosterSchedulerService
+
+
+@pytest.fixture
+def parser():
+    return RosterSchedulerService()._parse_cron_expression
+
+
+# ---------------------------------------------------------------------------
+# Happy path — standard 5-field "min hour day month dow"
+# ---------------------------------------------------------------------------
+
+
+def test_parses_standard_five_field_expression(parser):
+    assert parser("0 3 * * *") == {
+        "minute": "0",
+        "hour": "3",
+        "day": "*",
+        "month": "*",
+        "day_of_week": "*",
+    }
+
+
+def test_parses_specific_day_of_month(parser):
+    # 1st of every month at 09:30 — typical monthly roster cadence.
+    assert parser("30 9 1 * *") == {
+        "minute": "30",
+        "hour": "9",
+        "day": "1",
+        "month": "*",
+        "day_of_week": "*",
+    }
+
+
+def test_parses_step_and_range_atoms_passthrough(parser):
+    # We don't expand cron atoms — APScheduler does. Just confirm the
+    # passthrough preserves them exactly.
+    parsed = parser("*/5 8-18 * * 1-5")
+    assert parsed["minute"] == "*/5"
+    assert parsed["hour"] == "8-18"
+    assert parsed["day_of_week"] == "1-5"
+
+
+# ---------------------------------------------------------------------------
+# Whitespace tolerance — copy-paste from HackMD often introduces tabs or
+# multiple spaces. Standard split() collapses them.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "0 3 * * *",
+        "  0 3 * * *  ",
+        "0  3  *  *  *",
+        "0\t3\t*\t*\t*",
+    ],
+)
+def test_tolerates_extra_whitespace(parser, raw):
+    parsed = parser(raw)
+    assert parsed == {
+        "minute": "0",
+        "hour": "3",
+        "day": "*",
+        "month": "*",
+        "day_of_week": "*",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Field-count enforcement — APScheduler accepts a `seconds` field too, but
+# this codebase deliberately rejects 6+ to keep the contract simple. A 4-field
+# expression silently changes meaning (legacy 4-field cron has different
+# field positions), so we reject those too.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",  # empty
+        "0",  # one field
+        "0 3",  # two fields
+        "0 3 *",  # three fields
+        "0 3 * *",  # four fields
+        "0 3 * * * *",  # six fields (APScheduler-style with seconds)
+        "0 0 3 * * * *",  # seven fields
+    ],
+)
+def test_rejects_wrong_field_count(parser, raw):
+    with pytest.raises(ValueError, match="Invalid cron expression format"):
+        parser(raw)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases that have bitten production cron parsers in other systems.
+# We DON'T validate the ranges (APScheduler does that on schedule registration)
+# but we should make sure they parse without crashing.
+# ---------------------------------------------------------------------------
+
+
+def test_day_31_month_specifier_parses(parser):
+    # APScheduler is responsible for skipping months without a 31st;
+    # the parser just hands the field through.
+    parsed = parser("0 3 31 * *")
+    assert parsed["day"] == "31"
+
+
+def test_leap_day_specifier_parses(parser):
+    # Feb 29 — APScheduler will run this only on leap years.
+    parsed = parser("0 3 29 2 *")
+    assert parsed["day"] == "29"
+    assert parsed["month"] == "2"
+
+
+def test_complex_expression_with_lists_and_steps(parser):
+    # 09:00, 12:00, 17:00 on weekdays
+    parsed = parser("0 9,12,17 * * 1-5")
+    assert parsed["hour"] == "9,12,17"
+    assert parsed["day_of_week"] == "1-5"


### PR DESCRIPTION
## Summary

First chunk for #124. Adds two zero-IO test files (62 cases, 0.11s) covering two of the most footgun-prone parts of the roster subsystem that previously had **zero** automated coverage.

This PR is intentionally tiny so it can land green and fast. Subsequent PRs on the same issue will bring the harder sections (eligibility flow with fixtures, lifecycle, scheduler integration, FE Playwright).

## Files

- `backend/app/tests/test_roster_eligibility_operators.py` — covers `RosterService._evaluate_condition` (all 10 operators × happy + edge: None, whitespace, empty list, garbage numeric, unknown operator). § 1 of the test plan.
- `backend/app/tests/test_roster_scheduler_cron.py` — covers `RosterSchedulerService._parse_cron_expression` (5-field standard, whitespace tolerance, field-count enforcement, day-31/leap-29 passthrough). § 6a of the test plan.

## Why these two first

Both methods are dependency-free (no DB, no async, no IO), so the tests instantiate the service with a `MagicMock` session and call the bound method directly. That keeps this PR firmly inside what CI already knows how to run — no new fixtures, no flaky scheduler integration, no Playwright wiring.

Everything else in the test plan needs at least a DB fixture, plus the scheduler integration tests need an APScheduler harness. Doing those in separate PRs lets each one land on its own merits.

## Tracking

Followups for #124 (one PR per section as they get done):
- [ ] § 2 eligibility validation flow (fixtures: scholarship_config + rules + students)
- [ ] § 3 idempotency / concurrency (TOCTOU)
- [ ] § 4 lifecycle transitions
- [ ] § 5 received_months excluded-aware
- [ ] § 6b–d scheduler integration + missed-fire policy + slow E2E
- [ ] § 7 API contract / auth gates
- [ ] § 8 `frontend/e2e/specs/roster-admin.spec.ts`

## Test plan

- [x] Local `pytest` clean: 62 passed in 0.11s
- [x] `black --line-length=120` clean
- [x] No new fixtures, no DB, no scheduler — runs as a pure unit suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)