### PR TITLE
fix(bank-verification): skip re-verifying applications with already-verified accounts (#217)

### DIFF
--- a/backend/app/services/bank_verification_task_service.py
+++ b/backend/app/services/bank_verification_task_service.py
@@ -10,10 +10,12 @@ import uuid
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.application import Application
 from app.models.bank_verification_task import BankVerificationTask, BankVerificationTaskStatus
+from app.models.student_bank_account import StudentBankAccount
 from app.services.bank_verification_service import BankVerificationService
 
 logger = logging.getLogger(__name__)
@@ -207,8 +209,32 @@ class BankVerificationTaskService:
             # Process each application
             for idx, app_id in enumerate(application_ids):
                 try:
-                    # TODO: Check if application uses verified account (skip if yes)
-                    # For now, we'll just verify all
+                    # Skip if this application's bank account is already an
+                    # active verified StudentBankAccount for the same user.
+                    # Issue #217 / CLAUDE.md §7 — avoids re-verifying accounts
+                    # that have already been verified by another application.
+                    if await self._application_uses_verified_account(app_id, verification_service):
+                        logger.info(
+                            "Skipping bank verification for application %s: already-verified account",
+                            app_id,
+                        )
+                        skipped_count += 1
+                        results[app_id] = {
+                            "status": "skipped",
+                            "success": True,
+                            "reason": "Bank account already verified",
+                        }
+                        # Still advance progress for skipped items
+                        await self.update_task_progress(
+                            task_id=task_id,
+                            processed_count=idx + 1,
+                            verified_count=verified_count,
+                            needs_review_count=needs_review_count,
+                            failed_count=failed_count,
+                            skipped_count=skipped_count,
+                            results=results,
+                        )
+                        continue
 
                     # Perform verification
                     result = await verification_service.verify_bank_account(app_id)
@@ -273,3 +299,55 @@ class BankVerificationTaskService:
             logger.error(f"Fatal error processing task {task_id}: {str(e)}")
             await self.mark_task_as_failed(task_id, str(e))
             raise
+
+    async def _application_uses_verified_account(
+        self,
+        application_id: int,
+        verification_service: BankVerificationService,
+    ) -> bool:
+        """
+        Return True if this application's submitted bank account number matches
+        an active, verified StudentBankAccount for the same user.
+
+        Used by `process_batch_verification_task` to short-circuit
+        re-verification of accounts that the student has already had verified
+        through a previous application. Safe-by-default: any error (missing
+        application, unreadable form data, no account number) returns False so
+        the normal verification path runs.
+
+        Issue #217.
+        """
+        try:
+            application = await self.db.get(Application, application_id)
+            if application is None or not application.submitted_form_data:
+                return False
+
+            bank_fields = verification_service.extract_bank_fields_from_application(application)
+            account_number = bank_fields.get("account_number")
+            if not account_number:
+                return False
+
+            normalized = verification_service.normalize_account_number(account_number)
+            if not normalized:
+                return False
+
+            stmt = select(StudentBankAccount.id).where(
+                and_(
+                    StudentBankAccount.user_id == application.user_id,
+                    StudentBankAccount.account_number == normalized,
+                    StudentBankAccount.verification_status == "verified",
+                    StudentBankAccount.is_active.is_(True),
+                )
+            )
+            result = await self.db.execute(stmt)
+            return result.scalar_one_or_none() is not None
+        except Exception as exc:  # noqa: BLE001
+            # Fall through to normal verification on any lookup error — this is
+            # an optimisation, not a correctness boundary, so we don't want it
+            # to mask real verification work.
+            logger.warning(
+                "Skip-check failed for application %s; falling through to full verification: %s",
+                application_id,
+                exc,
+            )
+            return False


### PR DESCRIPTION
## Summary

Resolves the TODO at `bank_verification_task_service.py:210` — issue #217. The batch verification task previously ran AI verification on every application, including those whose bank account was already verified by a prior application from the same student. Wasted GPU time + miscounted batches.

## Change

Before calling `verification_service.verify_bank_account()`, the loop now checks if the application's submitted `account_number` matches an **active, verified** `StudentBankAccount` for the same user. If yes:

- Skip the verification call entirely
- Increment `skipped_count`, record `status="skipped"` with reason
- Advance task progress so the percentage reaches 100 correctly

New private helper `_application_uses_verified_account` uses existing infrastructure:
- `BankVerificationService.extract_bank_fields_from_application` — handles form-field aliasing (`postal_account` / `bank_account` / `帳號` / `郵局帳號`)
- `BankVerificationService.normalize_account_number` — same normalization the existing verifier uses, so the comparison stays consistent

## Safety

The helper is **safe-by-default**: any lookup error logs a warning and returns `False`, so the normal verification path runs. This is an optimisation, not a correctness boundary — we never silently mark an unverified account as verified.

No new failure modes:
| Scenario | Behavior |
|---|---|
| Account number changed since last verification | Lookup misses → normal verification runs |
| Different form data but same user | Lookup misses on account_number → normal verification runs |
| `StudentBankAccount.is_active=False` (revoked) | Lookup misses → normal verification runs |
| Application has no form data / no account_number | Returns False → normal verification runs |
| Any DB error in lookup | Logs warning, returns False → normal verification runs |

## Test plan

- [x] `python -m py_compile` clean
- [x] `black 26.3.1 --check` clean
- [x] `flake8 --max-line-length=120` clean
- [ ] CI's Backend Tests (existing bank-verification tests should still pass; this is an additive skip path)
- [ ] Post-merge: run a bank-verification batch on staging with a student who has both a verified account from PR #N and a new application — confirm the new application is marked `status: skipped` and not re-verified

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)