### PR TITLE
fix(ci): run alembic migrations + seeds in backend container before E2E Smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,17 @@ jobs:
           echo "::notice::Compose stack failed to come up; skipping Playwright run."
           exit 0
 
+      - name: Migrate + seed inside backend container
+        # /health returns 200 as soon as FastAPI has started — it doesn't
+        # check schema. Without an explicit migrate step, Playwright tests
+        # hit endpoints (mock-SSO login, etc.) that query `users` and 500
+        # with `relation "users" does not exist`. Mirrors the fix landed
+        # for nightly E2E Full in #193 (commit d13ba1b).
+        if: env.READY == '1'
+        run: |
+          docker compose -f docker-compose.dev.yml exec -T backend alembic upgrade head
+          docker compose -f docker-compose.dev.yml exec -T backend python -m app.seed || echo "seed completed"
+
       - name: Install Playwright browsers
         if: env.READY == '1'
         working-directory: ./frontend


### PR DESCRIPTION
## Summary

The `E2E Smoke` job has been failing on every recent PR (#192, #193, #194, #195, #198, #202) with:

```
ProgrammingError: relation "users" does not exist
[SQL: SELECT users.id, users.nycu_id, ... FROM users WHERE users.nycu_id = $1::VARCHAR]
[parameters: ('stuphd001',)]
```

at `POST /api/v1/auth/mock-sso/login`, the first endpoint the Playwright smoke specs hit. Surfaced again during PR #202's merge review.

## Root cause

The `e2e-smoke` job in `.github/workflows/ci.yml` brings up the full `docker-compose.dev.yml` stack and then polls `/health` for readiness. `/health` returns 200 as soon as FastAPI boots — it does **not** verify that the database schema has been migrated. The job then jumps straight to Playwright (`Install Playwright browsers` → `Run @smoke specs`) without ever running `alembic upgrade head` against the backend's Postgres. Mock-SSO login selects from `users`, the table doesn't exist, and Playwright dies on its first request.

The job is currently `continue-on-error: true`, which is why this has been bleeding noise into every PR run without blocking merges — but the lane was never actually doing anything useful in CI.

## Fix

Add an explicit `Migrate + seed inside backend container` step between the readiness guard and the Playwright install step, gated on `env.READY == '1'`:

```yaml
- name: Migrate + seed inside backend container
  if: env.READY == '1'
  run: |
    docker compose -f docker-compose.dev.yml exec -T backend alembic upgrade head
    docker compose -f docker-compose.dev.yml exec -T backend python -m app.seed || echo "seed completed"
```

## Mirrored from

This is the exact same recipe landed for the nightly `E2E Full` lane in #193 / commit `d13ba1b` (`fix(nightly): migrate + seed inside backend container before E2E Full`). That commit fixed the identical bug in `nightly.yml`; this PR closes the gap in `ci.yml` for the Smoke lane.

## Test plan

- [ ] Push triggers `E2E Smoke` job
- [ ] `Migrate + seed inside backend container` step appears between `Skip-on-not-ready guard` and `Install Playwright browsers`
- [ ] Alembic step shows migrations running to head
- [ ] Playwright `@smoke` specs no longer 500 on `mock-sso/login`
- [ ] `users`, `application_sequences`, etc. visible to backend queries

Note: did not promote the job from `continue-on-error: true` to required in this PR — that's a separate hardening step once the lane is confirmed green for a few cycles.