### PR TITLE
fix(nightly): apply node_modules chown to E2E Full (same EACCES as ci.yml)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -191,6 +191,14 @@ jobs:
       - name: Install Playwright browsers
         working-directory: ./frontend
         run: |
+          # Same workaround as ci.yml's E2E Smoke job (#190): the
+          # docker compose up --build above sometimes leaves
+          # frontend/node_modules with root ownership for a small
+          # set of transitive deps (notably @adobe/*), which then
+          # breaks the host-level `npm ci` with EACCES. Reclaim
+          # ownership before installing — no-op if already
+          # runner-owned or absent.
+          sudo chown -R "$(id -u):$(id -g)" node_modules 2>/dev/null || true
           npm ci
           npx playwright install --with-deps chromium
 


### PR DESCRIPTION
The validation nightly run [#25634776779](https://github.com/anud18/scholarship-system/actions/runs/25634776779) — triggered after merging #186/#187/#188/#189/#190 — surfaced that #190's chown workaround needs to also live in \`nightly.yml\`.

3 of 4 nightly jobs went green:
- ✅ Audit Log Contract
- ✅ Backend Slow + Performance
- ✅ File issue on failure
- ❌ E2E Full — hit the **exact same** EACCES on \`frontend/node_modules/@adobe\` during the host-level \`npm ci\` step that #190 fixed in \`ci.yml\`'s E2E Smoke

Same root cause, same fix: \`sudo chown -R \$(id -u):\$(id -g) node_modules || true\` immediately before \`npm ci\`.

After this lands, expect the next nightly run to be fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)