### PR TITLE
fix(deploy): bump cadvisor pin v0.54.2 → v0.55.1 (tag did not exist)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -234,7 +234,7 @@ services:
   # and monitor Docker containers. This is a known requirement for cAdvisor.
   # Security: Ensure this service is not exposed to the public internet.
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.54.2
+    image: gcr.io/cadvisor/cadvisor:v0.55.1
     container_name: cadvisor_prod_ap
     privileged: true
     devices:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -152,7 +152,7 @@ services:
 
   # cAdvisor - Container metrics
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.54.2
+    image: gcr.io/cadvisor/cadvisor:v0.55.1
     container_name: cadvisor_staging_ap
     privileged: true
     devices:


### PR DESCRIPTION
## Summary

Fixes the **Deploy to Staging** job on `main` (run [25549938231](https://github.com/anud18/scholarship-system/actions/runs/25549938231)). PR #155 pinned cadvisor to `v0.54.2` but that tag was never published on `gcr.io/cadvisor/cadvisor` — likely a typo for `v0.54.1`. The deploy fails pulling the image:

```
manifest for gcr.io/cadvisor/cadvisor:v0.54.2 not found:
manifest unknown: Failed to fetch "v0.54.2"
```

Recent valid tags on gcr.io: `v0.54.1`, `v0.55.1` (no `v0.55.0` published either, fwiw). Going to `v0.55.1` since #155's stated intent was "current-as-of-May-2026" — same major line, latest published stable.

Verified the other four pins from #155 are all valid on Docker Hub (`grafana/alloy:v1.11.0`, `prom/node-exporter:v1.10.1`, `nginx/nginx-prometheus-exporter:1.5.0`, `oliver006/redis_exporter:v1.79.0`). Only cadvisor was wrong.

## Files

- `docker-compose.staging.yml`
- `docker-compose.prod.yml`

## Test plan

- [x] `curl https://gcr.io/v2/cadvisor/cadvisor/manifests/v0.55.1` → 200
- [ ] After merge: Deploy to Staging job succeeds; cadvisor container reports healthy on the staging host

🤖 Generated with [Claude Code](https://claude.com/claude-code)