### PR TITLE
fix(nightly): pre-create nightly-failure label so issue filing works

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -233,6 +233,15 @@ jobs:
         run: |
           today=$(date -u +%F)
           run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # Pre-create the label so `gh issue create --label nightly-failure`
+          # doesn't 404 the very first time this fires on a fresh repo.
+          # `gh label create` exits non-zero if the label already exists,
+          # so swallow it.
+          gh label create nightly-failure \
+            --repo ${{ github.repository }} \
+            --color "d73a4a" \
+            --description "Auto-filed by nightly long-running lane" \
+            2>/dev/null || true
           # Find an existing nightly-failure issue from today, otherwise create one.
           existing=$(gh issue list \
             --repo ${{ github.repository }} \


### PR DESCRIPTION
The "File issue on failure" job at the tail of the nightly long-running lane was itself failing with:

\`\`\`
could not add label: 'nightly-failure' not found
\`\`\`

[Run #25607149559](https://github.com/anud18/scholarship-system/actions/runs/25607149559). \`gh issue create --label X\` hard-fails when the label doesn't exist on the repo. Same pattern that bit \`monitoring-alert-issue.yml\` in #179.

## Fix

Prepend a \`gh label create nightly-failure ... || true\` step inside the same shell block. Idempotent because \`gh label create\` exits non-zero on existing labels.

## What this PR doesn't do

The underlying job failures (audit-log-contract, e2e-full, backend-slow) are addressed by separate PRs from the swarm fixing the same nightly run — this PR only fixes the issue-filing step so future nightlies can self-document failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)