### PR TITLE
fix: close read-after-write race in POST /college-review/rankings (#199)

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -217,6 +217,11 @@ async def create_ranking(
             ranking_name=ranking_name,
             force_new=force_new,
         )
+        # Commit before building the response so the row is visible to any
+        # read-after-write query the caller makes immediately after receiving
+        # the HTTP 200 (e.g. direct pool.query in the E2E test suite).
+        # get_db will commit again on context exit but that is a no-op here.
+        await db.commit()
 
         return ApiResponse(
             success=True,


### PR DESCRIPTION
Closes #199

## Summary

- `POST /college-review/rankings` was flushing the new `CollegeRanking` row inside the SQLAlchemy session but relied on `get_db`'s post-yield `await session.commit()` for durability.
- FastAPI serializes and streams the HTTP 200 response to the client **before** that context-exit commit runs, opening a window where a caller that immediately queries the DB directly (like the `multi-role-phd.spec.ts` E2E `pool.query`) lands under `READ COMMITTED` isolation before the row is visible — explaining the intermittent `expect(rankingRows.length).toBe(1)` → Received: 0 failure.
- Fix: add `await db.commit()` in the endpoint right after `service.create_ranking()` returns, before the `ApiResponse` is built. The `get_db` cleanup commit that runs afterward is a harmless no-op on an already-clean session.

## Files changed

- `backend/app/api/v1/endpoints/college_review/ranking_management.py` — 5-line addition in the `create_ranking` endpoint handler.

## Test plan

- [ ] Existing backend unit + integration tests pass (no logic changed, commit semantics only)
- [ ] The `multi-role-phd.spec.ts` nightly E2E lane should no longer exhibit the intermittent 0-row race
- [ ] `POST /college-review/rankings` still returns 200 with the correct ranking `id` and fields

> Auto-fix by scheduled agent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FDiBoBnYnKctjWxNoCQpdN)_