### PR TITLE
feat(cache): NYCU employee cache + payment-roster lock (#162 PR 3)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/__init__.py
+++ b/backend/app/api/v1/endpoints/admin/__init__.py
@@ -26,6 +26,7 @@ from fastapi import APIRouter
 from .announcements import router as announcements_router
 from .applications import router as applications_router
 from .bank_verification import router as bank_verification_router
+from .cache import router as cache_router
 from .configurations import router as configurations_router
 from .dashboard import router as dashboard_router
 from .email_templates import router as email_templates_router
@@ -52,5 +53,6 @@ router.include_router(configurations_router, tags=["Admin - Configurations"])
 router.include_router(professors_router, tags=["Admin - Professors"])
 router.include_router(bank_verification_router, tags=["Admin - Bank Verification"])
 router.include_router(students_router, prefix="/students", tags=["Admin - Students"])
+router.include_router(cache_router, tags=["Admin - Cache"])
 
 __all__ = ["router"]

--- a/backend/app/api/v1/endpoints/admin/cache.py
+++ b/backend/app/api/v1/endpoints/admin/cache.py
@@ -1,0 +1,37 @@
+"""
+Admin cache management API endpoints.
+
+Manual purge buttons for ops. The cache layer (`app.core.cache`) auto-
+expires every entry, so this is a "I edited rows directly in psql, please
+refresh" escape hatch — not the primary invalidation path. Normal write
+paths invalidate themselves.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+
+from app.core.cache import invalidate
+from app.core.security import require_admin
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/cache/nycu-employees/refresh")
+async def refresh_nycu_employee_cache(current_user: User = Depends(require_admin)):
+    """Drop the cached NYCU employee directory.
+
+    The next /employees/all, /employees/search, or /employees/{no} call
+    will re-paginate the upstream directory. Useful right after a known
+    HR data change.
+    """
+    deleted = await invalidate("nycu:employees:")
+    logger.info("admin cache flush: nycu:employees: by user=%s, deleted=%d", current_user.id, deleted)
+    return {
+        "success": True,
+        "message": f"NYCU employee cache invalidated ({deleted} keys removed)",
+        "data": {"deleted_keys": deleted},
+    }

--- a/backend/app/api/v1/endpoints/nycu_employee.py
+++ b/backend/app/api/v1/endpoints/nycu_employee.py
@@ -7,11 +7,13 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
+from app.core.cache import cached
 from app.integrations.nycu_emp import (
     NYCUEmpAuthenticationError,
     NYCUEmpConnectionError,
     NYCUEmpError,
     NYCUEmpItem,
+    NYCUEmpPage,
     NYCUEmpTimeoutError,
     NYCUEmpValidationError,
     create_nycu_emp_client_from_env,
@@ -37,6 +39,33 @@ class EmployeeSearchResponse(BaseModel):
     employees: List[NYCUEmpItem]
     total_count: int
     filtered_count: int
+
+
+@cached(
+    key_fn=lambda status, **__: f"nycu:employees:{status}",
+    ttl=3600,
+)
+async def _get_all_employees_cached(status: str) -> List[dict]:
+    """Fetch the full upstream employee directory once per hour.
+
+    Returns a list of ``NYCUEmpPage.model_dump()`` dicts. Callers rehydrate
+    via ``NYCUEmpPage.model_validate(...)``. We cache *post-aggregation*
+    pages (not the raw HTTP), so repeated /search keystrokes filter
+    in-process against a single cached payload.
+    """
+    client = create_nycu_emp_client_from_env()
+    if hasattr(client, "__aenter__"):
+        async with client as c:
+            pages = await c.get_all_employees(status=status)
+    else:
+        pages = await client.get_all_employees(status=status)
+    return [page.model_dump() for page in pages]
+
+
+async def _get_all_pages(status: str) -> List[NYCUEmpPage]:
+    """Convenience: return rehydrated NYCUEmpPage objects."""
+    raw = await _get_all_employees_cached(status)
+    return [NYCUEmpPage.model_validate(p) for p in raw]
 
 
 @router.get("/employees")
@@ -106,15 +135,7 @@ async def get_all_employees(status: str = Query("01", description="Employee stat
         HTTPException: When API request fails
     """
     try:
-        # Create client based on environment
-        client = create_nycu_emp_client_from_env()
-
-        # Use context manager for HTTP client if needed
-        if hasattr(client, "__aenter__"):
-            async with client as c:
-                pages = await c.get_all_employees(status=status)
-        else:
-            pages = await client.get_all_employees(status=status)
+        pages = await _get_all_pages(status)
 
         # Convert to response format
         response_pages = []
@@ -169,15 +190,7 @@ async def search_employees(
         HTTPException: When API request fails
     """
     try:
-        # Create client based on environment
-        client = create_nycu_emp_client_from_env()
-
-        # Get all employees first
-        if hasattr(client, "__aenter__"):
-            async with client as c:
-                pages = await c.get_all_employees(status=status)
-        else:
-            pages = await client.get_all_employees(status=status)
+        pages = await _get_all_pages(status)
 
         # Combine all employees from all pages
         all_employees = []
@@ -245,15 +258,7 @@ async def get_employee_by_no(
         HTTPException: When API request fails
     """
     try:
-        # Create client based on environment
-        client = create_nycu_emp_client_from_env()
-
-        # Get all employees and search for the specific one
-        if hasattr(client, "__aenter__"):
-            async with client as c:
-                pages = await c.get_all_employees(status=status)
-        else:
-            pages = await client.get_all_employees(status=status)
+        pages = await _get_all_pages(status)
 
         # Search for employee across all pages
         for page in pages:

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session, selectinload
 from sqlalchemy.sql.functions import count
 
+from app.core.cache import LockBusy, with_lock_sync
 from app.core.deps import get_current_user
 from app.core.exceptions import RosterAlreadyExistsError, RosterGenerationError, RosterLockedError, RosterNotFoundError
 from app.core.path_security import validate_object_name_minio
@@ -48,20 +49,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/generate")
-def generate_payment_roster(
+def _generate_payment_roster_inner(
     request: RosterCreateRequest,
-    background_tasks: BackgroundTasks,
-    db: Session = Depends(get_sync_db),
-    current_user: User = Depends(get_current_user),
+    db: Session,
+    current_user: User,
 ):
-    """
-    產生造冊
-    Generate payment roster
-    """
-    # 檢查權限：只有管理員和處理人員可以產生造冊
-    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
-
+    """Body of generate_payment_roster — runs inside the Redis idempotency lock."""
     roster = None  # 用於錯誤處理時檢查是否需要標記為 FAILED
     try:
         roster_service = RosterService(db)
@@ -253,6 +246,39 @@ def generate_payment_roster(
             db.rollback()
 
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"造冊產生失敗: {str(e)}")
+
+
+@router.post("/generate")
+def generate_payment_roster(
+    request: RosterCreateRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_sync_db),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    產生造冊 / Generate payment roster.
+
+    Wraps the generation in a Redis SET-NX-EX mutex so a double-click on
+    "產生造冊" can't produce two parallel rosters for the same
+    (scholarship_configuration_id, period_label). The 300s TTL also acts
+    as a safety net if the backend dies mid-generation — the lock auto-
+    expires and the next attempt succeeds.
+    """
+    # 檢查權限：只有管理員和處理人員可以產生造冊
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
+
+    lock_key = f"roster:{request.scholarship_configuration_id}:{request.period_label}"
+    try:
+        with with_lock_sync(lock_key, ttl_seconds=300):
+            return _generate_payment_roster_inner(request, db, current_user)
+    except LockBusy:
+        # Concurrent generation in flight — fail fast rather than queue.
+        # UI already handles 409 from RosterAlreadyExistsError, so the
+        # path is well-trodden.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="造冊產生中，請稍候再試",
+        )
 
 
 @router.get("/available-rankings")

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -2346,6 +2346,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/cache/nycu-employees/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh Nycu Employee Cache
+         * @description Drop the cached NYCU employee directory.
+         *
+         *     The next /employees/all, /employees/search, or /employees/{no} call
+         *     will re-paginate the upstream directory. Useful right after a known
+         *     HR data change.
+         */
+        post: operations["refresh_nycu_employee_cache_api_v1_admin_cache_nycu_employees_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/scholarships": {
         parameters: {
             query?: never;
@@ -5875,8 +5899,13 @@ export interface paths {
         put?: never;
         /**
          * Generate Payment Roster
-         * @description 產生造冊
-         *     Generate payment roster
+         * @description 產生造冊 / Generate payment roster.
+         *
+         *     Wraps the generation in a Redis SET-NX-EX mutex so a double-click on
+         *     "產生造冊" can't produce two parallel rosters for the same
+         *     (scholarship_configuration_id, period_label). The 300s TTL also acts
+         *     as a safety net if the backend dies mid-generation — the lock auto-
+         *     expires and the next attempt succeeds.
          */
         post: operations["generate_payment_roster_api_v1_payment_rosters_generate_post"];
         delete?: never;
@@ -14137,6 +14166,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    refresh_nycu_employee_cache_api_v1_admin_cache_nycu_employees_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };


### PR DESCRIPTION
PR 3 of 3 in the Redis-leverage ladder. **Closes #162**.

## Summary

- **NYCU employee directory cache** (60-min TTL): \`/employees/all\`, \`/employees/search\`, \`/employees/{employee_no}\` now share a cached \`_get_all_employees_cached(status)\` helper. Repeated /search keystrokes filter in-process against a single cached payload instead of re-paginating upstream.
- **Admin manual purge**: \`POST /api/v1/admin/cache/nycu-employees/refresh\` for ops escape hatch.
- **Payment-roster idempotency lock**: \`/payment-rosters/generate\` wraps generation in \`with_lock_sync(\"roster:{config_id}:{period_label}\", ttl=300s)\`. Double-clicks now fail fast with HTTP 409 instead of producing duplicate rosters.

## E2E verification (dev stack)

\`\`\`
_get_all_pages('01')              cold=0.5ms  warm=0.2ms (mock client; real upstream win is 10-100x)
cache:v1:nycu:employees:01        TTL ≈ 3445s (3600s ± 10% jitter ✓)

with_lock_sync(\"roster:42:2026-1\")
  1st acquire                     OK
  2nd acquire (held)              LockBusy raised ✓
  after release                   re-acquire OK ✓

POST /api/v1/admin/cache/nycu-employees/refresh
  visible in OpenAPI ✓            returns deleted_keys count
\`\`\`

## Tests

\`\`\`
pytest backend/app/tests/test_cache.py              7 passed
pytest backend/app/tests/test_rate_limiting_unit.py 16 passed
black --check                                       4 files clean
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)