### PR TITLE
fix(pii): scrub historical std_pid plaintext from audit_logs

### DIFF
--- a/backend/alembic/versions/20260513_scrub_pii_from_audit_logs.py
+++ b/backend/alembic/versions/20260513_scrub_pii_from_audit_logs.py
@@ -1,0 +1,201 @@
+"""scrub historical std_pid plaintext from audit_logs JSON columns (issue #73 follow-up)
+
+PR #202 (``20260512_encrypt_std_pid``) only encrypted live
+``applications.student_data``. Historical rows in ``audit_logs.old_values``
+and ``audit_logs.new_values`` that snapshotted ``student_data`` still hold
+plaintext ``std_pid`` (Taiwan national ID) on disk. This migration walks
+``audit_logs`` in batches and replaces every ``std_pid`` value (at any
+depth) with ``[REDACTED]``.
+
+Design choices (mirrors ``20260512_encrypt_std_pid``):
+
+- **Batched cursor-based loop** over ``id`` so memory stays bounded even
+  on tables with millions of rows.
+- **Idempotent**: rows whose JSON columns don't textually contain
+  ``"std_pid"`` are skipped via a SQL ``LIKE`` filter; the in-memory walk
+  also short-circuits when no redaction was needed. Re-running is a no-op.
+- **Recursive walk**: ``redact_dict_pii`` only handles a shallow dict, but
+  ``audit_logs.old_values`` typically carries a snapshot of a full
+  ``applications`` row whose ``student_data`` is a nested object. We walk
+  dicts and lists in-place.
+- **Lazy import** of ``redact_dict_pii`` inside ``upgrade()`` so
+  ``alembic show`` works without the env / key material being loaded.
+- **No-op downgrade**: per CLAUDE.md "no backward compatibility" policy
+  and to match PR #202's pattern — we cannot un-redact ``[REDACTED]`` back
+  into the original ``std_pid``.
+
+Revision ID: 20260513_scrub_pii_audit
+Revises: 20260512_encrypt_std_pid
+Create Date: 2026-05-13
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260513_scrub_pii_audit"
+down_revision: Union[str, None] = "20260512_encrypt_std_pid"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_BATCH_SIZE = 500
+# JSON columns on audit_logs that may have captured a student_data snapshot
+# containing plaintext std_pid. ``meta_data`` and ``request_headers`` are
+# also JSON columns, but historically the writer only ever placed PII into
+# ``old_values`` / ``new_values``. We still walk all four for defense in
+# depth — the cost is negligible since we LIKE-filter rows up front.
+_JSON_COLUMNS = ("old_values", "new_values", "meta_data", "request_headers")
+_PII_KEYS = ("std_pid",)
+_PLACEHOLDER = "[REDACTED]"
+
+
+def _redact_recursive(node, redact_dict_pii, pii_keys, placeholder):
+    """Walk ``node`` (dict / list / scalar) and redact any value at a
+    ``pii_keys`` member key. Returns ``(new_node, changed)``.
+
+    Dict-level redaction is delegated to :func:`app.core.pii_crypto.redact_dict_pii`
+    (the shared helper introduced in PR #202) so both the audit-log writer
+    and this back-fill use the exact same redaction semantics. We layer
+    recursion on top because ``audit_logs.old_values`` typically captures a
+    nested snapshot (e.g. ``{"student_data": {"std_pid": ...}}``).
+
+    ``changed`` is ``True`` iff at least one redaction happened. Used by the
+    caller to skip the UPDATE when no change is needed (extra idempotency
+    layer on top of the SQL LIKE filter; a payload that mentions
+    ``std_pid`` somewhere unrelated will still skip this branch).
+    """
+    if isinstance(node, dict):
+        # First recurse into children so nested ``student_data`` blobs get
+        # rewritten too.
+        rewritten = {}
+        changed = False
+        for k, v in node.items():
+            new_v, sub_changed = _redact_recursive(v, redact_dict_pii, pii_keys, placeholder)
+            rewritten[k] = new_v
+            changed = changed or sub_changed
+        # Then apply the shallow helper at this level so the PR #202
+        # ``redact_dict_pii`` semantics own the actual key replacement.
+        after = redact_dict_pii(rewritten, keys=pii_keys, placeholder=placeholder)
+        if after is not rewritten:
+            # Helper returned a copy; detect whether it mutated a target key.
+            for k in pii_keys:
+                if k in rewritten and rewritten[k] not in (None, "") and after.get(k) == placeholder:
+                    if rewritten[k] != placeholder:
+                        changed = True
+                    break
+        return after, changed
+    if isinstance(node, list):
+        out = []
+        changed = False
+        for item in node:
+            new_item, sub_changed = _redact_recursive(item, redact_dict_pii, pii_keys, placeholder)
+            out.append(new_item)
+            changed = changed or sub_changed
+        return out, changed
+    return node, False
+
+
+def _coerce_json(value):
+    """Normalize a JSON column read result into a Python object or ``None``.
+
+    PostgreSQL ``JSON`` columns deserialize into Python ``dict`` / ``list``
+    automatically; SQLite ``JSON`` columns hand back a JSON-encoded string.
+    Either way, after this function the value is a native Python object or
+    ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        if value == "":
+            return None
+        try:
+            return json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            # Not valid JSON — leave it alone. We never overwrite a column
+            # whose content we can't safely parse.
+            return None
+    return None
+
+
+def upgrade() -> None:
+    """Redact ``std_pid`` from every audit_logs row's JSON snapshots."""
+    # Lazy import so ``alembic show`` works even when env keys aren't loaded.
+    from app.core.pii_crypto import redact_dict_pii
+
+    bind = op.get_bind()
+    is_sqlite = bind.dialect.name == "sqlite"
+
+    # The audit_logs table may not exist on a brand-new minimal test DB.
+    inspector = sa.inspect(bind)
+    if "audit_logs" not in inspector.get_table_names():
+        return
+
+    # Idempotency pre-filter: skip rows whose JSON columns don't textually
+    # contain "std_pid". Casting JSON to text is supported on both PG
+    # (``::text``) and SQLite (``CAST(... AS TEXT)``).
+    like_clauses = " OR ".join(
+        [
+            (f"CAST({col} AS TEXT) LIKE '%\"std_pid\"%'" if is_sqlite else f"({col})::text LIKE '%\"std_pid\"%'")
+            for col in _JSON_COLUMNS
+        ]
+    )
+
+    last_id = 0
+    while True:
+        select_sql = sa.text(
+            f"SELECT id, {', '.join(_JSON_COLUMNS)} FROM audit_logs "
+            f"WHERE id > :last_id AND ({like_clauses}) "
+            f"ORDER BY id ASC LIMIT :limit"
+        )
+        rows = bind.execute(
+            select_sql,
+            {"last_id": last_id, "limit": _BATCH_SIZE},
+        ).fetchall()
+
+        if not rows:
+            break
+
+        for row in rows:
+            row_id = row[0]
+            last_id = row_id
+
+            updates = {}
+            for idx, col_name in enumerate(_JSON_COLUMNS, start=1):
+                raw = row[idx]
+                parsed = _coerce_json(raw)
+                if parsed is None:
+                    continue
+                new_value, changed = _redact_recursive(parsed, redact_dict_pii, _PII_KEYS, _PLACEHOLDER)
+                if changed:
+                    updates[col_name] = new_value
+
+            if not updates:
+                continue
+
+            set_clause = ", ".join(
+                [f"{col} = CAST(:{col} AS JSON)" if not is_sqlite else f"{col} = :{col}" for col in updates]
+            )
+            params = {col: json.dumps(val, ensure_ascii=False) for col, val in updates.items()}
+            params["id"] = row_id
+            bind.execute(
+                sa.text(f"UPDATE audit_logs SET {set_clause} WHERE id = :id"),
+                params,
+            )
+
+
+def downgrade() -> None:
+    """Intentional no-op.
+
+    Mirrors ``20260512_encrypt_std_pid``'s no-op downgrade. Redaction is
+    lossy by design — the original ``std_pid`` plaintext was destroyed on
+    purpose and there is no inverse. Per CLAUDE.md's "no backward
+    compatibility" policy we do not synthesize fallback data here.
+    """
+    pass

--- a/backend/app/tests/test_scrub_pii_audit_logs_migration.py
+++ b/backend/app/tests/test_scrub_pii_audit_logs_migration.py
@@ -1,0 +1,301 @@
+"""Integration test: scrub_pii_from_audit_logs migration (issue #73 follow-up).
+
+Verifies the migration ``20260513_scrub_pii_from_audit_logs.py``:
+
+- redacts ``std_pid`` in ``audit_logs.old_values`` / ``new_values``
+  (including when nested inside a ``student_data`` snapshot)
+- leaves other keys untouched
+- is idempotent: running ``upgrade()`` a second time is a no-op
+- leaves rows without ``std_pid`` alone (control row)
+- handles ``meta_data`` and ``request_headers`` columns the same way
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "alembic" / "versions" / "20260513_scrub_pii_from_audit_logs.py"
+)
+
+
+def _load_migration_module():
+    """Import the migration file as a standalone module.
+
+    We don't go through alembic itself — we just want to call ``upgrade()``
+    against a controlled bind. ``op.get_bind()`` is the only alembic surface
+    the migration uses; we patch it to return our test engine connection.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "scrub_pii_audit_migration",
+        os.fspath(_MIGRATION_PATH),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def _create_audit_logs_table(conn):
+    """Create a minimal ``audit_logs`` table matching the columns the
+    migration touches. We don't import the SQLAlchemy model because that
+    drags in the full models package and triggers the StudentDataJSON
+    type decorator, which would need real PII keys for the unrelated
+    ``applications`` table."""
+    conn.execute(
+        text(
+            """
+            CREATE TABLE audit_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                action VARCHAR(50) NOT NULL,
+                resource_type VARCHAR(50) NOT NULL,
+                resource_id VARCHAR(50),
+                old_values JSON,
+                new_values JSON,
+                meta_data JSON,
+                request_headers JSON
+            )
+            """
+        )
+    )
+
+
+def _insert(conn, **cols):
+    """Insert one audit_logs row, JSON-encoding any dict values."""
+    payload = {
+        "user_id": 1,
+        "action": "update",
+        "resource_type": "application",
+        "resource_id": None,
+        "old_values": None,
+        "new_values": None,
+        "meta_data": None,
+        "request_headers": None,
+    }
+    payload.update(cols)
+    for k in ("old_values", "new_values", "meta_data", "request_headers"):
+        if isinstance(payload[k], (dict, list)):
+            payload[k] = json.dumps(payload[k], ensure_ascii=False)
+    conn.execute(
+        text(
+            "INSERT INTO audit_logs "
+            "(user_id, action, resource_type, resource_id, old_values, new_values, meta_data, request_headers) "
+            "VALUES (:user_id, :action, :resource_type, :resource_id, :old_values, :new_values, "
+            ":meta_data, :request_headers)"
+        ),
+        payload,
+    )
+
+
+def _fetch_json(conn, row_id, col):
+    raw = conn.execute(
+        text(f"SELECT {col} FROM audit_logs WHERE id = :id"),
+        {"id": row_id},
+    ).scalar()
+    if raw is None:
+        return None
+    if isinstance(raw, (dict, list)):
+        return raw
+    return json.loads(raw)
+
+
+# --- fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with eng.begin() as conn:
+        _create_audit_logs_table(conn)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def migration():
+    return _load_migration_module()
+
+
+def _run_upgrade(migration, engine):
+    """Invoke ``upgrade()`` with ``op.get_bind()`` patched to our engine.
+
+    The migration calls ``op.get_bind()`` once at the top to grab a bind,
+    then issues raw SQL through it. We patch the ``op`` module attribute
+    inside the loaded migration so it returns a live connection bound to
+    our test engine. Using ``engine.begin()`` ensures changes commit.
+    """
+    with engine.begin() as conn:
+        with patch.object(migration.op, "get_bind", return_value=conn):
+            migration.upgrade()
+
+
+# --- tests -------------------------------------------------------------------
+
+
+def test_redacts_std_pid_in_old_and_new_values(engine, migration):
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            old_values={"std_pid": "A123456789", "other": "ok"},
+            new_values={"std_pid": "B987654321", "other": "ok2"},
+        )
+
+    _run_upgrade(migration, engine)
+
+    with engine.connect() as conn:
+        old = _fetch_json(conn, 1, "old_values")
+        new = _fetch_json(conn, 1, "new_values")
+
+    assert old == {"std_pid": "[REDACTED]", "other": "ok"}
+    assert new == {"std_pid": "[REDACTED]", "other": "ok2"}
+
+
+def test_redacts_nested_std_pid_inside_student_data_snapshot(engine, migration):
+    nested_old = {
+        "student_data": {
+            "std_pid": "A123456789",
+            "std_cname": "王小明",
+            "trm_year": 114,
+        },
+        "status": "draft",
+    }
+    nested_new = {
+        "student_data": {
+            "std_pid": "A123456789",
+            "std_cname": "王小明",
+            "trm_year": 114,
+        },
+        "status": "submitted",
+    }
+    with engine.begin() as conn:
+        _insert(conn, old_values=nested_old, new_values=nested_new)
+
+    _run_upgrade(migration, engine)
+
+    with engine.connect() as conn:
+        old = _fetch_json(conn, 1, "old_values")
+        new = _fetch_json(conn, 1, "new_values")
+
+    assert old["student_data"]["std_pid"] == "[REDACTED]"
+    assert old["student_data"]["std_cname"] == "王小明"
+    assert old["student_data"]["trm_year"] == 114
+    assert old["status"] == "draft"
+
+    assert new["student_data"]["std_pid"] == "[REDACTED]"
+    assert new["status"] == "submitted"
+
+
+def test_control_row_without_std_pid_is_unchanged(engine, migration):
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            old_values={"other": "ok", "nested": {"x": 1}},
+            new_values={"other": "ok2"},
+        )
+
+    _run_upgrade(migration, engine)
+
+    with engine.connect() as conn:
+        old = _fetch_json(conn, 1, "old_values")
+        new = _fetch_json(conn, 1, "new_values")
+
+    assert old == {"other": "ok", "nested": {"x": 1}}
+    assert new == {"other": "ok2"}
+
+
+def test_redacts_in_meta_data_and_request_headers(engine, migration):
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            meta_data={"std_pid": "C111222333", "tag": "audit"},
+            request_headers={"X-Forwarded-For": "10.0.0.1", "std_pid": "D444555666"},
+        )
+
+    _run_upgrade(migration, engine)
+
+    with engine.connect() as conn:
+        md = _fetch_json(conn, 1, "meta_data")
+        rh = _fetch_json(conn, 1, "request_headers")
+
+    assert md == {"std_pid": "[REDACTED]", "tag": "audit"}
+    assert rh == {"X-Forwarded-For": "10.0.0.1", "std_pid": "[REDACTED]"}
+
+
+def test_idempotent_rerun_is_noop(engine, migration):
+    with engine.begin() as conn:
+        _insert(conn, old_values={"std_pid": "A123456789", "other": "ok"})
+
+    _run_upgrade(migration, engine)
+
+    with engine.connect() as conn:
+        first = _fetch_json(conn, 1, "old_values")
+    assert first == {"std_pid": "[REDACTED]", "other": "ok"}
+
+    # Re-run: should be a no-op (LIKE filter no longer matches; even if it
+    # did, recursive walk skips already-[REDACTED] values).
+    _run_upgrade(migration, engine)
+
+    with engine.connect() as conn:
+        second = _fetch_json(conn, 1, "old_values")
+    assert second == first
+
+
+def test_empty_table_is_safe(engine, migration):
+    # No rows at all — the loop should exit immediately without error.
+    _run_upgrade(migration, engine)
+    with engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM audit_logs")).scalar()
+    assert count == 0
+
+
+def test_null_json_columns_are_left_alone(engine, migration):
+    with engine.begin() as conn:
+        # All four JSON columns are NULL — the LIKE pre-filter excludes us.
+        _insert(conn)
+
+    _run_upgrade(migration, engine)
+
+    with engine.connect() as conn:
+        assert _fetch_json(conn, 1, "old_values") is None
+        assert _fetch_json(conn, 1, "new_values") is None
+        assert _fetch_json(conn, 1, "meta_data") is None
+        assert _fetch_json(conn, 1, "request_headers") is None
+
+
+def test_downgrade_is_noop(engine, migration):
+    with engine.begin() as conn:
+        _insert(conn, old_values={"std_pid": "A123456789"})
+    # Just verify it doesn't raise and doesn't touch data.
+    migration.downgrade()
+    with engine.connect() as conn:
+        assert _fetch_json(conn, 1, "old_values") == {"std_pid": "A123456789"}
+
+
+def test_missing_audit_logs_table_is_safe(migration):
+    """If the audit_logs table doesn't exist (fresh init scenario) the
+    migration must return cleanly rather than raise."""
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    try:
+        _run_upgrade(migration, eng)  # should be a clean no-op
+    finally:
+        eng.dispose()

--- a/backend/app/tests/test_scrub_pii_audit_logs_migration.py
+++ b/backend/app/tests/test_scrub_pii_audit_logs_migration.py
@@ -22,7 +22,6 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.pool import StaticPool
 
-
 # --- helpers -----------------------------------------------------------------
 
 
@@ -53,9 +52,7 @@ def _create_audit_logs_table(conn):
     drags in the full models package and triggers the StudentDataJSON
     type decorator, which would need real PII keys for the unrelated
     ``applications`` table."""
-    conn.execute(
-        text(
-            """
+    conn.execute(text("""
             CREATE TABLE audit_logs (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 user_id INTEGER NOT NULL,
@@ -67,9 +64,7 @@ def _create_audit_logs_table(conn):
                 meta_data JSON,
                 request_headers JSON
             )
-            """
-        )
-    )
+            """))
 
 
 def _insert(conn, **cols):


### PR DESCRIPTION
## Summary

- Adds Alembic migration ``20260513_scrub_pii_from_audit_logs`` that walks the ``audit_logs`` table in batches and replaces every plaintext ``std_pid`` (Taiwan national ID) value found inside ``old_values`` / ``new_values`` / ``meta_data`` / ``request_headers`` JSON columns with ``[REDACTED]``.
- Closes the follow-up scrub that PR #202 (``feat(pii): encrypt std_pid at rest with AES-256-GCM``, issue #73) explicitly deferred — that PR only encrypted live ``applications.student_data``; the historical snapshots in ``audit_logs`` still held plaintext PII on disk.
- Reuses the shared ``redact_dict_pii`` helper from PR #202 for the actual key replacement (matching audit-writer semantics) and layers recursion on top for nested ``student_data`` blobs.

## Design

- **Batched cursor loop** over ``id`` (``WHERE id > :last_id ORDER BY id LIMIT 500``) — same pattern as ``20260512_encrypt_std_pid``.
- **Idempotent**: SQL ``LIKE '%"std_pid"%'`` pre-filter on cast-to-text JSON columns skips rows that don't contain the key; the in-memory recursive walk also short-circuits when no redaction occurred, so the ``UPDATE`` is suppressed. Re-running is a no-op.
- **Lazy import** of ``redact_dict_pii`` inside ``upgrade()`` so ``alembic show`` works without env / key material loaded.
- **No-op ``downgrade()``** with the same justification as PR #202: redaction is lossy by design and CLAUDE.md "no backward compatibility" forbids synthesizing fallback data.
- **Cross-dialect**: handles PostgreSQL (``(col)::text``, ``CAST(:val AS JSON)``) and SQLite (``CAST(col AS TEXT)``, bind value direct) for the test environment.
- **Defensive**: returns early if ``audit_logs`` table doesn't exist (fresh init scenarios).

Chains: ``down_revision = "20260512_encrypt_std_pid"``.

## Test plan

- [x] ``test_scrub_pii_audit_logs_migration.py`` covers nine cases: top-level redaction, nested ``student_data`` snapshot, control row without ``std_pid``, ``meta_data`` / ``request_headers`` columns, idempotent re-run, empty table, all-``NULL`` JSON columns, no-op downgrade, missing-table tolerance. **9 / 9 pass.**
- [x] ``python -m black --line-length=120 --target-version=py311`` clean on both new files.
- [x] ``python -m flake8 --max-line-length=120`` clean on both new files.
- [x] Verified against fresh dev Postgres: ``alembic upgrade 20260513_scrub_pii_audit`` succeeds and leaves the head at this revision; a second ``alembic upgrade`` is a no-op (transactional DDL, no row touched).
- [x] Verified ``alembic show 20260513_scrub_pii_audit`` runs cleanly with ``ENVIRONMENT=production`` and no ``PII_ENCRYPTION_KEYS`` set (proves the lazy import works).

References: issue #73, PR #202.