### PR TITLE
fix(e2e): correct review table names + roster spec scholarship choice

### DIFF
--- a/frontend/e2e/helpers/db.ts
+++ b/frontend/e2e/helpers/db.ts
@@ -31,7 +31,7 @@ export async function getApplicationById(id: number): Promise<Record<string, unk
 export async function getReviews(applicationDbId: number): Promise<Array<Record<string, unknown>>> {
   const { rows } = await pool.query(
     `SELECT id, application_id, reviewer_id, recommendation, comments, reviewed_at
-     FROM reviews WHERE application_id = $1 ORDER BY id`,
+     FROM application_reviews WHERE application_id = $1 ORDER BY id`,
     [applicationDbId],
   );
   return rows;
@@ -79,12 +79,20 @@ export async function dumpRelated(opts: {
 }
 
 export async function deleteApplicationCascade(appId: string): Promise<void> {
-  // Best-effort idempotent cleanup. Order respects FKs: reviews → audit → application.
+  // Best-effort idempotent cleanup. Order respects FKs:
+  //   application_review_items → application_reviews → audit → application.
+  // The legacy `reviews`/`review_items` table names never existed in this
+  // schema; they came from an early draft of the helper. Each DELETE
+  // tolerates the absence of its table so older branches with partial
+  // schema still drain cleanly.
   const { rows } = await pool.query("SELECT id FROM applications WHERE app_id = $1", [appId]);
   if (!rows[0]) return;
   const id = rows[0].id as number;
-  await pool.query("DELETE FROM review_items WHERE review_id IN (SELECT id FROM reviews WHERE application_id = $1)", [id]).catch(() => undefined);
-  await pool.query("DELETE FROM reviews WHERE application_id = $1", [id]).catch(() => undefined);
+  await pool.query(
+    `DELETE FROM application_review_items
+     WHERE review_id IN (SELECT id FROM application_reviews WHERE application_id = $1)`,
+    [id],
+  ).catch(() => undefined);
   await pool.query("DELETE FROM application_reviews WHERE application_id = $1", [id]).catch(() => undefined);
   await pool.query("DELETE FROM application_audit_logs WHERE application_id = $1", [id]).catch(() => undefined);
   await pool.query("DELETE FROM applications WHERE id = $1", [id]);

--- a/frontend/e2e/specs/roster-generation.spec.ts
+++ b/frontend/e2e/specs/roster-generation.spec.ts
@@ -29,7 +29,14 @@ import {
 } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
 
-const SCHOLARSHIP_CODE = "phd";
+// Use direct_phd (NOT phd): seed_scholarship_configs.py:258 sets
+// direct_phd_114 to QuotaManagementMode.simple, while phd_114 is
+// matrix_based — and matrix-mode rosters require a prior matrix
+// distribution before /payment-rosters/generate will accept them
+// (see roster_service.py: "找不到已執行分發的排名"). This spec only
+// exercises the HTTP → RosterService → Postgres path; the matrix
+// distribution flow is its own scenario.
+const SCHOLARSHIP_CODE = "direct_phd";
 // Use a far-future period_label so this spec never collides with seed data
 // or with the multi-role-phd spec running in the same Postgres.
 const PERIOD_LABEL = "2099-E2E";


### PR DESCRIPTION
Two real test bugs uncovered by the third validation nightly run [#25635066450](https://github.com/anud18/scholarship-system/actions/runs/25635066450) — both were latent until #186/#187/#188/#189/#190/#192/#193 cleared the infra blockers.

## helpers/db.ts — wrong table names

\`getReviews\` queried \`FROM reviews\`; \`deleteApplicationCascade\` cleaned up \`reviews\` / \`review_items\`. Those names never existed in this schema. Actual tables: \`application_reviews\` (\`backend/app/models/review.py:21\`) and \`application_review_items\` (\`:48\`).

\`multi-role-phd.spec.ts:73\` hits this on diagnostic dump → \`relation \"reviews\" does not exist\`. Fixed.

## roster-generation.spec.ts — wrong scholarship code

The @smoke roster test posted to \`/payment-rosters/generate\` with \`SCHOLARSHIP_CODE = "phd"\`. \`seed_scholarship_configs.py:180\` makes \`phd_114\` matrix-mode, and \`roster_service\` rightly rejects matrix-mode rosters with no prior distribution: \"找不到已執行分發的排名\". The test always 500'd whenever seed actually ran end-to-end.

Switch to \`direct_phd\` — \`seed_scholarship_configs.py:258\` makes \`direct_phd_114\` simple-quota-mode, so the bare HTTP → RosterService → Postgres path the spec is meant to exercise works without a matrix-distribution setup step. Comment in the spec spells out the why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)