### PR TITLE
chore(e2e): drop dead-table reference in deleteApplicationCascade

### DIFF
--- a/frontend/e2e/helpers/db.ts
+++ b/frontend/e2e/helpers/db.ts
@@ -94,6 +94,10 @@ export async function deleteApplicationCascade(appId: string): Promise<void> {
     [id],
   ).catch(() => undefined);
   await pool.query("DELETE FROM application_reviews WHERE application_id = $1", [id]).catch(() => undefined);
-  await pool.query("DELETE FROM application_audit_logs WHERE application_id = $1", [id]).catch(() => undefined);
+  // The audit table is `audit_logs` (general-purpose), keyed by
+  // (resource_type, resource_id::text). `application_audit_logs` was an
+  // early-draft name that never existed in the schema; the previous query
+  // silently no-op'd via .catch(). Stop pretending to clean it up — the
+  // genuine audit rows are removed by their FK cascade on applications.
   await pool.query("DELETE FROM applications WHERE id = $1", [id]);
 }


### PR DESCRIPTION
\`helpers/db.ts:97\` had \`DELETE FROM application_audit_logs WHERE application_id = \$1\`. That table never existed in this schema — the audit table is the general-purpose \`audit_logs\` keyed by (resource_type, resource_id::text). The query silently no-op'd via \`.catch(() => undefined)\` swallowing the \"relation does not exist\" error every cleanup.

Same pattern as #194 (\`reviews\`/\`review_items\` → \`application_reviews\`/\`application_review_items\`); this was the missed third dead reference.

The actual audit rows are removed by FK cascade on \`applications\` deletion, so removing the explicit DELETE has no behavioral effect — just unblocks future legitimate \`.catch\` logic.

Surfaced while debugging a flaky line-193 failure in run #25686925509 (since cleared on the next nightly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)