### PR TITLE
fix(monitoring): guard PrometheusStorageLow alert against division-by-zero (#184)

### DIFF
--- a/monitoring/config/grafana/provisioning/alerting/rules-monitoring.yml
+++ b/monitoring/config/grafana/provisioning/alerting/rules-monitoring.yml
@@ -63,7 +63,12 @@ groups:
               to: 0
             datasourceUid: prometheus-uid
             model:
-              expr: (prometheus_tsdb_storage_blocks_bytes / prometheus_tsdb_retention_limit_bytes) > 0.8
+              # Guard against Prometheus deployments without `--storage.tsdb.retention.size`
+              # set: prometheus_tsdb_retention_limit_bytes == 0 → division → +Inf →
+              # always > 0.8 → the alert fires forever with value `+Inf%`. The
+              # `and ... > 0` clause filters those out so we only alert when a
+              # real retention target exists. See issue #184.
+              expr: (prometheus_tsdb_storage_blocks_bytes / prometheus_tsdb_retention_limit_bytes) > 0.8 and prometheus_tsdb_retention_limit_bytes > 0
               refId: A
               instant: true
         noDataState: OK


### PR DESCRIPTION
## Summary

The `PrometheusStorageLow` alert had this PromQL:

```promql
(prometheus_tsdb_storage_blocks_bytes / prometheus_tsdb_retention_limit_bytes) > 0.8
```

When Prometheus is started **without** `--storage.tsdb.retention.size`, `prometheus_tsdb_retention_limit_bytes` returns `0`. Division yields `+Inf`. `+Inf > 0.8` is always true, so the alert fires perpetually with value `+Inf%` — exactly what triggered issue #184 on staging.

## Fix

Add the same denominator guard pattern that `ContainerHighMemory` already uses (see `rules-container.yml`):

```diff
- (prometheus_tsdb_storage_blocks_bytes / prometheus_tsdb_retention_limit_bytes) > 0.8
+ (prometheus_tsdb_storage_blocks_bytes / prometheus_tsdb_retention_limit_bytes) > 0.8 and prometheus_tsdb_retention_limit_bytes > 0
```

Plus an inline comment documenting why the guard exists, so the next operator doesn't strip it.

## Trade-off

After this fix, deployments without retention.size get **no alert** (instead of a permanent false positive). That's the right behavior: operators discover the missing config when they investigate "why isn't the storage alert firing" rather than living with alert-fatigue noise. Stuck `+Inf%` is worse than silence.

A follow-up could fire a separate alert when `prometheus_tsdb_retention_limit_bytes == 0` to surface the misconfiguration — left as a future enhancement.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Grafana provisioning loads the rule on next staging restart
- [ ] After deploy, staging Loki should show no new firings of `alert: PrometheusStorageLow` over 30 minutes (verify before closing #184)

Closes #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)