### PR TITLE
chore(api): standardize ApiResponse + add missing endpoint logging

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -1069,6 +1069,10 @@ async def get_application_document_file(
         )
         file_content = response.read()
     except Exception as e:
+        logger.exception(
+            "Failed to fetch application document from MinIO",
+            extra={"application_id": application.id, "object_name": object_name},
+        )
         raise HTTPException(status_code=500, detail=f"無法取得文件: {str(e)}")
 
     content_type = "application/octet-stream"

--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -2,6 +2,7 @@
 Notification endpoints for managing user notifications and system announcements
 """
 
+import logging
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -17,6 +18,8 @@ from app.models.user import User
 from app.schemas.notification import NotificationCreate
 from app.schemas.response import ApiResponse
 from app.services.notification_service import NotificationService
+
+logger = logging.getLogger(__name__)
 
 func: Any = sa_func
 
@@ -49,6 +52,7 @@ async def getUserNotifications(
         return ApiResponse(success=True, message="通知列表獲取成功", data=notifications_data)
 
     except Exception as e:
+        logger.exception("Failed to fetch notifications for user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"獲取通知失敗: {str(e)}")
 
 
@@ -67,6 +71,7 @@ async def getUnreadNotificationCount(
         return ApiResponse(success=True, message="未讀通知數量獲取成功", data=count)
 
     except Exception as e:
+        logger.exception("Failed to fetch unread notification count for user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"獲取未讀通知數量失敗: {str(e)}")
 
 
@@ -91,6 +96,7 @@ async def markNotificationAsRead(
         raise
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to mark notification as read for user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"標記通知為已讀失敗: {str(e)}")
 
 
@@ -112,6 +118,7 @@ async def markAllNotificationsAsRead(
 
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to mark all notifications as read for user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"標記所有通知為已讀失敗: {str(e)}")
 
 
@@ -147,6 +154,7 @@ async def dismissNotification(
         raise
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to dismiss notification for user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"關閉通知失敗: {str(e)}")
 
 
@@ -202,6 +210,7 @@ async def getNotificationDetail(
     except HTTPException:
         raise
     except Exception as e:
+        logger.exception("Failed to fetch notification detail for user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"獲取通知詳情失敗: {str(e)}")
 
 
@@ -263,6 +272,7 @@ async def createSystemAnnouncement(
 
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to create system announcement by user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"創建系統公告失敗: {str(e)}")
 
 
@@ -326,6 +336,7 @@ async def createTestNotifications(current_user: User = Depends(get_current_user)
 
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to create test notifications by user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"創建測試通知失敗: {str(e)}")
 
 
@@ -414,6 +425,7 @@ async def getAllAnnouncements(
         )
 
     except Exception as e:
+        logger.exception("Failed to list system announcements for user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"獲取系統公告列表失敗: {str(e)}")
 
 
@@ -473,6 +485,7 @@ async def getAnnouncement(
     except HTTPException:
         raise
     except Exception as e:
+        logger.exception("Failed to fetch system announcement detail for user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"獲取系統公告詳情失敗: {str(e)}")
 
 
@@ -534,6 +547,7 @@ async def createAnnouncement(
 
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to create system announcement by user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"創建系統公告失敗: {str(e)}")
 
 
@@ -622,6 +636,7 @@ async def updateAnnouncement(
         raise
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to update system announcement by user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"更新系統公告失敗: {str(e)}")
 
 
@@ -668,4 +683,5 @@ async def deleteAnnouncement(
         raise
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to delete system announcement by user_id=%s", current_user.id)
         raise HTTPException(status_code=500, detail=f"刪除系統公告失敗: {str(e)}")

--- a/backend/app/api/v1/endpoints/reference_data.py
+++ b/backend/app/api/v1/endpoints/reference_data.py
@@ -32,56 +32,61 @@ router = APIRouter()
 @router.get("/degrees")
 async def get_degrees(
     session: AsyncSession = Depends(get_db),
-) -> List[dict]:
+) -> ApiResponse[List[dict]]:
     """Get all degree types"""
     result = await session.execute(select(Degree))
     degrees = result.scalars().all()
 
-    return [{"id": degree.id, "name": degree.name} for degree in degrees]
+    data = [{"id": degree.id, "name": degree.name} for degree in degrees]
+    return ApiResponse(success=True, message="Degrees retrieved successfully", data=data)
 
 
 @router.get("/identities")
 async def get_identities(
     session: AsyncSession = Depends(get_db),
-) -> List[dict]:
+) -> ApiResponse[List[dict]]:
     """Get all student identity types"""
     result = await session.execute(select(Identity))
     identities = result.scalars().all()
 
-    return [{"id": identity.id, "name": identity.name} for identity in identities]
+    data = [{"id": identity.id, "name": identity.name} for identity in identities]
+    return ApiResponse(success=True, message="Identities retrieved successfully", data=data)
 
 
 @router.get("/studying-statuses")
 async def get_studying_statuses(
     session: AsyncSession = Depends(get_db),
-) -> List[dict]:
+) -> ApiResponse[List[dict]]:
     """Get all studying status types"""
     result = await session.execute(select(StudyingStatus))
     statuses = result.scalars().all()
 
-    return [{"id": status.id, "name": status.name} for status in statuses]
+    data = [{"id": status.id, "name": status.name} for status in statuses]
+    return ApiResponse(success=True, message="Studying statuses retrieved successfully", data=data)
 
 
 @router.get("/school-identities")
 async def get_school_identities(
     session: AsyncSession = Depends(get_db),
-) -> List[dict]:
+) -> ApiResponse[List[dict]]:
     """Get all school identity types"""
     result = await session.execute(select(SchoolIdentity))
     school_identities = result.scalars().all()
 
-    return [{"id": school_identity.id, "name": school_identity.name} for school_identity in school_identities]
+    data = [{"id": school_identity.id, "name": school_identity.name} for school_identity in school_identities]
+    return ApiResponse(success=True, message="School identities retrieved successfully", data=data)
 
 
 @router.get("/genders")
 async def get_genders(
     session: AsyncSession = Depends(get_db),
-) -> List[dict]:
+) -> ApiResponse[List[dict]]:
     """Get all gender types"""
     result = await session.execute(select(Gender))
     genders = result.scalars().all()
 
-    return [{"id": gender.id, "name": gender.name} for gender in genders]
+    data = [{"id": gender.id, "name": gender.name} for gender in genders]
+    return ApiResponse(success=True, message="Genders retrieved successfully", data=data)
 
 
 @router.get("/academies")
@@ -100,12 +105,12 @@ async def get_academies(
 @router.get("/departments")
 async def get_departments(
     session: AsyncSession = Depends(get_db),
-) -> List[dict]:
+) -> ApiResponse[List[dict]]:
     """Get all department information with academy mapping"""
     result = await session.execute(select(Department).order_by(Department.code))
     departments = result.scalars().all()
 
-    return [
+    data = [
         {
             "id": department.id,
             "code": department.code,
@@ -114,13 +119,14 @@ async def get_departments(
         }
         for department in departments
     ]
+    return ApiResponse(success=True, message="Departments retrieved successfully", data=data)
 
 
 @router.get("/enroll-types")
 async def get_enroll_types(
     degree_id: Optional[int] = Query(None, description="Filter by degree ID"),
     session: AsyncSession = Depends(get_db),
-) -> List[dict]:
+) -> ApiResponse[List[dict]]:
     """Get enrollment types, optionally filtered by degree"""
     query = select(EnrollType).options(selectinload(EnrollType.degree))
 
@@ -130,7 +136,7 @@ async def get_enroll_types(
     result = await session.execute(query.order_by(EnrollType.degreeId, EnrollType.code))
     enroll_types = result.scalars().all()
 
-    return [
+    data = [
         {
             "degree_id": enroll_type.degreeId,
             "code": enroll_type.code,
@@ -140,6 +146,7 @@ async def get_enroll_types(
         }
         for enroll_type in enroll_types
     ]
+    return ApiResponse(success=True, message="Enroll types retrieved successfully", data=data)
 
 
 @router.get("/all")
@@ -235,7 +242,7 @@ async def _get_all_reference_data_cached(session: AsyncSession) -> dict:
 
 
 @router.get("/semesters")
-async def get_available_semesters() -> dict:
+async def get_available_semesters() -> ApiResponse[dict]:
     """Get available semester and academic year options for dynamic generation"""
     from datetime import datetime
 
@@ -278,20 +285,21 @@ async def get_available_semesters() -> dict:
         },
     ]
 
-    return {
+    data = {
         "academic_years": academic_years,
         "semesters": semesters,
         "current_academic_year": taiwan_year,
         "current_semester": current_semester,
         "current_western_year": current_year,
     }
+    return ApiResponse(success=True, message="Semesters retrieved successfully", data=data)
 
 
 @router.get("/semester-academic-year-combinations")
 async def get_semester_academic_year_combinations(
     include_statistics: bool = Query(False, description="Include application statistics"),
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> ApiResponse[dict]:
     """Get semester and academic year combinations with optional statistics"""
     from datetime import datetime
 
@@ -338,17 +346,22 @@ async def get_semester_academic_year_combinations(
     # Sort by year and semester (newest first)
     combinations.sort(key=lambda x: x["sort_order"], reverse=True)
 
-    return {
+    data = {
         "combinations": combinations,
         "current_combination": f"{taiwan_year}-{current_semester}",
         "total_combinations": len(combinations),
     }
+    return ApiResponse(
+        success=True,
+        message="Semester / academic-year combinations retrieved successfully",
+        data=data,
+    )
 
 
 @router.get("/active-academic-periods")
 async def get_active_academic_periods(
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> ApiResponse[dict]:
     """Get academic periods that have actual application data"""
 
     # Get distinct academic year/semester combinations that have applications
@@ -390,7 +403,8 @@ async def get_active_academic_periods(
             }
         )
 
-    return {"active_periods": active_periods, "total_periods": len(active_periods)}
+    data = {"active_periods": active_periods, "total_periods": len(active_periods)}
+    return ApiResponse(success=True, message="Active academic periods retrieved successfully", data=data)
 
 
 @router.get("/scholarship-periods")

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -2,6 +2,7 @@
 User management API endpoints
 """
 
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -15,6 +16,8 @@ from app.db.deps import get_db
 from app.models.user import EmployeeStatus, User, UserRole, UserType
 from app.schemas.user import BulkScholarshipAssignRequest, BulkScholarshipAssignResponse, UserCreate, UserUpdate
 from app.services.auth_service import AuthService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 

--- a/backend/app/tasks/deadline_checker.py
+++ b/backend/app/tasks/deadline_checker.py
@@ -192,7 +192,11 @@ class DeadlineChecker:
                 )
 
             except Exception as e:
-                logger.error(f"Failed to trigger deadline notification for application {application.id}: {e}")
+                logger.exception(
+                    "Failed to trigger deadline notification for application %s: %s",
+                    application.id,
+                    e,
+                )
 
     async def check_document_request_deadlines(self):
         """Check for approaching document request deadlines"""
@@ -287,7 +291,11 @@ class DeadlineChecker:
             try:
                 await self._schedule_professor_deadline_reminder(application, config, now)
             except Exception as e:
-                logger.error(f"Failed to schedule deadline reminder for application {application.id}: {e}")
+                logger.exception(
+                    "Failed to schedule deadline reminder for application %s: %s",
+                    application.id,
+                    e,
+                )
 
     async def _schedule_professor_deadline_reminder(
         self, application: Application, config: ScholarshipConfiguration, now: datetime
@@ -335,7 +343,11 @@ class DeadlineChecker:
                 context=context,
             )
         except Exception as e:
-            logger.error(f"Failed to render deadline reminder HTML for application {application.id}: {e}")
+            logger.exception(
+                "Failed to render deadline reminder HTML for application %s: %s",
+                application.id,
+                e,
+            )
 
         await EmailService().schedule_email(
             db=self.db,

--- a/backend/app/tests/test_reference_data_response_shape.py
+++ b/backend/app/tests/test_reference_data_response_shape.py
@@ -1,0 +1,80 @@
+"""
+Verify that reference-data endpoints return the standardized ApiResponse shape.
+
+Wave 1 of the production-readiness rollout (audit found 10 endpoints in
+``reference_data.py`` returning raw ``list[dict]`` / ``dict`` instead of
+``{success, message, data}`` per CLAUDE.md §5). This test pins the contract so
+a regression to a bare list/dict return would fail CI rather than silently
+break the frontend's auto-detection in ``frontend/lib/api.ts``.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+pytestmark = pytest.mark.smoke
+
+
+def _assert_api_response_shape(payload, expected_data_type=(list, dict)) -> None:
+    """Assert payload matches {success: bool, message: str, data: <type>}."""
+    assert isinstance(payload, dict), f"payload must be a dict, got {type(payload)}"
+    assert "success" in payload, f"missing 'success' key in {payload!r}"
+    assert "message" in payload, f"missing 'message' key in {payload!r}"
+    assert "data" in payload, f"missing 'data' key in {payload!r}"
+    assert isinstance(payload["success"], bool), "success must be bool"
+    assert isinstance(payload["message"], str), "message must be str"
+    assert isinstance(
+        payload["data"], expected_data_type
+    ), f"data must be {expected_data_type}, got {type(payload['data'])}"
+
+
+def test_degrees_returns_api_response():
+    """GET /api/v1/reference-data/degrees returns wrapped ApiResponse[list]."""
+    client = TestClient(app)
+    response = client.get("/api/v1/reference-data/degrees")
+    assert response.status_code == 200, response.text
+    _assert_api_response_shape(response.json(), expected_data_type=list)
+
+
+def test_identities_returns_api_response():
+    """GET /api/v1/reference-data/identities returns wrapped ApiResponse[list]."""
+    client = TestClient(app)
+    response = client.get("/api/v1/reference-data/identities")
+    assert response.status_code == 200, response.text
+    _assert_api_response_shape(response.json(), expected_data_type=list)
+
+
+def test_studying_statuses_returns_api_response():
+    """GET /api/v1/reference-data/studying-statuses returns wrapped ApiResponse[list]."""
+    client = TestClient(app)
+    response = client.get("/api/v1/reference-data/studying-statuses")
+    assert response.status_code == 200, response.text
+    _assert_api_response_shape(response.json(), expected_data_type=list)
+
+
+def test_genders_returns_api_response():
+    """GET /api/v1/reference-data/genders returns wrapped ApiResponse[list]."""
+    client = TestClient(app)
+    response = client.get("/api/v1/reference-data/genders")
+    assert response.status_code == 200, response.text
+    _assert_api_response_shape(response.json(), expected_data_type=list)
+
+
+def test_semesters_returns_api_response():
+    """GET /api/v1/reference-data/semesters returns wrapped ApiResponse[dict].
+
+    This endpoint historically returned a bare dict (academic_years, semesters,
+    current_*). Wave 1 wraps it in ApiResponse; verify the dict payload now sits
+    under data and the standardized envelope is present.
+    """
+    client = TestClient(app)
+    response = client.get("/api/v1/reference-data/semesters")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    _assert_api_response_shape(payload, expected_data_type=dict)
+    # The original dict keys are now under .data
+    data = payload["data"]
+    assert "academic_years" in data
+    assert "semesters" in data
+    assert "current_academic_year" in data

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -16330,7 +16330,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": components["schemas"]["ApiResponse_List_dict__"];
                 };
             };
         };
@@ -16350,7 +16350,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": components["schemas"]["ApiResponse_List_dict__"];
                 };
             };
         };
@@ -16370,7 +16370,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": components["schemas"]["ApiResponse_List_dict__"];
                 };
             };
         };
@@ -16390,7 +16390,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": components["schemas"]["ApiResponse_List_dict__"];
                 };
             };
         };
@@ -16410,7 +16410,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": components["schemas"]["ApiResponse_List_dict__"];
                 };
             };
         };
@@ -16450,7 +16450,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": components["schemas"]["ApiResponse_List_dict__"];
                 };
             };
         };
@@ -16473,7 +16473,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": components["schemas"]["ApiResponse_List_dict__"];
                 };
             };
             /** @description Validation Error */
@@ -16522,7 +16522,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ApiResponse_dict_"];
                 };
             };
         };
@@ -16545,7 +16545,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ApiResponse_dict_"];
                 };
             };
             /** @description Validation Error */
@@ -16574,7 +16574,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ApiResponse_dict_"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Wave 1 of the production-readiness rollout. Two concurrent fixes from the recent backend audit:

### 1. CLAUDE.md §5 — ApiResponse standardization

`reference_data.py` had 10 endpoints returning raw `list[dict]` / `dict` instead of the standard `{success, message, data}`. The frontend `lib/api.ts` auto-detection only unwraps `.data` when both `success` and `message` are present; bare returns work by accident but are a regression hazard.

Wrapped (10):
- Simple lookups: `get_degrees`, `get_identities`, `get_studying_statuses`, `get_school_identities`, `get_genders`
- Joined lookups: `get_departments`, `get_enroll_types`
- Computed payloads: `get_available_semesters`, `get_semester_academic_year_combinations`, `get_active_academic_periods`

`get_academies` already used the standard shape — left untouched.

### 2. Observability — missing endpoint logging

`users.py` + `notifications.py` had **zero `logger.*` calls** before this PR. Errors in those endpoints surfaced as HTTP 500 with no stack trace anywhere.

- Added module-level `logger = logging.getLogger(__name__)` to both files.
- In `notifications.py`: every `except Exception` block that raises HTTPException 500 now calls `logger.exception(...)` with `user_id` context before raising (12 blocks).
- `deadline_checker.py` lines 195/290/338: `logger.error` → `logger.exception` so tracebacks aren't lost in the email/scheduling failure paths.
- `applications.py:1072`: added `logger.exception` before the MinIO-fetch failure 500 raise.

## New test

`backend/app/tests/test_reference_data_response_shape.py` pins the ApiResponse contract on 5 of the wrapped endpoints. Future bare-list/dict regressions will fail CI rather than silently break the frontend.

## OpenAPI type regen

Type changes in `reference_data.py` may flow into `frontend/lib/api/generated/schema.d.ts`. CLAUDE.md §8 says to run `cd frontend && npm run api:generate` after API changes. Recommend doing this in a follow-up commit on the same branch OR on a separate frontend-types PR after merge — depends on whether CI's "Verify OpenAPI Types are Up-to-Date" check blocks merge.

## Test plan

- [x] All 5 modified files pass `python -m py_compile`
- [x] `uvx --from black==26.3.1 black --line-length=120 --target-version=py311` clean on all changed files
- [x] `uvx --from black==26.3.1 black --check --line-length=120 backend/` reports 295 files unchanged
- [x] `flake8` clean for changed files (pre-existing E712/E226 elsewhere are non-blocking warnings per CI config)
- [ ] CI's `Backend Tests` runs the new `test_reference_data_response_shape.py` against the standardized endpoints
- [ ] Manual smoke-test post-merge: hit `/api/v1/reference-data/{degrees,identities,semesters}` from staging and confirm the response shape is `{success: true, message: "...", data: ...}`

## Notes

- Frontend should NOT break: callers using `api.get(...)` get auto-unwrapped `data`; callers that already did `response.data` will see the same array/dict they got before.
- This is part 1 of 4 in the production-readiness rollout. Subsequent waves cover test coverage for major services, monitoring alert triage, and frontend audit follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)