### PR TITLE
test(ci): per-PR diff-cover gate on backend smoke row (Phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,34 @@ jobs:
           name: backend-${{ matrix.test-suite }}-coverage
           fail_ci_if_error: false
 
+      - name: Diff coverage gate (PR only, smoke row)
+        # Per-PR coverage ratchet: changed Python lines must be ≥80% covered
+        # by the smoke suite. Phase 2 of the test-surface-hardening plan.
+        # Gated to the smoke row so the gate runs once per PR against one
+        # canonical coverage.xml; gated to pull_request events so pushes
+        # to main / develop don't fail on baseline drift.
+        # Soft-gated until smoke is healthy enough to be the canonical
+        # source — promote to required once Phase 1 follow-ups land.
+        if: github.event_name == 'pull_request' && matrix.test-suite == 'smoke'
+        working-directory: ./backend
+        continue-on-error: true
+        run: |
+          python -m pip install --quiet diff-cover==9.2.0
+          # Need the base ref locally for diff-cover's --compare-branch.
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}" || true
+          diff-cover coverage.xml \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --fail-under=80 \
+            --html-report diff-cover-backend.html
+
+      - name: Upload diff-cover report (backend)
+        if: always() && matrix.test-suite == 'smoke'
+        uses: actions/upload-artifact@v4
+        with:
+          name: diff-cover-backend
+          path: backend/diff-cover-backend.html
+          retention-days: 7
+
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -401,6 +429,11 @@ jobs:
           flags: frontend
           name: frontend-coverage
           fail_ci_if_error: false
+
+      # Frontend diff-cover gate deferred: diff-cover is Python-only and the
+      # frontend job runs Node-only. Adding setup-python here would slow
+      # every frontend run; instead Phase 2 ships the backend gate first
+      # and a follow-up adds the frontend gate via a dedicated coverage job.
 
       - name: Upload test artifacts
         if: always()

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -13,6 +13,9 @@ httpx==0.28.1  # Match main requirements
 pytest-postgresql==6.1.1  # Updated for Python 3.13 compatibility
 aiosqlite==0.20.0  # For SQLite support in testing
 
+# Coverage tooling
+diff-cover==9.2.0  # Per-PR coverage ratchet (Phase 2 of test-surface-hardening plan)
+
 # Code quality and formatting
 black==26.3.1  # Updated for Python 3.13 compatibility
 isort==5.13.2  # Updated for Python 3.13 compatibility


### PR DESCRIPTION
## Summary

Phase 2 of the test-surface-hardening plan: a per-PR `diff-cover` gate on
changed Python lines, scoped to the `smoke` matrix row so it runs once
per PR against one canonical `coverage.xml`.

This complements (does not replace) the global `--cov-fail-under=0` in
the smoke step. Phase 1 deliberately set that to 0 because the smoke
lane is intentionally narrow; Phase 2 is the per-PR ratchet that stops
new code arriving uncovered without forcing a one-time mass-test
backfill on the rest of the codebase.

## Changes

- **`.github/workflows/ci.yml`** — new `Diff coverage gate (PR only,
  smoke row)` step after the existing Codecov upload. Installs
  `diff-cover==9.2.0`, fetches the base ref shallow, then runs
  `diff-cover coverage.xml --compare-branch=origin/<base> --fail-under=80`.
  Gated to `pull_request` events and `matrix.test-suite == 'smoke'`.
  Also uploads `diff-cover-backend.html` as an artifact (7-day
  retention).
- **`backend/requirements-dev.txt`** — pin `diff-cover==9.2.0` so
  contributors can reproduce locally:
  ```bash
  cd backend && diff-cover coverage.xml --compare-branch=origin/main
  ```

## Soft-gate (initial)

Set `continue-on-error: true` on the new step. The gate is informational
for now; it surfaces the diff-cover percentage and the HTML artifact
without blocking. Promotion to a hard gate happens together with the
smoke-lane hard-gate promotion, once Phase 1's follow-ups have landed
(test_mock_sso table-creation gap, async-mock bugs, stale fixtures,
`pytest.ini` section-name fix).

## Out of scope

Frontend diff-cover gate deferred — `diff-cover` is Python-only and the
`frontend-tests` job is Node-only; adding `setup-python` there would
slow every frontend run. Tracked as a separate follow-up; backend is
where the bulk of AI-generated diffs land in this codebase.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML
  parses.
- [x] `pip install --dry-run diff-cover==9.2.0` resolves cleanly.
- [ ] CI run on this PR: `Diff coverage gate (PR only, smoke row)`
  step appears on the smoke matrix row, runs, and uploads
  `diff-cover-backend` artifact.
- [ ] Subsequent PR with no test for new code shows the gate flagging
  uncovered lines (currently informational due to soft-gate).

https://claude.ai/code/session_011CYKj3nSHGdDKCKXaUJUop

---
_Generated by [Claude Code](https://claude.ai/code/session_011CYKj3nSHGdDKCKXaUJUop)_