### PR TITLE
feat: 系所申請總表 Excel 匯出（學院端 + 管理員）

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/__init__.py
+++ b/backend/app/api/v1/endpoints/college_review/__init__.py
@@ -14,6 +14,7 @@ This allows the router to be flexible and reusable.
 from fastapi import APIRouter
 
 from .application_review import router as application_router
+from .application_summary_export import router as application_summary_export_router
 from .distribution import router as distribution_router
 from .export_package import router as export_package_router
 from .ranking_management import router as ranking_router
@@ -24,6 +25,7 @@ router = APIRouter(tags=["College Review"])
 
 # Include all sub-routers with their respective tags
 router.include_router(application_router, tags=["College Review - Applications"])
+router.include_router(application_summary_export_router, tags=["College Review - Applications Summary"])
 router.include_router(ranking_router, tags=["College Review - Rankings"])
 router.include_router(distribution_router, tags=["College Review - Distribution"])
 router.include_router(utilities_router, tags=["College Review - Utilities"])

--- a/backend/app/api/v1/endpoints/college_review/_helpers.py
+++ b/backend/app/api/v1/endpoints/college_review/_helpers.py
@@ -187,7 +187,7 @@ async def load_export_aux_data(
             user_ids.add(uid)
 
     account_number_by_user: dict[int, str] = {}
-    advisor_name_by_user: dict[int, str] = {}
+    profile_advisor_by_user: dict[int, str] = {}
 
     if user_ids:
         profile_stmt = select(
@@ -197,7 +197,7 @@ async def load_export_aux_data(
             if acct:
                 account_number_by_user[uid] = acct
             if adv:
-                advisor_name_by_user[uid] = adv
+                profile_advisor_by_user[uid] = adv
 
     # 4. Advisor names from relationships
     advisor_names_by_user: dict[int, list[str]] = {uid: [] for uid in user_ids}
@@ -221,7 +221,7 @@ async def load_export_aux_data(
         names = advisor_names_by_user.get(uid) or []
         if names:
             advisor_string_by_user[uid] = "、".join(names)
-        elif uid in advisor_name_by_user:
-            advisor_string_by_user[uid] = advisor_name_by_user[uid]
+        elif uid in profile_advisor_by_user:
+            advisor_string_by_user[uid] = profile_advisor_by_user[uid]
 
     return dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user

--- a/backend/app/api/v1/endpoints/college_review/_helpers.py
+++ b/backend/app/api/v1/endpoints/college_review/_helpers.py
@@ -3,13 +3,17 @@ Shared helper functions for college review endpoints
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.application_field import ApplicationField, FieldType
+from app.models.professor_student import ProfessorStudentRelationship
 from app.models.scholarship import ScholarshipType
 from app.models.user import AdminScholarship, User
+from app.models.user_profile import UserProfile
+from app.services.college_ranking_export_service import DynamicFieldSpec
 
 logger = logging.getLogger(__name__)
 
@@ -122,3 +126,104 @@ async def _check_application_review_permission(user: User, application_id: int, 
 
     # Check if user has permission for this scholarship type
     return await _check_scholarship_permission(user, application.scholarship_type_id, db)
+
+
+async def load_export_aux_data(
+    db: AsyncSession,
+    *,
+    scholarship_type,  # ScholarshipType ORM object or None
+    applications: Iterable[Any],
+) -> tuple[
+    list[DynamicFieldSpec],
+    dict[str, str],
+    dict[int, str],
+    dict[int, str],
+]:
+    """Bulk-load auxiliary data shared by the 學生資料彙整表 exports.
+
+    Returns:
+        (dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user)
+    """
+
+    # 1. Dynamic text fields flagged for export
+    dynamic_fields: list[DynamicFieldSpec] = []
+    scholarship_type_code = scholarship_type.code if scholarship_type else None
+    if scholarship_type_code:
+        df_stmt = (
+            select(ApplicationField)
+            .where(
+                ApplicationField.scholarship_type == scholarship_type_code,
+                ApplicationField.include_in_college_export.is_(True),
+                ApplicationField.is_active.is_(True),
+                ApplicationField.field_type == FieldType.TEXT.value,
+            )
+            .order_by(ApplicationField.display_order, ApplicationField.id)
+        )
+        rows = (await db.execute(df_stmt)).scalars().all()
+        dynamic_fields = [
+            DynamicFieldSpec(
+                field_name=f.field_name,
+                field_label=f.field_label,
+                export_column_label=f.export_column_label,
+                display_order=f.display_order or 0,
+            )
+            for f in rows
+        ]
+
+    # 2. Sub-type Chinese labels
+    sub_type_labels: dict[str, str] = {}
+    if scholarship_type:
+        for cfg in getattr(scholarship_type, "sub_type_configs", []) or []:
+            if cfg.sub_type_code and cfg.name:
+                sub_type_labels[cfg.sub_type_code] = cfg.name
+
+    # 3. Profile lookups (account_number, advisor_name fallback)
+    user_ids: set[int] = set()
+    for app in applications:
+        if app is None:
+            continue
+        uid = getattr(app, "user_id", None)
+        if uid is not None:
+            user_ids.add(uid)
+
+    account_number_by_user: dict[int, str] = {}
+    advisor_name_by_user: dict[int, str] = {}
+
+    if user_ids:
+        profile_stmt = select(
+            UserProfile.user_id, UserProfile.account_number, UserProfile.advisor_name
+        ).where(UserProfile.user_id.in_(user_ids))
+        for uid, acct, adv in (await db.execute(profile_stmt)).all():
+            if acct:
+                account_number_by_user[uid] = acct
+            if adv:
+                advisor_name_by_user[uid] = adv
+
+    # 4. Advisor names from relationships
+    advisor_names_by_user: dict[int, list[str]] = {uid: [] for uid in user_ids}
+    if user_ids:
+        from app.models.user import User  # local to avoid circular imports
+
+        rel_stmt = (
+            select(ProfessorStudentRelationship.student_id, User.name)
+            .join(User, User.id == ProfessorStudentRelationship.professor_id)
+            .where(
+                ProfessorStudentRelationship.student_id.in_(user_ids),
+                ProfessorStudentRelationship.is_active.is_(True),
+                ProfessorStudentRelationship.relationship_type.in_(["advisor", "co_advisor"]),
+            )
+            .order_by(ProfessorStudentRelationship.student_id, User.name)
+        )
+        for student_id, prof_name in (await db.execute(rel_stmt)).all():
+            if prof_name:
+                advisor_names_by_user[student_id].append(prof_name)
+
+    advisor_string_by_user: dict[int, str] = {}
+    for uid in user_ids:
+        names = advisor_names_by_user.get(uid) or []
+        if names:
+            advisor_string_by_user[uid] = "、".join(names)
+        elif uid in advisor_name_by_user:
+            advisor_string_by_user[uid] = advisor_name_by_user[uid]
+
+    return dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user

--- a/backend/app/api/v1/endpoints/college_review/_helpers.py
+++ b/backend/app/api/v1/endpoints/college_review/_helpers.py
@@ -202,8 +202,6 @@ async def load_export_aux_data(
     # 4. Advisor names from relationships
     advisor_names_by_user: dict[int, list[str]] = {uid: [] for uid in user_ids}
     if user_ids:
-        from app.models.user import User  # local to avoid circular imports
-
         rel_stmt = (
             select(ProfessorStudentRelationship.student_id, User.name)
             .join(User, User.id == ProfessorStudentRelationship.professor_id)

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import selectinload
 
 from app.core.security import require_scholarship_manager
 from app.db.deps import get_db
-from app.models.application import Application
+from app.models.application import Application, ApplicationStatus
 from app.models.scholarship import ScholarshipType
 from app.models.student import Department
 from app.models.user import User, UserRole
@@ -35,7 +35,12 @@ from app.services.college_ranking_export_service import (
     ExportRow,
 )
 
-from ._helpers import load_export_aux_data, normalize_semester_value
+from ._helpers import (
+    _check_academic_year_permission,
+    _check_scholarship_permission,
+    load_export_aux_data,
+    normalize_semester_value,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +75,11 @@ async def export_department_summary_single(
     """Generate the 申請總表 Excel for one department."""
 
     normalised_semester = normalize_semester_value(semester)
+
+    if not await _check_scholarship_permission(current_user, scholarship_type_id, db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限存取此獎學金類型")
+    if not await _check_academic_year_permission(current_user, academic_year, db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限存取此學年度")
 
     # Resolve department row + auth check
     dept = (
@@ -111,7 +121,7 @@ async def export_department_summary_single(
         Application.scholarship_type_id == scholarship_type_id,
         Application.academic_year == academic_year,
         Application.deleted_at.is_(None),
-        Application.status != "deleted",
+        Application.status != ApplicationStatus.deleted.value,
     )
     if normalised_semester is None:
         stmt = stmt.where(Application.semester.is_(None))
@@ -182,6 +192,12 @@ async def export_department_summary_bulk(
     """Generate a ZIP archive containing one 申請總表 xlsx per department."""
 
     normalised_semester = normalize_semester_value(semester)
+
+    if not await _check_scholarship_permission(current_user, scholarship_type_id, db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限存取此獎學金類型")
+    if not await _check_academic_year_permission(current_user, academic_year, db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限存取此學年度")
+
     is_admin = current_user.role in (UserRole.admin, UserRole.super_admin)
 
     if scope == "all" and not is_admin:
@@ -232,7 +248,7 @@ async def export_department_summary_bulk(
         Application.scholarship_type_id == scholarship_type_id,
         Application.academic_year == academic_year,
         Application.deleted_at.is_(None),
-        Application.status != "deleted",
+        Application.status != ApplicationStatus.deleted.value,
     )
     if normalised_semester is None:
         stmt = stmt.where(Application.semester.is_(None))

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -15,7 +15,7 @@ import io
 import logging
 import re
 import zipfile
-from typing import Optional
+from typing import Literal, Optional
 from urllib.parse import quote as _url_quote
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -175,7 +175,7 @@ async def export_department_summary_bulk(
     scholarship_type_id: int = Query(...),
     academic_year: int = Query(...),
     semester: Optional[str] = Query(None),
-    scope: str = Query(..., pattern="^(college|all)$"),
+    scope: Literal["college", "all"] = Query(...),
     current_user: User = Depends(require_scholarship_manager),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -296,7 +296,7 @@ async def export_department_summary_bulk(
             )
             inner_name = (
                 f"{academic_year}學年度{scholarship_name}學生資料彙整表"
-                f"_{_sanitise_filename_part(dept_name)}.xlsx"
+                f"_{_sanitise_filename_part(dept_name)}_{_sanitise_filename_part(dept_code)}.xlsx"
             )
             zf.writestr(inner_name, xlsx_bytes)
 

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -1,0 +1,52 @@
+"""
+Application Summary (申請總表) Excel Export Endpoints
+
+Two endpoints, both under /api/v1/college-review/applications/:
+- GET /department-summary-export       → single department .xlsx
+- GET /department-summary-export-bulk  → multi-department .zip
+
+Reuses CollegeRankingExportService with ExportRow.rank_position=None so the
+學院初審會議之學院排序 column renders empty cells.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import zipfile
+from typing import Optional
+from urllib.parse import quote as _url_quote
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.security import require_college
+from app.db.deps import get_db
+from app.models.application import Application
+from app.models.scholarship import ScholarshipType
+from app.models.student import Department
+from app.models.user import User, UserRole
+from app.services.college_ranking_export_service import (
+    CollegeRankingExportService,
+    ExportRow,
+)
+
+from ._helpers import load_export_aux_data, normalize_semester_value
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+XLSX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+ZIP_MEDIA_TYPE = "application/zip"
+
+# Characters not allowed in cross-platform filenames
+_UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
+
+
+def _sanitise_filename_part(value: str) -> str:
+    return _UNSAFE_FILENAME_RE.sub("_", value).strip() or "untitled"

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -162,3 +162,158 @@ async def export_department_summary_single(
             "Content-Length": str(len(payload)),
         },
     )
+
+
+@router.get("/applications/department-summary-export-bulk")
+async def export_department_summary_bulk(
+    scholarship_type_id: int = Query(...),
+    academic_year: int = Query(...),
+    semester: Optional[str] = Query(None),
+    scope: str = Query(..., pattern="^(college|all)$"),
+    current_user: User = Depends(require_college),
+    db: AsyncSession = Depends(get_db),
+):
+    """Generate a ZIP archive containing one 申請總表 xlsx per department."""
+
+    normalised_semester = normalize_semester_value(semester)
+    is_admin = current_user.role in (UserRole.admin, UserRole.super_admin)
+
+    if scope == "all" and not is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="學院使用者僅能匯出本學院資料",
+        )
+
+    if scope == "college":
+        college_code = (current_user.college_code or "").strip()
+        if not college_code:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="未設定學院，無法使用本學院範圍",
+            )
+        dept_rows = (
+            await db.execute(
+                select(Department).where(Department.academy_code == college_code)
+            )
+        ).scalars().all()
+        target_dept_codes = [d.code for d in dept_rows if d.code]
+    else:  # scope == "all"
+        target_dept_codes = None  # no dept filter
+
+    # Load scholarship type
+    stype = (
+        await db.execute(
+            select(ScholarshipType)
+            .where(ScholarshipType.id == scholarship_type_id)
+            .options(selectinload(ScholarshipType.sub_type_configs))
+        )
+    ).scalar_one_or_none()
+    if stype is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"找不到獎學金類型 ID={scholarship_type_id}",
+        )
+
+    # Empty target list for college scope → no matches
+    if target_dept_codes is not None and not target_dept_codes:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="找不到符合條件的申請資料",
+        )
+
+    # Load applications
+    stmt = select(Application).where(
+        Application.scholarship_type_id == scholarship_type_id,
+        Application.academic_year == academic_year,
+        Application.deleted_at.is_(None),
+        Application.status != "deleted",
+    )
+    if normalised_semester is None:
+        stmt = stmt.where(Application.semester.is_(None))
+    else:
+        stmt = stmt.where(Application.semester == normalised_semester)
+
+    raw_apps = list((await db.execute(stmt)).scalars().all())
+    if target_dept_codes is not None:
+        allowed = set(target_dept_codes)
+        apps = [
+            a for a in raw_apps
+            if ((a.student_data or {}).get("std_depno") or "").strip() in allowed
+        ]
+    else:
+        apps = raw_apps
+
+    if not apps:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="找不到符合條件的申請資料",
+        )
+
+    apps.sort(key=lambda a: ((a.student_data or {}).get("std_stdcode") or "", a.id))
+
+    # Group by std_depno
+    groups: dict[str, list] = {}
+    for app in apps:
+        dept_code = ((app.student_data or {}).get("std_depno") or "").strip() or "未知"
+        groups.setdefault(dept_code, []).append(app)
+
+    # Department name lookup
+    dept_codes = list(groups.keys())
+    dept_name_rows = (
+        await db.execute(select(Department).where(Department.code.in_(dept_codes)))
+    ).scalars().all()
+    name_by_code = {d.code: d.name for d in dept_name_rows}
+
+    # Aux data — loaded once over the union of applicants
+    dynamic_fields, sub_type_labels, account_by_user, advisor_by_user = await load_export_aux_data(
+        db, scholarship_type=stype, applications=apps,
+    )
+
+    scholarship_name = stype.name or "獎學金"
+    service = CollegeRankingExportService()
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for dept_code, dept_apps in groups.items():
+            dept_name = name_by_code.get(dept_code) or dept_code
+            export_rows = [
+                ExportRow(
+                    rank_position=None,
+                    application=app,
+                    bank_account=account_by_user.get(app.user_id),
+                    advisor_names=advisor_by_user.get(app.user_id),
+                )
+                for app in dept_apps
+            ]
+            title = f"{academic_year}學年度{scholarship_name}學生資料彙整表 - {dept_name}"
+            sheet_name = f"{academic_year}學年"
+            xlsx_bytes = service.build_workbook(
+                rows=export_rows,
+                dynamic_fields=dynamic_fields,
+                sub_type_labels=sub_type_labels,
+                title=title,
+                sheet_name=sheet_name,
+            )
+            inner_name = (
+                f"{academic_year}學年度{scholarship_name}學生資料彙整表"
+                f"_{_sanitise_filename_part(dept_name)}.xlsx"
+            )
+            zf.writestr(inner_name, xlsx_bytes)
+
+    payload = buf.getvalue()
+
+    scope_label = current_user.college_code if scope == "college" else "全部"
+    base_filename = (
+        f"{academic_year}學年度{scholarship_name}學生資料彙整表"
+        f"_{_sanitise_filename_part(scope_label or '全部')}.zip"
+    )
+    encoded = _url_quote(base_filename, safe="")
+
+    return StreamingResponse(
+        iter([payload]),
+        media_type=ZIP_MEDIA_TYPE,
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{encoded}",
+            "Content-Length": str(len(payload)),
+        },
+    )

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -50,3 +50,115 @@ _UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
 
 def _sanitise_filename_part(value: str) -> str:
     return _UNSAFE_FILENAME_RE.sub("_", value).strip() or "untitled"
+
+
+@router.get("/applications/department-summary-export")
+async def export_department_summary_single(
+    scholarship_type_id: int = Query(..., description="Scholarship type ID"),
+    academic_year: int = Query(..., description="Academic year"),
+    semester: Optional[str] = Query(None, description="first / second / yearly / null"),
+    department_code: str = Query(..., min_length=1, description="Department code (Department.code)"),
+    current_user: User = Depends(require_college),
+    db: AsyncSession = Depends(get_db),
+):
+    """Generate the 申請總表 Excel for one department."""
+
+    normalised_semester = normalize_semester_value(semester)
+
+    # Resolve department row + auth check
+    dept = (
+        await db.execute(select(Department).where(Department.code == department_code))
+    ).scalar_one_or_none()
+    if dept is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"找不到系所代碼 {department_code}",
+        )
+
+    if current_user.role not in (UserRole.admin, UserRole.super_admin):
+        user_college = (current_user.college_code or "").strip()
+        dept_academy = (dept.academy_code or "").strip()
+        if not user_college or not dept_academy or user_college != dept_academy:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="無權限匯出此系所之資料",
+            )
+
+    # Load scholarship type (with sub_type_configs)
+    stype = (
+        await db.execute(
+            select(ScholarshipType)
+            .where(ScholarshipType.id == scholarship_type_id)
+            .options(selectinload(ScholarshipType.sub_type_configs))
+        )
+    ).scalar_one_or_none()
+    if stype is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"找不到獎學金類型 ID={scholarship_type_id}",
+        )
+
+    # Load applications. student_data is plain JSON (not JSONB) so filter by
+    # std_depno in Python rather than via SQL JSON-path. Typical N is < 1k per
+    # (scholarship_type, year, semester) so this is fine.
+    stmt = select(Application).where(
+        Application.scholarship_type_id == scholarship_type_id,
+        Application.academic_year == academic_year,
+        Application.deleted_at.is_(None),
+        Application.status != "deleted",
+    )
+    if normalised_semester is None:
+        stmt = stmt.where(Application.semester.is_(None))
+    else:
+        stmt = stmt.where(Application.semester == normalised_semester)
+
+    raw_apps = list((await db.execute(stmt)).scalars().all())
+    apps = [
+        a for a in raw_apps
+        if ((a.student_data or {}).get("std_depno") or "").strip() == department_code
+    ]
+    apps.sort(key=lambda a: ((a.student_data or {}).get("std_stdcode") or "", a.id))
+
+    # Aux data
+    dynamic_fields, sub_type_labels, account_by_user, advisor_by_user = await load_export_aux_data(
+        db, scholarship_type=stype, applications=apps,
+    )
+
+    # Build rows with rank_position=None — empty cell in column 2
+    export_rows = [
+        ExportRow(
+            rank_position=None,
+            application=app,
+            bank_account=account_by_user.get(app.user_id),
+            advisor_names=advisor_by_user.get(app.user_id),
+        )
+        for app in apps
+    ]
+
+    scholarship_name = stype.name or "獎學金"
+    dept_name = dept.name or department_code
+    title = f"{academic_year}學年度{scholarship_name}學生資料彙整表 - {dept_name}"
+    sheet_name = f"{academic_year}學年"
+    base_filename = (
+        f"{academic_year}學年度{scholarship_name}學生資料彙整表"
+        f"_{_sanitise_filename_part(dept_name)}.xlsx"
+    )
+    encoded = _url_quote(base_filename, safe="")
+
+    service = CollegeRankingExportService()
+    payload = service.build_workbook(
+        rows=export_rows,
+        dynamic_fields=dynamic_fields,
+        sub_type_labels=sub_type_labels,
+        title=title,
+        sheet_name=sheet_name,
+    )
+
+    return StreamingResponse(
+        iter([payload]),
+        media_type=XLSX_MEDIA_TYPE,
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{encoded}",
+            "Content-Length": str(len(payload)),
+        },
+    )

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -24,7 +24,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.core.security import require_college
+from app.core.security import require_scholarship_manager
 from app.db.deps import get_db
 from app.models.application import Application
 from app.models.scholarship import ScholarshipType
@@ -52,13 +52,19 @@ def _sanitise_filename_part(value: str) -> str:
     return _UNSAFE_FILENAME_RE.sub("_", value).strip() or "untitled"
 
 
+def _sort_key(a: "Application"):
+    """Sort key that places applications with a missing std_stdcode last."""
+    code = ((a.student_data or {}).get("std_stdcode") or "").strip()
+    return (not code, code, a.id)  # False(=0) for real codes → first; True(=1) for blanks → last
+
+
 @router.get("/applications/department-summary-export")
 async def export_department_summary_single(
     scholarship_type_id: int = Query(..., description="Scholarship type ID"),
     academic_year: int = Query(..., description="Academic year"),
     semester: Optional[str] = Query(None, description="first / second / yearly / null"),
     department_code: str = Query(..., min_length=1, description="Department code (Department.code)"),
-    current_user: User = Depends(require_college),
+    current_user: User = Depends(require_scholarship_manager),
     db: AsyncSession = Depends(get_db),
 ):
     """Generate the 申請總表 Excel for one department."""
@@ -117,7 +123,7 @@ async def export_department_summary_single(
         a for a in raw_apps
         if ((a.student_data or {}).get("std_depno") or "").strip() == department_code
     ]
-    apps.sort(key=lambda a: ((a.student_data or {}).get("std_stdcode") or "", a.id))
+    apps.sort(key=_sort_key)
 
     # Aux data
     dynamic_fields, sub_type_labels, account_by_user, advisor_by_user = await load_export_aux_data(
@@ -170,7 +176,7 @@ async def export_department_summary_bulk(
     academic_year: int = Query(...),
     semester: Optional[str] = Query(None),
     scope: str = Query(..., pattern="^(college|all)$"),
-    current_user: User = Depends(require_college),
+    current_user: User = Depends(require_scholarship_manager),
     db: AsyncSession = Depends(get_db),
 ):
     """Generate a ZIP archive containing one 申請總表 xlsx per department."""
@@ -249,10 +255,10 @@ async def export_department_summary_bulk(
             detail="找不到符合條件的申請資料",
         )
 
-    apps.sort(key=lambda a: ((a.student_data or {}).get("std_stdcode") or "", a.id))
+    apps.sort(key=_sort_key)
 
     # Group by std_depno
-    groups: dict[str, list] = {}
+    groups: dict[str, list[Application]] = {}
     for app in apps:
         dept_code = ((app.student_data or {}).get("std_depno") or "").strip() or "未知"
         groups.setdefault(dept_code, []).append(app)

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -30,7 +30,6 @@ from app.schemas.college_review import RankingImportItem, RankingOrderUpdate, Ra
 from app.schemas.response import ApiResponse
 from app.services.college_ranking_export_service import (
     CollegeRankingExportService,
-    DynamicFieldSpec,
     ExportRow,
 )
 from app.services.college_review_service import (

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import AuthorizationError, NotFoundError
-from app.core.security import require_college
+from app.core.security import require_college, require_scholarship_manager
 from app.db.deps import get_db
 from app.models.college_review import CollegeRanking, CollegeRankingItem
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
@@ -1089,7 +1089,7 @@ async def import_ranking_from_excel(
 @router.get("/rankings/{ranking_id}/export-excel")
 async def export_ranking_excel(
     ranking_id: int,
-    current_user: User = Depends(require_college),
+    current_user: User = Depends(require_scholarship_manager),
     db: AsyncSession = Depends(get_db),
 ):
     """Generate the 學生資料彙整表 Excel for a ranking.

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -41,7 +41,7 @@ from app.services.college_review_service import (
 )
 from app.services.review_service import ReviewService
 
-from ._helpers import normalize_semester_value
+from ._helpers import load_export_aux_data, normalize_semester_value
 
 logger = logging.getLogger(__name__)
 
@@ -1121,8 +1121,6 @@ async def export_ranking_excel(
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限匯出此學院之資料")
 
     # 3-5. Bulk-load aux data (dynamic fields, sub-type labels, accounts, advisors)
-    from ._helpers import load_export_aux_data  # local import keeps top-of-file imports small
-
     items_sorted = sorted(ranking.items or [], key=lambda x: x.rank_position)
     apps_in_ranking = [item.application for item in items_sorted if item.application is not None]
 

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -22,13 +22,10 @@ from sqlalchemy.orm import selectinload
 from app.core.exceptions import AuthorizationError, NotFoundError
 from app.core.security import require_college
 from app.db.deps import get_db
-from app.models.application_field import ApplicationField, FieldType
 from app.models.college_review import CollegeRanking, CollegeRankingItem
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.student import Department
-from app.models.professor_student import ProfessorStudentRelationship
 from app.models.user import User, UserRole
-from app.models.user_profile import UserProfile
 from app.schemas.college_review import RankingImportItem, RankingOrderUpdate, RankingUpdate
 from app.schemas.response import ApiResponse
 from app.services.college_ranking_export_service import (
@@ -1124,86 +1121,26 @@ async def export_ranking_excel(
         if not creator_college or not user_college or creator_college != user_college:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限匯出此學院之資料")
 
-    # 3. Load dynamic text fields flagged for export
-    scholarship_type_code = ranking.scholarship_type.code if ranking.scholarship_type else None
-    dynamic_fields: list[DynamicFieldSpec] = []
-    if scholarship_type_code:
-        df_stmt = (
-            select(ApplicationField)
-            .where(
-                ApplicationField.scholarship_type == scholarship_type_code,
-                ApplicationField.include_in_college_export.is_(True),
-                ApplicationField.is_active.is_(True),
-                ApplicationField.field_type == FieldType.TEXT.value,
-            )
-            .order_by(ApplicationField.display_order, ApplicationField.id)
-        )
-        dynamic_rows = (await db.execute(df_stmt)).scalars().all()
-        dynamic_fields = [
-            DynamicFieldSpec(
-                field_name=f.field_name,
-                field_label=f.field_label,
-                export_column_label=f.export_column_label,
-                display_order=f.display_order or 0,
-            )
-            for f in dynamic_rows
-        ]
+    # 3-5. Bulk-load aux data (dynamic fields, sub-type labels, accounts, advisors)
+    from ._helpers import load_export_aux_data  # local import keeps top-of-file imports small
 
-    # 4. Build sub-type label map from configured sub_type_configs
-    sub_type_labels: dict[str, str] = {}
-    if ranking.scholarship_type:
-        for cfg in getattr(ranking.scholarship_type, "sub_type_configs", []) or []:
-            if cfg.sub_type_code and cfg.name:
-                sub_type_labels[cfg.sub_type_code] = cfg.name
-
-    # 5. Bulk-load 郵局帳號 (user_profiles.account_number) and 指導教授姓名 for
-    # the applicants in this ranking. Bank account lives on user_profiles
-    # (collected by the application wizard's bank-account step). Advisor names
-    # come from professor_student_relationships JOIN users; if no structured
-    # relationship rows exist, fall back to user_profiles.advisor_name.
     items_sorted = sorted(ranking.items or [], key=lambda x: x.rank_position)
-    user_ids = {item.application.user_id for item in items_sorted if item.application is not None}
+    apps_in_ranking = [item.application for item in items_sorted if item.application is not None]
 
-    profile_account_by_user: dict[int, str] = {}
-    profile_advisor_by_user: dict[int, str] = {}
-    if user_ids:
-        profile_stmt = select(UserProfile.user_id, UserProfile.account_number, UserProfile.advisor_name).where(
-            UserProfile.user_id.in_(user_ids)
+    dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user = (
+        await load_export_aux_data(
+            db,
+            scholarship_type=ranking.scholarship_type,
+            applications=apps_in_ranking,
         )
-        for uid, acct, adv in (await db.execute(profile_stmt)).all():
-            if acct:
-                profile_account_by_user[uid] = acct
-            if adv:
-                profile_advisor_by_user[uid] = adv
-
-    advisor_names_by_user: dict[int, list[str]] = {uid: [] for uid in user_ids}
-    if user_ids:
-        rel_stmt = (
-            select(ProfessorStudentRelationship.student_id, User.name)
-            .join(User, User.id == ProfessorStudentRelationship.professor_id)
-            .where(
-                ProfessorStudentRelationship.student_id.in_(user_ids),
-                ProfessorStudentRelationship.is_active.is_(True),
-                ProfessorStudentRelationship.relationship_type.in_(["advisor", "co_advisor"]),
-            )
-            .order_by(ProfessorStudentRelationship.student_id, User.name)
-        )
-        for student_id, prof_name in (await db.execute(rel_stmt)).all():
-            if prof_name:
-                advisor_names_by_user[student_id].append(prof_name)
-
-    def _advisor_for(user_id: int) -> Optional[str]:
-        names = advisor_names_by_user.get(user_id) or []
-        if names:
-            return "、".join(names)
-        return profile_advisor_by_user.get(user_id)
+    )
 
     export_rows = [
         ExportRow(
             rank_position=item.rank_position,
             application=item.application,
-            bank_account=profile_account_by_user.get(item.application.user_id),
-            advisor_names=_advisor_for(item.application.user_id),
+            bank_account=account_number_by_user.get(item.application.user_id),
+            advisor_names=advisor_string_by_user.get(item.application.user_id),
         )
         for item in items_sorted
         if item.application is not None

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -42,7 +42,12 @@ from app.services.college_review_service import (
 )
 from app.services.review_service import ReviewService
 
-from ._helpers import load_export_aux_data, normalize_semester_value
+from ._helpers import (
+    _check_academic_year_permission,
+    _check_scholarship_permission,
+    load_export_aux_data,
+    normalize_semester_value,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1127,6 +1132,12 @@ async def export_ranking_excel(
         user_college = (current_user.college_code or "").strip()
         if not creator_college or not user_college or creator_college != user_college:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限匯出此學院之資料")
+
+    # 2b. Scholarship + academic-year permission checks (mirrors export_package.py pattern)
+    if not await _check_scholarship_permission(current_user, ranking.scholarship_type_id, db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限存取此獎學金類型")
+    if not await _check_academic_year_permission(current_user, ranking.academic_year, db):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限存取此學年度")
 
     # 3-5. Bulk-load aux data (dynamic fields, sub-type labels, accounts, advisors)
     items_sorted = sorted(ranking.items or [], key=lambda x: x.rank_position)

--- a/backend/app/services/college_ranking_export_service.py
+++ b/backend/app/services/college_ranking_export_service.py
@@ -54,7 +54,7 @@ class DynamicFieldSpec:
 class ExportRow:
     """One ranked application's data."""
 
-    rank_position: int
+    rank_position: Optional[int]
     application: Any  # Duck-typed: needs sub_type_preferences, sub_scholarship_type, student_data, submitted_form_data
     bank_account: Optional[str] = None  # 郵局帳號 (from user_profiles.account_number)
     advisor_names: Optional[str] = None  # 指導教授姓名 (comma-joined if multiple advisors)
@@ -123,7 +123,11 @@ class CollegeRankingExportService:
         sd = getattr(row.application, "student_data", None) or {}
 
         ws.cell(row=excel_row, column=1, value=row_index)
-        ws.cell(row=excel_row, column=2, value=row.rank_position)
+        ws.cell(
+            row=excel_row,
+            column=2,
+            value=(row.rank_position if row.rank_position is not None else ""),
+        )
         ws.cell(
             row=excel_row,
             column=3,

--- a/backend/app/tests/test_application_summary_export_endpoint.py
+++ b/backend/app/tests/test_application_summary_export_endpoint.py
@@ -104,6 +104,39 @@ def _make_college_user(college_code: str = "CE") -> User:
     )
 
 
+def _seed_college_permissions(
+    user_id: int = 9002,
+    scholarship_type_id: int = 1,
+    academic_year: int = 114,
+):
+    """Seed AdminScholarship + ScholarshipConfiguration so _check_*_permission passes
+    for a college user.  SQLite does not enforce FKs by default so the user row
+    itself does not need to exist in the DB."""
+
+    async def _impl():
+        async with _AsyncSession() as session:
+            session.add(
+                AdminScholarship(
+                    admin_id=user_id,
+                    scholarship_id=scholarship_type_id,
+                )
+            )
+            session.add(
+                ScholarshipConfiguration(
+                    id=500,
+                    scholarship_type_id=scholarship_type_id,
+                    academic_year=academic_year,
+                    config_name="Test Config",
+                    config_code=f"test_cfg_{scholarship_type_id}_{academic_year}",
+                    amount=0,
+                    is_active=True,
+                )
+            )
+            await session.commit()
+
+    _run_async(_impl())
+
+
 # ---------------------------------------------------------------------------
 # Test class
 # ---------------------------------------------------------------------------
@@ -264,6 +297,7 @@ class TestDepartmentSummaryExportEndpoint:
     def test_college_user_same_academy_succeeds(self):
         """College user whose college_code matches dept.academy_code gets 200."""
         self._seed_department_and_scholarship(dept_code="CE4460", academy_code="CE")
+        _seed_college_permissions(user_id=9002, scholarship_type_id=1, academic_year=114)
 
         college_user = _make_college_user(college_code="CE")
         client = self._client_with_user(college_user)
@@ -287,6 +321,8 @@ class TestDepartmentSummaryExportEndpoint:
 
 from app.models.application import Application  # noqa: E402
 from app.models.enums import SubTypeSelectionMode  # noqa: E402
+from app.models.scholarship import ScholarshipConfiguration  # noqa: E402
+from app.models.user import AdminScholarship  # noqa: E402
 
 
 class TestDepartmentSummaryExportBulkEndpoint:
@@ -410,6 +446,7 @@ class TestDepartmentSummaryExportBulkEndpoint:
         """College user (CE), scope=college: ZIP contains entries for CE academy depts."""
         self._seed_base()
         self._seed_applications()
+        _seed_college_permissions(user_id=9002, scholarship_type_id=1, academic_year=114)
 
         college_user = _make_college_user(college_code="CE")
         client = self._client_with_user(college_user)
@@ -442,8 +479,15 @@ class TestDepartmentSummaryExportBulkEndpoint:
     # ------------------------------------------------------------------
 
     def test_bulk_college_user_scope_all_forbidden(self):
-        """College user, scope=all → 403 with 學院使用者 in message."""
+        """College user with no scholarship permission, scope=all → 403.
+
+        With the new _check_scholarship_permission gate added in PR #203, the
+        permission check fires before the scope guard for college users that have
+        no AdminScholarship row.  Seed permissions and test the scope guard
+        separately from the scholarship-permission guard.
+        """
         self._seed_base()
+        _seed_college_permissions(user_id=9002, scholarship_type_id=1, academic_year=114)
 
         college_user = _make_college_user(college_code="CE")
         client = self._client_with_user(college_user)
@@ -460,6 +504,8 @@ class TestDepartmentSummaryExportBulkEndpoint:
         assert response.status_code == 403
         body = response.json()
         msg = body.get("message", body.get("detail", ""))
+        # After the permission gates pass, the scope=all guard fires with
+        # this message for non-admin users.
         assert "學院使用者" in msg
 
     # ------------------------------------------------------------------

--- a/backend/tests/test_application_summary_export_endpoint.py
+++ b/backend/tests/test_application_summary_export_endpoint.py
@@ -286,3 +286,237 @@ class TestDepartmentSummaryExportEndpoint:
 
         assert response.status_code == 200
         assert response.content[:2] == b"PK"
+
+
+# ---------------------------------------------------------------------------
+# Bulk ZIP endpoint tests
+# ---------------------------------------------------------------------------
+
+from app.models.application import Application  # noqa: E402
+from app.models.enums import SubTypeSelectionMode  # noqa: E402
+
+
+class TestDepartmentSummaryExportBulkEndpoint:
+    """Integration tests for the bulk ZIP 申請總表 export endpoint."""
+
+    def setup_method(self):
+        _create_tables()
+
+    def teardown_method(self):
+        _drop_tables()
+        app.dependency_overrides.clear()
+
+    def _client_with_user(self, user: User) -> TestClient:
+        """Return a TestClient that bypasses auth and uses an in-process DB session."""
+
+        async def _fake_db():
+            async with _AsyncSession() as session:
+                yield session
+
+        def _fake_auth():
+            return user
+
+        app.dependency_overrides[get_db] = _fake_db
+        app.dependency_overrides[require_college] = _fake_auth
+        return TestClient(app, raise_server_exceptions=True)
+
+    def _seed_base(self):
+        """Seed two departments (same academy CE) + one scholarship type."""
+
+        async def _impl():
+            async with _AsyncSession() as session:
+                session.add(Department(code="CE4460", name="土木工程學系", academy_code="CE"))
+                session.add(Department(code="CE4461", name="環境工程學系", academy_code="CE"))
+                session.add(ScholarshipType(id=1, code="phd_scholarship", name="博士生獎學金"))
+                await session.commit()
+
+        _run_async(_impl())
+
+    def _seed_applications(self):
+        """Seed one application per department under CE academy."""
+
+        async def _impl():
+            async with _AsyncSession() as session:
+                session.add(
+                    Application(
+                        id=1001,
+                        app_id="APP-114-1-00001",
+                        user_id=101,
+                        scholarship_type_id=1,
+                        academic_year=114,
+                        semester="first",
+                        status="submitted",
+                        sub_type_selection_mode=SubTypeSelectionMode.single,
+                        student_data={"std_depno": "CE4460", "std_stdcode": "S001"},
+                    )
+                )
+                session.add(
+                    Application(
+                        id=1002,
+                        app_id="APP-114-1-00002",
+                        user_id=102,
+                        scholarship_type_id=1,
+                        academic_year=114,
+                        semester="first",
+                        status="submitted",
+                        sub_type_selection_mode=SubTypeSelectionMode.single,
+                        student_data={"std_depno": "CE4461", "std_stdcode": "S002"},
+                    )
+                )
+                await session.commit()
+
+        _run_async(_impl())
+
+    # ------------------------------------------------------------------
+    # 1. Admin scope=all returns a ZIP with one XLSX per department
+    # ------------------------------------------------------------------
+
+    def test_bulk_admin_scope_all_returns_zip(self):
+        """Admin user, scope=all: returns 200 ZIP containing 2 xlsx files (one per dept)."""
+        self._seed_base()
+        self._seed_applications()
+
+        admin = _make_admin_user()
+        client = self._client_with_user(admin)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export-bulk",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 114,
+                "semester": "first",
+                "scope": "all",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith("application/zip")
+        content_disposition = response.headers["content-disposition"]
+        assert "filename*=UTF-8''" in content_disposition
+        # "全部" URL-encoded is %E5%85%A8%E9%83%A8
+        assert "%E5%85%A8%E9%83%A8" in content_disposition or "全部" in content_disposition
+
+        # ZIP magic bytes
+        assert response.content[:2] == b"PK"
+
+        # ZIP should contain 2 xlsx files
+        import io as _io
+        import zipfile as _zf
+
+        with _zf.ZipFile(_io.BytesIO(response.content)) as z:
+            names = z.namelist()
+
+        assert len(names) == 2
+        assert all(n.endswith(".xlsx") for n in names)
+
+    # ------------------------------------------------------------------
+    # 2. College user scope=college returns ZIP filtered to their academy
+    # ------------------------------------------------------------------
+
+    def test_bulk_college_user_scope_college(self):
+        """College user (CE), scope=college: ZIP contains entries for CE academy depts."""
+        self._seed_base()
+        self._seed_applications()
+
+        college_user = _make_college_user(college_code="CE")
+        client = self._client_with_user(college_user)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export-bulk",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 114,
+                "semester": "first",
+                "scope": "college",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith("application/zip")
+
+        import io as _io
+        import zipfile as _zf
+
+        with _zf.ZipFile(_io.BytesIO(response.content)) as z:
+            names = z.namelist()
+
+        # Both departments belong to CE academy, so both files should appear
+        assert len(names) == 2
+        assert all(n.endswith(".xlsx") for n in names)
+
+    # ------------------------------------------------------------------
+    # 3. College user requesting scope=all gets 403
+    # ------------------------------------------------------------------
+
+    def test_bulk_college_user_scope_all_forbidden(self):
+        """College user, scope=all → 403 with 學院使用者 in message."""
+        self._seed_base()
+
+        college_user = _make_college_user(college_code="CE")
+        client = self._client_with_user(college_user)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export-bulk",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 114,
+                "scope": "all",
+            },
+        )
+
+        assert response.status_code == 403
+        body = response.json()
+        msg = body.get("message", body.get("detail", ""))
+        assert "學院使用者" in msg
+
+    # ------------------------------------------------------------------
+    # 4. No matching applications → 404
+    # ------------------------------------------------------------------
+
+    def test_bulk_no_matches_returns_404(self):
+        """Admin, academic_year=9999 (no apps): 404 with 找不到 in message."""
+        self._seed_base()
+        # No applications seeded for year 9999
+
+        admin = _make_admin_user()
+        client = self._client_with_user(admin)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export-bulk",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 9999,
+                "scope": "all",
+            },
+        )
+
+        assert response.status_code == 404
+        body = response.json()
+        msg = body.get("message", body.get("detail", ""))
+        assert "找不到" in msg
+
+    # ------------------------------------------------------------------
+    # 5. Admin without college_code requesting scope=college → 400
+    # ------------------------------------------------------------------
+
+    def test_bulk_admin_no_college_code_scope_college_400(self):
+        """Admin without college_code, scope=college → 400."""
+        self._seed_base()
+
+        # Admin user has no college_code set
+        admin = _make_admin_user()
+        client = self._client_with_user(admin)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export-bulk",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 114,
+                "scope": "college",
+            },
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        msg = body.get("message", body.get("detail", ""))
+        assert "未設定學院" in msg

--- a/backend/tests/test_application_summary_export_endpoint.py
+++ b/backend/tests/test_application_summary_export_endpoint.py
@@ -1,0 +1,288 @@
+"""Tests for GET /api/v1/college-review/applications/department-summary-export.
+
+Approach: FastAPI TestClient with dependency_overrides for require_college and get_db.
+We use synchronous TestClient (not AsyncClient) since all tests here are synchronous
+at the test layer — the app itself is async but TestClient handles that transparently.
+
+We bypass JWT auth entirely by overriding require_college (and get_db) directly on
+app.dependency_overrides, which is the standard FastAPI testing pattern and avoids the
+need to generate real JWT tokens or seed an SSO-authenticated user.
+
+The DB is in-memory SQLite (via TestingSessionLocal from conftest helpers), seeded with
+just the rows each test needs: Department, ScholarshipType, and optionally Application.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Ensure test mode before any app import
+os.environ.setdefault("TESTING", "true")
+os.environ.setdefault("PYTEST_CURRENT_TEST", "true")
+
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.core.config import settings
+
+# Override DB URLs
+_TEST_SYNC = "sqlite:///:memory:"
+_TEST_ASYNC = "sqlite+aiosqlite:///:memory:"
+settings.database_url_sync = _TEST_SYNC
+settings.database_url = _TEST_ASYNC
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.core.security import require_college  # noqa: E402
+from app.db.base_class import Base  # noqa: E402
+from app.db.deps import get_db  # noqa: E402
+from app.main import app  # noqa: E402
+from app.models.scholarship import ScholarshipType  # noqa: E402
+from app.models.student import Department  # noqa: E402
+from app.models.user import EmployeeStatus, User, UserRole, UserType  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# In-process test DB (one sync engine per test via setup/teardown helpers)
+# ---------------------------------------------------------------------------
+
+_sync_engine = create_engine(
+    _TEST_SYNC,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_async_engine = create_async_engine(
+    _TEST_ASYNC,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_AsyncSession = async_sessionmaker(_async_engine, class_=AsyncSession, expire_on_commit=False)
+
+
+def _run_async(coro):
+    import asyncio
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(coro)
+
+
+def _create_tables():
+    async def _impl():
+        async with _async_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    _run_async(_impl())
+
+
+def _drop_tables():
+    async def _impl():
+        async with _async_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+    _run_async(_impl())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_admin_user() -> User:
+    return User(
+        id=9001,
+        nycu_id="admin_export",
+        name="Export Admin",
+        email="admin_export@test.nycu.edu.tw",
+        user_type=UserType.employee,
+        status=EmployeeStatus.active,
+        role=UserRole.admin,
+    )
+
+
+def _make_college_user(college_code: str = "CE") -> User:
+    return User(
+        id=9002,
+        nycu_id="college_export",
+        name="College Export",
+        email="college_export@test.nycu.edu.tw",
+        user_type=UserType.employee,
+        status=EmployeeStatus.active,
+        role=UserRole.college,
+        college_code=college_code,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+
+class TestDepartmentSummaryExportEndpoint:
+    """Integration tests for the single-department 申請總表 export endpoint."""
+
+    def setup_method(self):
+        _create_tables()
+
+    def teardown_method(self):
+        _drop_tables()
+        app.dependency_overrides.clear()
+
+    def _client_with_user(self, user: User) -> TestClient:
+        """Return a TestClient that bypasses auth and uses an in-process DB session."""
+
+        async def _fake_db():
+            async with _AsyncSession() as session:
+                yield session
+
+        def _fake_auth():
+            return user
+
+        app.dependency_overrides[get_db] = _fake_db
+        app.dependency_overrides[require_college] = _fake_auth
+        return TestClient(app, raise_server_exceptions=True)
+
+    def _seed_department_and_scholarship(self, dept_code: str = "CE4460", academy_code: str = "CE"):
+        """Insert a Department + ScholarshipType into the async in-memory DB."""
+
+        async def _impl():
+            async with _AsyncSession() as session:
+                dept = Department(code=dept_code, name="土木工程學系", academy_code=academy_code)
+                stype = ScholarshipType(
+                    id=1,
+                    code="phd_scholarship",
+                    name="博士生獎學金",
+                )
+                session.add(dept)
+                session.add(stype)
+                await session.commit()
+
+        _run_async(_impl())
+
+    # ------------------------------------------------------------------
+    # Happy-path test: admin downloads an empty (no applications) XLSX
+    # ------------------------------------------------------------------
+
+    def test_admin_happy_path_empty_xlsx(self):
+        """Admin user can export a department that exists; empty workbook returned."""
+        self._seed_department_and_scholarship(dept_code="CE4460", academy_code="CE")
+
+        admin = _make_admin_user()
+        client = self._client_with_user(admin)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 114,
+                "department_code": "CE4460",
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        # RFC 5987 encoded filename present
+        assert "filename*=UTF-8''" in response.headers["content-disposition"]
+        assert "114" in response.headers["content-disposition"]
+        # Non-empty bytes (openpyxl XLSX always has ZIP magic bytes PK)
+        assert response.content[:2] == b"PK"
+        # Content-Length header must be present and match body size
+        assert "content-length" in response.headers
+        assert int(response.headers["content-length"]) == len(response.content)
+
+    # ------------------------------------------------------------------
+    # Auth rejection: college user for a different academy gets 403
+    # ------------------------------------------------------------------
+
+    def test_college_user_cross_academy_rejected(self):
+        """College user whose college_code != dept.academy_code receives 403."""
+        self._seed_department_and_scholarship(dept_code="CE4460", academy_code="CE")
+
+        wrong_college_user = _make_college_user(college_code="EE")  # different academy
+        client = self._client_with_user(wrong_college_user)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 114,
+                "department_code": "CE4460",
+            },
+        )
+
+        assert response.status_code == 403
+        body = response.json()
+        # App exception handler wraps HTTPException as {"success": False, "message": ...}
+        assert "無權限" in body.get("message", body.get("detail", ""))
+
+    # ------------------------------------------------------------------
+    # 404: unknown department code
+    # ------------------------------------------------------------------
+
+    def test_unknown_department_returns_404(self):
+        """Unknown department_code produces a 404 with Chinese message."""
+        self._seed_department_and_scholarship(dept_code="CE4460", academy_code="CE")
+
+        admin = _make_admin_user()
+        client = self._client_with_user(admin)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 114,
+                "department_code": "NOSUCHDEPT",
+            },
+        )
+
+        assert response.status_code == 404
+        body = response.json()
+        assert "NOSUCHDEPT" in body.get("message", body.get("detail", ""))
+
+    # ------------------------------------------------------------------
+    # 404: unknown scholarship type
+    # ------------------------------------------------------------------
+
+    def test_unknown_scholarship_type_returns_404(self):
+        """Unknown scholarship_type_id produces a 404."""
+        self._seed_department_and_scholarship(dept_code="CE4460", academy_code="CE")
+
+        admin = _make_admin_user()
+        client = self._client_with_user(admin)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export",
+            params={
+                "scholarship_type_id": 999,
+                "academic_year": 114,
+                "department_code": "CE4460",
+            },
+        )
+
+        assert response.status_code == 404
+        body = response.json()
+        msg = body.get("message", body.get("detail", ""))
+        assert "999" in msg
+
+    # ------------------------------------------------------------------
+    # College user for correct academy succeeds
+    # ------------------------------------------------------------------
+
+    def test_college_user_same_academy_succeeds(self):
+        """College user whose college_code matches dept.academy_code gets 200."""
+        self._seed_department_and_scholarship(dept_code="CE4460", academy_code="CE")
+
+        college_user = _make_college_user(college_code="CE")
+        client = self._client_with_user(college_user)
+
+        response = client.get(
+            "/api/v1/college-review/applications/department-summary-export",
+            params={
+                "scholarship_type_id": 1,
+                "academic_year": 114,
+                "department_code": "CE4460",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.content[:2] == b"PK"

--- a/backend/tests/test_application_summary_export_endpoint.py
+++ b/backend/tests/test_application_summary_export_endpoint.py
@@ -22,7 +22,6 @@ import pytest
 os.environ.setdefault("TESTING", "true")
 os.environ.setdefault("PYTEST_CURRENT_TEST", "true")
 
-from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -36,7 +35,7 @@ settings.database_url = _TEST_ASYNC
 
 from fastapi.testclient import TestClient  # noqa: E402
 
-from app.core.security import require_college  # noqa: E402
+from app.core.security import require_scholarship_manager  # noqa: E402
 from app.db.base_class import Base  # noqa: E402
 from app.db.deps import get_db  # noqa: E402
 from app.main import app  # noqa: E402
@@ -48,11 +47,6 @@ from app.models.user import EmployeeStatus, User, UserRole, UserType  # noqa: E4
 # In-process test DB (one sync engine per test via setup/teardown helpers)
 # ---------------------------------------------------------------------------
 
-_sync_engine = create_engine(
-    _TEST_SYNC,
-    connect_args={"check_same_thread": False},
-    poolclass=StaticPool,
-)
 _async_engine = create_async_engine(
     _TEST_ASYNC,
     connect_args={"check_same_thread": False},
@@ -63,8 +57,7 @@ _AsyncSession = async_sessionmaker(_async_engine, class_=AsyncSession, expire_on
 
 def _run_async(coro):
     import asyncio
-    loop = asyncio.get_event_loop()
-    return loop.run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def _create_tables():
@@ -137,7 +130,7 @@ class TestDepartmentSummaryExportEndpoint:
             return user
 
         app.dependency_overrides[get_db] = _fake_db
-        app.dependency_overrides[require_college] = _fake_auth
+        app.dependency_overrides[require_scholarship_manager] = _fake_auth
         return TestClient(app, raise_server_exceptions=True)
 
     def _seed_department_and_scholarship(self, dept_code: str = "CE4460", academy_code: str = "CE"):
@@ -317,7 +310,7 @@ class TestDepartmentSummaryExportBulkEndpoint:
             return user
 
         app.dependency_overrides[get_db] = _fake_db
-        app.dependency_overrides[require_college] = _fake_auth
+        app.dependency_overrides[require_scholarship_manager] = _fake_auth
         return TestClient(app, raise_server_exceptions=True)
 
     def _seed_base(self):

--- a/backend/tests/test_college_ranking_export_service.py
+++ b/backend/tests/test_college_ranking_export_service.py
@@ -149,6 +149,21 @@ class TestStaticColumns:
             "指導教授姓名",
         ]
 
+    def test_rank_position_none_renders_empty_cell(self):
+        """Empty rank cell — used by 申請總表 export which has no rank yet."""
+        row = ExportRow(
+            rank_position=None,
+            application=FakeApplication(
+                sub_type_preferences=["nstc"],
+                student_data=_full_student_data(),
+            ),
+        )
+        rows = _build_workbook([row])
+        # rows[0] = title, rows[1] = headers, rows[2] = first data row
+        data = rows[2]
+        assert data[0] == 1  # NO. (1-based row index)
+        assert data[1] == ""  # rank should be empty when None
+
 
 class TestStaticFieldEdgeCases:
     @pytest.mark.parametrize(

--- a/docs/superpowers/plans/2026-05-13-application-summary-export.md
+++ b/docs/superpowers/plans/2026-05-13-application-summary-export.md
@@ -1,0 +1,1302 @@
+# Application Summary Excel Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a department-scoped 「申請總表」 Excel export reachable by college users (own academy only) and admins, reusing the existing 學生資料彙整表 layout with the rank column left blank. Supports single-department `.xlsx` and multi-department `.zip` modes.
+
+**Architecture:** Reuse `CollegeRankingExportService.build_workbook` by making `ExportRow.rank_position` optional. Extract the shared "load aux data" pipeline (dynamic fields, sub-type labels, profile account, advisor names) from the existing ranking export endpoint into a `_helpers.load_export_aux_data` function. Add two new endpoints under `/api/v1/college-review/applications/` — one returning a single `.xlsx`, one returning a `.zip` bundle. Frontend adds a department selector + 「匯出申請總表」 button to `ApplicationReviewPanel`.
+
+**Tech Stack:** FastAPI, SQLAlchemy (async), openpyxl, Python `zipfile`, Next.js, React, TypeScript, `fetch + blob` for binary downloads.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-application-summary-export-design.md`
+
+---
+
+## Pre-flight
+
+### Task 0: Verify endpoint test infrastructure
+
+**Why:** The prior ranking-export spec deferred endpoint integration tests due to an `aiosqlite` / `httpx.AsyncClient(app=...)` gap in `backend/app/tests/conftest.py`. Find out whether the gap still applies before depending on endpoint tests in later tasks.
+
+**Files:**
+- Inspect: `backend/app/tests/conftest.py`
+- Inspect: `backend/tests/conftest.py` (if exists)
+
+- [ ] **Step 1: Find the conftest and any existing endpoint tests**
+
+```bash
+find backend -name "conftest.py" -type f
+ls backend/tests/test_*endpoint*.py 2>/dev/null
+ls backend/app/tests/ 2>/dev/null
+```
+
+- [ ] **Step 2: Try running a smoke endpoint test if one exists**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/test_mock_sso.py -v 2>&1 | head -40
+```
+
+Expected outcomes:
+- PASS → endpoint tests work, proceed straight to Task 4.
+- FAIL with `httpx.AsyncClient(app=...)` or `aiosqlite` errors → record this; Task 4 must include the conftest fix as Step 1.
+
+- [ ] **Step 3: Document the decision**
+
+No commit. Just note in the conversation whether endpoint tests are usable as-is or whether Task 4 has to fix conftest first.
+
+---
+
+## Phase 1 — Service change (TDD)
+
+### Task 1: Make `ExportRow.rank_position` optional and render empty cell when `None`
+
+**Files:**
+- Modify: `backend/app/services/college_ranking_export_service.py`
+- Test: `backend/tests/test_college_ranking_export_service.py`
+
+- [ ] **Step 1: Add failing regression test**
+
+Append the following inside `backend/tests/test_college_ranking_export_service.py` at the end of the existing `class TestStaticColumns` block (so the helper imports are already in scope):
+
+```python
+    def test_rank_position_none_renders_empty_cell(self):
+        """Empty rank cell — used by 申請總表 export which has no rank yet."""
+        row = ExportRow(
+            rank_position=None,
+            application=FakeApplication(
+                sub_type_preferences=["nstc"],
+                student_data=_full_student_data(),
+            ),
+        )
+        wb_bytes = _build_workbook(rows=[row])
+        wb = load_workbook(io.BytesIO(wb_bytes))
+        ws = wb.active
+        # Data row is row 3 (row 1 = title, row 2 = header)
+        # Column 1 = NO. (row index = 1), Column 2 = rank
+        assert ws.cell(row=3, column=1).value == 1
+        assert ws.cell(row=3, column=2).value == ""
+```
+
+- [ ] **Step 2: Run the test, expect failure**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/test_college_ranking_export_service.py::TestStaticColumns::test_rank_position_none_renders_empty_cell -v
+```
+
+Expected: FAIL. Most likely the dataclass currently types `rank_position: int` and either the failure is a type complaint at construction time OR `ws.cell(...).value` ends up as `None` (openpyxl coerces `None` → empty) — either way the assertion will fail OR pass spuriously. We want the explicit `""` after the change, so check the failure message carefully.
+
+- [ ] **Step 3: Make `rank_position` optional and render `""` when `None`**
+
+In `backend/app/services/college_ranking_export_service.py`:
+
+```python
+# Around line 54 — change the dataclass field type
+@dataclass
+class ExportRow:
+    """One ranked application's data."""
+
+    rank_position: Optional[int]
+    application: Any  # Duck-typed: needs sub_type_preferences, sub_scholarship_type, student_data, submitted_form_data
+    bank_account: Optional[str] = None  # 郵局帳號 (from user_profiles.account_number)
+    advisor_names: Optional[str] = None  # 指導教授姓名 (comma-joined if multiple advisors)
+```
+
+```python
+# Around line 126 — change the cell value
+ws.cell(
+    row=excel_row,
+    column=2,
+    value=(row.rank_position if row.rank_position is not None else ""),
+)
+```
+
+- [ ] **Step 4: Run the new test plus the full service test file**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/test_college_ranking_export_service.py -v
+```
+
+Expected: ALL pass (new test + every existing test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/college_ranking_export_service.py backend/tests/test_college_ranking_export_service.py
+git commit -m "feat(export-service): allow Optional rank_position; render empty cell when None"
+```
+
+---
+
+## Phase 2 — Extract shared load helper (refactor)
+
+### Task 2: Move the export-aux-data loading block into `_helpers.load_export_aux_data`
+
+**Why:** Both the existing ranking export and the new summary export need the same four lookups (dynamic fields, sub-type labels, profile account numbers, advisor names). Centralising them in `_helpers.py` keeps the new endpoint compact and prevents drift.
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/college_review/_helpers.py`
+- Modify: `backend/app/api/v1/endpoints/college_review/ranking_management.py:1127-1199` (the load block; line numbers may have drifted slightly)
+- Test: covered by re-running existing service tests + the existing ranking export endpoint behaviour (manual smoke).
+
+- [ ] **Step 1: Add the helper function to `_helpers.py`**
+
+Append the following at the bottom of `backend/app/api/v1/endpoints/college_review/_helpers.py`. Imports go at the top of the file alongside the existing ones.
+
+```python
+# Add to imports at top of file
+from typing import Iterable
+
+from app.models.application_field import ApplicationField, FieldType
+from app.models.professor_student import ProfessorStudentRelationship
+from app.models.user_profile import UserProfile
+from app.services.college_ranking_export_service import DynamicFieldSpec
+
+
+async def load_export_aux_data(
+    db: AsyncSession,
+    *,
+    scholarship_type,  # ScholarshipType ORM object or None
+    applications: Iterable[Any],
+) -> tuple[
+    list[DynamicFieldSpec],
+    dict[str, str],
+    dict[int, str],
+    dict[int, str],
+]:
+    """Bulk-load auxiliary data shared by the 學生資料彙整表 exports.
+
+    Returns:
+        (dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user)
+    """
+
+    # 1. Dynamic text fields flagged for export
+    dynamic_fields: list[DynamicFieldSpec] = []
+    scholarship_type_code = scholarship_type.code if scholarship_type else None
+    if scholarship_type_code:
+        df_stmt = (
+            select(ApplicationField)
+            .where(
+                ApplicationField.scholarship_type == scholarship_type_code,
+                ApplicationField.include_in_college_export.is_(True),
+                ApplicationField.is_active.is_(True),
+                ApplicationField.field_type == FieldType.TEXT.value,
+            )
+            .order_by(ApplicationField.display_order, ApplicationField.id)
+        )
+        rows = (await db.execute(df_stmt)).scalars().all()
+        dynamic_fields = [
+            DynamicFieldSpec(
+                field_name=f.field_name,
+                field_label=f.field_label,
+                export_column_label=f.export_column_label,
+                display_order=f.display_order or 0,
+            )
+            for f in rows
+        ]
+
+    # 2. Sub-type Chinese labels
+    sub_type_labels: dict[str, str] = {}
+    if scholarship_type:
+        for cfg in getattr(scholarship_type, "sub_type_configs", []) or []:
+            if cfg.sub_type_code and cfg.name:
+                sub_type_labels[cfg.sub_type_code] = cfg.name
+
+    # 3. Profile lookups (account_number, advisor_name fallback)
+    user_ids: set[int] = set()
+    for app in applications:
+        if app is None:
+            continue
+        uid = getattr(app, "user_id", None)
+        if uid is not None:
+            user_ids.add(uid)
+
+    account_number_by_user: dict[int, str] = {}
+    advisor_name_by_user: dict[int, str] = {}
+
+    if user_ids:
+        profile_stmt = select(
+            UserProfile.user_id, UserProfile.account_number, UserProfile.advisor_name
+        ).where(UserProfile.user_id.in_(user_ids))
+        for uid, acct, adv in (await db.execute(profile_stmt)).all():
+            if acct:
+                account_number_by_user[uid] = acct
+            if adv:
+                advisor_name_by_user[uid] = adv
+
+    # 4. Advisor names from relationships
+    advisor_names_by_user: dict[int, list[str]] = {uid: [] for uid in user_ids}
+    if user_ids:
+        from app.models.user import User  # local to avoid circular imports
+
+        rel_stmt = (
+            select(ProfessorStudentRelationship.student_id, User.name)
+            .join(User, User.id == ProfessorStudentRelationship.professor_id)
+            .where(
+                ProfessorStudentRelationship.student_id.in_(user_ids),
+                ProfessorStudentRelationship.is_active.is_(True),
+                ProfessorStudentRelationship.relationship_type.in_(["advisor", "co_advisor"]),
+            )
+            .order_by(ProfessorStudentRelationship.student_id, User.name)
+        )
+        for student_id, prof_name in (await db.execute(rel_stmt)).all():
+            if prof_name:
+                advisor_names_by_user[student_id].append(prof_name)
+
+    advisor_string_by_user: dict[int, str] = {}
+    for uid in user_ids:
+        names = advisor_names_by_user.get(uid) or []
+        if names:
+            advisor_string_by_user[uid] = "、".join(names)
+        elif uid in advisor_name_by_user:
+            advisor_string_by_user[uid] = advisor_name_by_user[uid]
+
+    return dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user
+```
+
+- [ ] **Step 2: Replace the inline block in `ranking_management.py` with a helper call**
+
+In `backend/app/api/v1/endpoints/college_review/ranking_management.py`, locate the `export_ranking_excel` function (around line 1093). Replace the loading section (currently lines ~1127-1199, the four blocks loading dynamic fields, sub_type_labels, profile accounts, advisor names) with:
+
+```python
+    # 3-5. Bulk-load aux data (dynamic fields, sub-type labels, accounts, advisors)
+    from ._helpers import load_export_aux_data  # local import keeps top-of-file imports small
+
+    items_sorted = sorted(ranking.items or [], key=lambda x: x.rank_position)
+    apps_in_ranking = [item.application for item in items_sorted if item.application is not None]
+
+    dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user = (
+        await load_export_aux_data(
+            db,
+            scholarship_type=ranking.scholarship_type,
+            applications=apps_in_ranking,
+        )
+    )
+```
+
+Then update the `ExportRow` construction below to use the new dicts:
+
+```python
+    export_rows = [
+        ExportRow(
+            rank_position=item.rank_position,
+            application=item.application,
+            bank_account=account_number_by_user.get(item.application.user_id),
+            advisor_names=advisor_string_by_user.get(item.application.user_id),
+        )
+        for item in items_sorted
+        if item.application is not None
+    ]
+```
+
+Remove the now-unused imports from the top of `ranking_management.py` (`ApplicationField`, `FieldType`, `ProfessorStudentRelationship`, `UserProfile`) **only if no other code in the file still uses them**. Run `grep -n "ApplicationField\b\|FieldType\b\|ProfessorStudentRelationship\b\|UserProfile\b" backend/app/api/v1/endpoints/college_review/ranking_management.py` to verify before deleting any import.
+
+- [ ] **Step 3: Verify the refactor against existing service tests**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/test_college_ranking_export_service.py -v
+```
+
+Expected: all pass (refactor is at endpoint level; service tests still cover the rendering path).
+
+- [ ] **Step 4: Manual smoke — start dev stack and hit the existing ranking export endpoint**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d backend postgres
+# Wait until backend is ready
+docker compose -f docker-compose.dev.yml logs --tail 30 backend
+```
+
+In a separate terminal or with `curl`:
+```bash
+TOKEN="<dev admin token>"
+RANKING_ID="<any existing ranking id>"
+curl -s -o /tmp/ranking.xlsx -w "%{http_code}\n" \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8000/api/v1/college-review/rankings/$RANKING_ID/export-excel"
+file /tmp/ranking.xlsx
+```
+
+Expected: `200` and `/tmp/ranking.xlsx: Microsoft Excel 2007+`.
+
+If no existing ranking is available, skip this step but log it in the commit message ("Smoke deferred — no seed ranking in dev env").
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/college_review/_helpers.py \
+        backend/app/api/v1/endpoints/college_review/ranking_management.py
+git commit -m "refactor(college-review): extract load_export_aux_data helper"
+```
+
+---
+
+## Phase 3 — New endpoint module (TDD)
+
+### Task 3: Scaffold the new endpoint module and register the router
+
+**Files:**
+- Create: `backend/app/api/v1/endpoints/college_review/application_summary_export.py`
+- Modify: `backend/app/api/v1/endpoints/college_review/__init__.py`
+
+- [ ] **Step 1: Create the empty module with the router stub**
+
+Create `backend/app/api/v1/endpoints/college_review/application_summary_export.py`:
+
+```python
+"""
+Application Summary (申請總表) Excel Export Endpoints
+
+Two endpoints, both under /api/v1/college-review/applications/:
+- GET /department-summary-export       → single department .xlsx
+- GET /department-summary-export-bulk  → multi-department .zip
+
+Reuses CollegeRankingExportService with ExportRow.rank_position=None so the
+學院初審會議之學院排序 column renders empty cells.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import zipfile
+from typing import Optional
+from urllib.parse import quote as _url_quote
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.security import require_college
+from app.db.deps import get_db
+from app.models.application import Application
+from app.models.scholarship import ScholarshipType
+from app.models.student import Department
+from app.models.user import User, UserRole
+from app.services.college_ranking_export_service import (
+    CollegeRankingExportService,
+    ExportRow,
+)
+
+from ._helpers import load_export_aux_data, normalize_semester_value
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+XLSX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+ZIP_MEDIA_TYPE = "application/zip"
+
+# Characters not allowed in cross-platform filenames
+_UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
+
+
+def _sanitise_filename_part(value: str) -> str:
+    return _UNSAFE_FILENAME_RE.sub("_", value).strip() or "untitled"
+```
+
+- [ ] **Step 2: Register the router in `__init__.py`**
+
+Edit `backend/app/api/v1/endpoints/college_review/__init__.py`:
+
+```python
+from .application_review import router as application_router
+from .application_summary_export import router as application_summary_export_router
+from .distribution import router as distribution_router
+from .export_package import router as export_package_router
+from .ranking_management import router as ranking_router
+from .utilities import router as utilities_router
+
+# ... existing setup ...
+
+router.include_router(application_router, tags=["College Review - Applications"])
+router.include_router(application_summary_export_router, tags=["College Review - Applications Summary"])
+router.include_router(ranking_router, tags=["College Review - Rankings"])
+router.include_router(distribution_router, tags=["College Review - Distribution"])
+router.include_router(utilities_router, tags=["College Review - Utilities"])
+router.include_router(export_package_router, tags=["College Review - Export"])
+```
+
+- [ ] **Step 3: Verify backend starts**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d backend
+docker compose -f docker-compose.dev.yml logs --tail 50 backend | grep -E "Application startup|Error|Traceback" | head -20
+```
+
+Expected: `Application startup complete` and no import errors.
+
+- [ ] **Step 4: Commit the scaffold**
+
+```bash
+git add backend/app/api/v1/endpoints/college_review/application_summary_export.py \
+        backend/app/api/v1/endpoints/college_review/__init__.py
+git commit -m "feat(application-summary-export): scaffold router and module"
+```
+
+---
+
+### Task 4: Implement single-department endpoint (TDD)
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/college_review/application_summary_export.py`
+- Create: `backend/tests/test_application_summary_export_endpoint.py`
+
+**Note:** If Task 0 found the conftest broken, fix it as Step 0 here before writing tests:
+
+```python
+# In backend/app/tests/conftest.py — replace the broken AsyncClient pattern with:
+from httpx import ASGITransport, AsyncClient
+
+@pytest_asyncio.fixture
+async def async_client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+```
+
+And ensure `aiosqlite` is in `backend/pyproject.toml` `[project.optional-dependencies].dev`:
+
+```toml
+dev = [
+    # ... existing deps ...
+    "aiosqlite>=0.20.0",
+]
+```
+
+Skip this fix-step entirely if Task 0 confirmed endpoint tests already work.
+
+- [ ] **Step 1: Write the failing happy-path test**
+
+Create `backend/tests/test_application_summary_export_endpoint.py`:
+
+```python
+"""Integration tests for the 申請總表 (application summary) Excel export endpoints."""
+
+import io
+import zipfile
+
+import pytest
+from openpyxl import load_workbook
+
+
+pytestmark = pytest.mark.asyncio
+
+
+SINGLE_PATH = "/api/v1/college-review/applications/department-summary-export"
+BULK_PATH = "/api/v1/college-review/applications/department-summary-export-bulk"
+
+
+async def test_single_department_happy_path(
+    async_client, admin_token, seed_phd_apps_two_depts
+):
+    """Admin downloads a single dept .xlsx — should be 200 with non-empty body."""
+
+    scholarship_type_id, academic_year, dept_code = seed_phd_apps_two_depts
+    resp = await async_client.get(
+        SINGLE_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": academic_year,
+            "department_code": dept_code,
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    body = resp.content
+    assert len(body) > 0
+
+    wb = load_workbook(io.BytesIO(body))
+    ws = wb.active
+    # Row 1 = title, Row 2 = header, Row 3+ = data
+    # Column 2 = 學院初審會議之學院排序 — must be empty for summary export
+    assert ws.cell(row=3, column=2).value == ""
+
+
+async def test_single_department_college_user_own_dept_ok(
+    async_client, college_token_dept_a, seed_phd_apps_two_depts
+):
+    scholarship_type_id, academic_year, dept_code = seed_phd_apps_two_depts
+    resp = await async_client.get(
+        SINGLE_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": academic_year,
+            "department_code": dept_code,
+        },
+        headers={"Authorization": f"Bearer {college_token_dept_a}"},
+    )
+    assert resp.status_code == 200
+
+
+async def test_single_department_college_user_other_dept_forbidden(
+    async_client, college_token_dept_a, seed_phd_apps_two_depts_other_college
+):
+    scholarship_type_id, academic_year, dept_code = seed_phd_apps_two_depts_other_college
+    resp = await async_client.get(
+        SINGLE_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": academic_year,
+            "department_code": dept_code,
+        },
+        headers={"Authorization": f"Bearer {college_token_dept_a}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_single_department_not_found_returns_404(
+    async_client, admin_token, seed_phd_apps_two_depts
+):
+    scholarship_type_id, academic_year, _ = seed_phd_apps_two_depts
+    resp = await async_client.get(
+        SINGLE_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": academic_year,
+            "department_code": "ZZZZ_DOES_NOT_EXIST",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_single_department_no_applications_returns_header_only_workbook(
+    async_client, admin_token, seed_empty_department
+):
+    scholarship_type_id, academic_year, dept_code = seed_empty_department
+    resp = await async_client.get(
+        SINGLE_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": academic_year,
+            "department_code": dept_code,
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    wb = load_workbook(io.BytesIO(resp.content))
+    ws = wb.active
+    # Only title + header — no data row
+    assert ws.cell(row=3, column=1).value is None
+```
+
+> Fixtures (`async_client`, `admin_token`, `college_token_dept_a`, `seed_phd_apps_two_depts`, `seed_phd_apps_two_depts_other_college`, `seed_empty_department`) must exist in `backend/tests/conftest.py` or `backend/app/tests/conftest.py`. Add them now if any are missing — keep them minimal: factory functions that insert a `ScholarshipType`, two `Department` rows (one matching the college user's `college_code` academy), and a small batch of `Application` rows with `student_data["std_depno"]` set.
+
+> If the conftest setup is non-trivial (existing tests don't follow this pattern), keep the test file but mark each test `@pytest.mark.skipif(not has_fixture, reason="needs db seed fixture")` and surface the gap. The endpoint code still ships in Steps 2-4; service-only correctness is covered by Task 1's tests.
+
+- [ ] **Step 2: Run the test, expect failure**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/test_application_summary_export_endpoint.py::test_single_department_happy_path -v
+```
+
+Expected: FAIL with a 404 (endpoint not yet defined) or a 422 (path matched but handler missing).
+
+- [ ] **Step 3: Implement the single-department endpoint**
+
+Append the handler to `backend/app/api/v1/endpoints/college_review/application_summary_export.py`:
+
+```python
+@router.get("/applications/department-summary-export")
+async def export_department_summary_single(
+    scholarship_type_id: int = Query(..., description="Scholarship type ID"),
+    academic_year: int = Query(..., description="Academic year"),
+    semester: Optional[str] = Query(None, description="first / second / yearly / null"),
+    department_code: str = Query(..., min_length=1, description="Department code (Department.code)"),
+    current_user: User = Depends(require_college),
+    db: AsyncSession = Depends(get_db),
+):
+    """Generate the 申請總表 (申請總表) Excel for one department."""
+
+    normalised_semester = normalize_semester_value(semester)
+
+    # Resolve department row + auth check
+    dept = (
+        await db.execute(select(Department).where(Department.code == department_code))
+    ).scalar_one_or_none()
+    if dept is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"找不到系所代碼 {department_code}")
+
+    if current_user.role not in (UserRole.admin, UserRole.super_admin):
+        user_college = (current_user.college_code or "").strip()
+        dept_academy = (dept.academy_code or "").strip()
+        if not user_college or not dept_academy or user_college != dept_academy:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限匯出此系所之資料")
+
+    # Load scholarship type with sub_type_configs eager-loaded
+    stype = (
+        await db.execute(
+            select(ScholarshipType)
+            .where(ScholarshipType.id == scholarship_type_id)
+            .options(selectinload(ScholarshipType.sub_type_configs))
+        )
+    ).scalar_one_or_none()
+    if stype is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"找不到獎學金類型 ID={scholarship_type_id}")
+
+    # Load applications. student_data is plain JSON (not JSONB) so filter by
+    # std_depno in Python rather than via SQL JSON-path. Typical N is < 1k per
+    # (scholarship_type, year, semester) so this is fine.
+    stmt = select(Application).where(
+        Application.scholarship_type_id == scholarship_type_id,
+        Application.academic_year == academic_year,
+        Application.deleted_at.is_(None),
+        Application.status != "deleted",
+    )
+    if normalised_semester is None:
+        stmt = stmt.where(Application.semester.is_(None))
+    else:
+        stmt = stmt.where(Application.semester == normalised_semester)
+
+    raw_apps = list((await db.execute(stmt)).scalars().all())
+    apps = [
+        a for a in raw_apps
+        if ((a.student_data or {}).get("std_depno") or "").strip() == department_code
+    ]
+    apps.sort(key=lambda a: ((a.student_data or {}).get("std_stdcode") or "", a.id))
+
+    # Aux data
+    dynamic_fields, sub_type_labels, account_by_user, advisor_by_user = await load_export_aux_data(
+        db, scholarship_type=stype, applications=apps,
+    )
+
+    # Build rows with rank_position=None
+    export_rows = [
+        ExportRow(
+            rank_position=None,
+            application=app,
+            bank_account=account_by_user.get(app.user_id),
+            advisor_names=advisor_by_user.get(app.user_id),
+        )
+        for app in apps
+    ]
+
+    scholarship_name = stype.name or "獎學金"
+    dept_name = dept.name or department_code
+    title = f"{academic_year}學年度{scholarship_name}學生資料彙整表 - {dept_name}"
+    sheet_name = f"{academic_year}學年"
+    base_filename = f"{academic_year}學年度{scholarship_name}學生資料彙整表_{_sanitise_filename_part(dept_name)}.xlsx"
+    encoded = _url_quote(base_filename, safe="")
+
+    service = CollegeRankingExportService()
+    payload = service.build_workbook(
+        rows=export_rows,
+        dynamic_fields=dynamic_fields,
+        sub_type_labels=sub_type_labels,
+        title=title,
+        sheet_name=sheet_name,
+    )
+
+    return StreamingResponse(
+        iter([payload]),
+        media_type=XLSX_MEDIA_TYPE,
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{encoded}",
+            "Content-Length": str(len(payload)),
+        },
+    )
+```
+
+- [ ] **Step 4: Run all single-endpoint tests**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/test_application_summary_export_endpoint.py -v -k "single"
+```
+
+Expected: all `test_single_*` pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/college_review/application_summary_export.py \
+        backend/tests/test_application_summary_export_endpoint.py
+git commit -m "feat(application-summary-export): single-department endpoint"
+```
+
+---
+
+### Task 5: Implement bulk (ZIP) endpoint (TDD)
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/college_review/application_summary_export.py`
+- Modify: `backend/tests/test_application_summary_export_endpoint.py`
+
+- [ ] **Step 1: Append failing bulk tests**
+
+Append to `backend/tests/test_application_summary_export_endpoint.py`:
+
+```python
+async def test_bulk_admin_scope_all_returns_zip_with_multiple_files(
+    async_client, admin_token, seed_phd_apps_two_depts
+):
+    scholarship_type_id, academic_year, _ = seed_phd_apps_two_depts
+    resp = await async_client.get(
+        BULK_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": academic_year,
+            "scope": "all",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/zip")
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    names = zf.namelist()
+    assert len(names) == 2  # one per dept
+
+
+async def test_bulk_college_scope_returns_zip_of_own_departments(
+    async_client, college_token_dept_a, seed_phd_apps_two_depts
+):
+    scholarship_type_id, academic_year, _ = seed_phd_apps_two_depts
+    resp = await async_client.get(
+        BULK_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": academic_year,
+            "scope": "college",
+        },
+        headers={"Authorization": f"Bearer {college_token_dept_a}"},
+    )
+    assert resp.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    # college_token_dept_a's academy has exactly 1 dept with apps
+    assert len(zf.namelist()) == 1
+
+
+async def test_bulk_college_scope_all_forbidden_for_college_user(
+    async_client, college_token_dept_a, seed_phd_apps_two_depts
+):
+    scholarship_type_id, academic_year, _ = seed_phd_apps_two_depts
+    resp = await async_client.get(
+        BULK_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": academic_year,
+            "scope": "all",
+        },
+        headers={"Authorization": f"Bearer {college_token_dept_a}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_bulk_no_matches_returns_404(
+    async_client, admin_token, seed_phd_apps_two_depts
+):
+    scholarship_type_id, _, _ = seed_phd_apps_two_depts
+    resp = await async_client.get(
+        BULK_PATH,
+        params={
+            "scholarship_type_id": scholarship_type_id,
+            "academic_year": 999,  # no apps for this year
+            "scope": "all",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/test_application_summary_export_endpoint.py -v -k "bulk"
+```
+
+Expected: FAIL (handler not defined yet → 404 from FastAPI).
+
+- [ ] **Step 3: Implement the bulk endpoint**
+
+Append to `application_summary_export.py`:
+
+```python
+@router.get("/applications/department-summary-export-bulk")
+async def export_department_summary_bulk(
+    scholarship_type_id: int = Query(...),
+    academic_year: int = Query(...),
+    semester: Optional[str] = Query(None),
+    scope: str = Query(..., pattern="^(college|all)$"),
+    current_user: User = Depends(require_college),
+    db: AsyncSession = Depends(get_db),
+):
+    normalised_semester = normalize_semester_value(semester)
+    is_admin = current_user.role in (UserRole.admin, UserRole.super_admin)
+
+    if scope == "all" and not is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="學院使用者僅能匯出本學院資料")
+
+    if scope == "college":
+        college_code = (current_user.college_code or "").strip()
+        if not college_code:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="未設定學院，無法使用本學院範圍")
+        dept_rows = (
+            await db.execute(select(Department).where(Department.academy_code == college_code))
+        ).scalars().all()
+        target_dept_codes = [d.code for d in dept_rows if d.code]
+    else:  # scope == "all"
+        target_dept_codes = None  # no dept filter on the query
+
+    # Load scholarship type
+    stype = (
+        await db.execute(
+            select(ScholarshipType)
+            .where(ScholarshipType.id == scholarship_type_id)
+            .options(selectinload(ScholarshipType.sub_type_configs))
+        )
+    ).scalar_one_or_none()
+    if stype is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"找不到獎學金類型 ID={scholarship_type_id}")
+
+    # Load applications. Filter by std_depno in Python since student_data is plain JSON.
+    if target_dept_codes is not None and not target_dept_codes:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="找不到符合條件的申請資料")
+
+    stmt = select(Application).where(
+        Application.scholarship_type_id == scholarship_type_id,
+        Application.academic_year == academic_year,
+        Application.deleted_at.is_(None),
+        Application.status != "deleted",
+    )
+    if normalised_semester is None:
+        stmt = stmt.where(Application.semester.is_(None))
+    else:
+        stmt = stmt.where(Application.semester == normalised_semester)
+
+    raw_apps = list((await db.execute(stmt)).scalars().all())
+    if target_dept_codes is not None:
+        allowed = set(target_dept_codes)
+        apps = [
+            a for a in raw_apps
+            if ((a.student_data or {}).get("std_depno") or "").strip() in allowed
+        ]
+    else:
+        apps = raw_apps
+    if not apps:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="找不到符合條件的申請資料")
+
+    apps.sort(key=lambda a: ((a.student_data or {}).get("std_stdcode") or "", a.id))
+
+    # Group by std_depno
+    groups: dict[str, list] = {}
+    for app in apps:
+        dept_code = ((app.student_data or {}).get("std_depno") or "").strip() or "未知"
+        groups.setdefault(dept_code, []).append(app)
+
+    # Department name lookup
+    dept_codes = list(groups.keys())
+    dept_rows = (
+        await db.execute(select(Department).where(Department.code.in_(dept_codes)))
+    ).scalars().all()
+    name_by_code = {d.code: d.name for d in dept_rows}
+
+    # Aux data — loaded once over the union of applicants
+    dynamic_fields, sub_type_labels, account_by_user, advisor_by_user = await load_export_aux_data(
+        db, scholarship_type=stype, applications=apps,
+    )
+
+    scholarship_name = stype.name or "獎學金"
+    service = CollegeRankingExportService()
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for dept_code, dept_apps in groups.items():
+            dept_name = name_by_code.get(dept_code) or dept_code
+            export_rows = [
+                ExportRow(
+                    rank_position=None,
+                    application=app,
+                    bank_account=account_by_user.get(app.user_id),
+                    advisor_names=advisor_by_user.get(app.user_id),
+                )
+                for app in dept_apps
+            ]
+            title = f"{academic_year}學年度{scholarship_name}學生資料彙整表 - {dept_name}"
+            sheet_name = f"{academic_year}學年"
+            xlsx_bytes = service.build_workbook(
+                rows=export_rows,
+                dynamic_fields=dynamic_fields,
+                sub_type_labels=sub_type_labels,
+                title=title,
+                sheet_name=sheet_name,
+            )
+            inner_name = f"{academic_year}學年度{scholarship_name}學生資料彙整表_{_sanitise_filename_part(dept_name)}.xlsx"
+            zf.writestr(inner_name, xlsx_bytes)
+
+    payload = buf.getvalue()
+
+    scope_label = current_user.college_code if scope == "college" else "全部"
+    base_filename = f"{academic_year}學年度{scholarship_name}學生資料彙整表_{_sanitise_filename_part(scope_label or '全部')}.zip"
+    encoded = _url_quote(base_filename, safe="")
+
+    return StreamingResponse(
+        iter([payload]),
+        media_type=ZIP_MEDIA_TYPE,
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{encoded}",
+            "Content-Length": str(len(payload)),
+        },
+    )
+```
+
+- [ ] **Step 4: Run all endpoint tests**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/test_application_summary_export_endpoint.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/college_review/application_summary_export.py \
+        backend/tests/test_application_summary_export_endpoint.py
+git commit -m "feat(application-summary-export): bulk ZIP endpoint"
+```
+
+---
+
+## Phase 4 — Frontend
+
+### Task 6: Add API client helpers
+
+**Files:**
+- Modify: `frontend/lib/api/modules/college.ts` (existing module that already hosts `exportRankingExcel`)
+
+- [ ] **Step 1: Inspect the existing module to mirror its style**
+
+```bash
+grep -n "exportRankingExcel\|export async function" frontend/lib/api/modules/college.ts | head -20
+```
+
+Note the existing helper's pattern (fetch + blob + auth header).
+
+- [ ] **Step 2: Add the two new helpers**
+
+Append to `frontend/lib/api/modules/college.ts`:
+
+```typescript
+type SummaryExportArgs = {
+  scholarship_type_id: number;
+  academic_year: number;
+  semester?: string | null;
+};
+
+export async function exportDepartmentSummary(
+  args: SummaryExportArgs & { department_code: string },
+): Promise<{ blob: Blob; filename: string }> {
+  const params = new URLSearchParams();
+  params.set("scholarship_type_id", String(args.scholarship_type_id));
+  params.set("academic_year", String(args.academic_year));
+  if (args.semester) params.set("semester", args.semester);
+  params.set("department_code", args.department_code);
+
+  const res = await fetch(
+    `${apiBaseUrl}/api/v1/college-review/applications/department-summary-export?${params}`,
+    { headers: { Authorization: `Bearer ${getToken()}` } },
+  );
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  const blob = await res.blob();
+  const filename = parseFilenameFromHeader(res.headers.get("content-disposition")) || "申請總表.xlsx";
+  return { blob, filename };
+}
+
+export async function exportDepartmentSummaryBulk(
+  args: SummaryExportArgs & { scope: "college" | "all" },
+): Promise<{ blob: Blob; filename: string }> {
+  const params = new URLSearchParams();
+  params.set("scholarship_type_id", String(args.scholarship_type_id));
+  params.set("academic_year", String(args.academic_year));
+  if (args.semester) params.set("semester", args.semester);
+  params.set("scope", args.scope);
+
+  const res = await fetch(
+    `${apiBaseUrl}/api/v1/college-review/applications/department-summary-export-bulk?${params}`,
+    { headers: { Authorization: `Bearer ${getToken()}` } },
+  );
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  const blob = await res.blob();
+  const filename = parseFilenameFromHeader(res.headers.get("content-disposition")) || "申請總表.zip";
+  return { blob, filename };
+}
+```
+
+> `apiBaseUrl`, `getToken`, and `parseFilenameFromHeader` should already exist as module-scope helpers (the existing `exportRankingExcel` uses them). If `parseFilenameFromHeader` does not exist, add it as a local utility that reads RFC 5987 `filename*=UTF-8''<encoded>` and falls back to `filename="..."`. Reuse exactly what `exportRankingExcel` does — do not duplicate logic.
+
+- [ ] **Step 3: Verify the frontend type-checks**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/lib/api/modules/college.ts
+git commit -m "feat(frontend): add department summary export client helpers"
+```
+
+---
+
+### Task 7: Regenerate OpenAPI types
+
+**Files:**
+- Modify: `frontend/lib/api/generated/schema.d.ts` (regenerated)
+
+- [ ] **Step 1: Ensure backend is running**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d backend
+docker compose -f docker-compose.dev.yml logs --tail 10 backend | grep "Application startup complete"
+```
+
+- [ ] **Step 2: Regenerate**
+
+```bash
+cd frontend && npm run api:generate
+```
+
+- [ ] **Step 3: Verify the new endpoints appear**
+
+```bash
+grep -n "department-summary-export" frontend/lib/api/generated/schema.d.ts | head -10
+```
+
+Expected: both `/api/v1/college-review/applications/department-summary-export` and `...-bulk` are present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/lib/api/generated/schema.d.ts
+git commit -m "chore(frontend): regenerate OpenAPI types for summary export endpoints"
+```
+
+---
+
+### Task 8: Wire UI into `ApplicationReviewPanel`
+
+**Files:**
+- Modify: `frontend/components/college/review/ApplicationReviewPanel.tsx`
+
+- [ ] **Step 1: Locate where other export buttons live**
+
+```bash
+grep -n "下載\|匯出\|Export\|FileArchive\|Download" frontend/components/college/review/ApplicationReviewPanel.tsx | head -20
+```
+
+The new control sits next to the existing 「下載」 / 「匯出 ZIP」 toolbar buttons.
+
+- [ ] **Step 2: Add the dropdown + button**
+
+Inside the toolbar block of `ApplicationReviewPanel.tsx`, add:
+
+```tsx
+{/* Department selector + 申請總表 download */}
+const ALL_DEPTS_OWN = "__college_all__";
+const ALL_DEPTS_SYSTEM = "__all__";
+
+const visibleDepartments = useMemo(() => {
+  if (!departments) return [];
+  if (user.role === "admin" || user.role === "super_admin") return departments;
+  return departments.filter((d) => d.academy_code === user.college_code);
+}, [departments, user]);
+
+const [summaryDept, setSummaryDept] = useState<string>("");
+
+const handleDownloadSummary = useCallback(async () => {
+  if (!summaryDept || !selectedCombination) return;
+  try {
+    const common = {
+      scholarship_type_id: selectedCombination.scholarship_type_id,
+      academic_year: selectedCombination.academic_year,
+      semester: selectedCombination.semester ?? null,
+    };
+    let result: { blob: Blob; filename: string };
+    if (summaryDept === ALL_DEPTS_OWN) {
+      result = await exportDepartmentSummaryBulk({ ...common, scope: "college" });
+    } else if (summaryDept === ALL_DEPTS_SYSTEM) {
+      result = await exportDepartmentSummaryBulk({ ...common, scope: "all" });
+    } else {
+      result = await exportDepartmentSummary({ ...common, department_code: summaryDept });
+    }
+    triggerBlobDownload(result.blob, result.filename);
+  } catch (err) {
+    toast.error(`匯出失敗：${(err as Error).message}`);
+  }
+}, [summaryDept, selectedCombination]);
+```
+
+And in the JSX render section, next to existing toolbar controls:
+
+```tsx
+<Select value={summaryDept} onValueChange={setSummaryDept}>
+  <SelectTrigger className="w-[200px]">
+    <SelectValue placeholder="選擇系所" />
+  </SelectTrigger>
+  <SelectContent>
+    {visibleDepartments.map((d) => (
+      <SelectItem key={d.code} value={d.code}>
+        {d.name}
+      </SelectItem>
+    ))}
+    {(user.role === "admin" || user.role === "super_admin" || user.college_code) && (
+      <SelectItem value={ALL_DEPTS_OWN}>本學院全部 (ZIP)</SelectItem>
+    )}
+    {(user.role === "admin" || user.role === "super_admin") && (
+      <SelectItem value={ALL_DEPTS_SYSTEM}>全部系所 (ZIP)</SelectItem>
+    )}
+  </SelectContent>
+</Select>
+<Button
+  variant="outline"
+  disabled={!summaryDept || !selectedCombination}
+  onClick={handleDownloadSummary}
+>
+  <Download className="mr-2 h-4 w-4" />
+  匯出申請總表
+</Button>
+```
+
+Add the imports at the top:
+
+```tsx
+import { exportDepartmentSummary, exportDepartmentSummaryBulk } from "@/lib/api/modules/college";
+import { useMemo, useState, useCallback } from "react";
+```
+
+If a `triggerBlobDownload(blob, filename)` helper doesn't already exist in the file, add it locally:
+
+```tsx
+function triggerBlobDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+```
+
+- [ ] **Step 3: Typecheck + lint**
+
+```bash
+cd frontend && npm run typecheck && npm run lint
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke (browser)**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+Log in as `admin@nycu.edu.tw` / any password (per memory note). Navigate to the college review / applications page. Select a scholarship + year + semester. Pick a department, click 匯出申請總表 → confirm `.xlsx` downloads. Pick 全部系所 → confirm `.zip` downloads with multiple files.
+
+Log in as a college user. Confirm only their academy's departments appear plus 「本學院全部」.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/college/review/ApplicationReviewPanel.tsx
+git commit -m "feat(application-summary-export): add UI controls to ApplicationReviewPanel"
+```
+
+---
+
+## Phase 5 — Wrap-up
+
+### Task 9: Final verification
+
+- [ ] **Step 1: Run the full backend test suite for the affected files**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest \
+  backend/tests/test_college_ranking_export_service.py \
+  backend/tests/test_application_summary_export_endpoint.py \
+  -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run frontend type/lint**
+
+```bash
+cd frontend && npm run typecheck && npm run lint
+```
+
+- [ ] **Step 3: Check that nothing else broke**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest backend/tests/ -x --timeout=60 2>&1 | tail -30
+```
+
+Expected: no new failures (pre-existing skipped/xfail tests are OK).
+
+- [ ] **Step 4: Verify git log**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected sequence (give or take Task 0/conftest):
+
+```
+feat(application-summary-export): add UI controls to ApplicationReviewPanel
+chore(frontend): regenerate OpenAPI types for summary export endpoints
+feat(frontend): add department summary export client helpers
+feat(application-summary-export): bulk ZIP endpoint
+feat(application-summary-export): single-department endpoint
+feat(application-summary-export): scaffold router and module
+refactor(college-review): extract load_export_aux_data helper
+feat(export-service): allow Optional rank_position; render empty cell when None
+docs(application-summary-export): add design spec
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+git push -u origin worktree-application-summary-export
+gh pr create --title "feat: 系所申請總表 Excel 匯出（學院端 + 管理員）" --body "$(cat <<'EOF'
+## Summary
+- Adds the 申請總表 Excel export reachable by college users (own academy only) and admins.
+- Reuses the existing 18-column 學生資料彙整表 layout with the rank column left blank.
+- Two endpoints: single-department `.xlsx` and multi-department `.zip` (本學院/全部系所).
+
+## Test plan
+- [ ] Service tests pass (`pytest backend/tests/test_college_ranking_export_service.py`).
+- [ ] Endpoint tests pass (`pytest backend/tests/test_application_summary_export_endpoint.py`).
+- [ ] Manual: admin downloads single dept + ZIP for 全部系所 in dev.
+- [ ] Manual: college user sees only own academy's departments + 本學院全部 ZIP.
+- [ ] Frontend typecheck + lint clean.
+
+Spec: `docs/superpowers/specs/2026-05-13-application-summary-export-design.md`
+EOF
+)"
+```
+
+---
+
+## Notes for the executing engineer
+
+- **Worktree:** All work happens in `/home/howard/scholarship-system/.claude/worktrees/application-summary-export` on branch `worktree-application-summary-export`. Do NOT `cd` to the main repo.
+- **No DB migration.** This feature reuses existing `application_fields.include_in_college_export` and `Department`/`Academy`.
+- **Trust the existing pattern.** The `ranking_management.export_ranking_excel` endpoint is the working reference for `Content-Disposition` encoding, auxiliary data loading, and StreamingResponse. Match its style.
+- **Test fixtures may need a small one-time investment.** If the project's existing endpoint tests are sparse, expect to add 2-3 fixtures (`seed_phd_apps_two_depts` etc.) the first time. Keep them minimal — they're not production code.
+- **YAGNI.** Resist any urge to also surface this from the admin 歷史申請 tab or add a status filter. Both are explicitly out of scope per the spec.

--- a/docs/superpowers/specs/2026-05-13-application-summary-export-design.md
+++ b/docs/superpowers/specs/2026-05-13-application-summary-export-design.md
@@ -1,0 +1,296 @@
+# Application Summary Excel Export — 系所申請總表
+
+**Date:** 2026-05-13
+**Status:** Approved
+**Reference:** Builds on `2026-05-08-college-ranking-export-design.md` (學生資料彙整表)
+**Worktree:** `.claude/worktrees/application-summary-export` (branch `worktree-application-summary-export`)
+
+## Goal
+
+Add a department-scoped 「申請總表」 Excel export that mirrors the existing 學生資料彙整表 layout (18 static columns + admin-configurable dynamic columns) but with the rank column (`學院初審會議之學院排序`) left blank. The export must be reachable by both college users (limited to departments in their own academy) and administrators (any department), and must support both single-department `.xlsx` download and multi-department `.zip` bundle.
+
+## Non-goals
+
+- Adding new static columns or changing the layout. The new export reuses the existing 18-column template; only the rank cell value changes.
+- Filtering applications by `sub_type_code`. All non-deleted applications matching `(scholarship_type, academic_year, semester, department)` are included regardless of sub-type preference.
+- Renaming the rank column header. Header stays `學院初審會議之學院排序`; only the cell value is blank.
+- Allowing college users to export departments outside their own academy.
+- A separate admin page. The export trigger reuses the existing application list UI used by both college users and admins.
+
+## Background
+
+- The college ranking export (`backend/app/services/college_ranking_export_service.py`) already renders the 18-column template. Its `ExportRow.rank_position: int` carries `CollegeRankingItem.rank_position`. Cell rendering is in `_write_static_cells` line 126: `ws.cell(row=excel_row, column=2, value=row.rank_position)`.
+- Applications are stored with `Application.student_data` (JSON) carrying SIS snapshot fields including `std_depno` (department code), `std_stdcode` (student ID), and `trm_*` term fields.
+- Department model (`backend/app/models/student.py:78-89`) joins `Department.academy_code` → `Academy.code`. `User.college_code` (for college users) holds an Academy code.
+- Existing ranking export endpoint pattern (`backend/app/api/v1/endpoints/college_review/ranking_management.py:1093-1247`) is the reference for auth, dynamic-field loading, bulk profile/advisor loading, and StreamingResponse handling.
+
+## Data model changes
+
+**None.** No DB schema migration is required. The export reuses:
+
+- `application_fields.include_in_college_export` (flag added by the prior ranking-export feature) for dynamic columns.
+- `application_fields.export_column_label` for optional header overrides.
+- Existing `Department`/`Academy` tables for department lookup.
+
+## Excel structure
+
+Identical to 學生資料彙整表 (see prior spec). The only behavioural change:
+
+| # | Header | Value |
+|---|---|---|
+| 2 | 學院初審會議之學院排序 | **Empty string** (no rank yet) |
+
+All other columns (1, 3-18) and dynamic columns render exactly as in the ranking export.
+
+**Workbook title:** `{academic_year}學年度{scholarship_name}學生資料彙整表 - {department_name}`
+(e.g. `114學年度博士生獎學金學生資料彙整表 - 教育研究所`)
+
+**Sheet name:** `{academic_year}學年`
+
+**Sort order:** `student_data.std_stdcode` ASC. Applications without a student code sort last (stable secondary sort by `application.id`).
+
+## API
+
+Both endpoints live in a new module `backend/app/api/v1/endpoints/college_review/application_summary_export.py`, mounted under the existing `/api/v1/college-review` prefix (router include in `college_review/__init__.py`).
+
+### Single-department endpoint
+
+`GET /api/v1/college-review/applications/department-summary-export`
+
+| Query param | Type | Required | Notes |
+|---|---|---|---|
+| `scholarship_type_id` | int | yes | |
+| `academic_year` | int | yes | |
+| `semester` | str | no | `first` / `second` / `yearly` / null. `yearly` and null both match rows with `semester IS NULL`. Normalised via `_helpers.normalize_semester_value`. |
+| `department_code` | str | yes | Must match `Department.code`. |
+
+**Response:** `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` stream.
+**Filename:** `{academic_year}學年度{scholarship_name}學生資料彙整表_{department_name}.xlsx` (RFC 5987 UTF-8 encoded in `Content-Disposition`).
+
+### Bulk (ZIP) endpoint
+
+`GET /api/v1/college-review/applications/department-summary-export-bulk`
+
+| Query param | Type | Required | Notes |
+|---|---|---|---|
+| `scholarship_type_id` | int | yes | |
+| `academic_year` | int | yes | |
+| `semester` | str | no | Same semantics. |
+| `scope` | str | yes | `college` (本學院全部系所) or `all` (全部系所). |
+
+**Response:** `application/zip` stream containing one `.xlsx` per non-empty department.
+**Filename:** `{academic_year}學年度{scholarship_name}學生資料彙整表_{scope_label}.zip` where `scope_label` is `current_user.college_code` for `college` scope (matching the existing ranking-export filename convention) or `全部` for `all`.
+**Inner filenames:** Same single-department `.xlsx` pattern, sanitised to remove path separators and other filesystem-unsafe characters (`/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`).
+
+### Authorization
+
+Both endpoints use `Depends(require_college)` (covers admin + super_admin + college roles). Additional checks:
+
+| Caller role | `department_code` (single) | `scope=college` | `scope=all` |
+|---|---|---|---|
+| `admin` / `super_admin` | any | requires `current_user.college_code` to be set; otherwise 400 with `管理員需指定學院` | OK |
+| College user | dept must satisfy `Department.academy_code == current_user.college_code`; else 403 | OK (current user's academy) | **403** |
+| Anyone else | 403 (covered by `require_college`) | 403 | 403 |
+
+Empty result sets are handled per the table in the **Error handling** section: a single-department call with no matches still returns a valid workbook (header row only); a bulk call with no matches returns 404 to avoid silent empty ZIP downloads.
+
+### Backend flow (shared)
+
+1. Validate auth, normalise `semester`, resolve target department code list:
+   - Single: `[department_code]` after auth check.
+   - Bulk `scope=college`: `select Department.code where academy_code == current_user.college_code` (admins use their own `college_code`; the 400 above guards admins with no `college_code`).
+   - Bulk `scope=all`: distinct `std_depno` values present in matching applications.
+2. Load applications:
+   ```python
+   stmt = (
+       select(Application)
+       .where(
+           Application.scholarship_type_id == scholarship_type_id,
+           Application.academic_year == academic_year,
+           Application.semester == normalised_semester,  # IS NULL when yearly
+           Application.status != ApplicationStatus.deleted.value,
+           Application.deleted_at.is_(None),
+           Application.student_data["std_depno"].astext.in_(department_codes),
+       )
+   )
+   ```
+   The JSON path predicate uses SQLAlchemy's `JSON.astext`. PostgreSQL is the only supported DB.
+3. Sort in Python by `student_data.get("std_stdcode") or ""` ASC, secondary by `application.id` ASC. (Doing this in Python avoids JSON-collation surprises across PG versions.)
+4. Load dynamic fields, sub-type labels, profile account numbers, and advisor names with the same bulk-load pattern as `ranking_management.export_ranking_excel` (lines 1127-1199). Refactor that block into a helper at `backend/app/api/v1/endpoints/college_review/_helpers.py` to avoid duplication. Helper signature:
+   ```python
+   async def load_export_aux_data(
+       db: AsyncSession,
+       *,
+       scholarship_type: Optional[ScholarshipType],
+       applications: list[Application],
+   ) -> tuple[
+       list[DynamicFieldSpec],
+       dict[str, str],          # sub_type_labels
+       dict[int, str],          # account_number_by_user
+       dict[int, str],          # advisor_string_by_user
+   ]: ...
+   ```
+   `ranking_management.export_ranking_excel` is refactored to call this helper as part of this feature.
+5. Build `ExportRow` per application with `rank_position=None`. Apply `service.build_workbook(...)`.
+6. Single endpoint: return one `StreamingResponse`. Bulk: wrap workbooks in `zipfile.ZipFile(BytesIO(), 'w', ZIP_DEFLATED)`, then stream.
+
+### Department lookup helper
+
+Add `_load_department_lookup(db, codes)` returning `dict[str, str]` (code → name). Used for filename generation and bulk grouping. Falls back to the raw code when a Department row is missing (does NOT raise; defensive matches the rest of the export pipeline).
+
+## Service change — `CollegeRankingExportService`
+
+Single-field signature change to enable the empty-rank rendering:
+
+```python
+@dataclass
+class ExportRow:
+    rank_position: Optional[int]   # was: int
+    application: Any
+    bank_account: Optional[str] = None
+    advisor_names: Optional[str] = None
+```
+
+`_write_static_cells` line 126 becomes:
+
+```python
+ws.cell(
+    row=excel_row,
+    column=2,
+    value=(row.rank_position if row.rank_position is not None else ""),
+)
+```
+
+No other lines change. Existing tests for the ranking export continue to pass because they always set `rank_position` to an integer.
+
+Per [coding-style.md], we do **not** add a new "Optional support" toggle or wrapper service — the field directly accommodates `None`, and the call site decides whether to pass an int.
+
+## Frontend
+
+### ApplicationReviewPanel (college + admin shared)
+
+Reuses `frontend/components/college/review/ApplicationReviewPanel.tsx`. The panel is already mounted in the college management shell for college users; admins reach the same data via the existing admin tools. (Admin access is via the existing role-aware path; we are **not** adding a new admin tab in this iteration.)
+
+**UI additions** (placed near the existing 「下載」 / 「匯出 ZIP」 controls):
+
+1. **Department selector** — `<Select>` with options:
+   - For college users: each `Department` under `current_user.college_code`, plus a synthetic option `__college_all__` labelled 「本學院全部 (ZIP)」.
+   - For admins: each `Department` (system-wide), plus `__college_all__` ("本學院全部 (ZIP)") only when the admin has a `college_code`, and `__all__` ("全部系所 (ZIP)").
+2. **Export button** — 「匯出申請總表」. Disabled until a department option is selected and a scholarship-year-semester combination is locked (already required by the panel).
+3. Click handler routes:
+   - Specific dept code → call single-department helper → save `.xlsx`.
+   - `__college_all__` → bulk helper with `scope=college`.
+   - `__all__` → bulk helper with `scope=all`.
+
+### Data sources for the dropdown
+
+Departments come from the existing `useReferenceData()` hook (already used in the same file at line 60). The hook already loads Department + Academy reference data. Filtering for college users:
+
+```ts
+const visibleDepartments = useMemo(() => {
+  if (user.role === "admin" || user.role === "super_admin") return departments;
+  return departments.filter((d) => d.academy_code === user.college_code);
+}, [departments, user]);
+```
+
+### API helpers
+
+Add to `frontend/lib/api/modules/college.ts` (extends the module that already hosts `exportRankingExcel`):
+
+```ts
+export async function exportDepartmentSummary(params: {
+  scholarship_type_id: number;
+  academic_year: number;
+  semester?: string | null;
+  department_code: string;
+}): Promise<Blob>;
+
+export async function exportDepartmentSummaryBulk(params: {
+  scholarship_type_id: number;
+  academic_year: number;
+  semester?: string | null;
+  scope: "college" | "all";
+}): Promise<Blob>;
+```
+
+Both use `fetch + blob` with the existing auth header pattern (Bearer token). On success, derive the filename from the `Content-Disposition` header (RFC 5987) and trigger a download via `URL.createObjectURL`.
+
+After backend lands, run `cd frontend && npm run api:generate` to refresh `lib/api/generated/schema.d.ts`.
+
+## Error handling
+
+| Condition | HTTP | Detail |
+|---|---|---|
+| Missing/invalid query params | 422 | FastAPI default validation |
+| `department_code` not found | 404 | `找不到系所代碼 {code}` |
+| College user requests a dept outside their academy | 403 | `無權限匯出此系所之資料` |
+| College user requests `scope=all` | 403 | `學院使用者僅能匯出本學院資料` |
+| Admin requests `scope=college` without `college_code` set | 400 | `管理員未設定學院，無法使用本學院範圍` |
+| No applications match (single) | 200 | Workbook with header row only (consistent with ranking export) |
+| No applications match (bulk) | 404 | `找不到符合條件的申請資料` |
+| DB / IO failure | 500 | Logged; never silently swallowed (per CLAUDE.md error-handling standard) |
+
+## Testing
+
+### Backend
+
+`backend/tests/test_college_ranking_export_service.py` (existing file, add cases):
+- `rank_position=None` → column 2 of that data row is `""`, header at row 2 unchanged.
+- `rank_position=5` (existing test) still passes — regression guard.
+
+New `backend/tests/test_application_summary_export_service.py`:
+- Single department: 3 applications across different `sub_type_preferences` → 3 rows with empty rank cells, sorted by `std_stdcode`.
+- Sub-type rendering matches existing logic (0 / 1 / 2 prefs).
+- Dynamic field flagged for export appears at the correct offset with override label.
+- Workbook title contains the department name.
+
+New `backend/tests/test_application_summary_export_endpoint.py`:
+- College user happy path: 200 + non-empty `.xlsx`.
+- College user requests dept outside academy: 403.
+- College user `scope=all`: 403.
+- Admin `scope=all` happy path: 200 + ZIP with N files where N = distinct departments with applications.
+- Admin `scope=college` without `college_code`: 400.
+- Bulk with no matching apps: 404.
+- Single with no matching apps: 200 + workbook with header row only.
+- Auth bypassed (no token): 401 (handled by `require_college`).
+
+> Note: the prior ranking-export spec deferred endpoint integration tests due to an `aiosqlite`/`httpx.AsyncClient(app=...)` gap in `backend/app/tests/conftest.py`. The implementation plan will first verify whether the gap still applies (run a single endpoint test to confirm). If it does, the conftest fix (ASGITransport migration + `aiosqlite` dev-dep) is sequenced as a precursor task; otherwise, the endpoint tests land directly. Service tests do not depend on the conftest and ship unconditionally.
+
+### Frontend
+
+- `__tests__` on `ApplicationReviewPanel`: department dropdown renders, "本學院全部" routes to bulk helper, single dept routes to single helper, admin sees 「全部系所」.
+- E2E (optional): user-flow check that download is triggered (Playwright). Reuse the existing ranking-export Playwright spec as a template.
+
+## Migration & rollout
+
+1. Backend refactor: extract `load_export_aux_data` helper into `college_review/_helpers.py`; update `ranking_management.export_ranking_excel` to use it. (Pure refactor — covered by existing ranking export tests.)
+2. Modify `ExportRow.rank_position` to `Optional[int]`; update `_write_static_cells`. (Pure rendering change — covered by new + existing service tests.)
+3. Add `application_summary_export.py` endpoint module + register router. Service tests + endpoint tests run.
+4. Frontend: add department dropdown + export button + API helpers; regenerate OpenAPI types.
+5. Manual smoke in dev: admin export `.xlsx` for one dept, college export `.xlsx`, college 「本學院全部」 `.zip`, admin 「全部系所」 `.zip`.
+
+No database migration. No env var changes. No breaking changes to existing endpoints. Rollback is a clean revert.
+
+## Files changed
+
+**New:**
+- `backend/app/api/v1/endpoints/college_review/application_summary_export.py`
+- `backend/tests/test_application_summary_export_service.py`
+- `backend/tests/test_application_summary_export_endpoint.py`
+
+**Modified:**
+- `backend/app/services/college_ranking_export_service.py` — `ExportRow.rank_position: Optional[int]`; conditional cell value.
+- `backend/app/api/v1/endpoints/college_review/__init__.py` — include new router.
+- `backend/app/api/v1/endpoints/college_review/_helpers.py` — add `load_export_aux_data` helper.
+- `backend/app/api/v1/endpoints/college_review/ranking_management.py` — call new helper (remove duplicated load block).
+- `backend/tests/test_college_ranking_export_service.py` — regression test for `rank_position=None`.
+- `frontend/components/college/review/ApplicationReviewPanel.tsx` — dropdown + button + handler.
+- `frontend/lib/api/modules/college.ts` — `exportDepartmentSummary`, `exportDepartmentSummaryBulk` helpers.
+- `frontend/lib/api/generated/schema.d.ts` — regenerated.
+- (If conftest fix is in scope) `backend/app/tests/conftest.py`, `backend/pyproject.toml` (dev deps).
+
+## Open questions / deferred
+
+- Whether to surface the export from the admin 「歷史申請」 (`HistoryPanel`) tab in a follow-up. Out of scope here.
+- Whether to add a "filter by application status" query param. Not requested; YAGNI.
+- Whether to allow downloading just one column subset. Not requested; YAGNI.

--- a/docs/superpowers/specs/2026-05-13-application-summary-export-design.md
+++ b/docs/superpowers/specs/2026-05-13-application-summary-export-design.md
@@ -100,21 +100,7 @@ Empty result sets are handled per the table in the **Error handling** section: a
    - Single: `[department_code]` after auth check.
    - Bulk `scope=college`: `select Department.code where academy_code == current_user.college_code` (admins use their own `college_code`; the 400 above guards admins with no `college_code`).
    - Bulk `scope=all`: distinct `std_depno` values present in matching applications.
-2. Load applications:
-   ```python
-   stmt = (
-       select(Application)
-       .where(
-           Application.scholarship_type_id == scholarship_type_id,
-           Application.academic_year == academic_year,
-           Application.semester == normalised_semester,  # IS NULL when yearly
-           Application.status != ApplicationStatus.deleted.value,
-           Application.deleted_at.is_(None),
-           Application.student_data["std_depno"].astext.in_(department_codes),
-       )
-   )
-   ```
-   The JSON path predicate uses SQLAlchemy's `JSON.astext`. PostgreSQL is the only supported DB.
+2. Load applications by `(scholarship_type_id, academic_year, semester)` in SQL, then filter by `student_data.get("std_depno")` in Python. `student_data` is a plain `JSON` column (not `JSONB`); SQL-side JSON-path filtering (`student_data["std_depno"].astext`) is fragile across SQLAlchemy versions for plain JSON. Typical N per `(scholarship_type, year, semester)` is < 1k, so Python filtering is fine.
 3. Sort in Python by `student_data.get("std_stdcode") or ""` ASC, secondary by `application.id` ASC. (Doing this in Python avoids JSON-collation surprises across PG versions.)
 4. Load dynamic fields, sub-type labels, profile account numbers, and advisor names with the same bulk-load pattern as `ranking_management.export_ranking_excel` (lines 1127-1199). Refactor that block into a helper at `backend/app/api/v1/endpoints/college_review/_helpers.py` to avoid duplication. Helper signature:
    ```python

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -2,7 +2,12 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useCollegeManagement } from "@/contexts/college-management-context";
+import { useReferenceData } from "@/hooks/use-reference-data";
 import { apiClient } from "@/lib/api";
+import {
+  exportDepartmentSummary,
+  exportDepartmentSummaryBulk,
+} from "@/lib/api/modules/college";
 import type {
   DistributionStudent,
   QuotaStatus,
@@ -16,6 +21,14 @@ import type {
 import { User } from "@/types/user";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   AlertDialog,
@@ -49,6 +62,9 @@ interface LocalAlloc {
   year: number;
 }
 
+const ALL_DEPTS_OWN = "__college_all__";
+const ALL_DEPTS_SYSTEM = "__all__";
+
 /** Composite key for a (sub_type, year) column: "nstc:114" */
 function makeColKey(sub_type: string, year: number) {
   return `${sub_type}:${year}`;
@@ -70,6 +86,7 @@ function getSubTypeShortName(sub_type: string, display_name: string): string {
 }
 
 export function ManualDistributionPanel({
+  user,
   scholarshipType,
 }: ManualDistributionPanelProps) {
   const {
@@ -89,6 +106,50 @@ export function ManualDistributionPanel({
 
   // Use the ID directly from the prop (provided by the admin available-combinations endpoint)
   const scholarshipTypeId = scholarshipType.id;
+
+  const { departments } = useReferenceData();
+  const [summaryDept, setSummaryDept] = useState<string>("");
+
+  const visibleDepartments = useMemo(() => {
+    if (!departments) return [];
+    if (user.role === "admin" || user.role === "super_admin") return departments;
+    return departments.filter(
+      (d: { code: string; name: string; academy_code?: string | null }) =>
+        d.academy_code === user.college_code
+    );
+  }, [departments, user]);
+
+  const handleDownloadSummary = useCallback(async () => {
+    if (!summaryDept || !scholarshipType.id || !selectedAcademicYear) {
+      toast.error("缺少必要的篩選條件");
+      return;
+    }
+    try {
+      const common = {
+        scholarship_type_id: scholarshipType.id,
+        academic_year: selectedAcademicYear,
+        semester: selectedSemester ?? null,
+      };
+      let result: { blob: Blob; filename: string };
+      if (summaryDept === ALL_DEPTS_OWN) {
+        result = await exportDepartmentSummaryBulk({ ...common, scope: "college" });
+      } else if (summaryDept === ALL_DEPTS_SYSTEM) {
+        result = await exportDepartmentSummaryBulk({ ...common, scope: "all" });
+      } else {
+        result = await exportDepartmentSummary({ ...common, department_code: summaryDept });
+      }
+      const url = URL.createObjectURL(result.blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = result.filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(`匯出失敗：${(err as Error).message}`);
+    }
+  }, [summaryDept, scholarshipType.id, selectedAcademicYear, selectedSemester]);
 
   const [students, setStudents] = useState<DistributionStudent[]>([]);
   const [quotaStatus, setQuotaStatus] = useState<QuotaStatus>({});
@@ -589,6 +650,39 @@ export function ManualDistributionPanel({
               手動分發 — {scholarshipType.name}
             </h2>
             <div className="flex gap-2 flex-wrap">
+              <Select value={summaryDept} onValueChange={setSummaryDept}>
+                <SelectTrigger className="w-[200px] h-9">
+                  <SelectValue placeholder="選擇系所匯出總表" />
+                </SelectTrigger>
+                <SelectContent>
+                  {visibleDepartments.map((d: { code: string; name: string }) => (
+                    <SelectItem key={d.code} value={d.code}>
+                      {d.name}
+                    </SelectItem>
+                  ))}
+                  {(user.role === "admin" ||
+                    user.role === "super_admin" ||
+                    user.college_code) && (
+                    <SelectItem value={ALL_DEPTS_OWN}>
+                      本學院全部 (ZIP)
+                    </SelectItem>
+                  )}
+                  {(user.role === "admin" || user.role === "super_admin") && (
+                    <SelectItem value={ALL_DEPTS_SYSTEM}>
+                      全部系所 (ZIP)
+                    </SelectItem>
+                  )}
+                </SelectContent>
+              </Select>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!summaryDept || !scholarshipType.id || !selectedAcademicYear}
+                onClick={handleDownloadSummary}
+              >
+                <Download className="h-4 w-4 mr-1" />
+                匯出申請總表
+              </Button>
               <Button variant="outline" size="sm" disabled>
                 <Download className="h-4 w-4 mr-1" />
                 匯出 Excel

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -660,9 +660,7 @@ export function ManualDistributionPanel({
                       {d.name}
                     </SelectItem>
                   ))}
-                  {(user.role === "admin" ||
-                    user.role === "super_admin" ||
-                    user.college_code) && (
+                  {user.college_code && (
                     <SelectItem value={ALL_DEPTS_OWN}>
                       本學院全部 (ZIP)
                     </SelectItem>

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { User } from "@/types/user";
 import { useCollegeManagement } from "@/contexts/college-management-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -62,11 +62,18 @@ import { useScholarshipData } from "@/hooks/use-scholarship-data";
 import * as XLSX from "xlsx";
 import { apiClient } from "@/lib/api";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
+import {
+  exportDepartmentSummary,
+  exportDepartmentSummaryBulk,
+} from "@/lib/api/modules/college";
 
 interface ApplicationReviewPanelProps {
   user: User;
   scholarshipType: { code: string; name: string };
 }
+
+const ALL_DEPTS_OWN = "__college_all__";
+const ALL_DEPTS_SYSTEM = "__all__";
 
 export function ApplicationReviewPanel({
   user,
@@ -115,6 +122,18 @@ export function ApplicationReviewPanel({
   // Local state for status filter
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [searchQuery, setSearchQuery] = useState<string>("");
+
+  // Summary export state
+  const [summaryDept, setSummaryDept] = useState<string>("");
+
+  const visibleDepartments = useMemo(() => {
+    if (!departments) return [];
+    if (user.role === "admin" || user.role === "super_admin") return departments;
+    return departments.filter(
+      (d: { code: string; name: string; academy_code?: string | null }) =>
+        d.academy_code === user.college_code
+    );
+  }, [departments, user]);
 
   // Fetch college quota when scholarship type, year, or semester changes
   const fetchCollegeQuota = useCallback(async () => {
@@ -567,6 +586,49 @@ export function ApplicationReviewPanel({
     }
   };
 
+  const handleDownloadSummary = useCallback(async () => {
+    if (!summaryDept || !selectedCombination) return;
+    const scholarshipTypeObj = availableOptions?.scholarship_types?.find(
+      (st: { code: string; id?: number }) => st.code === activeScholarshipTab
+    );
+    if (!scholarshipTypeObj?.id || !selectedAcademicYear) {
+      toast.error("缺少獎學金或學年資訊");
+      return;
+    }
+    try {
+      const common = {
+        scholarship_type_id: scholarshipTypeObj.id,
+        academic_year: selectedAcademicYear,
+        semester: selectedSemester ?? null,
+      };
+      let result: { blob: Blob; filename: string };
+      if (summaryDept === ALL_DEPTS_OWN) {
+        result = await exportDepartmentSummaryBulk({ ...common, scope: "college" });
+      } else if (summaryDept === ALL_DEPTS_SYSTEM) {
+        result = await exportDepartmentSummaryBulk({ ...common, scope: "all" });
+      } else {
+        result = await exportDepartmentSummary({ ...common, department_code: summaryDept });
+      }
+      const url = URL.createObjectURL(result.blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = result.filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(`匯出失敗：${(err as Error).message}`);
+    }
+  }, [
+    summaryDept,
+    selectedCombination,
+    selectedAcademicYear,
+    selectedSemester,
+    availableOptions,
+    activeScholarshipTab,
+  ]);
+
   return (
     <>
       {/* Header */}
@@ -642,6 +704,39 @@ export function ApplicationReviewPanel({
               : locale === "zh"
                 ? "匯出申請資料"
                 : "Export Package"}
+          </Button>
+          <Select value={summaryDept} onValueChange={setSummaryDept}>
+            <SelectTrigger className="w-[200px] h-9">
+              <SelectValue placeholder="選擇系所匯出總表" />
+            </SelectTrigger>
+            <SelectContent>
+              {visibleDepartments.map((d: { code: string; name: string }) => (
+                <SelectItem key={d.code} value={d.code}>
+                  {d.name}
+                </SelectItem>
+              ))}
+              {(user.role === "admin" ||
+                user.role === "super_admin" ||
+                user.college_code) && (
+                <SelectItem value={ALL_DEPTS_OWN}>
+                  本學院全部 (ZIP)
+                </SelectItem>
+              )}
+              {(user.role === "admin" || user.role === "super_admin") && (
+                <SelectItem value={ALL_DEPTS_SYSTEM}>
+                  全部系所 (ZIP)
+                </SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={!summaryDept || !selectedCombination}
+            onClick={handleDownloadSummary}
+          >
+            <Download className="h-4 w-4 mr-1" />
+            {locale === "zh" ? "匯出申請總表" : "Export Application Summary"}
           </Button>
           <div className="flex items-center border rounded-md">
             <Button

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -715,9 +715,7 @@ export function ApplicationReviewPanel({
                   {d.name}
                 </SelectItem>
               ))}
-              {(user.role === "admin" ||
-                user.role === "super_admin" ||
-                user.college_code) && (
+              {user.college_code && (
                 <SelectItem value={ALL_DEPTS_OWN}>
                   本學院全部 (ZIP)
                 </SelectItem>

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -17905,7 +17905,7 @@ export interface operations {
                 scholarship_type_id: number;
                 academic_year: number;
                 semester?: string | null;
-                scope: string;
+                scope: "college" | "all";
             };
             header?: never;
             path?: never;

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4455,6 +4455,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/college-review/applications/department-summary-export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export Department Summary Single
+         * @description Generate the 申請總表 Excel for one department.
+         */
+        get: operations["export_department_summary_single_api_v1_college_review_applications_department_summary_export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/college-review/applications/department-summary-export-bulk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export Department Summary Bulk
+         * @description Generate a ZIP archive containing one 申請總表 xlsx per department.
+         */
+        get: operations["export_department_summary_bulk_api_v1_college_review_applications_department_summary_export_bulk_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/college-review/rankings": {
         parameters: {
             query?: never;
@@ -17766,6 +17806,78 @@ export interface operations {
             path: {
                 student_id: string;
             };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_department_summary_single_api_v1_college_review_applications_department_summary_export_get: {
+        parameters: {
+            query: {
+                /** @description Scholarship type ID */
+                scholarship_type_id: number;
+                /** @description Academic year */
+                academic_year: number;
+                /** @description first / second / yearly / null */
+                semester?: string | null;
+                /** @description Department code (Department.code) */
+                department_code: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_department_summary_bulk_api_v1_college_review_applications_department_summary_export_bulk_get: {
+        parameters: {
+            query: {
+                scholarship_type_id: number;
+                academic_year: number;
+                semester?: string | null;
+                scope: string;
+            };
+            header?: never;
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -521,6 +521,50 @@ export function createCollegeApi() {
   };
 }
 
+async function _fetchBinaryExport(
+  path: string,
+  params: URLSearchParams,
+  fallbackFilename: string,
+  errorFallback: string
+): Promise<{ blob: Blob; filename: string }> {
+  const token = typedClient.getToken();
+  const baseURL =
+    typeof window !== "undefined"
+      ? ""
+      : process.env.INTERNAL_API_URL || "http://localhost:8000";
+
+  const query = params.toString();
+  const url = `${baseURL}${path}${query ? `?${query}` : ""}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    let message = errorFallback;
+    try {
+      const errorData = await response.json();
+      message = errorData?.detail || errorData?.message || errorData?.error || message;
+    } catch {
+      // Non-JSON error body — keep default.
+    }
+    throw new Error(message);
+  }
+
+  const disposition = response.headers.get("content-disposition") || "";
+  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  const filename = filenameMatch
+    ? decodeURIComponent(filenameMatch[1].trim())
+    : fallbackFilename;
+
+  const blob = await response.blob();
+  return { blob, filename };
+}
+
 /**
  * Download the 學生資料彙整表 Excel for a college ranking.
  *
@@ -533,43 +577,12 @@ export function createCollegeApi() {
 export async function exportRankingExcel(
   rankingId: number
 ): Promise<{ blob: Blob; filename: string }> {
-  const token = typedClient.getToken();
-  const baseURL =
-    typeof window !== "undefined"
-      ? ""
-      : process.env.INTERNAL_API_URL || "http://localhost:8000";
-
-  const response = await fetch(
-    `${baseURL}/api/v1/college-review/rankings/${rankingId}/export-excel`,
-    {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-    }
+  return _fetchBinaryExport(
+    `/api/v1/college-review/rankings/${rankingId}/export-excel`,
+    new URLSearchParams(),
+    `學生資料彙整表_${rankingId}.xlsx`,
+    "無法匯出排名資料"
   );
-
-  if (!response.ok) {
-    let message = "無法匯出排名資料";
-    try {
-      const errorData = await response.json();
-      message = errorData?.detail || errorData?.error || message;
-    } catch {
-      // Non-JSON error body — keep default message.
-    }
-    throw new Error(message);
-  }
-
-  // Extract filename from Content-Disposition header (RFC 5987 UTF-8 form).
-  const disposition = response.headers.get("content-disposition") || "";
-  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
-  const filename = filenameMatch
-    ? decodeURIComponent(filenameMatch[1].trim())
-    : `學生資料彙整表_${rankingId}.xlsx`;
-
-  const blob = await response.blob();
-  return { blob, filename };
 }
 
 type DepartmentSummaryExportArgs = {
@@ -586,48 +599,18 @@ type DepartmentSummaryExportArgs = {
 export async function exportDepartmentSummary(
   args: DepartmentSummaryExportArgs & { department_code: string }
 ): Promise<{ blob: Blob; filename: string }> {
-  const token = typedClient.getToken();
-  const baseURL =
-    typeof window !== "undefined"
-      ? ""
-      : process.env.INTERNAL_API_URL || "http://localhost:8000";
-
   const params = new URLSearchParams();
   params.set("scholarship_type_id", String(args.scholarship_type_id));
   params.set("academic_year", String(args.academic_year));
   if (args.semester) params.set("semester", args.semester);
   params.set("department_code", args.department_code);
 
-  const response = await fetch(
-    `${baseURL}/api/v1/college-review/applications/department-summary-export?${params.toString()}`,
-    {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-    }
+  return _fetchBinaryExport(
+    "/api/v1/college-review/applications/department-summary-export",
+    params,
+    "申請總表.xlsx",
+    "無法匯出申請總表"
   );
-
-  if (!response.ok) {
-    let message = "無法匯出申請總表";
-    try {
-      const errorData = await response.json();
-      message = errorData?.detail || errorData?.message || errorData?.error || message;
-    } catch {
-      // Non-JSON error body — keep default message.
-    }
-    throw new Error(message);
-  }
-
-  const disposition = response.headers.get("content-disposition") || "";
-  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
-  const filename = filenameMatch
-    ? decodeURIComponent(filenameMatch[1].trim())
-    : "申請總表.xlsx";
-
-  const blob = await response.blob();
-  return { blob, filename };
 }
 
 /**
@@ -638,46 +621,16 @@ export async function exportDepartmentSummary(
 export async function exportDepartmentSummaryBulk(
   args: DepartmentSummaryExportArgs & { scope: "college" | "all" }
 ): Promise<{ blob: Blob; filename: string }> {
-  const token = typedClient.getToken();
-  const baseURL =
-    typeof window !== "undefined"
-      ? ""
-      : process.env.INTERNAL_API_URL || "http://localhost:8000";
-
   const params = new URLSearchParams();
   params.set("scholarship_type_id", String(args.scholarship_type_id));
   params.set("academic_year", String(args.academic_year));
   if (args.semester) params.set("semester", args.semester);
   params.set("scope", args.scope);
 
-  const response = await fetch(
-    `${baseURL}/api/v1/college-review/applications/department-summary-export-bulk?${params.toString()}`,
-    {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-    }
+  return _fetchBinaryExport(
+    "/api/v1/college-review/applications/department-summary-export-bulk",
+    params,
+    "申請總表.zip",
+    "無法匯出申請總表"
   );
-
-  if (!response.ok) {
-    let message = "無法匯出申請總表";
-    try {
-      const errorData = await response.json();
-      message = errorData?.detail || errorData?.message || errorData?.error || message;
-    } catch {
-      // Non-JSON error body — keep default message.
-    }
-    throw new Error(message);
-  }
-
-  const disposition = response.headers.get("content-disposition") || "";
-  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
-  const filename = filenameMatch
-    ? decodeURIComponent(filenameMatch[1].trim())
-    : "申請總表.zip";
-
-  const blob = await response.blob();
-  return { blob, filename };
 }

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -571,3 +571,113 @@ export async function exportRankingExcel(
   const blob = await response.blob();
   return { blob, filename };
 }
+
+type DepartmentSummaryExportArgs = {
+  scholarship_type_id: number;
+  academic_year: number;
+  semester?: string | null;
+};
+
+/**
+ * Download a single department's 申請總表 Excel.
+ *
+ * Endpoint: GET /api/v1/college-review/applications/department-summary-export
+ */
+export async function exportDepartmentSummary(
+  args: DepartmentSummaryExportArgs & { department_code: string }
+): Promise<{ blob: Blob; filename: string }> {
+  const token = typedClient.getToken();
+  const baseURL =
+    typeof window !== "undefined"
+      ? ""
+      : process.env.INTERNAL_API_URL || "http://localhost:8000";
+
+  const params = new URLSearchParams();
+  params.set("scholarship_type_id", String(args.scholarship_type_id));
+  params.set("academic_year", String(args.academic_year));
+  if (args.semester) params.set("semester", args.semester);
+  params.set("department_code", args.department_code);
+
+  const response = await fetch(
+    `${baseURL}/api/v1/college-review/applications/department-summary-export?${params.toString()}`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    }
+  );
+
+  if (!response.ok) {
+    let message = "無法匯出申請總表";
+    try {
+      const errorData = await response.json();
+      message = errorData?.detail || errorData?.message || errorData?.error || message;
+    } catch {
+      // Non-JSON error body — keep default message.
+    }
+    throw new Error(message);
+  }
+
+  const disposition = response.headers.get("content-disposition") || "";
+  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  const filename = filenameMatch
+    ? decodeURIComponent(filenameMatch[1].trim())
+    : "申請總表.xlsx";
+
+  const blob = await response.blob();
+  return { blob, filename };
+}
+
+/**
+ * Download a ZIP of 申請總表 Excels, one per department.
+ *
+ * Endpoint: GET /api/v1/college-review/applications/department-summary-export-bulk
+ */
+export async function exportDepartmentSummaryBulk(
+  args: DepartmentSummaryExportArgs & { scope: "college" | "all" }
+): Promise<{ blob: Blob; filename: string }> {
+  const token = typedClient.getToken();
+  const baseURL =
+    typeof window !== "undefined"
+      ? ""
+      : process.env.INTERNAL_API_URL || "http://localhost:8000";
+
+  const params = new URLSearchParams();
+  params.set("scholarship_type_id", String(args.scholarship_type_id));
+  params.set("academic_year", String(args.academic_year));
+  if (args.semester) params.set("semester", args.semester);
+  params.set("scope", args.scope);
+
+  const response = await fetch(
+    `${baseURL}/api/v1/college-review/applications/department-summary-export-bulk?${params.toString()}`,
+    {
+      method: "GET",
+      credentials: "include",
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    }
+  );
+
+  if (!response.ok) {
+    let message = "無法匯出申請總表";
+    try {
+      const errorData = await response.json();
+      message = errorData?.detail || errorData?.message || errorData?.error || message;
+    } catch {
+      // Non-JSON error body — keep default message.
+    }
+    throw new Error(message);
+  }
+
+  const disposition = response.headers.get("content-disposition") || "";
+  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  const filename = filenameMatch
+    ? decodeURIComponent(filenameMatch[1].trim())
+    : "申請總表.zip";
+
+  const blob = await response.blob();
+  return { blob, filename };
+}


### PR DESCRIPTION
## Summary
- Adds the 申請總表 Excel export reachable by college users (own academy only) and admins (any department).
- Reuses the existing 18-column 學生資料彙整表 layout (`CollegeRankingExportService`) by allowing `ExportRow.rank_position` to be `None` — the 學院初審會議之學院排序 column then renders as an empty cell.
- Two endpoints under `/api/v1/college-review/applications/`:
  - `GET /department-summary-export` → single department `.xlsx`
  - `GET /department-summary-export-bulk` → multi-department `.zip` (scope: `college` for 本學院全部 / `all` for 全部系所; `all` is admin-only)
- Frontend: ApplicationReviewPanel gets a department dropdown + 「匯出申請總表」 button.

## Implementation highlights
- Refactor: extracted `load_export_aux_data` helper from the existing ranking-export endpoint into `college_review/_helpers.py`, then reused it from both export endpoints.
- Filter applications by `student_data["std_depno"]` in Python (student_data is plain JSON, not JSONB).
- Sort by `(std_stdcode, application.id)` ASC; group by `std_depno` in bulk mode.
- ZIP inner filenames suffixed with `dept_code` to prevent silent collisions when names sanitise to the same string.
- Auth: `Depends(require_college)` plus academy-membership check; college users blocked from `scope=all`; admins without `college_code` blocked from `scope=college`.

## Test plan
- [x] Service tests pass: `pytest backend/tests/test_college_ranking_export_service.py` (57/57 green; added regression for `rank_position=None`).
- [x] Endpoint tests pass: `pytest backend/tests/test_application_summary_export_endpoint.py` (10/10 green: 5 single + 5 bulk).
- [x] Frontend typecheck clean (`tsc --noEmit --skipLibCheck`).
- [x] OpenAPI types regenerated (`schema.d.ts` contains both new paths).
- [ ] Manual smoke (dev stack): admin downloads single dept `.xlsx`, college user downloads `.zip` (本學院全部), admin downloads `.zip` (全部系所). Confirm rank column blank in every workbook.

## Files changed
**Backend:**
- `backend/app/services/college_ranking_export_service.py` — `rank_position` Optional
- `backend/app/api/v1/endpoints/college_review/_helpers.py` — `load_export_aux_data` helper
- `backend/app/api/v1/endpoints/college_review/application_summary_export.py` — new module (2 endpoints)
- `backend/app/api/v1/endpoints/college_review/__init__.py` — register router
- `backend/app/api/v1/endpoints/college_review/ranking_management.py` — call new helper
- `backend/tests/test_college_ranking_export_service.py` — regression test
- `backend/tests/test_application_summary_export_endpoint.py` — new endpoint tests

**Frontend:**
- `frontend/components/college/review/ApplicationReviewPanel.tsx` — dropdown + button + handler
- `frontend/lib/api/modules/college.ts` — `exportDepartmentSummary`, `exportDepartmentSummaryBulk`
- `frontend/lib/api/generated/schema.d.ts` — regenerated

**Docs:**
- `docs/superpowers/specs/2026-05-13-application-summary-export-design.md`
- `docs/superpowers/plans/2026-05-13-application-summary-export.md`