### PR TITLE
fix(docker): backend build COPY references missing emails path

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -117,15 +117,21 @@ jobs:
             type=raw,value=${{ needs.pre-deployment.outputs.version }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Copy email templates for backend build
-        if: matrix.component == 'backend'
-        run: cp -r frontend/emails backend/emails
-
       - name: Build and push ${{ matrix.component }} image
         id: docker_build
         uses: docker/build-push-action@v5
         with:
           context: ./${{ matrix.component }}
+          # Expose frontend/emails to the backend Dockerfile via a named
+          # build context (BuildKit). The backend Dockerfile pulls templates
+          # via `COPY --from=frontend_emails . /frontend/emails`. This
+          # replaces the previous `cp -r frontend/emails backend/emails`
+          # workaround, which polluted the working tree and was missing in
+          # docker-compose.dev.yml (causing the nightly E2E build to fail).
+          # The frontend matrix entry resolves to an empty string, which the
+          # action ignores.
+          build-contexts: |
+            ${{ matrix.component == 'backend' && 'frontend_emails=./frontend/emails' || '' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,15 +176,23 @@ jobs:
       run: |
         VERSION=${{ needs.prepare-release.outputs.version }}
 
-        # Build backend
-        docker build -t ghcr.io/${{ github.repository }}/backend:$VERSION \
+        # Build backend. The Dockerfile pulls React Email templates from a
+        # named build context (`frontend_emails`) so the build context
+        # itself stays at ./backend (no working-tree pollution / massive
+        # context). Requires buildx, which is configured above.
+        docker buildx build \
+                     -t ghcr.io/${{ github.repository }}/backend:$VERSION \
                      -t ghcr.io/${{ github.repository }}/backend:latest \
+                     --build-context frontend_emails=./frontend/emails \
+                     --load \
                      ./backend
 
         # Build frontend
-        docker build -t ghcr.io/${{ github.repository }}/frontend:$VERSION \
+        docker buildx build \
+                     -t ghcr.io/${{ github.repository }}/frontend:$VERSION \
                      -t ghcr.io/${{ github.repository }}/frontend:latest \
                      --build-arg NEXT_PUBLIC_API_URL=${{ secrets.PRODUCTION_API_URL }} \
+                     --load \
                      ./frontend
 
         # Push images

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -37,8 +37,15 @@ RUN uv pip install --system -r pyproject.toml
 # Copy application code
 COPY . .
 
-# Copy frontend email templates
-COPY emails /frontend/emails
+# Copy frontend email templates from the repo's frontend/emails dir.
+# The build context is ./backend (see docker-compose.*.yml), which does
+# not contain an emails/ subdir, so we depend on the named build context
+# `frontend_emails` provided by compose (additional_contexts:) or by
+# `docker buildx build --build-context frontend_emails=./frontend/emails ...`
+# in CI. The image bakes templates at /frontend/emails so prod (which has
+# no bind mount) finds them; dev compose still bind-mounts ./frontend/emails
+# at /react-email-templates and points REACT_EMAIL_TEMPLATES_DIR there.
+COPY --from=frontend_emails . /frontend/emails
 
 # Create uploads directory
 RUN mkdir -p uploads

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,6 +63,13 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+      # The Dockerfile bakes email templates into the image via
+      # `COPY --from=frontend_emails . /frontend/emails`. They live in
+      # ../frontend/emails relative to the backend build context, so we
+      # expose that path as a named build context here. (Required by
+      # BuildKit / Compose Spec; supported in Compose v2.4+.)
+      additional_contexts:
+        frontend_emails: ./frontend/emails
     image: ghcr.io/anud18/scholarship-system-backend:${TAG:-latest}
     container_name: scholarship_backend_dev
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Summary

The backend Dockerfile's `COPY emails /frontend/emails` line broke the nightly **E2E Full** job ([failing run](https://github.com/anud18/scholarship-system/actions/runs/25607149559)) with:

```
#19 ERROR: failed to calculate checksum of ref ...: "/emails": not found
target backend: failed to solve: failed to compute cache key: ...
```

**Root cause.** The backend build context is `./backend` (per `docker-compose.dev.yml`), but the React Email templates live at `frontend/emails/`. `deploy-pipeline.yml` had a `cp -r frontend/emails backend/emails` workaround that pre-staged them; `docker-compose.dev.yml` (the path the nightly E2E lane hits) had no such step, so once the nightly lane started running `docker compose ... up --build` the build broke. `release.yml` is also affected (same Dockerfile, same plain `./backend` context, no pre-copy).

**Fix.** Use a BuildKit named build context (`frontend_emails`) so every build path pulls templates straight from `frontend/emails/` — no working-tree pollution and one consistent mechanism:

- `backend/Dockerfile`: `COPY emails /frontend/emails` → `COPY --from=frontend_emails . /frontend/emails`
- `docker-compose.dev.yml`: add `additional_contexts: { frontend_emails: ./frontend/emails }` under the backend service build (this is what unblocks the nightly run that flagged the bug).
- `.github/workflows/deploy-pipeline.yml`: drop the `cp -r` workaround, pass `build-contexts: frontend_emails=./frontend/emails` to `docker/build-push-action@v5` for the backend matrix entry (frontend resolves to empty string, ignored).
- `.github/workflows/release.yml`: switch to `docker buildx build --build-context frontend_emails=./frontend/emails ./backend` (`setup-buildx-action@v3` is already configured). Frontend uses `docker buildx build` too for consistency.

## Test plan

- [x] `docker compose -f docker-compose.dev.yml -p e2e-fix build backend` succeeds locally
- [x] `docker run --rm --entrypoint=ls <image> /frontend/emails` shows all 8 templates (`application-submitted.tsx`, `professor-review-request.tsx`, `college-review-request.tsx`, `result-notification.tsx`, `deadline-reminder.tsx`, `document-request.tsx`, `roster-notification.tsx`, `whitelist-notification.tsx`) — matches `react_email_template_service.ALLOWED_TEMPLATES`
- [ ] Nightly **E2E Full** job passes after merge (workflow_dispatch on `nightly.yml` to verify before next scheduled run)
- [ ] `deploy-pipeline.yml` backend image still builds and pushes to GHCR
- [ ] (No `release.yml` exercise possible without cutting a release; the diff is small and follows the same `--build-context` pattern verified above)

## Notes

- No other services in `docker-compose.dev.yml` are touched.
- Production runtime is unchanged: dev still bind-mounts `./frontend/emails` to `/react-email-templates` and reads it via `REACT_EMAIL_TEMPLATES_DIR`; prod has no bind mount and reads from the image's baked-in `/frontend/emails` (still the case after this PR).
- `additional_contexts` (Compose) and `--build-context` (buildx) are both BuildKit standard features supported in Compose v2.4+ and Docker 19.03+ (CI runners use far newer versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)