### PR TITLE
fix(ci): chown frontend/node_modules before host npm ci in E2E Smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,14 @@ jobs:
         if: env.READY == '1'
         working-directory: ./frontend
         run: |
+          # docker compose up --build (above) can leave behind a
+          # node_modules tree owned by the in-container root user when
+          # the bind-mount + anonymous-volume interplay misbehaves on
+          # the runner. Subsequent host-level `npm ci` then trips with
+          # EACCES on a random transitive dep (we've seen @adobe).
+          # Re-take ownership before installing — no-op if the dir is
+          # already runner-owned or doesn't exist.
+          sudo chown -R "$(id -u):$(id -g)" node_modules 2>/dev/null || true
           npm ci
           npx playwright install --with-deps chromium
 


### PR DESCRIPTION
The E2E Smoke job started failing on PRs once #188 made \`docker compose up --build\` actually succeed. Symptom:

\`\`\`
Install Playwright browsers
  npm error code EACCES
  npm error syscall mkdir
  npm error path /home/runner/work/.../frontend/node_modules/@adobe
\`\`\`

The compose file already declares \`/app/node_modules\` as an anonymous volume to keep the container's npm install isolated from the host bind-mount, but on GitHub Actions runners that boundary leaks for a small set of transitive packages (\`@adobe/*\` reliably). They land on the host as root and then the next host-level \`npm ci\` (line 530) can't overwrite them.

## Fix

Add a \`sudo chown -R \$(id -u):\$(id -g) node_modules 2>/dev/null || true\` before the host \`npm ci\`. No-op if already runner-owned or absent.

E2E Smoke is \`continue-on-error: true\` so this isn't blocking merges, but the false-failure noise on every PR isn't useful and was masking real regressions.

Reproducibility: the EACCES hit twice on PR #188's CI ([failed run](https://github.com/anud18/scholarship-system/actions/runs/25634242219)), so this isn't a one-off flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)