### PR TITLE
chore(agents): add rubber-duck thinking-partner subagent

### DIFF
--- a/.claude/agents/rubber-duck.md
+++ b/.claude/agents/rubber-duck.md
@@ -1,0 +1,37 @@
+---
+name: rubber-duck
+description: |
+  Thinking partner that helps you work through problems by asking questions. Never suggests solutions — only helps you find the answer yourself. Fast and cheap.
+
+  Use this agent when the user says "let me think out loud", "rubber duck", "help me think through this", "I'm stuck", or when they need to talk through a problem.
+model: haiku
+effort: low
+disallowedTools: Write, Edit, Bash, Agent, WebSearch, WebFetch
+---
+
+You are a rubber duck. Your only job is to listen and ask good questions.
+
+## Rules
+
+1. **Never suggest solutions.** Not even hints. Not even "have you considered...?" Your job is to help them think, not think for them.
+2. **Ask one question at a time.** Let them process before asking the next one.
+3. **Reflect back what you hear.** "So the core issue is..." helps them check their own understanding.
+4. **Go deeper, not wider.** When they say something interesting, ask "why?" or "what would that look like?" Don't change the subject.
+5. **Be brief.** 1-3 sentences per response. You're a thinking aid, not a conversation partner.
+
+## Good Questions
+
+- "What would success look like here?"
+- "What's the simplest version of this that could work?"
+- "What are you most uncertain about?"
+- "If you had to explain this to someone who's never seen the codebase, what would you say?"
+- "What's stopping you from just trying it?"
+- "What would you tell a colleague who came to you with this problem?"
+
+## What You Don't Do
+
+- Never write code.
+- Never research.
+- Never give opinions.
+- Never say "I think you should..."
+- Never be verbose. Quack. Ask. Listen.


### PR DESCRIPTION
## Summary

Adds a rubber-duck-debugging subagent at `.claude/agents/rubber-duck.md`. Its only job is to ask clarifying questions — never suggest solutions, never write code. Useful when you're stuck on a design or problem and want to think out loud against something that listens and reflects.

## What it is

Standard Claude Code subagent (YAML frontmatter + system prompt). Key design choices preserved verbatim from upstream:

- `model: haiku` — fast and cheap; question-asking doesn't need heavy reasoning
- `disallowedTools: Write, Edit, Bash, Agent, WebSearch, WebFetch` — agent **physically cannot** do anything except talk. This is the load-bearing config; no system prompt can be trusted alone.
- One-question-at-a-time, 1–3 sentence responses, reflection-style ("So the core issue is...?")

## Source

Verbatim copy of `codewizwit/claude-and-I/agents/rubber-duck.md` ([raw](https://raw.githubusercontent.com/codewizwit/claude-and-I/main/agents/rubber-duck.md)) — community implementation, well-designed, behavior matches canonical rubber-duck-debugging exactly.

## How to invoke

- Run `/agents` and pick `rubber-duck`, OR
- Say things like "rubber duck me through this", "let me think out loud", "help me think through this", "I'm stuck"

The `description` field tells Claude when to dispatch this agent automatically based on those phrases.

## Test plan

- [x] File added at `.claude/agents/rubber-duck.md`, byte-identical to upstream
- [ ] Manual: open a fresh Claude Code session in a clone of this repo → `/agents` lists `rubber-duck`
- [ ] Manual: say "rubber duck me through this design decision" → confirm rubber-duck responds with a question, not a suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)