### PR TITLE
fix(tests): use lowercase enum member NotificationPriority.urgent

### DIFF
--- a/backend/app/tests/test_notification_service.py
+++ b/backend/app/tests/test_notification_service.py
@@ -351,7 +351,7 @@ class TestNotificationService:
             call_args = mock_create.call_args[1]
 
             assert "明天到期" in call_args["message"]
-            assert call_args["priority"] == NotificationPriority.URGENT.value
+            assert call_args["priority"] == NotificationPriority.urgent
 
             assert result == mock_notification
 
@@ -372,7 +372,7 @@ class TestNotificationService:
             call_args = mock_create.call_args[1]
 
             assert "已到期" in call_args["message"]
-            assert call_args["priority"] == NotificationPriority.URGENT.value
+            assert call_args["priority"] == NotificationPriority.urgent
 
             assert result == mock_notification
 


### PR DESCRIPTION
## Summary

`test_notification_service.py` had two assertions referencing `NotificationPriority.URGENT.value` (lines 354 and 375). The actual enum member is lowercase `urgent` per CLAUDE.md §4, so any test execution would raise `AttributeError` before checking the actual assertion.

Two compounding bugs:
1. `URGENT` doesn't exist — would raise `AttributeError`
2. The assertion compared a string (`.value`) to the value passed by the code, which is the enum instance — even with the fix to `.urgent`, the original `.value` would have made the assertion always False (enum != str).

Both fixed in the same one-line change × 2.

## Why this slipped through CI

These tests are part of `test_notification_service.py` which exists but doesn't appear in the unit-test selection (or the harness skips them — to be confirmed). Either way, the file was committed in a broken state and contributed zero coverage. Fixing the enum refs makes the assertions runnable; whether they actually pass on CI is a separate question that this PR will surface.

## Test plan

- [x] Black 26.3.1 clean
- [ ] Verify whether CI's Backend Tests now reaches/passes these assertions (or surfaces a different failure that needs a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)