### PR TITLE
ops(redis): prod maxmemory/LRU + staging --requirepass

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,21 @@ services:
       - redis_prod_data:/data
     networks:
       - scholarship_prod_network
-    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}", "--appendonly", "yes"]
+    # --maxmemory + allkeys-lru: cache namespace (cache:v1:*) is fully
+    # reconstructible, so LRU eviction is safe. Rate-limit keys
+    # (rate_limit:*) get evicted under the same policy, which is
+    # acceptable: a flushed sliding-window resets to "no recent traffic"
+    # and the next request just rebuilds it.
+    command:
+      - "redis-server"
+      - "--requirepass"
+      - "${REDIS_PASSWORD}"
+      - "--appendonly"
+      - "yes"
+      - "--maxmemory"
+      - "${REDIS_MAXMEMORY:-512mb}"
+      - "--maxmemory-policy"
+      - "allkeys-lru"
     healthcheck:
       test: ["CMD", "redis-cli", "--no-auth-warning", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 30s

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -9,8 +9,19 @@ services:
       - redis_staging_data:/data
     networks:
       - scholarship_staging_network
+    # Mirror prod: --requirepass + maxmemory/LRU. Staging needs to
+    # exercise the auth setup so REDIS_URL parsing + healthcheck flags
+    # match what we run in production.
+    command:
+      - "redis-server"
+      - "--requirepass"
+      - "${REDIS_PASSWORD}"
+      - "--maxmemory"
+      - "${REDIS_MAXMEMORY:-256mb}"
+      - "--maxmemory-policy"
+      - "allkeys-lru"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "--no-auth-warning", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -25,7 +36,7 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL}
       DATABASE_URL_SYNC: ${DATABASE_URL_SYNC}
-      REDIS_URL: redis://redis:6379/0
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
       SECRET_KEY: ${SECRET_KEY}
       DEBUG: "true"
       CORS_ORIGINS: ${CORS_ORIGINS}


### PR DESCRIPTION
Two operational follow-ups from the #162 cache-ladder plan, carried over after PRs #163, #164, #165 landed.

## Prod

- \`--maxmemory \${REDIS_MAXMEMORY:-512mb}\` + \`--maxmemory-policy allkeys-lru\`
- Cache namespace (\`cache:v1:*\`) is fully reconstructible — LRU eviction is safe. Without a cap, AOF + cache growth could OOM the container during a traffic burst.

## Staging

- \`--requirepass \${REDIS_PASSWORD}\` + healthcheck flag + \`REDIS_URL\` updated to include password
- \`--maxmemory \${REDIS_MAXMEMORY:-256mb}\` + same LRU policy
- Mirrors prod auth so \`REDIS_URL\` parsing + healthcheck flags get exercised before a release ships
- \`REDIS_PASSWORD\` must be set in the staging deploy environment (already documented in \`docs/GITHUB_SECRETS.md\`)

## Validation

\`\`\`
docker compose -f docker-compose.prod.yml    config --quiet → 0
docker compose -f docker-compose.staging.yml config --quiet → 0
\`\`\`

Rendered \`command:\` arrays inspected; both Redis services emit the expected redis-server flag list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)