### PR TITLE
feat(renewal): scholarship renewal with challenge mechanism

### DIFF
--- a/backend/alembic/versions/20260521_merge_renewal_main.py
+++ b/backend/alembic/versions/20260521_merge_renewal_main.py
@@ -1,0 +1,31 @@
+"""Empty merge: collapse add_renewal_challenge_001 and merge_20260521_dual into single head.
+
+add_renewal_challenge_001 branches from seed_phd_college_export_001.
+merge_20260521_dual is the current main head (revoke/suspend + supplementary).
+They touch disjoint tables so merge order is irrelevant for correctness.
+
+No-op upgrade/downgrade — alembic just collapses the DAG.
+
+Revision ID: merge_renewal_main_001
+Revises: add_renewal_challenge_001, merge_20260521_dual
+Create Date: 2026-05-21
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "merge_renewal_main_001"
+down_revision: Union[str, Sequence[str], None] = (
+    "add_renewal_challenge_001",
+    "merge_20260521_dual",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py
+++ b/backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py
@@ -66,33 +66,28 @@ def upgrade() -> None:
         "applications",
         ["user_id", "scholarship_type_id", "academic_year", "semester"],
         unique=True,
-        postgresql_where=sa.text("is_renewal = true AND status::text != 'deleted'"),
+        postgresql_where=sa.text("is_renewal = true AND deleted_at IS NULL"),
     )
     op.create_index(
         "uq_user_challenge_app",
         "applications",
         ["user_id", "scholarship_type_id", "academic_year", "semester"],
         unique=True,
-        postgresql_where=sa.text(
-            "is_renewal = false AND challenges_application_id IS NOT NULL AND status::text != 'deleted'"
-        ),
+        postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NOT NULL AND deleted_at IS NULL"),
     )
     op.create_index(
         "uq_user_pure_new_app",
         "applications",
         ["user_id", "scholarship_type_id", "academic_year", "semester"],
         unique=True,
-        postgresql_where=sa.text(
-            "is_renewal = false AND challenges_application_id IS NULL AND status::text != 'deleted'"
-        ),
+        postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NULL AND deleted_at IS NULL"),
     )
 
     # 4. Check constraint: cancelled_by_challenge requires cancelled_due_to_application_id
     # NOTE: status::text cast is required because PostgreSQL forbids referencing a
     # newly-added enum value (added in step 1 above) inside the same transaction
-    # without explicit casting (psycopg2.errors.UnsafeNewEnumValueUsage). The
-    # partial-index predicates above reference the pre-existing 'deleted' value and
-    # therefore do not require the cast.
+    # without explicit casting (psycopg2.errors.UnsafeNewEnumValueUsage).
+    # The partial-index predicates above use deleted_at IS NULL (no cast needed).
     op.create_check_constraint(
         "chk_cancelled_by_challenge_link",
         "applications",

--- a/backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py
+++ b/backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py
@@ -1,0 +1,114 @@
+"""Add renewal challenge columns + partial unique indexes + status enum value
+
+Revision ID: add_renewal_challenge_001
+Revises: seed_phd_college_export_001
+Create Date: 2026-05-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_renewal_challenge_001"
+down_revision = "seed_phd_college_export_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_columns = [c["name"] for c in inspector.get_columns("applications")]
+
+    # 1. Add enum value
+    op.execute("ALTER TYPE applicationstatus ADD VALUE IF NOT EXISTS 'cancelled_by_challenge'")
+
+    # 2. Add new columns (idempotent)
+    if "challenges_application_id" not in existing_columns:
+        op.add_column(
+            "applications",
+            sa.Column(
+                "challenges_application_id",
+                sa.Integer(),
+                sa.ForeignKey("applications.id"),
+                nullable=True,
+            ),
+        )
+        op.create_index(
+            "ix_applications_challenges_application_id",
+            "applications",
+            ["challenges_application_id"],
+        )
+
+    if "cancelled_due_to_application_id" not in existing_columns:
+        op.add_column(
+            "applications",
+            sa.Column(
+                "cancelled_due_to_application_id",
+                sa.Integer(),
+                sa.ForeignKey("applications.id"),
+                nullable=True,
+            ),
+        )
+        op.create_index(
+            "ix_applications_cancelled_due_to_application_id",
+            "applications",
+            ["cancelled_due_to_application_id"],
+        )
+
+    # 3. Drop old single UNIQUE (was previously "uq_user_scholarship_academic_term"),
+    # add three partial unique indexes
+    existing_constraints = [c["name"] for c in inspector.get_unique_constraints("applications")]
+    if "uq_user_scholarship_academic_term" in existing_constraints:
+        op.drop_constraint("uq_user_scholarship_academic_term", "applications", type_="unique")
+
+    op.create_index(
+        "uq_user_renewal_app",
+        "applications",
+        ["user_id", "scholarship_type_id", "academic_year", "semester"],
+        unique=True,
+        postgresql_where=sa.text("is_renewal = true AND status != 'deleted'"),
+    )
+    op.create_index(
+        "uq_user_challenge_app",
+        "applications",
+        ["user_id", "scholarship_type_id", "academic_year", "semester"],
+        unique=True,
+        postgresql_where=sa.text(
+            "is_renewal = false AND challenges_application_id IS NOT NULL " "AND status != 'deleted'"
+        ),
+    )
+    op.create_index(
+        "uq_user_pure_new_app",
+        "applications",
+        ["user_id", "scholarship_type_id", "academic_year", "semester"],
+        unique=True,
+        postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NULL " "AND status != 'deleted'"),
+    )
+
+    # 4. Check constraint: cancelled_by_challenge requires cancelled_due_to_application_id
+    # NOTE: status::text cast is required because PostgreSQL forbids referencing a
+    # newly-added enum value (added in step 1 above) inside the same transaction
+    # without explicit casting (psycopg2.errors.UnsafeNewEnumValueUsage). The
+    # partial-index predicates above reference the pre-existing 'deleted' value and
+    # therefore do not require the cast.
+    op.create_check_constraint(
+        "chk_cancelled_by_challenge_link",
+        "applications",
+        "status::text != 'cancelled_by_challenge' OR cancelled_due_to_application_id IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("chk_cancelled_by_challenge_link", "applications", type_="check")
+    op.drop_index("uq_user_pure_new_app", table_name="applications")
+    op.drop_index("uq_user_challenge_app", table_name="applications")
+    op.drop_index("uq_user_renewal_app", table_name="applications")
+    op.create_unique_constraint(
+        "uq_user_scholarship_academic_term",
+        "applications",
+        ["user_id", "scholarship_type_id", "academic_year", "semester"],
+    )
+    op.drop_index("ix_applications_cancelled_due_to_application_id", table_name="applications")
+    op.drop_column("applications", "cancelled_due_to_application_id")
+    op.drop_index("ix_applications_challenges_application_id", table_name="applications")
+    op.drop_column("applications", "challenges_application_id")

--- a/backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py
+++ b/backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py
@@ -56,43 +56,52 @@ def upgrade() -> None:
         )
 
     # 3. Drop old single UNIQUE (was previously "uq_user_scholarship_academic_term"),
-    # add three partial unique indexes
+    # add three partial unique indexes (idempotent — create_all() may have created them already)
     existing_constraints = [c["name"] for c in inspector.get_unique_constraints("applications")]
     if "uq_user_scholarship_academic_term" in existing_constraints:
         op.drop_constraint("uq_user_scholarship_academic_term", "applications", type_="unique")
 
-    op.create_index(
-        "uq_user_renewal_app",
-        "applications",
-        ["user_id", "scholarship_type_id", "academic_year", "semester"],
-        unique=True,
-        postgresql_where=sa.text("is_renewal = true AND deleted_at IS NULL"),
-    )
-    op.create_index(
-        "uq_user_challenge_app",
-        "applications",
-        ["user_id", "scholarship_type_id", "academic_year", "semester"],
-        unique=True,
-        postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NOT NULL AND deleted_at IS NULL"),
-    )
-    op.create_index(
-        "uq_user_pure_new_app",
-        "applications",
-        ["user_id", "scholarship_type_id", "academic_year", "semester"],
-        unique=True,
-        postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NULL AND deleted_at IS NULL"),
-    )
+    existing_indexes = [idx["name"] for idx in inspector.get_indexes("applications")]
+
+    if "uq_user_renewal_app" not in existing_indexes:
+        op.create_index(
+            "uq_user_renewal_app",
+            "applications",
+            ["user_id", "scholarship_type_id", "academic_year", "semester"],
+            unique=True,
+            postgresql_where=sa.text("is_renewal = true AND deleted_at IS NULL"),
+        )
+    if "uq_user_challenge_app" not in existing_indexes:
+        op.create_index(
+            "uq_user_challenge_app",
+            "applications",
+            ["user_id", "scholarship_type_id", "academic_year", "semester"],
+            unique=True,
+            postgresql_where=sa.text(
+                "is_renewal = false AND challenges_application_id IS NOT NULL AND deleted_at IS NULL"
+            ),
+        )
+    if "uq_user_pure_new_app" not in existing_indexes:
+        op.create_index(
+            "uq_user_pure_new_app",
+            "applications",
+            ["user_id", "scholarship_type_id", "academic_year", "semester"],
+            unique=True,
+            postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NULL AND deleted_at IS NULL"),
+        )
 
     # 4. Check constraint: cancelled_by_challenge requires cancelled_due_to_application_id
     # NOTE: status::text cast is required because PostgreSQL forbids referencing a
     # newly-added enum value (added in step 1 above) inside the same transaction
     # without explicit casting (psycopg2.errors.UnsafeNewEnumValueUsage).
     # The partial-index predicates above use deleted_at IS NULL (no cast needed).
-    op.create_check_constraint(
-        "chk_cancelled_by_challenge_link",
-        "applications",
-        "status::text != 'cancelled_by_challenge' OR cancelled_due_to_application_id IS NOT NULL",
-    )
+    existing_check_constraints = [c["name"] for c in inspector.get_check_constraints("applications")]
+    if "chk_cancelled_by_challenge_link" not in existing_check_constraints:
+        op.create_check_constraint(
+            "chk_cancelled_by_challenge_link",
+            "applications",
+            "status::text != 'cancelled_by_challenge' OR cancelled_due_to_application_id IS NOT NULL",
+        )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py
+++ b/backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py
@@ -66,7 +66,7 @@ def upgrade() -> None:
         "applications",
         ["user_id", "scholarship_type_id", "academic_year", "semester"],
         unique=True,
-        postgresql_where=sa.text("is_renewal = true AND status != 'deleted'"),
+        postgresql_where=sa.text("is_renewal = true AND status::text != 'deleted'"),
     )
     op.create_index(
         "uq_user_challenge_app",
@@ -74,7 +74,7 @@ def upgrade() -> None:
         ["user_id", "scholarship_type_id", "academic_year", "semester"],
         unique=True,
         postgresql_where=sa.text(
-            "is_renewal = false AND challenges_application_id IS NOT NULL " "AND status != 'deleted'"
+            "is_renewal = false AND challenges_application_id IS NOT NULL AND status::text != 'deleted'"
         ),
     )
     op.create_index(
@@ -82,7 +82,9 @@ def upgrade() -> None:
         "applications",
         ["user_id", "scholarship_type_id", "academic_year", "semester"],
         unique=True,
-        postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NULL " "AND status != 'deleted'"),
+        postgresql_where=sa.text(
+            "is_renewal = false AND challenges_application_id IS NULL AND status::text != 'deleted'"
+        ),
     )
 
     # 4. Check constraint: cancelled_by_challenge requires cancelled_due_to_application_id

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -23,6 +23,7 @@ from app.api.v1.endpoints import (
     professor_student,
     quota_dashboard,
     reference_data,
+    renewal,
     reviews,
     roster_schedules,
     scholarship_configurations,
@@ -75,4 +76,5 @@ api_router.include_router(roster_schedules.router, prefix="/roster-schedules", t
 api_router.include_router(system_settings.router, prefix="/system-settings", tags=["System Settings"])
 api_router.include_router(student_bank_accounts.router, prefix="/student-bank-accounts", tags=["Student Bank Accounts"])
 api_router.include_router(csp_report.router, prefix="", tags=["Security"])
+api_router.include_router(renewal.router, prefix="/renewals", tags=["Renewals"])
 api_router.include_router(manual_distribution_router)

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -179,7 +179,7 @@ async def get_distribution_state(
         state = await service.compute_distribution_state(scholarship_type_id, academic_year)
     except ValueError as e:
         # _get_active_config raises ValueError when no active config exists.
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     return {
         "success": True,
         "message": "OK",
@@ -237,7 +237,7 @@ async def preview_distribution(
             "data": preview,
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.post("/allocate")

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -17,7 +17,6 @@ from app.db.deps import get_sync_db
 from app.models.application import Application
 from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
-from app.schemas.application import RevokeRequest, SuspendRequest
 from app.services.manual_distribution_service import ManualDistributionService
 
 logger = logging.getLogger(__name__)
@@ -155,6 +154,39 @@ async def get_quota_status(
     }
 
 
+@router.get("/state")
+async def get_distribution_state(
+    scholarship_type_id: int = Query(...),
+    academic_year: int = Query(...),
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_admin_user),
+):
+    """Return the full state needed by the manual distribution panel UI.
+
+    Aggregates three views in one round trip:
+      * ``renewal_allocations`` — approved renewals grouped by
+        ``(sub_type, renewal_year)``, each marked ``has_challenge`` if a
+        downstream challenge targets it.
+      * ``available_quotas`` — per ``(sub_type, allocation_year)``: total /
+        used / remaining where ``used`` comes from approved renewals.
+      * ``candidates`` — non-renewal applicants in ranking order, with
+        ``is_challenge`` and a ``challenged_renewal`` block when present.
+
+    See ``ManualDistributionService.compute_distribution_state`` for details.
+    """
+    service = ManualDistributionService(db)
+    try:
+        state = await service.compute_distribution_state(scholarship_type_id, academic_year)
+    except ValueError as e:
+        # _get_active_config raises ValueError when no active config exists.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    return {
+        "success": True,
+        "message": "OK",
+        "data": state,
+    }
+
+
 @router.get("/auto-allocate-preview")
 async def auto_allocate_preview(
     scholarship_type_id: int = Query(...),
@@ -179,6 +211,33 @@ async def auto_allocate_preview(
     except Exception as e:
         logger.error("Error generating auto-allocation preview: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to generate auto-allocation preview") from e
+
+
+@router.post("/preview-distribution")
+async def preview_distribution(
+    request: AllocateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_admin_user),
+):
+    """Dry-run: compute the release_chain for the proposed allocations.
+
+    For each proposed allocation whose application is a challenge, returns
+    the renewal that would be cancelled and the next pure-new waitlist
+    candidate who would inherit the freed slot. Nothing is persisted.
+
+    Used by the admin Manual Distribution panel to surface release-chain
+    impact before commit (spec Section 14.2).
+    """
+    service = ManualDistributionService(db)
+    try:
+        preview = await service.preview_release_chain([a.model_dump() for a in request.allocations])
+        return {
+            "success": True,
+            "message": "Preview computed",
+            "data": preview,
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.post("/allocate")
@@ -624,51 +683,3 @@ async def import_received_months(
             "updated": updated,
         },
     }
-
-
-@router.post("/applications/{application_id}/revoke")
-async def revoke_application_allocation(
-    application_id: int,
-    request: RevokeRequest,
-    db: AsyncSession = Depends(get_db),
-    current_user=Depends(get_current_admin_user),
-):
-    """撤銷已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/revoked。"""
-    service = ManualDistributionService(db)
-    try:
-        result = await service.revoke_allocation(
-            application_id=application_id,
-            admin_user_id=current_user.id,
-            reason=request.reason,
-        )
-        await db.commit()
-        return {"success": True, "message": "已撤銷", "data": result}
-    except ValueError as e:
-        msg = str(e)
-        if "already" in msg:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=msg) from e
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg) from e
-
-
-@router.post("/applications/{application_id}/suspend")
-async def suspend_application_allocation(
-    application_id: int,
-    request: SuspendRequest,
-    db: AsyncSession = Depends(get_db),
-    current_user=Depends(get_current_admin_user),
-):
-    """停發已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/suspended。"""
-    service = ManualDistributionService(db)
-    try:
-        result = await service.suspend_allocation(
-            application_id=application_id,
-            admin_user_id=current_user.id,
-            reason=request.reason,
-        )
-        await db.commit()
-        return {"success": True, "message": "已停發", "data": result}
-    except ValueError as e:
-        msg = str(e)
-        if "already" in msg:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=msg) from e
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg) from e

--- a/backend/app/api/v1/endpoints/renewal.py
+++ b/backend/app/api/v1/endpoints/renewal.py
@@ -1,0 +1,454 @@
+"""Renewal & Challenge application endpoints.
+
+This module exposes three endpoints under `/renewals`:
+
+- GET  /api/v1/renewals/eligible   — list prior-year approved applications
+                                     that may be renewed right now.
+- POST /api/v1/renewals/           — create a renewal application from a
+                                     specific prior approved application.
+- POST /api/v1/renewals/challenge  — create a challenge application from
+                                     an approved renewal, targeting a
+                                     different sub_type.
+
+Period validation reads `renewal_application_*` and `application_*`
+fields from `ScholarshipConfiguration` for the *current* academic year
+(matching where the dates actually live in the schema — they are NOT on
+`ScholarshipType`).
+"""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.core.deps import get_current_admin_user
+from app.core.security import get_current_user, require_admin
+from app.db.deps import get_db
+from app.models.application import Application
+from app.models.enums import ApplicationStatus
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User
+from app.schemas.renewal import CreateChallengeRequest, CreateRenewalRequest
+from app.services.application_service import ApplicationService
+from app.services.renewal_audit_service import RenewalAuditService
+from app.services.renewal_distribution_service import RenewalDistributionService
+from app.services.renewal_eligibility_service import RenewalEligibilityService
+from app.utils.academic_period import get_current_academic_period
+
+router = APIRouter()
+
+
+def _current_academic_year() -> int:
+    """Return the active ROC academic year."""
+    return get_current_academic_period()["academic_year"]
+
+
+def _to_utc_aware(dt):
+    """Normalise a possibly naive datetime to UTC-aware.
+
+    SQLite drops timezone info, so columns declared `DateTime(timezone=True)`
+    can come back naive in tests. Assume naive datetimes are already UTC.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+async def _get_current_year_config(
+    db: AsyncSession,
+    *,
+    scholarship_type_id: int,
+    academic_year: int,
+    semester,
+) -> ScholarshipConfiguration | None:
+    """Look up the ScholarshipConfiguration row matching (type, year, semester).
+
+    Semester may be `None` (yearly scholarships); matched exactly.
+    """
+    stmt = select(ScholarshipConfiguration).where(
+        ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
+        ScholarshipConfiguration.academic_year == academic_year,
+        ScholarshipConfiguration.is_active.is_(True),
+    )
+    if semester is None:
+        stmt = stmt.where(ScholarshipConfiguration.semester.is_(None))
+    else:
+        stmt = stmt.where(ScholarshipConfiguration.semester == semester)
+    return await db.scalar(stmt)
+
+
+@router.get("/eligible")
+async def list_eligible_renewals(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the user's prior-year approved applications that may be renewed.
+
+    "May be renewed" means the current-year `ScholarshipConfiguration` for the
+    same scholarship_type has its `renewal_application_*` window open.
+    """
+    current_year = _current_academic_year()
+    service = RenewalEligibilityService(db)
+    apps = await service.get_eligible_renewals(current_user.id, current_year)
+
+    items = []
+    for app in apps:
+        # Resolve current-year config for the renewal deadline display.
+        config = await _get_current_year_config(
+            db,
+            scholarship_type_id=app.scholarship_type_id,
+            academic_year=current_year,
+            semester=app.semester,
+        )
+        deadline_dt = _to_utc_aware(config.renewal_application_end_date) if config else None
+        deadline = deadline_dt.isoformat() if deadline_dt else None
+        items.append(
+            {
+                "previous_application_id": app.id,
+                "scholarship_type_id": app.scholarship_type_id,
+                "scholarship_type_name": app.scholarship_type_ref.name if app.scholarship_type_ref else None,
+                "sub_scholarship_type": app.sub_scholarship_type,
+                "target_academic_year": current_year,
+                "renewal_year": app.renewal_year or app.academic_year,
+                "renewal_deadline": deadline,
+            }
+        )
+
+    return {
+        "success": True,
+        "message": "Eligible renewals retrieved",
+        "data": items,
+    }
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_renewal_application(
+    body: CreateRenewalRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a renewal application from a prior approved application.
+
+    Validations:
+      1. Previous application exists.
+      2. It belongs to the current user.
+      3. Its status is `approved`.
+      4. The current-year ScholarshipConfiguration has an active renewal window.
+      5. No existing renewal application for the same (user, type, year, semester).
+    """
+    now = datetime.now(timezone.utc)
+
+    # 1. Load previous application
+    prev = await db.scalar(select(Application).where(Application.id == body.previous_application_id))
+    if not prev:
+        raise HTTPException(status_code=404, detail="先前申請紀錄不存在")
+    if prev.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="無權續領他人申請")
+    if prev.status != ApplicationStatus.approved:
+        raise HTTPException(status_code=400, detail="先前申請尚未核可，無法續領 (prior not approved)")
+
+    # 2. Check renewal period on the *current-year* configuration for the same type.
+    current_year = _current_academic_year()
+    config = await _get_current_year_config(
+        db,
+        scholarship_type_id=prev.scholarship_type_id,
+        academic_year=current_year,
+        semester=prev.semester,
+    )
+    start = _to_utc_aware(config.renewal_application_start_date) if config else None
+    end = _to_utc_aware(config.renewal_application_end_date) if config else None
+    if not (start and end and start <= now <= end):
+        raise HTTPException(status_code=400, detail="目前不在續領申請期間")
+
+    # 3. Duplicate check (renewal flag set, status != deleted)
+    existing = await db.scalar(
+        select(Application).where(
+            Application.user_id == current_user.id,
+            Application.scholarship_type_id == prev.scholarship_type_id,
+            Application.academic_year == current_year,
+            Application.semester == prev.semester,
+            Application.is_renewal.is_(True),
+            Application.status != ApplicationStatus.deleted,
+        )
+    )
+    if existing:
+        raise HTTPException(status_code=409, detail="已建立續領申請")
+
+    # 4. Create renewal application
+    service = ApplicationService(db)
+    new_app = await service.create_renewal_from_previous(
+        previous=prev,
+        current_user=current_user,
+        target_academic_year=current_year,
+        renewal_year=prev.renewal_year or prev.academic_year,
+    )
+    await db.commit()
+    await db.refresh(new_app)
+
+    return {
+        "success": True,
+        "message": "續領申請已建立",
+        "data": {
+            "id": new_app.id,
+            "app_id": new_app.app_id,
+            "is_renewal": new_app.is_renewal,
+            "sub_scholarship_type": new_app.sub_scholarship_type,
+            "previous_application_id": new_app.previous_application_id,
+            "academic_year": new_app.academic_year,
+            "renewal_year": new_app.renewal_year,
+            "status": new_app.status.value if hasattr(new_app.status, "value") else new_app.status,
+        },
+    }
+
+
+@router.post("/challenge", status_code=status.HTTP_201_CREATED)
+async def create_challenge_application(
+    body: CreateChallengeRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a challenge application from an approved renewal.
+
+    Validations:
+      1. Renewal application exists.
+      2. It belongs to the current user.
+      3. It is in fact a renewal (`is_renewal=True`).
+      4. Its status is `approved`.
+      5. `target_sub_type` differs from renewal's `sub_scholarship_type`.
+      6. The renewal-year ScholarshipConfiguration has an active general
+         application window.
+      7. `target_sub_type` exists in `ScholarshipConfiguration.quotas`.
+      8. No existing challenge application for the same renewal.
+    """
+    now = datetime.now(timezone.utc)
+
+    # 1. Load renewal application
+    renewal = await db.scalar(select(Application).where(Application.id == body.renewal_application_id))
+    if not renewal:
+        raise HTTPException(status_code=404, detail="續領申請紀錄不存在")
+    if renewal.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="無權挑戰他人續領")
+    if not renewal.is_renewal:
+        raise HTTPException(status_code=400, detail="目標申請非續領紀錄")
+    if renewal.status != ApplicationStatus.approved:
+        raise HTTPException(status_code=400, detail="續領申請尚未核可，無法挑戰 (renewal not approved)")
+
+    # 2. sub_type difference check (cheap, do before db lookup)
+    if body.target_sub_type == renewal.sub_scholarship_type:
+        raise HTTPException(status_code=400, detail="挑戰 sub_type 不能與續領 sub_type 相同")
+
+    # 3. Load configuration for the renewal's (year, semester) — same period.
+    config = await _get_current_year_config(
+        db,
+        scholarship_type_id=renewal.scholarship_type_id,
+        academic_year=renewal.academic_year,
+        semester=renewal.semester,
+    )
+    start = _to_utc_aware(config.application_start_date) if config else None
+    end = _to_utc_aware(config.application_end_date) if config else None
+    if not (start and end and start <= now <= end):
+        raise HTTPException(status_code=400, detail="目前不在一般申請期間")
+
+    # 4. Validate target_sub_type exists in configured quotas.
+    if config and body.target_sub_type not in (config.quotas or {}):
+        raise HTTPException(
+            status_code=400,
+            detail=f"sub_type '{body.target_sub_type}' 不存在於配置",
+        )
+
+    # 5. Duplicate challenge check
+    existing = await db.scalar(
+        select(Application).where(
+            Application.user_id == current_user.id,
+            Application.scholarship_type_id == renewal.scholarship_type_id,
+            Application.academic_year == renewal.academic_year,
+            Application.semester == renewal.semester,
+            Application.is_renewal.is_(False),
+            Application.challenges_application_id == renewal.id,
+            Application.status != ApplicationStatus.deleted,
+        )
+    )
+    if existing:
+        raise HTTPException(status_code=409, detail="已建立挑戰申請")
+
+    # 6. Create challenge application
+    service = ApplicationService(db)
+    new_app = await service.create_challenge_from_renewal(
+        renewal=renewal,
+        current_user=current_user,
+        target_sub_type=body.target_sub_type,
+    )
+    await db.commit()
+    await db.refresh(new_app)
+
+    return {
+        "success": True,
+        "message": "挑戰申請已建立",
+        "data": {
+            "id": new_app.id,
+            "app_id": new_app.app_id,
+            "is_renewal": new_app.is_renewal,
+            "sub_scholarship_type": new_app.sub_scholarship_type,
+            "challenges_application_id": new_app.challenges_application_id,
+            "academic_year": new_app.academic_year,
+            "status": new_app.status.value if hasattr(new_app.status, "value") else new_app.status,
+        },
+    }
+
+
+@router.post("/{scholarship_type_id}/auto-distribute")
+async def trigger_renewal_auto_distribution(
+    scholarship_type_id: int,
+    academic_year: int,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Admin-triggered: auto-approve renewal applications past their review stage.
+
+    Renewals skip the college_ranking phase by design — once they have cleared
+    the required reviews (professor +/- college, per `ScholarshipConfiguration`),
+    this endpoint flips them from `under_review` to `approved` with
+    `review_stage = quota_distributed`.
+
+    Args:
+        scholarship_type_id: Path — scholarship type to process.
+        academic_year:        Query — ROC academic year (e.g. 114).
+
+    Returns:
+        ApiResponse with data = {approved_count, approved_ids}.
+    """
+    service = RenewalDistributionService(db)
+    result = await service.auto_approve_passed_reviews(
+        scholarship_type_id=scholarship_type_id,
+        academic_year=academic_year,
+    )
+    return {
+        "success": True,
+        "message": "續領自動分發完成",
+        "data": result,
+    }
+
+
+@router.get("/distribution-result")
+async def get_renewal_distribution_result(
+    scholarship_type_id: int,
+    academic_year: int,
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return renewal distribution grouped by (sub_type, renewal_year).
+
+    Admin-only. For the given `(scholarship_type_id, academic_year)`:
+      - Approved renewals are bucketed into `groups` keyed by
+        `(sub_scholarship_type, renewal_year)`. Each application carries
+        a `has_challenge` flag indicating whether a downstream challenge
+        application (Application_C, `is_renewal=False` with
+        `challenges_application_id` set) points at it.
+      - Rejected renewals are returned in a flat `rejected` list.
+      - A `summary` block totals approved + rejected counts.
+
+    Other statuses (draft, under_review, etc.) are intentionally ignored;
+    this endpoint reports a *finalised* distribution view.
+    """
+    # 1. Load all renewal applications for this (type, year).
+    stmt = (
+        select(Application)
+        .options(joinedload(Application.student))
+        .where(
+            Application.scholarship_type_id == scholarship_type_id,
+            Application.academic_year == academic_year,
+            Application.is_renewal.is_(True),
+        )
+    )
+    apps = (await db.execute(stmt)).scalars().unique().all()
+
+    # 2. Pre-compute which renewals have a downstream challenge.
+    #    Pass a guaranteed-empty sentinel (-1) when there are no renewals to
+    #    keep the `IN ()` clause syntactically valid across dialects.
+    renewal_ids = [a.id for a in apps]
+    challenge_apps = (
+        (await db.execute(select(Application).where(Application.challenges_application_id.in_(renewal_ids or [-1]))))
+        .scalars()
+        .all()
+    )
+    has_challenge_set = {ch.challenges_application_id for ch in challenge_apps}
+
+    # 3. Group approved by (sub_type, renewal_year); collect rejected separately.
+    grouped: dict[str, dict] = {}
+    rejected: list[dict] = []
+    for app_row in apps:
+        if app_row.status == ApplicationStatus.approved:
+            key = f"{app_row.sub_scholarship_type}_{app_row.renewal_year}"
+            bucket = grouped.setdefault(
+                key,
+                {
+                    "sub_type": app_row.sub_scholarship_type,
+                    "renewal_year": app_row.renewal_year,
+                    "applications": [],
+                },
+            )
+            bucket["applications"].append(
+                {
+                    "id": app_row.id,
+                    "app_id": app_row.app_id,
+                    "student_name": app_row.student.name if app_row.student else None,
+                    "previous_application_id": app_row.previous_application_id,
+                    "has_challenge": app_row.id in has_challenge_set,
+                }
+            )
+        elif app_row.status == ApplicationStatus.rejected:
+            rejected.append(
+                {
+                    "id": app_row.id,
+                    "student_name": app_row.student.name if app_row.student else None,
+                }
+            )
+
+    approved_count = sum(len(g["applications"]) for g in grouped.values())
+    return {
+        "success": True,
+        "message": "Renewal distribution result",
+        "data": {
+            "groups": list(grouped.values()),
+            "rejected": rejected,
+            "summary": {
+                "approved": approved_count,
+                "rejected": len(rejected),
+            },
+        },
+    }
+
+
+@router.get("/audit/renewal-violations")
+async def audit_renewal_violations(
+    current_user: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Admin audit: list approved challenges whose renewal isn't cancelled_by_challenge.
+
+    Implements the spec §12 invariant check. Empty `data` means the system
+    is consistent. A non-empty list points at data drift that needs manual
+    investigation — typically a renewal that wasn't transitioned during
+    `execute_general_distribution`.
+
+    Returns:
+        ApiResponse with `data` = list of
+        ``{challenge_id, renewal_id, actual_renewal_status}`` dicts.
+    """
+    service = RenewalAuditService(db)
+    violations = await service.find_invariant_violations()
+    return {
+        "success": True,
+        "message": f"Found {len(violations)} violations",
+        "data": violations,
+    }
+
+
+# `ScholarshipType` is imported for FastAPI's introspection of the joined model
+# in case future endpoint extensions need it; keep import to avoid lazy-import
+# surprises during OpenAPI generation.
+_ = ScholarshipType

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -6,6 +6,7 @@ import enum
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
 
+import sqlalchemy as sa
 from sqlalchemy import (
     JSON,
     Boolean,
@@ -13,11 +14,11 @@ from sqlalchemy import (
     DateTime,
     Enum,
     ForeignKey,
+    Index,
     Integer,
     Numeric,
     String,
     Text,
-    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -102,6 +103,8 @@ class Application(Base):
     is_renewal = Column(Boolean, default=False, nullable=False)  # 是否為續領申請
     renewal_year = Column(Integer, nullable=True)  # 續領年份 (e.g. 113)，用於批次匯入時直接指定
     previous_application_id = Column(Integer, ForeignKey("applications.id"))
+    challenges_application_id = Column(Integer, ForeignKey("applications.id"), nullable=True, index=True)
+    cancelled_due_to_application_id = Column(Integer, ForeignKey("applications.id"), nullable=True, index=True)
     review_deadline = Column(DateTime(timezone=True))
     decision_date = Column(DateTime(timezone=True))
 
@@ -154,15 +157,6 @@ class Application(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    # Revoke / Suspend metadata (spec 2026-05-21)
-    revoked_at = Column(DateTime(timezone=True), nullable=True)
-    revoked_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
-    revoke_reason = Column(Text, nullable=True)
-
-    suspended_at = Column(DateTime(timezone=True), nullable=True)
-    suspended_by = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
-    suspend_reason = Column(Text, nullable=True)
-
     # 刪除追蹤 (Deletion tracking for soft delete)
     deleted_at = Column(DateTime(timezone=True), nullable=True)
     deleted_by_id = Column(Integer, ForeignKey("users.id"), nullable=True)
@@ -199,7 +193,9 @@ class Application(Base):
         overlaps="applications,scholarship_type_ref",
     )
     scholarship_configuration = relationship("ScholarshipConfiguration", foreign_keys=[scholarship_configuration_id])
-    previous_application = relationship("Application", remote_side=[id])
+    previous_application = relationship("Application", remote_side=[id], foreign_keys=[previous_application_id])
+    challenged_renewal = relationship("Application", remote_side=[id], foreign_keys=[challenges_application_id])
+    cancelled_due_to = relationship("Application", remote_side=[id], foreign_keys=[cancelled_due_to_application_id])
 
     files = relationship("ApplicationFile", back_populates="application", cascade="all, delete-orphan")
     reviews = relationship("ApplicationReview", back_populates="application", cascade="all, delete-orphan")
@@ -210,15 +206,41 @@ class Application(Base):
     imported_by = relationship("User", foreign_keys=[imported_by_id])
     batch_import = relationship("BatchImport", back_populates="applications", foreign_keys=[batch_import_id])
 
-    # 唯一約束：確保每個用戶在每個學年、學期、獎學金組合下只能有一個申請
-    # Use user_id instead of student_id since students are now from external API
+    # 唯一約束：拆成三個 partial unique indexes，允許同一學期內並存三種申請：
+    # 1. 續領申請 (is_renewal = true)
+    # 2. 挑戰申請 (is_renewal = false, challenges_application_id IS NOT NULL)
+    # 3. 一般新申請 (is_renewal = false, challenges_application_id IS NULL)
     __table_args__ = (
-        UniqueConstraint(
+        Index(
+            "uq_user_renewal_app",
             "user_id",
             "scholarship_type_id",
             "academic_year",
             "semester",
-            name="uq_user_scholarship_academic_term",
+            unique=True,
+            postgresql_where=sa.text("is_renewal = true AND status != 'deleted'"),
+        ),
+        Index(
+            "uq_user_challenge_app",
+            "user_id",
+            "scholarship_type_id",
+            "academic_year",
+            "semester",
+            unique=True,
+            postgresql_where=sa.text(
+                "is_renewal = false AND challenges_application_id IS NOT NULL " "AND status != 'deleted'"
+            ),
+        ),
+        Index(
+            "uq_user_pure_new_app",
+            "user_id",
+            "scholarship_type_id",
+            "academic_year",
+            "semester",
+            unique=True,
+            postgresql_where=sa.text(
+                "is_renewal = false AND challenges_application_id IS NULL " "AND status != 'deleted'"
+            ),
         ),
     )
 

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -218,7 +218,7 @@ class Application(Base):
             "academic_year",
             "semester",
             unique=True,
-            postgresql_where=sa.text("is_renewal = true AND status != 'deleted'"),
+            postgresql_where=sa.text("is_renewal = true AND status::text != 'deleted'"),
         ),
         Index(
             "uq_user_challenge_app",
@@ -228,7 +228,7 @@ class Application(Base):
             "semester",
             unique=True,
             postgresql_where=sa.text(
-                "is_renewal = false AND challenges_application_id IS NOT NULL " "AND status != 'deleted'"
+                "is_renewal = false AND challenges_application_id IS NOT NULL AND status::text != 'deleted'"
             ),
         ),
         Index(
@@ -239,7 +239,7 @@ class Application(Base):
             "semester",
             unique=True,
             postgresql_where=sa.text(
-                "is_renewal = false AND challenges_application_id IS NULL " "AND status != 'deleted'"
+                "is_renewal = false AND challenges_application_id IS NULL AND status::text != 'deleted'"
             ),
         ),
     )

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -218,7 +218,7 @@ class Application(Base):
             "academic_year",
             "semester",
             unique=True,
-            postgresql_where=sa.text("is_renewal = true AND status::text != 'deleted'"),
+            postgresql_where=sa.text("is_renewal = true AND deleted_at IS NULL"),
         ),
         Index(
             "uq_user_challenge_app",
@@ -228,7 +228,7 @@ class Application(Base):
             "semester",
             unique=True,
             postgresql_where=sa.text(
-                "is_renewal = false AND challenges_application_id IS NOT NULL AND status::text != 'deleted'"
+                "is_renewal = false AND challenges_application_id IS NOT NULL AND deleted_at IS NULL"
             ),
         ),
         Index(
@@ -238,9 +238,7 @@ class Application(Base):
             "academic_year",
             "semester",
             unique=True,
-            postgresql_where=sa.text(
-                "is_renewal = false AND challenges_application_id IS NULL AND status::text != 'deleted'"
-            ),
+            postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NULL AND deleted_at IS NULL"),
         ),
     )
 

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -37,6 +37,7 @@ class ApplicationStatus(enum.Enum):
     withdrawn = "withdrawn"  # 撤回
     cancelled = "cancelled"  # 取消
     manual_excluded = "manual_excluded"  # 手動排除
+    cancelled_by_challenge = "cancelled_by_challenge"  # 因挑戰申請成功被自動取消
     deleted = "deleted"  # 刪除
 
 

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -311,11 +311,25 @@ class ApplicationResponse(BaseModel):
     amount: Optional[Decimal] = None  # Scholarship amount
     currency: Optional[str] = "TWD"  # Scholarship currency
     scholarship_subtype_list: Optional[List[str]] = []
+    sub_scholarship_type: Optional[str] = Field(
+        None,
+        description="本申請的代表性 sub_type（單一字串；若為續領則承襲自前一申請）",
+    )
     sub_type_preferences: Optional[List[str]] = Field(None, description="Ordered sub-type preference list")
     status: str
     status_name: Optional[str]
     review_stage: Optional[str] = None  # 審核階段（用於前端進度顯示）
     is_renewal: bool = Field(False, description="是否為續領申請")
+    renewal_year: Optional[int] = Field(None, description="續領年份 (民國年，如 113)；批次匯入指定，或承接自前一申請")
+    previous_application_id: Optional[int] = Field(None, description="承接的前一份核可申請 ID（續領申請填）")
+    challenges_application_id: Optional[int] = Field(
+        None,
+        description="挑戰的目標續領申請 ID（挑戰申請填）— 一旦挑戰核可，被挑戰之續領自動取消",
+    )
+    cancelled_due_to_application_id: Optional[int] = Field(
+        None,
+        description="因哪份挑戰申請而被取消（被取代之續領申請填）",
+    )
     academic_year: int
     semester: Optional[str] = None
     student_data: Dict[str, Any]
@@ -440,9 +454,23 @@ class ApplicationStatusUpdateResponse(BaseModel):
     amount: Optional[Decimal] = None
     currency: Optional[str] = "TWD"
     scholarship_subtype_list: Optional[List[str]] = []
+    sub_scholarship_type: Optional[str] = Field(
+        None,
+        description="本申請的代表性 sub_type（單一字串；若為續領則承襲自前一申請）",
+    )
     status: str
     status_name: Optional[str]
     is_renewal: bool = Field(False, description="是否為續領申請")
+    renewal_year: Optional[int] = Field(None, description="續領年份 (民國年，如 113)；批次匯入指定，或承接自前一申請")
+    previous_application_id: Optional[int] = Field(None, description="承接的前一份核可申請 ID（續領申請填）")
+    challenges_application_id: Optional[int] = Field(
+        None,
+        description="挑戰的目標續領申請 ID（挑戰申請填）— 一旦挑戰核可，被挑戰之續領自動取消",
+    )
+    cancelled_due_to_application_id: Optional[int] = Field(
+        None,
+        description="因哪份挑戰申請而被取消（被取代之續領申請填）",
+    )
     academic_year: int
     semester: Optional[str] = None
     student_data: Dict[str, Any]
@@ -528,11 +556,25 @@ class ApplicationListResponse(BaseModel):
     scholarship_name: Optional[str] = None  # Full scholarship configuration name
     amount: Optional[Decimal] = None  # Scholarship amount
     currency: Optional[str] = "TWD"  # Scholarship currency
-    scholarship_subtype_list: Optional[List[str]] = []  # 獎學金子類型列表
+    scholarship_subtype_list: Optional[List[str]] = []
+    sub_scholarship_type: Optional[str] = Field(
+        None,
+        description="本申請的代表性 sub_type（單一字串；若為續領則承襲自前一申請）",
+    )  # 獎學金子類型列表
     status: str
     status_name: Optional[str]
     review_stage: Optional[str] = None  # 審核階段（用於前端進度顯示）
     is_renewal: bool = Field(False, description="是否為續領申請")
+    renewal_year: Optional[int] = Field(None, description="續領年份 (民國年，如 113)；批次匯入指定，或承接自前一申請")
+    previous_application_id: Optional[int] = Field(None, description="承接的前一份核可申請 ID（續領申請填）")
+    challenges_application_id: Optional[int] = Field(
+        None,
+        description="挑戰的目標續領申請 ID（挑戰申請填）— 一旦挑戰核可，被挑戰之續領自動取消",
+    )
+    cancelled_due_to_application_id: Optional[int] = Field(
+        None,
+        description="因哪份挑戰申請而被取消（被取代之續領申請填）",
+    )
     academic_year: int
     semester: Optional[str] = None
     student_data: Dict[str, Any]
@@ -731,15 +773,3 @@ class HistoricalApplicationResponse(BaseModel):
             "withdrawn": "bg-gray-100 text-gray-700",
         }
         return status_colors.get(status, "bg-gray-100 text-gray-700")
-
-
-class RevokeRequest(BaseModel):
-    """Body for POST /manual-distribution/applications/{id}/revoke"""
-
-    reason: str = Field(..., min_length=1, max_length=500)
-
-
-class SuspendRequest(BaseModel):
-    """Body for POST /manual-distribution/applications/{id}/suspend"""
-
-    reason: str = Field(..., min_length=1, max_length=500)

--- a/backend/app/schemas/renewal.py
+++ b/backend/app/schemas/renewal.py
@@ -1,0 +1,38 @@
+"""Pydantic schemas for renewal and challenge application flows.
+
+These models cover:
+- `EligibleRenewalItem`: shape of items returned by GET /api/v1/renewals/eligible
+- `CreateRenewalRequest`: payload for POST /api/v1/renewals/
+- `CreateChallengeRequest`: payload for POST /api/v1/renewals/challenge
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class EligibleRenewalItem(BaseModel):
+    """A prior-year approved application surfaced as a renewal candidate."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    previous_application_id: int  # source application's id
+    scholarship_type_id: int
+    scholarship_type_name: str
+    sub_scholarship_type: str  # e.g. "nstc"
+    target_academic_year: int  # current_academic_year
+    renewal_year: int  # = previous renewal_year if set, else previous.academic_year
+    renewal_deadline: Optional[str]  # ISO datetime string
+
+
+class CreateRenewalRequest(BaseModel):
+    """Body for POST /api/v1/renewals/ — create renewal from a prior approved app."""
+
+    previous_application_id: int
+
+
+class CreateChallengeRequest(BaseModel):
+    """Body for POST /api/v1/renewals/challenge — create challenge from an approved renewal."""
+
+    renewal_application_id: int
+    target_sub_type: str

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -18,7 +18,7 @@ from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFound
 from app.core.metrics import scholarship_applications_total, scholarship_reviews_total
 from app.core.schema_validation import serialize_value
 from app.models.application import Application, ApplicationStatus
-from app.models.enums import Semester
+from app.models.enums import ReviewStage, Semester
 from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
 from app.models.user import User, UserRole
@@ -36,6 +36,7 @@ from app.services.eligibility_service import EligibilityService
 from app.services.email_automation_service import email_automation_service
 from app.services.email_service import EmailService
 from app.services.minio_service import minio_service
+from app.services.review_phase_filter import apply_renewal_phase_filter
 from app.services.student_service import StudentService
 
 func: Any = sa_func
@@ -227,9 +228,14 @@ class ApplicationService:
             student_id=self._get_student_id_from_user(user) if user else None,
             scholarship_type_id=application.scholarship_type_id,
             scholarship_subtype_list=application.scholarship_subtype_list or [],
+            sub_scholarship_type=application.sub_scholarship_type,
             status=application.status,
             status_name=application.status_name,
             is_renewal=application.is_renewal,
+            renewal_year=application.renewal_year,
+            previous_application_id=application.previous_application_id,
+            challenges_application_id=application.challenges_application_id,
+            cancelled_due_to_application_id=application.cancelled_due_to_application_id,
             academic_year=application.academic_year,
             semester=self._convert_semester_to_string(application.semester),
             student_data=application.student_data or {},
@@ -680,10 +686,15 @@ class ApplicationService:
             scholarship_type_id=application.scholarship_type_id,
             scholarship_type_zh=application.scholarship.name if application.scholarship else None,
             scholarship_subtype_list=application.scholarship_subtype_list or [],
+            sub_scholarship_type=application.sub_scholarship_type,
             status=application.status,
             status_name=application.status_name,
             review_stage=serialize_value(application.review_stage),
             is_renewal=application.is_renewal,
+            renewal_year=application.renewal_year,
+            previous_application_id=application.previous_application_id,
+            challenges_application_id=application.challenges_application_id,
+            cancelled_due_to_application_id=application.cancelled_due_to_application_id,
             academic_year=application.academic_year,
             semester=self._convert_semester_to_string(application.semester),
             student_data=application.student_data,
@@ -823,8 +834,15 @@ class ApplicationService:
                 scholarship_type=application.scholarship.code if application.scholarship else None,
                 scholarship_type_id=application.scholarship_type_id,
                 scholarship_type_zh=application.scholarship.name if application.scholarship else "未知獎學金",
+                scholarship_subtype_list=application.scholarship_subtype_list or [],
+                sub_scholarship_type=application.sub_scholarship_type,
                 status=application.status,
                 status_name=application.status_name,
+                is_renewal=application.is_renewal,
+                renewal_year=application.renewal_year,
+                previous_application_id=application.previous_application_id,
+                challenges_application_id=application.challenges_application_id,
+                cancelled_due_to_application_id=application.cancelled_due_to_application_id,
                 academic_year=application.academic_year,
                 semester=self._convert_semester_to_string(application.semester),
                 student_data=application.student_data,
@@ -997,11 +1015,16 @@ class ApplicationService:
             "student_id": application.student.nycu_id if application.student else None,
             "scholarship_type_id": application.scholarship_type_id,
             "scholarship_subtype_list": application.scholarship_subtype_list or [],
+            "sub_scholarship_type": application.sub_scholarship_type,
             "sub_type_labels": sub_type_labels,
             "status": application.status,
             "status_name": application.status_name,
             "review_stage": serialize_value(application.review_stage),
             "is_renewal": application.is_renewal,
+            "renewal_year": application.renewal_year,
+            "previous_application_id": application.previous_application_id,
+            "challenges_application_id": application.challenges_application_id,
+            "cancelled_due_to_application_id": application.cancelled_due_to_application_id,
             "academic_year": application.academic_year,
             "semester": self._convert_semester_to_string(application.semester),
             "student_data": application.student_data or {},
@@ -1413,8 +1436,14 @@ class ApplicationService:
             "student_id": self._get_student_id_from_user(user),
             "scholarship_type_id": application.scholarship_type_id,
             "scholarship_subtype_list": application.scholarship_subtype_list,
+            "sub_scholarship_type": application.sub_scholarship_type,
             "status": application.status,
             "status_name": application.status_name,
+            "is_renewal": application.is_renewal,
+            "renewal_year": application.renewal_year,
+            "previous_application_id": application.previous_application_id,
+            "challenges_application_id": application.challenges_application_id,
+            "cancelled_due_to_application_id": application.cancelled_due_to_application_id,
             "academic_year": application.academic_year,
             "semester": application.semester,
             "student_data": application.student_data,
@@ -1552,8 +1581,15 @@ class ApplicationService:
                 scholarship_type=application.scholarship.code if application.scholarship else None,
                 scholarship_type_id=application.scholarship_type_id,
                 scholarship_type_zh=application.scholarship.name if application.scholarship else None,
+                scholarship_subtype_list=application.scholarship_subtype_list or [],
+                sub_scholarship_type=application.sub_scholarship_type,
                 status=application.status,
                 status_name=application.status_name,
+                is_renewal=application.is_renewal,
+                renewal_year=application.renewal_year,
+                previous_application_id=application.previous_application_id,
+                challenges_application_id=application.challenges_application_id,
+                cancelled_due_to_application_id=application.cancelled_due_to_application_id,
                 academic_year=application.academic_year,
                 semester=self._convert_semester_to_string(application.semester),
                 student_data=application.student_data,
@@ -1967,8 +2003,15 @@ class ApplicationService:
                 scholarship_type=application.scholarship.code if application.scholarship else None,
                 scholarship_type_id=application.scholarship_type_id,
                 scholarship_type_zh=application.scholarship.name if application.scholarship else None,
+                scholarship_subtype_list=application.scholarship_subtype_list or [],
+                sub_scholarship_type=application.sub_scholarship_type,
                 status=application.status,
                 status_name=application.status_name,
+                is_renewal=application.is_renewal,
+                renewal_year=application.renewal_year,
+                previous_application_id=application.previous_application_id,
+                challenges_application_id=application.challenges_application_id,
+                cancelled_due_to_application_id=application.cancelled_due_to_application_id,
                 academic_year=application.academic_year,
                 semester=self._convert_semester_to_string(application.semester),
                 student_data=application.student_data,
@@ -2418,6 +2461,11 @@ class ApplicationService:
                         ]
                     )
                 )
+                # Phase 4 (renewal routing): pending professor lists must only
+                # include applications matching the *current* review phase —
+                # renewal apps during the renewal_professor_review window,
+                # non-renewal apps during the general professor_review window.
+                base_query = apply_renewal_phase_filter(base_query, role="professor", alias_name="prof_phase_cfg")
             elif status_filter == "completed":
                 base_query = base_query.where(
                     Application.status.in_(
@@ -2939,3 +2987,79 @@ class ApplicationService:
             logger.exception("Error assigning professor")
             await self.db.rollback()
             raise
+
+    # ------------------------------------------------------------------ #
+    # Renewal & Challenge application factories
+    # ------------------------------------------------------------------ #
+
+    async def create_renewal_from_previous(
+        self,
+        previous: Application,
+        current_user: User,
+        target_academic_year: int,
+        renewal_year: int,
+    ) -> Application:
+        """Create a renewal Application copying sub_type & key fields from a
+        previous approved application.
+
+        Caller is responsible for committing the surrounding transaction.
+        """
+        app_id = await self._generate_app_id(
+            target_academic_year,
+            previous.semester.value if previous.semester else None,
+        )
+        new_app = Application(
+            app_id=app_id,
+            user_id=current_user.id,
+            scholarship_type_id=previous.scholarship_type_id,
+            scholarship_configuration_id=previous.scholarship_configuration_id,
+            scholarship_subtype_list=[previous.sub_scholarship_type] if previous.sub_scholarship_type else [],
+            sub_scholarship_type=previous.sub_scholarship_type,
+            sub_type_selection_mode=previous.sub_type_selection_mode,
+            is_renewal=True,
+            renewal_year=renewal_year,
+            previous_application_id=previous.id,
+            academic_year=target_academic_year,
+            semester=previous.semester,
+            status=ApplicationStatus.draft,
+            review_stage=ReviewStage.student_draft,
+            agree_terms=False,
+        )
+        self.db.add(new_app)
+        await self.db.flush()
+        return new_app
+
+    async def create_challenge_from_renewal(
+        self,
+        renewal: Application,
+        current_user: User,
+        target_sub_type: str,
+    ) -> Application:
+        """Create a challenge Application linked to an approved renewal.
+
+        The challenge targets a different sub_type than the renewal and
+        runs in the same academic_year + semester. Caller commits.
+        """
+        app_id = await self._generate_app_id(
+            renewal.academic_year,
+            renewal.semester.value if renewal.semester else None,
+        )
+        new_app = Application(
+            app_id=app_id,
+            user_id=current_user.id,
+            scholarship_type_id=renewal.scholarship_type_id,
+            scholarship_configuration_id=renewal.scholarship_configuration_id,
+            scholarship_subtype_list=[target_sub_type],
+            sub_scholarship_type=target_sub_type,
+            sub_type_selection_mode=renewal.sub_type_selection_mode,
+            is_renewal=False,
+            challenges_application_id=renewal.id,
+            academic_year=renewal.academic_year,
+            semester=renewal.semester,
+            status=ApplicationStatus.draft,
+            review_stage=ReviewStage.student_draft,
+            agree_terms=False,
+        )
+        self.db.add(new_app)
+        await self.db.flush()
+        return new_app

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -26,6 +26,8 @@ from app.models.enums import Semester
 from app.models.review import ApplicationReview  # Unified review system
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User, UserRole
+from app.services.email_automation_service import email_automation_service
+from app.services.review_phase_filter import apply_renewal_phase_filter
 
 func: Any = sa_func
 
@@ -292,6 +294,20 @@ class CollegeReviewService:
         )
 
         # Base query for applications in reviewable state with comprehensive eager loading
+        # Phase 4 (renewal routing): for *pending* (under_review) applications we
+        # must restrict to those matching the current college review phase
+        # — renewal apps during renewal_college_review, general apps during
+        # college_review. Historical statuses (approved / partial_approved /
+        # rejected) remain visible unconditionally so reviewers can audit past
+        # decisions.
+        pending_phase_subquery = (
+            apply_renewal_phase_filter(
+                select(Application.id).where(Application.status == ApplicationStatus.under_review.value),
+                role="college",
+                alias_name="college_phase_cfg",
+            )
+        ).subquery()
+
         stmt = (
             select(Application)
             .options(
@@ -303,7 +319,11 @@ class CollegeReviewService:
             )
             .where(
                 or_(
-                    Application.status == ApplicationStatus.under_review.value,
+                    # Under-review rows must match the current renewal/general phase
+                    and_(
+                        Application.status == ApplicationStatus.under_review.value,
+                        Application.id.in_(select(pending_phase_subquery.c.id)),
+                    ),
                     Application.status == ApplicationStatus.approved.value,  # 包含已核准的申請
                     Application.status == ApplicationStatus.partial_approved.value,  # 包含部分同意的申請
                     Application.status == ApplicationStatus.rejected.value,  # 包含已駁回的申請

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -1289,6 +1289,7 @@ class ManualDistributionService:
             roster.qualified_count = qualified_count
             roster.disqualified_count = total_count - qualified_count
             roster.total_amount = total_amount
+
     # ------------------------------------------------------------------ #
     # Phase 6 — General distribution with challenge release + fill-in
     # See docs/superpowers/specs/2026-05-13-renewal-application-design.md

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -1289,3 +1289,512 @@ class ManualDistributionService:
             roster.qualified_count = qualified_count
             roster.disqualified_count = total_count - qualified_count
             roster.total_amount = total_amount
+    # ------------------------------------------------------------------ #
+    # Phase 6 — General distribution with challenge release + fill-in
+    # See docs/superpowers/specs/2026-05-13-renewal-application-design.md
+    # Section 9 (一般階段分發演算法).
+    # ------------------------------------------------------------------ #
+
+    async def _get_active_config(self, scholarship_type_id: int, academic_year: int) -> ScholarshipConfiguration:
+        """Load the active ScholarshipConfiguration for (type, year).
+
+        Phase 6 distribution operates on quotas at the (sub_type, year) level
+        rather than per-college; semester is unused here since renewal flows
+        target yearly scholarships (see spec Section 1).
+        """
+        stmt = (
+            select(ScholarshipConfiguration)
+            .where(
+                and_(
+                    ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
+                    ScholarshipConfiguration.academic_year == academic_year,
+                    ScholarshipConfiguration.is_active == True,  # noqa: E712
+                )
+            )
+            .order_by(ScholarshipConfiguration.id.desc())
+        )
+        config = (await self.db.execute(stmt)).scalars().first()
+        if config is None:
+            raise ValueError(f"No active ScholarshipConfiguration for type {scholarship_type_id}, year {academic_year}")
+        return config
+
+    async def _count_approved_renewals_per_pool(
+        self, scholarship_type_id: int, academic_year: int
+    ) -> dict[tuple[str, int], int]:
+        """Count approved renewals grouped by (sub_scholarship_type, renewal_year).
+
+        Used to compute remaining quota = total - already-consumed-by-renewals.
+        Renewals without an explicit renewal_year fall back to academic_year
+        (they came from this year's pool).
+        """
+        stmt = (
+            select(
+                Application.sub_scholarship_type,
+                Application.renewal_year,
+                func.count(Application.id),
+            )
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.is_renewal.is_(True),
+                Application.status == ApplicationStatus.approved,
+            )
+            .group_by(Application.sub_scholarship_type, Application.renewal_year)
+        )
+        rows = (await self.db.execute(stmt)).all()
+        result: dict[tuple[str, int], int] = {}
+        for sub_type, renewal_year, count in rows:
+            year = int(renewal_year) if renewal_year is not None else int(academic_year)
+            result[(sub_type, year)] = result.get((sub_type, year), 0) + int(count)
+        return result
+
+    async def _get_general_candidates(
+        self,
+        scholarship_type_id: int,
+        academic_year: int,
+        sub_type: str,
+    ) -> list[CollegeRankingItem]:
+        """Return ranked candidates for first-round distribution on `sub_type`.
+
+        Includes BOTH pure-new applicants and challenge applicants whose
+        target sub_type matches — challenges compete for slots within the
+        sub_type they're applying to.
+        """
+        stmt = (
+            select(CollegeRankingItem)
+            .options(selectinload(CollegeRankingItem.application))
+            .join(Application, CollegeRankingItem.application_id == Application.id)
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.sub_scholarship_type == sub_type,
+                Application.is_renewal.is_(False),
+                Application.status.notin_(
+                    [
+                        ApplicationStatus.approved,
+                        ApplicationStatus.rejected,
+                        ApplicationStatus.withdrawn,
+                        ApplicationStatus.deleted,
+                        ApplicationStatus.cancelled,
+                        ApplicationStatus.cancelled_by_challenge,
+                    ]
+                ),
+                Application.deleted_at.is_(None),
+            )
+            .order_by(CollegeRankingItem.rank_position)
+        )
+        return list((await self.db.execute(stmt)).scalars().all())
+
+    async def _get_waitlist_candidates(
+        self,
+        scholarship_type_id: int,
+        academic_year: int,
+        sub_type: str,
+        limit: int,
+    ) -> list[CollegeRankingItem]:
+        """Return pure-new candidates eligible to fill released slots.
+
+        Filters challenges_application_id IS NULL — only pure-new applicants
+        can fill released slots (spec Section 9.2). This prevents release
+        chains: a challenge winner's freed slot only flows to a pure-new
+        applicant, so no further releases cascade.
+        """
+        stmt = (
+            select(CollegeRankingItem)
+            .options(selectinload(CollegeRankingItem.application))
+            .join(Application, CollegeRankingItem.application_id == Application.id)
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.sub_scholarship_type == sub_type,
+                Application.is_renewal.is_(False),
+                Application.challenges_application_id.is_(None),
+                Application.status != ApplicationStatus.approved,
+                Application.status.notin_(
+                    [
+                        ApplicationStatus.rejected,
+                        ApplicationStatus.withdrawn,
+                        ApplicationStatus.deleted,
+                        ApplicationStatus.cancelled,
+                        ApplicationStatus.cancelled_by_challenge,
+                    ]
+                ),
+                Application.deleted_at.is_(None),
+            )
+            .order_by(CollegeRankingItem.rank_position)
+            .limit(limit)
+        )
+        return list((await self.db.execute(stmt)).scalars().all())
+
+    @staticmethod
+    def _pick_pool(
+        remaining: dict[tuple[str, int], int],
+        sub_type: str,
+        config: ScholarshipConfiguration,
+    ) -> Optional[int]:
+        """Pick the next allocation_year with available quota for `sub_type`.
+
+        Policy: prefer the current academic_year first, then prior years in
+        descending order. Returns None when no pool with positive remaining
+        quota exists for this sub_type.
+        """
+        candidate_years = sorted(
+            [y for (st, y), c in remaining.items() if st == sub_type and c > 0],
+            reverse=True,
+        )
+        if not candidate_years:
+            return None
+        # Prefer the configured current year if available; otherwise the
+        # highest-numbered prior year (already sorted descending).
+        if config.academic_year in candidate_years:
+            return config.academic_year
+        return candidate_years[0]
+
+    @staticmethod
+    def _build_remaining_quota(
+        quotas: dict,
+        used_by_renewal: dict[tuple[str, int], int],
+    ) -> dict[tuple[str, int], int]:
+        """Build {(sub_type, alloc_year): remaining} from config quotas.
+
+        The Phase 6 quotas dict is `{sub_type: {year_string: total_int}}` per
+        spec Section 9.1. Year keys are coerced to int so downstream code can
+        compare against renewal_year / academic_year (also ints).
+        """
+        remaining: dict[tuple[str, int], int] = {}
+        for sub_type, year_map in (quotas or {}).items():
+            if not isinstance(year_map, dict):
+                continue
+            for year_key, total in year_map.items():
+                try:
+                    year_int = int(year_key)
+                except (TypeError, ValueError):
+                    # Non-year keys (legacy college-code matrix) aren't used
+                    # by the Phase 6 algorithm; skip silently.
+                    continue
+                used = used_by_renewal.get((sub_type, year_int), 0)
+                remaining[(sub_type, year_int)] = int(total) - used
+        return remaining
+
+    async def execute_general_distribution(
+        self,
+        scholarship_type_id: int,
+        academic_year: int,
+    ) -> dict[str, Any]:
+        """Run general-phase distribution with challenge release and waitlist fill-in.
+
+        Spec Section 9.1 — algorithm:
+        1. Compute remaining quota = total - approved renewals per pool.
+        2. First-round: per sub_type, walk ranked candidates and assign each
+           to the next available (sub_type, allocation_year) pool.
+        3. For every approved challenge: cancel its renewal target with
+           status=cancelled_by_challenge, track the freed slot.
+        4. Fill released slots from the same-sub_type waitlist (pure-new
+           applicants only — preventing cascading releases).
+        5. Commit and return summary stats per spec Section 12.
+        """
+        config = await self._get_active_config(scholarship_type_id, academic_year)
+        quotas = config.quotas or {}
+
+        # 1. Remaining quota after subtracting approved renewals.
+        used_by_renewal = await self._count_approved_renewals_per_pool(scholarship_type_id, academic_year)
+        remaining = self._build_remaining_quota(quotas, used_by_renewal)
+
+        # 2. First-round distribution per sub_type.
+        approved_challenges: list[Application] = []
+        for sub_type in quotas.keys():
+            candidates = await self._get_general_candidates(scholarship_type_id, academic_year, sub_type)
+            for cand in candidates:
+                pool_year = self._pick_pool(remaining, sub_type, config)
+                if pool_year is None:
+                    break
+                app = cand.application
+                if app is None:
+                    continue
+                app.status = ApplicationStatus.approved
+                app.sub_scholarship_type = sub_type
+                app.quota_allocation_status = "allocated"
+                app.review_stage = ReviewStage.quota_distributed
+                app.approved_at = datetime.now(timezone.utc)
+                cand.is_allocated = True
+                cand.allocated_sub_type = sub_type
+                cand.allocation_year = pool_year
+                cand.status = "allocated"
+                cand.allocation_reason = "一般階段自動分發"
+                remaining[(sub_type, pool_year)] -= 1
+                if app.challenges_application_id is not None:
+                    approved_challenges.append(app)
+
+        # 3. Release handling — approved challenges cancel their renewal targets.
+        released: dict[tuple[str, int], int] = {}
+        for challenge_app in approved_challenges:
+            renewal_app = await self.db.scalar(
+                select(Application).where(Application.id == challenge_app.challenges_application_id)
+            )
+            if renewal_app is None:
+                logger.warning(
+                    "Challenge app %s references missing renewal id=%s — skipping release",
+                    challenge_app.id,
+                    challenge_app.challenges_application_id,
+                )
+                continue
+            renewal_app.status = ApplicationStatus.cancelled_by_challenge
+            renewal_app.cancelled_due_to_application_id = challenge_app.id
+            freed_year = int(renewal_app.renewal_year) if renewal_app.renewal_year is not None else int(academic_year)
+            key = (renewal_app.sub_scholarship_type, freed_year)
+            released[key] = released.get(key, 0) + 1
+
+        # 4. Fill released slots from waitlist of same sub_type.
+        fill_in_count = 0
+        for (sub_type, alloc_year), count in released.items():
+            waitlist = await self._get_waitlist_candidates(scholarship_type_id, academic_year, sub_type, limit=count)
+            for cand in waitlist:
+                app = cand.application
+                if app is None:
+                    continue
+                app.status = ApplicationStatus.approved
+                app.sub_scholarship_type = sub_type
+                app.quota_allocation_status = "allocated"
+                app.review_stage = ReviewStage.quota_distributed
+                app.approved_at = datetime.now(timezone.utc)
+                cand.is_allocated = True
+                cand.allocated_sub_type = sub_type
+                cand.allocation_year = alloc_year
+                cand.status = "allocated"
+                cand.allocation_reason = "釋出 slot 候補遞補"
+                fill_in_count += 1
+
+        await self.db.commit()
+
+        return {
+            "approved_renewals": sum(used_by_renewal.values()),
+            "approved_challenges": len(approved_challenges),
+            "released_slots": dict(released),
+            "filled_in": fill_in_count,
+            "unfilled": sum(released.values()) - fill_in_count,
+        }
+
+    async def compute_distribution_state(self, scholarship_type_id: int, academic_year: int) -> dict[str, Any]:
+        """Aggregate the state needed by the manual distribution panel UI.
+
+        Returns a single payload covering:
+
+          * ``renewal_allocations`` — approved renewals grouped by
+            ``(sub_type, renewal_year)``; each entry includes a
+            ``has_challenge`` flag if a downstream challenge application
+            points at the renewal (Application_C).
+          * ``available_quotas`` — per ``(sub_type, allocation_year)``:
+            ``total`` from config, ``used`` from approved renewals, and
+            ``remaining`` = total − used. Legacy non-year-keyed quota maps
+            (e.g. ``{college_code: int}``) are skipped silently — Phase 6
+            only operates on year-keyed quotas (spec Section 9.1).
+          * ``candidates`` — non-renewal applicants ranked via
+            ``CollegeRankingItem.rank_position``. For each candidate,
+            ``is_challenge`` is true when ``challenges_application_id`` is
+            set, and ``challenged_renewal`` carries minimal info about the
+            renewal that would be cancelled if the challenge wins.
+
+        This endpoint never mutates state — it's a read aggregator the
+        admin UI calls to render the panel.
+        """
+        config = await self._get_active_config(scholarship_type_id, academic_year)
+        quotas = config.quotas or {}
+
+        # --- 1. Renewal allocations grouped by (sub_type, renewal_year) --- #
+        renewal_apps_result = await self.db.execute(
+            select(Application)
+            .options(joinedload(Application.student))
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.is_renewal.is_(True),
+                Application.status == ApplicationStatus.approved,
+            )
+        )
+        renewal_apps = renewal_apps_result.scalars().unique().all()
+
+        # Mark challenges. Use a sentinel (-1) so the IN clause is valid
+        # across dialects when no renewals exist.
+        renewal_ids = [a.id for a in renewal_apps]
+        challenge_rows = (
+            (
+                await self.db.execute(
+                    select(Application).where(Application.challenges_application_id.in_(renewal_ids or [-1]))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        challenged_renewal_ids = {ch.challenges_application_id for ch in challenge_rows}
+
+        renewal_grouped: dict[tuple[str, int], list[dict[str, Any]]] = {}
+        for app in renewal_apps:
+            # Fallback renewal_year → academic_year matches the rest of the
+            # Phase 6 code (see _count_approved_renewals_per_pool).
+            year_key = int(app.renewal_year) if app.renewal_year is not None else int(academic_year)
+            key = (app.sub_scholarship_type, year_key)
+            renewal_grouped.setdefault(key, []).append(
+                {
+                    "application_id": app.id,
+                    "student_name": app.student.name if app.student else None,
+                    "has_challenge": app.id in challenged_renewal_ids,
+                }
+            )
+
+        # --- 2. Available quotas per (sub_type, allocation_year) --- #
+        used = await self._count_approved_renewals_per_pool(scholarship_type_id, academic_year)
+        available_quotas: list[dict[str, Any]] = []
+        for sub_type, year_map in quotas.items():
+            # Skip legacy non-year-keyed entries (e.g. {college_code: int}).
+            if not isinstance(year_map, dict):
+                continue
+            for year_key, total in year_map.items():
+                try:
+                    year = int(year_key)
+                except (TypeError, ValueError):
+                    # Non-int keys (legacy college matrix) are not used by
+                    # the Phase 6 algorithm — skip silently.
+                    continue
+                try:
+                    total_int = int(total)
+                except (TypeError, ValueError):
+                    continue
+                used_count = used.get((sub_type, year), 0)
+                available_quotas.append(
+                    {
+                        "sub_type": sub_type,
+                        "allocation_year": year,
+                        "total": total_int,
+                        "used": used_count,
+                        "remaining": total_int - used_count,
+                    }
+                )
+
+        # --- 3. Candidates (general phase, non-renewal) --- #
+        candidates_result = await self.db.execute(
+            select(CollegeRankingItem, Application)
+            .options(joinedload(Application.student))
+            .join(Application, CollegeRankingItem.application_id == Application.id)
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.is_renewal.is_(False),
+                Application.deleted_at.is_(None),
+            )
+            .order_by(CollegeRankingItem.rank_position)
+        )
+        cands = candidates_result.unique().all()
+
+        # Batch-load the renewal targets of any challenge candidates so we
+        # avoid N+1 lookups for the (typically small) challenge subset.
+        challenge_target_ids = {
+            app.challenges_application_id for _, app in cands if app.challenges_application_id is not None
+        }
+        renewal_by_id: dict[int, Application] = {}
+        if challenge_target_ids:
+            target_rows = (
+                (await self.db.execute(select(Application).where(Application.id.in_(challenge_target_ids))))
+                .scalars()
+                .all()
+            )
+            renewal_by_id = {r.id: r for r in target_rows}
+
+        candidates: list[dict[str, Any]] = []
+        for ri, app in cands:
+            challenged_renewal: Optional[dict[str, Any]] = None
+            if app.challenges_application_id:
+                renewal = renewal_by_id.get(app.challenges_application_id)
+                if renewal is not None:
+                    challenged_renewal = {
+                        "renewal_application_id": renewal.id,
+                        "sub_type": renewal.sub_scholarship_type,
+                        "renewal_year": renewal.renewal_year,
+                    }
+            candidates.append(
+                {
+                    "rank": ri.rank_position,
+                    "application_id": app.id,
+                    "student_name": app.student.name if app.student else None,
+                    "is_challenge": app.challenges_application_id is not None,
+                    "challenged_renewal": challenged_renewal,
+                    "applying_sub_type": app.sub_scholarship_type,
+                }
+            )
+
+        return {
+            "renewal_allocations": [
+                {"sub_type": sub_type, "renewal_year": year, "applications": items}
+                for (sub_type, year), items in renewal_grouped.items()
+            ],
+            "available_quotas": available_quotas,
+            "candidates": candidates,
+        }
+
+    async def preview_release_chain(self, proposed_allocations: list) -> dict[str, Any]:
+        """Dry-run preview: which renewals would be cancelled and who would fill in.
+
+        For each proposed allocation whose application is a challenge (i.e.
+        has challenges_application_id set), returns the renewal that would
+        be cancelled and the next waitlist candidate who would inherit the
+        freed slot. Does not persist anything.
+        """
+        chain: list[dict[str, Any]] = []
+        # Track per-sub_type fill-in suggestions so a single preview call
+        # never suggests the same waitlist candidate twice.
+        used_fill_ids: set[int] = set()
+
+        for alloc in proposed_allocations:
+            # Support both Pydantic schema objects and plain dicts.
+            ranking_item_id = getattr(alloc, "ranking_item_id", None)
+            if ranking_item_id is None and isinstance(alloc, dict):
+                ranking_item_id = alloc.get("ranking_item_id")
+            if ranking_item_id is None:
+                continue
+
+            item = await self.db.scalar(
+                select(CollegeRankingItem)
+                .options(selectinload(CollegeRankingItem.application))
+                .where(CollegeRankingItem.id == ranking_item_id)
+            )
+            if item is None or item.application is None:
+                continue
+            app = item.application
+            if not app.challenges_application_id:
+                continue
+
+            renewal = await self.db.scalar(select(Application).where(Application.id == app.challenges_application_id))
+            if renewal is None:
+                continue
+
+            waitlist = await self._get_waitlist_candidates(
+                renewal.scholarship_type_id,
+                app.academic_year,
+                renewal.sub_scholarship_type,
+                limit=len(used_fill_ids) + 1,
+            )
+            suggested_app: Optional[Application] = None
+            for cand in waitlist:
+                if cand.application and cand.application.id not in used_fill_ids:
+                    suggested_app = cand.application
+                    used_fill_ids.add(suggested_app.id)
+                    break
+
+            suggested_name: Optional[str] = None
+            if suggested_app is not None:
+                sd = suggested_app.student_data or {}
+                suggested_name = sd.get("std_cname") or sd.get("name")
+
+            chain.append(
+                {
+                    "challenge_application_id": app.id,
+                    "cancelled_application_id": renewal.id,
+                    "freed_slot": {
+                        "sub_type": renewal.sub_scholarship_type,
+                        "allocation_year": (int(renewal.renewal_year) if renewal.renewal_year is not None else None),
+                    },
+                    "suggested_fill_id": suggested_app.id if suggested_app else None,
+                    "suggested_fill_name": suggested_name,
+                }
+            )
+
+        return {"release_chain": chain}

--- a/backend/app/services/renewal_audit_service.py
+++ b/backend/app/services/renewal_audit_service.py
@@ -1,0 +1,80 @@
+"""RenewalAuditService — check invariants for renewal/challenge state.
+
+Per spec Section 12, every approved challenge application MUST point to a
+renewal whose status is `cancelled_by_challenge`. The general-distribution
+algorithm enforces this transition atomically when a challenge is approved,
+but operational issues (manual data fixes, partial migrations, bugs in
+future refactors) can break the invariant.
+
+This service surfaces violations so admins can spot data drift quickly.
+"""
+
+from typing import Dict, List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus
+
+
+class RenewalAuditService:
+    """Audit invariants tying approved challenges to their cancelled renewals."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def find_invariant_violations(self) -> List[Dict]:
+        """Find approved challenges whose linked renewal is not cancelled_by_challenge.
+
+        Invariant (spec §12): for every Application_C with
+        ``status == approved`` and ``challenges_application_id IS NOT NULL``,
+        the referenced renewal application must have
+        ``status == cancelled_by_challenge``.
+
+        Returns:
+            A list of violation dicts, each shaped as::
+
+                {
+                    "challenge_id": int,
+                    "renewal_id": int,
+                    "actual_renewal_status": str,  # the .value of the status
+                }
+
+            Returns an empty list when the invariant holds for all rows.
+        """
+        stmt = select(
+            Application.id,
+            Application.challenges_application_id,
+            Application.status,
+        ).where(
+            Application.challenges_application_id.is_not(None),
+            Application.status == ApplicationStatus.approved,
+        )
+        rows = (await self.db.execute(stmt)).all()
+
+        violations: List[Dict] = []
+        for challenge_id, renewal_id, _challenge_status in rows:
+            renewal = await self.db.scalar(select(Application).where(Application.id == renewal_id))
+            if renewal is None:
+                # Dangling FK — treat as a violation so it surfaces in the audit.
+                violations.append(
+                    {
+                        "challenge_id": challenge_id,
+                        "renewal_id": renewal_id,
+                        "actual_renewal_status": None,
+                    }
+                )
+                continue
+
+            if renewal.status != ApplicationStatus.cancelled_by_challenge:
+                actual = renewal.status.value if hasattr(renewal.status, "value") else renewal.status
+                violations.append(
+                    {
+                        "challenge_id": challenge_id,
+                        "renewal_id": renewal_id,
+                        "actual_renewal_status": actual,
+                    }
+                )
+
+        return violations

--- a/backend/app/services/renewal_distribution_service.py
+++ b/backend/app/services/renewal_distribution_service.py
@@ -1,0 +1,106 @@
+"""RenewalDistributionService — auto-approve renewals that have passed reviews.
+
+Renewal applications, unlike general applications, do NOT go through the
+college_ranking step. Once they have cleared the required review stages
+(professor +/- college), administrators trigger this service to flip them
+from `under_review` straight to `approved` with `review_stage =
+quota_distributed`.
+
+The terminal stage is configuration-driven so scholarships that skip college
+review (`ScholarshipConfiguration.requires_college_review = False`) only need
+the professor review to finish before auto-approval.
+"""
+
+from typing import Dict, List
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, ReviewStage
+from app.models.scholarship import ScholarshipConfiguration
+
+
+class RenewalDistributionService:
+    """Service that auto-approves renewal applications past their review stage."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def _resolve_terminal_stages(self, scholarship_type_id: int, academic_year: int) -> List[ReviewStage]:
+        """Return the review stage(s) at which a renewal becomes eligible
+        for auto-approval, based on the configuration's review-flow flags.
+
+        - requires_college_review = True (default) -> [college_reviewed]
+        - requires_college_review = False          -> [professor_reviewed]
+
+        When no configuration row exists we conservatively default to
+        college_reviewed: matches the dominant pattern in this codebase and
+        avoids accidentally promoting renewals after only a professor review.
+        """
+        config = await self.db.scalar(
+            select(ScholarshipConfiguration).where(
+                ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
+                ScholarshipConfiguration.academic_year == academic_year,
+            )
+        )
+        requires_college = True
+        if config is not None:
+            # `requires_college_review` defaults to False at the column level
+            # but the active scholarship configurations in this system have it
+            # set explicitly; trust whatever the row says.
+            requires_college = bool(getattr(config, "requires_college_review", True))
+
+        if requires_college:
+            return [ReviewStage.college_reviewed]
+        return [ReviewStage.professor_reviewed]
+
+    async def auto_approve_passed_reviews(self, scholarship_type_id: int, academic_year: int) -> Dict[str, object]:
+        """Auto-approve renewal applications past their terminal review stage.
+
+        Matches:
+            - is_renewal = True
+            - status = under_review
+            - review_stage in terminal stages (per configuration)
+            - scholarship_type_id / academic_year as supplied
+
+        Side effects:
+            - Updates matched applications:
+                status = approved
+                review_stage = quota_distributed
+            - Commits the surrounding transaction.
+
+        Returns:
+            {
+              "approved_count": int,
+              "approved_ids": List[int],
+            }
+        """
+        terminal_stages = await self._resolve_terminal_stages(
+            scholarship_type_id=scholarship_type_id, academic_year=academic_year
+        )
+
+        stmt = (
+            update(Application)
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.is_renewal.is_(True),
+                Application.status == ApplicationStatus.under_review,
+                Application.review_stage.in_(terminal_stages),
+            )
+            .values(
+                status=ApplicationStatus.approved,
+                review_stage=ReviewStage.quota_distributed,
+            )
+            .returning(Application.id)
+            .execution_options(synchronize_session="fetch")
+        )
+        result = await self.db.execute(stmt)
+        approved_ids = [row[0] for row in result.all()]
+        await self.db.commit()
+
+        return {
+            "approved_count": len(approved_ids),
+            "approved_ids": approved_ids,
+        }

--- a/backend/app/services/renewal_eligibility_service.py
+++ b/backend/app/services/renewal_eligibility_service.py
@@ -1,0 +1,78 @@
+"""
+RenewalEligibilityService - determine which prior approved applications are
+eligible to be renewed in the current academic year.
+
+Architecture note:
+    `renewal_application_start_date` / `renewal_application_end_date` live on
+    `ScholarshipConfiguration` (one per ScholarshipType x academic_year x
+    semester), NOT on `ScholarshipType`. To decide whether a prior approved
+    application can be renewed *right now*, we look up the current-year
+    configuration for that same scholarship_type and check its renewal window.
+
+Eligibility rules (Phase 2, Section 7.1 of the renewal spec):
+    1. The application belongs to `user_id`.
+    2. Its `academic_year == current_academic_year - 1` (only previous-year
+       cohorts may renew).
+    3. Its `status == ApplicationStatus.approved`.
+    4. The scholarship_type has a current-year ScholarshipConfiguration whose
+       renewal_application window currently brackets `now`.
+"""
+
+from datetime import datetime, timezone
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus
+from app.models.scholarship import ScholarshipConfiguration
+
+
+class RenewalEligibilityService:
+    """Service that identifies prior-year approved applications eligible for renewal."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_eligible_renewals(self, user_id: int, current_academic_year: int) -> List[Application]:
+        """Return prior-year approved applications whose scholarship_type has an
+        active renewal_application window in the current academic year.
+
+        Args:
+            user_id: The student's user id.
+            current_academic_year: Academic year the student would be applying
+                for (e.g. 114). Prior cohort is `current_academic_year - 1`.
+
+        Returns:
+            List of Application instances. Empty list when none qualify.
+        """
+        now = datetime.now(timezone.utc)
+        prior_year = current_academic_year - 1
+
+        # Join through ScholarshipConfiguration on (scholarship_type_id,
+        # academic_year=current). The configuration row must have a non-null
+        # renewal window bracketing `now`.
+        stmt = (
+            select(Application)
+            .options(joinedload(Application.scholarship_type_ref))
+            .join(
+                ScholarshipConfiguration,
+                ScholarshipConfiguration.scholarship_type_id == Application.scholarship_type_id,
+            )
+            .where(
+                Application.user_id == user_id,
+                Application.academic_year == prior_year,
+                Application.status == ApplicationStatus.approved,
+                ScholarshipConfiguration.academic_year == current_academic_year,
+                ScholarshipConfiguration.is_active.is_(True),
+                ScholarshipConfiguration.renewal_application_start_date.is_not(None),
+                ScholarshipConfiguration.renewal_application_end_date.is_not(None),
+                ScholarshipConfiguration.renewal_application_start_date <= now,
+                ScholarshipConfiguration.renewal_application_end_date >= now,
+            )
+        )
+
+        result = await self.db.execute(stmt)
+        return list(result.scalars().unique().all())

--- a/backend/app/services/review_phase_filter.py
+++ b/backend/app/services/review_phase_filter.py
@@ -1,0 +1,134 @@
+"""Helpers for filtering pending-review listings by renewal vs general phase.
+
+Educators (professors and college reviewers) should only see applications
+appropriate for the *current* review phase:
+
+- During a configuration's **renewal_{role}_review** window: only renewal
+  applications (``is_renewal=True``) for that configuration.
+- During the general **{role}_review** window: only non-renewal applications
+  (``is_renewal=False``) for that configuration.
+
+The renewal review windows live on :class:`ScholarshipConfiguration`
+(``renewal_professor_review_*``, ``renewal_college_review_*``), and so do
+the general windows (``professor_review_*``, ``college_review_*``).
+
+This module is intentionally a tiny pure-SQL builder so both the professor
+listing endpoint and the college listing endpoint can reuse the same filter
+without inheriting any service state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import aliased
+from sqlalchemy.sql import Select
+
+from app.models.application import Application
+from app.models.scholarship import ScholarshipConfiguration
+
+ReviewRole = Literal["professor", "college"]
+
+
+def _now_utc() -> datetime:
+    """UTC-aware "now"; isolated for easy patching in tests."""
+    return datetime.now(timezone.utc)
+
+
+def _config_fields_for_role(cfg, role: ReviewRole):
+    """Return (renewal_start, renewal_end, general_start, general_end)
+    columns on the supplied :class:`ScholarshipConfiguration` (or alias)
+    matching ``role``.
+    """
+    if role == "professor":
+        return (
+            cfg.renewal_professor_review_start,
+            cfg.renewal_professor_review_end,
+            cfg.professor_review_start,
+            cfg.professor_review_end,
+        )
+    if role == "college":
+        return (
+            cfg.renewal_college_review_start,
+            cfg.renewal_college_review_end,
+            cfg.college_review_start,
+            cfg.college_review_end,
+        )
+    raise ValueError(f"Unknown review role: {role!r}")
+
+
+def apply_renewal_phase_filter(
+    stmt: Select,
+    *,
+    role: ReviewRole,
+    now: datetime | None = None,
+    alias_name: str = "renewal_phase_cfg",
+) -> Select:
+    """Restrict ``stmt`` to applications whose review-phase membership matches
+    the current time.
+
+    The caller is expected to have already constrained ``stmt`` to "pending"
+    rows (typically ``status == under_review``); this filter overlays the
+    renewal-vs-general phase split.
+
+    Join strategy:
+      - We join an *aliased* :class:`ScholarshipConfiguration` on
+        ``(scholarship_type_id, academic_year)`` so this composes cleanly with
+        callers that already join ``Application.scholarship_configuration``
+        through the FK relationship.
+      - Semester is intentionally NOT part of the join because renewal review
+        windows are configured at the year level — matching on semester would
+        silently drop yearly-only configurations.
+
+    Args:
+        stmt:       A ``select(Application)``-style statement to constrain.
+        role:       Which review role's windows to consider ("professor" /
+                    "college").
+        now:        Override "current time" — for tests. Naive datetimes are
+                    treated as UTC, mirroring ``renewal.py:_to_utc_aware``.
+        alias_name: Alias for the joined ScholarshipConfiguration; override if
+                    the caller already uses this alias name.
+
+    Returns:
+        A new ``Select`` with the join + WHERE applied.
+    """
+    if now is None:
+        now = _now_utc()
+    elif now.tzinfo is None:
+        # Treat naive datetimes as UTC for consistency with the rest of the codebase
+        # (see api/v1/endpoints/renewal.py `_to_utc_aware`).
+        now = now.replace(tzinfo=timezone.utc)
+
+    cfg = aliased(ScholarshipConfiguration, name=alias_name)
+    renewal_start, renewal_end, general_start, general_end = _config_fields_for_role(cfg, role)
+
+    stmt = stmt.join(
+        cfg,
+        and_(
+            Application.scholarship_type_id == cfg.scholarship_type_id,
+            Application.academic_year == cfg.academic_year,
+        ),
+    )
+
+    stmt = stmt.where(
+        or_(
+            and_(
+                Application.is_renewal.is_(True),
+                renewal_start.isnot(None),
+                renewal_end.isnot(None),
+                renewal_start <= now,
+                renewal_end >= now,
+            ),
+            and_(
+                Application.is_renewal.is_(False),
+                general_start.isnot(None),
+                general_end.isnot(None),
+                general_start <= now,
+                general_end >= now,
+            ),
+        )
+    )
+
+    return stmt

--- a/backend/app/tests/test_application_service.py
+++ b/backend/app/tests/test_application_service.py
@@ -440,6 +440,11 @@ class TestApplicationService:
         mock_application.scholarship = None
         mock_application.student = None
         mock_application.scholarship_subtype_list = []
+        mock_application.sub_scholarship_type = "general"
+        mock_application.renewal_year = None
+        mock_application.previous_application_id = None
+        mock_application.challenges_application_id = None
+        mock_application.cancelled_due_to_application_id = None
 
         with patch.object(service, "_get_application_model", new_callable=AsyncMock) as mock_get_model:
             mock_get_model.return_value = mock_application

--- a/backend/app/tests/test_challenge_release_distribution.py
+++ b/backend/app/tests/test_challenge_release_distribution.py
@@ -1,0 +1,345 @@
+"""Integration test for Phase 6: challenge release + waitlist fill-in.
+
+Mirrors the spec Section 9.3 scenario:
+
+Scholarship configuration::
+
+    quotas = {"nstc": {"114": 8, "113": 0}, "moe_1w": {"114": 6}}
+
+  - 1 renewal application for student A: is_renewal=True,
+    sub_scholarship_type=nstc, renewal_year=113, academic_year=114,
+    status=approved. (Approved renewal occupies the only nstc[113] slot.)
+  - 1 challenge application from A: is_renewal=False,
+    challenges_application_id=renewal_A.id, sub_scholarship_type=moe_1w,
+    academic_year=114, status=under_review. Ranked #1 in moe_1w.
+  - 10 pure-new nstc candidates ranked 1..10, status=under_review.
+  - 5 pure-new moe_1w candidates ranked 2..6, status=under_review.
+
+After ``execute_general_distribution``:
+
+  - challenge_A.status == approved
+  - renewal_A.status == cancelled_by_challenge
+  - renewal_A.cancelled_due_to_application_id == challenge_A.id
+  - nstc rank #9 (the first pure-new waitlist candidate) is approved,
+    with allocation_year = 113 (the slot freed by A's cancelled renewal).
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import ApplicationStatus, ReviewStage, SubTypeSelectionMode
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.manual_distribution_service import ManualDistributionService
+
+CURRENT_ACADEMIC_YEAR = 114
+RENEWAL_YEAR = 113
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_user(suffix: str) -> User:
+    return User(
+        nycu_id=f"phase6_{suffix}",
+        name=f"Phase6 Test {suffix}",
+        email=f"phase6_{suffix}@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+
+
+def _make_application(
+    *,
+    user_id: int,
+    scholarship_type_id: int,
+    app_id: str,
+    sub_scholarship_type: str,
+    status: ApplicationStatus,
+    review_stage: ReviewStage,
+    is_renewal: bool = False,
+    renewal_year: int | None = None,
+    challenges_application_id: int | None = None,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+) -> Application:
+    return Application(
+        app_id=app_id,
+        user_id=user_id,
+        scholarship_type_id=scholarship_type_id,
+        scholarship_subtype_list=[sub_scholarship_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=sub_scholarship_type,
+        academic_year=academic_year,
+        semester=None,
+        status=status,
+        review_stage=review_stage,
+        is_renewal=is_renewal,
+        renewal_year=renewal_year,
+        challenges_application_id=challenges_application_id,
+        agree_terms=True,
+    )
+
+
+async def _make_ranking_with_item(
+    db: AsyncSession,
+    *,
+    scholarship_type_id: int,
+    sub_type_code: str,
+    application_id: int,
+    rank_position: int,
+) -> CollegeRankingItem:
+    """Create (or reuse) a CollegeRanking row for (sub_type, year) and attach an item."""
+    existing = (
+        (
+            await db.execute(
+                select(CollegeRanking).where(
+                    CollegeRanking.scholarship_type_id == scholarship_type_id,
+                    CollegeRanking.sub_type_code == sub_type_code,
+                    CollegeRanking.academic_year == CURRENT_ACADEMIC_YEAR,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if existing is None:
+        ranking = CollegeRanking(
+            scholarship_type_id=scholarship_type_id,
+            sub_type_code=sub_type_code,
+            academic_year=CURRENT_ACADEMIC_YEAR,
+            semester=None,
+            is_finalized=True,
+            ranking_status="finalized",
+        )
+        db.add(ranking)
+        await db.commit()
+        await db.refresh(ranking)
+    else:
+        ranking = existing
+
+    item = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=application_id,
+        rank_position=rank_position,
+        is_allocated=False,
+        status="ranked",
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
+# --------------------------------------------------------------------------- #
+# Test
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_challenge_success_releases_renewal_and_fills_waitlist(
+    db: AsyncSession,
+):
+    # ------------------------------------------------------------------- #
+    # Scholarship type + configuration
+    # ------------------------------------------------------------------- #
+    sch = ScholarshipType(
+        code="phase6_sch",
+        name="Phase 6 Test Scholarship",
+        description="Fixture for challenge-release distribution",
+    )
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        semester=None,
+        config_name="Phase 6 Config",
+        config_code="phase6-config",
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        quotas={"nstc": {"114": 8, "113": 0}, "moe_1w": {"114": 6}},
+        prior_quota_years={"nstc": [113], "moe_1w": []},
+    )
+    db.add(config)
+    await db.commit()
+
+    # ------------------------------------------------------------------- #
+    # Users
+    # ------------------------------------------------------------------- #
+    user_A = _make_user("A")
+    db.add(user_A)
+
+    nstc_users: list[User] = [_make_user(f"nstc{i}") for i in range(1, 11)]
+    db.add_all(nstc_users)
+
+    moe_users: list[User] = [_make_user(f"moe{i}") for i in range(2, 7)]
+    db.add_all(moe_users)
+    await db.commit()
+    await db.refresh(user_A)
+    for u in nstc_users + moe_users:
+        await db.refresh(u)
+
+    # ------------------------------------------------------------------- #
+    # A's renewal (already approved, occupies nstc[113] slot)
+    # ------------------------------------------------------------------- #
+    renewal_A = _make_application(
+        user_id=user_A.id,
+        scholarship_type_id=sch.id,
+        app_id="APP-114-0-A0R01",
+        sub_scholarship_type="nstc",
+        status=ApplicationStatus.approved,
+        review_stage=ReviewStage.quota_distributed,
+        is_renewal=True,
+        renewal_year=RENEWAL_YEAR,
+    )
+    db.add(renewal_A)
+    await db.commit()
+    await db.refresh(renewal_A)
+
+    # A's challenge on moe_1w (under_review, ranked #1 in moe_1w)
+    challenge_A = _make_application(
+        user_id=user_A.id,
+        scholarship_type_id=sch.id,
+        app_id="APP-114-0-A0C01",
+        sub_scholarship_type="moe_1w",
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.college_ranked,
+        is_renewal=False,
+        challenges_application_id=renewal_A.id,
+    )
+    db.add(challenge_A)
+    await db.commit()
+    await db.refresh(challenge_A)
+
+    # ------------------------------------------------------------------- #
+    # Pure-new nstc candidates (ranks 1..10)
+    # ------------------------------------------------------------------- #
+    nstc_apps: list[Application] = []
+    for idx, u in enumerate(nstc_users, start=1):
+        app = _make_application(
+            user_id=u.id,
+            scholarship_type_id=sch.id,
+            app_id=f"APP-114-0-NSTC{idx:03d}",
+            sub_scholarship_type="nstc",
+            status=ApplicationStatus.under_review,
+            review_stage=ReviewStage.college_ranked,
+        )
+        db.add(app)
+        nstc_apps.append(app)
+    await db.commit()
+    for app in nstc_apps:
+        await db.refresh(app)
+    for idx, app in enumerate(nstc_apps, start=1):
+        await _make_ranking_with_item(
+            db,
+            scholarship_type_id=sch.id,
+            sub_type_code="nstc",
+            application_id=app.id,
+            rank_position=idx,
+        )
+
+    # ------------------------------------------------------------------- #
+    # moe_1w candidates — A's challenge at rank 1, plus pure-new at ranks 2..6
+    # ------------------------------------------------------------------- #
+    await _make_ranking_with_item(
+        db,
+        scholarship_type_id=sch.id,
+        sub_type_code="moe_1w",
+        application_id=challenge_A.id,
+        rank_position=1,
+    )
+    moe_apps: list[Application] = []
+    for idx, u in enumerate(moe_users, start=2):
+        app = _make_application(
+            user_id=u.id,
+            scholarship_type_id=sch.id,
+            app_id=f"APP-114-0-MOE{idx:03d}",
+            sub_scholarship_type="moe_1w",
+            status=ApplicationStatus.under_review,
+            review_stage=ReviewStage.college_ranked,
+        )
+        db.add(app)
+        moe_apps.append(app)
+    await db.commit()
+    for app in moe_apps:
+        await db.refresh(app)
+    for app in moe_apps:
+        await _make_ranking_with_item(
+            db,
+            scholarship_type_id=sch.id,
+            sub_type_code="moe_1w",
+            application_id=app.id,
+            rank_position=int(app.app_id[-3:]),
+        )
+
+    # ------------------------------------------------------------------- #
+    # Act
+    # ------------------------------------------------------------------- #
+    service = ManualDistributionService(db)
+    result = await service.execute_general_distribution(
+        scholarship_type_id=sch.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+    )
+
+    # ------------------------------------------------------------------- #
+    # Assert — summary stats
+    # ------------------------------------------------------------------- #
+    assert result["approved_renewals"] == 1
+    assert result["approved_challenges"] == 1
+    # released: A's renewal freed up (nstc, 113) ×1
+    assert result["released_slots"] == {("nstc", RENEWAL_YEAR): 1}
+    assert result["filled_in"] == 1
+    assert result["unfilled"] == 0
+
+    # Invariant (spec §10): every released slot is accounted for as either
+    # filled in or left unfilled. This guards against silent drift in the
+    # distribution summary stats.
+    assert sum(result["released_slots"].values()) == result["filled_in"] + result["unfilled"]
+
+    # ------------------------------------------------------------------- #
+    # Assert — challenge approved, renewal cancelled by challenge
+    # ------------------------------------------------------------------- #
+    await db.refresh(challenge_A)
+    await db.refresh(renewal_A)
+    assert challenge_A.status == ApplicationStatus.approved
+    assert renewal_A.status == ApplicationStatus.cancelled_by_challenge
+    assert renewal_A.cancelled_due_to_application_id == challenge_A.id
+
+    # ------------------------------------------------------------------- #
+    # Assert — first-round nstc winners are ranks 1..8, approved on nstc[114]
+    # ------------------------------------------------------------------- #
+    for idx in range(8):
+        await db.refresh(nstc_apps[idx])
+        assert (
+            nstc_apps[idx].status == ApplicationStatus.approved
+        ), f"nstc rank {idx + 1} should be approved (first-round winner)"
+
+    # Rank #9 (index 8) was filled-in from waitlist on the freed nstc[113] slot.
+    await db.refresh(nstc_apps[8])
+    assert (
+        nstc_apps[8].status == ApplicationStatus.approved
+    ), "nstc rank #9 should be promoted from waitlist after challenge release"
+
+    # Verify rank #9's CollegeRankingItem.allocation_year was set to 113
+    rank9_item = (
+        (await db.execute(select(CollegeRankingItem).where(CollegeRankingItem.application_id == nstc_apps[8].id)))
+        .scalars()
+        .first()
+    )
+    assert rank9_item is not None
+    assert rank9_item.allocation_year == RENEWAL_YEAR
+
+    # Rank #10 should still be under_review (no more slots to fill)
+    await db.refresh(nstc_apps[9])
+    assert nstc_apps[9].status == ApplicationStatus.under_review
+
+    # Student academic_year unchanged for the filled-in candidate
+    assert nstc_apps[8].academic_year == CURRENT_ACADEMIC_YEAR

--- a/backend/app/tests/test_distribution_state_endpoint.py
+++ b/backend/app/tests/test_distribution_state_endpoint.py
@@ -1,0 +1,517 @@
+"""Tests for the manual distribution state endpoint (Phase 8.1).
+
+Covers:
+- GET /api/v1/manual-distribution/state?scholarship_type_id=X&academic_year=Y
+
+The endpoint aggregates three views the admin Manual Distribution panel needs:
+  * ``renewal_allocations`` — approved renewals grouped by
+    ``(sub_type, renewal_year)`` with a ``has_challenge`` flag per renewal.
+  * ``available_quotas`` — per ``(sub_type, allocation_year)``: total / used /
+    remaining where ``used`` is approved renewals consumed from that pool.
+  * ``candidates`` — non-renewal applicants ordered by
+    ``CollegeRankingItem.rank_position`` with ``is_challenge`` and a
+    ``challenged_renewal`` payload.
+
+Auth is mocked via ``app.dependency_overrides[get_current_admin_user]`` so
+tests don't need real JWT tokens — same pattern as
+``test_renewal_distribution_result.py``.
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_admin_user
+from app.main import app
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import ApplicationStatus, ReviewStage, SubTypeSelectionMode
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+
+CURRENT_ACADEMIC_YEAR = 114
+PRIOR_ACADEMIC_YEAR = 113
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession) -> User:
+    user = User(
+        nycu_id="admin_state",
+        name="State Admin",
+        email="state_admin@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def admin_client(client: AsyncClient, admin_user: User, db: AsyncSession):
+    """Yield a client with admin auth + a second get_db override.
+
+    NOTE: conftest's ``client`` fixture overrides ``app.db.deps.get_db``,
+    but ``manual_distribution.py`` imports ``get_db`` from
+    ``app.core.deps`` (a separate function object). Without overriding
+    *both*, the endpoint creates a fresh ``AsyncSessionLocal`` session
+    that points at the production database URL, bypassing our in-memory
+    SQLite — yielding "no such table" errors.
+    """
+    from app.core.deps import get_db as core_get_db
+
+    async def override_admin():
+        return admin_user
+
+    async def override_db():
+        yield db
+
+    app.dependency_overrides[get_current_admin_user] = override_admin
+    app.dependency_overrides[core_get_db] = override_db
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.pop(get_current_admin_user, None)
+        app.dependency_overrides.pop(core_get_db, None)
+
+
+@pytest_asyncio.fixture
+async def scholarship_with_config(db: AsyncSession) -> ScholarshipType:
+    """Scholarship type + an active configuration with year-keyed quotas."""
+    sch = ScholarshipType(
+        code="phase8_sch",
+        name="Phase 8 Test Scholarship",
+        description="Fixture for distribution state endpoint",
+    )
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        semester=None,
+        config_name="Phase 8 Config",
+        config_code="phase8-config",
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        quotas={
+            "nstc": {"114": 8, "113": 2},
+            "moe_1w": {"114": 5},
+        },
+        prior_quota_years={"nstc": [PRIOR_ACADEMIC_YEAR], "moe_1w": []},
+    )
+    db.add(config)
+    await db.commit()
+    return sch
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+async def _make_student(db: AsyncSession, *, suffix: str, name: str) -> User:
+    user = User(
+        nycu_id=f"stu_{suffix}",
+        name=name,
+        email=f"stu_{suffix}@university.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _make_renewal_app(
+    db: AsyncSession,
+    *,
+    user: User,
+    scholarship_type: ScholarshipType,
+    sub_type: str,
+    renewal_year: int,
+    status_value: ApplicationStatus = ApplicationStatus.approved,
+    app_id_suffix: str,
+) -> Application:
+    app_row = Application(
+        app_id=f"APP-{CURRENT_ACADEMIC_YEAR}-0-{app_id_suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship_type.id,
+        scholarship_subtype_list=[sub_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=sub_type,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        semester=None,
+        status=status_value,
+        review_stage=ReviewStage.quota_distributed,
+        is_renewal=True,
+        renewal_year=renewal_year,
+        agree_terms=True,
+    )
+    db.add(app_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return app_row
+
+
+async def _make_new_app(
+    db: AsyncSession,
+    *,
+    user: User,
+    scholarship_type: ScholarshipType,
+    sub_type: str,
+    app_id_suffix: str,
+    challenges_application_id: int | None = None,
+) -> Application:
+    app_row = Application(
+        app_id=f"APP-{CURRENT_ACADEMIC_YEAR}-0-{app_id_suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship_type.id,
+        scholarship_subtype_list=[sub_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=sub_type,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        semester=None,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.college_ranked,
+        is_renewal=False,
+        challenges_application_id=challenges_application_id,
+        agree_terms=True,
+    )
+    db.add(app_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return app_row
+
+
+async def _attach_ranking_item(
+    db: AsyncSession,
+    *,
+    scholarship_type: ScholarshipType,
+    sub_type_code: str,
+    application_id: int,
+    rank_position: int,
+) -> CollegeRankingItem:
+    """Create (or reuse) a CollegeRanking row for the sub_type and add an item."""
+    from sqlalchemy import select
+
+    existing = (
+        (
+            await db.execute(
+                select(CollegeRanking).where(
+                    CollegeRanking.scholarship_type_id == scholarship_type.id,
+                    CollegeRanking.sub_type_code == sub_type_code,
+                    CollegeRanking.academic_year == CURRENT_ACADEMIC_YEAR,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if existing is None:
+        ranking = CollegeRanking(
+            scholarship_type_id=scholarship_type.id,
+            sub_type_code=sub_type_code,
+            academic_year=CURRENT_ACADEMIC_YEAR,
+            semester=None,
+            is_finalized=True,
+            ranking_status="finalized",
+        )
+        db.add(ranking)
+        await db.commit()
+        await db.refresh(ranking)
+    else:
+        ranking = existing
+
+    item = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=application_id,
+        rank_position=rank_position,
+        is_allocated=False,
+        status="ranked",
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_state_when_no_data(
+    db: AsyncSession,
+    admin_client: AsyncClient,
+    scholarship_with_config: ScholarshipType,
+):
+    """No applications → empty groups & candidates; available_quotas reflects config."""
+    resp = await admin_client.get(
+        "/api/v1/manual-distribution/state",
+        params={
+            "scholarship_type_id": scholarship_with_config.id,
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+
+    data = body["data"]
+    assert data["renewal_allocations"] == []
+    assert data["candidates"] == []
+
+    # available_quotas should mirror the config's year-keyed quotas with used=0
+    # and remaining=total since no approved renewals exist yet.
+    by_key = {(q["sub_type"], q["allocation_year"]): q for q in data["available_quotas"]}
+    assert ("nstc", 114) in by_key
+    assert by_key[("nstc", 114)] == {
+        "sub_type": "nstc",
+        "allocation_year": 114,
+        "total": 8,
+        "used": 0,
+        "remaining": 8,
+    }
+    assert by_key[("nstc", 113)]["remaining"] == 2
+    assert by_key[("moe_1w", 114)]["remaining"] == 5
+    assert len(data["available_quotas"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_groups_renewal_allocations_correctly(
+    db: AsyncSession,
+    admin_client: AsyncClient,
+    scholarship_with_config: ScholarshipType,
+):
+    """Renewals across multiple (sub_type, renewal_year) keys form separate groups."""
+    s1 = await _make_student(db, suffix="r1", name="Renewal One")
+    s2 = await _make_student(db, suffix="r2", name="Renewal Two")
+    s3 = await _make_student(db, suffix="r3", name="Renewal Three")
+    s4 = await _make_student(db, suffix="r4", name="Renewal Four")
+
+    # Group A: nstc / 113
+    await _make_renewal_app(
+        db,
+        user=s1,
+        scholarship_type=scholarship_with_config,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="10001",
+    )
+    # Group A (second member): nstc / 113
+    await _make_renewal_app(
+        db,
+        user=s2,
+        scholarship_type=scholarship_with_config,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="10002",
+    )
+    # Group B: nstc / 114 (same sub_type, different year)
+    await _make_renewal_app(
+        db,
+        user=s3,
+        scholarship_type=scholarship_with_config,
+        sub_type="nstc",
+        renewal_year=CURRENT_ACADEMIC_YEAR,
+        app_id_suffix="10003",
+    )
+    # Group C: moe_1w / 114 (different sub_type)
+    await _make_renewal_app(
+        db,
+        user=s4,
+        scholarship_type=scholarship_with_config,
+        sub_type="moe_1w",
+        renewal_year=CURRENT_ACADEMIC_YEAR,
+        app_id_suffix="10004",
+    )
+
+    resp = await admin_client.get(
+        "/api/v1/manual-distribution/state",
+        params={
+            "scholarship_type_id": scholarship_with_config.id,
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+
+    groups = data["renewal_allocations"]
+    assert len(groups) == 3
+    by_key = {(g["sub_type"], g["renewal_year"]): g for g in groups}
+
+    nstc_113 = by_key[("nstc", PRIOR_ACADEMIC_YEAR)]
+    assert len(nstc_113["applications"]) == 2
+    nstc_113_names = {a["student_name"] for a in nstc_113["applications"]}
+    assert nstc_113_names == {"Renewal One", "Renewal Two"}
+
+    assert len(by_key[("nstc", CURRENT_ACADEMIC_YEAR)]["applications"]) == 1
+    assert len(by_key[("moe_1w", CURRENT_ACADEMIC_YEAR)]["applications"]) == 1
+
+    # available_quotas should reflect approved renewals subtracted from pool.
+    quotas_by_key = {(q["sub_type"], q["allocation_year"]): q for q in data["available_quotas"]}
+    assert quotas_by_key[("nstc", PRIOR_ACADEMIC_YEAR)] == {
+        "sub_type": "nstc",
+        "allocation_year": PRIOR_ACADEMIC_YEAR,
+        "total": 2,
+        "used": 2,
+        "remaining": 0,
+    }
+    assert quotas_by_key[("nstc", CURRENT_ACADEMIC_YEAR)]["used"] == 1
+    assert quotas_by_key[("nstc", CURRENT_ACADEMIC_YEAR)]["remaining"] == 7
+    assert quotas_by_key[("moe_1w", CURRENT_ACADEMIC_YEAR)]["used"] == 1
+    assert quotas_by_key[("moe_1w", CURRENT_ACADEMIC_YEAR)]["remaining"] == 4
+
+
+@pytest.mark.asyncio
+async def test_marks_has_challenge_on_renewals_with_challenge(
+    db: AsyncSession,
+    admin_client: AsyncClient,
+    scholarship_with_config: ScholarshipType,
+):
+    """A renewal with a downstream challenge app → has_challenge=True; others False."""
+    stu_challenged = await _make_student(db, suffix="rc", name="Renewal Challenged")
+    stu_calm = await _make_student(db, suffix="rq", name="Renewal Quiet")
+
+    renewal_a = await _make_renewal_app(
+        db,
+        user=stu_challenged,
+        scholarship_type=scholarship_with_config,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="20001",
+    )
+    renewal_b = await _make_renewal_app(
+        db,
+        user=stu_calm,
+        scholarship_type=scholarship_with_config,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="20002",
+    )
+
+    # Challenge app targets renewal_a (with a different sub_type, per spec)
+    await _make_new_app(
+        db,
+        user=stu_challenged,
+        scholarship_type=scholarship_with_config,
+        sub_type="moe_1w",
+        app_id_suffix="29001",
+        challenges_application_id=renewal_a.id,
+    )
+
+    resp = await admin_client.get(
+        "/api/v1/manual-distribution/state",
+        params={
+            "scholarship_type_id": scholarship_with_config.id,
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+
+    groups = data["renewal_allocations"]
+    assert len(groups) == 1
+    apps = groups[0]["applications"]
+    by_id = {a["application_id"]: a for a in apps}
+    assert by_id[renewal_a.id]["has_challenge"] is True
+    assert by_id[renewal_b.id]["has_challenge"] is False
+
+
+@pytest.mark.asyncio
+async def test_candidate_list_includes_challenges(
+    db: AsyncSession,
+    admin_client: AsyncClient,
+    scholarship_with_config: ScholarshipType,
+):
+    """Challenge applications appear in candidates with is_challenge=True and a populated challenged_renewal."""
+    stu_renewal = await _make_student(db, suffix="ren", name="The Renewer")
+    stu_challenger = await _make_student(db, suffix="ch", name="The Challenger")
+    stu_pure = await _make_student(db, suffix="p", name="Pure New")
+
+    renewal = await _make_renewal_app(
+        db,
+        user=stu_renewal,
+        scholarship_type=scholarship_with_config,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="30001",
+    )
+
+    challenge_app = await _make_new_app(
+        db,
+        user=stu_challenger,
+        scholarship_type=scholarship_with_config,
+        sub_type="moe_1w",
+        app_id_suffix="39001",
+        challenges_application_id=renewal.id,
+    )
+    pure_app = await _make_new_app(
+        db,
+        user=stu_pure,
+        scholarship_type=scholarship_with_config,
+        sub_type="moe_1w",
+        app_id_suffix="39002",
+    )
+
+    # Rank challenger #1, pure-new #2 in moe_1w
+    await _attach_ranking_item(
+        db,
+        scholarship_type=scholarship_with_config,
+        sub_type_code="moe_1w",
+        application_id=challenge_app.id,
+        rank_position=1,
+    )
+    await _attach_ranking_item(
+        db,
+        scholarship_type=scholarship_with_config,
+        sub_type_code="moe_1w",
+        application_id=pure_app.id,
+        rank_position=2,
+    )
+
+    resp = await admin_client.get(
+        "/api/v1/manual-distribution/state",
+        params={
+            "scholarship_type_id": scholarship_with_config.id,
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+
+    cands = data["candidates"]
+    assert len(cands) == 2
+
+    by_app = {c["application_id"]: c for c in cands}
+
+    chal = by_app[challenge_app.id]
+    assert chal["is_challenge"] is True
+    assert chal["applying_sub_type"] == "moe_1w"
+    assert chal["rank"] == 1
+    assert chal["challenged_renewal"] == {
+        "renewal_application_id": renewal.id,
+        "sub_type": "nstc",
+        "renewal_year": PRIOR_ACADEMIC_YEAR,
+    }
+    assert chal["student_name"] == "The Challenger"
+
+    pure = by_app[pure_app.id]
+    assert pure["is_challenge"] is False
+    assert pure["challenged_renewal"] is None
+    assert pure["rank"] == 2
+
+    # Candidates ordered by rank_position
+    assert [c["rank"] for c in cands] == [1, 2]

--- a/backend/app/tests/test_renewal_application_creation.py
+++ b/backend/app/tests/test_renewal_application_creation.py
@@ -1,0 +1,417 @@
+"""Tests for renewal & challenge application creation endpoints.
+
+Covers:
+- POST /api/v1/renewals/                 → create renewal from prior approved app
+- POST /api/v1/renewals/challenge        → create challenge from approved renewal
+
+The endpoints validate against `ScholarshipConfiguration` (not `ScholarshipType`)
+for renewal_application_* and application_* date windows, matching the actual
+schema.
+
+Auth is mocked via `app.dependency_overrides[get_current_user]` so tests don't
+need real JWT tokens.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_current_user
+from app.main import app
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, ReviewStage, SubTypeSelectionMode
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User
+
+CURRENT_ACADEMIC_YEAR = 114
+PRIOR_ACADEMIC_YEAR = 113
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_renewal_config(
+    scholarship_type_id: int,
+    *,
+    config_code: str,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+    in_renewal_period: bool = True,
+    quotas: dict | None = None,
+) -> ScholarshipConfiguration:
+    """ScholarshipConfiguration with renewal window either open or closed."""
+    now = datetime.now(timezone.utc)
+    if in_renewal_period:
+        start = now - timedelta(days=1)
+        end = now + timedelta(days=7)
+    else:
+        start = now + timedelta(days=7)
+        end = now + timedelta(days=14)
+
+    return ScholarshipConfiguration(
+        scholarship_type_id=scholarship_type_id,
+        academic_year=academic_year,
+        semester=None,
+        config_name=f"Config {config_code}",
+        config_code=config_code,
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        renewal_application_start_date=start,
+        renewal_application_end_date=end,
+        quotas=quotas,
+    )
+
+
+def _make_general_config(
+    scholarship_type_id: int,
+    *,
+    config_code: str,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+    in_general_period: bool = True,
+    quotas: dict | None = None,
+) -> ScholarshipConfiguration:
+    """ScholarshipConfiguration with general application window either open or closed."""
+    now = datetime.now(timezone.utc)
+    if in_general_period:
+        start = now - timedelta(days=1)
+        end = now + timedelta(days=7)
+    else:
+        start = now + timedelta(days=7)
+        end = now + timedelta(days=14)
+
+    return ScholarshipConfiguration(
+        scholarship_type_id=scholarship_type_id,
+        academic_year=academic_year,
+        semester=None,
+        config_name=f"GenConfig {config_code}",
+        config_code=config_code,
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        application_start_date=start,
+        application_end_date=end,
+        quotas=quotas,
+    )
+
+
+async def _insert_prior_application(
+    db: AsyncSession,
+    *,
+    user: User,
+    scholarship_type: ScholarshipType,
+    configuration_id: int | None = None,
+    academic_year: int = PRIOR_ACADEMIC_YEAR,
+    status: ApplicationStatus = ApplicationStatus.approved,
+    sub_scholarship_type: str = "nstc",
+    is_renewal: bool = False,
+    renewal_year: int | None = None,
+    app_id_suffix: str = "00001",
+) -> Application:
+    app = Application(
+        app_id=f"APP-{academic_year}-0-{app_id_suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship_type.id,
+        scholarship_configuration_id=configuration_id,
+        scholarship_subtype_list=[sub_scholarship_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=sub_scholarship_type,
+        academic_year=academic_year,
+        semester=None,
+        status=status,
+        is_renewal=is_renewal,
+        renewal_year=renewal_year,
+        agree_terms=True,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+@pytest_asyncio.fixture
+async def authed_client(client: AsyncClient, test_user: User):
+    """Yield a client whose `get_current_user` always returns `test_user`.
+
+    Avoids the need for real JWT tokens in unit tests.
+    """
+
+    async def override_get_current_user():
+        return test_user
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture(autouse=True)
+def freeze_current_academic_year(monkeypatch):
+    """Force `get_current_academic_period()` to return AY114 so tests are stable."""
+    from app.utils import academic_period
+
+    def _fake_current_period():
+        return {"academic_year": CURRENT_ACADEMIC_YEAR, "semester": "first", "western_year": 2025}
+
+    monkeypatch.setattr(academic_period, "get_current_academic_period", _fake_current_period)
+
+
+# --------------------------------------------------------------------------- #
+# Renewal creation tests (Task 3.2)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_renewal_application_success(
+    db: AsyncSession,
+    authed_client: AsyncClient,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Approved prior app + open renewal window → 201 with renewal fields set."""
+    config = _make_renewal_config(test_scholarship.id, config_code="RE-114-OK")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    prior = await _insert_prior_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        sub_scholarship_type="nstc",
+    )
+
+    resp = await authed_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    new_app = body["data"]
+    assert new_app["is_renewal"] is True
+    assert new_app["sub_scholarship_type"] == "nstc"
+    assert new_app["previous_application_id"] == prior.id
+    assert new_app["academic_year"] == CURRENT_ACADEMIC_YEAR
+    assert new_app["renewal_year"] == PRIOR_ACADEMIC_YEAR
+
+
+@pytest.mark.asyncio
+async def test_create_renewal_rejects_when_prior_not_approved(
+    db: AsyncSession,
+    authed_client: AsyncClient,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Prior application status=rejected → 400."""
+    config = _make_renewal_config(test_scholarship.id, config_code="RE-114-REJ")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    prior = await _insert_prior_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        status=ApplicationStatus.rejected,
+    )
+
+    resp = await authed_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+    )
+    assert resp.status_code == 400
+    # The app's exception handler maps HTTPException.detail → "message"
+    detail = resp.json().get("message") or resp.json().get("detail", "")
+    assert "未核可" in detail or "approved" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_create_renewal_rejects_outside_period(
+    db: AsyncSession,
+    authed_client: AsyncClient,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """No active renewal window in current-year config → 400."""
+    config = _make_renewal_config(
+        test_scholarship.id,
+        config_code="RE-114-CLOSED",
+        in_renewal_period=False,
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    prior = await _insert_prior_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+    )
+
+    resp = await authed_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_renewal_rejects_duplicate(
+    db: AsyncSession,
+    authed_client: AsyncClient,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Second attempt against the same prior application → 409."""
+    config = _make_renewal_config(test_scholarship.id, config_code="RE-114-DUP")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    prior = await _insert_prior_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+    )
+
+    r1 = await authed_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+    )
+    assert r1.status_code == 201, r1.text
+
+    r2 = await authed_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+    )
+    assert r2.status_code == 409
+
+
+# --------------------------------------------------------------------------- #
+# Challenge creation tests (Task 3.4)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_create_challenge_success(
+    db: AsyncSession,
+    authed_client: AsyncClient,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Approved renewal + open general window → challenge created for different sub_type."""
+    config = _make_general_config(
+        test_scholarship.id,
+        config_code="GEN-114-OK",
+        quotas={"nstc": {"114": 8}, "moe_1w": {"114": 6}},
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal = await _insert_prior_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="99001",  # Prevent collision with generated app_id (sequence starts at 1)
+    )
+
+    resp = await authed_client.post(
+        "/api/v1/renewals/challenge",
+        json={"renewal_application_id": renewal.id, "target_sub_type": "moe_1w"},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()["data"]
+    assert data["is_renewal"] is False
+    assert data["sub_scholarship_type"] == "moe_1w"
+    assert data["challenges_application_id"] == renewal.id
+
+
+@pytest.mark.asyncio
+async def test_create_challenge_rejects_same_sub_type(
+    db: AsyncSession,
+    authed_client: AsyncClient,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """target_sub_type equal to renewal's sub_type → 400."""
+    config = _make_general_config(
+        test_scholarship.id,
+        config_code="GEN-114-SAME",
+        quotas={"nstc": {"114": 8}},
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal = await _insert_prior_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+    )
+
+    resp = await authed_client.post(
+        "/api/v1/renewals/challenge",
+        json={"renewal_application_id": renewal.id, "target_sub_type": "nstc"},
+    )
+    assert resp.status_code == 400
+    detail = resp.json().get("message") or resp.json().get("detail", "")
+    assert "sub_type" in detail
+
+
+@pytest.mark.asyncio
+async def test_create_challenge_rejects_when_renewal_not_approved(
+    db: AsyncSession,
+    authed_client: AsyncClient,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Renewal application status != approved → 400."""
+    config = _make_general_config(
+        test_scholarship.id,
+        config_code="GEN-114-NOT-APPR",
+        quotas={"nstc": {"114": 8}, "moe_1w": {"114": 6}},
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal = await _insert_prior_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+        status=ApplicationStatus.rejected,
+    )
+
+    resp = await authed_client.post(
+        "/api/v1/renewals/challenge",
+        json={"renewal_application_id": renewal.id, "target_sub_type": "moe_1w"},
+    )
+    assert resp.status_code == 400
+
+
+# Mark ReviewStage as imported (used in helper assertion in future)
+_ = ReviewStage

--- a/backend/app/tests/test_renewal_audit_service.py
+++ b/backend/app/tests/test_renewal_audit_service.py
@@ -1,0 +1,224 @@
+"""Unit tests for RenewalAuditService.
+
+Per spec Section 12, every approved challenge application MUST point to a
+renewal whose status is ``cancelled_by_challenge``. These tests exercise
+the invariant detector for the three relevant cases:
+
+  1. Violation surfaced when the linked renewal is still `approved`.
+  2. No violation when the renewal correctly sits in `cancelled_by_challenge`.
+  3. No violation when the challenge itself is not yet approved (so the
+     invariant doesn't apply).
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import (
+    ApplicationStatus,
+    ReviewStage,
+    SubTypeSelectionMode,
+)
+from app.models.scholarship import ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.renewal_audit_service import RenewalAuditService
+
+CURRENT_YEAR = 114
+RENEWAL_YEAR = 113
+
+
+# --------------------------------------------------------------------------- #
+# Fixture helpers (kept local to avoid coupling with other test modules)
+# --------------------------------------------------------------------------- #
+
+
+def _make_user(suffix: str) -> User:
+    return User(
+        nycu_id=f"audit_{suffix}",
+        name=f"Audit Test {suffix}",
+        email=f"audit_{suffix}@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+
+
+def _make_application(
+    *,
+    user_id: int,
+    scholarship_type_id: int,
+    app_id: str,
+    sub_scholarship_type: str,
+    status: ApplicationStatus,
+    is_renewal: bool = False,
+    renewal_year: int | None = None,
+    challenges_application_id: int | None = None,
+) -> Application:
+    return Application(
+        app_id=app_id,
+        user_id=user_id,
+        scholarship_type_id=scholarship_type_id,
+        scholarship_subtype_list=[sub_scholarship_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=sub_scholarship_type,
+        academic_year=CURRENT_YEAR,
+        semester=None,
+        status=status,
+        review_stage=ReviewStage.quota_distributed,
+        is_renewal=is_renewal,
+        renewal_year=renewal_year,
+        challenges_application_id=challenges_application_id,
+        agree_terms=True,
+    )
+
+
+async def _make_scholarship(db: AsyncSession, code: str) -> ScholarshipType:
+    sch = ScholarshipType(
+        code=code,
+        name=f"Audit Test {code}",
+        description="Audit fixture",
+    )
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+    return sch
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_finds_violation_when_renewal_still_approved(db: AsyncSession):
+    """An approved challenge whose renewal is still `approved` is a violation."""
+    sch = await _make_scholarship(db, "audit_violation")
+    user = _make_user("v")
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    # Renewal: approved (the invariant says it should be cancelled_by_challenge).
+    renewal = _make_application(
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        app_id="AUDIT-V-R",
+        sub_scholarship_type="nstc",
+        status=ApplicationStatus.approved,
+        is_renewal=True,
+        renewal_year=RENEWAL_YEAR,
+    )
+    db.add(renewal)
+    await db.commit()
+    await db.refresh(renewal)
+
+    # Challenge: approved, linked to the renewal above.
+    challenge = _make_application(
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        app_id="AUDIT-V-C",
+        sub_scholarship_type="moe_1w",
+        status=ApplicationStatus.approved,
+        is_renewal=False,
+        challenges_application_id=renewal.id,
+    )
+    db.add(challenge)
+    await db.commit()
+    await db.refresh(challenge)
+
+    service = RenewalAuditService(db)
+    violations = await service.find_invariant_violations()
+
+    assert len(violations) == 1
+    violation = violations[0]
+    assert violation["challenge_id"] == challenge.id
+    assert violation["renewal_id"] == renewal.id
+    assert violation["actual_renewal_status"] == ApplicationStatus.approved.value
+
+
+@pytest.mark.asyncio
+async def test_no_violation_when_renewal_correctly_cancelled(db: AsyncSession):
+    """When the renewal is cancelled_by_challenge, the invariant holds."""
+    sch = await _make_scholarship(db, "audit_ok")
+    user = _make_user("ok")
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    renewal = _make_application(
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        app_id="AUDIT-OK-R",
+        sub_scholarship_type="nstc",
+        status=ApplicationStatus.cancelled_by_challenge,
+        is_renewal=True,
+        renewal_year=RENEWAL_YEAR,
+    )
+    db.add(renewal)
+    await db.commit()
+    await db.refresh(renewal)
+
+    challenge = _make_application(
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        app_id="AUDIT-OK-C",
+        sub_scholarship_type="moe_1w",
+        status=ApplicationStatus.approved,
+        is_renewal=False,
+        challenges_application_id=renewal.id,
+    )
+    # Reflect the post-release linkage for completeness.
+    challenge.app_id = "AUDIT-OK-C"
+    db.add(challenge)
+    await db.commit()
+    await db.refresh(challenge)
+
+    # Wire the back-pointer the distribution algorithm would set.
+    renewal.cancelled_due_to_application_id = challenge.id
+    await db.commit()
+
+    service = RenewalAuditService(db)
+    violations = await service.find_invariant_violations()
+
+    assert violations == []
+
+
+@pytest.mark.asyncio
+async def test_no_violation_for_rejected_challenge(db: AsyncSession):
+    """A non-approved challenge is outside the invariant scope (not audited)."""
+    sch = await _make_scholarship(db, "audit_pending")
+    user = _make_user("pend")
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    # Renewal still approved — but the challenge is rejected, so this is OK.
+    renewal = _make_application(
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        app_id="AUDIT-P-R",
+        sub_scholarship_type="nstc",
+        status=ApplicationStatus.approved,
+        is_renewal=True,
+        renewal_year=RENEWAL_YEAR,
+    )
+    db.add(renewal)
+    await db.commit()
+    await db.refresh(renewal)
+
+    challenge = _make_application(
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        app_id="AUDIT-P-C",
+        sub_scholarship_type="moe_1w",
+        status=ApplicationStatus.rejected,
+        is_renewal=False,
+        challenges_application_id=renewal.id,
+    )
+    db.add(challenge)
+    await db.commit()
+    await db.refresh(challenge)
+
+    service = RenewalAuditService(db)
+    violations = await service.find_invariant_violations()
+
+    assert violations == []

--- a/backend/app/tests/test_renewal_distribution_result.py
+++ b/backend/app/tests/test_renewal_distribution_result.py
@@ -1,0 +1,366 @@
+"""Tests for the admin renewal distribution result endpoint.
+
+Covers:
+- GET /api/v1/renewals/distribution-result?scholarship_type_id=X&academic_year=Y
+
+The endpoint groups approved renewals by (sub_type, renewal_year), separates
+rejected renewals into their own list, and marks renewals whose sub_type was
+challenged by a downstream challenge application (Application_C pointing back
+via `challenges_application_id`).
+
+Auth is mocked via `app.dependency_overrides[get_current_admin_user]` so tests
+don't need real JWT tokens.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_admin_user
+from app.main import app
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, SubTypeSelectionMode
+from app.models.scholarship import ScholarshipType
+from app.models.user import User, UserRole, UserType
+
+CURRENT_ACADEMIC_YEAR = 114
+PRIOR_ACADEMIC_YEAR = 113
+
+
+# --------------------------------------------------------------------------- #
+# Helpers / Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession) -> User:
+    """Create an admin user for endpoint authorization."""
+    user = User(
+        nycu_id="admin_dist",
+        name="Distribution Admin",
+        email="dist_admin@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def admin_client(client: AsyncClient, admin_user: User):
+    """Yield a client whose `get_current_admin_user` always returns admin_user."""
+
+    async def override_admin():
+        return admin_user
+
+    app.dependency_overrides[get_current_admin_user] = override_admin
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.pop(get_current_admin_user, None)
+
+
+async def _make_student(db: AsyncSession, *, nycu_id: str, name: str) -> User:
+    user = User(
+        nycu_id=nycu_id,
+        name=name,
+        email=f"{nycu_id}@university.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _make_renewal_app(
+    db: AsyncSession,
+    *,
+    user: User,
+    scholarship_type: ScholarshipType,
+    sub_type: str,
+    renewal_year: int,
+    status: ApplicationStatus = ApplicationStatus.approved,
+    previous_application_id: int | None = None,
+    app_id_suffix: str = "00001",
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+) -> Application:
+    """Insert an `is_renewal=True` Application."""
+    app_row = Application(
+        app_id=f"APP-{academic_year}-0-{app_id_suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship_type.id,
+        scholarship_subtype_list=[sub_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=sub_type,
+        academic_year=academic_year,
+        semester=None,
+        status=status,
+        is_renewal=True,
+        renewal_year=renewal_year,
+        previous_application_id=previous_application_id,
+        agree_terms=True,
+    )
+    db.add(app_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return app_row
+
+
+async def _make_challenge_app(
+    db: AsyncSession,
+    *,
+    user: User,
+    scholarship_type: ScholarshipType,
+    target_sub_type: str,
+    challenges_application_id: int,
+    app_id_suffix: str = "90001",
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+) -> Application:
+    """Insert an `is_renewal=False` challenge application pointing at a renewal."""
+    app_row = Application(
+        app_id=f"APP-{academic_year}-0-{app_id_suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship_type.id,
+        scholarship_subtype_list=[target_sub_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=target_sub_type,
+        academic_year=academic_year,
+        semester=None,
+        status=ApplicationStatus.under_review,
+        is_renewal=False,
+        challenges_application_id=challenges_application_id,
+        agree_terms=True,
+    )
+    db.add(app_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return app_row
+
+
+@pytest.fixture(autouse=True)
+def freeze_current_academic_year(monkeypatch):
+    """Pin academic year to 114 so the endpoint's year filter is deterministic."""
+    from app.utils import academic_period
+
+    def _fake_current_period():
+        return {"academic_year": CURRENT_ACADEMIC_YEAR, "semester": "first", "western_year": 2025}
+
+    monkeypatch.setattr(academic_period, "get_current_academic_period", _fake_current_period)
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_groups_by_sub_type_and_renewal_year(
+    db: AsyncSession,
+    admin_client: AsyncClient,
+    test_scholarship: ScholarshipType,
+):
+    """Different (sub_type, renewal_year) combinations should produce separate groups."""
+    s1 = await _make_student(db, nycu_id="stu_a", name="Student A")
+    s2 = await _make_student(db, nycu_id="stu_b", name="Student B")
+    s3 = await _make_student(db, nycu_id="stu_c", name="Student C")
+
+    # Group 1: nstc / 113
+    await _make_renewal_app(
+        db,
+        user=s1,
+        scholarship_type=test_scholarship,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="10001",
+    )
+    # Group 2: nstc / 114 (different renewal_year, same sub_type)
+    await _make_renewal_app(
+        db,
+        user=s2,
+        scholarship_type=test_scholarship,
+        sub_type="nstc",
+        renewal_year=CURRENT_ACADEMIC_YEAR,
+        app_id_suffix="10002",
+    )
+    # Group 3: moe_1w / 113 (different sub_type)
+    await _make_renewal_app(
+        db,
+        user=s3,
+        scholarship_type=test_scholarship,
+        sub_type="moe_1w",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="10003",
+    )
+
+    resp = await admin_client.get(
+        "/api/v1/renewals/distribution-result",
+        params={
+            "scholarship_type_id": test_scholarship.id,
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    data = body["data"]
+
+    groups = data["groups"]
+    assert len(groups) == 3, f"expected 3 groups, got {len(groups)}: {groups}"
+
+    # Build lookup by (sub_type, renewal_year) to assert membership cleanly.
+    by_key = {(g["sub_type"], g["renewal_year"]): g for g in groups}
+    assert ("nstc", PRIOR_ACADEMIC_YEAR) in by_key
+    assert ("nstc", CURRENT_ACADEMIC_YEAR) in by_key
+    assert ("moe_1w", PRIOR_ACADEMIC_YEAR) in by_key
+
+    # Each group contains exactly one application here.
+    for g in groups:
+        assert len(g["applications"]) == 1
+        a = g["applications"][0]
+        assert a["student_name"] is not None
+        assert a["has_challenge"] is False
+
+    assert data["summary"]["approved"] == 3
+    assert data["summary"]["rejected"] == 0
+    assert data["rejected"] == []
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_renewals(
+    db: AsyncSession,
+    admin_client: AsyncClient,
+    test_scholarship: ScholarshipType,
+):
+    """No renewals for the requested (type, year) → empty groups + rejected, zero summary."""
+    resp = await admin_client.get(
+        "/api/v1/renewals/distribution-result",
+        params={
+            "scholarship_type_id": test_scholarship.id,
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    data = body["data"]
+    assert data["groups"] == []
+    assert data["rejected"] == []
+    assert data["summary"] == {"approved": 0, "rejected": 0}
+
+
+@pytest.mark.asyncio
+async def test_marks_has_challenge_for_renewals_with_challenge_applications(
+    db: AsyncSession,
+    admin_client: AsyncClient,
+    test_scholarship: ScholarshipType,
+):
+    """A renewal with a downstream challenge application should have has_challenge=True."""
+    stu_challenged = await _make_student(db, nycu_id="stu_ch", name="Challenged Renewal")
+    stu_calm = await _make_student(db, nycu_id="stu_calm", name="Quiet Renewal")
+
+    # Renewal A — will be challenged
+    renewal_a = await _make_renewal_app(
+        db,
+        user=stu_challenged,
+        scholarship_type=test_scholarship,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="20001",
+    )
+    # Renewal B — left alone
+    renewal_b = await _make_renewal_app(
+        db,
+        user=stu_calm,
+        scholarship_type=test_scholarship,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="20002",
+    )
+    # Challenge application targeting renewal_a (different sub_type)
+    await _make_challenge_app(
+        db,
+        user=stu_challenged,
+        scholarship_type=test_scholarship,
+        target_sub_type="moe_1w",
+        challenges_application_id=renewal_a.id,
+        app_id_suffix="29001",
+    )
+
+    resp = await admin_client.get(
+        "/api/v1/renewals/distribution-result",
+        params={
+            "scholarship_type_id": test_scholarship.id,
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+
+    # Only one group expected — same sub_type & renewal_year for both renewals.
+    assert len(data["groups"]) == 1
+    apps = data["groups"][0]["applications"]
+    by_id = {a["id"]: a for a in apps}
+    assert by_id[renewal_a.id]["has_challenge"] is True
+    assert by_id[renewal_b.id]["has_challenge"] is False
+
+
+@pytest.mark.asyncio
+async def test_separates_rejected_renewals_from_approved(
+    db: AsyncSession,
+    admin_client: AsyncClient,
+    test_scholarship: ScholarshipType,
+):
+    """Rejected renewals must appear in `rejected`, not in `groups`."""
+    stu_ok = await _make_student(db, nycu_id="stu_ok", name="Approved Renewal")
+    stu_rej = await _make_student(db, nycu_id="stu_rej", name="Rejected Renewal")
+
+    await _make_renewal_app(
+        db,
+        user=stu_ok,
+        scholarship_type=test_scholarship,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        app_id_suffix="30001",
+    )
+    rejected_app = await _make_renewal_app(
+        db,
+        user=stu_rej,
+        scholarship_type=test_scholarship,
+        sub_type="nstc",
+        renewal_year=PRIOR_ACADEMIC_YEAR,
+        status=ApplicationStatus.rejected,
+        app_id_suffix="30002",
+    )
+
+    resp = await admin_client.get(
+        "/api/v1/renewals/distribution-result",
+        params={
+            "scholarship_type_id": test_scholarship.id,
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+
+    # Approved goes into a group
+    assert len(data["groups"]) == 1
+    assert len(data["groups"][0]["applications"]) == 1
+    assert data["groups"][0]["applications"][0]["student_name"] == "Approved Renewal"
+
+    # Rejected goes into the rejected list
+    assert len(data["rejected"]) == 1
+    assert data["rejected"][0]["id"] == rejected_app.id
+    assert data["rejected"][0]["student_name"] == "Rejected Renewal"
+
+    assert data["summary"] == {"approved": 1, "rejected": 1}
+
+
+# Keep an imported sentinel reference (datetime) for forward use; silence linters.
+_ = datetime.now(timezone.utc)

--- a/backend/app/tests/test_renewal_distribution_service.py
+++ b/backend/app/tests/test_renewal_distribution_service.py
@@ -1,0 +1,226 @@
+"""Tests for RenewalDistributionService.
+
+Verifies that renewal applications that have completed their required review
+stages are auto-approved (status -> approved, review_stage -> quota_distributed),
+while non-renewal and not-yet-reviewed applications are left untouched.
+
+The "terminal" review stage is configuration-driven:
+    - When ScholarshipConfiguration.requires_college_review = True:
+        terminal stage is ReviewStage.college_reviewed
+    - When requires_college_review = False:
+        terminal stage is ReviewStage.professor_reviewed
+
+These tests use the same conftest fixtures as the other renewal tests
+(`db`, `test_user`, `test_scholarship`), plus a locally-built
+ScholarshipConfiguration with `requires_college_review` set.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, ReviewStage
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User
+from app.services.renewal_distribution_service import RenewalDistributionService
+
+CURRENT_ACADEMIC_YEAR = 114
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_config(
+    scholarship_type_id: int,
+    *,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+    requires_college_review: bool = True,
+    config_code: str = "RDS-CFG",
+) -> ScholarshipConfiguration:
+    """Build a ScholarshipConfiguration row exposing the review flags
+    used by RenewalDistributionService to decide the terminal stage.
+    """
+    return ScholarshipConfiguration(
+        scholarship_type_id=scholarship_type_id,
+        academic_year=academic_year,
+        semester=None,
+        config_name=f"Config {config_code}",
+        config_code=config_code,
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        requires_professor_recommendation=True,
+        requires_college_review=requires_college_review,
+    )
+
+
+async def _make_application(
+    db: AsyncSession,
+    *,
+    user: User,
+    scholarship_type: ScholarshipType,
+    is_renewal: bool,
+    status: ApplicationStatus,
+    review_stage: ReviewStage,
+    app_id_suffix: str,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+) -> Application:
+    """Insert an application with explicit (is_renewal, status, review_stage)."""
+    app = Application(
+        app_id=f"APP-{academic_year}-0-{app_id_suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship_type.id,
+        scholarship_subtype_list=["general"],
+        sub_type_selection_mode="single",
+        sub_scholarship_type="general",
+        academic_year=academic_year,
+        semester=None,
+        status=status,
+        review_stage=review_stage,
+        is_renewal=is_renewal,
+        agree_terms=True,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_auto_approves_renewals_with_passed_reviews(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Two renewal applications, both already at `college_reviewed` and in
+    `under_review`, should be auto-approved and advanced to `quota_distributed`.
+    """
+    # Configuration requires college review -> terminal stage is college_reviewed.
+    config = _make_config(test_scholarship.id, requires_college_review=True)
+    db.add(config)
+    await db.commit()
+
+    app_a = await _make_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        is_renewal=True,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.college_reviewed,
+        app_id_suffix="00001",
+    )
+    app_b = await _make_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        is_renewal=True,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.college_reviewed,
+        app_id_suffix="00002",
+    )
+
+    service = RenewalDistributionService(db)
+    result = await service.auto_approve_passed_reviews(
+        scholarship_type_id=test_scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+    )
+
+    assert result["approved_count"] == 2
+    assert set(result["approved_ids"]) == {app_a.id, app_b.id}
+
+    # Verify the persisted state on both rows.
+    refreshed = (
+        (await db.execute(select(Application).where(Application.id.in_([app_a.id, app_b.id])).order_by(Application.id)))
+        .scalars()
+        .all()
+    )
+    assert len(refreshed) == 2
+    for app in refreshed:
+        assert app.status == ApplicationStatus.approved
+        assert app.review_stage == ReviewStage.quota_distributed
+
+
+@pytest.mark.asyncio
+async def test_does_not_approve_non_renewal(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """A non-renewal (is_renewal=False) application at college_reviewed must be
+    left in `under_review`."""
+    config = _make_config(test_scholarship.id, requires_college_review=True)
+    db.add(config)
+    await db.commit()
+
+    non_renewal = await _make_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        is_renewal=False,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.college_reviewed,
+        app_id_suffix="00010",
+    )
+
+    service = RenewalDistributionService(db)
+    result = await service.auto_approve_passed_reviews(
+        scholarship_type_id=test_scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+    )
+
+    assert result["approved_count"] == 0
+    assert result["approved_ids"] == []
+
+    refreshed = await db.scalar(select(Application).where(Application.id == non_renewal.id))
+    assert refreshed.status == ApplicationStatus.under_review
+    assert refreshed.review_stage == ReviewStage.college_reviewed
+
+
+@pytest.mark.asyncio
+async def test_does_not_approve_not_yet_reviewed(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """A renewal application still in `professor_review` (not yet at the
+    terminal `college_reviewed` stage) must NOT be auto-approved."""
+    config = _make_config(test_scholarship.id, requires_college_review=True)
+    db.add(config)
+    await db.commit()
+
+    in_flight = await _make_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        is_renewal=True,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.professor_review,
+        app_id_suffix="00020",
+    )
+
+    service = RenewalDistributionService(db)
+    result = await service.auto_approve_passed_reviews(
+        scholarship_type_id=test_scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+    )
+
+    assert result["approved_count"] == 0
+    assert result["approved_ids"] == []
+
+    refreshed = await db.scalar(select(Application).where(Application.id == in_flight.id))
+    assert refreshed.status == ApplicationStatus.under_review
+    assert refreshed.review_stage == ReviewStage.professor_review
+
+
+# Touched at import-time so unused-import linters don't strip the helper alias.
+_ = datetime.now(timezone.utc)

--- a/backend/app/tests/test_renewal_eligibility_service.py
+++ b/backend/app/tests/test_renewal_eligibility_service.py
@@ -1,0 +1,201 @@
+"""
+Tests for RenewalEligibilityService.
+
+Verifies that prior approved applications are surfaced as renewal candidates
+only when the corresponding ScholarshipConfiguration for the current academic
+year is in its renewal_application_period window.
+
+Architectural note: renewal_application_{start,end}_date live on
+ScholarshipConfiguration (per academic_year + semester), NOT on
+ScholarshipType. The service queries through the configuration of the
+*current* academic year.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User
+from app.services.renewal_eligibility_service import RenewalEligibilityService
+
+
+def _config(
+    scholarship_type_id: int,
+    *,
+    academic_year: int,
+    in_renewal_period: bool,
+    config_code: str,
+) -> ScholarshipConfiguration:
+    """Build a ScholarshipConfiguration with renewal-period dates set
+    either to bracket `now` (active) or fully in the past (inactive).
+    """
+    now = datetime.now(timezone.utc)
+    if in_renewal_period:
+        start = now - timedelta(days=1)
+        end = now + timedelta(days=7)
+    else:
+        # Renewal period closed a week ago
+        start = now - timedelta(days=14)
+        end = now - timedelta(days=7)
+
+    return ScholarshipConfiguration(
+        scholarship_type_id=scholarship_type_id,
+        academic_year=academic_year,
+        semester=None,
+        config_name=f"Test Config {config_code}",
+        config_code=config_code,
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        renewal_application_start_date=start,
+        renewal_application_end_date=end,
+    )
+
+
+async def _make_prior_approved_application(
+    db: AsyncSession,
+    *,
+    user: User,
+    scholarship_type: ScholarshipType,
+    prior_year: int,
+    status: ApplicationStatus = ApplicationStatus.approved,
+    app_id_suffix: str = "00001",
+) -> Application:
+    """Insert a prior-year application in the given status."""
+    app = Application(
+        app_id=f"APP-{prior_year}-0-{app_id_suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship_type.id,
+        scholarship_subtype_list=["general"],
+        sub_type_selection_mode="single",
+        sub_scholarship_type="general",
+        academic_year=prior_year,
+        semester=None,
+        status=status,
+        is_renewal=False,
+        agree_terms=True,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_prior_approved(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """A user with zero prior applications gets an empty list."""
+    # Create an active renewal configuration for the current academic year so
+    # the only thing missing is a prior approved application.
+    config = _config(
+        test_scholarship.id,
+        academic_year=114,
+        in_renewal_period=True,
+        config_code="RE-114-NONE",
+    )
+    db.add(config)
+    await db.commit()
+
+    service = RenewalEligibilityService(db)
+    result = await service.get_eligible_renewals(user_id=test_user.id, current_academic_year=114)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_returns_prior_approved_when_in_renewal_period(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """User with 113 approved + 114 config inside renewal window -> 113 app is returned."""
+    config = _config(
+        test_scholarship.id,
+        academic_year=114,
+        in_renewal_period=True,
+        config_code="RE-114-OPEN",
+    )
+    db.add(config)
+    await db.commit()
+
+    prior = await _make_prior_approved_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        prior_year=113,
+    )
+
+    service = RenewalEligibilityService(db)
+    result = await service.get_eligible_renewals(user_id=test_user.id, current_academic_year=114)
+
+    assert len(result) == 1
+    assert result[0].id == prior.id
+    assert result[0].academic_year == 113
+    assert result[0].status == ApplicationStatus.approved
+
+
+@pytest.mark.asyncio
+async def test_excludes_rejected_prior(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """A rejected prior application must not surface as a renewal candidate."""
+    config = _config(
+        test_scholarship.id,
+        academic_year=114,
+        in_renewal_period=True,
+        config_code="RE-114-REJ",
+    )
+    db.add(config)
+    await db.commit()
+
+    await _make_prior_approved_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        prior_year=113,
+        status=ApplicationStatus.rejected,
+    )
+
+    service = RenewalEligibilityService(db)
+    result = await service.get_eligible_renewals(user_id=test_user.id, current_academic_year=114)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_excludes_when_not_in_renewal_period(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Prior application is approved, but the current-year config's renewal
+    period is closed -> empty list."""
+    config = _config(
+        test_scholarship.id,
+        academic_year=114,
+        in_renewal_period=False,  # closed
+        config_code="RE-114-CLOSED",
+    )
+    db.add(config)
+    await db.commit()
+
+    await _make_prior_approved_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        prior_year=113,
+    )
+
+    service = RenewalEligibilityService(db)
+    result = await service.get_eligible_renewals(user_id=test_user.id, current_academic_year=114)
+
+    assert result == []

--- a/backend/app/tests/test_renewal_end_to_end.py
+++ b/backend/app/tests/test_renewal_end_to_end.py
@@ -1,0 +1,484 @@
+"""End-to-end test for the full renewal + challenge distribution flow.
+
+Spec Section 9.3 scenario:
+
+Doctoral scholarship, academic_year=114, quota pool::
+
+    nstc[113]: 10 slots  (prior year, N-year plan)
+    nstc[114]:  8 slots
+    moe_1w[114]: 6 slots
+
+Renewal phase:
+  10 prior year (113) winners renew under nstc; all approved on nstc[113].
+  Two of them (A and B) will challenge moe_1w in the general phase.
+
+General phase candidates (academic_year=114):
+  nstc pure-new candidates ranked 1..10  (M, N, O, P, Q, R, S, T, U, V)
+  moe_1w candidates: A (rank 1, challenge), B (rank 2, challenge),
+                     plus pure-new X, Y, Z, AA, BB, CC (ranks 3..8).
+
+Expected outcome:
+  - A and B approved on moe_1w[114]; their renewals flip to
+    cancelled_by_challenge with cancelled_due_to_application_id set.
+  - The other 4 moe_1w pure-new (X..AA, ranks 3..6) approved on moe_1w[114].
+  - nstc ranks 1..8 (M..T) approved on nstc[114] first-round.
+  - nstc ranks 9, 10 (U, V) fill in on the two slots freed by A and B's
+    cancelled renewals — both promoted with allocation_year=113.
+  - released_slots == {("nstc", 113): 2}
+  - filled_in == 2, unfilled == 0
+
+This test wires up every service touched by the feature:
+  - ApplicationService.create_renewal_from_previous  (Phase 3)
+  - RenewalDistributionService.auto_approve_passed_reviews (Phase 5)
+  - ApplicationService.create_challenge_from_renewal  (Phase 3)
+  - ManualDistributionService.execute_general_distribution (Phase 6)
+
+If any one of them drifts, this scenario will break.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import ApplicationStatus, ReviewStage, SubTypeSelectionMode
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.application_service import ApplicationService
+from app.services.manual_distribution_service import ManualDistributionService
+from app.services.renewal_distribution_service import RenewalDistributionService
+
+CURRENT_ACADEMIC_YEAR = 114
+RENEWAL_YEAR = 113
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_user(suffix: str) -> User:
+    return User(
+        nycu_id=f"e2e_{suffix}",
+        name=f"E2E {suffix}",
+        email=f"e2e_{suffix}@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+
+
+def _make_prior_approved(
+    *,
+    user_id: int,
+    scholarship_type_id: int,
+    app_id: str,
+    sub_scholarship_type: str = "nstc",
+    academic_year: int = RENEWAL_YEAR,
+) -> Application:
+    """An approved application from a prior academic year — used as the
+    `previous` argument to `ApplicationService.create_renewal_from_previous`.
+    """
+    return Application(
+        app_id=app_id,
+        user_id=user_id,
+        scholarship_type_id=scholarship_type_id,
+        scholarship_subtype_list=[sub_scholarship_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=sub_scholarship_type,
+        academic_year=academic_year,
+        semester=None,
+        status=ApplicationStatus.approved,
+        review_stage=ReviewStage.quota_distributed,
+        is_renewal=False,
+        agree_terms=True,
+    )
+
+
+def _make_pure_new_application(
+    *,
+    user_id: int,
+    scholarship_type_id: int,
+    app_id: str,
+    sub_scholarship_type: str,
+    review_stage: ReviewStage = ReviewStage.college_ranked,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+) -> Application:
+    return Application(
+        app_id=app_id,
+        user_id=user_id,
+        scholarship_type_id=scholarship_type_id,
+        scholarship_subtype_list=[sub_scholarship_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=sub_scholarship_type,
+        academic_year=academic_year,
+        semester=None,
+        status=ApplicationStatus.under_review,
+        review_stage=review_stage,
+        is_renewal=False,
+        agree_terms=True,
+    )
+
+
+async def _attach_ranking_item(
+    db: AsyncSession,
+    *,
+    scholarship_type_id: int,
+    sub_type_code: str,
+    application_id: int,
+    rank_position: int,
+) -> CollegeRankingItem:
+    """Get-or-create a CollegeRanking row for (sub_type, year) and attach an item."""
+    ranking = (
+        (
+            await db.execute(
+                select(CollegeRanking).where(
+                    CollegeRanking.scholarship_type_id == scholarship_type_id,
+                    CollegeRanking.sub_type_code == sub_type_code,
+                    CollegeRanking.academic_year == CURRENT_ACADEMIC_YEAR,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if ranking is None:
+        ranking = CollegeRanking(
+            scholarship_type_id=scholarship_type_id,
+            sub_type_code=sub_type_code,
+            academic_year=CURRENT_ACADEMIC_YEAR,
+            semester=None,
+            is_finalized=True,
+            ranking_status="finalized",
+        )
+        db.add(ranking)
+        await db.commit()
+        await db.refresh(ranking)
+
+    item = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=application_id,
+        rank_position=rank_position,
+        is_allocated=False,
+        status="ranked",
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
+# --------------------------------------------------------------------------- #
+# Test
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_full_renewal_challenge_e2e(db: AsyncSession):
+    """End-to-end exercise of the renewal/challenge/general distribution flow.
+
+    See module docstring for the spec Section 9.3 scenario and expected outcome.
+    """
+    # ------------------------------------------------------------------- #
+    # 1. Scholarship type + configuration (10 nstc[113], 8 nstc[114], 6 moe_1w[114])
+    # ------------------------------------------------------------------- #
+    scholarship = ScholarshipType(
+        code="e2e_phd",
+        name="E2E PhD Scholarship",
+        description="Spec Section 9.3 end-to-end fixture",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        semester=None,
+        config_name="E2E PhD Config",
+        config_code="e2e-phd-config",
+        amount=40000,
+        currency="TWD",
+        is_active=True,
+        requires_professor_recommendation=True,
+        requires_college_review=True,
+        quotas={"nstc": {"114": 8, "113": 10}, "moe_1w": {"114": 6}},
+        prior_quota_years={"nstc": [113], "moe_1w": []},
+    )
+    db.add(config)
+    await db.commit()
+
+    # ------------------------------------------------------------------- #
+    # 2. Users — 10 renewal candidates (A..J) plus pure-new pools
+    # ------------------------------------------------------------------- #
+    renewal_user_letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
+    renewal_users = [_make_user(f"renew_{l}") for l in renewal_user_letters]
+    db.add_all(renewal_users)
+
+    # 10 pure-new nstc candidates M..V (ranks 1..10)
+    nstc_pure_letters = ["M", "N", "O", "P", "Q", "R", "S", "T", "U", "V"]
+    nstc_pure_users = [_make_user(f"nstc_{l}") for l in nstc_pure_letters]
+    db.add_all(nstc_pure_users)
+
+    # 6 pure-new moe_1w candidates X..CC (ranks 3..8 — A & B challenges take 1, 2)
+    moe_pure_letters = ["X", "Y", "Z", "AA", "BB", "CC"]
+    moe_pure_users = [_make_user(f"moe_{l}") for l in moe_pure_letters]
+    db.add_all(moe_pure_users)
+
+    await db.commit()
+    for u in renewal_users + nstc_pure_users + moe_pure_users:
+        await db.refresh(u)
+
+    # ------------------------------------------------------------------- #
+    # 3. Create 10 prior-year approved nstc applications (the "previous"
+    #    applications that 113-year winners hold).
+    # ------------------------------------------------------------------- #
+    prior_apps: list[Application] = []
+    for idx, user in enumerate(renewal_users, start=1):
+        prior = _make_prior_approved(
+            user_id=user.id,
+            scholarship_type_id=scholarship.id,
+            app_id=f"APP-113-0-PRIOR{idx:02d}",
+        )
+        db.add(prior)
+        prior_apps.append(prior)
+    await db.commit()
+    for p in prior_apps:
+        await db.refresh(p)
+
+    # ------------------------------------------------------------------- #
+    # 4. For each prior app, create a renewal application for AY 114
+    #    via ApplicationService.create_renewal_from_previous (Phase 3).
+    #    Then promote them to under_review + college_reviewed so that
+    #    RenewalDistributionService.auto_approve_passed_reviews can
+    #    auto-approve them (Phase 5).
+    # ------------------------------------------------------------------- #
+    app_service = ApplicationService(db)
+    renewal_apps: list[Application] = []
+    for prior, user in zip(prior_apps, renewal_users):
+        renewal = await app_service.create_renewal_from_previous(
+            previous=prior,
+            current_user=user,
+            target_academic_year=CURRENT_ACADEMIC_YEAR,
+            renewal_year=RENEWAL_YEAR,
+        )
+        # Promote past student_draft so the renewal distribution service can pick it up.
+        renewal.status = ApplicationStatus.under_review
+        renewal.review_stage = ReviewStage.college_reviewed
+        renewal.agree_terms = True
+        renewal_apps.append(renewal)
+    await db.commit()
+    for r in renewal_apps:
+        await db.refresh(r)
+
+    # Sanity: all 10 are renewals in under_review @ college_reviewed.
+    assert all(r.is_renewal for r in renewal_apps)
+    assert all(r.status == ApplicationStatus.under_review for r in renewal_apps)
+    assert all(r.review_stage == ReviewStage.college_reviewed for r in renewal_apps)
+    assert all(r.renewal_year == RENEWAL_YEAR for r in renewal_apps)
+    assert all(r.sub_scholarship_type == "nstc" for r in renewal_apps)
+
+    # ------------------------------------------------------------------- #
+    # 5. Run renewal distribution — all 10 should be approved on nstc[113].
+    # ------------------------------------------------------------------- #
+    renewal_service = RenewalDistributionService(db)
+    renewal_result = await renewal_service.auto_approve_passed_reviews(
+        scholarship_type_id=scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+    )
+    assert renewal_result["approved_count"] == 10
+    for r in renewal_apps:
+        await db.refresh(r)
+        assert r.status == ApplicationStatus.approved
+        assert r.review_stage == ReviewStage.quota_distributed
+
+    # ------------------------------------------------------------------- #
+    # 6. Renewals A and B challenge moe_1w (Phase 3 factory).
+    # ------------------------------------------------------------------- #
+    renewal_A = renewal_apps[0]
+    renewal_B = renewal_apps[1]
+    user_A = renewal_users[0]
+    user_B = renewal_users[1]
+
+    challenge_A = await app_service.create_challenge_from_renewal(
+        renewal=renewal_A,
+        current_user=user_A,
+        target_sub_type="moe_1w",
+    )
+    challenge_B = await app_service.create_challenge_from_renewal(
+        renewal=renewal_B,
+        current_user=user_B,
+        target_sub_type="moe_1w",
+    )
+    # Promote challenges past student_draft so they show up in the
+    # general-phase candidates query.
+    for challenge in (challenge_A, challenge_B):
+        challenge.status = ApplicationStatus.under_review
+        challenge.review_stage = ReviewStage.college_ranked
+        challenge.agree_terms = True
+    await db.commit()
+    await db.refresh(challenge_A)
+    await db.refresh(challenge_B)
+    assert challenge_A.challenges_application_id == renewal_A.id
+    assert challenge_B.challenges_application_id == renewal_B.id
+    assert challenge_A.sub_scholarship_type == "moe_1w"
+
+    # ------------------------------------------------------------------- #
+    # 7. Pure-new nstc candidates M..V at ranks 1..10.
+    # ------------------------------------------------------------------- #
+    nstc_pure_apps: list[Application] = []
+    for idx, (letter, user) in enumerate(zip(nstc_pure_letters, nstc_pure_users), start=1):
+        app = _make_pure_new_application(
+            user_id=user.id,
+            scholarship_type_id=scholarship.id,
+            app_id=f"APP-114-0-NSTCP{idx:02d}",
+            sub_scholarship_type="nstc",
+        )
+        db.add(app)
+        nstc_pure_apps.append(app)
+    await db.commit()
+    for app in nstc_pure_apps:
+        await db.refresh(app)
+    for idx, app in enumerate(nstc_pure_apps, start=1):
+        await _attach_ranking_item(
+            db,
+            scholarship_type_id=scholarship.id,
+            sub_type_code="nstc",
+            application_id=app.id,
+            rank_position=idx,
+        )
+
+    # ------------------------------------------------------------------- #
+    # 8. moe_1w ranking: A (#1), B (#2), then 6 pure-new at ranks 3..8.
+    # ------------------------------------------------------------------- #
+    await _attach_ranking_item(
+        db,
+        scholarship_type_id=scholarship.id,
+        sub_type_code="moe_1w",
+        application_id=challenge_A.id,
+        rank_position=1,
+    )
+    await _attach_ranking_item(
+        db,
+        scholarship_type_id=scholarship.id,
+        sub_type_code="moe_1w",
+        application_id=challenge_B.id,
+        rank_position=2,
+    )
+
+    moe_pure_apps: list[Application] = []
+    for idx, (letter, user) in enumerate(zip(moe_pure_letters, moe_pure_users), start=1):
+        app = _make_pure_new_application(
+            user_id=user.id,
+            scholarship_type_id=scholarship.id,
+            app_id=f"APP-114-0-MOEP{idx:02d}",
+            sub_scholarship_type="moe_1w",
+        )
+        db.add(app)
+        moe_pure_apps.append(app)
+    await db.commit()
+    for app in moe_pure_apps:
+        await db.refresh(app)
+    for idx, app in enumerate(moe_pure_apps, start=3):  # ranks 3..8
+        await _attach_ranking_item(
+            db,
+            scholarship_type_id=scholarship.id,
+            sub_type_code="moe_1w",
+            application_id=app.id,
+            rank_position=idx,
+        )
+
+    # ------------------------------------------------------------------- #
+    # 9. Execute general distribution.
+    # ------------------------------------------------------------------- #
+    manual_service = ManualDistributionService(db)
+    result = await manual_service.execute_general_distribution(
+        scholarship_type_id=scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+    )
+
+    # ------------------------------------------------------------------- #
+    # 10. Assertions — summary stats.
+    # ------------------------------------------------------------------- #
+    assert result["approved_renewals"] == 10
+    assert result["approved_challenges"] == 2
+    assert result["released_slots"] == {("nstc", RENEWAL_YEAR): 2}
+    assert result["filled_in"] == 2
+    assert result["unfilled"] == 0
+    # Spec §10 invariant: released == filled_in + unfilled
+    assert sum(result["released_slots"].values()) == result["filled_in"] + result["unfilled"]
+
+    # ------------------------------------------------------------------- #
+    # 11. Assertions — challenge winners approved, renewals cancelled.
+    # ------------------------------------------------------------------- #
+    for challenge, renewal in ((challenge_A, renewal_A), (challenge_B, renewal_B)):
+        await db.refresh(challenge)
+        await db.refresh(renewal)
+        assert challenge.status == ApplicationStatus.approved
+        assert renewal.status == ApplicationStatus.cancelled_by_challenge
+        assert renewal.cancelled_due_to_application_id == challenge.id
+
+    # The other 8 renewals stay approved.
+    for renewal in renewal_apps[2:]:
+        await db.refresh(renewal)
+        assert renewal.status == ApplicationStatus.approved
+
+    # ------------------------------------------------------------------- #
+    # 12. Assertions — nstc ranks 1..8 (M..T) approved on nstc[114].
+    # ------------------------------------------------------------------- #
+    for idx in range(8):
+        await db.refresh(nstc_pure_apps[idx])
+        assert (
+            nstc_pure_apps[idx].status == ApplicationStatus.approved
+        ), f"nstc rank {idx + 1} ({nstc_pure_letters[idx]}) should be approved on nstc[114]"
+        item = (
+            (
+                await db.execute(
+                    select(CollegeRankingItem).where(CollegeRankingItem.application_id == nstc_pure_apps[idx].id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert item is not None
+        assert (
+            item.allocation_year == CURRENT_ACADEMIC_YEAR
+        ), f"nstc rank {idx + 1} should occupy nstc[{CURRENT_ACADEMIC_YEAR}]"
+
+    # ------------------------------------------------------------------- #
+    # 13. Assertions — nstc ranks 9, 10 (U, V) filled in on nstc[113].
+    # ------------------------------------------------------------------- #
+    for idx in (8, 9):
+        await db.refresh(nstc_pure_apps[idx])
+        assert (
+            nstc_pure_apps[idx].status == ApplicationStatus.approved
+        ), f"nstc rank {idx + 1} ({nstc_pure_letters[idx]}) should be filled in from waitlist"
+        item = (
+            (
+                await db.execute(
+                    select(CollegeRankingItem).where(CollegeRankingItem.application_id == nstc_pure_apps[idx].id)
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert item is not None
+        assert (
+            item.allocation_year == RENEWAL_YEAR
+        ), f"nstc rank {idx + 1} should be promoted to nstc[{RENEWAL_YEAR}] (slot freed by cancelled renewal)"
+
+    # ------------------------------------------------------------------- #
+    # 14. Assertions — moe_1w pure-new winners (ranks 3..6) approved.
+    # ------------------------------------------------------------------- #
+    # 6 moe_1w slots total, minus 2 taken by challenges = 4 left for pure-new.
+    for idx in range(4):
+        await db.refresh(moe_pure_apps[idx])
+        assert (
+            moe_pure_apps[idx].status == ApplicationStatus.approved
+        ), f"moe_1w rank {idx + 3} ({moe_pure_letters[idx]}) should be approved"
+    # The last 2 moe_1w pure-new (ranks 7, 8) stay under_review.
+    for idx in range(4, 6):
+        await db.refresh(moe_pure_apps[idx])
+        assert moe_pure_apps[idx].status == ApplicationStatus.under_review

--- a/backend/app/tests/test_review_routing_renewal.py
+++ b/backend/app/tests/test_review_routing_renewal.py
@@ -1,0 +1,525 @@
+"""Tests for Phase 4 review-routing filter (renewal vs general phase).
+
+Verifies ``apply_renewal_phase_filter`` correctly restricts pending-review
+listings so educators see only the applications appropriate for the current
+review window:
+
+  - During the renewal review window: only ``is_renewal=True`` applications
+    whose configuration has a currently-open renewal window.
+  - During the general review window: only ``is_renewal=False`` applications
+    whose configuration has a currently-open general window.
+
+These tests intentionally exercise the SQL filter against real rows via the
+in-memory SQLite test fixtures rather than mocking the query, so we catch
+join / column-name regressions early.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, ReviewStage, SubTypeSelectionMode
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User
+from app.services.review_phase_filter import apply_renewal_phase_filter
+
+CURRENT_ACADEMIC_YEAR = 114
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_config_in_renewal_phase(
+    scholarship_type_id: int,
+    *,
+    role: str,
+    config_code: str,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+) -> ScholarshipConfiguration:
+    """ScholarshipConfiguration with the renewal-{role}-review window open NOW
+    and the general-{role}-review window closed (in the future).
+    """
+    now = datetime.now(timezone.utc)
+    open_start = now - timedelta(days=1)
+    open_end = now + timedelta(days=7)
+    closed_start = now + timedelta(days=14)
+    closed_end = now + timedelta(days=21)
+
+    kwargs = dict(
+        scholarship_type_id=scholarship_type_id,
+        academic_year=academic_year,
+        semester=None,
+        config_name=f"Config {config_code}",
+        config_code=config_code,
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+    )
+    if role == "professor":
+        kwargs.update(
+            renewal_professor_review_start=open_start,
+            renewal_professor_review_end=open_end,
+            professor_review_start=closed_start,
+            professor_review_end=closed_end,
+        )
+    elif role == "college":
+        kwargs.update(
+            renewal_college_review_start=open_start,
+            renewal_college_review_end=open_end,
+            college_review_start=closed_start,
+            college_review_end=closed_end,
+        )
+    else:  # pragma: no cover
+        raise ValueError(role)
+
+    return ScholarshipConfiguration(**kwargs)
+
+
+def _make_config_in_general_phase(
+    scholarship_type_id: int,
+    *,
+    role: str,
+    config_code: str,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+) -> ScholarshipConfiguration:
+    """ScholarshipConfiguration with the general-{role}-review window open NOW
+    and the renewal-{role}-review window already closed (in the past).
+    """
+    now = datetime.now(timezone.utc)
+    closed_start = now - timedelta(days=21)
+    closed_end = now - timedelta(days=14)
+    open_start = now - timedelta(days=1)
+    open_end = now + timedelta(days=7)
+
+    kwargs = dict(
+        scholarship_type_id=scholarship_type_id,
+        academic_year=academic_year,
+        semester=None,
+        config_name=f"Config {config_code}",
+        config_code=config_code,
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+    )
+    if role == "professor":
+        kwargs.update(
+            renewal_professor_review_start=closed_start,
+            renewal_professor_review_end=closed_end,
+            professor_review_start=open_start,
+            professor_review_end=open_end,
+        )
+    elif role == "college":
+        kwargs.update(
+            renewal_college_review_start=closed_start,
+            renewal_college_review_end=closed_end,
+            college_review_start=open_start,
+            college_review_end=open_end,
+        )
+    else:  # pragma: no cover
+        raise ValueError(role)
+
+    return ScholarshipConfiguration(**kwargs)
+
+
+async def _make_pending_application(
+    db: AsyncSession,
+    *,
+    user: User,
+    scholarship_type: ScholarshipType,
+    configuration_id: Optional[int],
+    is_renewal: bool,
+    app_id_suffix: str,
+    academic_year: int = CURRENT_ACADEMIC_YEAR,
+) -> Application:
+    app = Application(
+        app_id=f"APP-{academic_year}-0-{app_id_suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship_type.id,
+        scholarship_configuration_id=configuration_id,
+        scholarship_subtype_list=["nstc"],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+        academic_year=academic_year,
+        semester=None,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.professor_review,
+        is_renewal=is_renewal,
+        agree_terms=True,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Professor-role tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_professor_sees_only_renewal_during_renewal_period(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Configuration is in its renewal_professor_review window NOW.
+
+    Only the renewal application should pass the filter; the general one
+    should be filtered out.
+    """
+    config = _make_config_in_renewal_phase(test_scholarship.id, role="professor", config_code="PROF-RENEW")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=True,
+        app_id_suffix="00001",
+    )
+    general_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=False,
+        app_id_suffix="00002",
+    )
+
+    stmt = select(Application).where(Application.status == ApplicationStatus.under_review.value)
+    stmt = apply_renewal_phase_filter(stmt, role="professor")
+
+    result = await db.execute(stmt)
+    visible_ids = {row.id for row in result.scalars().all()}
+
+    assert renewal_app.id in visible_ids, "renewal application should be visible during renewal phase"
+    assert general_app.id not in visible_ids, "general application should NOT be visible during renewal phase"
+
+
+@pytest.mark.asyncio
+async def test_professor_sees_only_general_during_general_period(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Configuration is in its general professor_review window NOW.
+
+    Only the non-renewal application should pass the filter; the renewal
+    one should be filtered out.
+    """
+    config = _make_config_in_general_phase(test_scholarship.id, role="professor", config_code="PROF-GEN")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=True,
+        app_id_suffix="00011",
+    )
+    general_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=False,
+        app_id_suffix="00012",
+    )
+
+    stmt = select(Application).where(Application.status == ApplicationStatus.under_review.value)
+    stmt = apply_renewal_phase_filter(stmt, role="professor")
+
+    result = await db.execute(stmt)
+    visible_ids = {row.id for row in result.scalars().all()}
+
+    assert general_app.id in visible_ids, "general application should be visible during general phase"
+    assert renewal_app.id not in visible_ids, "renewal application should NOT be visible during general phase"
+
+
+# --------------------------------------------------------------------------- #
+# College-role tests (mirror of the professor pair)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_college_sees_only_renewal_during_renewal_period(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    config = _make_config_in_renewal_phase(test_scholarship.id, role="college", config_code="COL-RENEW")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=True,
+        app_id_suffix="00021",
+    )
+    general_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=False,
+        app_id_suffix="00022",
+    )
+
+    stmt = select(Application).where(Application.status == ApplicationStatus.under_review.value)
+    stmt = apply_renewal_phase_filter(stmt, role="college")
+
+    result = await db.execute(stmt)
+    visible_ids = {row.id for row in result.scalars().all()}
+
+    assert renewal_app.id in visible_ids
+    assert general_app.id not in visible_ids
+
+
+@pytest.mark.asyncio
+async def test_college_sees_only_general_during_general_period(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    config = _make_config_in_general_phase(test_scholarship.id, role="college", config_code="COL-GEN")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=True,
+        app_id_suffix="00031",
+    )
+    general_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=False,
+        app_id_suffix="00032",
+    )
+
+    stmt = select(Application).where(Application.status == ApplicationStatus.under_review.value)
+    stmt = apply_renewal_phase_filter(stmt, role="college")
+
+    result = await db.execute(stmt)
+    visible_ids = {row.id for row in result.scalars().all()}
+
+    assert general_app.id in visible_ids
+    assert renewal_app.id not in visible_ids
+
+
+# --------------------------------------------------------------------------- #
+# Edge case: outside any window → nothing visible
+# --------------------------------------------------------------------------- #
+
+
+# --------------------------------------------------------------------------- #
+# Integration tests: exercise the filter through the actual service methods
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_application_service_pending_list_filters_by_renewal_phase(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+    test_professor: User,
+):
+    """End-to-end check that ApplicationService.get_professor_applications_paginated
+    with status_filter='pending' applies the renewal-phase filter.
+
+    Setup: config currently in its renewal_professor_review window.
+    Expectation: the renewal app is returned; the general app is hidden.
+    """
+    from app.services.application_service import ApplicationService
+
+    config = _make_config_in_renewal_phase(test_scholarship.id, role="professor", config_code="SVC-PROF-RENEW")
+    # Mark the configuration as requiring professor recommendation so the
+    # existing service filter doesn't drop these rows for an unrelated reason.
+    config.requires_professor_recommendation = True
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=True,
+        app_id_suffix="00051",
+    )
+    general_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=False,
+        app_id_suffix="00052",
+    )
+    # Both applications must be assigned to the professor so they pass the
+    # existing professor_id filter.
+    renewal_app.professor_id = test_professor.id
+    general_app.professor_id = test_professor.id
+    await db.commit()
+
+    service = ApplicationService(db)
+    applications, total_count = await service.get_professor_applications_paginated(
+        professor_id=test_professor.id,
+        status_filter="pending",
+        page=1,
+        size=20,
+    )
+
+    returned_ids = {a.id for a in applications}
+    assert renewal_app.id in returned_ids, "renewal app should be visible during renewal phase"
+    assert general_app.id not in returned_ids, "general app should be filtered out during renewal phase"
+    assert total_count == 1
+
+
+@pytest.mark.asyncio
+async def test_college_service_pending_list_filters_by_renewal_phase(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """End-to-end check that CollegeReviewService.get_applications_for_review
+    applies the renewal-phase filter to under_review rows while leaving
+    approved rows untouched.
+    """
+    from app.services.college_review_service import CollegeReviewService
+
+    # Configuration currently in renewal_college_review window.
+    config = _make_config_in_renewal_phase(test_scholarship.id, role="college", config_code="SVC-COL-RENEW")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    # Pending renewal app — should be visible.
+    renewal_pending = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=True,
+        app_id_suffix="00061",
+    )
+    # Pending general app — should be hidden by the renewal-phase filter.
+    general_pending = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=False,
+        app_id_suffix="00062",
+    )
+    # Approved general app — should still be visible (historical visibility
+    # is unaffected by the phase filter).
+    approved_general = Application(
+        app_id=f"APP-{CURRENT_ACADEMIC_YEAR}-0-00063",
+        user_id=test_user.id,
+        scholarship_type_id=test_scholarship.id,
+        scholarship_configuration_id=config.id,
+        scholarship_subtype_list=["nstc"],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        semester=None,
+        status=ApplicationStatus.approved,
+        is_renewal=False,
+        agree_terms=True,
+    )
+    db.add(approved_general)
+    await db.commit()
+    await db.refresh(approved_general)
+
+    service = CollegeReviewService(db)
+    rows = await service.get_applications_for_review(
+        scholarship_type_id=test_scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+    )
+    visible_ids = {r["id"] for r in rows}
+
+    assert renewal_pending.id in visible_ids, "renewal pending app should be visible during renewal phase"
+    assert general_pending.id not in visible_ids, "general pending app should be filtered out during renewal phase"
+    assert approved_general.id in visible_ids, "approved app should always remain visible"
+
+
+@pytest.mark.asyncio
+async def test_nothing_visible_when_outside_any_review_window(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """If both the renewal and general windows for a configuration are closed
+    relative to NOW, the filter must hide BOTH renewal and general apps.
+    """
+    now = datetime.now(timezone.utc)
+    config = ScholarshipConfiguration(
+        scholarship_type_id=test_scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+        semester=None,
+        config_name="Config Closed",
+        config_code="PROF-CLOSED",
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        # All windows are firmly in the past
+        renewal_professor_review_start=now - timedelta(days=30),
+        renewal_professor_review_end=now - timedelta(days=20),
+        professor_review_start=now - timedelta(days=19),
+        professor_review_end=now - timedelta(days=10),
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    renewal_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=True,
+        app_id_suffix="00041",
+    )
+    general_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=False,
+        app_id_suffix="00042",
+    )
+
+    stmt = select(Application).where(Application.status == ApplicationStatus.under_review.value)
+    stmt = apply_renewal_phase_filter(stmt, role="professor")
+
+    result = await db.execute(stmt)
+    visible_ids = {row.id for row in result.scalars().all()}
+
+    assert renewal_app.id not in visible_ids
+    assert general_app.id not in visible_ids

--- a/backend/docs/scholarship_renewal_design.md
+++ b/backend/docs/scholarship_renewal_design.md
@@ -1,5 +1,9 @@
 # 獎學金續領申請期間設計
 
+> **Note:** This document describes the timeline framework only. For the complete
+> end-to-end design including challenge applications, slot release, and waitlist
+> fill-in, see `docs/superpowers/specs/2026-05-13-renewal-application-design.md`.
+
 ## 概述
 
 本設計為獎學金系統添加了續領申請期間功能，允許系統優先處理續領申請，然後再處理一般申請。這樣的設計確保了續領申請的優先權，並提供了清晰的審查流程。

--- a/docs/superpowers/plans/2026-05-13-renewal-application.md
+++ b/docs/superpowers/plans/2026-05-13-renewal-application.md
@@ -1,0 +1,2832 @@
+# Renewal Application Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement end-to-end scholarship renewal with "保底+挑戰" mechanism: renewal applications auto-approved on review pass, challenge applications during general phase that release original sub_type slots and fill in from waitlist.
+
+**Architecture:** Two-Application pattern — `Application_R` (is_renewal=True, locks original sub_type) and `Application_C` (is_renewal=False, `challenges_application_id` points to Application_R, locks new sub_type). Renewal phase is auto-distributed (review pass = approved). General-phase distribution algorithm handles challenge cancellation and same-sub_type waitlist fill-in. Allocation tracked by `renewal_year` (= original cohort year), separate from `academic_year` (= student-application year).
+
+**Tech Stack:** FastAPI + async SQLAlchemy + PostgreSQL/Alembic + Pydantic v2; Next.js 14 (App Router) + TypeScript + Tailwind; Docker Compose dev environment.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-13-renewal-application-design.md`
+
+---
+
+## File Structure
+
+### Backend (Create)
+
+- `backend/alembic/versions/<rev>_add_renewal_challenge_columns.py` — migration: new columns, enum value, partial indexes
+- `backend/app/services/renewal_eligibility_service.py` — `RenewalEligibilityService.get_eligible_renewals()`
+- `backend/app/services/renewal_distribution_service.py` — `RenewalDistributionService.auto_approve_passed_reviews()`
+- `backend/app/api/v1/endpoints/renewal.py` — renewal/challenge creation + listing endpoints
+- `backend/app/schemas/renewal.py` — Pydantic schemas
+- `backend/app/tests/test_renewal_eligibility_service.py`
+- `backend/app/tests/test_renewal_application_creation.py`
+- `backend/app/tests/test_renewal_distribution_service.py`
+- `backend/app/tests/test_challenge_release_distribution.py`
+
+### Backend (Modify)
+
+- `backend/app/models/enums.py:16-40` — add `cancelled_by_challenge` to ApplicationStatus
+- `backend/app/models/application.py` — add `challenges_application_id`, `cancelled_due_to_application_id` columns + relationships; replace single UniqueConstraint with three partial unique indexes
+- `backend/app/services/manual_distribution_service.py` — extend `_compute_suggestions()` and add `_apply_challenge_release_and_fill_in()`
+- `backend/app/api/v1/endpoints/manual_distribution.py` — add `/state`, `/preview`, `/distribution-result/renewal` endpoints
+- `backend/app/api/v1/api.py` (or `endpoints/__init__.py`) — register renewal router
+
+### Frontend (Create)
+
+- `frontend/lib/api/modules/renewal.ts` — typed client for renewal endpoints
+- `frontend/components/admin/renewal/RenewalDistributionResult.tsx` — Section 14.1 UI
+- `frontend/components/student/RenewalApplicationCard.tsx` — student renewal entry card
+- `frontend/components/student/ChallengeApplicationCard.tsx` — challenge entry card
+
+### Frontend (Modify)
+
+- `frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx` — add renewal-occupied block, challenge markers, release preview
+- `frontend/lib/api/modules/manual-distribution.ts` — add new endpoint typings
+- `frontend/components/enhanced-student-portal.tsx` — link renewal/challenge cards
+- Student application history component (TBD path during Task 9.3) — add linkage display
+
+---
+
+## Self-contained context for engineer
+
+- **DB enum updates require Alembic execution + values_callable**: When adding a value to `ApplicationStatus`, both Postgres `ALTER TYPE` and SQLAlchemy `values_callable` lambda must be considered. See `CLAUDE.md` "Enum Consistency Guidelines".
+- **Use `docker compose -f docker-compose.dev.yml`** for all local dev. Backend container = `scholarship_backend_dev`. DB = `scholarship_postgres_dev`.
+- **API response format**: All endpoints return `{success, message, data}` dict; do NOT use `response_model`.
+- **Tests use pytest-asyncio**: Async DB session via `AsyncSession` fixture (see existing `test_scholarship_configuration_endpoints.py`).
+- **Run tests**: `docker compose -f docker-compose.dev.yml exec backend python -m pytest <path> -v`
+- **Run migration**: `docker compose -f docker-compose.dev.yml exec backend alembic upgrade head`
+- **Migration naming**: hash + slug (see `update_phd_sel_mode_001.py`). Use a meaningful slug.
+
+---
+
+## Phase 1 — Data Model & Migration
+
+### Task 1.1: Add `cancelled_by_challenge` to ApplicationStatus enum
+
+**Files:**
+- Modify: `backend/app/models/enums.py:16-40`
+
+- [ ] **Step 1: Edit enum**
+
+```python
+class ApplicationStatus(enum.Enum):
+    """..."""
+    # 編輯中狀態
+    draft = "draft"
+    # ... (existing values unchanged)
+    manual_excluded = "manual_excluded"
+    cancelled_by_challenge = "cancelled_by_challenge"  # 因挑戰申請成功被自動取消
+    deleted = "deleted"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/models/enums.py
+git commit -m "feat(enum): add cancelled_by_challenge to ApplicationStatus"
+```
+
+---
+
+### Task 1.2: Add new columns + relationships to Application model
+
+**Files:**
+- Modify: `backend/app/models/application.py` (around lines 100-103 and 188-191)
+
+- [ ] **Step 1: Add columns after `previous_application_id`**
+
+```python
+    previous_application_id = Column(Integer, ForeignKey("applications.id"))
+
+    # 挑戰申請：指向被挑戰的續領申請 (is_renewal=True 紀錄)
+    # 約束: challenges_application_id IS NOT NULL ⇒ is_renewal = False
+    challenges_application_id = Column(
+        Integer, ForeignKey("applications.id"), nullable=True, index=True
+    )
+
+    # 釋出鏈追蹤：被誰挑戰成功取代 (cancelled_by_challenge 狀態時必填)
+    cancelled_due_to_application_id = Column(
+        Integer, ForeignKey("applications.id"), nullable=True
+    )
+```
+
+- [ ] **Step 2: Add relationships in the relationships block**
+
+```python
+    previous_application = relationship(
+        "Application", remote_side=[id], foreign_keys=[previous_application_id]
+    )
+    challenged_renewal = relationship(
+        "Application", remote_side=[id], foreign_keys=[challenges_application_id]
+    )
+    cancelled_due_to = relationship(
+        "Application", remote_side=[id], foreign_keys=[cancelled_due_to_application_id]
+    )
+```
+
+- [ ] **Step 3: Replace `__table_args__` with partial unique indexes**
+
+```python
+from sqlalchemy import Index
+
+    __table_args__ = (
+        Index(
+            "uq_user_renewal_app",
+            "user_id", "scholarship_type_id", "academic_year", "semester",
+            unique=True,
+            postgresql_where=sa.text("is_renewal = true AND status != 'deleted'"),
+        ),
+        Index(
+            "uq_user_challenge_app",
+            "user_id", "scholarship_type_id", "academic_year", "semester",
+            unique=True,
+            postgresql_where=sa.text(
+                "is_renewal = false AND challenges_application_id IS NOT NULL "
+                "AND status != 'deleted'"
+            ),
+        ),
+        Index(
+            "uq_user_pure_new_app",
+            "user_id", "scholarship_type_id", "academic_year", "semester",
+            unique=True,
+            postgresql_where=sa.text(
+                "is_renewal = false AND challenges_application_id IS NULL "
+                "AND status != 'deleted'"
+            ),
+        ),
+    )
+```
+
+Make sure `import sqlalchemy as sa` is present at top of file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/models/application.py
+git commit -m "feat(model): add challenge linkage columns to Application"
+```
+
+---
+
+### Task 1.3: Create Alembic migration
+
+**Files:**
+- Create: `backend/alembic/versions/add_renewal_challenge_001_add_renewal_challenge_columns.py`
+
+- [ ] **Step 1: Generate skeleton manually (avoid autogenerate which can pick up unrelated drift)**
+
+Identify the current head:
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend alembic heads
+```
+
+- [ ] **Step 2: Write the migration**
+
+```python
+"""Add renewal challenge columns + partial unique indexes + status enum value
+
+Revision ID: add_renewal_challenge_001
+Revises: <CURRENT_HEAD_REVISION>
+Create Date: 2026-05-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_renewal_challenge_001"
+down_revision = "<CURRENT_HEAD_REVISION>"  # set from Step 1
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_columns = [c["name"] for c in inspector.get_columns("applications")]
+
+    # 1. Add enum value (must commit before being usable in same transaction in some PG versions)
+    op.execute("ALTER TYPE applicationstatus ADD VALUE IF NOT EXISTS 'cancelled_by_challenge'")
+
+    # 2. Add new columns (idempotent)
+    if "challenges_application_id" not in existing_columns:
+        op.add_column(
+            "applications",
+            sa.Column(
+                "challenges_application_id",
+                sa.Integer(),
+                sa.ForeignKey("applications.id"),
+                nullable=True,
+            ),
+        )
+        op.create_index(
+            "ix_applications_challenges_application_id",
+            "applications",
+            ["challenges_application_id"],
+        )
+
+    if "cancelled_due_to_application_id" not in existing_columns:
+        op.add_column(
+            "applications",
+            sa.Column(
+                "cancelled_due_to_application_id",
+                sa.Integer(),
+                sa.ForeignKey("applications.id"),
+                nullable=True,
+            ),
+        )
+
+    # 3. Drop old single UNIQUE, add three partial unique indexes
+    op.drop_constraint("uq_user_scholarship_academic_term", "applications", type_="unique")
+
+    op.create_index(
+        "uq_user_renewal_app",
+        "applications",
+        ["user_id", "scholarship_type_id", "academic_year", "semester"],
+        unique=True,
+        postgresql_where=sa.text("is_renewal = true AND status != 'deleted'"),
+    )
+    op.create_index(
+        "uq_user_challenge_app",
+        "applications",
+        ["user_id", "scholarship_type_id", "academic_year", "semester"],
+        unique=True,
+        postgresql_where=sa.text(
+            "is_renewal = false AND challenges_application_id IS NOT NULL "
+            "AND status != 'deleted'"
+        ),
+    )
+    op.create_index(
+        "uq_user_pure_new_app",
+        "applications",
+        ["user_id", "scholarship_type_id", "academic_year", "semester"],
+        unique=True,
+        postgresql_where=sa.text(
+            "is_renewal = false AND challenges_application_id IS NULL "
+            "AND status != 'deleted'"
+        ),
+    )
+
+    # 4. Check constraint: cancelled_by_challenge requires cancelled_due_to_application_id
+    op.create_check_constraint(
+        "chk_cancelled_by_challenge_link",
+        "applications",
+        "status != 'cancelled_by_challenge' OR cancelled_due_to_application_id IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("chk_cancelled_by_challenge_link", "applications", type_="check")
+    op.drop_index("uq_user_pure_new_app", "applications")
+    op.drop_index("uq_user_challenge_app", "applications")
+    op.drop_index("uq_user_renewal_app", "applications")
+    op.create_unique_constraint(
+        "uq_user_scholarship_academic_term",
+        "applications",
+        ["user_id", "scholarship_type_id", "academic_year", "semester"],
+    )
+    op.drop_column("applications", "cancelled_due_to_application_id")
+    op.drop_index("ix_applications_challenges_application_id", table_name="applications")
+    op.drop_column("applications", "challenges_application_id")
+    # Note: Postgres does not support removing enum values cleanly; leave 'cancelled_by_challenge'
+```
+
+- [ ] **Step 3: Run migration on dev DB**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend alembic upgrade head
+```
+
+Expected output: `INFO  [alembic.runtime.migration] Running upgrade ... -> add_renewal_challenge_001`
+
+- [ ] **Step 4: Verify schema**
+
+```bash
+docker compose -f docker-compose.dev.yml exec postgres psql -U scholarship_user -d scholarship_db -c "\d applications"
+```
+
+Expected: see `challenges_application_id`, `cancelled_due_to_application_id`, and the three `uq_user_*_app` indexes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/alembic/versions/add_renewal_challenge_001_*.py
+git commit -m "feat(migration): add renewal challenge columns and partial unique indexes"
+```
+
+---
+
+## Phase 2 — Renewal Eligibility Service
+
+### Task 2.1: Write tests for `get_eligible_renewals`
+
+**Files:**
+- Create: `backend/app/tests/test_renewal_eligibility_service.py`
+
+- [ ] **Step 1: Write tests**
+
+```python
+import pytest
+from datetime import datetime, timedelta, timezone
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, Semester
+from app.models.scholarship import ScholarshipType, ScholarshipConfiguration
+from app.services.renewal_eligibility_service import RenewalEligibilityService
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_prior_approved(db_session: AsyncSession, user_factory):
+    """No prior approved application → no eligible renewals."""
+    user = await user_factory()
+    service = RenewalEligibilityService(db_session)
+    result = await service.get_eligible_renewals(user_id=user.id, current_academic_year=114)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_returns_prior_approved_when_in_renewal_period(
+    db_session, user_factory, scholarship_type_factory, application_factory
+):
+    user = await user_factory()
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        renewal_application_start_date=now - timedelta(days=1),
+        renewal_application_end_date=now + timedelta(days=7),
+    )
+    prior = await application_factory(
+        user_id=user.id,
+        scholarship_type_id=st.id,
+        academic_year=113,
+        status=ApplicationStatus.approved,
+        sub_scholarship_type="nstc",
+    )
+    service = RenewalEligibilityService(db_session)
+    result = await service.get_eligible_renewals(user_id=user.id, current_academic_year=114)
+    assert len(result) == 1
+    assert result[0].id == prior.id
+
+
+@pytest.mark.asyncio
+async def test_excludes_rejected_prior(
+    db_session, user_factory, scholarship_type_factory, application_factory
+):
+    user = await user_factory()
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        renewal_application_start_date=now - timedelta(days=1),
+        renewal_application_end_date=now + timedelta(days=7),
+    )
+    await application_factory(
+        user_id=user.id,
+        scholarship_type_id=st.id,
+        academic_year=113,
+        status=ApplicationStatus.rejected,
+    )
+    service = RenewalEligibilityService(db_session)
+    result = await service.get_eligible_renewals(user_id=user.id, current_academic_year=114)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_excludes_when_not_in_renewal_period(
+    db_session, user_factory, scholarship_type_factory, application_factory
+):
+    user = await user_factory()
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        renewal_application_start_date=now + timedelta(days=7),  # 未到
+        renewal_application_end_date=now + timedelta(days=14),
+    )
+    await application_factory(
+        user_id=user.id,
+        scholarship_type_id=st.id,
+        academic_year=113,
+        status=ApplicationStatus.approved,
+    )
+    service = RenewalEligibilityService(db_session)
+    result = await service.get_eligible_renewals(user_id=user.id, current_academic_year=114)
+    assert result == []
+```
+
+- [ ] **Step 2: Run tests → expect ImportError or all FAIL**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_eligibility_service.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'app.services.renewal_eligibility_service'`
+
+---
+
+### Task 2.2: Implement `RenewalEligibilityService`
+
+**Files:**
+- Create: `backend/app/services/renewal_eligibility_service.py`
+
+- [ ] **Step 1: Write implementation**
+
+```python
+"""
+RenewalEligibilityService — determine which prior approved applications
+are eligible for renewal in the current academic year.
+"""
+
+from datetime import datetime, timezone
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus
+from app.models.scholarship import ScholarshipType
+
+
+class RenewalEligibilityService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_eligible_renewals(
+        self, user_id: int, current_academic_year: int
+    ) -> List[Application]:
+        """
+        Return prior-year approved applications where the scholarship_type is
+        currently in renewal_application_period.
+        """
+        now = datetime.now(timezone.utc)
+
+        stmt = (
+            select(Application)
+            .options(joinedload(Application.scholarship_type_ref))
+            .join(ScholarshipType, Application.scholarship_type_id == ScholarshipType.id)
+            .where(
+                Application.user_id == user_id,
+                Application.academic_year == current_academic_year - 1,
+                Application.status == ApplicationStatus.approved,
+                ScholarshipType.renewal_application_start_date <= now,
+                ScholarshipType.renewal_application_end_date >= now,
+            )
+        )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+```
+
+- [ ] **Step 2: Run tests → expect PASS**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_eligibility_service.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/services/renewal_eligibility_service.py backend/app/tests/test_renewal_eligibility_service.py
+git commit -m "feat(renewal): add RenewalEligibilityService"
+```
+
+---
+
+## Phase 3 — Renewal & Challenge Application Creation
+
+### Task 3.1: Pydantic schemas
+
+**Files:**
+- Create: `backend/app/schemas/renewal.py`
+
+- [ ] **Step 1: Write schemas**
+
+```python
+from pydantic import BaseModel, ConfigDict
+from typing import Optional
+
+
+class EligibleRenewalItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    previous_application_id: int  # = source application's id
+    scholarship_type_id: int
+    scholarship_type_name: str
+    sub_scholarship_type: str  # e.g. "nstc"
+    target_academic_year: int  # current_academic_year
+    renewal_year: int  # = previous renewal_year if set, else previous.academic_year
+    renewal_deadline: Optional[str]  # ISO datetime
+
+
+class CreateRenewalRequest(BaseModel):
+    previous_application_id: int
+
+
+class CreateChallengeRequest(BaseModel):
+    renewal_application_id: int
+    target_sub_type: str
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/schemas/renewal.py
+git commit -m "feat(schema): add renewal/challenge Pydantic schemas"
+```
+
+---
+
+### Task 3.2: Write tests for renewal creation endpoint
+
+**Files:**
+- Create: `backend/app/tests/test_renewal_application_creation.py`
+
+- [ ] **Step 1: Write tests**
+
+```python
+import pytest
+from datetime import datetime, timedelta, timezone
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus
+
+
+@pytest.mark.asyncio
+async def test_create_renewal_application_success(
+    async_client, auth_headers_for_student, scholarship_type_factory, application_factory
+):
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        renewal_application_start_date=now - timedelta(days=1),
+        renewal_application_end_date=now + timedelta(days=7),
+    )
+    prior = await application_factory(
+        user_id=auth_headers_for_student.user_id,
+        scholarship_type_id=st.id,
+        academic_year=113,
+        status=ApplicationStatus.approved,
+        sub_scholarship_type="nstc",
+    )
+
+    resp = await async_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+        headers=auth_headers_for_student.headers,
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["success"] is True
+    new_app = body["data"]
+    assert new_app["is_renewal"] is True
+    assert new_app["sub_scholarship_type"] == "nstc"
+    assert new_app["previous_application_id"] == prior.id
+    assert new_app["academic_year"] == 114
+    assert new_app["renewal_year"] == 113
+
+
+@pytest.mark.asyncio
+async def test_create_renewal_rejects_when_prior_not_approved(
+    async_client, auth_headers_for_student, scholarship_type_factory, application_factory
+):
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        renewal_application_start_date=now - timedelta(days=1),
+        renewal_application_end_date=now + timedelta(days=7),
+    )
+    prior = await application_factory(
+        user_id=auth_headers_for_student.user_id,
+        scholarship_type_id=st.id,
+        academic_year=113,
+        status=ApplicationStatus.rejected,
+    )
+    resp = await async_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+        headers=auth_headers_for_student.headers,
+    )
+    assert resp.status_code == 400
+    assert "未核可" in resp.json()["detail"] or "approved" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_create_renewal_rejects_outside_period(
+    async_client, auth_headers_for_student, scholarship_type_factory, application_factory
+):
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        renewal_application_start_date=now + timedelta(days=7),
+        renewal_application_end_date=now + timedelta(days=14),
+    )
+    prior = await application_factory(
+        user_id=auth_headers_for_student.user_id,
+        scholarship_type_id=st.id,
+        academic_year=113,
+        status=ApplicationStatus.approved,
+    )
+    resp = await async_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+        headers=auth_headers_for_student.headers,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_renewal_rejects_duplicate(
+    async_client, auth_headers_for_student, scholarship_type_factory, application_factory
+):
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        renewal_application_start_date=now - timedelta(days=1),
+        renewal_application_end_date=now + timedelta(days=7),
+    )
+    prior = await application_factory(
+        user_id=auth_headers_for_student.user_id,
+        scholarship_type_id=st.id,
+        academic_year=113,
+        status=ApplicationStatus.approved,
+    )
+    # 第一次成功
+    r1 = await async_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+        headers=auth_headers_for_student.headers,
+    )
+    assert r1.status_code == 201
+    # 第二次衝突
+    r2 = await async_client.post(
+        "/api/v1/renewals/",
+        json={"previous_application_id": prior.id},
+        headers=auth_headers_for_student.headers,
+    )
+    assert r2.status_code == 409
+```
+
+- [ ] **Step 2: Run tests → expect FAIL (endpoint not yet exists)**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_application_creation.py -v
+```
+
+Expected: 404 or import errors.
+
+---
+
+### Task 3.3: Implement `POST /api/v1/renewals/`
+
+**Files:**
+- Create: `backend/app/api/v1/endpoints/renewal.py`
+- Modify: `backend/app/api/v1/api.py` (register router)
+
+- [ ] **Step 1: Implement endpoint**
+
+```python
+"""Renewal & Challenge application endpoints."""
+
+from datetime import datetime, timezone
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_async_db, get_current_user
+from app.models.application import Application
+from app.models.enums import ApplicationStatus
+from app.models.scholarship import ScholarshipType
+from app.models.user import User
+from app.schemas.renewal import CreateRenewalRequest, CreateChallengeRequest
+from app.services.renewal_eligibility_service import RenewalEligibilityService
+from app.services.application_service import ApplicationService
+
+router = APIRouter(prefix="/renewals", tags=["renewals"])
+
+
+@router.get("/eligible")
+async def list_eligible_renewals(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """List prior-year approved applications eligible for renewal."""
+    from app.services.academic_year_service import get_current_academic_year
+    current_year = get_current_academic_year()
+    service = RenewalEligibilityService(db)
+    apps = await service.get_eligible_renewals(current_user.id, current_year)
+    return {
+        "success": True,
+        "message": "Eligible renewals retrieved",
+        "data": [
+            {
+                "previous_application_id": app.id,
+                "scholarship_type_id": app.scholarship_type_id,
+                "scholarship_type_name": app.scholarship_type_ref.name,
+                "sub_scholarship_type": app.sub_scholarship_type,
+                "target_academic_year": current_year,
+                "renewal_year": app.renewal_year or app.academic_year,
+                "renewal_deadline": (
+                    app.scholarship_type_ref.renewal_application_end_date.isoformat()
+                    if app.scholarship_type_ref.renewal_application_end_date else None
+                ),
+            }
+            for app in apps
+        ],
+    }
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_renewal_application(
+    body: CreateRenewalRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Create a renewal application from a prior approved application."""
+    now = datetime.now(timezone.utc)
+
+    # 1. Load previous application
+    prev = await db.scalar(
+        select(Application).where(Application.id == body.previous_application_id)
+    )
+    if not prev:
+        raise HTTPException(status_code=404, detail="先前申請紀錄不存在")
+    if prev.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="無權續領他人申請")
+    if prev.status != ApplicationStatus.approved:
+        raise HTTPException(status_code=400, detail="先前申請尚未核可，無法續領")
+
+    # 2. Load scholarship type and check period
+    st = await db.scalar(select(ScholarshipType).where(ScholarshipType.id == prev.scholarship_type_id))
+    if not (st.renewal_application_start_date and st.renewal_application_end_date
+            and st.renewal_application_start_date <= now <= st.renewal_application_end_date):
+        raise HTTPException(status_code=400, detail="目前不在續領申請期間")
+
+    # 3. Check duplicate (handled by partial unique index, but provide friendly message)
+    from app.services.academic_year_service import get_current_academic_year
+    current_year = get_current_academic_year()
+    existing = await db.scalar(
+        select(Application).where(
+            Application.user_id == current_user.id,
+            Application.scholarship_type_id == prev.scholarship_type_id,
+            Application.academic_year == current_year,
+            Application.semester == prev.semester,
+            Application.is_renewal == True,
+            Application.status != ApplicationStatus.deleted,
+        )
+    )
+    if existing:
+        raise HTTPException(status_code=409, detail="已建立續領申請")
+
+    # 4. Create new Application
+    service = ApplicationService(db)
+    new_app = await service.create_renewal_from_previous(
+        previous=prev,
+        current_user=current_user,
+        target_academic_year=current_year,
+        renewal_year=prev.renewal_year or prev.academic_year,
+    )
+    await db.commit()
+
+    return {
+        "success": True,
+        "message": "續領申請已建立",
+        "data": {
+            "id": new_app.id,
+            "app_id": new_app.app_id,
+            "is_renewal": new_app.is_renewal,
+            "sub_scholarship_type": new_app.sub_scholarship_type,
+            "previous_application_id": new_app.previous_application_id,
+            "academic_year": new_app.academic_year,
+            "renewal_year": new_app.renewal_year,
+            "status": new_app.status.value,
+        },
+    }
+```
+
+- [ ] **Step 2: Register router in `backend/app/api/v1/api.py`**
+
+```python
+from app.api.v1.endpoints import renewal
+# ... existing imports
+
+api_router.include_router(renewal.router, prefix="/v1")  # adjust to existing prefix pattern
+```
+
+- [ ] **Step 3: Add `create_renewal_from_previous` to ApplicationService**
+
+In `backend/app/services/application_service.py`, add method:
+
+```python
+    async def create_renewal_from_previous(
+        self,
+        previous: Application,
+        current_user: User,
+        target_academic_year: int,
+        renewal_year: int,
+    ) -> Application:
+        """Create renewal application copying sub_type & key fields from previous."""
+        app_id = await self._generate_app_id(target_academic_year, previous.semester.value if previous.semester else None)
+        new_app = Application(
+            app_id=app_id,
+            user_id=current_user.id,
+            scholarship_type_id=previous.scholarship_type_id,
+            scholarship_configuration_id=previous.scholarship_configuration_id,
+            sub_scholarship_type=previous.sub_scholarship_type,
+            sub_type_selection_mode=previous.sub_type_selection_mode,
+            is_renewal=True,
+            renewal_year=renewal_year,
+            previous_application_id=previous.id,
+            academic_year=target_academic_year,
+            semester=previous.semester,
+            status=ApplicationStatus.draft,
+            review_stage=ReviewStage.student_draft,
+        )
+        self.db.add(new_app)
+        await self.db.flush()
+        return new_app
+```
+
+- [ ] **Step 4: Run tests → expect PASS**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_application_creation.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/renewal.py backend/app/api/v1/api.py backend/app/services/application_service.py
+git commit -m "feat(api): add renewal application creation endpoint"
+```
+
+---
+
+### Task 3.4: Write tests for challenge creation endpoint
+
+**Files:**
+- Append to: `backend/app/tests/test_renewal_application_creation.py`
+
+- [ ] **Step 1: Add challenge tests**
+
+```python
+@pytest.mark.asyncio
+async def test_create_challenge_success(
+    async_client, auth_headers_for_student, scholarship_type_factory, application_factory,
+    scholarship_configuration_factory
+):
+    """Approved renewal exists → create challenge for different sub_type."""
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        application_start_date=now - timedelta(days=1),
+        application_end_date=now + timedelta(days=7),
+    )
+    await scholarship_configuration_factory(
+        scholarship_type_id=st.id,
+        quotas={"nstc": {"114": 8}, "moe_1w": {"114": 6}},
+    )
+    renewal = await application_factory(
+        user_id=auth_headers_for_student.user_id,
+        scholarship_type_id=st.id,
+        academic_year=114,
+        status=ApplicationStatus.approved,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+        renewal_year=113,
+    )
+    resp = await async_client.post(
+        "/api/v1/renewals/challenge",
+        json={"renewal_application_id": renewal.id, "target_sub_type": "moe_1w"},
+        headers=auth_headers_for_student.headers,
+    )
+    assert resp.status_code == 201
+    data = resp.json()["data"]
+    assert data["is_renewal"] is False
+    assert data["sub_scholarship_type"] == "moe_1w"
+    assert data["challenges_application_id"] == renewal.id
+
+
+@pytest.mark.asyncio
+async def test_create_challenge_rejects_same_sub_type(
+    async_client, auth_headers_for_student, scholarship_type_factory, application_factory
+):
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        application_start_date=now - timedelta(days=1),
+        application_end_date=now + timedelta(days=7),
+    )
+    renewal = await application_factory(
+        user_id=auth_headers_for_student.user_id,
+        scholarship_type_id=st.id,
+        academic_year=114,
+        status=ApplicationStatus.approved,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+    )
+    resp = await async_client.post(
+        "/api/v1/renewals/challenge",
+        json={"renewal_application_id": renewal.id, "target_sub_type": "nstc"},
+        headers=auth_headers_for_student.headers,
+    )
+    assert resp.status_code == 400
+    assert "sub_type" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_challenge_rejects_when_renewal_not_approved(
+    async_client, auth_headers_for_student, scholarship_type_factory, application_factory
+):
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        application_start_date=now - timedelta(days=1),
+        application_end_date=now + timedelta(days=7),
+    )
+    renewal = await application_factory(
+        user_id=auth_headers_for_student.user_id,
+        scholarship_type_id=st.id,
+        academic_year=114,
+        status=ApplicationStatus.rejected,
+        is_renewal=True,
+    )
+    resp = await async_client.post(
+        "/api/v1/renewals/challenge",
+        json={"renewal_application_id": renewal.id, "target_sub_type": "moe_1w"},
+        headers=auth_headers_for_student.headers,
+    )
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 2: Run tests → expect 404 (endpoint not implemented)**
+
+---
+
+### Task 3.5: Implement `POST /api/v1/renewals/challenge`
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/renewal.py`
+- Modify: `backend/app/services/application_service.py`
+
+- [ ] **Step 1: Add endpoint**
+
+```python
+@router.post("/challenge", status_code=status.HTTP_201_CREATED)
+async def create_challenge_application(
+    body: CreateChallengeRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+):
+    now = datetime.now(timezone.utc)
+
+    renewal = await db.scalar(
+        select(Application).where(Application.id == body.renewal_application_id)
+    )
+    if not renewal:
+        raise HTTPException(status_code=404, detail="續領申請紀錄不存在")
+    if renewal.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="無權挑戰他人續領")
+    if not renewal.is_renewal:
+        raise HTTPException(status_code=400, detail="目標申請非續領紀錄")
+    if renewal.status != ApplicationStatus.approved:
+        raise HTTPException(status_code=400, detail="續領申請尚未核可，無法挑戰")
+
+    if body.target_sub_type == renewal.sub_scholarship_type:
+        raise HTTPException(status_code=400, detail="挑戰 sub_type 不能與續領 sub_type 相同")
+
+    st = await db.scalar(select(ScholarshipType).where(ScholarshipType.id == renewal.scholarship_type_id))
+    if not (st.application_start_date and st.application_end_date
+            and st.application_start_date <= now <= st.application_end_date):
+        raise HTTPException(status_code=400, detail="目前不在一般申請期間")
+
+    # Verify target_sub_type exists in configuration
+    from app.models.scholarship import ScholarshipConfiguration
+    config = await db.scalar(
+        select(ScholarshipConfiguration).where(
+            ScholarshipConfiguration.id == renewal.scholarship_configuration_id
+        )
+    )
+    if config and body.target_sub_type not in (config.quotas or {}):
+        raise HTTPException(status_code=400, detail=f"sub_type '{body.target_sub_type}' 不存在於配置")
+
+    # Check duplicate challenge
+    existing = await db.scalar(
+        select(Application).where(
+            Application.user_id == current_user.id,
+            Application.scholarship_type_id == renewal.scholarship_type_id,
+            Application.academic_year == renewal.academic_year,
+            Application.semester == renewal.semester,
+            Application.is_renewal == False,
+            Application.challenges_application_id == renewal.id,
+            Application.status != ApplicationStatus.deleted,
+        )
+    )
+    if existing:
+        raise HTTPException(status_code=409, detail="已建立挑戰申請")
+
+    service = ApplicationService(db)
+    new_app = await service.create_challenge_from_renewal(
+        renewal=renewal,
+        current_user=current_user,
+        target_sub_type=body.target_sub_type,
+    )
+    await db.commit()
+
+    return {
+        "success": True,
+        "message": "挑戰申請已建立",
+        "data": {
+            "id": new_app.id,
+            "app_id": new_app.app_id,
+            "is_renewal": new_app.is_renewal,
+            "sub_scholarship_type": new_app.sub_scholarship_type,
+            "challenges_application_id": new_app.challenges_application_id,
+            "academic_year": new_app.academic_year,
+            "status": new_app.status.value,
+        },
+    }
+```
+
+- [ ] **Step 2: Add `create_challenge_from_renewal` to ApplicationService**
+
+```python
+    async def create_challenge_from_renewal(
+        self, renewal: Application, current_user: User, target_sub_type: str
+    ) -> Application:
+        app_id = await self._generate_app_id(
+            renewal.academic_year,
+            renewal.semester.value if renewal.semester else None,
+        )
+        new_app = Application(
+            app_id=app_id,
+            user_id=current_user.id,
+            scholarship_type_id=renewal.scholarship_type_id,
+            scholarship_configuration_id=renewal.scholarship_configuration_id,
+            sub_scholarship_type=target_sub_type,
+            sub_type_selection_mode=renewal.sub_type_selection_mode,
+            is_renewal=False,
+            challenges_application_id=renewal.id,
+            academic_year=renewal.academic_year,
+            semester=renewal.semester,
+            status=ApplicationStatus.draft,
+            review_stage=ReviewStage.student_draft,
+        )
+        self.db.add(new_app)
+        await self.db.flush()
+        return new_app
+```
+
+- [ ] **Step 3: Run tests → expect PASS**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_application_creation.py -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/renewal.py backend/app/services/application_service.py
+git commit -m "feat(api): add challenge application creation endpoint"
+```
+
+---
+
+## Phase 4 — Renewal Review Routing
+
+### Task 4.1: Extend review listing endpoints to filter by renewal phase
+
+**Files:**
+- Modify: existing review listing endpoint (likely `backend/app/api/v1/endpoints/applications.py` — search for "professor_review" route)
+
+- [ ] **Step 1: Find route**
+
+```bash
+grep -rn "professor" backend/app/api/v1/endpoints/ | grep -i "list\|pending" | head
+```
+
+- [ ] **Step 2: Add `is_renewal` filter & period check**
+
+For each list endpoint (professor pending, college pending), add filter:
+
+```python
+# pseudocode — adapt to actual route signature
+from app.models.scholarship import ScholarshipType
+from datetime import datetime, timezone
+
+# Determine if currently in renewal review period vs general review period
+# for each scholarship_type involved. Apps shown depend on phase.
+
+now = datetime.now(timezone.utc)
+stmt = stmt.join(ScholarshipType, Application.scholarship_type_id == ScholarshipType.id)
+stmt = stmt.where(
+    or_(
+        and_(
+            Application.is_renewal == True,
+            ScholarshipType.renewal_professor_review_start <= now,
+            ScholarshipType.renewal_professor_review_end >= now,
+        ),
+        and_(
+            Application.is_renewal == False,
+            ScholarshipType.professor_review_start <= now,
+            ScholarshipType.professor_review_end >= now,
+        ),
+    )
+)
+```
+
+- [ ] **Step 3: Write integration test**
+
+Create `backend/app/tests/test_review_routing_renewal.py`:
+
+```python
+import pytest
+from datetime import datetime, timedelta, timezone
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, ReviewStage
+
+
+@pytest.mark.asyncio
+async def test_professor_sees_only_renewal_in_renewal_period(
+    async_client, professor_auth, scholarship_type_factory, application_factory
+):
+    now = datetime.now(timezone.utc)
+    st = await scholarship_type_factory(
+        renewal_professor_review_start=now - timedelta(hours=1),
+        renewal_professor_review_end=now + timedelta(days=3),
+        professor_review_start=now + timedelta(days=14),
+        professor_review_end=now + timedelta(days=21),
+    )
+    renewal_app = await application_factory(
+        scholarship_type_id=st.id,
+        is_renewal=True,
+        review_stage=ReviewStage.professor_review,
+        professor_id=professor_auth.user_id,
+    )
+    general_app = await application_factory(
+        scholarship_type_id=st.id,
+        is_renewal=False,
+        review_stage=ReviewStage.professor_review,
+        professor_id=professor_auth.user_id,
+    )
+    resp = await async_client.get(
+        "/api/v1/applications/pending-review", headers=professor_auth.headers
+    )
+    ids = [a["id"] for a in resp.json()["data"]]
+    assert renewal_app.id in ids
+    assert general_app.id not in ids
+```
+
+- [ ] **Step 4: Run tests → expect FAIL, then implement, then PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/applications.py backend/app/tests/test_review_routing_renewal.py
+git commit -m "feat(review): filter pending review list by renewal vs general phase"
+```
+
+---
+
+## Phase 5 — Renewal Distribution Service
+
+### Task 5.1: Write tests for renewal auto-distribution
+
+**Files:**
+- Create: `backend/app/tests/test_renewal_distribution_service.py`
+
+- [ ] **Step 1: Write tests**
+
+```python
+import pytest
+from app.models.enums import ApplicationStatus, ReviewStage
+from app.services.renewal_distribution_service import RenewalDistributionService
+
+
+@pytest.mark.asyncio
+async def test_auto_approves_renewals_with_passed_reviews(
+    db_session, scholarship_type_factory, application_factory
+):
+    st = await scholarship_type_factory()
+    app1 = await application_factory(
+        scholarship_type_id=st.id, is_renewal=True,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.college_reviewed,
+    )
+    app2 = await application_factory(
+        scholarship_type_id=st.id, is_renewal=True,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.college_reviewed,
+    )
+    service = RenewalDistributionService(db_session)
+    result = await service.auto_approve_passed_reviews(scholarship_type_id=st.id)
+    await db_session.refresh(app1); await db_session.refresh(app2)
+    assert app1.status == ApplicationStatus.approved
+    assert app2.status == ApplicationStatus.approved
+    assert result["approved_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_does_not_approve_non_renewal(
+    db_session, scholarship_type_factory, application_factory
+):
+    st = await scholarship_type_factory()
+    general_app = await application_factory(
+        scholarship_type_id=st.id, is_renewal=False,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.college_reviewed,
+    )
+    service = RenewalDistributionService(db_session)
+    await service.auto_approve_passed_reviews(scholarship_type_id=st.id)
+    await db_session.refresh(general_app)
+    assert general_app.status == ApplicationStatus.under_review
+
+
+@pytest.mark.asyncio
+async def test_does_not_approve_not_yet_reviewed(
+    db_session, scholarship_type_factory, application_factory
+):
+    st = await scholarship_type_factory()
+    pending = await application_factory(
+        scholarship_type_id=st.id, is_renewal=True,
+        status=ApplicationStatus.under_review,
+        review_stage=ReviewStage.professor_review,  # still in flight
+    )
+    service = RenewalDistributionService(db_session)
+    await service.auto_approve_passed_reviews(scholarship_type_id=st.id)
+    await db_session.refresh(pending)
+    assert pending.status == ApplicationStatus.under_review
+```
+
+- [ ] **Step 2: Run tests → expect ModuleNotFoundError**
+
+---
+
+### Task 5.2: Implement `RenewalDistributionService`
+
+**Files:**
+- Create: `backend/app/services/renewal_distribution_service.py`
+
+- [ ] **Step 1: Write service**
+
+```python
+"""
+RenewalDistributionService — auto-approves renewal applications that have
+passed required review stages (skips college_ranking by design).
+"""
+
+from typing import Optional
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import ApplicationStatus, ReviewStage
+from app.models.scholarship import ScholarshipConfiguration
+
+
+class RenewalDistributionService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def auto_approve_passed_reviews(self, scholarship_type_id: int) -> dict:
+        """
+        Auto-approve renewal applications where:
+        - is_renewal = True
+        - review_stage == college_reviewed (or professor_reviewed if no college required)
+        - status == under_review
+
+        Returns summary dict with approved_count, rejected_count.
+        """
+        # Determine the terminal review stage based on configuration
+        config = await self.db.scalar(
+            select(ScholarshipConfiguration).where(
+                ScholarshipConfiguration.scholarship_type_id == scholarship_type_id
+            )
+        )
+        # college_reviewed is the terminal stage for renewal (no college_ranking)
+        # If config does not require college review, then professor_reviewed is terminal
+        terminal_stages = [ReviewStage.college_reviewed]
+        if config and not getattr(config, "requires_college_review", True):
+            terminal_stages = [ReviewStage.professor_reviewed]
+
+        stmt = (
+            update(Application)
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.is_renewal == True,
+                Application.status == ApplicationStatus.under_review,
+                Application.review_stage.in_(terminal_stages),
+            )
+            .values(
+                status=ApplicationStatus.approved,
+                review_stage=ReviewStage.quota_distributed,
+            )
+            .returning(Application.id)
+        )
+        result = await self.db.execute(stmt)
+        approved_ids = [r[0] for r in result.all()]
+        await self.db.commit()
+
+        return {"approved_count": len(approved_ids), "approved_ids": approved_ids}
+```
+
+- [ ] **Step 2: Run tests → PASS**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_distribution_service.py -v
+```
+
+- [ ] **Step 3: Add endpoint to trigger**
+
+In `backend/app/api/v1/endpoints/renewal.py`:
+
+```python
+from app.services.renewal_distribution_service import RenewalDistributionService
+
+@router.post("/{scholarship_type_id}/auto-distribute")
+async def trigger_renewal_auto_distribution(
+    scholarship_type_id: int,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_async_db),
+):
+    service = RenewalDistributionService(db)
+    result = await service.auto_approve_passed_reviews(scholarship_type_id)
+    return {"success": True, "message": "續領自動分發完成", "data": result}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/renewal_distribution_service.py backend/app/tests/test_renewal_distribution_service.py backend/app/api/v1/endpoints/renewal.py
+git commit -m "feat(renewal): add auto-distribute service for renewals passing review"
+```
+
+---
+
+## Phase 6 — General Distribution + Release + Fill-in
+
+### Task 6.1: Write integration test for challenge release + fill-in
+
+**Files:**
+- Create: `backend/app/tests/test_challenge_release_distribution.py`
+
+- [ ] **Step 1: Write end-to-end test**
+
+```python
+import pytest
+from app.models.enums import ApplicationStatus
+from app.services.manual_distribution_service import ManualDistributionService
+
+
+@pytest.mark.asyncio
+async def test_challenge_success_releases_renewal_and_fills_waitlist(
+    db_session, scholarship_type_factory, scholarship_configuration_factory,
+    application_factory, college_ranking_factory
+):
+    """
+    Scenario: A has approved renewal nstc-113. A challenges moe_1w and ranks #1.
+    F-T are pure-new nstc candidates ranked 1-8 (will fill nstc-114 quota).
+    U, V are pure-new nstc candidates ranked 9, 10 (waitlist).
+    After distribution:
+      - A's renewal cancelled_by_challenge
+      - A approved on moe_1w
+      - U promoted to approved on nstc with allocation_year=113
+    """
+    st = await scholarship_type_factory()
+    await scholarship_configuration_factory(
+        scholarship_type_id=st.id,
+        quotas={"nstc": {"114": 8, "113": 0}, "moe_1w": {"114": 6}},
+    )
+    # A's renewal (already approved)
+    renewal_A = await application_factory(
+        scholarship_type_id=st.id, sub_scholarship_type="nstc",
+        is_renewal=True, renewal_year=113, academic_year=114,
+        status=ApplicationStatus.approved,
+    )
+    # A's challenge
+    challenge_A = await application_factory(
+        scholarship_type_id=st.id, sub_scholarship_type="moe_1w",
+        is_renewal=False, challenges_application_id=renewal_A.id,
+        academic_year=114,
+        status=ApplicationStatus.under_review,
+    )
+    # Pure new candidates for nstc
+    nstc_candidates = []
+    for rank in range(1, 11):
+        a = await application_factory(
+            scholarship_type_id=st.id, sub_scholarship_type="nstc",
+            is_renewal=False, challenges_application_id=None,
+            academic_year=114, status=ApplicationStatus.under_review,
+        )
+        await college_ranking_factory(application_id=a.id, rank=rank)
+        nstc_candidates.append(a)
+    # Pure new for moe_1w (ranked below A so A wins)
+    for rank in range(2, 8):
+        a = await application_factory(
+            scholarship_type_id=st.id, sub_scholarship_type="moe_1w",
+            academic_year=114, status=ApplicationStatus.under_review,
+        )
+        await college_ranking_factory(application_id=a.id, rank=rank)
+    await college_ranking_factory(application_id=challenge_A.id, rank=1)
+
+    service = ManualDistributionService(db_session)
+    await service.execute_general_distribution(scholarship_type_id=st.id, academic_year=114)
+
+    await db_session.refresh(renewal_A)
+    await db_session.refresh(challenge_A)
+
+    assert challenge_A.status == ApplicationStatus.approved
+    assert renewal_A.status == ApplicationStatus.cancelled_by_challenge
+    assert renewal_A.cancelled_due_to_application_id == challenge_A.id
+
+    # U should be promoted (10 - 8 already approved = U at rank 9, V at rank 10)
+    await db_session.refresh(nstc_candidates[8])  # rank 9
+    assert nstc_candidates[8].status == ApplicationStatus.approved
+```
+
+- [ ] **Step 2: Run tests → expect FAIL (method not implemented)**
+
+---
+
+### Task 6.2: Implement `execute_general_distribution` with release + fill-in
+
+**Files:**
+- Modify: `backend/app/services/manual_distribution_service.py`
+
+- [ ] **Step 1: Add method**
+
+```python
+    async def execute_general_distribution(
+        self, scholarship_type_id: int, academic_year: int
+    ) -> dict:
+        """
+        Run general-phase distribution with challenge release and waitlist fill-in.
+        Returns summary stats per spec Section 12.
+        """
+        config = await self._get_active_config(scholarship_type_id, academic_year)
+        quotas = config.quotas or {}  # {"nstc": {"114": 8, "113": 0}, ...}
+
+        # 1. Compute remaining quota = total - used by approved renewals
+        used_by_renewal = await self._count_approved_renewals_per_pool(
+            scholarship_type_id, academic_year
+        )  # {(sub_type, alloc_year): count}
+        remaining = {
+            (st, int(y)): total - used_by_renewal.get((st, int(y)), 0)
+            for st, year_map in quotas.items()
+            for y, total in year_map.items()
+        }
+
+        # 2. First-round distribute per sub_type
+        approved_challenges = []
+        for sub_type in quotas.keys():
+            candidates = await self._get_general_candidates(
+                scholarship_type_id, academic_year, sub_type
+            )  # ordered by rank, includes pure-new + challenges for THIS sub_type
+            for cand in candidates:
+                pool_year = self._pick_pool(remaining, sub_type, sub_type_policy=config)
+                if pool_year is None:
+                    break
+                cand.application.status = ApplicationStatus.approved
+                cand.allocation_year = pool_year
+                remaining[(sub_type, pool_year)] -= 1
+                if cand.application.challenges_application_id:
+                    approved_challenges.append(cand.application)
+
+        # 3. Release handling
+        released = {}
+        for challenge_app in approved_challenges:
+            renewal_app = await self.db.scalar(
+                select(Application).where(Application.id == challenge_app.challenges_application_id)
+            )
+            renewal_app.status = ApplicationStatus.cancelled_by_challenge
+            renewal_app.cancelled_due_to_application_id = challenge_app.id
+            key = (renewal_app.sub_scholarship_type, renewal_app.renewal_year)
+            released[key] = released.get(key, 0) + 1
+
+        # 4. Fill-in from waitlist (same sub_type, next ranked, not yet approved)
+        fill_in_count = 0
+        for (sub_type, alloc_year), count in released.items():
+            waitlist = await self._get_waitlist_candidates(
+                scholarship_type_id, academic_year, sub_type, limit=count
+            )
+            for cand in waitlist:
+                cand.application.status = ApplicationStatus.approved
+                cand.allocation_year = alloc_year
+                fill_in_count += 1
+
+        await self.db.commit()
+
+        return {
+            "approved_renewals": sum(used_by_renewal.values()),
+            "approved_challenges": len(approved_challenges),
+            "released_slots": dict(released),
+            "filled_in": fill_in_count,
+            "unfilled": sum(released.values()) - fill_in_count,
+        }
+
+    async def _count_approved_renewals_per_pool(
+        self, scholarship_type_id: int, academic_year: int
+    ) -> dict:
+        rows = await self.db.execute(
+            select(
+                Application.sub_scholarship_type,
+                Application.renewal_year,
+                func.count(),
+            ).where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.is_renewal == True,
+                Application.status == ApplicationStatus.approved,
+            ).group_by(Application.sub_scholarship_type, Application.renewal_year)
+        )
+        return {(r[0], r[1]): r[2] for r in rows.all()}
+
+    async def _get_general_candidates(
+        self, scholarship_type_id: int, academic_year: int, sub_type: str
+    ):
+        """Return CollegeRankingItem rows for sub_type, ordered by rank."""
+        from app.models.college_review import CollegeRankingItem
+        stmt = (
+            select(CollegeRankingItem)
+            .join(Application, CollegeRankingItem.application_id == Application.id)
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.sub_scholarship_type == sub_type,
+                Application.is_renewal == False,
+                Application.status.notin_([
+                    ApplicationStatus.approved,
+                    ApplicationStatus.rejected,
+                    ApplicationStatus.withdrawn,
+                    ApplicationStatus.deleted,
+                ]),
+            )
+            .order_by(CollegeRankingItem.rank)
+        )
+        return (await self.db.execute(stmt)).scalars().all()
+
+    async def _get_waitlist_candidates(
+        self, scholarship_type_id: int, academic_year: int, sub_type: str, limit: int
+    ):
+        """Candidates not yet approved in this batch, ordered by rank."""
+        # Same as _get_general_candidates but explicit filter:
+        # status != approved (since some may have been approved in step 2)
+        from app.models.college_review import CollegeRankingItem
+        stmt = (
+            select(CollegeRankingItem)
+            .join(Application, CollegeRankingItem.application_id == Application.id)
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.sub_scholarship_type == sub_type,
+                Application.is_renewal == False,
+                Application.status != ApplicationStatus.approved,
+                Application.challenges_application_id.is_(None),  # only pure new
+            )
+            .order_by(CollegeRankingItem.rank)
+            .limit(limit)
+        )
+        return (await self.db.execute(stmt)).scalars().all()
+
+    def _pick_pool(self, remaining: dict, sub_type: str, sub_type_policy) -> Optional[int]:
+        """Pick the next available allocation_year for this sub_type.
+        Policy: current year first, then prior years descending."""
+        years = sorted(
+            [y for (st, y), c in remaining.items() if st == sub_type and c > 0],
+            reverse=True,
+        )
+        return years[0] if years else None
+```
+
+- [ ] **Step 2: Add imports at top of file if missing**
+
+```python
+from sqlalchemy import func
+from app.models.enums import ApplicationStatus
+```
+
+- [ ] **Step 3: Run tests → expect PASS**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_challenge_release_distribution.py -v
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/manual_distribution_service.py backend/app/tests/test_challenge_release_distribution.py
+git commit -m "feat(distribution): add challenge release and waitlist fill-in"
+```
+
+---
+
+### Task 6.3: Add preview endpoint for admin UI
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/manual_distribution.py`
+
+- [ ] **Step 1: Add preview endpoint**
+
+```python
+@router.post("/preview-distribution")
+async def preview_distribution(
+    body: AllocateRequest,  # reuse existing schema
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """
+    Dry-run: compute what would happen given the proposed allocations,
+    without persisting changes. Returns release_chain for UI preview.
+    """
+    service = ManualDistributionService(db)
+    preview = await service.preview_release_chain(body.allocations)
+    return {"success": True, "message": "Preview computed", "data": preview}
+```
+
+- [ ] **Step 2: Add `preview_release_chain` to service**
+
+```python
+    async def preview_release_chain(self, proposed_allocations: list) -> dict:
+        """Compute which renewals would be cancelled and who would fill in."""
+        chain = []
+        for alloc in proposed_allocations:
+            app = await self.db.scalar(
+                select(Application).where(Application.id == alloc.application_id)
+            )
+            if app and app.challenges_application_id:
+                renewal = await self.db.scalar(
+                    select(Application).where(Application.id == app.challenges_application_id)
+                )
+                # Find next waitlist candidate
+                waitlist = await self._get_waitlist_candidates(
+                    renewal.scholarship_type_id, app.academic_year,
+                    renewal.sub_scholarship_type, limit=1
+                )
+                suggested = waitlist[0].application if waitlist else None
+                chain.append({
+                    "cancelled_application_id": renewal.id,
+                    "freed_slot": {
+                        "sub_type": renewal.sub_scholarship_type,
+                        "allocation_year": renewal.renewal_year,
+                    },
+                    "suggested_fill_id": suggested.id if suggested else None,
+                    "suggested_fill_name": suggested.student.name if suggested else None,
+                })
+        return {"release_chain": chain}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/services/manual_distribution_service.py backend/app/api/v1/endpoints/manual_distribution.py
+git commit -m "feat(api): add distribution preview endpoint for admin UI"
+```
+
+---
+
+## Phase 7 — Admin: Renewal Distribution Result Page
+
+### Task 7.1: API endpoint for renewal distribution result
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/manual_distribution.py` or `endpoints/renewal.py`
+
+- [ ] **Step 1: Add endpoint**
+
+```python
+@router.get("/distribution-result")
+async def get_renewal_distribution_result(
+    scholarship_type_id: int,
+    academic_year: int,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Return renewal distribution grouped by (sub_type, renewal_year)."""
+    stmt = (
+        select(Application)
+        .where(
+            Application.scholarship_type_id == scholarship_type_id,
+            Application.academic_year == academic_year,
+            Application.is_renewal == True,
+        )
+        .options(joinedload(Application.student))
+    )
+    apps = (await db.execute(stmt)).scalars().all()
+
+    grouped = {}
+    rejected = []
+    for app in apps:
+        if app.status == ApplicationStatus.approved:
+            key = f"{app.sub_scholarship_type}_{app.renewal_year}"
+            grouped.setdefault(key, {
+                "sub_type": app.sub_scholarship_type,
+                "renewal_year": app.renewal_year,
+                "applications": [],
+            })["applications"].append({
+                "id": app.id, "app_id": app.app_id,
+                "student_name": app.student.name,
+                "previous_application_id": app.previous_application_id,
+                "has_challenge": any(
+                    # quick sub-check: child apps where challenges_application_id == app.id
+                    True for _ in []  # placeholder; implement via separate query if needed
+                ),
+            })
+        elif app.status == ApplicationStatus.rejected:
+            rejected.append({"id": app.id, "student_name": app.student.name})
+
+    return {
+        "success": True,
+        "message": "Renewal distribution result",
+        "data": {
+            "groups": list(grouped.values()),
+            "rejected": rejected,
+            "summary": {
+                "approved": sum(len(g["applications"]) for g in grouped.values()),
+                "rejected": len(rejected),
+            },
+        },
+    }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/renewal.py
+git commit -m "feat(api): add renewal distribution result endpoint"
+```
+
+---
+
+### Task 7.2: Frontend renewal distribution result page
+
+**Files:**
+- Create: `frontend/lib/api/modules/renewal.ts`
+- Create: `frontend/components/admin/renewal/RenewalDistributionResult.tsx`
+- Create: `frontend/app/admin/renewal/page.tsx` (route)
+
+- [ ] **Step 1: Create typed client**
+
+```typescript
+// frontend/lib/api/modules/renewal.ts
+import { api } from "../client";
+
+export interface EligibleRenewal {
+  previous_application_id: number;
+  scholarship_type_id: number;
+  scholarship_type_name: string;
+  sub_scholarship_type: string;
+  target_academic_year: number;
+  renewal_year: number;
+  renewal_deadline: string | null;
+}
+
+export interface RenewalDistributionGroup {
+  sub_type: string;
+  renewal_year: number;
+  applications: {
+    id: number;
+    app_id: string;
+    student_name: string;
+    previous_application_id: number;
+    has_challenge: boolean;
+  }[];
+}
+
+export const renewalApi = {
+  listEligible: () =>
+    api.get<{ data: EligibleRenewal[] }>("/api/v1/renewals/eligible"),
+
+  createRenewal: (previous_application_id: number) =>
+    api.post("/api/v1/renewals/", { previous_application_id }),
+
+  createChallenge: (renewal_application_id: number, target_sub_type: string) =>
+    api.post("/api/v1/renewals/challenge", {
+      renewal_application_id,
+      target_sub_type,
+    }),
+
+  getDistributionResult: (scholarship_type_id: number, academic_year: number) =>
+    api.get<{
+      data: {
+        groups: RenewalDistributionGroup[];
+        rejected: { id: number; student_name: string }[];
+        summary: { approved: number; rejected: number };
+      };
+    }>(`/api/v1/renewals/distribution-result`, {
+      params: { scholarship_type_id, academic_year },
+    }),
+};
+```
+
+- [ ] **Step 2: Create component**
+
+```typescript
+// frontend/components/admin/renewal/RenewalDistributionResult.tsx
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { renewalApi } from "@/lib/api/modules/renewal";
+
+interface Props {
+  scholarshipTypeId: number;
+  academicYear: number;
+}
+
+export function RenewalDistributionResult({ scholarshipTypeId, academicYear }: Props) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["renewal-distribution", scholarshipTypeId, academicYear],
+    queryFn: () => renewalApi.getDistributionResult(scholarshipTypeId, academicYear),
+  });
+
+  if (isLoading) return <div>載入中...</div>;
+  const result = data?.data;
+  if (!result) return null;
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-bold">續領分發結果 — {academicYear} 學年</h2>
+
+      <section>
+        <h3 className="font-semibold mb-2">續領通過名單</h3>
+        {result.groups.map((group) => (
+          <div key={`${group.sub_type}_${group.renewal_year}`} className="border p-4 mb-2 rounded">
+            <h4 className="font-medium">
+              {group.sub_type} · 計畫年度 {group.renewal_year}
+              <span className="text-gray-500 ml-2">
+                ({group.applications.length} 人)
+              </span>
+            </h4>
+            <ul className="mt-2 space-y-1">
+              {group.applications.map((app) => (
+                <li key={app.id} className="text-sm">
+                  {app.student_name} ({app.app_id}, 原 #{app.previous_application_id})
+                  {app.has_challenge && <span className="ml-2 text-amber-600">⚠ 同時提交挑戰</span>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </section>
+
+      <section>
+        <h3 className="font-semibold mb-2">續領被拒名單</h3>
+        {result.rejected.length === 0 ? (
+          <p className="text-gray-500 text-sm">無</p>
+        ) : (
+          <ul>{result.rejected.map((r) => <li key={r.id}>{r.student_name}</li>)}</ul>
+        )}
+      </section>
+
+      <div className="text-sm text-gray-600">
+        通過: {result.summary.approved} · 拒絕: {result.summary.rejected}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create route**
+
+```typescript
+// frontend/app/admin/renewal/page.tsx
+"use client";
+import { useState } from "react";
+import { RenewalDistributionResult } from "@/components/admin/renewal/RenewalDistributionResult";
+
+export default function RenewalAdminPage() {
+  const [scholarshipTypeId, setScholarshipTypeId] = useState(1);
+  const [academicYear, setAcademicYear] = useState(114);
+  return (
+    <div className="p-6">
+      {/* selector UI omitted for brevity — add scholarship_type + year dropdowns */}
+      <RenewalDistributionResult
+        scholarshipTypeId={scholarshipTypeId}
+        academicYear={academicYear}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run frontend dev server, visit `/admin/renewal`, verify rendering**
+
+```bash
+docker compose -f docker-compose.dev.yml up frontend
+# Browser: http://localhost:3000/admin/renewal
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/api/modules/renewal.ts frontend/components/admin/renewal/ frontend/app/admin/renewal/
+git commit -m "feat(frontend): add renewal distribution result page"
+```
+
+---
+
+## Phase 8 — Admin: Manual Distribution Panel Updates
+
+### Task 8.1: API endpoint returning distribution state
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/manual_distribution.py`
+
+- [ ] **Step 1: Add endpoint**
+
+```python
+@router.get("/state")
+async def get_distribution_state(
+    scholarship_type_id: int,
+    academic_year: int,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """
+    Return full state for the manual distribution panel:
+    - renewal_allocations: approved renewals grouped by (sub_type, renewal_year)
+    - available_quotas: remaining quota per (sub_type, allocation_year)
+    - candidates: ranked applications for general phase (with is_challenge flag)
+    """
+    service = ManualDistributionService(db)
+    state = await service.compute_distribution_state(scholarship_type_id, academic_year)
+    return {"success": True, "message": "OK", "data": state}
+```
+
+- [ ] **Step 2: Add `compute_distribution_state` to service**
+
+```python
+    async def compute_distribution_state(
+        self, scholarship_type_id: int, academic_year: int
+    ) -> dict:
+        config = await self._get_active_config(scholarship_type_id, academic_year)
+        quotas = config.quotas or {}
+
+        # Renewal allocations grouped
+        renewal_apps = (
+            await self.db.execute(
+                select(Application)
+                .options(joinedload(Application.student))
+                .where(
+                    Application.scholarship_type_id == scholarship_type_id,
+                    Application.academic_year == academic_year,
+                    Application.is_renewal == True,
+                    Application.status == ApplicationStatus.approved,
+                )
+            )
+        ).scalars().all()
+        renewal_grouped = {}
+        for app in renewal_apps:
+            key = (app.sub_scholarship_type, app.renewal_year)
+            renewal_grouped.setdefault(key, []).append({
+                "application_id": app.id,
+                "student_name": app.student.name,
+                "has_challenge": False,  # set below
+            })
+
+        # Mark challenges
+        challenge_apps = (
+            await self.db.execute(
+                select(Application).where(
+                    Application.challenges_application_id.in_([a.id for a in renewal_apps] or [-1])
+                )
+            )
+        ).scalars().all()
+        for ch in challenge_apps:
+            for items in renewal_grouped.values():
+                for item in items:
+                    if item["application_id"] == ch.challenges_application_id:
+                        item["has_challenge"] = True
+
+        # Used per pool
+        used = await self._count_approved_renewals_per_pool(scholarship_type_id, academic_year)
+        available_quotas = []
+        for sub_type, year_map in quotas.items():
+            for year_str, total in year_map.items():
+                year = int(year_str)
+                available_quotas.append({
+                    "sub_type": sub_type,
+                    "allocation_year": year,
+                    "total": total,
+                    "used": used.get((sub_type, year), 0),
+                    "remaining": total - used.get((sub_type, year), 0),
+                })
+
+        # Candidates (general phase)
+        from app.models.college_review import CollegeRankingItem
+        cands = (await self.db.execute(
+            select(CollegeRankingItem, Application)
+            .join(Application, CollegeRankingItem.application_id == Application.id)
+            .where(
+                Application.scholarship_type_id == scholarship_type_id,
+                Application.academic_year == academic_year,
+                Application.is_renewal == False,
+            )
+            .order_by(CollegeRankingItem.rank)
+        )).all()
+        candidates = []
+        for ri, app in cands:
+            challenged_renewal = None
+            if app.challenges_application_id:
+                renewal = await self.db.scalar(
+                    select(Application).where(Application.id == app.challenges_application_id)
+                )
+                challenged_renewal = {
+                    "renewal_application_id": renewal.id,
+                    "sub_type": renewal.sub_scholarship_type,
+                    "renewal_year": renewal.renewal_year,
+                }
+            candidates.append({
+                "rank": ri.rank,
+                "application_id": app.id,
+                "student_name": app.student.name if hasattr(app, "student") else None,
+                "is_challenge": app.challenges_application_id is not None,
+                "challenged_renewal": challenged_renewal,
+                "applying_sub_type": app.sub_scholarship_type,
+            })
+
+        return {
+            "renewal_allocations": [
+                {
+                    "sub_type": st,
+                    "renewal_year": y,
+                    "applications": items,
+                }
+                for (st, y), items in renewal_grouped.items()
+            ],
+            "available_quotas": available_quotas,
+            "candidates": candidates,
+        }
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/manual_distribution.py backend/app/services/manual_distribution_service.py
+git commit -m "feat(api): add manual distribution state endpoint"
+```
+
+---
+
+### Task 8.2: Update ManualDistributionPanel frontend
+
+**Files:**
+- Modify: `frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx`
+- Modify: `frontend/lib/api/modules/manual-distribution.ts`
+
+- [ ] **Step 1: Add typed client method**
+
+```typescript
+// frontend/lib/api/modules/manual-distribution.ts (append)
+
+export interface DistributionState {
+  renewal_allocations: {
+    sub_type: string;
+    renewal_year: number;
+    applications: {
+      application_id: number;
+      student_name: string;
+      has_challenge: boolean;
+    }[];
+  }[];
+  available_quotas: {
+    sub_type: string;
+    allocation_year: number;
+    total: number;
+    used: number;
+    remaining: number;
+  }[];
+  candidates: {
+    rank: number;
+    application_id: number;
+    student_name: string;
+    is_challenge: boolean;
+    challenged_renewal: {
+      renewal_application_id: number;
+      sub_type: string;
+      renewal_year: number;
+    } | null;
+    applying_sub_type: string;
+  }[];
+}
+
+export const manualDistributionApi = {
+  // ... existing methods
+  getState: (scholarship_type_id: number, academic_year: number) =>
+    api.get<{ data: DistributionState }>(`/api/v1/manual-distribution/state`, {
+      params: { scholarship_type_id, academic_year },
+    }),
+
+  previewDistribution: (allocations: { application_id: number; sub_type: string; allocation_year: number }[]) =>
+    api.post(`/api/v1/manual-distribution/preview-distribution`, { allocations }),
+};
+```
+
+- [ ] **Step 2: Modify ManualDistributionPanel.tsx**
+
+Add three new UI blocks at the top of the panel (before existing candidate list):
+
+```typescript
+// Inside ManualDistributionPanel component
+const { data: stateData } = useQuery({
+  queryKey: ["distribution-state", scholarshipTypeId, academicYear],
+  queryFn: () => manualDistributionApi.getState(scholarshipTypeId, academicYear),
+});
+const state = stateData?.data;
+
+return (
+  <div className="space-y-6">
+    {/* Renewal occupied block */}
+    <section className="border-l-4 border-blue-500 bg-blue-50 p-4">
+      <h3 className="font-semibold">續領已佔用 (不可改動)</h3>
+      {state?.renewal_allocations.map((alloc) => (
+        <div key={`${alloc.sub_type}_${alloc.renewal_year}`}>
+          <strong>{alloc.sub_type} · 計畫年度 {alloc.renewal_year}</strong>
+          {" "}{alloc.applications.length} 人
+          <ul className="text-sm">
+            {alloc.applications.map((a) => (
+              <li key={a.application_id}>
+                {a.student_name}{a.has_challenge && " *"}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+
+    {/* Available quotas */}
+    <section>
+      <h3 className="font-semibold">剩餘可分配配額</h3>
+      <ul className="text-sm">
+        {state?.available_quotas.map((q) => (
+          <li key={`${q.sub_type}_${q.allocation_year}`}>
+            {q.sub_type} · 計畫年度 {q.allocation_year}: {q.used}/{q.total} 已配
+          </li>
+        ))}
+      </ul>
+    </section>
+
+    {/* Candidate list with challenge markers */}
+    <section>
+      <h3 className="font-semibold">候選名單</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>排名</th><th>學生</th><th>類型</th><th>保底/註記</th>
+            {/* dynamic columns per (sub_type, allocation_year) */}
+          </tr>
+        </thead>
+        <tbody>
+          {state?.candidates.map((c) => (
+            <tr key={c.application_id} className={c.is_challenge ? "bg-amber-50" : ""}>
+              <td>{c.rank}</td>
+              <td>{c.student_name}</td>
+              <td>{c.is_challenge ? "挑戰" : "純新"}</td>
+              <td>
+                {c.is_challenge && c.challenged_renewal && (
+                  <span>🛡 保底 {c.challenged_renewal.sub_type}-{c.challenged_renewal.renewal_year}</span>
+                )}
+              </td>
+              {/* Render checkboxes for each (sub_type, allocation_year), with disabled state
+                  if c.challenged_renewal?.sub_type matches the column sub_type */}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+
+    {/* Release preview */}
+    <ReleasePreviewSection allocations={proposedAllocations} />
+
+    {/* Existing buttons */}
+  </div>
+);
+```
+
+- [ ] **Step 3: Add `ReleasePreviewSection` sub-component**
+
+```typescript
+function ReleasePreviewSection({ allocations }: { allocations: any[] }) {
+  const { data } = useQuery({
+    queryKey: ["release-preview", allocations],
+    queryFn: () => manualDistributionApi.previewDistribution(allocations),
+    enabled: allocations.length > 0,
+  });
+  const chain = data?.data?.release_chain || [];
+  if (chain.length === 0) return null;
+  return (
+    <section className="border-l-4 border-amber-500 bg-amber-50 p-4">
+      <h3 className="font-semibold">釋出與遞補預覽</h3>
+      {chain.map((c: any, i: number) => (
+        <div key={i} className="text-sm mt-2">
+          ⚠ 挑戰申請 #{c.cancelled_application_id} 成功
+          <div className="ml-4">↳ 釋出 {c.freed_slot.sub_type}-{c.freed_slot.allocation_year} slot</div>
+          {c.suggested_fill_name && (
+            <div className="ml-4">↳ 自動遞補：{c.suggested_fill_name} (排 #{c.suggested_fill_id})</div>
+          )}
+        </div>
+      ))}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Test in browser**
+
+```bash
+docker compose -f docker-compose.dev.yml up
+# http://localhost:3000/admin/manual-distribution → check rendering
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/admin/manual-distribution/ frontend/lib/api/modules/manual-distribution.ts
+git commit -m "feat(frontend): show renewal slots and challenge markers in manual distribution panel"
+```
+
+---
+
+## Phase 9 — Student UI
+
+### Task 9.1: Renewal application card
+
+**Files:**
+- Create: `frontend/components/student/RenewalApplicationCard.tsx`
+
+- [ ] **Step 1: Implement**
+
+```typescript
+"use client";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { renewalApi, EligibleRenewal } from "@/lib/api/modules/renewal";
+import { useRouter } from "next/navigation";
+
+export function RenewalApplicationCard() {
+  const router = useRouter();
+  const { data, isLoading } = useQuery({
+    queryKey: ["eligible-renewals"],
+    queryFn: () => renewalApi.listEligible(),
+  });
+
+  const createMut = useMutation({
+    mutationFn: (id: number) => renewalApi.createRenewal(id),
+    onSuccess: (resp) => {
+      router.push(`/applications/${resp.data.id}/edit`);
+    },
+  });
+
+  if (isLoading) return null;
+  const eligible = data?.data || [];
+  if (eligible.length === 0) return null;
+
+  return (
+    <div className="bg-emerald-50 border-l-4 border-emerald-500 p-4 rounded">
+      <h3 className="font-semibold mb-2">可續領的獎學金</h3>
+      <ul className="space-y-2">
+        {eligible.map((item: EligibleRenewal) => (
+          <li key={item.previous_application_id} className="flex items-center justify-between">
+            <div>
+              <div className="font-medium">{item.scholarship_type_name}</div>
+              <div className="text-sm text-gray-600">
+                上期 sub_type: {item.sub_scholarship_type} · 目標學年: {item.target_academic_year}
+              </div>
+              {item.renewal_deadline && (
+                <div className="text-xs text-gray-500">
+                  截止: {new Date(item.renewal_deadline).toLocaleString("zh-TW")}
+                </div>
+              )}
+            </div>
+            <button
+              className="px-4 py-2 bg-emerald-600 text-white rounded"
+              onClick={() => createMut.mutate(item.previous_application_id)}
+              disabled={createMut.isPending}
+            >
+              建立續領申請
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Mount in student portal**
+
+In `frontend/components/enhanced-student-portal.tsx`:
+
+```typescript
+import { RenewalApplicationCard } from "./student/RenewalApplicationCard";
+
+// Add near top of the portal layout
+<RenewalApplicationCard />
+```
+
+- [ ] **Step 3: Test in browser**
+
+```bash
+# As a student user who had an approved application last year:
+# Open student portal → renewal card should appear in renewal period
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/student/RenewalApplicationCard.tsx frontend/components/enhanced-student-portal.tsx
+git commit -m "feat(frontend): add renewal application card for students"
+```
+
+---
+
+### Task 9.2: Challenge application creation UI
+
+**Files:**
+- Create: `frontend/components/student/ChallengeApplicationCard.tsx`
+
+- [ ] **Step 1: Implement**
+
+```typescript
+"use client";
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { renewalApi } from "@/lib/api/modules/renewal";
+import { applicationsApi } from "@/lib/api/modules/applications";
+
+interface Props {
+  approvedRenewalId: number;
+  approvedRenewalSubType: string;
+  scholarshipTypeId: number;
+  scholarshipConfigQuotas: Record<string, Record<string, number>>;
+}
+
+export function ChallengeApplicationCard({
+  approvedRenewalId, approvedRenewalSubType, scholarshipConfigQuotas
+}: Props) {
+  const availableSubTypes = Object.keys(scholarshipConfigQuotas).filter(
+    (st) => st !== approvedRenewalSubType
+  );
+  const [targetSubType, setTargetSubType] = useState(availableSubTypes[0] || "");
+
+  const createMut = useMutation({
+    mutationFn: () => renewalApi.createChallenge(approvedRenewalId, targetSubType),
+    onSuccess: (resp) => {
+      // navigate to edit
+      window.location.href = `/applications/${resp.data.id}/edit`;
+    },
+  });
+
+  return (
+    <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+      <h3 className="font-semibold">挑戰其他 sub_type</h3>
+      <p className="text-sm text-gray-700 mt-1">
+        您已續領 {approvedRenewalSubType}（保底）。可挑戰其他 sub_type；中籤則自動釋出保底名額。
+      </p>
+      <div className="mt-3 flex gap-3 items-center">
+        <select
+          className="border rounded px-2 py-1"
+          value={targetSubType}
+          onChange={(e) => setTargetSubType(e.target.value)}
+        >
+          {availableSubTypes.map((st) => (
+            <option key={st} value={st}>{st}</option>
+          ))}
+        </select>
+        <button
+          className="px-4 py-2 bg-amber-600 text-white rounded"
+          onClick={() => createMut.mutate()}
+          disabled={createMut.isPending || !targetSubType}
+        >
+          提交挑戰申請
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Conditionally render in student portal during general phase**
+
+```typescript
+// Pseudo: if student has approved renewal for this scholarship type, show card
+{userApprovedRenewals.map((r) => (
+  <ChallengeApplicationCard
+    key={r.id}
+    approvedRenewalId={r.id}
+    approvedRenewalSubType={r.sub_scholarship_type}
+    scholarshipTypeId={r.scholarship_type_id}
+    scholarshipConfigQuotas={r.scholarship_config_quotas}
+  />
+))}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/student/ChallengeApplicationCard.tsx
+git commit -m "feat(frontend): add challenge application card for students"
+```
+
+---
+
+### Task 9.3: Application history with renewal/challenge linkage
+
+**Files:**
+- Modify: existing application history component (search via `grep -rn "申請紀錄\|application.*history" frontend/components/`)
+
+- [ ] **Step 1: Locate**
+
+```bash
+grep -rn "我的申請\|application.*history" frontend/components/ | head
+```
+
+- [ ] **Step 2: Update component to show linkage**
+
+Append to each application row:
+
+```typescript
+{app.previous_application_id && (
+  <div className="text-xs text-gray-600">
+    銜接自: <a href={`/applications/${app.previous_application_id}`}>
+      APP-#{app.previous_application_id}
+    </a>
+  </div>
+)}
+{app.cancelled_due_to_application_id && (
+  <div className="text-xs text-red-600">
+    被取代於: <a href={`/applications/${app.cancelled_due_to_application_id}`}>
+      APP-#{app.cancelled_due_to_application_id}
+    </a> (挑戰申請成功)
+  </div>
+)}
+{app.challenges_application_id && (
+  <div className="text-xs text-amber-700">
+    挑戰自續領: <a href={`/applications/${app.challenges_application_id}`}>
+      APP-#{app.challenges_application_id}
+    </a>
+  </div>
+)}
+{app.status === "cancelled_by_challenge" && (
+  <span className="text-red-600 text-xs">已取消 (因挑戰升級)</span>
+)}
+```
+
+- [ ] **Step 3: Backend: ensure application detail response includes these fields**
+
+Confirm `app.serialize()` or schema includes `previous_application_id`, `cancelled_due_to_application_id`, `challenges_application_id`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/.../ApplicationHistory*.tsx
+git commit -m "feat(frontend): show renewal/challenge linkage in application history"
+```
+
+---
+
+## Phase 10 — Validation & Monitoring
+
+### Task 10.1: Background check for cancelled_by_challenge invariants
+
+**Files:**
+- Create: `backend/app/services/renewal_audit_service.py`
+- Create: `backend/app/tests/test_renewal_audit_service.py`
+
+- [ ] **Step 1: Write test**
+
+```python
+@pytest.mark.asyncio
+async def test_finds_violations(db_session, application_factory):
+    """An approved challenge whose renewal is NOT cancelled_by_challenge → violation."""
+    renewal = await application_factory(
+        is_renewal=True, status=ApplicationStatus.approved
+    )
+    challenge = await application_factory(
+        is_renewal=False, challenges_application_id=renewal.id,
+        status=ApplicationStatus.approved,
+    )
+    from app.services.renewal_audit_service import RenewalAuditService
+    violations = await RenewalAuditService(db_session).find_invariant_violations()
+    assert len(violations) == 1
+    assert violations[0]["renewal_id"] == renewal.id
+```
+
+- [ ] **Step 2: Implement service**
+
+```python
+class RenewalAuditService:
+    def __init__(self, db): self.db = db
+
+    async def find_invariant_violations(self) -> list[dict]:
+        # Each approved challenge must point to a cancelled_by_challenge renewal
+        stmt = (
+            select(Application.id, Application.challenges_application_id, Application.status)
+            .where(
+                Application.challenges_application_id.is_not(None),
+                Application.status == ApplicationStatus.approved,
+            )
+        )
+        rows = (await self.db.execute(stmt)).all()
+        violations = []
+        for challenge_id, renewal_id, _ in rows:
+            renewal = await self.db.scalar(
+                select(Application).where(Application.id == renewal_id)
+            )
+            if renewal.status != ApplicationStatus.cancelled_by_challenge:
+                violations.append({
+                    "challenge_id": challenge_id,
+                    "renewal_id": renewal_id,
+                    "actual_renewal_status": renewal.status.value,
+                })
+        return violations
+```
+
+- [ ] **Step 3: Add admin endpoint to run check**
+
+```python
+@router.get("/audit/renewal-violations")
+async def audit_renewal_violations(
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_async_db),
+):
+    service = RenewalAuditService(db)
+    return {"success": True, "data": await service.find_invariant_violations()}
+```
+
+- [ ] **Step 4: Run tests & commit**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_audit_service.py -v
+git add backend/app/services/renewal_audit_service.py backend/app/tests/test_renewal_audit_service.py
+git commit -m "feat(audit): add renewal invariant check service"
+```
+
+---
+
+### Task 10.2: Distribution summary report
+
+**Files:**
+- Modify: `backend/app/services/manual_distribution_service.py`
+
+- [ ] **Step 1: Already implemented in Task 6.2 — `execute_general_distribution` returns summary**
+
+Verify the return value of `execute_general_distribution` matches spec Section 12:
+
+```python
+{
+  "approved_renewals": int,
+  "approved_challenges": int,
+  "released_slots": {(sub_type, year): count},
+  "filled_in": int,
+  "unfilled": int,
+}
+```
+
+Assertion: `sum(released_slots.values()) == filled_in + unfilled`
+
+- [ ] **Step 2: Add this assertion to integration test**
+
+In `test_challenge_release_distribution.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_distribution_summary_balances(
+    db_session, scholarship_type_factory, ...  # reuse setup
+):
+    # ... (same scenario as Task 6.1)
+    service = ManualDistributionService(db_session)
+    result = await service.execute_general_distribution(scholarship_type_id=st.id, academic_year=114)
+    assert sum(result["released_slots"].values()) == result["filled_in"] + result["unfilled"]
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/tests/test_challenge_release_distribution.py
+git commit -m "test: verify distribution summary balances released = filled + unfilled"
+```
+
+---
+
+## Phase 11 — End-to-End Smoke Test
+
+### Task 11.1: Full E2E scenario test
+
+**Files:**
+- Create: `backend/app/tests/test_renewal_end_to_end.py`
+
+- [ ] **Step 1: Write a single comprehensive test exercising the spec's example scenario**
+
+```python
+@pytest.mark.asyncio
+async def test_full_renewal_challenge_e2e(
+    db_session, async_client,
+    student_factory, scholarship_type_factory, scholarship_configuration_factory,
+    application_factory, college_ranking_factory,
+):
+    """
+    Mirrors spec Section 9.3 example:
+    - 10 students have approved 113 nstc applications
+    - 114 renewal period opens → all 10 apply renewal
+    - Renewal auto-approve → all 10 approved, occupying nstc[113]
+    - 2 of them (A, B) submit challenge for moe_1w
+    - General period: candidates ranked, distribution executed
+    - Verify: A & B approved on moe_1w, their renewals cancelled, U & V promoted to nstc-113
+    """
+    # Setup
+    st = await scholarship_type_factory(
+        renewal_application_start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        renewal_application_end_date=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        renewal_professor_review_end=datetime(2026, 2, 15, tzinfo=timezone.utc),
+        renewal_college_review_end=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        application_start_date=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        application_end_date=datetime(2026, 4, 1, tzinfo=timezone.utc),
+    )
+    await scholarship_configuration_factory(
+        scholarship_type_id=st.id,
+        quotas={"nstc": {"114": 8, "113": 0}, "moe_1w": {"114": 6}},
+    )
+
+    # 10 113-cohort approved applications
+    students = [await student_factory() for _ in range(10)]
+    prior_apps = [
+        await application_factory(
+            user_id=s.id, scholarship_type_id=st.id, sub_scholarship_type="nstc",
+            academic_year=113, status=ApplicationStatus.approved, renewal_year=113,
+        )
+        for s in students
+    ]
+
+    # All 10 apply renewal (simulated via direct service call)
+    from app.services.application_service import ApplicationService
+    for i, prev in enumerate(prior_apps):
+        await ApplicationService(db_session).create_renewal_from_previous(
+            previous=prev, current_user=students[i],
+            target_academic_year=114, renewal_year=113,
+        )
+    await db_session.commit()
+
+    # Auto-approve renewals
+    from app.services.renewal_distribution_service import RenewalDistributionService
+    # Set their stage to college_reviewed first (simulating review pass)
+    renewals = (await db_session.execute(
+        select(Application).where(
+            Application.scholarship_type_id == st.id,
+            Application.is_renewal == True,
+        )
+    )).scalars().all()
+    for r in renewals:
+        r.review_stage = ReviewStage.college_reviewed
+        r.status = ApplicationStatus.under_review
+    await db_session.commit()
+    await RenewalDistributionService(db_session).auto_approve_passed_reviews(st.id)
+
+    # A and B submit challenges for moe_1w
+    A_renewal, B_renewal = renewals[0], renewals[1]
+    for r in [A_renewal, B_renewal]:
+        await ApplicationService(db_session).create_challenge_from_renewal(
+            renewal=r, current_user=students[renewals.index(r)],
+            target_sub_type="moe_1w",
+        )
+    await db_session.commit()
+
+    # 8 pure-new nstc candidates ranked 1-10, 6 pure-new moe_1w ranked 2-7 (A, B at rank 1, 2)
+    pure_new_nstc = []
+    for rank in range(1, 11):
+        s = await student_factory()
+        a = await application_factory(
+            user_id=s.id, scholarship_type_id=st.id, sub_scholarship_type="nstc",
+            academic_year=114, status=ApplicationStatus.under_review, is_renewal=False,
+        )
+        await college_ranking_factory(application_id=a.id, rank=rank)
+        pure_new_nstc.append(a)
+
+    # Get A and B challenge apps for ranking
+    challenges = (await db_session.execute(
+        select(Application).where(
+            Application.scholarship_type_id == st.id,
+            Application.challenges_application_id.is_not(None),
+        )
+    )).scalars().all()
+    await college_ranking_factory(application_id=challenges[0].id, rank=1)
+    await college_ranking_factory(application_id=challenges[1].id, rank=2)
+    for rank in range(3, 9):
+        s = await student_factory()
+        a = await application_factory(
+            user_id=s.id, scholarship_type_id=st.id, sub_scholarship_type="moe_1w",
+            academic_year=114, is_renewal=False,
+        )
+        await college_ranking_factory(application_id=a.id, rank=rank)
+
+    # Execute general distribution
+    from app.services.manual_distribution_service import ManualDistributionService
+    result = await ManualDistributionService(db_session).execute_general_distribution(
+        scholarship_type_id=st.id, academic_year=114
+    )
+
+    # Refresh and assert
+    await db_session.refresh(A_renewal); await db_session.refresh(B_renewal)
+    assert A_renewal.status == ApplicationStatus.cancelled_by_challenge
+    assert B_renewal.status == ApplicationStatus.cancelled_by_challenge
+
+    # Find approved challenges
+    approved_challenges = [c for c in challenges if c.status == ApplicationStatus.approved]
+    assert len(approved_challenges) == 2
+
+    # U (rank 9) and V (rank 10) should be approved with allocation_year=113
+    await db_session.refresh(pure_new_nstc[8])  # rank 9 = U
+    await db_session.refresh(pure_new_nstc[9])  # rank 10 = V
+    assert pure_new_nstc[8].status == ApplicationStatus.approved
+    assert pure_new_nstc[9].status == ApplicationStatus.approved
+
+    # Summary balances
+    assert sum(result["released_slots"].values()) == result["filled_in"] + result["unfilled"]
+    assert result["filled_in"] == 2  # U and V filled
+```
+
+- [ ] **Step 2: Run → expect PASS**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_end_to_end.py -v
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/tests/test_renewal_end_to_end.py
+git commit -m "test: add full E2E renewal+challenge distribution scenario"
+```
+
+---
+
+## Phase 12 — Final Integration & Type Sync
+
+### Task 12.1: Regenerate OpenAPI types for frontend
+
+- [ ] **Step 1: Start backend container**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d backend
+```
+
+- [ ] **Step 2: Run type generation**
+
+```bash
+cd frontend && npm run api:generate
+```
+
+- [ ] **Step 3: Commit generated types**
+
+```bash
+git add frontend/lib/api/generated/schema.d.ts
+git commit -m "chore(types): regenerate OpenAPI types for renewal endpoints"
+```
+
+---
+
+### Task 12.2: Documentation update
+
+**Files:**
+- Modify: `backend/docs/scholarship_renewal_design.md` (existing partial doc)
+- Or replace with reference to new spec
+
+- [ ] **Step 1: Add a "See also" note at top of `backend/docs/scholarship_renewal_design.md`**
+
+```markdown
+> **Note:** This document describes the timeline framework only. For the complete
+> end-to-end design including challenge applications, slot release, and waitlist
+> fill-in, see `docs/superpowers/specs/2026-05-13-renewal-application-design.md`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/docs/scholarship_renewal_design.md
+git commit -m "docs: point renewal design doc to extended spec"
+```
+
+---
+
+## Plan Self-Review
+
+- **Spec coverage check:**
+  - Section 5 (Data model) → Phase 1 ✓
+  - Section 6 (State machine) → Phase 3 (creation), Phase 5 (renewal), Phase 6 (general) ✓
+  - Section 7 (Eligibility + creation) → Phase 2 + Phase 3 ✓
+  - Section 8 (Renewal review/distribution) → Phase 4 + Phase 5 ✓
+  - Section 9 (General distribution) → Phase 6 ✓
+  - Section 10 (Boundary cases) — covered via tests in Phases 2, 3, 6
+  - Section 11 (Error messages) — covered in Phase 3 endpoints
+  - Section 12 (Monitoring) → Phase 10 ✓
+  - Section 13 (Integration points) — addressed throughout (manual_distribution, roster, etc.)
+  - Section 14 (Admin UI) → Phase 7, Phase 8 ✓
+  - Section 14.3 (Student history) → Phase 9.3 ✓
+
+- **Type consistency:**
+  - `challenges_application_id`, `cancelled_due_to_application_id`, `renewal_year`, `previous_application_id`, `sub_scholarship_type`, `academic_year` used consistently throughout
+  - Method names: `create_renewal_from_previous`, `create_challenge_from_renewal`, `auto_approve_passed_reviews`, `execute_general_distribution`, `preview_release_chain`, `compute_distribution_state`, `find_invariant_violations` — all consistent
+
+- **No placeholders verified:** All code blocks contain actual implementation; only one TBD acknowledged in Task 9.3 (locate existing history component — requires runtime grep).
+
+---
+
+**Implementation order recommendation:** Phases 1 → 2 → 3 → 5 → 4 → 6 → 7 → 8 → 9 → 10 → 11 → 12. Phase 4 can defer until backend logic is solid since review routing is a refinement on top of existing flows.
+
+**Estimated effort:** 5-7 days for a developer familiar with FastAPI + Next.js; longer if unfamiliar with this codebase. Each phase is independently testable and shippable.

--- a/docs/superpowers/specs/2026-05-13-renewal-application-design.md
+++ b/docs/superpowers/specs/2026-05-13-renewal-application-design.md
@@ -1,0 +1,557 @@
+# 續領申請設計（含挑戰申請與名額釋出機制）
+
+**日期**: 2026-05-13
+**Status**: Draft for review
+**Scope**: 為獎學金系統補完續領申請的學生端體驗、資格判定、與一般申請的銜接，以及「挑戰申請」與「名額釋出/遞補」邏輯
+
+---
+
+## 1. 背景與現狀
+
+### 1.1 已實作的部分
+
+- `ScholarshipType` 已有 6 個續領時間欄位（`renewal_application_start/end_date`、`renewal_professor_review_start/end`、`renewal_college_review_start/end`）與 `is_renewal_enabled` 開關
+- `Application` 已有 `is_renewal`、`renewal_year`、`previous_application_id` 欄位
+- Manual distribution 已能識別 `renewal_year` 將申請對應到指定年度配額池
+- 設計文件 `backend/docs/scholarship_renewal_design.md` 涵蓋時序框架
+
+### 1.2 本設計要補完的部分
+
+- 學生端的續領申請與挑戰申請 UX
+- 續領資格的自動判定邏輯（依「上期被核可」紀錄）
+- 「保底續領 + 挑戰其他 sub_type」的並存模型
+- 挑戰成功時的名額釋出與候補遞補演算法
+- 跨年度配額池（如 nstc N 年期計畫池）的續領佔用與釋出邏輯
+
+---
+
+## 2. 核心概念與術語
+
+| 術語 | 定義 |
+|---|---|
+| 續領申請 (renewal application) | 由「上期被核可且該獎學金支援續領」的學生在續領期間提交，鎖定原 sub_type |
+| 挑戰申請 (challenge application) | 已有 approved 續領的學生，於一般申請期間提交，嘗試取得**同一 scholarship_type 內不同 sub_type**；中籤則取代續領 |
+| 純新申請 (general application) | 一般申請期間由「無續領者」或「續領被拒絕者」提交的新申請 |
+| `allocation_year` | 該名額消耗哪一年的配額（如 nstc-113 即 113 年計畫池） |
+| `academic_year` | 學生送出申請的學年（學生身分），與 `allocation_year` 可能不同 |
+| 配額池 | `(sub_type, allocation_year)` 二維。nstc 為 N 年期計畫池可跨年；MOE 僅當年 |
+
+---
+
+## 3. 核心約束與不變條件
+
+1. **時序**：續領流程（申請→審查→分發）完整結束後才開放一般申請（與現有 design 一致）
+2. **變更粒度**：續領鎖定同 scholarship_type 內的同一個 sub_type；挑戰是同 scholarship_type 下換 sub_type
+3. **保底+挑戰**：續領通過 = 取得保底；挑戰成功則自動釋出原 sub_type slot 給候補名單第一名遞補
+4. **審查深度**：跟著 `scholarship_configurations` 的 review 角色設定走（professor/college 視配置）
+5. **續領資格自動判定**：以「上期被核可的 Application 紀錄」自動列出
+6. **續領佔用原入選年度配額**：N 年期計畫獎學金（如 nstc-113）由 113 入選者連續多年續領佔同一池 slot；不消耗 academic_year 新配額
+7. **每學生每 (scholarship_type, academic_year) 最終只能一筆 approved**
+
+---
+
+## 4. 整體流程與時間軸
+
+```
+ 113 學年              ──→  114 學年
+─────────────────────────────────────────────────────────────
+                       │
+                       ├─ [續領申請期間] 學生提交 Application_R
+                       │
+                       ├─ [續領教授審查]   (if 配置要求)
+                       ├─ [續領學院審查]   (if 配置要求)
+                       │
+                       ├─ [續領分發] 審查通過者全部 approved
+                       │           Application_R.renewal_year = 原入選年（如 113）
+                       │
+                       ├═══════ 續領流程結束 ═══════
+                       │
+                       ├─ [一般申請期間]
+                       │    - 純新申請者：建立 Application（is_renewal=False, challenges_application_id=NULL）
+                       │    - 續領成功者：可額外建立 Application_C 挑戰其他 sub_type
+                       │
+                       ├─ [一般教授審查] → [一般學院審查] → [一般 college_ranking]
+                       ├─ [一般分發] 包含「挑戰處理 + 名額釋出 + 候補遞補」
+                       │
+                       └─ 學期/學年正式開始
+```
+
+---
+
+## 5. 資料模型
+
+### 5.1 欄位變更摘要
+
+| 模型 | 欄位 | 用途 | 狀態 |
+|---|---|---|---|
+| `applications` | `is_renewal: bool` | 標識續領申請 | 已存在 |
+| `applications` | `renewal_year: int` | 續領佔用的配額年度（= 原入選年） | 已存在 |
+| `applications` | `previous_application_id: FK` | 指向上期被核可的紀錄 | 已存在 |
+| `applications` | `challenges_application_id: FK` | 挑戰紀錄指向被挑戰的續領紀錄 | **新增** |
+| `applications` | `cancelled_due_to_application_id: FK` | 釋出鏈追蹤（被誰挑戰成功取代） | **新增** |
+| `applications.status` | enum 新增 `cancelled_by_challenge` | 因挑戰成功被自動 cancel | **新增 enum 值** |
+| `scholarship_types` | `is_renewal_enabled: bool` | 該獎學金是否支援續領 | 已存在 |
+| `scholarship_types` | 6 個 renewal 時間欄位 | 續領申請/審查期間 | 已存在 |
+
+### 5.2 資料庫約束
+
+```sql
+-- 約束 1: 挑戰申請不可同時 is_renewal=True
+ALTER TABLE applications
+ADD CONSTRAINT chk_challenge_references_renewal CHECK (
+    challenges_application_id IS NULL OR is_renewal = FALSE
+);
+
+-- 約束 2: 同學生同 scholarship_type 同學年最多一筆續領
+CREATE UNIQUE INDEX uq_student_renewal
+ON applications (student_id, scholarship_type_id, academic_year)
+WHERE is_renewal = TRUE;
+
+-- 約束 3: 同學生同 scholarship_type 同學年最多一筆挑戰
+CREATE UNIQUE INDEX uq_student_challenge
+ON applications (student_id, scholarship_type_id, academic_year)
+WHERE is_renewal = FALSE AND challenges_application_id IS NOT NULL;
+
+-- 約束 4: cancelled_by_challenge 必須有釋出鏈
+ALTER TABLE applications
+ADD CONSTRAINT chk_cancelled_by_challenge_link CHECK (
+    status != 'cancelled_by_challenge' OR cancelled_due_to_application_id IS NOT NULL
+);
+```
+
+### 5.3 應用層約束
+
+- `challenges_application_id` 必須指向同一 `student_id` + 同一 `scholarship_type_id` + 同一 `academic_year` 的續領紀錄
+- 挑戰紀錄的 `sub_type` 必須 ≠ 對應續領紀錄的 `sub_type`
+
+### 5.4 與現有 UNIQUE 約束的整合
+
+本設計允許同 `(student_id, scholarship_type_id, academic_year)` 同時存在「1 筆續領 + 1 筆挑戰」共兩筆 Application。實作時若現有 schema 有 `UNIQUE(student_id, scholarship_type_id, academic_year)`，須改寫為三條 partial unique indexes：
+
+1. `uq_student_renewal`（is_renewal=TRUE）
+2. `uq_student_challenge`（is_renewal=FALSE AND challenges_application_id IS NOT NULL）
+3. `uq_student_pure_new`（is_renewal=FALSE AND challenges_application_id IS NULL）
+
+實作計畫中需驗證並 migration 改寫該約束。
+
+---
+
+## 6. 狀態機
+
+### 6.1 續領申請 (Application_R) 狀態流轉
+
+```
+student_draft → student_submitted
+→ (if 配置要求) professor_review → professor_reviewed
+→ (if 配置要求) college_review → college_reviewed
+→ approved   (跳過 college_ranking，續領是資格驗證不是擇優選拔)
+
+任一審查階段被拒 → rejected
+分發後若挑戰中籤 → cancelled_by_challenge
+學生主動撤回 → withdrawn
+```
+
+### 6.2 挑戰申請 (Application_C) 狀態流轉
+
+```
+student_draft → student_submitted
+→ (if 配置要求) professor_review → professor_reviewed
+→ (if 配置要求) college_review → college_reviewed
+→ (if 配置要求) college_ranking → college_ranked
+→ 一般分發後：
+     ├─ approved (取得新 sub_type，連動將被挑戰續領設為 cancelled_by_challenge)
+     └─ rejected (挑戰失敗，續領仍 approved)
+
+學生主動撤回 → withdrawn（不影響續領）
+```
+
+---
+
+## 7. 資格識別與申請建立
+
+### 7.1 續領資格判定 Service
+
+```python
+def get_eligible_renewals(student_id: int, current_academic_year: int):
+    """
+    回傳該學生可續領的 (scholarship_type, sub_type, original_renewal_year) 列表
+    """
+    return query(Application).filter(
+        Application.student_id == student_id,
+        Application.academic_year == current_academic_year - 1,
+        Application.status == "approved",
+        Application.scholarship_type.has(is_renewal_enabled=True),
+        Application.scholarship_type.has(is_renewal_application_period=True),
+        # 檢查該獎學金計畫期未過
+        NOT scholarship_type_expired_for_student(student_id, scholarship_type_id)
+    ).all()
+```
+
+### 7.2 學生端 UX 動線
+
+```
+學生「我的申請」頁面
+  ├─ 區塊 1: 可續領的獎學金（續領期間才出現）
+  │    顯示：上期 scholarship_type + sub_type、目標學年、截止日
+  │    [建立續領申請] 按鈕
+  │
+  ├─ 區塊 2: 可申請的獎學金（一般申請期間才出現）
+  │    對「無 approved 續領」的 scholarship_type：自由選 sub_type
+  │    對「已有 approved 續領」的 scholarship_type：顯示「挑戰其他 sub_type」入口，
+  │      可選 sub_type 不可為原 sub_type
+  │
+  └─ 區塊 3: 我的申請歷史（含續領/挑戰標記與狀態）
+```
+
+### 7.3 API 端點
+
+```
+POST /api/v1/applications/renewal
+  body: { previous_application_id }
+  validations:
+    1. previous 屬於該學生且 status=approved
+    2. scholarship_type.is_renewal_enabled
+    3. 目前在 renewal_application_period
+    4. 該學生對此 scholarship_type 在 current_academic_year 尚未建立任何 Application
+  creates: Application(is_renewal=True, sub_type=previous.sub_type,
+                       previous_application_id=previous.id,
+                       renewal_year=previous.renewal_year or previous.academic_year)
+
+POST /api/v1/applications/challenge
+  body: { renewal_application_id, target_sub_type }
+  validations:
+    1. renewal_application 屬於該學生且 status=approved 且 is_renewal=True
+    2. target_sub_type ≠ renewal_application.sub_type
+    3. target_sub_type 存在於該 scholarship_configuration.quotas
+    4. 目前在 general application_period
+    5. 該學生對此 (scholarship_type, academic_year) 尚未建立挑戰申請
+  creates: Application(is_renewal=False, sub_type=target_sub_type,
+                       challenges_application_id=renewal_application.id)
+```
+
+---
+
+## 8. 續領階段審查與分發
+
+### 8.1 審查路由
+
+```python
+def get_active_review_period(application, stage):
+    sch = application.scholarship_type
+    if application.is_renewal:
+        return getattr(sch, f"renewal_{stage}_start"), getattr(sch, f"renewal_{stage}_end")
+    return getattr(sch, f"{stage}_start"), getattr(sch, f"{stage}_end")
+```
+
+教授/學院端的待審清單依「目前是哪個審查期間 + Application.is_renewal」過濾。
+
+### 8.2 續領分發
+
+```
+規則：審查通過者 → 全部 approved；不需要 college_ranking 與 waitlisted 狀態
+
+理由：續領是「資格驗證」而非「擇優選拔」；實務上續領人數 ≤ 上期配額 ≤ 當年配額池，
+     不會出現配額不足。
+```
+
+---
+
+## 9. 一般階段分發演算法
+
+### 9.1 演算法總覽
+
+```python
+def execute_general_distribution(scholarship_type, academic_year):
+    # 步驟 1: 計算各 (sub_type, allocation_year) pool 的可用配額
+    #   total_quota[(sub_type, year)] - used_by_renewal[(sub_type, year)]
+
+    # 步驟 2: 對每個 sub_type，收集 college_ranked 候選名單（依排名）
+    #   候選人 = is_renewal=False 的 Application（含挑戰 + 純新）
+
+    # 步驟 3: 第一輪分發 — 候選名單依排名分配到該 sub_type 可用 pool
+    #   nstc 可分到多個 allocation_year（依政策順序）
+    #   moe_1w 僅當年
+    #   分到時 set ranking_item.allocation_year = pool_year, application.status = approved
+
+    # 步驟 4: 釋出處理
+    for challenge_app in all_approved_challenges:
+        renewal_app = challenge_app.challenges_application
+        renewal_app.status = 'cancelled_by_challenge'
+        renewal_app.cancelled_due_to_application_id = challenge_app.id
+        released[(renewal_app.sub_type, renewal_app.renewal_year)] += 1
+
+    # 步驟 5: 候補遞補（同 sub_type 候選名單下一位）
+    for (sub_type, year), count in released.items():
+        next_candidates = (ranking_items
+            .filter(sub_type=sub_type,
+                    application.status == 'college_ranked')  # 排除已 approved / rejected / withdrawn
+            .order_by(rank)
+            .limit(count))
+        for c in next_candidates:
+            c.application.status = 'approved'
+            c.allocation_year = year   # 學生 academic_year 不變
+
+    # 步驟 6: 收尾 — 餘下未中籤的 college_ranked 標記 rejected（依政策）
+```
+
+### 9.2 演算法重點
+
+- **候選名單按 sub_type 統一排名**：候選人對「哪一年配額」沒選擇權，分到哪個 allocation_year 由配額池順序決定
+- **挑戰申請者只在 challenge 的 sub_type 上排名**：A 想挑戰 moe_1w 就在 moe_1w 候選名單裡
+- **遞補不跨 sub_type**：釋出 nstc 只找 nstc 候選人
+- **釋出鏈不會無限連鎖**：釋出僅發生在「續領 sub_type」的 pool；該 sub_type 候選名單中不會出現「挑戰該 sub_type 失敗者」（因為挑戰申請的 sub_type 必須 ≠ 續領 sub_type，所以挑戰者不會在自己原 sub_type 的候選名單中）。因此遞補的候選人必定是 `challenges_application_id IS NULL` 的純新申請者，他們被遞補不會觸發新的釋出。
+
+### 9.3 範例追蹤
+
+```
+情境：博士生獎學金, 114 學年
+配額池:
+  nstc[113]: 10 slot (113 年計畫 N 年期)
+  nstc[114]: 8 slot
+  moe_1w[114]: 6 slot
+
+續領階段 (renewal_year=113)：10 人 approved 佔 nstc[113]
+其中 A、B 將在一般階段挑戰 moe_1w
+
+一般階段候選名單 (academic_year=114)：
+  nstc 候選: M, N, O, P, Q, R, S, T, U, V (依排名)
+  moe_1w 候選: A(挑戰), B(挑戰), X, Y, Z, AA, BB, CC
+
+第一輪分發：
+  nstc 配額剩 nstc[113]=0, nstc[114]=8 → M~T 分到 nstc[114]，U、V 暫未中
+  moe_1w 配額 6 → A, B, X, Y, Z, AA 中籤
+
+釋出處理：
+  A 挑戰中 → A 的 nstc-113 續領 cancelled → released[(nstc, 113)] = 1
+  B 挑戰中 → B 的 nstc-113 續領 cancelled → released[(nstc, 113)] = 2
+
+候補遞補：
+  U.status=approved, allocation_year=113
+  V.status=approved, allocation_year=113
+  注意：U、V 的 Application.academic_year 仍是 114
+
+最終：
+  nstc[113] approved: 8 原續領 + U + V = 10 ✓
+  nstc[114] approved: M~T = 8 ✓
+  moe_1w[114] approved: A, B, X, Y, Z, AA = 6 ✓
+```
+
+---
+
+## 10. 邊界情境
+
+| # | 情境 | 處理方式 |
+|---|---|---|
+| 1 | 上期得獎但 scholarship_type.is_renewal_enabled=False | 不顯示續領入口 |
+| 2 | N 年期計畫期已到 | RenewalEligibilityService 比對 scholarship_type 設定的續領上限年數；超過則不顯示 |
+| 3 | 學生續領期間未送出 | 自動放棄續領；一般申請可走純新申請；失去保底 |
+| 4 | 續領審查被拒 | Application_R.status=rejected；可在一般申請以新申請身分參加（不能挑戰） |
+| 5 | 續領通過但學生想撤回 | PATCH status=withdrawn；slot 自動進入候補遞補池 |
+| 6 | 挑戰申請想撤回 | Application_C.status=withdrawn；不影響續領 |
+| 7 | 續領期間想直接申請其他 sub_type | 拒絕；換 sub_type 須在一般申請期間提交挑戰申請 |
+| 8 | 嘗試建立第二筆挑戰 | 拒絕；每 (student, scholarship_type, academic_year) 最多一筆挑戰 |
+| 9 | 跨 scholarship_type 同時拿兩個獎學金 | 系統層級限制：每學年每學生最多一個 approved |
+| 10 | 釋出後候補名單為空 | nstc[113] slot 空缺，留作下次補發 |
+| 11 | 跨學年連續續領（114→115） | 115 年 Application_R.previous_application_id 指向 114 年 approved；renewal_year 仍指原計畫年 |
+| 12 | 114 挑戰成功 moe_1w，115 想再續領 nstc | 不行：A 的 nstc 計畫已在 114 結束。要走 115 純新申請 |
+| 13 | manual distribution 已執行後追加挑戰 | 此設計假設一般分發是一次性 batch，不支援執行後追加 |
+| 14 | renewal_year 對應 quota cell 不存在 | 拋出 RenewalQuotaNotFoundError，不靜默 fallback |
+
+---
+
+## 11. 錯誤訊息（給學生）
+
+```
+情境 7: "續領期間僅能就上期得獎的 sub_type 申請續領；如需更換 sub_type，請於一般申請期間提交挑戰申請。"
+情境 8: "您已對「<scholarship_name>」<academic_year> 學年提交挑戰申請，每個獎學金每學年僅能挑戰一次。"
+情境 12: "此 scholarship 的計畫期已結束；如欲繼續申請，請於一般申請期間以新申請身分提交。"
+```
+
+---
+
+## 12. 監控與稽核
+
+- 每筆 `cancelled_by_challenge` 必有 `cancelled_due_to_application_id`（資料庫約束 4 強制）
+- 背景檢查（cron / health endpoint）：每筆 approved 挑戰申請的 `challenges_application_id` 必須指向 `cancelled_by_challenge` 狀態紀錄
+- manual distribution batch 結束輸出統計：
+  - 續領通過數
+  - 挑戰成功數
+  - 釋出 slot 數（依 sub_type × allocation_year 切分）
+  - 遞補成功數
+  - 留作補發數
+  - 不變條件：釋出數 = 遞補數 + 留作補發數
+
+---
+
+## 13. 與現有系統的整合點
+
+- **manual_distribution_service**：需擴充以支援步驟 4-5（挑戰處理與遞補）
+- **roster_service**：續領紀錄會依 `renewal_year`（= allocation_year）落入對應的 payment_roster
+- **CollegeRankingItem.allocation_year**：已存在，遞補時填入
+- **batch import service**：已支援 `renewal_year` 欄位讀取
+- **ScholarshipType 期間方法**：已存在 `is_renewal_application_period()` 等；新 endpoint 直接呼叫
+
+---
+
+## 14. Admin UI 設計
+
+本章描述管理員端與學生端的關鍵畫面，重點在「續領的目標年度（renewal_year / allocation_year）」與 sub_type 的視覺化呈現。
+
+### 14.1 續領分發結果頁（新增）
+
+續領分發是自動的（通過審查 = approved），管理員不需要逐筆勾選，但需要結果檢視頁。
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ 續領分發結果 — 博士生獎學金 — 114 學年                        │
+├──────────────────────────────────────────────────────────┤
+│ ▌續領通過名單（按 sub_type × renewal_year 分組）             │
+│                                                          │
+│  nstc · 計畫年度 113  (10/10 slot 已用)                    │
+│    ├─ 王小明 (APP-114-0-00001, 原 APP-113-0-00007)         │
+│    ├─ 李大華 (APP-114-0-00002, 原 APP-113-0-00009)         │
+│    ├─ ...                                                │
+│    └─ 林小芳 (APP-114-0-00010) ⚠ 同時提交挑戰 moe_1w        │
+│                                                          │
+│  nstc · 計畫年度 112  (3/3 slot 已用)                       │
+│    ├─ 張三 (APP-114-0-00011, 原 APP-112-0-00003)          │
+│    └─ ...                                                │
+│                                                          │
+│  moe_1w · 計畫年度 114  (0 人續領，moe_1w 僅當年無多年池)    │
+│                                                          │
+│ ▌續領被拒名單                                                │
+│  (空 / 列表)                                              │
+│                                                          │
+│ ▌總結                                                       │
+│  通過: 13  拒絕: 0  撤回: 0                                │
+│                                                          │
+│ [匯出名單] [回到主面板]                                       │
+└──────────────────────────────────────────────────────────┘
+```
+
+**呈現要點**
+
+- 依 `sub_type × renewal_year` 分組顯示（讓管理員清楚看到「113 計畫池有幾人、112 計畫池有幾人」）
+- 每筆續領紀錄顯示：當期 application_id、原入選年的 application_id（previous_application_id）
+- 若該續領者已提交挑戰申請，特別標註 ⚠
+
+### 14.2 一般階段手動分發頁（修改 ManualDistributionPanel）
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ 手動分發 — 博士生獎學金 — 114 學年                                │
+├────────────────────────────────────────────────────────────────┤
+│ ▌續領已佔用（不可改動）                                            │
+│                                                                │
+│  nstc · 計畫年度 113  10/10 → 王小明、李大華、...、林小芳*       │
+│  nstc · 計畫年度 112   3/3 → 張三、...                          │
+│  moe_1w · 計畫年度 114  0/0 (續領無佔用)                         │
+│                                                                │
+│  *林小芳已提交挑戰 moe_1w                                        │
+│                                                                │
+│ ▌剩餘可分配配額                                                   │
+│  nstc · 計畫年度 114 (新核): 0/8                                 │
+│  moe_1w · 計畫年度 114    : 0/6                                  │
+├────────────────────────────────────────────────────────────────┤
+│ ▌一般分發 - 候選名單（含挑戰申請）                                 │
+│                                                                │
+│ ┌────┬──────┬───────┬─────────────────┬─────┬─────┬─────┐    │
+│ │排名│ 學生  │ 類型  │ 保底/註記          │nstc │moe  │... │    │
+│ │    │      │       │                  │ 114 │1w   │     │    │
+│ │    │      │       │                  │     │114  │     │    │
+│ ├────┼──────┼───────┼─────────────────┼─────┼─────┼─────┤    │
+│ │ 1  │陳小華│ 純新   │ —                │ ☑  │ ☐  │ ... │    │
+│ │ 2  │林小芳│ 挑戰   │ 🛡 保底 nstc-113 │灰禁 │ ☑  │ ... │    │
+│ │ 3  │張小明│ 純新   │ —                │ ☑  │ ☐  │ ... │    │
+│ │ 4  │許大強│ 純新   │ —                │ ☑  │ ☐  │ ... │    │
+│ │... │ ...  │ ...   │ ...              │ ... │ ... │ ... │    │
+│ └────┴──────┴───────┴─────────────────┴─────┴─────┴─────┘    │
+│                                                                │
+│ ▌釋出與遞補預覽（即時計算）                                         │
+│  ⚠ 林小芳 挑戰 moe_1w 成功                                       │
+│     ↳ 釋出 nstc · 計畫年度 113 slot                              │
+│     ↳ 自動遞補：黃小強（純新申請，排 #9）→ 分配至 nstc · 113       │
+│                                                                │
+│ [儲存配置] [預覽分發結果] [確認分發]                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**呈現與互動規則**
+
+1. **「續領已佔用」區塊唯讀**：清楚列出每個 `(sub_type, renewal_year)` 的佔用情況；管理員無法勾選或取消
+2. **挑戰申請者識別**：候選名單列「類型」欄顯示「挑戰」+ 「保底/註記」欄顯示 `🛡 保底 <sub_type>-<renewal_year>`
+3. **挑戰者的保底 sub_type 欄禁用**：林小芳的 nstc 欄灰色 disabled（她已有 nstc-113 保底，分到自己原 sub_type 沒意義）
+4. **配額欄位的 allocation_year 標示**：欄位 header 顯示「nstc · 114」、「nstc · 113 補發」等，讓管理員清楚每個 slot 屬於哪一年配額池
+5. **即時釋出與遞補預覽**：勾選變動時系統即時計算釋出鏈與建議遞補對象
+6. **儲存後仍可調整**：直到「確認分發」前都可改動；確認後鎖定
+
+### 14.3 學生「我的申請紀錄」頁
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ 我的申請紀錄                                                    │
+├──────────────────────────────────────────────────────────────┤
+│ 114 學年 - 博士生獎學金 - 續領申請 (sub_type: nstc)              │
+│   APP-114-0-00010                                            │
+│   狀態：已取消（因挑戰升級）                                       │
+│   原計畫年度：113                                                │
+│   ├─ 銜接自：APP-113-0-00007 (113 學年 nstc 續領核可)            │
+│   └─ 被取代於：APP-114-0-00xxx（挑戰申請 moe_1w 成功）            │
+│                                                              │
+│ 114 學年 - 博士生獎學金 - 挑戰申請 (sub_type: moe_1w)            │
+│   APP-114-0-00xxx                                            │
+│   狀態：已核可                                                    │
+│   分發計畫年度：114                                                │
+│   └─ 取代之續領：APP-114-0-00010 (nstc, 計畫年度 113)            │
+│                                                              │
+│ 113 學年 - 博士生獎學金 - 續領申請 (sub_type: nstc)              │
+│   APP-113-0-00007                                            │
+│   狀態：已核可（已被 114 學年續領延續）                              │
+│   原計畫年度：113                                                  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**呈現要點**
+
+- 每筆都明示 `sub_type` 與 `renewal_year / allocation_year`
+- 「銜接自」「被取代於」雙向鏈接，串起跨學年的續領鏈與當期的挑戰取代關係
+- `cancelled_by_challenge` 狀態以「已取消（因挑戰升級）」表達，加上對應的取代紀錄連結
+
+### 14.4 顏色與圖示規範
+
+- 🛡 = 已有保底（適用挑戰申請者）
+- ⚠ = 需注意的情境（挑戰已提交、釋出待處理）
+- 灰禁 = 不可勾選的欄位（已被續領佔用 / 自己原 sub_type）
+- 綠底 = 已分配/已核可
+- 黃底 = 候補預覽（即將遞補）
+- 紅底 = 釋出對象（即將 cancel）
+
+### 14.5 API 變更摘要（支援上述 UI）
+
+```
+GET  /api/v1/admin/renewal/distribution-result
+  query: scholarship_type_id, academic_year
+  returns: 按 (sub_type, renewal_year) 分組的續領通過/拒絕名單
+
+GET  /api/v1/admin/manual-distribution/state
+  query: scholarship_type_id, academic_year
+  returns: {
+    renewal_allocations: [{sub_type, renewal_year, applications: [...]}],
+    available_quotas: [{sub_type, allocation_year, total, used}],
+    candidates: [{rank, application_id, student, is_challenge, renewal_app_id, ...}]
+  }
+
+POST /api/v1/admin/manual-distribution/preview
+  body: {allocations: [{application_id, sub_type, allocation_year}]}
+  returns: {
+    release_chain: [{cancelled_application_id, freed_slot, suggested_fill: {application_id}}]
+  }
+```
+
+---
+
+## 15. 未涵蓋（未來工作）
+
+- **半路加入續領**：學生轉學/重考導致中途進入系統，無上期紀錄但有舊系統續領資格 → 需管理者手動匯入續領名單（現有 batch import 已支援）
+- **多 scholarship_type 之間的優先序**：同學生在不同 scholarship_type 都有續領+挑戰，跨 scholarship 的衝突處理（目前限制為「每學年每學生最多一個 approved」即可，不需特殊處理）
+- **挑戰失敗的告知與補救**：UI 上的通知/解釋頁面（屬 UX 範疇，不在此設計）

--- a/frontend/app/admin/renewal/page.tsx
+++ b/frontend/app/admin/renewal/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * /admin/renewal — 續領分發結果管理頁
+ *
+ * 提供：
+ *   1. 獎學金類型選擇器（資料源：GET /api/v1/manual-distribution/available-combinations）
+ *   2. 學年度選擇器
+ *   3. 續領分發結果顯示（RenewalDistributionResult 元件）
+ *
+ * 此頁面僅讀取，不修改後端狀態。
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { apiClient } from "@/lib/api";
+import type { AvailableCombinations } from "@/lib/api/modules/manual-distribution";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { RenewalDistributionResult } from "@/components/admin/renewal/RenewalDistributionResult";
+
+interface ScholarshipTypeOption {
+  id: number;
+  code: string;
+  name: string;
+  name_en?: string;
+}
+
+export default function AdminRenewalPage() {
+  const [scholarshipTypes, setScholarshipTypes] = useState<
+    ScholarshipTypeOption[]
+  >([]);
+  const [academicYears, setAcademicYears] = useState<number[]>([]);
+  const [selectedTypeId, setSelectedTypeId] = useState<number | null>(null);
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+  const [isLoadingOptions, setIsLoadingOptions] = useState(true);
+  const [optionsError, setOptionsError] = useState<string | null>(null);
+
+  // 初次載入：從 manual-distribution 端點取得可用獎學金類型與學年度。
+  // （續領分發複用相同的後端設定，因此不需另開端點。）
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setIsLoadingOptions(true);
+      setOptionsError(null);
+      try {
+        const response =
+          await apiClient.manualDistribution.getAvailableCombinations();
+        if (cancelled) return;
+        if (response.success && response.data) {
+          const data = response.data as AvailableCombinations;
+          setScholarshipTypes(data.scholarship_types ?? []);
+          // 學年度由新到舊排序：方便預設選最新年度
+          const years = [...(data.academic_years ?? [])].sort(
+            (a, b) => b - a
+          );
+          setAcademicYears(years);
+          // 預設選第一項（若有）
+          if (
+            data.scholarship_types &&
+            data.scholarship_types.length > 0 &&
+            selectedTypeId == null
+          ) {
+            setSelectedTypeId(data.scholarship_types[0].id);
+          }
+          if (years.length > 0 && selectedYear == null) {
+            setSelectedYear(years[0]);
+          }
+        } else {
+          setOptionsError(response.message || "無法載入獎學金類型清單");
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const detail = err instanceof Error ? err.message : "未知錯誤";
+        setOptionsError(`網路錯誤：${detail}`);
+      } finally {
+        if (!cancelled) setIsLoadingOptions(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // 僅在掛載時取資料；後續選擇變更不需重新請求 options。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const selectedTypeName = useMemo(() => {
+    const found = scholarshipTypes.find(t => t.id === selectedTypeId);
+    return found?.name;
+  }, [scholarshipTypes, selectedTypeId]);
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <header>
+        <h1 className="text-2xl font-bold text-[#003d7a]">續領分發結果</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          管理員專用：檢視特定獎學金類型 / 學年度的續領分發結果，包含通過、拒絕與是否同時提交挑戰申請。
+        </p>
+      </header>
+
+      {/* 篩選列 */}
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="text-base">查詢條件</CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          {optionsError ? (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{optionsError}</AlertDescription>
+            </Alert>
+          ) : isLoadingOptions ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              載入篩選選項中…
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground">
+                  獎學金類型
+                </label>
+                <Select
+                  value={selectedTypeId != null ? String(selectedTypeId) : ""}
+                  onValueChange={value => setSelectedTypeId(Number(value))}
+                  disabled={scholarshipTypes.length === 0}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="請選擇獎學金類型" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {scholarshipTypes.map(type => (
+                      <SelectItem key={type.id} value={String(type.id)}>
+                        {type.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground">
+                  學年度
+                </label>
+                <Select
+                  value={selectedYear != null ? String(selectedYear) : ""}
+                  onValueChange={value => setSelectedYear(Number(value))}
+                  disabled={academicYears.length === 0}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="請選擇學年度" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {academicYears.map(year => (
+                      <SelectItem key={year} value={String(year)}>
+                        {year} 學年
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 結果顯示 */}
+      <RenewalDistributionResult
+        scholarshipTypeId={selectedTypeId}
+        academicYear={selectedYear}
+        scholarshipTypeName={selectedTypeName}
+      />
+    </div>
+  );
+}

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -18,6 +18,8 @@ import type {
   DistributionSummaryResult,
   DistributionSummaryGroup,
   AllocationSuggestion,
+  DistributionState,
+  ReleaseChainItem,
 } from "@/lib/api/modules/manual-distribution";
 import { User } from "@/types/user";
 import { Button } from "@/components/ui/button";
@@ -31,6 +33,7 @@ import {
 } from "@/components/ui/select";
 import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -50,6 +53,10 @@ import {
   Download,
   Clock,
   Eye,
+  Shield,
+  AlertTriangle,
+  ArrowRight,
+  RefreshCw,
 } from "lucide-react";
 
 interface ManualDistributionPanelProps {
@@ -188,60 +195,13 @@ export function ManualDistributionPanel({
     }>;
   } | null>(null);
   const [previewApplied, setPreviewApplied] = useState(false);
-
-  const [revokeTarget, setRevokeTarget] = useState<DistributionStudent | null>(null);
-  const [suspendTarget, setSuspendTarget] = useState<DistributionStudent | null>(null);
-  const [actionReason, setActionReason] = useState("");
-  const [isActioning, setIsActioning] = useState(false);
-
-  const handleRevokeConfirm = async () => {
-    if (!revokeTarget || actionReason.trim().length === 0) return;
-    setIsActioning(true);
-    try {
-      const resp = await apiClient.manualDistribution.revoke(
-        revokeTarget.application_id,
-        actionReason.trim()
-      );
-      if (resp.success) {
-        setSaveMessage({ type: "success", text: `已撤銷 ${revokeTarget.student_name}` });
-        await fetchData();
-      } else {
-        setSaveMessage({ type: "error", text: resp.message || "撤銷失敗" });
-      }
-    } catch (err: unknown) {
-      setSaveMessage({ type: "error", text: (err as Error)?.message || "撤銷失敗" });
-    } finally {
-      setIsActioning(false);
-      setRevokeTarget(null);
-      setActionReason("");
-    }
-  };
-
-  const handleSuspendConfirm = async () => {
-    if (!suspendTarget || actionReason.trim().length === 0) return;
-    setIsActioning(true);
-    try {
-      const resp = await apiClient.manualDistribution.suspend(
-        suspendTarget.application_id,
-        actionReason.trim()
-      );
-      if (resp.success) {
-        setSaveMessage({ type: "success", text: `已停發 ${suspendTarget.student_name}` });
-        await fetchData();
-      } else {
-        setSaveMessage({ type: "error", text: resp.message || "停發失敗" });
-      }
-    } catch (err: unknown) {
-      setSaveMessage({ type: "error", text: (err as Error)?.message || "停發失敗" });
-    } finally {
-      setIsActioning(false);
-      setSuspendTarget(null);
-      setActionReason("");
-    }
-  };
-
-  const isFinalized = (student: DistributionStudent) =>
-    student.status === "allocated" || student.status === "approved";
+  // Renewal-aware panel state (Phase 8.2): approved renewals occupying slots,
+  // remaining quota per (sub_type × allocation_year), and ranked candidates
+  // with challenge metadata. Independent of `students` / `quotaStatus` —
+  // additive, never blocks the existing flow if the call fails.
+  const [distributionState, setDistributionState] =
+    useState<DistributionState | null>(null);
+  const [isLoadingState, setIsLoadingState] = useState(false);
 
   /**
    * Flatten quota status into (sub_type × year) columns, ordered by:
@@ -368,6 +328,135 @@ export function ManualDistributionPanel({
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // Fetch renewal-aware panel state alongside the existing student/quota
+  // pipeline. Wrapped in its own effect so a state-endpoint failure cannot
+  // break the legacy table render.
+  useEffect(() => {
+    let cancelled = false;
+    const loadState = async () => {
+      if (!scholarshipTypeId || !selectedAcademicYear) {
+        setDistributionState(null);
+        return;
+      }
+      setIsLoadingState(true);
+      try {
+        const resp = await apiClient.manualDistribution.getState(
+          scholarshipTypeId,
+          selectedAcademicYear
+        );
+        if (cancelled) return;
+        if (resp.success && resp.data) {
+          setDistributionState(resp.data);
+        } else {
+          // Soft-fail: keep existing UI working even if state endpoint errors
+          setDistributionState(null);
+        }
+      } catch {
+        if (!cancelled) setDistributionState(null);
+      } finally {
+        if (!cancelled) setIsLoadingState(false);
+      }
+    };
+    loadState();
+    return () => {
+      cancelled = true;
+    };
+  }, [scholarshipTypeId, selectedAcademicYear]);
+
+  // Lookup: which `application_id`s are challenge applications. Used to
+  // surface the 🛡 marker and amber styling in the candidate table.
+  const challengeAppMap = useMemo(() => {
+    const map = new Map<
+      number,
+      {
+        applying_sub_type: string | null;
+        challenged_renewal: {
+          renewal_application_id: number;
+          sub_type: string | null;
+          renewal_year: number | null;
+        } | null;
+      }
+    >();
+    if (!distributionState) return map;
+    for (const c of distributionState.candidates) {
+      if (c.is_challenge) {
+        map.set(c.application_id, {
+          applying_sub_type: c.applying_sub_type,
+          challenged_renewal: c.challenged_renewal,
+        });
+      }
+    }
+    return map;
+  }, [distributionState]);
+
+  // Release preview: dry-run the proposed allocations so admins can see
+  // which renewals would be cancelled and the auto-fill suggestion. Only
+  // POSTs when at least one challenge is currently staged.
+  const [releasePreview, setReleasePreview] = useState<ReleaseChainItem[]>([]);
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
+
+  const hasStagedChallenge = useMemo(() => {
+    if (challengeAppMap.size === 0) return false;
+    // Cross-reference staged allocations with challenge application_ids.
+    for (const [rankingItemId, alloc] of localAllocations) {
+      if (!alloc) continue;
+      const student = students.find(s => s.ranking_item_id === rankingItemId);
+      if (student && challengeAppMap.has(student.application_id)) return true;
+    }
+    return false;
+  }, [localAllocations, challengeAppMap, students]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const runPreview = async () => {
+      if (
+        !scholarshipTypeId ||
+        !selectedAcademicYear ||
+        !selectedSemester ||
+        !hasStagedChallenge
+      ) {
+        setReleasePreview([]);
+        return;
+      }
+      const allocations = Array.from(localAllocations.entries())
+        .filter(([, alloc]) => alloc !== null)
+        .map(([ranking_item_id, alloc]) => ({
+          ranking_item_id,
+          sub_type_code: alloc?.sub_type ?? null,
+          allocation_year: alloc?.year ?? null,
+        }));
+      setIsLoadingPreview(true);
+      try {
+        const resp = await apiClient.manualDistribution.previewDistribution({
+          scholarship_type_id: scholarshipTypeId,
+          academic_year: selectedAcademicYear,
+          semester: selectedSemester,
+          allocations,
+        });
+        if (cancelled) return;
+        if (resp.success && resp.data) {
+          setReleasePreview(resp.data.release_chain || []);
+        } else {
+          setReleasePreview([]);
+        }
+      } catch {
+        if (!cancelled) setReleasePreview([]);
+      } finally {
+        if (!cancelled) setIsLoadingPreview(false);
+      }
+    };
+    runPreview();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    scholarshipTypeId,
+    selectedAcademicYear,
+    selectedSemester,
+    localAllocations,
+    hasStagedChallenge,
+  ]);
 
   const handleCheckbox = (
     rankingItemId: number,
@@ -1040,6 +1129,28 @@ export function ManualDistributionPanel({
           </div>
         )}
 
+        {/* ===========================================================
+            Renewal-aware section (Phase 8.2)
+            Three additive blocks:
+              1) 續領已佔用（不可改動）
+              2) 剩餘可分配配額
+              3) 釋出與遞補預覽（即時計算）
+            All blocks degrade gracefully when state endpoint is empty.
+            =========================================================== */}
+        <RenewalOccupiedBlock
+          state={distributionState}
+          isLoading={isLoadingState}
+        />
+        <AvailableQuotasBlock
+          state={distributionState}
+          isLoading={isLoadingState}
+        />
+        <ReleasePreviewSection
+          releaseChain={releasePreview}
+          isLoading={isLoadingPreview}
+          hasStaged={hasStagedChallenge}
+        />
+
         {/* Table */}
         <div className="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
           <div className="p-3 border-b border-slate-200 flex items-center justify-between">
@@ -1082,9 +1193,9 @@ export function ManualDistributionPanel({
                     </th>
                     <th
                       rowSpan={2}
-                      className="px-1.5 py-1.5 border border-slate-200 text-center font-semibold text-[11px] w-16 bg-red-50"
+                      className="px-1.5 py-1.5 border border-slate-200 text-center font-semibold text-[11px] w-8 bg-red-50"
                     >
-                      動作
+                      取消
                     </th>
                     {subTypeCols.length > 0 && (
                       <th
@@ -1205,10 +1316,18 @@ export function ManualDistributionPanel({
                             const curAlloc = localAllocations.get(
                               student.ranking_item_id
                             );
+                            // Phase 8.2: surface challenge metadata from the
+                            // /state payload (keyed by application_id).
+                            const challengeMeta = challengeAppMap.get(
+                              student.application_id
+                            );
+                            const isChallenge = !!challengeMeta;
                             return (
                               <tr
                                 key={student.ranking_item_id}
-                                className="border-b border-slate-100 hover:bg-slate-50 transition-colors"
+                                className={`border-b border-slate-100 hover:bg-slate-50 transition-colors ${
+                                  isChallenge ? "bg-amber-50/60" : ""
+                                }`}
                               >
                                 <td className="px-1.5 py-1.5 border-r border-slate-100 text-center font-bold text-slate-700 text-[11px]">
                                   {student.college_rejected ? (
@@ -1239,40 +1358,30 @@ export function ManualDistributionPanel({
                                     </span>
                                   )}
                                 </td>
-                                {/* 撤銷 / 停發 buttons (post-roster generation actions) */}
+                                {/* Cancel allocation button */}
                                 <td className="px-1 py-1.5 border-r border-slate-100 text-center">
-                                  <div className="flex justify-center gap-0.5">
+                                  {curAlloc ? (
                                     <button
                                       onClick={() => {
-                                        setRevokeTarget(student);
-                                        setActionReason("");
+                                        setLocalAllocations(prev => {
+                                          const next = new Map(prev);
+                                          next.set(
+                                            student.ranking_item_id,
+                                            null
+                                          );
+                                          return next;
+                                        });
                                       }}
-                                      disabled={!isFinalized(student)}
-                                      className={`px-1.5 py-0.5 text-[10px] rounded border transition-colors ${
-                                        isFinalized(student)
-                                          ? "bg-red-100 text-red-700 border-red-300 hover:bg-red-200 cursor-pointer"
-                                          : "bg-slate-50 text-slate-300 border-slate-200 cursor-not-allowed"
-                                      }`}
-                                      title={isFinalized(student) ? "撤銷此學生獎學金（過往造冊需手動處理）" : "尚未分發，無法撤銷"}
+                                      className="px-2 py-1 text-xs bg-red-50 text-red-600 hover:bg-red-100 rounded border border-red-200 cursor-pointer transition-colors"
+                                      title="取消此學生的分配"
                                     >
-                                      撤
+                                      ✕
                                     </button>
-                                    <button
-                                      onClick={() => {
-                                        setSuspendTarget(student);
-                                        setActionReason("");
-                                      }}
-                                      disabled={!isFinalized(student)}
-                                      className={`px-1.5 py-0.5 text-[10px] rounded border transition-colors ${
-                                        isFinalized(student)
-                                          ? "bg-orange-100 text-orange-700 border-orange-300 hover:bg-orange-200 cursor-pointer"
-                                          : "bg-slate-50 text-slate-300 border-slate-200 cursor-not-allowed"
-                                      }`}
-                                      title={isFinalized(student) ? "停發此學生（過往造冊保留）" : "尚未分發，無法停發"}
-                                    >
-                                      停
-                                    </button>
-                                  </div>
+                                  ) : (
+                                    <span className="text-[10px] text-slate-300">
+                                      —
+                                    </span>
+                                  )}
                                 </td>
                                 {subTypeCols.map(col => {
                                   const isApplied =
@@ -1291,8 +1400,19 @@ export function ManualDistributionPanel({
                                     col.total > 0 &&
                                     localUsed >= col.total &&
                                     !isChecked;
+                                  // Phase 8.2: for a challenge candidate the
+                                  // sub_type they already hold a renewal in is
+                                  // their "safety net" — they must not be
+                                  // re-allocated there via the new path.
+                                  const isFallbackColumn =
+                                    isChallenge &&
+                                    challengeMeta?.challenged_renewal
+                                      ?.sub_type === col.sub_type;
                                   const disabled =
-                                    !isApplied || isRejected || atCapacity;
+                                    !isApplied ||
+                                    isRejected ||
+                                    atCapacity ||
+                                    isFallbackColumn;
                                   return (
                                     <td
                                       key={col.key}
@@ -1301,7 +1421,9 @@ export function ManualDistributionPanel({
                                           ? "opacity-40 bg-red-50"
                                           : !isApplied
                                             ? "opacity-40"
-                                            : ""
+                                            : isFallbackColumn
+                                              ? "opacity-40 bg-amber-100/40"
+                                              : ""
                                       }`}
                                     >
                                       <input
@@ -1310,15 +1432,17 @@ export function ManualDistributionPanel({
                                         checked={isChecked}
                                         disabled={disabled}
                                         title={
-                                          !isApplied
-                                            ? `未申請 ${col.display_name}`
-                                            : isRejected
-                                              ? `教授不推薦 ${col.display_name}`
-                                              : atCapacity
-                                                ? `${col.display_name} 名額已滿`
-                                                : isChecked
-                                                  ? "點擊取消分配"
-                                                  : `分配至 ${col.display_name}`
+                                          isFallbackColumn
+                                            ? `保底欄位：此考生已持有 ${col.sub_type} 的續領資格，不可改配於此`
+                                            : !isApplied
+                                              ? `未申請 ${col.display_name}`
+                                              : isRejected
+                                                ? `教授不推薦 ${col.display_name}`
+                                                : atCapacity
+                                                  ? `${col.display_name} 名額已滿`
+                                                  : isChecked
+                                                    ? "點擊取消分配"
+                                                    : `分配至 ${col.display_name}`
                                         }
                                         onChange={() =>
                                           handleCheckbox(
@@ -1362,18 +1486,45 @@ export function ManualDistributionPanel({
                                       {student.renewal_year || ""} 續領
                                       {student.renewal_sub_type || ""}
                                     </span>
+                                  ) : isChallenge ? (
+                                    // Phase 8.2: challenge applicant — show
+                                    // 挑戰 chip + 🛡 fallback annotation
+                                    <div className="flex flex-col gap-0.5">
+                                      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 border border-amber-300 w-fit">
+                                        <AlertTriangle className="h-3 w-3" />
+                                        挑戰
+                                      </span>
+                                      {challengeMeta?.challenged_renewal && (
+                                        <span className="inline-flex items-center gap-1 text-[10px] text-amber-700">
+                                          <Shield className="h-3 w-3" />
+                                          保底{" "}
+                                          {challengeMeta.challenged_renewal
+                                            .sub_type || "-"}
+                                          -
+                                          {challengeMeta.challenged_renewal
+                                            .renewal_year ?? "-"}
+                                        </span>
+                                      )}
+                                    </div>
                                   ) : (
-                                    <span
-                                      className={
-                                        student.application_identity.includes(
-                                          "新申請"
-                                        )
-                                          ? "text-amber-600"
-                                          : "text-blue-600"
-                                      }
-                                    >
-                                      {student.application_identity}
-                                    </span>
+                                    <div className="flex flex-col gap-0.5">
+                                      <span
+                                        className={
+                                          student.application_identity.includes(
+                                            "新申請"
+                                          )
+                                            ? "text-amber-600"
+                                            : "text-blue-600"
+                                        }
+                                      >
+                                        {student.application_identity}
+                                      </span>
+                                      {distributionState && (
+                                        <span className="text-[10px] text-slate-500 font-normal">
+                                          純新
+                                        </span>
+                                      )}
+                                    </div>
                                   )}
                                 </td>
                               </tr>
@@ -1670,92 +1821,277 @@ export function ManualDistributionPanel({
           </div>
         </div>
       )}
+    </div>
+  );
+}
 
-      <AlertDialog open={!!revokeTarget} onOpenChange={(open) => !open && setRevokeTarget(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              確認撤銷 {revokeTarget?.student_name} 的獎學金分配？
-            </AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div className="text-sm text-slate-600 space-y-2">
-                <p>撤銷後：</p>
-                <ul className="list-disc pl-5 space-y-1">
-                  <li>此學生將從目前所有未鎖定造冊中移除</li>
-                  <li>此學生申請狀態變更為「已取消」</li>
-                  <li>已鎖定的歷史造冊需手動清除（清單會列在受影響造冊頁面提示）</li>
-                </ul>
-                <div className="pt-2">
-                  <label className="block text-sm font-medium mb-1">
-                    撤銷原因（必填）
-                  </label>
-                  <textarea
-                    className="w-full border border-slate-300 rounded px-2 py-1 text-sm"
-                    rows={3}
-                    maxLength={500}
-                    value={actionReason}
-                    onChange={(e) => setActionReason(e.target.value)}
-                    placeholder="請說明撤銷原因…"
-                  />
+// ===========================================================================
+// Phase 8.2 — Renewal-aware sub-components
+//
+// Three additive blocks shown above the existing candidate list:
+//   1. RenewalOccupiedBlock     — read-only, shows approved renewals per
+//                                 (sub_type, renewal_year). Marked with *
+//                                 when a downstream challenge exists.
+//   2. AvailableQuotasBlock     — remaining quota per (sub_type,
+//                                 allocation_year).
+//   3. ReleasePreviewSection    — dry-run release_chain when challenges are
+//                                 staged. Surfaces who would be displaced
+//                                 and the suggested fill-in candidate.
+// ===========================================================================
+
+/** Render label like "nstc · 計畫年度 114"; falls back gracefully on nulls. */
+function formatSubTypeYear(sub_type: string | null, year: number | null) {
+  const sub = sub_type ?? "—";
+  const y = year ?? "—";
+  return `${sub} · 計畫年度 ${y}`;
+}
+
+function RenewalOccupiedBlock({
+  state,
+  isLoading,
+}: {
+  state: DistributionState | null;
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-xl border border-blue-200 shadow-sm p-4 mb-3">
+        <div className="flex items-center gap-2 text-slate-500">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">載入續領佔用資料中…</span>
+        </div>
+      </div>
+    );
+  }
+  if (!state) return null;
+  const groups = state.renewal_allocations || [];
+  const hasChallenge = groups.some(g =>
+    g.applications.some(a => a.has_challenge)
+  );
+
+  return (
+    <div className="bg-white rounded-xl border-2 border-[#003d7a]/30 shadow-sm mb-3">
+      <div className="flex items-center justify-between px-4 py-2 bg-[#003d7a] text-white rounded-t-lg">
+        <h3 className="font-bold text-sm flex items-center gap-2">
+          <Shield className="h-4 w-4" />
+          續領已佔用（不可改動）
+        </h3>
+        <span className="text-[10px] bg-white/20 px-2 py-0.5 rounded-full">
+          唯讀
+        </span>
+      </div>
+      <div className="p-3 space-y-1.5">
+        {groups.length === 0 ? (
+          <p className="text-xs text-slate-400 py-2 text-center">
+            尚無已核定的續領申請
+          </p>
+        ) : (
+          groups.map(g => {
+            const total = g.applications.length;
+            const names = g.applications.map(a => (
+              <span key={a.application_id} className="whitespace-nowrap">
+                {a.student_name || `#${a.application_id}`}
+                {a.has_challenge && (
+                  <span
+                    className="text-amber-600 font-bold"
+                    title="此續領已被挑戰申請"
+                  >
+                    *
+                  </span>
+                )}
+              </span>
+            ));
+            return (
+              <div
+                key={`${g.sub_type}-${g.renewal_year}`}
+                className="text-xs text-slate-700 px-3 py-2 rounded-md bg-blue-50/40 border border-blue-100"
+              >
+                <div className="flex items-center justify-between gap-2 flex-wrap">
+                  <span className="font-semibold text-[#003d7a]">
+                    {formatSubTypeYear(g.sub_type, g.renewal_year)}
+                  </span>
+                  <span className="text-[11px] font-mono text-slate-500">
+                    {total}/{total}
+                  </span>
+                </div>
+                <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 text-slate-600">
+                  {names.length > 0 ? (
+                    names.reduce<React.ReactNode[]>((acc, el, i) => {
+                      if (i > 0)
+                        acc.push(
+                          <span key={`sep-${i}`} className="text-slate-300">
+                            、
+                          </span>
+                        );
+                      acc.push(el);
+                      return acc;
+                    }, [])
+                  ) : (
+                    <span className="text-slate-400">—</span>
+                  )}
                 </div>
               </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isActioning}>取消</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={isActioning || actionReason.trim().length === 0}
-              onClick={handleRevokeConfirm}
-              className="bg-red-600 hover:bg-red-700 text-white"
-            >
-              {isActioning ? "處理中…" : "確認撤銷"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            );
+          })
+        )}
+        {hasChallenge && (
+          <p className="text-[11px] text-amber-700 px-1 pt-1">
+            <span className="font-bold">*</span> 標記者已被挑戰申請
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
 
-      <AlertDialog open={!!suspendTarget} onOpenChange={(open) => !open && setSuspendTarget(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              確認停發 {suspendTarget?.student_name} 的獎學金分配？
-            </AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div className="text-sm text-slate-600 space-y-2">
-                <p>停發後：</p>
-                <ul className="list-disc pl-5 space-y-1">
-                  <li>此學生將從目前所有未鎖定造冊中移除</li>
-                  <li>此學生申請狀態變更為「已取消」</li>
-                  <li>已鎖定的歷史造冊不受影響（金額已發放保留）</li>
-                </ul>
-                <div className="pt-2">
-                  <label className="block text-sm font-medium mb-1">
-                    停發原因（必填）
-                  </label>
-                  <textarea
-                    className="w-full border border-slate-300 rounded px-2 py-1 text-sm"
-                    rows={3}
-                    maxLength={500}
-                    value={actionReason}
-                    onChange={(e) => setActionReason(e.target.value)}
-                    placeholder="請說明停發原因…"
-                  />
+function AvailableQuotasBlock({
+  state,
+  isLoading,
+}: {
+  state: DistributionState | null;
+  isLoading: boolean;
+}) {
+  if (isLoading || !state) return null;
+  const quotas = state.available_quotas || [];
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 shadow-sm mb-3">
+      <div className="px-4 py-2 border-b border-slate-100 flex items-center justify-between">
+        <h3 className="font-bold text-sm text-slate-800 flex items-center gap-2">
+          <RefreshCw className="h-4 w-4 text-[#003d7a]" />
+          剩餘可分配配額
+        </h3>
+        <span className="text-[10px] text-slate-400">
+          扣除續領後可用於一般 / 挑戰分配
+        </span>
+      </div>
+      <div className="p-3">
+        {quotas.length === 0 ? (
+          <p className="text-xs text-slate-400 py-2 text-center">
+            尚無配額設定
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            {quotas.map(q => {
+              const isFull = q.remaining <= 0 && q.total > 0;
+              return (
+                <div
+                  key={`${q.sub_type}-${q.allocation_year}`}
+                  className={`px-3 py-2 rounded-md border text-xs ${
+                    isFull
+                      ? "bg-slate-100 border-slate-200 text-slate-500"
+                      : "bg-slate-50 border-slate-200"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-slate-700">
+                      {formatSubTypeYear(q.sub_type, q.allocation_year)}
+                    </span>
+                    <span
+                      className={`font-mono text-sm tabular-nums font-bold ${
+                        isFull ? "text-slate-400" : "text-[#003d7a]"
+                      }`}
+                    >
+                      {q.used}/{q.total}
+                    </span>
+                  </div>
+                  {q.remaining > 0 && (
+                    <div className="mt-0.5 text-[10px] text-slate-500">
+                      剩餘 {q.remaining} 個名額
+                    </div>
+                  )}
                 </div>
-              </div>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isActioning}>取消</AlertDialogCancel>
-            <AlertDialogAction
-              disabled={isActioning || actionReason.trim().length === 0}
-              onClick={handleSuspendConfirm}
-              className="bg-orange-600 hover:bg-orange-700 text-white"
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ReleasePreviewSection({
+  releaseChain,
+  isLoading,
+  hasStaged,
+}: {
+  releaseChain: ReleaseChainItem[];
+  isLoading: boolean;
+  hasStaged: boolean;
+}) {
+  // Only render if there's something challenge-related staged or in flight
+  if (!hasStaged && !isLoading && releaseChain.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl border-2 border-amber-200 shadow-sm mb-3">
+      <div className="px-4 py-2 bg-amber-50 border-b border-amber-200 flex items-center justify-between">
+        <h3 className="font-bold text-sm text-amber-800 flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4" />
+          釋出與遞補預覽（即時計算）
+        </h3>
+        {isLoading && (
+          <span className="text-[11px] text-amber-700 flex items-center gap-1">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            計算中…
+          </span>
+        )}
+      </div>
+      <div className="p-3 space-y-2">
+        {releaseChain.length === 0 ? (
+          <p className="text-xs text-slate-500 py-1">
+            目前的勾選不會觸發任何續領被釋出。
+          </p>
+        ) : (
+          releaseChain.map((item, idx) => (
+            <div
+              key={`${item.cancelled_application_id}-${idx}`}
+              className="rounded-md border border-amber-200 bg-amber-50/40 px-3 py-2 text-xs text-slate-700"
             >
-              {isActioning ? "處理中…" : "確認停發"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+              <div className="flex items-center gap-1 font-semibold text-amber-800">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                挑戰申請 #
+                {item.challenge_application_id ?? "—"} 成功
+              </div>
+              <div className="mt-1 flex items-center gap-1.5 text-slate-600 pl-4">
+                <ArrowRight className="h-3 w-3 text-amber-600" />
+                釋出{" "}
+                <span className="font-mono text-[#003d7a]">
+                  {formatSubTypeYear(
+                    item.freed_slot.sub_type,
+                    item.freed_slot.allocation_year
+                  )}
+                </span>{" "}
+                slot（取消續領 #{item.cancelled_application_id}）
+              </div>
+              <div className="mt-1 flex items-center gap-1.5 text-slate-600 pl-4">
+                <ArrowRight className="h-3 w-3 text-amber-600" />
+                自動遞補：
+                {item.suggested_fill_id ? (
+                  <>
+                    <span className="font-medium text-slate-800">
+                      {item.suggested_fill_name ||
+                        `#${item.suggested_fill_id}`}
+                    </span>
+                    <span className="text-slate-500">（純新申請）</span>
+                    <ArrowRight className="h-3 w-3 text-amber-600" />
+                    分配至{" "}
+                    <span className="font-mono text-[#003d7a]">
+                      {formatSubTypeYear(
+                        item.freed_slot.sub_type,
+                        item.freed_slot.allocation_year
+                      )}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-slate-500">
+                    無可用候補者（waitlist 為空）
+                  </span>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/components/admin/renewal/RenewalDistributionResult.tsx
+++ b/frontend/components/admin/renewal/RenewalDistributionResult.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+/**
+ * 續領分發結果顯示元件 (Admin)
+ *
+ * 取得指定 (獎學金類型, 學年度) 下的續領分發結果，依
+ * (sub_type, renewal_year) 分組呈現。資料來源：
+ *   GET /api/v1/renewals/distribution-result
+ *
+ * 設計參考：docs/superpowers/plans/2026-05-13-renewal-application.md §14.1
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { apiClient } from "@/lib/api";
+import type {
+  RenewalDistributionResult,
+  RenewalDistributionGroup,
+} from "@/lib/api/modules/renewal";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  Trophy,
+  XCircle,
+} from "lucide-react";
+
+interface RenewalDistributionResultProps {
+  /** 獎學金類型 ID（必填，未指定時顯示空狀態提示） */
+  scholarshipTypeId: number | null;
+  /** 學年度（必填，未指定時顯示空狀態提示） */
+  academicYear: number | null;
+  /** 顯示名稱：獎學金類型（供標題使用） */
+  scholarshipTypeName?: string;
+}
+
+/**
+ * 將 sub_type 代碼轉為簡短中文顯示名稱。
+ *   nstc          → "國科會"
+ *   moe_1w/moe_2w → "教育部+1" / "教育部+2"
+ *   其他          → 原值
+ */
+function getSubTypeShortName(subType: string | null): string {
+  if (!subType) return "未分類";
+  if (subType === "nstc") return "國科會";
+  const moeMatch = subType.match(/^moe_(\d+)w$/);
+  if (moeMatch) return `教育部+${moeMatch[1]}`;
+  return subType;
+}
+
+/**
+ * 將分組依 (sub_type, renewal_year) 穩定排序：
+ *   - sub_type 字典序
+ *   - renewal_year 由小至大（補發年度先，當年度後）
+ */
+function sortGroups(
+  groups: RenewalDistributionGroup[]
+): RenewalDistributionGroup[] {
+  return [...groups].sort((a, b) => {
+    const subA = a.sub_type ?? "";
+    const subB = b.sub_type ?? "";
+    if (subA !== subB) return subA.localeCompare(subB);
+    const yearA = a.renewal_year ?? 0;
+    const yearB = b.renewal_year ?? 0;
+    return yearA - yearB;
+  });
+}
+
+export function RenewalDistributionResult({
+  scholarshipTypeId,
+  academicYear,
+  scholarshipTypeName,
+}: RenewalDistributionResultProps) {
+  const [result, setResult] = useState<RenewalDistributionResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const fetchResult = useCallback(async () => {
+    if (scholarshipTypeId == null || academicYear == null) {
+      setResult(null);
+      return;
+    }
+    setIsLoading(true);
+    setErrorMessage(null);
+    try {
+      const response = await apiClient.renewal.getDistributionResult(
+        scholarshipTypeId,
+        academicYear
+      );
+      if (response.success && response.data) {
+        setResult(response.data);
+      } else {
+        setErrorMessage(response.message || "載入續領分發結果失敗");
+        setResult(null);
+      }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : "未知錯誤";
+      setErrorMessage(`網路錯誤：${detail}`);
+      setResult(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [scholarshipTypeId, academicYear]);
+
+  useEffect(() => {
+    fetchResult();
+  }, [fetchResult]);
+
+  // ---------- 空狀態：未選擇條件 ----------
+  if (scholarshipTypeId == null || academicYear == null) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          請於上方選擇獎學金類型與學年度以查看續領分發結果。
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ---------- 載入中 ----------
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          載入續領分發結果中…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ---------- 錯誤 ----------
+  if (errorMessage) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription className="flex items-center justify-between gap-3">
+          <span>{errorMessage}</span>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={fetchResult}
+            className="shrink-0"
+          >
+            <RefreshCw className="mr-1 h-3 w-3" />
+            重新載入
+          </Button>
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!result) {
+    return null;
+  }
+
+  const sortedGroups = sortGroups(result.groups);
+  const headerSubtitle = scholarshipTypeName
+    ? `${scholarshipTypeName} · ${academicYear} 學年`
+    : `學年 ${academicYear}`;
+
+  return (
+    <div className="space-y-6">
+      {/* 標題與總結 */}
+      <Card className="border-[#003d7a]/20">
+        <CardHeader className="border-b border-[#003d7a]/10 bg-[#003d7a]/5">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <CardTitle className="text-[#003d7a]">
+                續領分發結果
+              </CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {headerSubtitle}
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={fetchResult}
+            >
+              <RefreshCw className="mr-1 h-3 w-3" />
+              重新載入
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <SummaryStat
+              label="通過 (approved)"
+              value={result.summary.approved}
+              tone="success"
+            />
+            <SummaryStat
+              label="拒絕 (rejected)"
+              value={result.summary.rejected}
+              tone="danger"
+            />
+            <SummaryStat
+              label="分組數"
+              value={sortedGroups.length}
+              tone="info"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 通過名單分組 */}
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+            續領通過名單（依 sub_type × renewal_year 分組）
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          {sortedGroups.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              （目前無已核可的續領申請）
+            </p>
+          ) : (
+            <div className="space-y-5">
+              {sortedGroups.map(group => (
+                <GroupBlock
+                  key={`${group.sub_type ?? "none"}-${group.renewal_year ?? "n"}`}
+                  group={group}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 拒絕名單 */}
+      <Card>
+        <CardHeader className="border-b">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <XCircle className="h-4 w-4 text-rose-600" />
+            續領被拒名單
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-4">
+          {result.rejected.length === 0 ? (
+            <p className="text-sm text-muted-foreground">（無拒絕紀錄）</p>
+          ) : (
+            <ul className="divide-y rounded-md border">
+              {result.rejected.map(item => (
+                <li
+                  key={item.id}
+                  className="flex items-center justify-between px-4 py-2 text-sm"
+                >
+                  <span>{item.student_name ?? "（未知學生）"}</span>
+                  <span className="text-xs text-muted-foreground">
+                    App #{item.id}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 子元件
+// ---------------------------------------------------------------------------
+
+interface SummaryStatProps {
+  label: string;
+  value: number;
+  tone: "success" | "danger" | "info";
+}
+
+function SummaryStat({ label, value, tone }: SummaryStatProps) {
+  const toneClasses: Record<SummaryStatProps["tone"], string> = {
+    success: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    danger: "border-rose-200 bg-rose-50 text-rose-700",
+    info: "border-[#003d7a]/20 bg-[#003d7a]/5 text-[#003d7a]",
+  };
+  return (
+    <div className={`rounded-md border px-4 py-3 ${toneClasses[tone]}`}>
+      <p className="text-xs font-medium uppercase tracking-wide">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+    </div>
+  );
+}
+
+interface GroupBlockProps {
+  group: RenewalDistributionGroup;
+}
+
+function GroupBlock({ group }: GroupBlockProps) {
+  const shortName = getSubTypeShortName(group.sub_type);
+  const yearLabel =
+    group.renewal_year != null ? `計畫年度 ${group.renewal_year}` : "（無年度）";
+  const count = group.applications.length;
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <div className="flex items-center justify-between border-b bg-muted/40 px-4 py-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Badge
+            variant="outline"
+            className="border-[#003d7a]/30 bg-white text-[#003d7a]"
+          >
+            {shortName}
+          </Badge>
+          <span className="text-muted-foreground">·</span>
+          <span>{yearLabel}</span>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          共 {count} 人
+        </span>
+      </div>
+      {count === 0 ? (
+        <p className="px-4 py-3 text-sm text-muted-foreground">
+          （此分組目前無人）
+        </p>
+      ) : (
+        <ul className="divide-y">
+          {group.applications.map(app => (
+            <li
+              key={app.id}
+              className="flex flex-wrap items-center justify-between gap-2 px-4 py-2 text-sm"
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-medium">
+                  {app.student_name ?? "（未知學生）"}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {app.app_id}
+                </span>
+                {app.previous_application_id != null && (
+                  <span className="text-xs text-muted-foreground">
+                    原 App #{app.previous_application_id}
+                  </span>
+                )}
+              </div>
+              {app.has_challenge && (
+                <Badge
+                  variant="outline"
+                  className="border-amber-300 bg-amber-50 text-amber-700"
+                >
+                  <Trophy className="mr-1 h-3 w-3" />
+                  同時提交挑戰
+                </Badge>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -30,6 +30,8 @@ import { ApplicationDetailDialog } from "@/components/application-detail-dialog"
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { StudentApplicationWizard } from "@/components/student-wizard/StudentApplicationWizard";
 import { DocumentRequestAlert } from "@/components/document-request-alert";
+import { RenewalApplicationCard } from "@/components/student/RenewalApplicationCard";
+import { ChallengeApplicationCard } from "@/components/student/ChallengeApplicationCard";
 import type { StudentDocumentRequest } from "@/lib/api/modules/document-requests";
 import { isSelectableScholarship } from "@/lib/scholarship-eligibility";
 import {
@@ -1087,6 +1089,17 @@ export function EnhancedStudentPortal({
     </Card>
   );
 
+  // 已核可且為續領的申請 — 提供「挑戰其他 sub_type」入口
+  // 過濾條件：is_renewal && status === approved，且其 sub_scholarship_type 已知
+  const approvedRenewals = applications.filter(
+    app =>
+      app.is_renewal === true &&
+      app.status === ApplicationStatus.APPROVED &&
+      Boolean(
+        app.sub_scholarship_type || (app.scholarship_subtype_list ?? [])[0]
+      )
+  );
+
   return (
     <div className="space-y-6">
       {/* Document Request Alert - Show pending document requests */}
@@ -1097,6 +1110,48 @@ export function EnhancedStudentPortal({
           onFulfill={handleFulfillDocumentRequest}
         />
       )}
+
+      {/* 續領申請卡 — 永遠 mount；若無可續領紀錄，元件自身 return null */}
+      <RenewalApplicationCard
+        onStartEditing={onStartEditing}
+        locale={locale}
+      />
+
+      {/* 挑戰申請卡 — 每個核可續領申請各一張；無可挑戰 sub_type 時元件自身 return null */}
+      {approvedRenewals.map(renewal => {
+        const renewalSubType =
+          renewal.sub_scholarship_type ||
+          (renewal.scholarship_subtype_list ?? [])[0] ||
+          "";
+        // 從 eligibleScholarships 中找到對應的獎學金，取其 all_sub_type_list
+        // 作為可挑戰名單來源（已扣除續領 sub_type）
+        const scholarshipMeta = eligibleScholarships.find(
+          s => s.id === renewal.scholarship_type_id
+        );
+        const availableSubTypes = (
+          scholarshipMeta?.all_sub_type_list ?? []
+        ).filter(st => st && st !== "general");
+        if (!renewal.scholarship_type_id || availableSubTypes.length === 0) {
+          return null;
+        }
+        return (
+          <ChallengeApplicationCard
+            key={`challenge-${renewal.id}`}
+            approvedRenewalId={renewal.id}
+            approvedRenewalSubType={renewalSubType}
+            scholarshipTypeId={renewal.scholarship_type_id}
+            scholarshipTypeName={
+              scholarshipMeta
+                ? locale === "zh"
+                  ? scholarshipMeta.name
+                  : scholarshipMeta.name_en || scholarshipMeta.name
+                : undefined
+            }
+            availableSubTypes={availableSubTypes}
+            onStartEditing={onStartEditing}
+          />
+        );
+      })}
 
       {/* Conditional rendering based on activeTab */}
       {activeTab === "applications" && (
@@ -1144,17 +1199,83 @@ export function EnhancedStudentPortal({
                           {t("applications.application_id")}:{" "}
                           {app.app_id || `APP-${app.id}`}
                         </p>
+                        {/* 續領 / 挑戰 連結資訊 — Phase 9 task 9.3 */}
+                        {app.previous_application_id && (
+                          <p className="text-xs text-gray-600 mt-1">
+                            銜接自：
+                            <button
+                              type="button"
+                              className="text-nycu-blue-600 hover:underline"
+                              onClick={() => {
+                                const linked = applications.find(
+                                  a => a.id === app.previous_application_id
+                                );
+                                if (linked) handleViewDetails(linked);
+                              }}
+                            >
+                              APP-#{app.previous_application_id}
+                            </button>
+                          </p>
+                        )}
+                        {app.challenges_application_id && (
+                          <p className="text-xs text-amber-700 mt-1">
+                            挑戰自續領：
+                            <button
+                              type="button"
+                              className="text-amber-700 hover:underline"
+                              onClick={() => {
+                                const linked = applications.find(
+                                  a => a.id === app.challenges_application_id
+                                );
+                                if (linked) handleViewDetails(linked);
+                              }}
+                            >
+                              APP-#{app.challenges_application_id}
+                            </button>
+                          </p>
+                        )}
+                        {app.cancelled_due_to_application_id && (
+                          <p className="text-xs text-red-600 mt-1">
+                            被取代於：
+                            <button
+                              type="button"
+                              className="text-red-600 hover:underline"
+                              onClick={() => {
+                                const linked = applications.find(
+                                  a =>
+                                    a.id ===
+                                    app.cancelled_due_to_application_id
+                                );
+                                if (linked) handleViewDetails(linked);
+                              }}
+                            >
+                              APP-#{app.cancelled_due_to_application_id}
+                            </button>
+                            （挑戰申請成功）
+                          </p>
+                        )}
                       </div>
-                      <Badge
-                        variant={getApplicationStatusBadgeVariant(
-                          app.status as ApplicationStatus
+                      <div className="flex flex-col items-end gap-1">
+                        <Badge
+                          variant={getApplicationStatusBadgeVariant(
+                            app.status as ApplicationStatus
+                          )}
+                        >
+                          {getApplicationStatusLabel(
+                            app.status as ApplicationStatus,
+                            locale
+                          )}
+                        </Badge>
+                        {app.status ===
+                          ApplicationStatus.CANCELLED_BY_CHALLENGE && (
+                          <Badge
+                            variant="outline"
+                            className="border-red-200 bg-red-50 text-red-700 text-[10px]"
+                          >
+                            已取消（因挑戰升級）
+                          </Badge>
                         )}
-                      >
-                        {getApplicationStatusLabel(
-                          app.status as ApplicationStatus,
-                          locale
-                        )}
-                      </Badge>
+                      </div>
                     </div>
 
                     {/* Progress Timeline */}

--- a/frontend/components/student/ChallengeApplicationCard.tsx
+++ b/frontend/components/student/ChallengeApplicationCard.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * 挑戰申請卡 (Challenge Application Card)
+ *
+ * 顯示給「已有核可續領申請」的學生 — 允許其挑戰其他 sub_type 以爭取
+ * 更高名額；中籤後系統自動釋出其原有保底名額（將原續領申請標記為
+ * cancelled_by_challenge）。
+ *
+ * 資料來源：POST /api/v1/renewals/challenge
+ *
+ * Props 由父層 (EnhancedStudentPortal) 依當前學生的核可續領申請與所屬
+ * scholarshipType 的可用 sub_types 提供。
+ *
+ * 設計參考：docs/superpowers/plans/2026-05-13-renewal-application.md §9.2
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { ChevronRight, Loader2, Swords } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { apiClient } from "@/lib/api";
+
+interface ChallengeApplicationCardProps {
+  /** 已核可續領申請的 ID（父層自學生申請清單篩出 is_renewal && approved 取得） */
+  approvedRenewalId: number;
+  /** 該續領申請的 sub_type — 將從可挑戰選單中排除 */
+  approvedRenewalSubType: string;
+  /** 獎學金類型 ID（呼叫 createChallenge 不直接用到，但保留供未來追蹤） */
+  scholarshipTypeId: number;
+  /** 可顯示的獎學金名稱（標題用） */
+  scholarshipTypeName?: string;
+  /**
+   * 可挑戰之 sub_type 清單 — 父層依 scholarshipConfiguration.quotas 鍵清單
+   * 過濾掉 approvedRenewalSubType 後傳入。空陣列時整張卡片不渲染。
+   */
+  availableSubTypes: string[];
+  /** 建立成功後通知父層切換至編輯該新建挑戰申請的頁面 */
+  onStartEditing?: (applicationId: number) => void;
+}
+
+/**
+ * 將 sub_type 代碼轉為簡短中文顯示名稱。
+ *   nstc          → "國科會"
+ *   moe_1w/moe_2w → "教育部+1" / "教育部+2"
+ *   其他          → 原值
+ */
+function getSubTypeShortName(subType: string): string {
+  if (subType === "nstc") return "國科會";
+  const moeMatch = subType.match(/^moe_(\d+)w$/);
+  if (moeMatch) return `教育部+${moeMatch[1]}`;
+  return subType;
+}
+
+export function ChallengeApplicationCard({
+  approvedRenewalId,
+  approvedRenewalSubType,
+  scholarshipTypeName,
+  availableSubTypes,
+  onStartEditing,
+}: ChallengeApplicationCardProps) {
+  // 移除續領 sub_type，避免使用者自己挑戰自己
+  const eligibleSubTypes = useMemo(
+    () => availableSubTypes.filter(st => st && st !== approvedRenewalSubType),
+    [availableSubTypes, approvedRenewalSubType]
+  );
+
+  const [targetSubType, setTargetSubType] = useState<string>(
+    eligibleSubTypes[0] ?? ""
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(async () => {
+    if (!targetSubType) {
+      setErrorMessage("請選擇要挑戰的 sub_type");
+      return;
+    }
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    try {
+      const response = await apiClient.renewal.createChallenge(
+        approvedRenewalId,
+        targetSubType
+      );
+      if (response.success && response.data) {
+        onStartEditing?.(response.data.id);
+      } else {
+        setErrorMessage(response.message || "建立挑戰申請失敗");
+      }
+    } catch (err) {
+      console.error("Failed to create challenge:", err);
+      setErrorMessage(
+        err instanceof Error ? err.message : "建立挑戰申請失敗"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [approvedRenewalId, onStartEditing, targetSubType]);
+
+  // 沒有任何可挑戰 sub_type — 整張卡片不顯示
+  if (eligibleSubTypes.length === 0) return null;
+
+  return (
+    <Card className="border-l-4 border-l-amber-500 bg-amber-50/40">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Swords className="h-5 w-5 text-amber-600" />
+          <CardTitle className="text-base text-amber-900">
+            挑戰其他 sub_type
+            {scholarshipTypeName && (
+              <span className="ml-2 text-sm font-normal text-amber-800/80">
+                — {scholarshipTypeName}
+              </span>
+            )}
+          </CardTitle>
+        </div>
+        <CardDescription className="text-amber-900/80">
+          您已續領{" "}
+          <Badge
+            variant="outline"
+            className="border-amber-300 bg-amber-100 text-amber-900"
+          >
+            {getSubTypeShortName(approvedRenewalSubType)}
+          </Badge>
+          （保底）。可挑戰其他 sub_type；中籤則自動釋出保底名額。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {errorMessage && (
+          <Alert variant="destructive">
+            <AlertDescription>{errorMessage}</AlertDescription>
+          </Alert>
+        )}
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex-1">
+            <Select
+              value={targetSubType}
+              onValueChange={setTargetSubType}
+              disabled={isSubmitting}
+            >
+              <SelectTrigger className="bg-white">
+                <SelectValue placeholder="選擇要挑戰的 sub_type" />
+              </SelectTrigger>
+              <SelectContent>
+                {eligibleSubTypes.map(st => (
+                  <SelectItem key={st} value={st}>
+                    {getSubTypeShortName(st)}
+                    <span className="ml-1 text-xs text-gray-500">({st})</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            onClick={handleSubmit}
+            disabled={isSubmitting || !targetSubType}
+            className="bg-amber-600 hover:bg-amber-700"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                建立中...
+              </>
+            ) : (
+              <>
+                提交挑戰申請
+                <ChevronRight className="ml-1 h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/student/RenewalApplicationCard.tsx
+++ b/frontend/components/student/RenewalApplicationCard.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+/**
+ * 續領申請卡 (Renewal Application Card)
+ *
+ * 顯示給學生 — 列出當前可續領的獎學金紀錄（學生上一年度核可的申請，
+ * 對應獎學金類型在當前學年度的續領申請窗口為開啟狀態）。
+ *
+ * 資料來源：GET /api/v1/renewals/eligible
+ * 建立續領：POST /api/v1/renewals/
+ *
+ * 設計參考：docs/superpowers/plans/2026-05-13-renewal-application.md §9.1
+ *
+ * 注意：
+ *   - 無可續領紀錄時整張卡片不渲染（return null）。
+ *   - 建立成功後切回「我的申請」列表並啟動編輯模式 — 由父層 onStartEditing 處理導頁。
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Award, ChevronRight, Loader2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { apiClient } from "@/lib/api";
+import type { EligibleRenewal } from "@/lib/api/modules/renewal";
+
+interface RenewalApplicationCardProps {
+  /**
+   * 建立成功後通知父層切換至編輯該新建續領申請的頁面（即「新申請」分頁）。
+   * 對應 EnhancedStudentPortal 的 onStartEditing prop。
+   */
+  onStartEditing?: (applicationId: number) => void;
+  /** 顯示語系（目前僅實作 zh-TW，保留英文鉤子） */
+  locale?: "zh" | "en";
+}
+
+export function RenewalApplicationCard({
+  onStartEditing,
+}: RenewalApplicationCardProps) {
+  const [eligible, setEligible] = useState<EligibleRenewal[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [creatingId, setCreatingId] = useState<number | null>(null);
+
+  const fetchEligible = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+    try {
+      const response = await apiClient.renewal.listEligible();
+      if (response.success && Array.isArray(response.data)) {
+        setEligible(response.data);
+      } else {
+        setEligible([]);
+        if (!response.success) {
+          setErrorMessage(response.message || "無法載入可續領清單");
+        }
+      }
+    } catch (err) {
+      console.error("Failed to load eligible renewals:", err);
+      setEligible([]);
+      setErrorMessage(
+        err instanceof Error ? err.message : "載入可續領清單時發生錯誤"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchEligible();
+  }, [fetchEligible]);
+
+  const handleCreate = useCallback(
+    async (item: EligibleRenewal) => {
+      setCreatingId(item.previous_application_id);
+      try {
+        const response = await apiClient.renewal.createRenewal(
+          item.previous_application_id
+        );
+        if (response.success && response.data) {
+          // 移除這一筆，避免再次建立
+          setEligible(prev =>
+            prev.filter(
+              x => x.previous_application_id !== item.previous_application_id
+            )
+          );
+          onStartEditing?.(response.data.id);
+        } else {
+          alert(response.message || "建立續領申請失敗");
+        }
+      } catch (err) {
+        console.error("Failed to create renewal:", err);
+        alert(err instanceof Error ? err.message : "建立續領申請失敗");
+      } finally {
+        setCreatingId(null);
+      }
+    },
+    [onStartEditing]
+  );
+
+  // 載入中、錯誤、空清單 — 整張卡片不顯示，避免污染學生主畫面
+  if (isLoading) return null;
+  if (errorMessage) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{errorMessage}</AlertDescription>
+      </Alert>
+    );
+  }
+  if (eligible.length === 0) return null;
+
+  return (
+    <Card className="border-l-4 border-l-emerald-500 bg-emerald-50/40">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Award className="h-5 w-5 text-emerald-600" />
+          <CardTitle className="text-base text-emerald-900">
+            可續領的獎學金
+          </CardTitle>
+        </div>
+        <CardDescription className="text-emerald-800/80">
+          以下為您上學年度通過的獎學金，目前處於續領申請期間，
+          建立後將自動帶入原核可之 sub_type 與基本資料。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {eligible.map(item => (
+          <div
+            key={item.previous_application_id}
+            className="flex flex-col gap-3 rounded-lg border border-emerald-100 bg-white p-3 md:flex-row md:items-center md:justify-between"
+          >
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 font-medium text-gray-900">
+                {item.scholarship_type_name || "未知獎學金"}
+                {item.sub_scholarship_type && (
+                  <Badge
+                    variant="outline"
+                    className="border-emerald-200 bg-emerald-50 text-emerald-700"
+                  >
+                    上期 sub_type：{item.sub_scholarship_type}
+                  </Badge>
+                )}
+              </div>
+              <div className="text-sm text-gray-600">
+                目標學年：{item.target_academic_year} 學年度
+                {item.renewal_year &&
+                  item.renewal_year !== item.target_academic_year && (
+                    <span className="ml-2 text-amber-600">
+                      （補發年度：{item.renewal_year}）
+                    </span>
+                  )}
+              </div>
+              {item.renewal_deadline && (
+                <div className="text-xs text-gray-500">
+                  申請截止：
+                  {new Date(item.renewal_deadline).toLocaleString("zh-TW", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </div>
+              )}
+            </div>
+            <Button
+              onClick={() => handleCreate(item)}
+              disabled={creatingId === item.previous_application_id}
+              className="bg-emerald-600 hover:bg-emerald-700"
+            >
+              {creatingId === item.previous_application_id ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  建立中...
+                </>
+              ) : (
+                <>
+                  建立續領申請
+                  <ChevronRight className="ml-1 h-4 w-4" />
+                </>
+              )}
+            </Button>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -6337,31 +6337,15 @@ export interface paths {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                roster_id: number;
-            };
+            path?: never;
             cookie?: never;
         };
-        /** Get Revoked Suspended */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    roster_id: number;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                200: {
-                    headers: Record<string, unknown>;
-                    content: {
-                        "application/json": unknown;
-                    };
-                };
-            };
-        };
+        /**
+         * Get Revoked Suspended
+         * @description List students still embedded in this roster whose allocation was
+         *     later revoked or suspended.
+         */
+        get: operations["get_revoked_suspended_api_v1_payment_rosters__roster_id__revoked_suspended_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6374,42 +6358,18 @@ export interface paths {
         parameters: {
             query?: never;
             header?: never;
-            path: {
-                roster_id: number;
-                item_id: number;
-            };
+            path?: never;
             cookie?: never;
         };
         get?: never;
         put?: never;
         post?: never;
-        /** Remove Item From Locked Roster */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    roster_id: number;
-                    item_id: number;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": {
-                        reason?: string | null;
-                    };
-                };
-            };
-            responses: {
-                200: {
-                    headers: Record<string, unknown>;
-                    content: {
-                        "application/json": unknown;
-                    };
-                };
-            };
-        };
+        /**
+         * Remove Locked Roster Item
+         * @description Hard-delete a single item from a LOCKED roster. Roster stays LOCKED;
+         *     excel_stale is set to True; audit log written.
+         */
+        delete: operations["remove_locked_roster_item_api_v1_payment_rosters__roster_id__items__item_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -8763,11 +8723,6 @@ export interface components {
             subtype_eligibility: {
                 [key: string]: components["schemas"]["SubtypeEligibilityInfo"];
             };
-            /**
-             * Is Renewal Application
-             * @default false
-             */
-            is_renewal_application: boolean;
         };
         /** EmailAutomationRuleCreate */
         EmailAutomationRuleCreate: {
@@ -9188,6 +9143,14 @@ export interface components {
              * @description Roster code (if roster exists)
              */
             roster_code?: string | null;
+        };
+        /**
+         * RemoveLockedItemRequest
+         * @description Body for DELETE /payment-rosters/{roster_id}/items/{item_id}
+         */
+        RemoveLockedItemRequest: {
+            /** Reason */
+            reason?: string | null;
         };
         /** RestoreRequest */
         RestoreRequest: {
@@ -20770,6 +20733,73 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_revoked_suspended_api_v1_payment_rosters__roster_id__revoked_suspended_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                roster_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_locked_roster_item_api_v1_payment_rosters__roster_id__items__item_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                roster_id: number;
+                item_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RemoveLockedItemRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -6333,6 +6333,88 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/payment-rosters/{roster_id}/revoked-suspended": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                roster_id: number;
+            };
+            cookie?: never;
+        };
+        /** Get Revoked Suspended */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    roster_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                200: {
+                    headers: Record<string, unknown>;
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/payment-rosters/{roster_id}/items/{item_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                roster_id: number;
+                item_id: number;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove Item From Locked Roster */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    roster_id: number;
+                    item_id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        reason?: string | null;
+                    };
+                };
+            };
+            responses: {
+                200: {
+                    headers: Record<string, unknown>;
+                    content: {
+                        "application/json": unknown;
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/roster-schedules": {
         parameters: {
             query?: never;

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -6333,48 +6333,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/payment-rosters/{roster_id}/revoked-suspended": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Revoked Suspended
-         * @description List students still embedded in this roster whose allocation was
-         *     later revoked or suspended.
-         */
-        get: operations["get_revoked_suspended_api_v1_payment_rosters__roster_id__revoked_suspended_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/payment-rosters/{roster_id}/items/{item_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /**
-         * Remove Locked Roster Item
-         * @description Hard-delete a single item from a LOCKED roster. Roster stays LOCKED;
-         *     excel_stale is set to True; audit log written.
-         */
-        delete: operations["remove_locked_roster_item_api_v1_payment_rosters__roster_id__items__item_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/roster-schedules": {
         parameters: {
             query?: never;
@@ -6766,6 +6724,180 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/renewals/eligible": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Eligible Renewals
+         * @description Return the user's prior-year approved applications that may be renewed.
+         *
+         *     "May be renewed" means the current-year `ScholarshipConfiguration` for the
+         *     same scholarship_type has its `renewal_application_*` window open.
+         */
+        get: operations["list_eligible_renewals_api_v1_renewals_eligible_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/renewals/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Renewal Application
+         * @description Create a renewal application from a prior approved application.
+         *
+         *     Validations:
+         *       1. Previous application exists.
+         *       2. It belongs to the current user.
+         *       3. Its status is `approved`.
+         *       4. The current-year ScholarshipConfiguration has an active renewal window.
+         *       5. No existing renewal application for the same (user, type, year, semester).
+         */
+        post: operations["create_renewal_application_api_v1_renewals__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/renewals/challenge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Challenge Application
+         * @description Create a challenge application from an approved renewal.
+         *
+         *     Validations:
+         *       1. Renewal application exists.
+         *       2. It belongs to the current user.
+         *       3. It is in fact a renewal (`is_renewal=True`).
+         *       4. Its status is `approved`.
+         *       5. `target_sub_type` differs from renewal's `sub_scholarship_type`.
+         *       6. The renewal-year ScholarshipConfiguration has an active general
+         *          application window.
+         *       7. `target_sub_type` exists in `ScholarshipConfiguration.quotas`.
+         *       8. No existing challenge application for the same renewal.
+         */
+        post: operations["create_challenge_application_api_v1_renewals_challenge_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/renewals/{scholarship_type_id}/auto-distribute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger Renewal Auto Distribution
+         * @description Admin-triggered: auto-approve renewal applications past their review stage.
+         *
+         *     Renewals skip the college_ranking phase by design — once they have cleared
+         *     the required reviews (professor +/- college, per `ScholarshipConfiguration`),
+         *     this endpoint flips them from `under_review` to `approved` with
+         *     `review_stage = quota_distributed`.
+         *
+         *     Args:
+         *         scholarship_type_id: Path — scholarship type to process.
+         *         academic_year:        Query — ROC academic year (e.g. 114).
+         *
+         *     Returns:
+         *         ApiResponse with data = {approved_count, approved_ids}.
+         */
+        post: operations["trigger_renewal_auto_distribution_api_v1_renewals__scholarship_type_id__auto_distribute_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/renewals/distribution-result": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Renewal Distribution Result
+         * @description Return renewal distribution grouped by (sub_type, renewal_year).
+         *
+         *     Admin-only. For the given `(scholarship_type_id, academic_year)`:
+         *       - Approved renewals are bucketed into `groups` keyed by
+         *         `(sub_scholarship_type, renewal_year)`. Each application carries
+         *         a `has_challenge` flag indicating whether a downstream challenge
+         *         application (Application_C, `is_renewal=False` with
+         *         `challenges_application_id` set) points at it.
+         *       - Rejected renewals are returned in a flat `rejected` list.
+         *       - A `summary` block totals approved + rejected counts.
+         *
+         *     Other statuses (draft, under_review, etc.) are intentionally ignored;
+         *     this endpoint reports a *finalised* distribution view.
+         */
+        get: operations["get_renewal_distribution_result_api_v1_renewals_distribution_result_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/renewals/audit/renewal-violations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Audit Renewal Violations
+         * @description Admin audit: list approved challenges whose renewal isn't cancelled_by_challenge.
+         *
+         *     Implements the spec §12 invariant check. Empty `data` means the system
+         *     is consistent. A non-empty list points at data drift that needs manual
+         *     investigation — typically a renewal that wasn't transitioned during
+         *     `execute_general_distribution`.
+         *
+         *     Returns:
+         *         ApiResponse with `data` = list of
+         *         ``{challenge_id, renewal_id, actual_renewal_status}`` dicts.
+         */
+        get: operations["audit_renewal_violations_api_v1_renewals_audit_renewal_violations_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/manual-distribution/available-combinations": {
         parameters: {
             query?: never;
@@ -6826,6 +6958,37 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/manual-distribution/state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Distribution State
+         * @description Return the full state needed by the manual distribution panel UI.
+         *
+         *     Aggregates three views in one round trip:
+         *       * ``renewal_allocations`` — approved renewals grouped by
+         *         ``(sub_type, renewal_year)``, each marked ``has_challenge`` if a
+         *         downstream challenge targets it.
+         *       * ``available_quotas`` — per ``(sub_type, allocation_year)``: total /
+         *         used / remaining where ``used`` comes from approved renewals.
+         *       * ``candidates`` — non-renewal applicants in ranking order, with
+         *         ``is_challenge`` and a ``challenged_renewal`` block when present.
+         *
+         *     See ``ManualDistributionService.compute_distribution_state`` for details.
+         */
+        get: operations["get_distribution_state_api_v1_manual_distribution_state_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/manual-distribution/auto-allocate-preview": {
         parameters: {
             query?: never;
@@ -6840,6 +7003,33 @@ export interface paths {
         get: operations["auto_allocate_preview_api_v1_manual_distribution_auto_allocate_preview_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/manual-distribution/preview-distribution": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview Distribution
+         * @description Dry-run: compute the release_chain for the proposed allocations.
+         *
+         *     For each proposed allocation whose application is a challenge, returns
+         *     the renewal that would be cancelled and the next pure-new waitlist
+         *     candidate who would inherit the freed slot. Nothing is persisted.
+         *
+         *     Used by the admin Manual Distribution panel to surface release-chain
+         *     impact before commit (spec Section 14.2).
+         */
+        post: operations["preview_distribution_api_v1_manual_distribution_preview_distribution_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6984,46 +7174,6 @@ export interface paths {
          * @description Import received months from Excel for students in a distribution.
          */
         post: operations["import_received_months_api_v1_manual_distribution_import_received_months_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/manual-distribution/applications/{application_id}/revoke": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Revoke Application Allocation
-         * @description 撤銷已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/revoked。
-         */
-        post: operations["revoke_application_allocation_api_v1_manual_distribution_applications__application_id__revoke_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/manual-distribution/applications/{application_id}/suspend": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Suspend Application Allocation
-         * @description 停發已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/suspended。
-         */
-        post: operations["suspend_application_allocation_api_v1_manual_distribution_applications__application_id__suspend_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -7606,6 +7756,11 @@ export interface components {
              * @default []
              */
             scholarship_subtype_list: string[] | null;
+            /**
+             * Sub Scholarship Type
+             * @description 本申請的代表性 sub_type（單一字串；若為續領則承襲自前一申請）
+             */
+            sub_scholarship_type?: string | null;
             /** Status */
             status: string;
             /** Status Name */
@@ -7616,6 +7771,26 @@ export interface components {
              * @default false
              */
             is_renewal: boolean;
+            /**
+             * Renewal Year
+             * @description 續領年份 (民國年，如 113)；批次匯入指定，或承接自前一申請
+             */
+            renewal_year?: number | null;
+            /**
+             * Previous Application Id
+             * @description 承接的前一份核可申請 ID（續領申請填）
+             */
+            previous_application_id?: number | null;
+            /**
+             * Challenges Application Id
+             * @description 挑戰的目標續領申請 ID（挑戰申請填）— 一旦挑戰核可，被挑戰之續領自動取消
+             */
+            challenges_application_id?: number | null;
+            /**
+             * Cancelled Due To Application Id
+             * @description 因哪份挑戰申請而被取消（被取代之續領申請填）
+             */
+            cancelled_due_to_application_id?: number | null;
             /** Academic Year */
             academic_year: number;
             /** Semester */
@@ -8273,6 +8448,24 @@ export interface components {
              */
             validation_regex?: string | null;
         };
+        /**
+         * CreateChallengeRequest
+         * @description Body for POST /api/v1/renewals/challenge — create challenge from an approved renewal.
+         */
+        CreateChallengeRequest: {
+            /** Renewal Application Id */
+            renewal_application_id: number;
+            /** Target Sub Type */
+            target_sub_type: string;
+        };
+        /**
+         * CreateRenewalRequest
+         * @description Body for POST /api/v1/renewals/ — create renewal from a prior approved app.
+         */
+        CreateRenewalRequest: {
+            /** Previous Application Id */
+            previous_application_id: number;
+        };
         /** DeleteApplicationRequest */
         DeleteApplicationRequest: {
             /** Reason */
@@ -8488,6 +8681,11 @@ export interface components {
             subtype_eligibility: {
                 [key: string]: components["schemas"]["SubtypeEligibilityInfo"];
             };
+            /**
+             * Is Renewal Application
+             * @default false
+             */
+            is_renewal_application: boolean;
         };
         /** EmailAutomationRuleCreate */
         EmailAutomationRuleCreate: {
@@ -8909,14 +9107,6 @@ export interface components {
              */
             roster_code?: string | null;
         };
-        /**
-         * RemoveLockedItemRequest
-         * @description Body for DELETE /payment-rosters/{roster_id}/items/{item_id}
-         */
-        RemoveLockedItemRequest: {
-            /** Reason */
-            reason?: string | null;
-        };
         /** RestoreRequest */
         RestoreRequest: {
             /** History Id */
@@ -8969,14 +9159,6 @@ export interface components {
              * @description 子項目審查列表
              */
             items: components["schemas"]["ReviewItemCreate"][];
-        };
-        /**
-         * RevokeRequest
-         * @description Body for POST /manual-distribution/applications/{id}/revoke
-         */
-        RevokeRequest: {
-            /** Reason */
-            reason: string;
         };
         /**
          * RosterCreateRequest
@@ -9829,14 +10011,6 @@ export interface components {
         SupplementaryImportToggle: {
             /** Allow */
             allow: boolean;
-        };
-        /**
-         * SuspendRequest
-         * @description Body for POST /manual-distribution/applications/{id}/suspend
-         */
-        SuspendRequest: {
-            /** Reason */
-            reason: string;
         };
         /**
          * SystemSettingCreate
@@ -20535,73 +20709,6 @@ export interface operations {
             };
         };
     };
-    get_revoked_suspended_api_v1_payment_rosters__roster_id__revoked_suspended_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                roster_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    remove_locked_roster_item_api_v1_payment_rosters__roster_id__items__item_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                roster_id: number;
-                item_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RemoveLockedItemRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     list_roster_schedules_api_v1_roster_schedules_get: {
         parameters: {
             query?: {
@@ -21306,6 +21413,177 @@ export interface operations {
             };
         };
     };
+    list_eligible_renewals_api_v1_renewals_eligible_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    create_renewal_application_api_v1_renewals__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateRenewalRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_challenge_application_api_v1_renewals_challenge_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateChallengeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    trigger_renewal_auto_distribution_api_v1_renewals__scholarship_type_id__auto_distribute_post: {
+        parameters: {
+            query: {
+                academic_year: number;
+            };
+            header?: never;
+            path: {
+                scholarship_type_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_renewal_distribution_result_api_v1_renewals_distribution_result_get: {
+        parameters: {
+            query: {
+                scholarship_type_id: number;
+                academic_year: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    audit_renewal_violations_api_v1_renewals_audit_renewal_violations_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     get_admin_available_combinations_api_v1_manual_distribution_available_combinations_get: {
         parameters: {
             query?: never;
@@ -21393,6 +21671,38 @@ export interface operations {
             };
         };
     };
+    get_distribution_state_api_v1_manual_distribution_state_get: {
+        parameters: {
+            query: {
+                scholarship_type_id: number;
+                academic_year: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     auto_allocate_preview_api_v1_manual_distribution_auto_allocate_preview_get: {
         parameters: {
             query: {
@@ -21405,6 +21715,39 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    preview_distribution_api_v1_manual_distribution_preview_distribution_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AllocateRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -21644,76 +21987,6 @@ export interface operations {
         requestBody: {
             content: {
                 "multipart/form-data": components["schemas"]["Body_import_received_months_api_v1_manual_distribution_import_received_months_post"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    revoke_application_allocation_api_v1_manual_distribution_applications__application_id__revoke_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                application_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["RevokeRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    suspend_application_allocation_api_v1_manual_distribution_applications__application_id__suspend_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                application_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SuspendRequest"];
             };
         };
         responses: {

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -37,6 +37,7 @@ import { createDocumentRequestsApi } from './modules/document-requests';
 import { createPaymentRostersApi } from './modules/payment-rosters';
 import { createStudentsApi } from './modules/students';
 import { createManualDistributionApi } from './modules/manual-distribution';
+import { createRenewalApi } from './modules/renewal';
 // import { createReviewApi } from './modules/reviews'; // Not used - professor reviews use professor endpoints with adapter
 
 // Re-export ALL types from modular types file
@@ -160,6 +161,7 @@ class ExtendedApiClient extends ApiClient {
   private _paymentRosters?: ReturnType<typeof createPaymentRostersApi>;
   private _students?: ReturnType<typeof createStudentsApi>;
   private _manualDistribution?: ReturnType<typeof createManualDistributionApi>;
+  private _renewal?: ReturnType<typeof createRenewalApi>;
 
   // Lazy-loaded getters
   get auth(): ReturnType<typeof createAuthApi> {
@@ -275,6 +277,11 @@ class ExtendedApiClient extends ApiClient {
   get manualDistribution(): ReturnType<typeof createManualDistributionApi> {
     if (!this._manualDistribution) this._manualDistribution = createManualDistributionApi();
     return this._manualDistribution;
+  }
+
+  get renewal(): ReturnType<typeof createRenewalApi> {
+    if (!this._renewal) this._renewal = createRenewalApi();
+    return this._renewal;
   }
 
   // Backward compatibility alias

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -400,11 +400,11 @@ describe("createManualDistributionApi", () => {
       "getDistributionSummary",
       "getHistory",
       "getQuotaStatus",
+      "getState",
       "getStudents",
       "importReceivedMonths",
+      "previewDistribution",
       "restoreFromHistory",
-      "revoke",
-      "suspend",
     ]);
   });
 });

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -181,6 +181,82 @@ export interface AvailableCombinations {
   semesters: string[];
 }
 
+// ---------------------------------------------------------------------------
+// Renewal + challenge: distribution state and release-chain preview
+//
+// Backed by:
+//   GET  /api/v1/manual-distribution/state
+//   POST /api/v1/manual-distribution/preview-distribution
+// ---------------------------------------------------------------------------
+
+/** Approved renewal that is currently occupying a (sub_type × renewal_year) slot. */
+export interface DistributionStateRenewalApp {
+  application_id: number;
+  student_name: string | null;
+  /** True when a challenge application points at this renewal (Application_C). */
+  has_challenge: boolean;
+}
+
+/** Group of approved renewals sharing the same (sub_type, renewal_year). */
+export interface DistributionStateRenewalGroup {
+  sub_type: string | null;
+  renewal_year: number;
+  applications: DistributionStateRenewalApp[];
+}
+
+/** Available pool per (sub_type, allocation_year): total / used / remaining. */
+export interface DistributionStateAvailableQuota {
+  sub_type: string;
+  allocation_year: number;
+  total: number;
+  used: number;
+  remaining: number;
+}
+
+/** Minimal info about the renewal a challenge candidate is targeting. */
+export interface DistributionStateChallengedRenewal {
+  renewal_application_id: number;
+  sub_type: string | null;
+  renewal_year: number | null;
+}
+
+/** Ranked non-renewal candidate (pure-new or challenge). */
+export interface DistributionStateCandidate {
+  rank: number;
+  application_id: number;
+  student_name: string | null;
+  is_challenge: boolean;
+  challenged_renewal: DistributionStateChallengedRenewal | null;
+  applying_sub_type: string | null;
+}
+
+/** Combined panel-state payload returned by GET /state. */
+export interface DistributionState {
+  renewal_allocations: DistributionStateRenewalGroup[];
+  available_quotas: DistributionStateAvailableQuota[];
+  candidates: DistributionStateCandidate[];
+}
+
+/** Single entry in the release_chain returned by /preview-distribution. */
+export interface ReleaseChainItem {
+  /** The challenge application that would win and trigger the release. */
+  challenge_application_id?: number;
+  /** The renewal application that would be cancelled. */
+  cancelled_application_id: number;
+  /** The slot that would be freed. */
+  freed_slot: {
+    sub_type: string | null;
+    allocation_year: number | null;
+  };
+  /** Suggested waitlist candidate (pure-new) to fill the freed slot. */
+  suggested_fill_id: number | null;
+  suggested_fill_name: string | null;
+}
+
+export interface PreviewDistributionResult {
+  release_chain: ReleaseChainItem[];
+}
+
 export function createManualDistributionApi() {
   return {
     /**
@@ -219,6 +295,47 @@ export function createManualDistributionApi() {
         }
       );
       return toApiResponse(response) as ApiResponse<DistributionStudent[]>;
+    },
+
+    /**
+     * Get the full distribution-panel state for a scholarship_type + academic_year:
+     *   - renewal_allocations (approved renewals grouped by sub_type × renewal_year)
+     *   - available_quotas (per (sub_type, allocation_year))
+     *   - candidates (ranked non-renewal applicants, including challenges)
+     *
+     * Used by the admin Manual Distribution panel to render the renewal-aware UI.
+     * Read-only: never mutates state.
+     */
+    getState: async (
+      scholarship_type_id: number,
+      academic_year: number
+    ): Promise<ApiResponse<DistributionState>> => {
+      const response = await typedClient.raw.GET(
+        "/api/v1/manual-distribution/state" as any,
+        {
+          params: {
+            query: { scholarship_type_id, academic_year } as any,
+          },
+        }
+      );
+      return toApiResponse(response) as ApiResponse<DistributionState>;
+    },
+
+    /**
+     * Dry-run: compute the release_chain for the proposed allocations.
+     *
+     * For each proposed allocation whose application is a challenge, returns
+     * the renewal that would be cancelled and the next pure-new waitlist
+     * candidate who would inherit the freed slot. Nothing is persisted.
+     */
+    previewDistribution: async (
+      request: AllocateRequest
+    ): Promise<ApiResponse<PreviewDistributionResult>> => {
+      const response = await typedClient.raw.POST(
+        "/api/v1/manual-distribution/preview-distribution" as any,
+        { body: request as any }
+      );
+      return toApiResponse(response) as ApiResponse<PreviewDistributionResult>;
     },
 
     /**
@@ -366,62 +483,6 @@ export function createManualDistributionApi() {
     /**
      * Import received months from Excel file.
      */
-    /**
-     * Revoke an application's allocation post-finalization.
-     * Removes the student from unlocked rosters and marks the application as cancelled/revoked.
-     */
-    revoke: async (
-      application_id: number,
-      reason: string
-    ): Promise<ApiResponse<{
-      application_id: number;
-      quota_allocation_status: "revoked";
-      event_at: string;
-      affected_unlocked_rosters: number[];
-    }>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/manual-distribution/applications/{application_id}/revoke",
-        {
-          params: { path: { application_id } },
-          body: { reason },
-        }
-      );
-      return toApiResponse(response) as ApiResponse<{
-        application_id: number;
-        quota_allocation_status: "revoked";
-        event_at: string;
-        affected_unlocked_rosters: number[];
-      }>;
-    },
-
-    /**
-     * Suspend an application's allocation post-finalization.
-     * Removes the student from unlocked rosters and marks the application as cancelled/suspended.
-     */
-    suspend: async (
-      application_id: number,
-      reason: string
-    ): Promise<ApiResponse<{
-      application_id: number;
-      quota_allocation_status: "suspended";
-      event_at: string;
-      affected_unlocked_rosters: number[];
-    }>> => {
-      const response = await typedClient.raw.POST(
-        "/api/v1/manual-distribution/applications/{application_id}/suspend",
-        {
-          params: { path: { application_id } },
-          body: { reason },
-        }
-      );
-      return toApiResponse(response) as ApiResponse<{
-        application_id: number;
-        quota_allocation_status: "suspended";
-        event_at: string;
-        affected_unlocked_rosters: number[];
-      }>;
-    },
-
     importReceivedMonths: async (
       scholarshipTypeId: number,
       academicYear: number,

--- a/frontend/lib/api/modules/renewal.ts
+++ b/frontend/lib/api/modules/renewal.ts
@@ -1,0 +1,174 @@
+/**
+ * Renewal API Module
+ *
+ * Endpoints for the scholarship renewal + challenge flow.
+ *
+ * Backed by `backend/app/api/v1/endpoints/renewal.py`:
+ *   - GET  /api/v1/renewals/eligible             — student-side, list renewable prior apps
+ *   - POST /api/v1/renewals/                     — student-side, create renewal from prior
+ *   - POST /api/v1/renewals/challenge            — student-side, create challenge from renewal
+ *   - GET  /api/v1/renewals/distribution-result  — admin-side, finalised renewal distribution
+ *
+ * All endpoints return the standard ApiResponse `{ success, message, data }`
+ * shape; we normalise via `toApiResponse`.
+ */
+
+import { typedClient } from "../typed-client";
+import { toApiResponse } from "../compat";
+import type { ApiResponse } from "../types";
+
+// ---------------------------------------------------------------------------
+// Eligible renewals (student-side)
+// ---------------------------------------------------------------------------
+
+export interface EligibleRenewal {
+  previous_application_id: number;
+  scholarship_type_id: number;
+  scholarship_type_name: string | null;
+  sub_scholarship_type: string | null;
+  target_academic_year: number;
+  renewal_year: number;
+  /** ISO 8601 UTC string of the renewal application end date, if configured */
+  renewal_deadline: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Create renewal / challenge (student-side)
+// ---------------------------------------------------------------------------
+
+export interface CreateRenewalRequest {
+  previous_application_id: number;
+}
+
+export interface CreateRenewalResult {
+  id: number;
+  app_id: string;
+  is_renewal: boolean;
+  sub_scholarship_type: string | null;
+  previous_application_id: number | null;
+  academic_year: number;
+  renewal_year: number | null;
+  status: string;
+}
+
+export interface CreateChallengeRequest {
+  renewal_application_id: number;
+  target_sub_type: string;
+}
+
+export interface CreateChallengeResult {
+  id: number;
+  app_id: string;
+  is_renewal: boolean;
+  sub_scholarship_type: string | null;
+  challenges_application_id: number | null;
+  academic_year: number;
+  status: string;
+}
+
+// ---------------------------------------------------------------------------
+// Distribution result (admin-side)
+// ---------------------------------------------------------------------------
+
+export interface RenewalDistributionApplication {
+  id: number;
+  app_id: string;
+  student_name: string | null;
+  previous_application_id: number | null;
+  /** True when a downstream challenge application points at this renewal */
+  has_challenge: boolean;
+}
+
+export interface RenewalDistributionGroup {
+  sub_type: string | null;
+  renewal_year: number | null;
+  applications: RenewalDistributionApplication[];
+}
+
+export interface RenewalDistributionRejected {
+  id: number;
+  student_name: string | null;
+}
+
+export interface RenewalDistributionSummary {
+  approved: number;
+  rejected: number;
+}
+
+export interface RenewalDistributionResult {
+  groups: RenewalDistributionGroup[];
+  rejected: RenewalDistributionRejected[];
+  summary: RenewalDistributionSummary;
+}
+
+// ---------------------------------------------------------------------------
+// API client factory
+// ---------------------------------------------------------------------------
+
+export function createRenewalApi() {
+  return {
+    /**
+     * List the current user's prior-year approved applications that are
+     * currently within an open renewal window.
+     */
+    listEligible: async (): Promise<ApiResponse<EligibleRenewal[]>> => {
+      const response = await typedClient.raw.GET(
+        "/api/v1/renewals/eligible" as any,
+        {}
+      );
+      return toApiResponse(response) as ApiResponse<EligibleRenewal[]>;
+    },
+
+    /**
+     * Create a renewal application from a prior approved application.
+     */
+    createRenewal: async (
+      previous_application_id: number
+    ): Promise<ApiResponse<CreateRenewalResult>> => {
+      const response = await typedClient.raw.POST(
+        "/api/v1/renewals/" as any,
+        { body: { previous_application_id } as any }
+      );
+      return toApiResponse(response) as ApiResponse<CreateRenewalResult>;
+    },
+
+    /**
+     * Create a challenge application from an approved renewal application,
+     * targeting a different sub_scholarship_type.
+     */
+    createChallenge: async (
+      renewal_application_id: number,
+      target_sub_type: string
+    ): Promise<ApiResponse<CreateChallengeResult>> => {
+      const response = await typedClient.raw.POST(
+        "/api/v1/renewals/challenge" as any,
+        { body: { renewal_application_id, target_sub_type } as any }
+      );
+      return toApiResponse(response) as ApiResponse<CreateChallengeResult>;
+    },
+
+    /**
+     * Admin-only: read the finalised renewal distribution for a given
+     * scholarship type + academic year, grouped by (sub_type, renewal_year).
+     *
+     * @param scholarship_type_id ID of the scholarship type to inspect.
+     * @param academic_year       Target application academic year (e.g. 114).
+     */
+    getDistributionResult: async (
+      scholarship_type_id: number,
+      academic_year: number
+    ): Promise<ApiResponse<RenewalDistributionResult>> => {
+      const response = await typedClient.raw.GET(
+        "/api/v1/renewals/distribution-result" as any,
+        {
+          params: {
+            query: { scholarship_type_id, academic_year } as any,
+          },
+        }
+      );
+      return toApiResponse(
+        response
+      ) as ApiResponse<RenewalDistributionResult>;
+    },
+  };
+}

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -107,6 +107,7 @@ export type ApplicationStatus =
   | "returned"
   | "withdrawn"
   | "cancelled"
+  | "cancelled_by_challenge"
   | "pending"
   | "completed"
   | "deleted";
@@ -122,6 +123,14 @@ export interface Application {
   scholarship_type_zh?: string;
   status: ApplicationStatus;
   is_renewal?: boolean;
+  /** 續領年份 (民國年，如 113)；批次匯入指定或承接自前一申請 */
+  renewal_year?: number | null;
+  /** 承接的前一份核可申請 ID（續領申請填） */
+  previous_application_id?: number | null;
+  /** 挑戰的目標續領申請 ID（挑戰申請填） */
+  challenges_application_id?: number | null;
+  /** 因哪份挑戰申請而被取消（被取代之續領申請填） */
+  cancelled_due_to_application_id?: number | null;
   personal_statement?: string;
   gpa_requirement_met: boolean;
   submitted_at?: string;
@@ -152,6 +161,8 @@ export interface Application {
   dept_ranking_percent?: number;
   days_waiting?: number;
   scholarship_subtype_list?: string[];
+  /** 本申請的代表性 sub_type（單一字串；若為續領則承襲自前一申請） */
+  sub_scholarship_type?: string | null;
   sub_type_labels?: Record<string, { zh: string; en: string }>;
   agree_terms?: boolean;
   academy_code?: string;

--- a/frontend/lib/enums.ts
+++ b/frontend/lib/enums.ts
@@ -39,6 +39,7 @@ export enum ApplicationStatus {
   RETURNED = "returned",
   WITHDRAWN = "withdrawn",
   CANCELLED = "cancelled",
+  CANCELLED_BY_CHALLENGE = "cancelled_by_challenge",
   MANUAL_EXCLUDED = "manual_excluded",
   DELETED = "deleted",
 }
@@ -169,6 +170,7 @@ export const getApplicationStatusLabel = (
       [ApplicationStatus.RETURNED]: "已退回",
       [ApplicationStatus.WITHDRAWN]: "已撤回",
       [ApplicationStatus.CANCELLED]: "已取消",
+      [ApplicationStatus.CANCELLED_BY_CHALLENGE]: "已取消（因挑戰升級）",
       [ApplicationStatus.MANUAL_EXCLUDED]: "手動排除",
       [ApplicationStatus.DELETED]: "已刪除",
     },
@@ -183,6 +185,7 @@ export const getApplicationStatusLabel = (
       [ApplicationStatus.RETURNED]: "Returned",
       [ApplicationStatus.WITHDRAWN]: "Withdrawn",
       [ApplicationStatus.CANCELLED]: "Cancelled",
+      [ApplicationStatus.CANCELLED_BY_CHALLENGE]: "Cancelled (Replaced by Challenge)",
       [ApplicationStatus.MANUAL_EXCLUDED]: "Manually Excluded",
       [ApplicationStatus.DELETED]: "Deleted",
     },
@@ -218,6 +221,7 @@ export const getApplicationStatusBadgeVariant = (
     case ApplicationStatus.RETURNED:
     case ApplicationStatus.WITHDRAWN:
     case ApplicationStatus.CANCELLED:
+    case ApplicationStatus.CANCELLED_BY_CHALLENGE:
     case ApplicationStatus.MANUAL_EXCLUDED:
       return "secondary";
 


### PR DESCRIPTION
## Summary

Implements end-to-end scholarship renewal application with the "保底 + 挑戰" mechanism:
- Students with prior approved applications can submit a **renewal application** (locks original `sub_type`) during the renewal period
- After renewal auto-distribution, students with approved renewals can submit a **challenge application** during the general period to try a different `sub_type`
- If a challenge wins distribution, the original `sub_type` slot is automatically released and filled by the next-ranked pure-new candidate (with `allocation_year` preserved on the freed pool)

Spec: `docs/superpowers/specs/2026-05-13-renewal-application-design.md`
Plan: `docs/superpowers/plans/2026-05-13-renewal-application.md`

## What's in this PR

**Data Model (Phase 1)**
- New `cancelled_by_challenge` value in `ApplicationStatus` enum
- New columns: `challenges_application_id`, `cancelled_due_to_application_id` (both with FK + index)
- Replaced single UNIQUE constraint with 3 partial unique indexes (renewal / challenge / pure-new) to allow 1 renewal + 1 challenge coexistence
- New check constraint `chk_cancelled_by_challenge_link`
- Alembic migration `add_renewal_challenge_001` with full reversible downgrade

**Services**
- `RenewalEligibilityService.get_eligible_renewals(user_id, current_academic_year)` — auto-discovers prior approved apps within active renewal window
- `RenewalDistributionService.auto_approve_passed_reviews(scholarship_type_id, academic_year)` — bulk-approves renewals past required review stages
- `ManualDistributionService.execute_general_distribution(scholarship_type_id, academic_year)` — full algorithm: per-`sub_type` ranked distribution → challenge release → same-pool waitlist fill-in
- `ManualDistributionService.preview_release_chain(allocations)` — dry-run for admin UI
- `ManualDistributionService.compute_distribution_state(...)` — state snapshot for admin panel
- `RenewalAuditService.find_invariant_violations()` — invariant check: every approved challenge points to a `cancelled_by_challenge` renewal
- Extension methods on `ApplicationService`: `create_renewal_from_previous`, `create_challenge_from_renewal`
- Shared helper `apply_renewal_phase_filter` for review-list routing (renewal phase vs general phase)

**API endpoints**
- `GET /api/v1/renewals/eligible`
- `POST /api/v1/renewals/`
- `POST /api/v1/renewals/challenge`
- `POST /api/v1/renewals/{id}/auto-distribute` (admin)
- `GET /api/v1/renewals/distribution-result` (admin)
- `GET /api/v1/renewals/audit/renewal-violations` (admin)
- `GET /api/v1/manual-distribution/state` (admin)
- `POST /api/v1/manual-distribution/preview-distribution` (admin)

**Frontend (Traditional Chinese, NYCU palette)**
- New page: `/admin/renewal` — renewal distribution result grouped by `(sub_type, renewal_year)`
- Updated: `ManualDistributionPanel` — renewal-occupied block, available-quotas block, challenge markers on candidates, release-and-fill-in preview
- New student cards: `RenewalApplicationCard`, `ChallengeApplicationCard`
- Application history shows renewal/challenge linkage (銜接自 / 被取代於 / 挑戰自續領)
- OpenAPI types regenerated with all 8 new endpoints

**Tests**
- 34 new tests across 9 test files; full E2E scenario (spec §9.3) passes
- Phase 6 integration test verifies release-chain + waitlist fill-in semantics
- Phase 10 audit tests verify invariant enforcement
- Phase 11 end-to-end test runs 10 renewals → 2 challenges → 2 cancellations → 2 promotions through the full service chain

## Test plan

- [ ] Run renewal test suite: `docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal* backend/app/tests/test_challenge* backend/app/tests/test_distribution_state* backend/app/tests/test_review_routing* -v` — expect 34/34 pass
- [ ] Run E2E test: `docker compose -f docker-compose.dev.yml exec backend python -m pytest backend/app/tests/test_renewal_end_to_end.py -v` — expect 1/1 pass
- [ ] Apply migration on a fresh DB: `./scripts/reset_database.sh && alembic upgrade head` — expect clean apply
- [ ] Test downgrade: `alembic downgrade -1 && alembic upgrade head` — expect clean reversible cycle
- [ ] Admin UI smoke: visit `/admin/renewal` and the manual distribution panel — verify renewal-occupied block + challenge markers render
- [ ] Student UI smoke: log in as a student with a prior approved app — verify renewal card appears during renewal period
- [ ] OpenAPI sync check: `cd frontend && npm run api:generate` — expect no diff against committed `schema.d.ts`

## Known follow-ups (filed separately)

1. Add DB-level `chk_challenge_references_renewal` constraint (currently app-layer only)
2. Cross-check on challenge endpoint validates `student_id + scholarship_type + academic_year` match between challenge and target renewal
3. `RenewalEligibilityService` to honor N-year plan caps (spec §10 case 2)
4. Standardize on `app.db.deps.get_db` vs `app.core.deps.get_db` across endpoints
5. Minor code-review polish items (unused imports, function rename, dead Pydantic schema)