### PR TITLE
chore(workflows): opt every workflow into Node.js 24 runtime

### DIFF
--- a/.github/workflows/api-types-check.yml
+++ b/.github/workflows/api-types-check.yml
@@ -24,6 +24,7 @@ permissions:
 env:
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.13'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   verify-api-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   USER: ${{ github.repository_owner }}
   IMAGE_NAME: ${{ github.repository }}
   CI: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   # Detect changes to optimize CI runs

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,9 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   claude-review:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   # schedule:
   #   - cron: '37 13 * * 0'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/deploy-monitoring-stack.yml
+++ b/.github/workflows/deploy-monitoring-stack.yml
@@ -16,6 +16,9 @@ on:
         default: false
 
 # SECURITY: Limit GITHUB_TOKEN permissions to minimum required
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -21,6 +21,7 @@ env:
   PYTHON_VERSION: '3.13'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   # Determine deployment targets

--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -19,6 +19,7 @@ permissions:
 env:
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.13'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   # Auto-label PRs based on changes

--- a/.github/workflows/mirror-to-production.yml
+++ b/.github/workflows/mirror-to-production.yml
@@ -19,6 +19,9 @@ on:
         type: string
 
 # SECURITY: Limit GITHUB_TOKEN permissions to minimum required
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: write  # Need write for creating/updating production branch
 

--- a/.github/workflows/monitoring-alert-issue.yml
+++ b/.github/workflows/monitoring-alert-issue.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [monitoring-alert]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   issues: write
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ permissions:
 env:
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.13'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   backend-slow:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ on:
           - patch
           - prerelease
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/sarif-to-pdf.yml
+++ b/.github/workflows/sarif-to-pdf.yml
@@ -8,6 +8,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   generate-pdf:
     name: Generate PDF from SARIF

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,7 @@ permissions:
 env:
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.13'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   # CodeQL Analysis

--- a/.github/workflows/staging-evidence.yml
+++ b/.github/workflows/staging-evidence.yml
@@ -22,6 +22,9 @@ on:
   pull_request:
     types: [labeled]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   summary:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Actions surfaced Node 20 deprecation warnings on every job of nightly run [#25635963188](https://github.com/anud18/scholarship-system/actions/runs/25635963188), and on every PR via ci.yml:

> Node.js 20 actions are deprecated. ... Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **Sept 16th, 2026**.

Per GitHub's migration note, the official opt-in is \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\` set in the workflow file.

## Change

Added the env var at the top-level \`env:\` of all 15 workflows in \`.github/workflows/\`. For files with an existing \`env:\` block, appended one line; for files without, inserted a 2-line block before \`permissions:\` / \`jobs:\`.

## Why now (≈3 weeks before the cliff)

- Silences every Node 20 deprecation warning today.
- Surfaces any Node 24-specific action incompatibility now, rather than at the June 2 cutover when GH flips the default.
- Makes the Sept 16 Node 20 removal a no-op for us.

## What this PR doesn't do

Pin newer action major versions (\`checkout@v5\`, \`setup-node@v5\`, etc.). That's a larger change with its own compat surface, deferred as a follow-up. This PR is the minimal-surface fix.

YAML validated for all 15 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)