### PR TITLE
test(roster): hypothesis property tests for _evaluate_condition (Phase 6)

### DIFF
--- a/backend/app/tests/test_roster_evaluate_condition_property.py
+++ b/backend/app/tests/test_roster_evaluate_condition_property.py
@@ -1,0 +1,137 @@
+"""
+Property-based tests for RosterService._evaluate_condition.
+
+Phase 6 of test-surface-hardening: incremental, not transformative.
+The 26 parametrize cases in test_scholarship_rules_service.py already
+cover the operator surface well; hypothesis adds value here only for
+properties that parametrize cannot easily express:
+
+  1. Symmetry: for every (actual, op, expected),
+       evaluate(a, op, e) != evaluate(a, negate(op), e)
+     for paired operators (>=/<, ==/!=, in/not_in, contains/not_contains).
+  2. None-safety: evaluate(None, op, expected) is False for any
+     (op, expected). Roster_service.py:1187 short-circuits None →
+     this property guards against a future "fix" that drops the guard.
+  3. Type-coercion idempotence: numeric comparisons agree across the
+     int / float / numeric-string forms of the same value
+     (roster_service.py:1193 wraps both sides in float()).
+
+`_evaluate_condition` is reachable on a RosterService instance built with
+no DB session — the method is purely functional. We instantiate with
+db=None and call the bound method directly.
+
+Cap: max_examples=200, deadline=500ms — keeps the suite under 10s and
+fits inside the smoke time budget.
+"""
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.services.roster_service import RosterService
+
+pytestmark = pytest.mark.unit
+
+
+# Pairs of operators whose results must be inverses on the same input.
+# (When `actual` is None, both branches return False — the symmetry
+# property is conditional on actual being non-None and the inputs being
+# parseable for the operator's coercion strategy.)
+_NUMERIC_INVERSES = [(">=", "<"), ("<=", ">")]
+_STRING_INVERSES = [
+    ("==", "!="),
+    ("in", "not_in"),
+    ("contains", "not_contains"),
+]
+
+
+def _svc() -> RosterService:
+    """A purely-functional RosterService — _evaluate_condition uses no db."""
+    # Even though __init__ assigns self.student_verification_service = ...,
+    # _evaluate_condition only reads its arguments; the constructor side
+    # effects are tolerated.
+    return RosterService(db=None)
+
+
+class TestEvaluateConditionNoneSafety:
+    """Property: None actual → False, regardless of operator/expected."""
+
+    @given(
+        op=st.sampled_from([">=", "<=", ">", "<", "==", "!=", "in", "not_in", "contains", "not_contains"]),
+        expected=st.text(min_size=0, max_size=20),
+    )
+    @settings(max_examples=100, deadline=500)
+    def test_none_actual_always_false(self, op, expected):
+        assert _svc()._evaluate_condition(None, op, expected) is False
+
+
+class TestEvaluateConditionNumericSymmetry:
+    """Property: paired numeric operators are mutually exclusive on equal inputs."""
+
+    @pytest.mark.parametrize("op_a,op_b", _NUMERIC_INVERSES)
+    @given(
+        actual=st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+        expected=st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+    )
+    @settings(max_examples=200, deadline=500)
+    def test_numeric_pair_partitions_when_unequal(self, op_a, op_b, actual, expected):
+        # When actual == expected, both >= and <= are true (and < and > are
+        # both false). The strict partition only holds when the values
+        # differ. Skip the equal case rather than weakening the property.
+        if actual == expected:
+            return
+        a = _svc()._evaluate_condition(actual, op_a, str(expected))
+        b = _svc()._evaluate_condition(actual, op_b, str(expected))
+        assert a != b, (
+            f"expected {op_a} and {op_b} to be inverses on " f"actual={actual} expected={expected}, both returned {a}"
+        )
+
+
+class TestEvaluateConditionStringSymmetry:
+    """Property: paired string-style operators are inverses."""
+
+    @pytest.mark.parametrize("op_a,op_b", _STRING_INVERSES)
+    @given(
+        actual=st.text(
+            alphabet=st.characters(min_codepoint=33, max_codepoint=126),
+            min_size=1,
+            max_size=10,
+        ),
+        expected=st.text(
+            alphabet=st.characters(min_codepoint=33, max_codepoint=126),
+            min_size=1,
+            max_size=10,
+        ),
+    )
+    @settings(max_examples=200, deadline=500)
+    def test_string_pair_inverses(self, op_a, op_b, actual, expected):
+        # `in` / `not_in` split `expected` on commas; we exclude commas from
+        # the alphabet via codepoint range (33..126 contains comma at 44, so
+        # filter explicitly).
+        if "," in expected or "," in actual:
+            return
+        a = _svc()._evaluate_condition(actual, op_a, expected)
+        b = _svc()._evaluate_condition(actual, op_b, expected)
+        assert a != b, (
+            f"{op_a} and {op_b} returned the same value ({a}) for " f"actual={actual!r} expected={expected!r}"
+        )
+
+
+class TestEvaluateConditionTypeCoercion:
+    """Property: numeric comparisons agree across int / float / str forms."""
+
+    @given(
+        actual=st.integers(min_value=-1000, max_value=1000),
+        expected=st.integers(min_value=-1000, max_value=1000),
+        op=st.sampled_from([">=", "<=", ">", "<"]),
+    )
+    @settings(max_examples=200, deadline=500)
+    def test_numeric_form_idempotent(self, actual, expected, op):
+        svc = _svc()
+        as_int = svc._evaluate_condition(actual, op, str(expected))
+        as_float = svc._evaluate_condition(float(actual), op, str(float(expected)))
+        as_str = svc._evaluate_condition(str(actual), op, str(expected))
+        assert as_int == as_float == as_str, (
+            f"int/float/str disagreed on op={op} actual={actual} expected={expected}: "
+            f"int={as_int} float={as_float} str={as_str}"
+        )

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -16,6 +16,9 @@ aiosqlite==0.20.0  # For SQLite support in testing
 # Coverage tooling
 diff-cover==9.2.0  # Per-PR coverage ratchet (Phase 2 of test-surface-hardening plan)
 
+# Property-based testing (Phase 6 of test-surface-hardening plan)
+hypothesis==6.112.0  # Symmetry / none-safety properties for RosterService._evaluate_condition
+
 # Code quality and formatting
 black==26.3.1  # Updated for Python 3.13 compatibility
 isort==5.13.2  # Updated for Python 3.13 compatibility


### PR DESCRIPTION
## Summary

Phase 6 (final) of the test-surface-hardening plan. Adds three property
tests on `RosterService._evaluate_condition`
(`backend/app/services/roster_service.py:1184`) using hypothesis.

This is deliberately small and scoped. Per the original plan: **do not**
spread hypothesis across the rest of the codebase — ROI elsewhere is
negative. The existing 26 parametrize cases in
`test_scholarship_rules_service.py` already cover the operator surface
well. Hypothesis adds value here only for properties that parametrize
cannot easily express.

## Properties

| Property | Why hypothesis (vs. parametrize) | Catches |
|---|---|---|
| **Symmetry** — paired operators (`>=`/`<`, `<=`/`>`, `==`/`!=`, `in`/`not_in`, `contains`/`not_contains`) produce inverse results | Operator pairing is the universal-quantifier shape parametrize doesn't express | Refactor that swaps a comparator inside one branch of the if/elif chain at lines 1192–1213 |
| **None-safety** — `evaluate(None, op, expected) is False` for every `(op, expected)` | `expected` is universally quantified | A future "fix" that drops the short-circuit at line 1187 |
| **Type-coercion idempotence** — numeric comparisons agree across `int` / `float` / numeric-string forms | Universal over all numerics | Regression where a single branch silently stops coercing |

## Configuration

- `max_examples=200, deadline=500` — keeps the suite ≤10s, fits inside
  the smoke time budget.
- Equal-value cases for numeric inverses are skipped explicitly (both
  `>=` and `<=` are true at equality; only the strict pairing partitions
  cleanly), with a comment in the test explaining why.
- Comma in string-symmetry inputs is filtered because `in` / `not_in`
  split `expected` on commas (roster_service.py:1205).

## Implementation

`_evaluate_condition` is purely functional, so the test instantiates
`RosterService(db=None)` and calls the bound method directly. No DB,
no fixtures, no I/O.

`backend/requirements-dev.txt` adds `hypothesis==6.112.0`.

## Test plan

- [x] AST-parse, black `--line-length=120`, flake8 `--max-line-length=120 --extend-ignore=E203,W503,E501` — all clean.
- [x] `pip install --dry-run hypothesis==6.112.0` resolves with the
  rest of `requirements-dev.txt`.
- [ ] CI run: tests run on the unit matrix row (carry
  `pytestmark = pytest.mark.unit`), <10s wall-clock.
- [ ] Inducing a regression (e.g. negate the inner comparator on the
  `>=` branch in `_evaluate_condition`) makes the symmetry test red
  with a hypothesis-shrunk minimal counterexample.

## Plan complete

This closes Phases 2–6. See PRs #170 (Phase 2), #171 (Phase 3),
#172 (Phase 4), #173 (Phase 5) for the rest. Each PR is independent
and can land in any order; the merged Phase 1 (#166) is the only
prerequisite.

https://claude.ai/code/session_011CYKj3nSHGdDKCKXaUJUop

---
_Generated by [Claude Code](https://claude.ai/code/session_011CYKj3nSHGdDKCKXaUJUop)_