### PR TITLE
chore(workflows): bump built-in actions to Node-24-native majors

### DIFF
--- a/.github/workflows/api-types-check.yml
+++ b/.github/workflows/api-types-check.yml
@@ -58,11 +58,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Backend setup
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -123,7 +123,7 @@ jobs:
 
       # Frontend setup
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -180,7 +180,7 @@ jobs:
       # Comment on PR if types are outdated
       - name: Comment on PR
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({
@@ -212,10 +212,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -232,7 +232,7 @@ jobs:
           NEXT_PUBLIC_API_URL: http://localhost:8000
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frontend-build
           path: frontend/.next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       dependencies: ${{ steps.changes.outputs.dependencies }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -101,18 +101,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python (if needed)
         if: matrix.check == 'backend-lint' || matrix.check == 'security-scan'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Setup Node.js (if needed)
         if: matrix.check == 'frontend-lint' || matrix.check == 'dependency-check'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -248,16 +248,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -365,7 +365,7 @@ jobs:
 
       - name: Upload diff-cover report (backend)
         if: always() && matrix.test-suite == 'smoke'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: diff-cover-backend
           path: backend/diff-cover-backend.html
@@ -373,7 +373,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-backend-${{ matrix.test-suite }}
           path: |
@@ -391,17 +391,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
       - name: Cache npm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -431,7 +431,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-frontend
           path: |
@@ -447,10 +447,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -480,10 +480,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -552,7 +552,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report-smoke
           path: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -152,7 +152,7 @@ jobs:
 
     - name: Upload SARIF as artifact for PDF generation
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: codeql-sarif-${{ matrix.language }}
         path: sarif-results/${{ steps.sarif-lang.outputs.name }}.sarif

--- a/.github/workflows/deploy-monitoring-stack.yml
+++ b/.github/workflows/deploy-monitoring-stack.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pre-flight secret check
         env:
@@ -356,7 +356,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Pre-flight secret check
         env:

--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -158,7 +158,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/dev-workflow.yml
+++ b/.github/workflows/dev-workflow.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Label based on files changed
         uses: actions/labeler@v5
@@ -44,7 +44,7 @@ jobs:
 
       - name: Calculate PR size
         id: pr-size
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -138,7 +138,7 @@ jobs:
 
       - name: Comment on conflicts
         if: failure() && steps.conflict-check.outputs.conflicts == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const conflictMessage = [
@@ -178,10 +178,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -231,7 +231,7 @@ jobs:
 
       - name: Comment bundle analysis
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -280,10 +280,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Auto-assign reviewers
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -382,7 +382,7 @@ jobs:
 
     steps:
       - name: Check PR readiness
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({

--- a/.github/workflows/mirror-to-production.yml
+++ b/.github/workflows/mirror-to-production.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history for proper merging
           token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,9 +48,9 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -117,9 +117,9 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -168,9 +168,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report-nightly
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22'
 
@@ -161,7 +161,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -290,7 +290,7 @@ jobs:
 
     - name: Create release announcement
       if: needs.create-release.result == 'success'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const version = '${{ needs.prepare-release.outputs.version }}';

--- a/.github/workflows/sarif-to-pdf.yml
+++ b/.github/workflows/sarif-to-pdf.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get latest CodeQL run ID
         if: ${{ github.event.inputs.run_id == '' }}
@@ -53,7 +53,7 @@ jobs:
           if_no_artifact_found: warn
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -410,14 +410,14 @@ jobs:
         run: ls -lh codeql-security-report.pdf
 
       - name: Upload PDF Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: codeql-security-report
           path: codeql-security-report.pdf
           retention-days: 90
 
       - name: Upload HTML Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: codeql-security-report-html
           path: codeql-report.html

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -63,10 +63,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -88,7 +88,7 @@ jobs:
         continue-on-error: false
 
       - name: Upload security reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: backend-security-reports
@@ -107,10 +107,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect secrets with detect-secrets
         run: |
@@ -232,7 +232,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for outdated Python dependencies
         working-directory: ./backend
@@ -251,7 +251,7 @@ jobs:
 
       - name: Create security summary
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const summary = `## 🔒 Security Scan Summary

--- a/.github/workflows/staging-evidence.yml
+++ b/.github/workflows/staging-evidence.yml
@@ -61,13 +61,13 @@ jobs:
           echo "resolved evidence date: $DATE"
 
       - name: Checkout evidence branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ steps.resolve.outputs.ref }}
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload evidence artifact
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: staging-evidence-${{ steps.resolve.outputs.date }}-${{ github.run_id }}
           path: _evidence-out
@@ -96,7 +96,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           DATE: ${{ steps.resolve.outputs.date }}
           ARTIFACT_NAME: staging-evidence-${{ steps.resolve.outputs.date }}-${{ github.run_id }}

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run AI inference
         id: inference


### PR DESCRIPTION
## Summary
- Follow-up to #195. That PR added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to every workflow so v4/v5 actions ran on Node 24, but GitHub's deprecation banners stayed because the action manifests still declared `runs.using: node20`. Recent nightly runs (E2E Full, Backend Slow + Performance, Audit Log Contract) kept surfacing the deprecation annotation.
- Bumps every built-in action to the first major release that declares `runs.using: node24`:

  | Action | Before | After | Why this major |
  |---|---|---|---|
  | `actions/checkout` | v4 | v5 | First Node-24 major; v6 introduces credential-file changes we don't need |
  | `actions/setup-python` | v5 | v6 | First Node-24 major |
  | `actions/setup-node` | v4 | v5 | First Node-24 major; auto-cache risk reviewed below |
  | `actions/upload-artifact` | v4 | v6 | v5 had only "preliminary" Node 24 support and still defaulted to Node 20 — v6 is what actually silences the warning |
  | `actions/github-script` | v7 | v8 | v9 ships ESM-only `@actions/github`; staying on v8 keeps the v7-compatible script API |
  | `actions/cache` | v4 | v5 | First Node-24 major |

- Leaves `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in place as a safety net for any third-party action still declaring `node20`. It is now a no-op for everything touched here; cleanup can happen in a separate sweep.

## Pre-flight checks on breaking changes
- **setup-node@v5** enables automatic dependency caching when `package.json` declares a `packageManager` field. `frontend/package.json` does not, so no implicit cache wiring appears.
- **github-script@v9** breaks `require('@actions/github')` and `const getOctokit = ...` redeclarations. Greped all 9 inline scripts in this repo — neither pattern is used. Conservatively staying on `@v8` anyway.
- **upload-artifact@v5** documentation explicitly says it still defaults to Node 20; **v6** is the first major where the runtime default flips. Picked v6 so the warning actually goes away.
- **checkout@v6** persists git credentials to a separate file (subtle behavior change for multi-step flows). Sticking to v5 keeps existing flows untouched.
- All bumped actions require Actions Runner >= **v2.327.1**. GitHub-hosted runners are well past that; no self-hosted runners in this repo.

## Test plan
- [ ] CI green on PR (api-types-check, ci, security, codeql)
- [ ] Confirm no \"Node.js 20 is deprecated\" annotation appears on this PR's check runs
- [ ] After merge, watch one nightly cycle to confirm E2E Full / Backend Slow / Audit Log Contract no longer surface the deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)