### PR TITLE
feat(cache): dashboard + quota stats caching (#162 PR 2)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/dashboard.py
+++ b/backend/app/api/v1/endpoints/admin/dashboard.py
@@ -18,6 +18,7 @@ from sqlalchemy import case, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.cache import cached
 from app.core.config import settings
 from app.core.security import require_admin
 from app.db.deps import get_db
@@ -42,30 +43,17 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/dashboard/stats")
-async def get_dashboard_stats(current_user: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
+@cached(
+    key_fn=lambda current_user, db, **__: f"dashboard:stats:{current_user.id}",
+    ttl=60,
+)
+async def _get_dashboard_stats_cached(current_user: User, db: AsyncSession) -> dict:
+    """Body of get_dashboard_stats — cached by admin user_id for 60s.
+
+    Front-end auto-polls every 30s; 60s cache means alternating polls hit
+    cache. Invalidated from application_service after every status change
+    and from users/permissions after admin scope changes.
     """
-    Get dashboard statistics for admin
-
-    Returns system overview data including:
-
-    Primary statistics (matching frontend DashboardStats interface):
-    - total_applications: Total non-draft applications
-    - pending_review: Applications pending review (submitted/under_review)
-    - approved: Approved applications
-    - rejected: Rejected applications
-    - avg_processing_time: Average processing time in days
-
-    Additional statistics (for backward compatibility):
-    - totalUsers: Total registered users
-    - activeApplications: Active applications (same as pending_review)
-    - completedReviews: Completed reviews (approved + rejected)
-    - pendingReviews: Pending reviews (same as pending_review)
-    - totalScholarships: Total scholarship types
-    - systemUptime: System uptime percentage
-    - avgResponseTime: Average response time (same as avg_processing_time)
-    """
-
     # Get user's scholarship permissions
     allowed_scholarship_ids = await get_allowed_scholarship_ids(current_user, db)
 
@@ -150,6 +138,12 @@ async def get_dashboard_stats(current_user: User = Depends(require_admin), db: A
             "totalScholarships": total_scholarships,
         },
     }
+
+
+@router.get("/dashboard/stats")
+async def get_dashboard_stats(current_user: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
+    """Get dashboard statistics for admin (60s cache, scoped to admin user)."""
+    return await _get_dashboard_stats_cached(current_user, db)
 
 
 @router.get("/system/health")
@@ -387,14 +381,12 @@ async def get_recent_applications(
     }
 
 
-@router.get("/scholarships/stats")
-async def get_scholarship_stats(current_user: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
-    """
-    Get scholarship statistics grouped by scholarship type
-
-    Returns applications count and status breakdown for each scholarship type
-    """
-
+@cached(
+    key_fn=lambda current_user, db, **__: f"dashboard:scholarship_stats:{current_user.id}",
+    ttl=60,
+)
+async def _get_scholarship_stats_cached(current_user: User, db: AsyncSession) -> dict:
+    """Body of get_scholarship_stats — cached by admin user_id for 60s."""
     # Get user's scholarship permissions
     allowed_scholarship_ids = await get_allowed_scholarship_ids(current_user, db)
 
@@ -444,6 +436,12 @@ async def get_scholarship_stats(current_user: User = Depends(require_admin), db:
         "message": "Scholarship statistics retrieved successfully",
         "data": stats,
     }
+
+
+@router.get("/scholarships/stats")
+async def get_scholarship_stats(current_user: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
+    """Get scholarship statistics grouped by scholarship type (60s cache)."""
+    return await _get_scholarship_stats_cached(current_user, db)
 
 
 @router.get("/system-announcements")

--- a/backend/app/api/v1/endpoints/admin/permissions.py
+++ b/backend/app/api/v1/endpoints/admin/permissions.py
@@ -13,6 +13,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.cache import invalidate as cache_invalidate
 from app.core.security import check_scholarship_permission, get_current_user, require_admin
 from app.db.deps import get_db
 from app.models.scholarship import ScholarshipType
@@ -230,6 +231,7 @@ async def create_scholarship_permission(
     db.add(new_permission)
     await db.commit()
     await db.refresh(new_permission)
+    await cache_invalidate("dashboard:")
 
     return {
         "success": True,
@@ -313,5 +315,6 @@ async def delete_scholarship_permission(
     # Delete permission
     await db.delete(permission)
     await db.commit()
+    await cache_invalidate("dashboard:")
 
     return {"success": True, "message": "Scholarship permission deleted successfully", "data": None}

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -475,6 +475,7 @@ async def update_matrix_quota(
         # surfaces. quota:* prefix is owned by PR 2 (quota_service caching).
         await invalidate("refdata:")
         await invalidate("formconfig:")
+        await invalidate("quota:")
 
         return ApiResponse(
             success=True,
@@ -795,6 +796,7 @@ async def create_scholarship_configuration(
 
         await invalidate("refdata:")
         await invalidate("formconfig:")
+        await invalidate("quota:")
 
         return ApiResponse(
             success=True,
@@ -1043,6 +1045,7 @@ async def update_scholarship_configuration(
 
         await invalidate("refdata:")
         await invalidate("formconfig:")
+        await invalidate("quota:")
 
         return ApiResponse(
             success=True, message="配置更新成功", data={"id": config.id, "config_code": config.config_code}
@@ -1096,6 +1099,7 @@ async def deactivate_scholarship_configuration(
 
         await invalidate("refdata:")
         await invalidate("formconfig:")
+        await invalidate("quota:")
 
         return ApiResponse(
             success=True, message="配置已停用", data={"id": config.id, "config_code": config.config_code}
@@ -1182,6 +1186,7 @@ async def duplicate_scholarship_configuration(
 
         await invalidate("refdata:")
         await invalidate("formconfig:")
+        await invalidate("quota:")
 
         return ApiResponse(
             success=True, message="配置複製成功", data={"id": new_config.id, "config_code": new_config.config_code}

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -9,6 +9,7 @@ from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.functions import count
 
+from app.core.cache import invalidate as cache_invalidate
 from app.core.security import get_current_user, require_admin
 from app.db.deps import get_db
 from app.models.user import EmployeeStatus, User, UserRole, UserType
@@ -351,6 +352,8 @@ async def update_user(
 
     await db.commit()
     await db.refresh(user)
+    # Role / college_code change can affect dashboard scope for this admin.
+    await cache_invalidate("dashboard:")
 
     return {
         "success": True,
@@ -382,6 +385,7 @@ async def delete_user(
 
     await db.delete(user)
     await db.commit()
+    await cache_invalidate("dashboard:")
 
     return {
         "success": True,
@@ -439,6 +443,7 @@ async def update_user_college(
     user.college_code = college_code
     await db.commit()
     await db.refresh(user)
+    await cache_invalidate("dashboard:")
 
     return {
         "success": True,
@@ -518,6 +523,8 @@ async def bulk_assign_scholarships(
         raise HTTPException(status_code=400, detail="Invalid operation. Use 'set' or 'add'")
 
     await db.commit()
+    # Admin scope changed: dashboard cache for this admin must be rebuilt.
+    await cache_invalidate("dashboard:")
 
     # Get final scholarship list
     final_stmt = (

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -13,6 +13,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.cache import invalidate as cache_invalidate
 from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFoundError, ValidationError
 from app.core.schema_validation import serialize_value
 from app.models.application import Application, ApplicationStatus, ReviewStatus
@@ -72,6 +73,19 @@ class ApplicationService:
         self.db = db
         self.emailService = EmailService()
         self.student_service = StudentService()
+
+    @staticmethod
+    async def _invalidate_app_caches() -> None:
+        """Invalidate dashboard + quota caches after an application status change.
+
+        Best-effort: failures here never raise, so a Redis outage degrades to
+        "cache shows stale stats up to TTL" not "request fails."
+        """
+        try:
+            await cache_invalidate("dashboard:")
+            await cache_invalidate("quota:")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("cache invalidation failed (non-fatal): %s", exc)
 
     def _serialize_for_json(self, data: Any) -> Any:
         """Serialize data for JSON response"""
@@ -1098,6 +1112,8 @@ class ApplicationService:
 
         await self.db.commit()
         await self.db.refresh(application)
+        if update_data.status:
+            await self._invalidate_app_caches()
 
         # Clone bank account proof document when saving draft or updating application
         # This ensures the document is available in the application
@@ -1266,6 +1282,7 @@ class ApplicationService:
                     )
 
         await self.db.commit()
+        await self._invalidate_app_caches()
 
         # Re-query with eager loading to avoid MissingGreenlet on expired attributes
         stmt = (
@@ -1609,6 +1626,7 @@ class ApplicationService:
         application.reviewed_at = datetime.now(timezone.utc)
 
         await self.db.commit()
+        await self._invalidate_app_caches()
 
         # Return fresh copy with all relationships loaded
         return await self.get_application_by_id(application_id, user)
@@ -2025,6 +2043,7 @@ class ApplicationService:
             # Delete from database (cascade will delete related ApplicationFile records)
             await self.db.delete(application)
             await self.db.commit()
+            await self._invalidate_app_caches()
 
             logger.info(f"Hard deleted draft application {application.app_id} from database")
             return application
@@ -2040,6 +2059,7 @@ class ApplicationService:
 
             await self.db.commit()
             await self.db.refresh(application)
+            await self._invalidate_app_caches()
 
             logger.info(f"Soft deleted application {application.app_id}")
             return application
@@ -2101,6 +2121,7 @@ class ApplicationService:
 
         await self.db.commit()
         await self.db.refresh(application)
+        await self._invalidate_app_caches()
 
         return application
 
@@ -2126,6 +2147,7 @@ class ApplicationService:
 
         await self.db.commit()
         await self.db.refresh(application)
+        await self._invalidate_app_caches()
 
         return application
 
@@ -2735,6 +2757,7 @@ class ApplicationService:
 
             logger.info("Step 7: Committing transaction")
             await self.db.commit()
+            await self._invalidate_app_caches()
 
             # Return the created review
             logger.info("Step 8: Fetching created review to return")

--- a/backend/app/services/quota_service.py
+++ b/backend/app/services/quota_service.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.cache import cached
 from app.models.application import Application, ApplicationStatus
 from app.models.enums import QuotaManagementMode
 from app.models.scholarship import ScholarshipConfiguration
@@ -163,6 +164,12 @@ class QuotaService:
             "total": total_count,
         }
 
+    @cached(
+        key_fn=lambda self, scholarship_type_id, sub_type, academic_year, semester, **__: (
+            f"quota:{scholarship_type_id}:{sub_type}:{academic_year}:{semester or 'all'}"
+        ),
+        ttl=300,
+    )
     async def get_quota_status(
         self, scholarship_type_id: int, sub_type: str, academic_year: int, semester: Optional[str]
     ) -> Dict[str, Any]:

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -1068,25 +1068,7 @@ export interface paths {
         };
         /**
          * Get Dashboard Stats
-         * @description Get dashboard statistics for admin
-         *
-         *     Returns system overview data including:
-         *
-         *     Primary statistics (matching frontend DashboardStats interface):
-         *     - total_applications: Total non-draft applications
-         *     - pending_review: Applications pending review (submitted/under_review)
-         *     - approved: Approved applications
-         *     - rejected: Rejected applications
-         *     - avg_processing_time: Average processing time in days
-         *
-         *     Additional statistics (for backward compatibility):
-         *     - totalUsers: Total registered users
-         *     - activeApplications: Active applications (same as pending_review)
-         *     - completedReviews: Completed reviews (approved + rejected)
-         *     - pendingReviews: Pending reviews (same as pending_review)
-         *     - totalScholarships: Total scholarship types
-         *     - systemUptime: System uptime percentage
-         *     - avgResponseTime: Average response time (same as avg_processing_time)
+         * @description Get dashboard statistics for admin (60s cache, scoped to admin user).
          */
         get: operations["get_dashboard_stats_api_v1_admin_dashboard_stats_get"];
         put?: never;
@@ -1166,9 +1148,7 @@ export interface paths {
         };
         /**
          * Get Scholarship Stats
-         * @description Get scholarship statistics grouped by scholarship type
-         *
-         *     Returns applications count and status breakdown for each scholarship type
+         * @description Get scholarship statistics grouped by scholarship type (60s cache).
          */
         get: operations["get_scholarship_stats_api_v1_admin_scholarships_stats_get"];
         put?: never;


### PR DESCRIPTION
PR 2 of 3 in the Redis-leverage ladder. Tracking issue: #162. Builds on #163.

## Summary

- **Dashboard stats**: \`GET /api/v1/admin/dashboard/stats\` and \`GET /api/v1/admin/scholarships/stats\` cached for 60s, keyed per admin user (scope-isolated)
- **Quota service**: \`QuotaService.get_quota_status\` cached for 5min, keyed by \`(type_id, sub_type, year, semester)\`
- **Invalidation hooks**: 7 application status-mutation paths in \`application_service.py\`, user CRUD + scope-change endpoints in \`users.py\` and \`admin/permissions.py\`, quota-changing config mutations in \`scholarship_configurations.py\`

## Out of scope (deferred)

- \`get_current_user\` caching from the original plan: skipped here. User has lazy-loaded relationships traversed inside model methods (\`professor_relationships\` in \`can_access_student_data\`), and the per-request win is small (~5–15ms for a PK lookup). Will revisit if benchmarks show it dominating P50.

## E2E verification (dev stack)

\`\`\`
dashboard/stats          cold=  18.6ms  warm=  0.1ms  speedup= 150.0x
scholarships/stats       cold=   6.7ms  warm=  0.1ms  speedup=  81.1x
quota_service.status     cold= 136.8ms  warm=  0.2ms  speedup= 828.1x

cache:v1:dashboard:stats:{user_id}             TTL ≈ 60s ✓
cache:v1:dashboard:scholarship_stats:{user_id} TTL ≈ 60s ✓
cache:v1:quota:1:general:113:first             TTL ≈ 312s (300s ± 10% jitter ✓)
\`\`\`

## Tests

\`\`\`
pytest backend/app/tests/test_cache.py              7 passed
pytest backend/app/tests/test_rate_limiting_unit.py 16 passed
black --check                                       6 files clean
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)