### PR TITLE
fix(ci): migrate + seed inside backend container before E2E Smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,17 @@ jobs:
           echo "::notice::Compose stack failed to come up; skipping Playwright run."
           exit 0
 
+      - name: Migrate + seed inside backend container
+        # /health returns 200 as soon as FastAPI has started — it doesn't
+        # check schema. Without an explicit migrate step, Playwright tests
+        # hit endpoints (mock-SSO login, etc.) that query `users` and 500
+        # with `relation "users" does not exist`. Mirror of the fix #193
+        # applied to nightly.yml's E2E Full job.
+        if: env.READY == '1'
+        run: |
+          docker compose -f docker-compose.dev.yml exec -T backend alembic upgrade head
+          docker compose -f docker-compose.dev.yml exec -T backend python -m app.seed || echo "seed completed"
+
       - name: Install Playwright browsers
         if: env.READY == '1'
         working-directory: ./frontend


### PR DESCRIPTION
## Summary
- Mirrors the fix from #193 (`nightly.yml` E2E Full) into `ci.yml`'s E2E Smoke job, which still had the same latent gap.
- PR #204's CI surfaced this on a workflow-only change: dorny/paths-filter mis-classified `.github/workflows/**` as backend+frontend changes, so the gated `E2E Smoke` job actually ran — and predictably failed with `relation \"users\" does not exist` on the very first `mock-SSO` call.

## Why this is needed
The E2E Smoke job's readiness wait checks `/health`, which returns 200 as soon as FastAPI boots — it does **not** verify schema. The backend service in `docker-compose.dev.yml` does not auto-run migrations on container start, so Playwright tests hit a fresh empty postgres and 500 on the first query that touches `users`.

## What changes
Adds one new step in `ci.yml` between \"Skip-on-not-ready guard\" and \"Install Playwright browsers\":

\`\`\`yaml
- name: Migrate + seed inside backend container
  if: env.READY == '1'
  run: |
    docker compose -f docker-compose.dev.yml exec -T backend alembic upgrade head
    docker compose -f docker-compose.dev.yml exec -T backend python -m app.seed || echo \"seed completed\"
\`\`\`

Same recipe `ci.yml` already uses for backend-tests (lines 287–306) and `nightly.yml` uses for backend-slow / audit-log-contract / e2e-full.

The job remains `continue-on-error: true`, but it can now actually exercise the smoke specs instead of failing on the first auth call.

## Test plan
- [ ] CI green on this PR
- [ ] On this PR, the \"E2E Smoke\" check transitions from `fail` to either `pass` or `skipped` (depending on path-filter outputs)
- [ ] Backend logs no longer show `relation \"users\" does not exist` in the E2E Smoke run

🤖 Generated with [Claude Code](https://claude.com/claude-code)