### PR TITLE
fix(tests): tag slow tests so the nightly slow-lane has something to run

### DIFF
--- a/backend/app/tests/test_ocr_service.py
+++ b/backend/app/tests/test_ocr_service.py
@@ -197,10 +197,17 @@ class TestOCRService:
             await service.extract_bank_info_from_image(small_image_bytes)
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     @patch("app.services.ocr_service.settings")
     @patch("app.services.ocr_service.genai")
     async def test_large_image_resizing(self, mock_genai, mock_settings):
-        """Test automatic resizing of large images"""
+        """Test automatic resizing of large images.
+
+        Marked `slow`: builds and JPEG-encodes a 5000x5000 PIL image in-memory,
+        then runs the OCR resize pipeline. ~0.65s — slowest non-property test
+        in the suite by ~5x. Belongs in the nightly `backend-slow` lane, not
+        in per-PR CI.
+        """
         mock_settings.ocr_service_enabled = True
         mock_settings.gemini_api_key = "test-key"
         mock_settings.gemini_model = "gemini-2.0-flash"

--- a/backend/app/tests/test_roster_evaluate_condition_property.py
+++ b/backend/app/tests/test_roster_evaluate_condition_property.py
@@ -30,7 +30,13 @@ from hypothesis import strategies as st
 
 from app.services.roster_service import RosterService
 
-pytestmark = pytest.mark.unit
+# Property-based fuzzing with hypothesis: each class burns 100-200 examples
+# per parametrize case, which dwarfs every other unit test in the suite
+# (~2.5s combined vs 0.05s typical). Mark `slow` so the nightly long-running
+# lane (.github/workflows/nightly.yml job `backend-slow`) collects it,
+# while the per-PR `unit` lane keeps moving. We can crank max_examples higher
+# in nightly later without touching per-PR runtime.
+pytestmark = [pytest.mark.unit, pytest.mark.slow]
 
 
 # Pairs of operators whose results must be inverses on the same input.


### PR DESCRIPTION
## Summary

The Nightly Long-Running Lane's `backend-slow` job runs `pytest -m "slow or performance"`, but **no tests in the suite carried either marker** — pytest deselected all 943 tests, exited 5 (no tests collected), and the nightly job has been failing every night.

Failed run: https://github.com/anud18/scholarship-system/actions/runs/25607149559

```
collecting ... collected 943 items / 943 deselected / 0 selected
=========================== 943 deselected in 18.83s ===========================
##[error]Process completed with exit code 5.
```

## Changes

Tag two genuinely-slow tests with `@pytest.mark.slow`:

- **`backend/app/tests/test_roster_evaluate_condition_property.py`** (module-level mark, 7 tests) — hypothesis property-based tests at 100-200 examples per parametrize case. ~2.5s combined; the slowest unit tests in the suite by an order of magnitude. The slow lane lets us crank `max_examples` higher in nightly later without hurting per-PR runtime.
- **`backend/app/tests/test_ocr_service.py::TestOCRService::test_large_image_resizing`** — builds and JPEG-encodes a 5000x5000 PIL image in-memory and runs it through the OCR resize pipeline. ~0.65s, the slowest non-property test in the suite.

8 tests total — comfortably above the "at least 3-5 tests so the lane has signal" guidance.

## Verification

```
$ docker exec scholarship_backend_dev python -m pytest -m "slow or performance" --collect-only -q --no-cov
=============== 8/943 tests collected (935 deselected) in 1.50s ================

$ docker exec scholarship_backend_dev python -m pytest -m "slow or performance" --no-cov -q
====================== 8 passed, 935 deselected in 2.81s =======================

$ docker exec scholarship_backend_dev python -m pytest -m "not slow" --collect-only -q --no-cov
=============== 935/943 tests collected (8 deselected) in 1.61s ================
```

The per-PR lane is unaffected (still collects 935 tests; 8 carved out for nightly).

`pytest.ini` already had `slow` and `performance` registered under `markers =` in the correct `[pytest]` section — no config changes needed.

## Test plan

- [x] `pytest -m "slow or performance" --collect-only` selects 8 tests (was 0)
- [x] `pytest -m "slow or performance"` runs and all 8 pass in ~2.8s
- [x] `pytest -m "not slow"` still collects 935 tests (per-PR lane unaffected)
- [ ] Next nightly run: `backend-slow` job reports passing instead of exit-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)