### PR TITLE
feat(college-review): implement statistics endpoint (closes #216)

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/utilities.py
+++ b/backend/app/api/v1/endpoints/college_review/utilities.py
@@ -11,15 +11,14 @@ Handles:
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.security import require_college
 from app.db.deps import get_db
-
-# Note: CollegeReview model removed - replaced by unified ApplicationReview system
-# from app.models.college_review import CollegeReview
+from app.models.application import Application
+from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipStatus, ScholarshipType
 from app.models.student import Academy
 from app.models.user import AdminScholarship, User
@@ -30,11 +29,142 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-# REMOVED: GET /statistics endpoint
-# This endpoint was removed as part of CollegeReview table removal (Phase 3).
-# The CollegeReview model no longer exists. Statistics should be calculated from
-# the unified ApplicationReview system instead.
-# TODO: Implement new statistics endpoint using ApplicationReview + ApplicationReviewItem
+@router.get("/statistics")
+async def get_review_statistics(
+    current_user: User = Depends(require_college),
+    db: AsyncSession = Depends(get_db),
+):
+    """College review statistics scoped to the caller's scholarship permissions.
+
+    Aggregates reviewer-recommendation counts from the unified ApplicationReview
+    + ApplicationReviewItem tables (CLAUDE.md §7: no scoring system, recommendation-only).
+
+    Filters to scholarship_types this college user has permission for (via
+    AdminScholarship). Returns per-scholarship totals plus a system-wide rollup.
+    """
+    # Scope: which scholarship_types this college user can see.
+    permission_rows = await db.execute(
+        select(AdminScholarship.scholarship_id).where(AdminScholarship.admin_id == current_user.id)
+    )
+    allowed_scholarship_ids = [row[0] for row in permission_rows.fetchall()]
+
+    if not allowed_scholarship_ids:
+        logger.warning(
+            "College user %s (id=%s) has no scholarship permissions; returning empty statistics.",
+            current_user.nycu_id,
+            current_user.id,
+        )
+        return {
+            "success": True,
+            "message": "查詢成功",
+            "data": {
+                "per_scholarship": [],
+                "totals": {
+                    "applications": 0,
+                    "reviews": 0,
+                    "items_by_recommendation": {},
+                    "reviews_by_recommendation": {},
+                },
+            },
+        }
+
+    # ─── Per-scholarship breakdown ────────────────────────────────────────
+    # Applications count per scholarship_type (scoped to allowed types).
+    app_count_rows = await db.execute(
+        select(Application.scholarship_type_id, func.count(Application.id))
+        .where(Application.scholarship_type_id.in_(allowed_scholarship_ids))
+        .group_by(Application.scholarship_type_id)
+    )
+    apps_per_type: dict[int, int] = {row[0]: row[1] for row in app_count_rows.fetchall()}
+
+    # Review-level recommendation counts (top-level recommendation derived per CLAUDE.md §7):
+    # 'approve' | 'partial_approve' | 'reject'.
+    review_rec_rows = await db.execute(
+        select(
+            Application.scholarship_type_id,
+            ApplicationReview.recommendation,
+            func.count(ApplicationReview.id),
+        )
+        .join(Application, ApplicationReview.application_id == Application.id)
+        .where(Application.scholarship_type_id.in_(allowed_scholarship_ids))
+        .group_by(Application.scholarship_type_id, ApplicationReview.recommendation)
+    )
+    reviews_per_type: dict[int, dict[str, int]] = {}
+    for st_id, rec, count in review_rec_rows.fetchall():
+        reviews_per_type.setdefault(st_id, {})[rec] = count
+
+    # Item-level recommendation counts ('approve' | 'reject'), bucketed by sub_type_code.
+    item_rec_rows = await db.execute(
+        select(
+            Application.scholarship_type_id,
+            ApplicationReviewItem.sub_type_code,
+            ApplicationReviewItem.recommendation,
+            func.count(ApplicationReviewItem.id),
+        )
+        .join(ApplicationReview, ApplicationReviewItem.review_id == ApplicationReview.id)
+        .join(Application, ApplicationReview.application_id == Application.id)
+        .where(Application.scholarship_type_id.in_(allowed_scholarship_ids))
+        .group_by(
+            Application.scholarship_type_id,
+            ApplicationReviewItem.sub_type_code,
+            ApplicationReviewItem.recommendation,
+        )
+    )
+    items_per_type: dict[int, dict[str, dict[str, int]]] = {}
+    for st_id, sub_type, rec, count in item_rec_rows.fetchall():
+        bucket = items_per_type.setdefault(st_id, {}).setdefault(sub_type, {})
+        bucket[rec] = count
+
+    # Pull scholarship-type names so the response is human-readable
+    # without a second round trip from the caller.
+    name_rows = await db.execute(
+        select(ScholarshipType.id, ScholarshipType.code, ScholarshipType.name, ScholarshipType.name_en).where(
+            ScholarshipType.id.in_(allowed_scholarship_ids)
+        )
+    )
+    name_index = {row[0]: {"code": row[1], "name": row[2], "name_en": row[3] or row[2]} for row in name_rows.fetchall()}
+
+    per_scholarship = []
+    for st_id in allowed_scholarship_ids:
+        info = name_index.get(st_id) or {"code": None, "name": None, "name_en": None}
+        per_scholarship.append(
+            {
+                "scholarship_type_id": st_id,
+                "code": info["code"],
+                "name": info["name"],
+                "name_en": info["name_en"],
+                "applications": apps_per_type.get(st_id, 0),
+                "reviews_by_recommendation": reviews_per_type.get(st_id, {}),
+                "items_by_sub_type_and_recommendation": items_per_type.get(st_id, {}),
+            }
+        )
+
+    # ─── System-wide totals (scoped to allowed types) ─────────────────────
+    total_apps = sum(apps_per_type.values())
+    total_reviews_by_rec: dict[str, int] = {}
+    for buckets in reviews_per_type.values():
+        for rec, count in buckets.items():
+            total_reviews_by_rec[rec] = total_reviews_by_rec.get(rec, 0) + count
+
+    total_items_by_rec: dict[str, int] = {}
+    for sub_type_map in items_per_type.values():
+        for rec_map in sub_type_map.values():
+            for rec, count in rec_map.items():
+                total_items_by_rec[rec] = total_items_by_rec.get(rec, 0) + count
+
+    return {
+        "success": True,
+        "message": "查詢成功",
+        "data": {
+            "per_scholarship": per_scholarship,
+            "totals": {
+                "applications": total_apps,
+                "reviews": sum(total_reviews_by_rec.values()),
+                "reviews_by_recommendation": total_reviews_by_rec,
+                "items_by_recommendation": total_items_by_rec,
+            },
+        },
+    }
 
 
 @router.get("/available-combinations")

--- a/backend/app/tests/test_college_review_statistics_endpoint.py
+++ b/backend/app/tests/test_college_review_statistics_endpoint.py
@@ -1,0 +1,279 @@
+"""
+Unit tests for the new college-review statistics endpoint (issue #216).
+
+Pins the aggregation contract for
+`GET /api/v1/college-review/statistics`:
+
+- Permission-scoping: only scholarship_types in AdminScholarship for the
+  caller appear in the response. Empty perms ⇒ empty data, success=True.
+- Counts: applications, reviews-by-recommendation, items-by-sub-type-and-
+  recommendation roll up correctly.
+- Response shape: `{success, message, data}` per CLAUDE.md §5.
+- Recommendation values stay strings ('approve' | 'partial_approve' |
+  'reject' for reviews; 'approve' | 'reject' for items) so the frontend
+  doesn't have to special-case enums.
+
+We invoke the endpoint coroutine directly with a seeded async DB,
+bypassing FastAPI's dependency injection — this keeps the test below
+a second and avoids the SSO auth round trip.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.endpoints.college_review.utilities import get_review_statistics
+from app.models.application import Application, ApplicationStatus
+from app.models.review import ApplicationReview, ApplicationReviewItem
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import AdminScholarship, User, UserRole, UserType
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def _seed_user(db: AsyncSession, *, role: UserRole, suffix: str) -> User:
+    user = User(
+        nycu_id=f"stats_{role.value}_{suffix}",
+        name=f"Stats {role.value} {suffix}",
+        email=f"stats_{role.value}_{suffix}@u.edu",
+        user_type=UserType.employee if role != UserRole.student else UserType.student,
+        role=role,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _seed_scholarship(db: AsyncSession, *, code: str, name: str) -> ScholarshipType:
+    stype = ScholarshipType(code=code, name=name, status="active")
+    db.add(stype)
+    await db.commit()
+    await db.refresh(stype)
+    return stype
+
+
+async def _seed_config(db: AsyncSession, *, scholarship_type_id: int, suffix: str) -> ScholarshipConfiguration:
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=scholarship_type_id,
+        config_code=f"stats_cfg_{suffix}",
+        config_name=f"Stats config {suffix}",
+        academic_year=114,
+        application_start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        application_end_date=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        requires_professor_recommendation=True,
+        requires_college_review=True,
+        amount=0,
+        is_active=True,
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+    return cfg
+
+
+async def _seed_app(
+    db: AsyncSession, *, student: User, scholarship_type_id: int, config_id: int, suffix: str
+) -> Application:
+    app = Application(
+        app_id=f"APP-STATS-{suffix}",
+        user_id=student.id,
+        scholarship_type_id=scholarship_type_id,
+        scholarship_configuration_id=config_id,
+        academic_year=114,
+        sub_type_selection_mode="single",
+        status=ApplicationStatus.submitted.value,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+async def _seed_review(
+    db: AsyncSession,
+    *,
+    application: Application,
+    reviewer: User,
+    recommendation: str,
+    items: list[tuple[str, str]],  # [(sub_type_code, recommendation)]
+) -> ApplicationReview:
+    review = ApplicationReview(
+        application_id=application.id,
+        reviewer_id=reviewer.id,
+        recommendation=recommendation,
+        comments="seed",
+        reviewed_at=_utcnow(),
+    )
+    db.add(review)
+    await db.commit()
+    await db.refresh(review)
+
+    for sub_type, item_rec in items:
+        db.add(
+            ApplicationReviewItem(
+                review_id=review.id,
+                sub_type_code=sub_type,
+                recommendation=item_rec,
+                comments="seed item",
+            )
+        )
+    await db.commit()
+    return review
+
+
+@pytest.mark.asyncio
+async def test_statistics_empty_when_user_has_no_permissions(db: AsyncSession):
+    """College user with no AdminScholarship rows ⇒ empty data, still success."""
+    college_user = await _seed_user(db, role=UserRole.college, suffix="noperm")
+
+    result = await get_review_statistics(current_user=college_user, db=db)
+
+    assert result["success"] is True
+    assert result["data"]["per_scholarship"] == []
+    assert result["data"]["totals"]["applications"] == 0
+    assert result["data"]["totals"]["reviews"] == 0
+    assert result["data"]["totals"]["reviews_by_recommendation"] == {}
+    assert result["data"]["totals"]["items_by_recommendation"] == {}
+
+
+@pytest.mark.asyncio
+async def test_statistics_aggregates_per_scholarship_and_total(db: AsyncSession):
+    """Counts roll up correctly per scholarship + system-wide."""
+    college_user = await _seed_user(db, role=UserRole.college, suffix="agg")
+    professor = await _seed_user(db, role=UserRole.professor, suffix="agg")
+    student = await _seed_user(db, role=UserRole.student, suffix="agg")
+
+    phd_type = await _seed_scholarship(db, code="phd_agg", name="PhD agg")
+    undergrad_type = await _seed_scholarship(db, code="ug_agg", name="UG agg")
+
+    # User can see both scholarships.
+    db.add(AdminScholarship(admin_id=college_user.id, scholarship_id=phd_type.id))
+    db.add(AdminScholarship(admin_id=college_user.id, scholarship_id=undergrad_type.id))
+    await db.commit()
+
+    phd_cfg = await _seed_config(db, scholarship_type_id=phd_type.id, suffix="phd")
+    ug_cfg = await _seed_config(db, scholarship_type_id=undergrad_type.id, suffix="ug")
+
+    # 2 PhD apps, 1 UG app.
+    phd_app1 = await _seed_app(
+        db, student=student, scholarship_type_id=phd_type.id, config_id=phd_cfg.id, suffix="phd1"
+    )
+    phd_app2 = await _seed_app(
+        db, student=student, scholarship_type_id=phd_type.id, config_id=phd_cfg.id, suffix="phd2"
+    )
+    ug_app1 = await _seed_app(
+        db, student=student, scholarship_type_id=undergrad_type.id, config_id=ug_cfg.id, suffix="ug1"
+    )
+
+    # 1 PhD review (approve) with 2 items (nstc=approve, moe_1w=reject).
+    await _seed_review(
+        db,
+        application=phd_app1,
+        reviewer=professor,
+        recommendation="partial_approve",
+        items=[("nstc", "approve"), ("moe_1w", "reject")],
+    )
+    # 1 PhD review (reject) with 1 item.
+    await _seed_review(
+        db,
+        application=phd_app2,
+        reviewer=professor,
+        recommendation="reject",
+        items=[("nstc", "reject")],
+    )
+    # 1 UG review (approve) with 1 item.
+    await _seed_review(
+        db,
+        application=ug_app1,
+        reviewer=professor,
+        recommendation="approve",
+        items=[("default", "approve")],
+    )
+
+    result = await get_review_statistics(current_user=college_user, db=db)
+
+    assert result["success"] is True
+    assert result["message"] == "查詢成功"
+
+    data = result["data"]
+    per = {row["scholarship_type_id"]: row for row in data["per_scholarship"]}
+    assert set(per.keys()) == {phd_type.id, undergrad_type.id}
+
+    # PhD: 2 apps, 1 partial_approve + 1 reject review.
+    assert per[phd_type.id]["applications"] == 2
+    assert per[phd_type.id]["reviews_by_recommendation"] == {"partial_approve": 1, "reject": 1}
+    phd_items = per[phd_type.id]["items_by_sub_type_and_recommendation"]
+    assert phd_items["nstc"] == {"approve": 1, "reject": 1}
+    assert phd_items["moe_1w"] == {"reject": 1}
+
+    # UG: 1 app, 1 approve review.
+    assert per[undergrad_type.id]["applications"] == 1
+    assert per[undergrad_type.id]["reviews_by_recommendation"] == {"approve": 1}
+    assert per[undergrad_type.id]["items_by_sub_type_and_recommendation"] == {"default": {"approve": 1}}
+
+    # System-wide totals.
+    totals = data["totals"]
+    assert totals["applications"] == 3
+    assert totals["reviews"] == 3
+    assert totals["reviews_by_recommendation"] == {"partial_approve": 1, "reject": 1, "approve": 1}
+    assert totals["items_by_recommendation"] == {"approve": 2, "reject": 2}
+
+
+@pytest.mark.asyncio
+async def test_statistics_excludes_unpermitted_scholarships(db: AsyncSession):
+    """Scholarships the user has no AdminScholarship for must not appear."""
+    college_user = await _seed_user(db, role=UserRole.college, suffix="scoped")
+    professor = await _seed_user(db, role=UserRole.professor, suffix="scoped")
+    student = await _seed_user(db, role=UserRole.student, suffix="scoped")
+
+    allowed_type = await _seed_scholarship(db, code="allowed", name="Allowed scholarship")
+    forbidden_type = await _seed_scholarship(db, code="forbidden", name="Forbidden scholarship")
+
+    # Only the allowed type is granted.
+    db.add(AdminScholarship(admin_id=college_user.id, scholarship_id=allowed_type.id))
+    await db.commit()
+
+    allowed_cfg = await _seed_config(db, scholarship_type_id=allowed_type.id, suffix="allowed")
+    forbidden_cfg = await _seed_config(db, scholarship_type_id=forbidden_type.id, suffix="forbidden")
+
+    allowed_app = await _seed_app(
+        db, student=student, scholarship_type_id=allowed_type.id, config_id=allowed_cfg.id, suffix="allowed"
+    )
+    forbidden_app = await _seed_app(
+        db,
+        student=student,
+        scholarship_type_id=forbidden_type.id,
+        config_id=forbidden_cfg.id,
+        suffix="forbidden",
+    )
+
+    await _seed_review(
+        db,
+        application=allowed_app,
+        reviewer=professor,
+        recommendation="approve",
+        items=[("nstc", "approve")],
+    )
+    await _seed_review(
+        db,
+        application=forbidden_app,
+        reviewer=professor,
+        recommendation="reject",
+        items=[("nstc", "reject")],
+    )
+
+    result = await get_review_statistics(current_user=college_user, db=db)
+
+    per = {row["scholarship_type_id"]: row for row in result["data"]["per_scholarship"]}
+    assert set(per.keys()) == {allowed_type.id}, "forbidden scholarship leaked into response"
+
+    # Totals reflect only the allowed scope.
+    totals = result["data"]["totals"]
+    assert totals["applications"] == 1
+    assert totals["reviews"] == 1
+    assert totals["reviews_by_recommendation"] == {"approve": 1}
+    assert totals["items_by_recommendation"] == {"approve": 1}

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4685,6 +4685,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/college-review/statistics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Review Statistics
+         * @description College review statistics scoped to the caller's scholarship permissions.
+         *
+         *     Aggregates reviewer-recommendation counts from the unified ApplicationReview
+         *     + ApplicationReviewItem tables (CLAUDE.md §7: no scoring system, recommendation-only).
+         *
+         *     Filters to scholarship_types this college user has permission for (via
+         *     AdminScholarship). Returns per-scholarship totals plus a system-wide rollup.
+         */
+        get: operations["get_review_statistics_api_v1_college_review_statistics_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/college-review/available-combinations": {
         parameters: {
             query?: never;
@@ -18211,6 +18237,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_review_statistics_api_v1_college_review_statistics_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };


### PR DESCRIPTION
## Summary
Closes #216. Replaces the `# TODO: Implement new statistics endpoint using ApplicationReview + ApplicationReviewItem` placeholder at `backend/app/api/v1/endpoints/college_review/utilities.py:37` with a working `GET /api/v1/college-review/statistics`.

## Shape
```jsonc
{
  "success": true,
  "message": "查詢成功",
  "data": {
    "per_scholarship": [
      {
        "scholarship_type_id": 1,
        "code": "phd",
        "name": "...",
        "name_en": "...",
        "applications": 2,
        "reviews_by_recommendation": { "approve": 1, "reject": 1 },
        "items_by_sub_type_and_recommendation": {
          "nstc": { "approve": 1, "reject": 1 },
          "moe_1w": { "reject": 1 }
        }
      }
    ],
    "totals": {
      "applications": 3,
      "reviews": 3,
      "reviews_by_recommendation": { "approve": 1, "partial_approve": 1, "reject": 1 },
      "items_by_recommendation": { "approve": 2, "reject": 2 }
    }
  }
}
```

## Design notes
- **No scoring**: per CLAUDE.md §7, the unified review system stores `recommendation` strings, not scores. The endpoint aggregates counts only.
- **Permission-scoped**: only `AdminScholarship` rows visible to the caller appear in `per_scholarship`. Users with no permissions get an empty payload (`success=true`), not a 403 — matches the rest of the college-review endpoints' behavior.
- **Four GROUP BY queries**: applications-per-type, reviews-by-recommendation, items-by-sub-type-recommendation, scholarship-name lookup. No N+1.
- **ApiResponse shape** (`{success, message, data}`) per CLAUDE.md §5.

## Test plan
- [x] `test_college_review_statistics_endpoint.py` — 3 cases covering: empty perms, full aggregation, scope exclusion.
- [x] Tests invoke the endpoint coroutine directly with a seeded async DB (no HTTP layer needed) — mirrors `test_review_service_status_gating.py` pattern.
- [x] `python -m py_compile` clean.
- [x] Formatted with `black==26.3.1` (CI-pinned).
- [ ] CI green.
- [ ] OpenAPI types check may require frontend type regen — handle in CI feedback.

Refs #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)