### PR TITLE
feat(cache): foundation + reference-data + form-config caching (#162 PR 1)

### DIFF
--- a/backend/app/api/v1/endpoints/application_fields.py
+++ b/backend/app/api/v1/endpoints/application_fields.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.cache import cached, invalidate
 from app.core.deps import get_db
 from app.core.path_security import validate_upload_file
 from app.core.security import get_current_user, require_admin
@@ -37,10 +38,17 @@ async def get_fields_by_scholarship_type(
     scholarship_type: str, db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)
 ):
     """Get all fields for a scholarship type"""
-    service = ApplicationFieldService(db)
-    fields = await service.get_fields_by_scholarship_type(scholarship_type)
-
+    fields = await _get_fields_by_scholarship_type_cached(scholarship_type, db)
     return ApiResponse(success=True, message=f"Fields retrieved for {scholarship_type}", data=fields)
+
+
+@cached(
+    key_fn=lambda scholarship_type, *_, **__: f"fields:{scholarship_type}",
+    ttl=86400,  # 24 h
+)
+async def _get_fields_by_scholarship_type_cached(scholarship_type: str, db: AsyncSession):
+    service = ApplicationFieldService(db)
+    return await service.get_fields_by_scholarship_type(scholarship_type)
 
 
 @router.post("/fields")
@@ -50,7 +58,8 @@ async def create_field(
     """Create a new application field"""
     service = ApplicationFieldService(db)
     field = await service.create_field(field_data, current_user.id)
-
+    await invalidate(f"fields:{field_data.scholarship_type}")
+    await invalidate(f"formconfig:{field_data.scholarship_type}")
     return ApiResponse(success=True, message="Application field created successfully", data=field)
 
 
@@ -68,6 +77,16 @@ async def update_field(
     if not field:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application field not found")
 
+    # `field` is a Pydantic response; pull scholarship_type either from response
+    # or fall back to a broad invalidate.
+    sct = getattr(field, "scholarship_type", None)
+    if sct:
+        await invalidate(f"fields:{sct}")
+        await invalidate(f"formconfig:{sct}")
+    else:
+        await invalidate("fields:")
+        await invalidate("formconfig:")
+
     return ApiResponse(success=True, message="Application field updated successfully", data=field)
 
 
@@ -80,6 +99,10 @@ async def delete_field(field_id: int, db: AsyncSession = Depends(get_db), curren
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application field not found")
 
+    # We don't have scholarship_type cheaply post-delete; clobber the namespace.
+    await invalidate("fields:")
+    await invalidate("formconfig:")
+
     return ApiResponse(success=True, message="Application field deleted successfully", data=True)
 
 
@@ -89,10 +112,17 @@ async def get_documents_by_scholarship_type(
     scholarship_type: str, db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)
 ):
     """Get all documents for a scholarship type"""
-    service = ApplicationFieldService(db)
-    documents = await service.get_documents_by_scholarship_type(scholarship_type)
-
+    documents = await _get_documents_by_scholarship_type_cached(scholarship_type, db)
     return ApiResponse(success=True, message=f"Documents retrieved for {scholarship_type}", data=documents)
+
+
+@cached(
+    key_fn=lambda scholarship_type, *_, **__: f"documents:{scholarship_type}",
+    ttl=86400,  # 24 h
+)
+async def _get_documents_by_scholarship_type_cached(scholarship_type: str, db: AsyncSession):
+    service = ApplicationFieldService(db)
+    return await service.get_documents_by_scholarship_type(scholarship_type)
 
 
 @router.post("/documents")
@@ -104,7 +134,8 @@ async def create_document(
     """Create a new application document"""
     service = ApplicationFieldService(db)
     document = await service.create_document(document_data, current_user.id)
-
+    await invalidate(f"documents:{document_data.scholarship_type}")
+    await invalidate(f"formconfig:{document_data.scholarship_type}")
     return ApiResponse(success=True, message="Application document created successfully", data=document)
 
 
@@ -122,6 +153,14 @@ async def update_document(
     if not document:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application document not found")
 
+    sct = getattr(document, "scholarship_type", None)
+    if sct:
+        await invalidate(f"documents:{sct}")
+        await invalidate(f"formconfig:{sct}")
+    else:
+        await invalidate("documents:")
+        await invalidate("formconfig:")
+
     return ApiResponse(success=True, message="Application document updated successfully", data=document)
 
 
@@ -135,6 +174,9 @@ async def delete_document(
 
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application document not found")
+
+    await invalidate("documents:")
+    await invalidate("formconfig:")
 
     return ApiResponse(success=True, message="Application document deleted successfully", data=True)
 
@@ -153,14 +195,17 @@ async def get_scholarship_form_config(
     """Get complete form configuration for a scholarship type"""
     try:
         logger.debug(f"API: Getting form config for {scholarship_type}")
-        service = ApplicationFieldService(db)
 
         # 管理員可以看到所有欄位（包括停用的），其他用戶只能看到啟用的
         is_admin = current_user.role in ["admin", "super_admin"]
         should_include_inactive = include_inactive or is_admin
 
-        config = await service.get_scholarship_form_config(
-            scholarship_type, should_include_inactive, user_id=current_user.id
+        # We key cache on the *resolved* should_include_inactive so admin and
+        # non-admin views never share an entry. user_id is intentionally NOT
+        # part of the key — the config is identical for everyone in the same
+        # admin/non-admin bucket; user_id is only forwarded for audit logging.
+        config = await _get_scholarship_form_config_cached(
+            scholarship_type, should_include_inactive, db, current_user.id
         )
 
         logger.info(f"API: Form config retrieved successfully for {scholarship_type}")
@@ -172,6 +217,21 @@ async def get_scholarship_form_config(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Form configuration not found for scholarship type: {scholarship_type}",
         )
+
+
+@cached(
+    key_fn=lambda scholarship_type, should_include_inactive, *_, **__: (
+        f"formconfig:{scholarship_type}:{'all' if should_include_inactive else 'active'}"
+    ),
+    ttl=21600,  # 6 h
+)
+async def _get_scholarship_form_config_cached(
+    scholarship_type: str, should_include_inactive: bool, db: AsyncSession, user_id: int
+):
+    service = ApplicationFieldService(db)
+    return await service.get_scholarship_form_config(
+        scholarship_type, should_include_inactive, user_id=user_id
+    )
 
 
 class FormConfigSaveRequest(BaseModel):
@@ -197,6 +257,10 @@ async def save_scholarship_form_config(
         documents_data=config_data.documents,
         user_id=current_user.id,
     )
+
+    await invalidate(f"fields:{scholarship_type}")
+    await invalidate(f"documents:{scholarship_type}")
+    await invalidate(f"formconfig:{scholarship_type}")
 
     return ApiResponse(success=True, message=f"Form configuration saved for {scholarship_type}", data=config)
 

--- a/backend/app/api/v1/endpoints/application_fields.py
+++ b/backend/app/api/v1/endpoints/application_fields.py
@@ -229,9 +229,7 @@ async def _get_scholarship_form_config_cached(
     scholarship_type: str, should_include_inactive: bool, db: AsyncSession, user_id: int
 ):
     service = ApplicationFieldService(db)
-    return await service.get_scholarship_form_config(
-        scholarship_type, should_include_inactive, user_id=user_id
-    )
+    return await service.get_scholarship_form_config(scholarship_type, should_include_inactive, user_id=user_id)
 
 
 class FormConfigSaveRequest(BaseModel):

--- a/backend/app/api/v1/endpoints/reference_data.py
+++ b/backend/app/api/v1/endpoints/reference_data.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.cache import cached
 from app.core.deps import get_db
 from app.models.application import Application
 from app.models.enums import ApplicationCycle, Semester
@@ -149,14 +150,24 @@ async def get_all_reference_data(
     """
     Get all reference data in a single request.
 
-    SECURITY: Sets no-cache headers to prevent sensitive organizational data from being cached.
+    SECURITY: Sets no-cache headers to prevent sensitive organizational data from
+    being cached by browsers / CDNs. Server-side Redis caching (24h) is still
+    applied — it's an internal performance optimisation that never leaks into
+    HTTP cache layers.
     """
 
-    # SECURITY: Prevent caching of organizational structure data
+    # SECURITY: Prevent client-side / CDN caching of organizational structure
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "0"
 
+    return await _get_all_reference_data_cached(session)
+
+
+@cached(key_fn=lambda *_, **__: "refdata:all", ttl=86400)  # 24 h
+async def _get_all_reference_data_cached(session: AsyncSession) -> dict:
+    """Server-side cached body of /reference-data/all. See the wrapper above for
+    the no-store HTTP header rationale."""
     # Get all reference data in parallel
     degrees_result = await session.execute(select(Degree))
     identities_result = await session.execute(select(Identity))
@@ -493,7 +504,11 @@ async def get_scholarship_types_with_cycles(
     session: AsyncSession = Depends(get_db),
 ) -> dict:
     """Get all scholarship types with their application cycles"""
+    return await _get_scholarship_types_with_cycles_cached(session)
 
+
+@cached(key_fn=lambda *_, **__: "refdata:scholarships:active", ttl=43200)  # 12 h
+async def _get_scholarship_types_with_cycles_cached(session: AsyncSession) -> dict:
     stmt = select(ScholarshipType).where(ScholarshipType.status == "active")
     result = await session.execute(stmt)
     scholarships = result.scalars().all()

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.orm.attributes import flag_modified
 
+from app.core.cache import invalidate
 from app.core.security import require_admin, require_staff
 from app.db.deps import get_db
 
@@ -470,6 +471,11 @@ async def update_matrix_quota(
         await db.commit()
         await db.refresh(config)
 
+        # Cache invalidation: matrix quota changes affect refdata + form-config
+        # surfaces. quota:* prefix is owned by PR 2 (quota_service caching).
+        await invalidate("refdata:")
+        await invalidate("formconfig:")
+
         return ApiResponse(
             success=True,
             message=f"Matrix quota updated: {sub_type} - {college}: {old_quota} → {new_quota}",
@@ -787,6 +793,9 @@ async def create_scholarship_configuration(
         await db.commit()
         await db.refresh(new_config)
 
+        await invalidate("refdata:")
+        await invalidate("formconfig:")
+
         return ApiResponse(
             success=True,
             message="獎學金配置建立成功",
@@ -1032,6 +1041,9 @@ async def update_scholarship_configuration(
         await db.commit()
         await db.refresh(config)
 
+        await invalidate("refdata:")
+        await invalidate("formconfig:")
+
         return ApiResponse(
             success=True, message="配置更新成功", data={"id": config.id, "config_code": config.config_code}
         )
@@ -1081,6 +1093,9 @@ async def deactivate_scholarship_configuration(
         config.updated_by = current_user.id
 
         await db.commit()
+
+        await invalidate("refdata:")
+        await invalidate("formconfig:")
 
         return ApiResponse(
             success=True, message="配置已停用", data={"id": config.id, "config_code": config.config_code}
@@ -1164,6 +1179,9 @@ async def duplicate_scholarship_configuration(
         db.add(new_config)
         await db.commit()
         await db.refresh(new_config)
+
+        await invalidate("refdata:")
+        await invalidate("formconfig:")
 
         return ApiResponse(
             success=True, message="配置複製成功", data={"id": new_config.id, "config_code": new_config.config_code}
@@ -1417,6 +1435,9 @@ async def batch_add_whitelist(
 
     await db.commit()
 
+    # Whitelist mutations affect eligibility-driven reference UI.
+    await invalidate("refdata:")
+
     return ApiResponse(
         success=True,
         message=f"成功新增 {added_count} 位學生到白名單",
@@ -1460,6 +1481,8 @@ async def batch_remove_whitelist(
     config.updated_by = current_user.id
 
     await db.commit()
+
+    await invalidate("refdata:")
 
     return ApiResponse(success=True, message=f"成功移除 {removed_count} 位學生", data={"removed_count": removed_count})
 
@@ -1525,6 +1548,7 @@ async def import_whitelist_excel(
         flag_modified(config, "whitelist_student_ids")
         config.updated_by = current_user.id
         await db.commit()
+        await invalidate("refdata:")
 
     return ApiResponse(
         success=True,

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -1,0 +1,304 @@
+"""
+Redis-backed cache + distributed-lock helper.
+
+Mirrors the singleton pattern of `app.core.rate_limiting.get_rate_limiter` so
+the same connection wiring + fail-open semantics apply.
+
+Usage:
+
+    from app.core.cache import cached, invalidate
+
+    @cached(key_fn=lambda scholarship_type, **_: f"fields:{scholarship_type}",
+            ttl=86400)
+    async def get_fields(scholarship_type: str, db=Depends(...), ...):
+        ...
+
+    # Later, after a write:
+    await invalidate("fields:")            # any prefix; uses SCAN + DEL
+
+    async with with_lock("roster:42:2025-1", ttl_seconds=300):
+        ...
+
+Notes for future maintainers:
+  • Cached values must be JSON-serialisable. Pydantic ``BaseModel`` is
+    handled transparently via ``.model_dump()``; datetime/date via
+    ``.isoformat()``. SQLAlchemy ORM rows are NOT supported — call
+    ``.model_dump()`` or convert to a plain dict before returning. This
+    avoids the lazy-loaded-relationship gotcha that bites pickle.
+  • Manual ``psql UPDATE`` outside the app does NOT trigger
+    invalidation. Run ``redis-cli --scan --pattern 'cache:v1:*' | xargs
+    redis-cli del`` after direct DB surgery, or just bump ``KEY_PREFIX``.
+  • Any Redis error falls through to the source-of-truth (cache miss
+    counts as fail-open). A Redis outage degrades the app to "no cache,"
+    not "site down."
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+import uuid
+from contextlib import asynccontextmanager, contextmanager
+from datetime import date, datetime
+from decimal import Decimal
+from functools import wraps
+from typing import Any, Awaitable, Callable, Optional
+
+import redis.asyncio as redis_async
+import redis as redis_sync
+
+logger = logging.getLogger(__name__)
+
+# Bump this to invalidate the entire cache namespace in one shot
+# (deploy a new prefix and the old keys become orphaned, evicted by LRU).
+KEY_PREFIX = "cache:v1:"
+
+_async_client: Optional[redis_async.Redis] = None
+_sync_client: Optional[redis_sync.Redis] = None
+
+
+def _redis_url() -> str:
+    """Resolve at call time so test fixtures can monkeypatch settings."""
+    from app.core.config import settings
+
+    return settings.redis_url
+
+
+def get_cache() -> redis_async.Redis:
+    """Lazy async Redis client. Mirrors ``rate_limiting.get_rate_limiter``."""
+    global _async_client
+    if _async_client is None:
+        _async_client = redis_async.from_url(_redis_url(), decode_responses=False)
+    return _async_client
+
+
+def get_cache_sync() -> redis_sync.Redis:
+    """Lazy sync Redis client (used by sync-only endpoints; PR 3 path)."""
+    global _sync_client
+    if _sync_client is None:
+        _sync_client = redis_sync.from_url(_redis_url(), decode_responses=False)
+    return _sync_client
+
+
+def reset_clients_for_tests() -> None:
+    """Drop the singletons. Used by tests to swap in a FakeRedis."""
+    global _async_client, _sync_client
+    _async_client = None
+    _sync_client = None
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def _default(obj: Any) -> Any:
+    """JSON encoder fallback for the types our app actually returns."""
+    if hasattr(obj, "model_dump"):  # Pydantic v2 BaseModel
+        return obj.model_dump()
+    if hasattr(obj, "dict") and callable(obj.dict):  # Pydantic v1 BaseModel
+        return obj.dict()
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, Decimal):
+        return str(obj)
+    if isinstance(obj, set):
+        return list(obj)
+    raise TypeError(f"Cache value not JSON-serialisable: {type(obj).__name__}")
+
+
+def _dumps(value: Any) -> bytes:
+    return json.dumps(value, default=_default, separators=(",", ":")).encode("utf-8")
+
+
+def _loads(blob: bytes) -> Any:
+    return json.loads(blob)
+
+
+# ---------------------------------------------------------------------------
+# @cached decorator
+# ---------------------------------------------------------------------------
+
+
+def cached(key_fn: Callable[..., str], ttl: int, jitter: float = 0.1):
+    """Cache the return value of an async function in Redis.
+
+    Args:
+        key_fn:    callable(*args, **kwargs) → str. Returns the suffix
+                   appended to ``KEY_PREFIX``. Should ignore Depends-injected
+                   args (db, current_user, response) — typically with ``**_``.
+        ttl:       seconds. Effective expiry has ±``jitter`` randomisation
+                   to avoid stampedes when a hot key expires.
+        jitter:    fraction of ``ttl`` to randomly add/subtract (default
+                   10 %). Set to 0 for deterministic TTL in tests.
+    """
+
+    def decorator(fn: Callable[..., Awaitable[Any]]):
+        @wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any):
+            try:
+                client = get_cache()
+                key = (KEY_PREFIX + key_fn(*args, **kwargs)).encode("utf-8")
+            except TypeError as exc:
+                # Most common cause: key_fn signature doesn't accept the
+                # positional/keyword args the wrapped function receives.
+                # E.g. `lambda **_:` rejects positional. Surface loudly so
+                # the bug doesn't masquerade as "cache silently disabled".
+                logger.error(
+                    "cache: key_fn for %s rejected its args (%s) — "
+                    "caching disabled for this call. Fix the lambda.",
+                    fn.__qualname__, exc,
+                )
+                return await fn(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001
+                # Redis init failure: fail open, retry on next call.
+                logger.warning("cache: key build / redis init failed: %s", exc)
+                return await fn(*args, **kwargs)
+
+            # Lookup
+            try:
+                hit = await client.get(key)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("cache: GET failed (%s); falling through", exc)
+                return await fn(*args, **kwargs)
+
+            if hit is not None:
+                try:
+                    return _loads(hit)
+                except Exception as exc:  # noqa: BLE001
+                    # Corrupt cache entry — drop it and recompute.
+                    logger.warning("cache: parse failed (%s); recomputing", exc)
+                    try:
+                        await client.delete(key)
+                    except Exception:
+                        pass
+
+            # Miss: compute + store
+            value = await fn(*args, **kwargs)
+            try:
+                ttl_actual = max(1, int(ttl * (1 + random.uniform(-jitter, jitter))))
+                await client.set(key, _dumps(value), ex=ttl_actual)
+            except TypeError as exc:
+                # Value isn't serialisable — log loudly so devs notice and
+                # convert to dict, but still return the live value.
+                logger.error(
+                    "cache: value for key=%s is not JSON-serialisable: %s",
+                    key, exc,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("cache: SET failed (%s); not cached", exc)
+            return value
+
+        return wrapper
+
+    return decorator
+
+
+async def invalidate(prefix: str) -> int:
+    """Delete every key matching ``KEY_PREFIX + prefix + *``.
+
+    Uses SCAN, not KEYS, so it's safe in production. Returns the number
+    of keys deleted (best-effort; 0 on Redis error).
+    """
+    try:
+        client = get_cache()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("invalidate: redis init failed (%s)", exc)
+        return 0
+
+    pattern = (KEY_PREFIX + prefix + "*").encode("utf-8")
+    cursor = 0
+    deleted = 0
+    try:
+        while True:
+            cursor, keys = await client.scan(cursor=cursor, match=pattern, count=500)
+            if keys:
+                deleted += await client.delete(*keys)
+            if cursor == 0:
+                break
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("invalidate: SCAN/DEL failed for %r: %s", pattern, exc)
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Distributed lock (SET NX EX)
+# ---------------------------------------------------------------------------
+
+
+class LockBusy(RuntimeError):
+    """Raised when ``with_lock`` cannot acquire the lock immediately."""
+
+    def __init__(self, key: str):
+        super().__init__(f"lock busy: {key}")
+        self.key = key
+
+
+# Lua so check-and-del is atomic; otherwise a stale lock holder could
+# delete someone else's freshly-acquired lock if its TTL elapsed mid-op.
+_RELEASE_LUA = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then "
+    "  return redis.call('del', KEYS[1]) "
+    "else "
+    "  return 0 "
+    "end"
+)
+
+
+@asynccontextmanager
+async def with_lock(key: str, ttl_seconds: int = 60):
+    """Acquire a distributed mutex via SET NX EX.
+
+    Raises ``LockBusy`` if the key is already held. Releases on exit if
+    we still own the token (atomic Lua check-and-del).
+
+    Designed for "prevent the same expensive operation from running
+    twice concurrently" — e.g. payment-roster generation. NOT a
+    fairness primitive; competing callers fail fast rather than wait.
+    """
+    client = get_cache()
+    token = uuid.uuid4().hex.encode("utf-8")
+    full = (KEY_PREFIX + "lock:" + key).encode("utf-8")
+    acquired = await client.set(full, token, nx=True, ex=ttl_seconds)
+    if not acquired:
+        raise LockBusy(full.decode("utf-8"))
+    try:
+        yield token.decode("utf-8")
+    finally:
+        try:
+            await client.eval(_RELEASE_LUA, 1, full, token)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("with_lock: release failed for %s: %s", key, exc)
+
+
+@contextmanager
+def with_lock_sync(key: str, ttl_seconds: int = 60):
+    """Sync sibling of ``with_lock``. Same semantics; for sync endpoints
+    (e.g. the payment-roster generator that uses get_sync_db)."""
+    client = get_cache_sync()
+    token = uuid.uuid4().hex.encode("utf-8")
+    full = (KEY_PREFIX + "lock:" + key).encode("utf-8")
+    acquired = client.set(full, token, nx=True, ex=ttl_seconds)
+    if not acquired:
+        raise LockBusy(full.decode("utf-8"))
+    try:
+        yield token.decode("utf-8")
+    finally:
+        try:
+            client.eval(_RELEASE_LUA, 1, full, token)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("with_lock_sync: release failed for %s: %s", key, exc)
+
+
+__all__ = [
+    "cached",
+    "invalidate",
+    "with_lock",
+    "with_lock_sync",
+    "LockBusy",
+    "get_cache",
+    "get_cache_sync",
+    "reset_clients_for_tests",
+    "KEY_PREFIX",
+]

--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -32,6 +32,7 @@ Notes for future maintainers:
     counts as fail-open). A Redis outage degrades the app to "no cache,"
     not "site down."
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -146,9 +147,9 @@ def cached(key_fn: Callable[..., str], ttl: int, jitter: float = 0.1):
                 # E.g. `lambda **_:` rejects positional. Surface loudly so
                 # the bug doesn't masquerade as "cache silently disabled".
                 logger.error(
-                    "cache: key_fn for %s rejected its args (%s) — "
-                    "caching disabled for this call. Fix the lambda.",
-                    fn.__qualname__, exc,
+                    "cache: key_fn for %s rejected its args (%s) — " "caching disabled for this call. Fix the lambda.",
+                    fn.__qualname__,
+                    exc,
                 )
                 return await fn(*args, **kwargs)
             except Exception as exc:  # noqa: BLE001
@@ -184,7 +185,8 @@ def cached(key_fn: Callable[..., str], ttl: int, jitter: float = 0.1):
                 # convert to dict, but still return the live value.
                 logger.error(
                     "cache: value for key=%s is not JSON-serialisable: %s",
-                    key, exc,
+                    key,
+                    exc,
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.warning("cache: SET failed (%s); not cached", exc)
@@ -238,11 +240,7 @@ class LockBusy(RuntimeError):
 # Lua so check-and-del is atomic; otherwise a stale lock holder could
 # delete someone else's freshly-acquired lock if its TTL elapsed mid-op.
 _RELEASE_LUA = (
-    "if redis.call('get', KEYS[1]) == ARGV[1] then "
-    "  return redis.call('del', KEYS[1]) "
-    "else "
-    "  return 0 "
-    "end"
+    "if redis.call('get', KEYS[1]) == ARGV[1] then " "  return redis.call('del', KEYS[1]) " "else " "  return 0 " "end"
 )
 
 

--- a/backend/app/tests/test_cache.py
+++ b/backend/app/tests/test_cache.py
@@ -4,6 +4,7 @@ Reuses the FakeRedis pattern from test_rate_limiting_unit.py — we deliberately
 do NOT add the `fakeredis` package to dependencies. The shape needed is small:
 get/set/scan/delete/eval/expiry-aware NX SET. ~80 lines.
 """
+
 from __future__ import annotations
 
 import asyncio

--- a/backend/app/tests/test_cache.py
+++ b/backend/app/tests/test_cache.py
@@ -1,0 +1,215 @@
+"""Unit tests for app.core.cache.
+
+Reuses the FakeRedis pattern from test_rate_limiting_unit.py — we deliberately
+do NOT add the `fakeredis` package to dependencies. The shape needed is small:
+get/set/scan/delete/eval/expiry-aware NX SET. ~80 lines.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Optional
+
+import pytest
+from pydantic import BaseModel
+
+from app.core import cache as cache_mod
+
+
+class FakeAsyncRedis:
+    """Minimal in-memory async Redis for tests. Implements just the
+    operations cache.py touches."""
+
+    def __init__(self) -> None:
+        self._store: dict[bytes, tuple[bytes, Optional[float]]] = {}  # key → (value, expires_at)
+        self.fail_next: Optional[Exception] = None  # arm to make next op raise
+
+    def _expired(self, key: bytes) -> bool:
+        entry = self._store.get(key)
+        if entry is None:
+            return True
+        _, exp = entry
+        return exp is not None and exp < time.time()
+
+    async def get(self, key: bytes):
+        if self.fail_next:
+            exc, self.fail_next = self.fail_next, None
+            raise exc
+        if self._expired(key):
+            self._store.pop(key, None)
+            return None
+        return self._store[key][0]
+
+    async def set(self, key: bytes, value: bytes, ex: Optional[int] = None, nx: bool = False, **_):
+        if self.fail_next:
+            exc, self.fail_next = self.fail_next, None
+            raise exc
+        if nx and not self._expired(key) and key in self._store:
+            return None  # NX fails when key exists
+        self._store[key] = (value, time.time() + ex if ex else None)
+        return True
+
+    async def delete(self, *keys: bytes):
+        n = 0
+        for k in keys:
+            if self._store.pop(k, None) is not None:
+                n += 1
+        return n
+
+    async def scan(self, cursor: int = 0, match: bytes = b"*", count: int = 100):
+        pattern = match.decode("utf-8") if isinstance(match, bytes) else match
+        # Naive glob implementation: only support trailing '*'
+        prefix = pattern[:-1].encode("utf-8") if pattern.endswith("*") else pattern.encode("utf-8")
+        # Live-key filter so expired entries don't leak.
+        matched = [k for k in list(self._store.keys()) if k.startswith(prefix) and not self._expired(k)]
+        return 0, matched
+
+    async def eval(self, script: str, numkeys: int, *keys_and_args):
+        # Implement just the release-Lua: check token equals expected, del if so.
+        keys = keys_and_args[:numkeys]
+        args = keys_and_args[numkeys:]
+        key = keys[0] if isinstance(keys[0], bytes) else keys[0].encode("utf-8")
+        expected = args[0] if isinstance(args[0], bytes) else args[0].encode("utf-8")
+        if key in self._store and self._store[key][0] == expected:
+            del self._store[key]
+            return 1
+        return 0
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Replace the cache module's get_cache() with a FakeAsyncRedis singleton."""
+    fake = FakeAsyncRedis()
+    cache_mod.reset_clients_for_tests()
+    monkeypatch.setattr(cache_mod, "get_cache", lambda: fake)
+    yield fake
+    cache_mod.reset_clients_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# @cached
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cached_hits_after_first_call(fake_redis):
+    calls = 0
+
+    @cache_mod.cached(key_fn=lambda x, **_: f"sq:{x}", ttl=60, jitter=0)
+    async def square(x):
+        nonlocal calls
+        calls += 1
+        return {"x": x, "y": x * x}
+
+    a = await square(7)
+    b = await square(7)
+    c = await square(8)
+
+    assert a == {"x": 7, "y": 49}
+    assert a == b
+    assert c == {"x": 8, "y": 64}
+    assert calls == 2  # cache hit on second 7
+
+
+@pytest.mark.asyncio
+async def test_cached_falls_through_on_redis_error(fake_redis):
+    calls = 0
+
+    @cache_mod.cached(key_fn=lambda **_: "boom", ttl=60, jitter=0)
+    async def fn():
+        nonlocal calls
+        calls += 1
+        return {"ok": True}
+
+    fake_redis.fail_next = RuntimeError("redis down")
+    result = await fn()  # GET fails, fall through to live function
+    assert result == {"ok": True}
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cached_handles_pydantic(fake_redis):
+    class Item(BaseModel):
+        name: str
+        n: int
+
+    @cache_mod.cached(key_fn=lambda **_: "items", ttl=60, jitter=0)
+    async def get_items():
+        return [Item(name="a", n=1), Item(name="b", n=2)]
+
+    first = await get_items()
+    second = await get_items()
+    # Pydantic instance the first call; list of dicts on cache hit.
+    assert isinstance(first, list)
+    assert isinstance(second, list)
+    assert second[0]["name"] == "a"
+    assert second[1]["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# invalidate()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_drops_matching_prefix(fake_redis):
+    @cache_mod.cached(key_fn=lambda x, **_: f"fields:{x}", ttl=60, jitter=0)
+    async def fetch(x):
+        return {"x": x}
+
+    @cache_mod.cached(key_fn=lambda **_: "refdata:all", ttl=60, jitter=0)
+    async def fetch_all():
+        return {"all": True}
+
+    await fetch("nstc")
+    await fetch("moe")
+    await fetch_all()
+    assert len(fake_redis._store) == 3
+
+    deleted = await cache_mod.invalidate("fields:")
+    assert deleted == 2
+    # refdata key untouched
+    assert any(b"refdata:all" in k for k in fake_redis._store.keys())
+
+
+@pytest.mark.asyncio
+async def test_invalidate_safe_when_redis_down(fake_redis):
+    fake_redis.fail_next = RuntimeError("redis down")
+    deleted = await cache_mod.invalidate("anything")
+    assert deleted == 0  # no exception
+
+
+# ---------------------------------------------------------------------------
+# with_lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_with_lock_rejects_concurrent_acquirer(fake_redis):
+    async def hold(seconds):
+        async with cache_mod.with_lock("roster:42", ttl_seconds=10):
+            await asyncio.sleep(seconds)
+
+    holder = asyncio.create_task(hold(0.1))
+    await asyncio.sleep(0.01)  # let holder acquire
+
+    with pytest.raises(cache_mod.LockBusy):
+        async with cache_mod.with_lock("roster:42", ttl_seconds=10):
+            pass
+
+    await holder
+
+    # Lock released: a fresh acquire works
+    async with cache_mod.with_lock("roster:42", ttl_seconds=10):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_with_lock_releases_on_exception(fake_redis):
+    with pytest.raises(ValueError):
+        async with cache_mod.with_lock("flaky", ttl_seconds=10):
+            raise ValueError("oops")
+
+    # Subsequent acquire succeeds — lock was released on context exit
+    async with cache_mod.with_lock("flaky", ttl_seconds=10):
+        pass

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -3759,7 +3759,10 @@ export interface paths {
          * Get All Reference Data
          * @description Get all reference data in a single request.
          *
-         *     SECURITY: Sets no-cache headers to prevent sensitive organizational data from being cached.
+         *     SECURITY: Sets no-cache headers to prevent sensitive organizational data from
+         *     being cached by browsers / CDNs. Server-side Redis caching (24h) is still
+         *     applied — it's an internal performance optimisation that never leaks into
+         *     HTTP cache layers.
          */
         get: operations["get_all_reference_data_api_v1_reference_data_all_get"];
         put?: never;


### PR DESCRIPTION
PR 1 of 3 in the Redis-leverage ladder. Tracking issue: #162.

## Summary

- **New**: \`app/core/cache.py\` — \`@cached\`, \`invalidate()\`, \`with_lock\` (async + sync) — ~210 LOC, JSON-only serialisation, Pydantic-friendly, fail-open on Redis error
- **Cached**: \`/reference-data/all\` (24h), \`/reference-data/scholarship-types-with-cycles\` (12h), \`/application-fields/{fields,documents,form-config}/{type}\` (6–24h)
- **Invalidation hooks** added on every write path that mutates this data (application_fields create/update/delete + form-config save, scholarship_configurations CRUD + matrix-quota + whitelist)

## E2E verification (dev stack)

\`\`\`
/reference-data/all                  92ms → 4ms  (~23×)
/reference-data/scholarship-types... 15ms → 2ms  (~7×)
\`\`\`

\`Cache-Control: no-store\` HTTP headers preserved on \`/reference-data/all\` (server-side Redis cache is internal only, never reaches browser/CDN).

## Tests

\`\`\`
pytest backend/app/tests/test_cache.py              7 passed
pytest backend/app/tests/test_rate_limiting_unit.py 16 passed
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)