### PR TITLE
fix(types): repair TS strict regressions in batch-import-panel + debug-panel

### DIFF
--- a/frontend/components/batch-import-panel.tsx
+++ b/frontend/components/batch-import-panel.tsx
@@ -487,13 +487,18 @@ export function BatchImportPanel({ locale = "zh" }: BatchImportPanelProps) {
                 <td className="border border-gray-200 px-4 py-2 text-sm font-medium">
                   {locale === "zh" ? `第 ${idx + 1} 筆` : `#${idx + 1}`}
                 </td>
-                {columns.map((col) => (
-                  <td key={col} className="border border-gray-200 px-4 py-2 text-sm">
-                    {typeof row[col] === 'object' && row[col] !== null
-                      ? JSON.stringify(row[col])
-                      : row[col] ?? ''}
-                  </td>
-                ))}
+                {columns.map((col) => {
+                  const cell = row[col];
+                  const display: string | number | boolean =
+                    typeof cell === "object" && cell !== null
+                      ? JSON.stringify(cell)
+                      : (cell as string | number | boolean | null | undefined) ?? "";
+                  return (
+                    <td key={col} className="border border-gray-200 px-4 py-2 text-sm">
+                      {display}
+                    </td>
+                  );
+                })}
                 <td className="border border-gray-200 px-4 py-2 text-sm">
                   <Button
                     variant="ghost"

--- a/frontend/components/debug-panel.tsx
+++ b/frontend/components/debug-panel.tsx
@@ -138,7 +138,7 @@ export function DebugPanel({ isTestMode = false }: DebugPanelProps) {
       }
       // Check if API URL points to mock service
       if (
-        studentData.api_url &&
+        typeof studentData.api_url === "string" &&
         studentData.api_url.includes("mock-student-api")
       ) {
         return "mock";
@@ -749,19 +749,19 @@ export function DebugPanel({ isTestMode = false }: DebugPanelProps) {
                         <div>
                           <div className="font-semibold text-sm mb-2">基本資料</div>
                           <div className="font-mono text-xs overflow-x-auto bg-white p-2 rounded">
-                            {renderValue(studentData.student || studentData)}
+                            {renderValue((studentData.student as JsonValue) ?? (studentData as JsonValue))}
                           </div>
                         </div>
 
                         {/* Debug: Show what's in studentData */}
                         <div className="text-xs text-gray-500 bg-yellow-50 p-2 rounded">
                           Debug: semesters exists: {String(!!studentData.semesters)} |
-                          length: {studentData.semesters?.length || 0} |
+                          length: {Array.isArray(studentData.semesters) ? studentData.semesters.length : 0} |
                           keys: {Object.keys(studentData).join(', ')}
                         </div>
 
                         {/* Semester Data */}
-                        {studentData.semesters && studentData.semesters.length > 0 && (
+                        {Array.isArray(studentData.semesters) && studentData.semesters.length > 0 && (
                           <div>
                             <div className="font-semibold text-sm mb-2">
                               學期資料 ({studentData.semesters.length} 筆)


### PR DESCRIPTION
## Summary
Hotfix for TypeScript strict-mode regressions introduced by the recent any→unknown sweeps in PR #221 (debug-panel) and PR #227 (batch-import-panel). These weren't caught by per-PR CI because the \`type-check\` step gates on \`Verify OpenAPI Types are Up-to-Date\`, and later PRs (#238, #239) broke that job first — so the type errors only surface once OpenAPI was fixed.

## Errors fixed
| File | Line | TS error | Fix |
| --- | --- | --- | --- |
| batch-import-panel.tsx | 492 | TS2322 \`Type '{}' is not assignable to type 'ReactNode'\` | extract \`cell\`, cast non-object branch to \`string\|number\|boolean\|null\|undefined\` |
| debug-panel.tsx | 142 | TS2339 \`Property 'includes' does not exist on type '{}'\` | \`typeof studentData.api_url === "string"\` guard |
| debug-panel.tsx | 756 | TS2322 \`Type 'unknown' is not assignable to type 'ReactNode'\` | \`as JsonValue\` cast at renderValue call site |
| debug-panel.tsx | 759/764/767 | TS2339 \`Property 'length' does not exist on type '{}'\` | \`Array.isArray(...)\` guard |

All sites previously typed \`unknown\` (correct per the strict-typing PRs); these fixes narrow at the use site rather than reverting to \`any\`.

## Test plan
- [x] Local \`bunx tsc --noEmit --skipLibCheck\` reports zero TS2322/TS2339 errors in these two files.
- [ ] CI \`Verify OpenAPI Types are Up-to-Date\` (which includes the type-check step) green.
- [ ] Other in-flight PRs (#238, #239) inherit this fix on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)