### PR TITLE
feat(document-request): add deadline field + reminder task (closes #215)

### DIFF
--- a/backend/alembic/versions/20260513_add_deadline_to_document_requests.py
+++ b/backend/alembic/versions/20260513_add_deadline_to_document_requests.py
@@ -1,0 +1,70 @@
+"""Add deadline column to document_requests
+
+Revision ID: 20260513_doc_req_deadline
+Revises: 20260513_scrub_pii_audit, b7c3a1f8d290, add_college_rejected_001
+Create Date: 2026-05-13
+
+Closes issue #215: the deadline-checker task (backend/app/tasks/deadline_checker.py)
+needs a deadline column on document_requests to send reminder notifications.
+
+This migration also folds the three open alembic heads on main into a single
+head so future migrations can append cleanly without `alembic upgrade head`
+choking on ambiguous lineage.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260513_doc_req_deadline"
+down_revision = (
+    "20260513_scrub_pii_audit",
+    "b7c3a1f8d290",
+    "add_college_rejected_001",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "document_requests" not in inspector.get_table_names():
+        # The table was renamed or dropped — nothing to do.
+        return
+
+    columns = {col["name"] for col in inspector.get_columns("document_requests")}
+    if "deadline" in columns:
+        return
+
+    op.add_column(
+        "document_requests",
+        sa.Column(
+            "deadline",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="When the student must fulfill this request by; null = no hard deadline.",
+        ),
+    )
+    op.create_index(
+        "ix_document_requests_deadline",
+        "document_requests",
+        ["deadline"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "document_requests" not in inspector.get_table_names():
+        return
+
+    indexes = {idx["name"] for idx in inspector.get_indexes("document_requests")}
+    if "ix_document_requests_deadline" in indexes:
+        op.drop_index("ix_document_requests_deadline", table_name="document_requests")
+
+    columns = {col["name"] for col in inspector.get_columns("document_requests")}
+    if "deadline" in columns:
+        op.drop_column("document_requests", "deadline")

--- a/backend/app/api/v1/endpoints/document_requests.py
+++ b/backend/app/api/v1/endpoints/document_requests.py
@@ -60,6 +60,7 @@ async def create_document_request(
         requested_documents=request_data.requested_documents,
         reason=request_data.reason,
         notes=request_data.notes,
+        deadline=request_data.deadline,
         status=DocumentRequestStatus.pending.value,
     )
 

--- a/backend/app/models/document_request.py
+++ b/backend/app/models/document_request.py
@@ -58,6 +58,12 @@ class DocumentRequest(Base):
         index=True,
     )
     fulfilled_at = Column(DateTime(timezone=True), nullable=True)
+    deadline = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        index=True,
+        comment="When the student must fulfill this request by; null = no hard deadline.",
+    )
     cancelled_at = Column(DateTime(timezone=True), nullable=True)
     cancelled_by_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     cancellation_reason = Column(Text, nullable=True)

--- a/backend/app/schemas/document_request.py
+++ b/backend/app/schemas/document_request.py
@@ -29,6 +29,10 @@ class DocumentRequestCreate(BaseModel):
         max_length=2000,
         examples=["請於一週內上傳，並確保文件清晰可讀"],
     )
+    deadline: Optional[datetime] = Field(
+        None,
+        description="When the student must fulfill this request by; null = no hard deadline.",
+    )
 
 
 class DocumentRequestFulfill(BaseModel):
@@ -65,6 +69,7 @@ class DocumentRequestResponse(BaseModel):
 
     status: str  # Using string value from enum
     fulfilled_at: Optional[datetime] = None
+    deadline: Optional[datetime] = None
     cancelled_at: Optional[datetime] = None
     cancelled_by_id: Optional[int] = None
     cancellation_reason: Optional[str] = None
@@ -93,6 +98,7 @@ class DocumentRequestListItem(BaseModel):
     reason: str
     status: str
     fulfilled_at: Optional[datetime] = None
+    deadline: Optional[datetime] = None
     cancelled_at: Optional[datetime] = None
     created_at: datetime
 
@@ -115,5 +121,6 @@ class StudentDocumentRequestResponse(BaseModel):
     reason: str
     notes: Optional[str] = None
     status: str
+    deadline: Optional[datetime] = None
 
     created_at: datetime

--- a/backend/app/tasks/deadline_checker.py
+++ b/backend/app/tasks/deadline_checker.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import selectinload
 from app.core.config import settings
 from app.db.session import AsyncSessionLocal
 from app.models.application import Application, ApplicationStatus
+from app.models.document_request import DocumentRequest, DocumentRequestStatus
 from app.models.email_management import EmailCategory, ScheduledEmail
 from app.models.review import ApplicationReview
 from app.models.scholarship import ScholarshipConfiguration
@@ -199,14 +200,86 @@ class DeadlineChecker:
                 )
 
     async def check_document_request_deadlines(self):
-        """Check for approaching document request deadlines"""
+        """Check for approaching document request deadlines.
+
+        For each warning threshold (7/3/1 days out), find pending
+        DocumentRequest rows whose deadline lands inside the day-long
+        window and fire a deadline-approaching notification scoped to
+        the document_request category. Mirrors check_submission_deadlines.
+        """
         logger.info("Checking document request deadlines...")
 
-        # Note: Current DocumentRequest model doesn't have a deadline field
-        # This is a placeholder for future implementation
-        # TODO: Add deadline field to DocumentRequest model
+        for days_remaining in self.WARNING_DAYS:
+            target_date = datetime.now(timezone.utc) + timedelta(days=days_remaining)
+            target_date_start = target_date.replace(hour=0, minute=0, second=0, microsecond=0)
+            target_date_end = target_date.replace(hour=23, minute=59, second=59, microsecond=999999)
 
-        logger.info("Document request deadline checking not yet implemented (no deadline field)")
+            stmt = (
+                select(DocumentRequest)
+                .options(
+                    selectinload(DocumentRequest.application).selectinload(Application.student),
+                    selectinload(DocumentRequest.application).selectinload(Application.scholarship_type_ref),
+                )
+                .where(
+                    and_(
+                        DocumentRequest.status == DocumentRequestStatus.pending.value,
+                        DocumentRequest.deadline.isnot(None),
+                        DocumentRequest.deadline >= target_date_start,
+                        DocumentRequest.deadline <= target_date_end,
+                    )
+                )
+            )
+
+            result = await self.db.execute(stmt)
+            pending_requests = result.scalars().all()
+
+            logger.info(
+                "Found %d pending document requests with deadline in %d days",
+                len(pending_requests),
+                days_remaining,
+            )
+
+            for doc_request in pending_requests:
+                application = doc_request.application
+                if not application or not application.student:
+                    logger.warning(
+                        "DocumentRequest %s has no application/student, skipping notification",
+                        doc_request.id,
+                    )
+                    continue
+
+                student_data = application.student_data or {}
+                scholarship_name = (
+                    application.scholarship_type_ref.name if application.scholarship_type_ref else "Unknown"
+                )
+
+                try:
+                    await email_automation_service.trigger_deadline_approaching(
+                        db=self.db,
+                        application_id=application.id,
+                        deadline_data={
+                            "app_id": application.app_id,
+                            "student_name": student_data.get("name") or application.student.name,
+                            "student_email": student_data.get("email") or application.student.email,
+                            "deadline": doc_request.deadline.strftime("%Y-%m-%d %H:%M"),
+                            "days_remaining": str(days_remaining),
+                            "deadline_type": "document_request",
+                            "document_request_id": doc_request.id,
+                            "requested_documents": doc_request.requested_documents,
+                            "scholarship_name": scholarship_name,
+                        },
+                    )
+                    logger.info(
+                        "Triggered document-request deadline notification for request %s (app %s)",
+                        doc_request.id,
+                        application.id,
+                    )
+                except Exception as e:
+                    logger.exception(
+                        "Failed to trigger document-request deadline notification for request %s: %s",
+                        doc_request.id,
+                        e,
+                    )
 
     async def check_review_deadlines(self):
         """Check for approaching review deadlines"""

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -8235,6 +8235,11 @@ export interface components {
              * @example 請於一週內上傳，並確保文件清晰可讀
              */
             notes?: string | null;
+            /**
+             * Deadline
+             * @description When the student must fulfill this request by; null = no hard deadline.
+             */
+            deadline?: string | null;
         };
         /**
          * DocumentRequestFulfill


### PR DESCRIPTION
## Summary
Closes #215. Replaces the `# TODO: Add deadline field to DocumentRequest model` placeholder in `backend/app/tasks/deadline_checker.py` with a real implementation backed by a new `deadline` column on `document_requests`.

### What changed
- **Model**: `DocumentRequest.deadline` — nullable `timestamptz` with index.
- **Schema**: optional `deadline` on `DocumentRequestCreate`; surfaced on `DocumentRequestResponse`, `DocumentRequestListItem`, `StudentDocumentRequestResponse`.
- **Endpoint**: `POST /applications/{application_id}/document-requests` now passes the deadline through.
- **Task**: `check_document_request_deadlines` mirrors the existing `check_submission_deadlines` shape — iterates `WARNING_DAYS = [7, 3, 1]`, runs one day-windowed query per threshold, fires `email_automation_service.trigger_deadline_approaching` with `deadline_type="document_request"` so the email-automation engine can pick a doc-request-specific template.
- **Migration** `20260513_doc_req_deadline`:
  - Idempotent (skips if column exists, skips if table missing).
  - Also functions as a **merge migration** folding the three open alembic heads on main (`20260513_scrub_pii_audit`, `b7c3a1f8d290`, `add_college_rejected_001`) into a single head, so future migrations append cleanly.

### Why merge the heads here
Three open heads on `main` means `alembic upgrade head` either errors or applies only one branch. Adding any new migration would force the next author to write a no-op merge anyway. Folding them into this migration's `down_revision` tuple is the minimum-friction path forward.

## Test plan
- [x] `python -m py_compile` clean on all changed files.
- [x] Formatted with `black==26.3.1` (CI-pinned).
- [x] Migration body has table-exists + column-exists guards (CLAUDE.md migration policy).
- [ ] CI runs alembic upgrade/downgrade in fresh-DB smoke.
- [ ] Manual: create a document request with `deadline=now+1day`, run the checker — verify exactly one notification fires.

Refs #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)