### PR TITLE
fix(monitoring): bridge collapses envelope into 1 dispatch (revert PR #154 fan-out)

### DIFF
--- a/monitoring/webhook-bridge/bridge.py
+++ b/monitoring/webhook-bridge/bridge.py
@@ -55,26 +55,50 @@ def read_pat() -> str:
         return f.read().strip()
 
 
-def transform_one(
-    a: dict[str, Any], envelope_status: str, external_url: str
-) -> dict[str, Any]:
-    """Build one GitHub-/dispatches-shaped payload for a single alert
-    (max 10 client_payload keys)."""
-    labels = a.get("labels") or {}
-    annotations = a.get("annotations") or {}
+def transform_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Collapse a Grafana envelope (which can carry 25+ alerts for the
+    same rule firing on different instances) into ONE GitHub
+    /dispatches payload. The handler workflow dedupes by
+    `(alertname, env)` labels anyway, so per-alert fan-out just spams
+    the same issue with redundant comments. Instead, fold the
+    instance list into a single payload so the issue body shows all
+    affected instances at once.
+
+    Max 10 client_payload keys (GitHub /dispatches limit)."""
+    alerts = envelope.get("alerts") or []
+    a0 = (alerts[0] if alerts else {}) or {}
+    labels0 = a0.get("labels") or {}
+    annotations0 = a0.get("annotations") or {}
+
+    # Collect distinct instances across all alerts so the issue body
+    # shows the full footprint, not just the first one.
+    instances = []
+    seen = set()
+    for a in alerts:
+        inst = (a.get("labels") or {}).get("instance") or ""
+        if inst and inst not in seen:
+            seen.add(inst)
+            instances.append(inst)
+    # Truncate to keep the payload reasonable (issue body / GH JSON size).
+    MAX_LISTED = 20
+    instance_str = ", ".join(instances[:MAX_LISTED])
+    if len(instances) > MAX_LISTED:
+        instance_str += f" (+{len(instances) - MAX_LISTED} more)"
+
     return {
         "event_type": GH_EVENT_TYPE,
         "client_payload": {
-            "alertname": labels.get("alertname") or "(unknown)",
-            "severity": labels.get("severity") or "info",
-            "status": envelope_status or a.get("status") or "firing",
-            "summary": annotations.get("summary") or "(no summary)",
-            "description": annotations.get("description") or "(no description)",
-            "instance": labels.get("instance") or "",
-            "environment": labels.get("environment") or "",
-            "value": str(a.get("valueString") or ""),
-            "fired_at": str(a.get("startsAt") or ""),
-            "grafana_url": external_url or "",
+            "alertname": labels0.get("alertname") or "(unknown)",
+            "severity": labels0.get("severity") or "info",
+            "status": envelope.get("status") or a0.get("status") or "firing",
+            "summary": annotations0.get("summary") or "(no summary)",
+            "description": annotations0.get("description") or "(no description)",
+            # `instance` now carries the full deduped list (up to 20).
+            "instance": instance_str or labels0.get("instance") or "",
+            "environment": labels0.get("environment") or "",
+            "value": f"{len(alerts)} alert(s) in this batch",
+            "fired_at": str(a0.get("startsAt") or ""),
+            "grafana_url": envelope.get("externalURL") or "",
         },
     }
 
@@ -108,56 +132,36 @@ async def grafana(request: Request):
         log.error("failed to read PAT file: %s", exc)
         raise HTTPException(500, f"failed to read PAT file: {exc}") from exc
 
-    envelope_status = envelope.get("status") or ""
-    external_url = envelope.get("externalURL") or ""
+    payload = transform_envelope(envelope)
+    cp = payload["client_payload"]
+    log.info(
+        "forwarding alertname=%s severity=%s status=%s alerts=%d instances=%s",
+        cp["alertname"], cp["severity"], cp["status"], len(alerts),
+        cp["instance"][:80],
+    )
+
     headers = {
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {pat}",
         "X-GitHub-Api-Version": "2022-11-28",
         "User-Agent": "grafana-github-webhook-bridge/1.0",
     }
-
-    # Fan out: send one /dispatches per alert. Grafana groups alerts by
-    # (alertname, environment) so a single envelope can carry 25+ alerts
-    # for the same rule firing across multiple instances. The previous
-    # implementation only forwarded the first alert and silently dropped
-    # the rest. The handler workflow already deduplicates by labels, so
-    # repeats from the same group append a comment instead of opening
-    # duplicate issues.
-    sent = 0
-    failures: list[str] = []
     async with httpx.AsyncClient(timeout=10.0) as client:
-        for a in alerts:
-            payload = transform_one(a, envelope_status, external_url)
-            cp = payload["client_payload"]
-            log.info(
-                "forwarding alertname=%s severity=%s status=%s instance=%s",
-                cp["alertname"], cp["severity"], cp["status"], cp["instance"],
+        try:
+            r = await client.post(
+                f"https://api.github.com/repos/{GH_REPO}/dispatches",
+                json=payload,
+                headers=headers,
             )
-            try:
-                r = await client.post(
-                    f"https://api.github.com/repos/{GH_REPO}/dispatches",
-                    json=payload,
-                    headers=headers,
-                )
-            except httpx.HTTPError as exc:
-                log.error("upstream connection failed: %s", exc)
-                failures.append(f"connection: {exc}")
-                continue
+        except httpx.HTTPError as exc:
+            log.error("upstream connection failed: %s", exc)
+            raise HTTPException(502, f"upstream connection failed: {exc}") from exc
 
-            if 200 <= r.status_code < 300:
-                sent += 1
-            else:
-                log.warning(
-                    "github rejected: %s body=%s",
-                    r.status_code, r.text[:200],
-                )
-                failures.append(f"{r.status_code}: {r.text[:80]}")
-
-    if failures and sent == 0:
-        raise HTTPException(502, f"all {len(alerts)} dispatches failed; first: {failures[0]}")
-    log.info("forwarded %d/%d alerts", sent, len(alerts))
-    return {"status": "ok", "sent": sent, "total": len(alerts), "failures": failures}
+    if 200 <= r.status_code < 300:
+        log.info("github accepted: %s", r.status_code)
+        return {"status": "ok", "alerts_collapsed": len(alerts), "github_status": r.status_code}
+    log.warning("github rejected: %s body=%s", r.status_code, r.text[:200])
+    raise HTTPException(502, f"upstream {r.status_code}: {r.text[:200]}")
 
 
 def main():


### PR DESCRIPTION
PR #154 fanned out one webhook per alert — handler dedupes by labels so 35 runs all hit the same issue with 35 redundant comments. 100 runs in 13 minutes observed.

Collapse back to 1 dispatch but fold instance list into client_payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)