### PR TITLE
fix(cache): cast ApplicationStatus enum to .value in scholarship_stats

### DIFF
--- a/backend/app/api/v1/endpoints/admin/dashboard.py
+++ b/backend/app/api/v1/endpoints/admin/dashboard.py
@@ -408,7 +408,12 @@ async def _get_scholarship_stats_cached(current_user: User, db: AsyncSession) ->
         )
 
         result = await db.execute(stmt)
-        status_counts = {row[0]: row[1] for row in result.fetchall()}
+        # row[0] is an ApplicationStatus enum; cast to its string value so the
+        # surrounding dict can be JSON-serialised by the Redis cache layer
+        # (json.dumps rejects enum keys; the response was previously fine
+        # because FastAPI's jsonable_encoder normalises them, but the cache
+        # path uses plain json.dumps and would log an error every call).
+        status_counts = {row[0].value: row[1] for row in result.fetchall()}
 
         # Get unique sub-types for this scholarship
         stmt = select(Application.scholarship_subtype_list).where(


### PR DESCRIPTION
## Summary

`GET /admin/scholarships/stats` was emitting an `ERROR` log on every call:

```
cache: value for key=b'cache:v1:dashboard:scholarship_stats:2' is not JSON-serialisable: keys must be str, int, float, bool or None, not ApplicationStatus
```

This was tripping the **BackendErrorSpike** monitoring alert (>5 ERROR/5min) on staging — see [#175](https://github.com/anud18/scholarship-system/issues/175).

## Root cause

In `backend/app/api/v1/endpoints/admin/dashboard.py:411` the function builds:

```python
status_counts = {row[0]: row[1] for row in result.fetchall()}
```

`row[0]` is an `ApplicationStatus` enum instance (SQLAlchemy hands them back as enum members for `Enum`-typed columns). The HTTP response is fine because FastAPI's `jsonable_encoder` normalises enum keys to their `.value` string. But the `@cached` decorator wraps the same dict in plain `json.dumps`, which has no equivalent normalisation — `json.dumps`'s `default=` callback handles non-serialisable **values**, not keys, so it raises `TypeError` before `_default` is ever consulted (see `backend/app/core/cache.py:97-113`).

The cache layer's error path catches the exception, logs it, and falls through to the live value — so users see correct data, but the 60s cache is silently disabled and every call writes an ERROR log line.

## Fix

Cast at the source: `{row[0].value: row[1] for ...}`. The JSON shape over the wire is unchanged (was already string-keyed via `jsonable_encoder`), and the cache layer now serialises cleanly, restoring the intended caching behaviour.

## Why fix at the call site, not the cache layer

Considered making `cache._dumps` recursively normalise enum keys before `json.dumps`. Decided against:

- Minimal-fix principle (CLAUDE.md): one-line change at the source vs. recursive normaliser as a generic safety net.
- The other admin stats endpoints (`students.py:132`, `users.py:560-580`) already cast `.value` at source. This one was the outlier; bringing it in line is more consistent than papering over it in the cache layer.
- A future bug of the same shape will surface as an ERROR log immediately and be easy to grep — vs. being silently swallowed by a generic normaliser.

## Test plan

- [x] `python -m black --check` passes (file unchanged after formatting)
- [ ] After merge: confirm no new "is not JSON-serialisable" ERRORs in staging Loki for `{environment="staging", container=~"scholarship_backend.*"} |~ "ERROR"` over a 10-minute window
- [ ] After merge: confirm `BackendErrorSpike` alert clears on staging (issue #175 should auto-close on next eval cycle)
- [ ] Manual: hit `GET /admin/scholarships/stats` as admin twice; second call should be a cache hit (verify via redis-cli `KEYS "cache:v1:dashboard:scholarship_stats*"` shows a TTL)

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)