### PR TITLE
fix(review): gate status approval on configured pipeline (closes #182)

### DIFF
--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -414,6 +414,29 @@ class ReviewService:
         application.review_stage = new_stage
         await self.db.flush()
 
+    async def _awaits_further_required_review(
+        self, application: Application, latest_reviewer_role: Optional[str]
+    ) -> bool:
+        """Whether the configured pipeline still expects another required reviewer.
+
+        Issue #182: a single professor "approve" used to flip ``status`` to
+        ``approved`` even when ``requires_college_review=True``, which both
+        bypassed college review and locked the student out of ``withdraw``
+        (only ``submitted``/``under_review`` are withdrawable). Returning
+        True here keeps the app at ``under_review`` until the college (or
+        any later required role) signs off.
+        """
+        if not latest_reviewer_role or not application.scholarship_configuration_id:
+            return False
+        from app.models.scholarship import ScholarshipConfiguration
+
+        config = await self.db.get(ScholarshipConfiguration, application.scholarship_configuration_id)
+        if not config:
+            return False
+        # College is the only post-professor required-reviewer surface today.
+        # Add chained gates here as the pipeline grows (admin, finance, …).
+        return latest_reviewer_role == "professor" and bool(config.requires_college_review)
+
     async def update_application_status(self, application_id: int) -> str:
         """
         根據子項目累積狀態更新 Application 狀態和階段
@@ -440,15 +463,8 @@ class ReviewService:
         all_approved = all(status["status"] == "approved" for status in subtype_status.values())
         all_rejected = all(status["status"] == "rejected" for status in subtype_status.values())
 
-        if all_approved:
-            application.status = ApplicationStatus.approved.value
-        elif all_rejected:
-            application.status = ApplicationStatus.rejected.value
-        else:
-            # 部分同意
-            application.status = ApplicationStatus.partial_approved.value
-
-        # 更新審核階段（基於最新審查者角色）
+        # Determine latest reviewer role first — used both for review_stage
+        # below AND for gating the terminal status transitions (issue #182).
         stmt = (
             select(ApplicationReview)
             .where(ApplicationReview.application_id == application_id)
@@ -458,20 +474,39 @@ class ReviewService:
         result = await self.db.execute(stmt)
         latest_review = result.scalar_one_or_none()
 
+        latest_reviewer_role: Optional[str] = None
         if latest_review and latest_review.reviewer:
-            reviewer_role = (
+            latest_reviewer_role = (
                 latest_review.reviewer.role.value
                 if hasattr(latest_review.reviewer.role, "value")
                 else str(latest_review.reviewer.role).lower()
             )
 
-            # 根據審查者角色更新階段
-            if reviewer_role == "professor":
-                application.review_stage = ReviewStage.professor_reviewed.value
-            elif reviewer_role == "college":
-                application.review_stage = ReviewStage.college_reviewed.value
-            elif reviewer_role in ["admin", "super_admin"]:
-                application.review_stage = ReviewStage.admin_reviewed.value
+        awaits_further = await self._awaits_further_required_review(application, latest_reviewer_role)
+
+        if all_approved:
+            application.status = (
+                ApplicationStatus.under_review.value if awaits_further else ApplicationStatus.approved.value
+            )
+        elif all_rejected:
+            # Outright rejection is terminal regardless of remaining reviewers —
+            # if every sub-type is rejected, no later role can rescue it.
+            application.status = ApplicationStatus.rejected.value
+        else:
+            # 部分同意 — also gated: if college hasn't weighed in yet, we
+            # shouldn't lock a partial outcome in (and the student should
+            # still be able to withdraw).
+            application.status = (
+                ApplicationStatus.under_review.value if awaits_further else ApplicationStatus.partial_approved.value
+            )
+
+        # 根據審查者角色更新階段
+        if latest_reviewer_role == "professor":
+            application.review_stage = ReviewStage.professor_reviewed.value
+        elif latest_reviewer_role == "college":
+            application.review_stage = ReviewStage.college_reviewed.value
+        elif latest_reviewer_role in ("admin", "super_admin"):
+            application.review_stage = ReviewStage.admin_reviewed.value
 
         return application.status
 

--- a/backend/app/tests/test_review_service_status_gating.py
+++ b/backend/app/tests/test_review_service_status_gating.py
@@ -1,0 +1,218 @@
+"""
+Regression tests for ReviewService.update_application_status — issue #182.
+
+Before the fix, a single professor "approve" recommendation flipped
+``application.status`` straight to ``approved``, even when the scholarship
+configuration had ``requires_college_review=True``. That bypassed the
+college step AND locked the student out of withdrawal (``withdraw`` only
+accepts ``submitted`` / ``under_review``).
+
+These tests pin the gating behavior in place: with college review required,
+a professor "approve" must keep the app at ``under_review``; once college
+also approves, status flips to ``approved``.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, ReviewStage
+from app.models.review import ApplicationReview, ApplicationReviewItem
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.review_service import ReviewService
+
+
+def _val(x):
+    """Normalise enum/string for stable equality assertions."""
+    return x.value if hasattr(x, "value") else x
+
+
+def _user(role: UserRole, suffix: str) -> User:
+    return User(
+        nycu_id=f"gating_{role.value}_{suffix}",
+        name=f"Gating {role.value} {suffix}",
+        email=f"gating_{role.value}_{suffix}@u.edu",
+        user_type=UserType.employee if role != UserRole.student else UserType.student,
+        role=role,
+    )
+
+
+async def _seed_scholarship_and_config(db: AsyncSession, *, requires_college_review: bool) -> ScholarshipConfiguration:
+    """Insert a minimal ScholarshipType + ScholarshipConfiguration pair."""
+    stype = ScholarshipType(
+        code=f"phd_test_{int(requires_college_review)}",
+        name=f"PhD test ({'college' if requires_college_review else 'no-college'})",
+        status="active",
+    )
+    db.add(stype)
+    await db.commit()
+    await db.refresh(stype)
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=stype.id,
+        config_code=f"phd_test_cfg_{int(requires_college_review)}",
+        config_name="PhD test config",
+        academic_year=114,
+        application_start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        application_end_date=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        requires_professor_recommendation=True,
+        requires_college_review=requires_college_review,
+        amount=0,
+        is_active=True,
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+    return config
+
+
+async def _seed_app(db: AsyncSession, *, student: User, config: ScholarshipConfiguration) -> Application:
+    app = Application(
+        app_id=f"APP-GATING-{config.id}",
+        user_id=student.id,
+        scholarship_type_id=config.scholarship_type_id,
+        scholarship_configuration_id=config.id,
+        academic_year=114,
+        sub_type_selection_mode="single",
+        status=ApplicationStatus.submitted.value,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+async def _seed_review(
+    db: AsyncSession,
+    *,
+    application: Application,
+    reviewer: User,
+    sub_type_code: str,
+    recommendation: str,
+) -> None:
+    review = ApplicationReview(
+        application_id=application.id,
+        reviewer_id=reviewer.id,
+        recommendation=recommendation,
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    db.add(review)
+    await db.commit()
+    await db.refresh(review)
+
+    item = ApplicationReviewItem(
+        review_id=review.id,
+        sub_type_code=sub_type_code,
+        recommendation=recommendation,
+    )
+    db.add(item)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# The bug fix — issue #182
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_professor_approve_keeps_status_under_review_when_college_required(db: AsyncSession):
+    """The exact scenario from issue #182.
+
+    Config: requires_professor_recommendation=True, requires_college_review=True.
+    Action: a professor approves the only sub-type.
+    Expected: status stays at under_review (NOT approved); review_stage=professor_reviewed.
+    """
+    student = _user(UserRole.student, "s")
+    professor = _user(UserRole.professor, "p")
+    db.add_all([student, professor])
+    await db.commit()
+    await db.refresh(student)
+    await db.refresh(professor)
+
+    config = await _seed_scholarship_and_config(db, requires_college_review=True)
+    app = await _seed_app(db, student=student, config=config)
+    await _seed_review(db, application=app, reviewer=professor, sub_type_code="default", recommendation="approve")
+
+    service = ReviewService(db)
+    final_status = await service.update_application_status(app.id)
+
+    assert (
+        _val(final_status) == ApplicationStatus.under_review.value
+    ), f"professor approve should not promote to approved when college review required; got {final_status}"
+    # Identity-mapped — the object the test holds is the same one the service
+    # mutated. We assert directly rather than db.refresh, because refresh would
+    # revert the in-memory change back to the (still-uncommitted) DB row.
+    assert _val(app.status) == ApplicationStatus.under_review.value
+    assert _val(app.review_stage) == ReviewStage.professor_reviewed.value
+
+
+@pytest.mark.asyncio
+async def test_college_approve_after_professor_promotes_to_approved(db: AsyncSession):
+    """Continuing #182 — once college also approves, status should flip to approved."""
+    student = _user(UserRole.student, "s2")
+    professor = _user(UserRole.professor, "p2")
+    college = _user(UserRole.college, "c2")
+    db.add_all([student, professor, college])
+    await db.commit()
+    for u in (student, professor, college):
+        await db.refresh(u)
+
+    config = await _seed_scholarship_and_config(db, requires_college_review=True)
+    app = await _seed_app(db, student=student, config=config)
+    await _seed_review(db, application=app, reviewer=professor, sub_type_code="default", recommendation="approve")
+    await _seed_review(db, application=app, reviewer=college, sub_type_code="default", recommendation="approve")
+
+    service = ReviewService(db)
+    final_status = await service.update_application_status(app.id)
+
+    assert _val(final_status) == ApplicationStatus.approved.value
+    assert _val(app.review_stage) == ReviewStage.college_reviewed.value
+
+
+@pytest.mark.asyncio
+async def test_professor_approve_promotes_to_approved_when_no_college_review(db: AsyncSession):
+    """Pre-fix happy path must not regress.
+
+    Config: requires_college_review=False.
+    A professor approve should still flip status to approved immediately
+    (there's no college step in the configured pipeline).
+    """
+    student = _user(UserRole.student, "s3")
+    professor = _user(UserRole.professor, "p3")
+    db.add_all([student, professor])
+    await db.commit()
+    await db.refresh(student)
+    await db.refresh(professor)
+
+    config = await _seed_scholarship_and_config(db, requires_college_review=False)
+    app = await _seed_app(db, student=student, config=config)
+    await _seed_review(db, application=app, reviewer=professor, sub_type_code="default", recommendation="approve")
+
+    service = ReviewService(db)
+    final_status = await service.update_application_status(app.id)
+
+    assert _val(final_status) == ApplicationStatus.approved.value
+    assert _val(app.review_stage) == ReviewStage.professor_reviewed.value
+
+
+@pytest.mark.asyncio
+async def test_full_reject_is_terminal_regardless_of_pipeline(db: AsyncSession):
+    """All-rejected should still be terminal — no later role can rescue."""
+    student = _user(UserRole.student, "s4")
+    professor = _user(UserRole.professor, "p4")
+    db.add_all([student, professor])
+    await db.commit()
+    await db.refresh(student)
+    await db.refresh(professor)
+
+    config = await _seed_scholarship_and_config(db, requires_college_review=True)
+    app = await _seed_app(db, student=student, config=config)
+    await _seed_review(db, application=app, reviewer=professor, sub_type_code="default", recommendation="reject")
+
+    service = ReviewService(db)
+    final_status = await service.update_application_status(app.id)
+
+    assert _val(final_status) == ApplicationStatus.rejected.value


### PR DESCRIPTION
Closes #182.

A single professor "approve" was flipping `application.status` straight to `approved` even when `requires_college_review=True` on the scholarship config. Two consequences:

1. **College review was silently skipped** — the configured pipeline was ignored and the ranking step never happened.
2. **Status=`approved` blocked withdraw** (only `submitted` / `under_review` are withdrawable). Admin DELETE was also blocked. The only escape was direct DB intervention.

Surfaced today on staging while running the apply → review → admin chain — produced `APP-114-0-00035` stuck in `approved` after a single professor approval. See #182 for repro.

## Fix

`ReviewService.update_application_status` now consults the configured pipeline before flipping to a terminal status:

- New helper `_awaits_further_required_review(application, latest_role)` loads the `ScholarshipConfiguration` via the FK and returns True iff `config.requires_college_review` and the latest reviewer was a professor.
- When `all_approved` and that helper is True, status stays at `under_review` (keeps withdrawal open) and `review_stage` advances to `professor_reviewed`. Once college also approves, `latest_role="college"` → helper returns False → status flips to `approved`.
- Same gating applied to the partial-approval branch.
- `all_rejected` remains terminal — no later role can rescue a fully-rejected app.

## Tests

```
pytest backend/app/tests/test_review_service_status_gating.py      4 passed
pytest backend/app/tests/test_review_service_lock.py               7 passed
black --check                                                      clean
```

Four new scenarios in `test_review_service_status_gating.py`:
- `test_professor_approve_keeps_status_under_review_when_college_required` — the exact #182 repro
- `test_college_approve_after_professor_promotes_to_approved` — chain continuation
- `test_professor_approve_promotes_to_approved_when_no_college_review` — happy path doesn't regress when no college step is configured
- `test_full_reject_is_terminal_regardless_of_pipeline` — all-rejected stays terminal

## Operational note

Once this lands, the staging row `APP-114-0-00035` (id=87) is still stuck at `approved`. It needs separate manual cleanup (DB-level) — not addressed by this PR. Future apps will not get into the same state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)