### PR TITLE
fix(workflows): monitoring-alert label creation + summary apostrophe escaping

### DIFF
--- a/.github/workflows/monitoring-alert-issue.yml
+++ b/.github/workflows/monitoring-alert-issue.yml
@@ -81,6 +81,27 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Ensure dynamic labels exist
+        # gh issue create --label fails hard if the label doesn't already
+        # exist on the repo. The alert/env/severity values come from
+        # arbitrary Grafana payloads, so pre-create them on demand.
+        # `gh label create` returns non-zero if the label already exists,
+        # hence the `|| true` swallow.
+        if: github.event.client_payload.status == 'firing'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALERT: ${{ github.event.client_payload.alertname }}
+          ENV: ${{ github.event.client_payload.environment }}
+          SEVERITY: ${{ github.event.client_payload.severity }}
+        run: |
+          for label in "alert:${ALERT:-unknown}" "env:${ENV:-unknown}" "severity:${SEVERITY:-warning}"; do
+            gh label create "$label" \
+              --repo "${{ github.repository }}" \
+              --color "ededed" \
+              --description "Auto-created by monitoring-alert workflow" \
+              2>/dev/null || true
+          done
+
       - name: Create new issue (no existing match, status=firing)
         if: steps.find.outputs.found != 'true' && github.event.client_payload.status == 'firing'
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -26,8 +26,12 @@ jobs:
             Body: ${{ github.event.issue.body }}
 
       - name: Comment with AI summary
+        # Pass the AI response via env var rather than templating it into
+        # single quotes — apostrophes in the response (e.g. "repository's
+        # status") otherwise terminate the quoted string and break the
+        # shell command.
         run: |
-          gh issue comment $ISSUE_NUMBER --body '${{ steps.inference.outputs.response }}'
+          gh issue comment "$ISSUE_NUMBER" --body "$RESPONSE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
Three failed Action runs reported (2× monitoring-alert dispatch, 1× Summarize new issues on #178). Both were narrow shell/label bugs.

## monitoring-alert-issue.yml

\`gh issue create --label 'env:monitoring'\` failed with \`could not add label: 'env:monitoring' not found\` — first \`PrometheusStorageLow\` alert had \`environment=monitoring\` but only \`env:staging\` existed on the repo (run [25589387620](https://github.com/anud18/scholarship-system/actions/runs/25589387620)).

**Fix**: pre-create \`alert:*\`, \`env:*\`, \`severity:*\` labels on demand via \`gh label create … || true\` before the issue-create step. \`monitoring-alert\` itself stays required-pre-existing so we don't silently invent it.

## summary.yml

When the AI response contained \"repository's status\", the runner step \`gh issue comment "$ISSUE_NUMBER" --body '<full response>'\` saw an unbalanced single quote and exited 2 with \`unexpected EOF while looking for matching '''\` (run [25587296135](https://github.com/anud18/scholarship-system/actions/runs/25587296135)).

**Fix**: swap \`--body '<template>'\` → \`--body \"\$RESPONSE\"\`. The \`RESPONSE\` env var was already declared but unused. Double-quoted env-var expansion handles apostrophes/dollar-signs/newlines correctly.

## Validation

YAML parses for both files; no behavior change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)