### PR TITLE
test(frontend/lib/scholarship-eligibility): isSelectableScholarship (7 cases)

### DIFF
--- a/frontend/lib/__tests__/scholarship-eligibility.test.ts
+++ b/frontend/lib/__tests__/scholarship-eligibility.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for `lib/scholarship-eligibility.ts:isSelectableScholarship`.
+ *
+ * This predicate decides whether a scholarship card on the student
+ * dashboard is selectable (shows "Apply" button) or grayed out. Wrong
+ * verdict either:
+ * - Hides scholarships students COULD apply for (functional bug, the
+ *   student misses the deadline thinking they're ineligible).
+ * - Shows scholarships students CAN'T apply for (clicks lead to a
+ *   confusing 422 from backend).
+ *
+ * The contract: a scholarship is selectable iff
+ *   eligible_sub_types is a non-empty array AND
+ *   there's no top-level (sub_type-less) error rule.
+ *
+ * 7 cases.
+ */
+import { isSelectableScholarship } from "../scholarship-eligibility";
+
+// Minimal ScholarshipType shape — only the fields the predicate reads.
+type _Sch = {
+  id?: number;
+  code?: string;
+  eligible_sub_types?: string[];
+  errors?: Array<{ sub_type?: string | null; rule_id?: number }>;
+};
+
+const scholarship = (s: _Sch) => s as unknown as Parameters<typeof isSelectableScholarship>[0];
+
+describe("isSelectableScholarship", () => {
+  it("returns true when eligible_sub_types is non-empty and no common errors", () => {
+    /** Happy path — at least one sub-type passes all gates. */
+    expect(
+      isSelectableScholarship(
+        scholarship({ eligible_sub_types: ["nstc", "moe_1w"], errors: [] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when eligible_sub_types is empty array", () => {
+    /** No sub-type passed → no application path → not selectable. */
+    expect(
+      isSelectableScholarship(scholarship({ eligible_sub_types: [], errors: [] })),
+    ).toBe(false);
+  });
+
+  it("returns false when eligible_sub_types is undefined", () => {
+    /** Defensive: missing field treated same as empty (not selectable).
+     * Pin so a backend regression that drops the field doesn't silently
+     * make all scholarships appear selectable. */
+    expect(isSelectableScholarship(scholarship({ errors: [] }))).toBe(false);
+  });
+
+  it("returns false when eligible_sub_types is not an array (defensive)", () => {
+    /** If the backend ships a malformed payload (string instead of array),
+     * the Array.isArray guard prevents .length crash. */
+    expect(
+      isSelectableScholarship(
+        scholarship({ eligible_sub_types: "nstc" as never, errors: [] }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when a common (sub_type-less) error rule exists", () => {
+    /** Errors without sub_type apply to ALL sub-types — student can't
+     * proceed even if some sub-types appear eligible. The check is
+     * `.sub_type` falsy (undefined OR null OR ''). */
+    const sch = scholarship({
+      eligible_sub_types: ["nstc"],
+      errors: [{ sub_type: undefined, rule_id: 1 }],
+    });
+    expect(isSelectableScholarship(sch)).toBe(false);
+  });
+
+  it("returns true when errors exist but ALL have a sub_type (per-track)", () => {
+    /** Per-sub-type errors don't block the whole scholarship — student
+     * just has fewer tracks. Pin so partial-eligibility scholarships
+     * still show as selectable. */
+    const sch = scholarship({
+      eligible_sub_types: ["nstc"],
+      errors: [{ sub_type: "moe_1w", rule_id: 1 }],
+    });
+    expect(isSelectableScholarship(sch)).toBe(true);
+  });
+
+  it("returns false when errors is undefined and eligible_sub_types is empty", () => {
+    /** Combined edge case: missing errors AND empty sub_types. The
+     * `|| false` shortcircuit in `hasCommonErrors` prevents undefined
+     * propagating into the final boolean. */
+    expect(
+      isSelectableScholarship(scholarship({ eligible_sub_types: [] })),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This predicate decides whether a scholarship card on the student dashboard is selectable ('Apply' button) or grayed out. Wrong verdict either:
- Hides scholarships students **could** apply for → student misses deadline
- Shows scholarships students **can't** apply for → confusing 422 from backend

## Coverage (7 cases)

Contract pinned: selectable iff \`eligible_sub_types\` is a non-empty array AND no top-level (sub_type-less) error.

- Happy path (non-empty + no common errors) → true
- Empty array → not selectable
- Undefined field → not selectable (defensive against backend regression)
- Non-array malformed payload → no crash, not selectable
- Common error (sub_type-less) → blocks the whole scholarship
- Per-track errors → don't block; partial eligibility still selectable
- Undefined errors + empty sub_types → false (\`|| false\` shortcircuit pinned)

## Test plan

- [x] All 7 cases pass locally with jest
- [x] No infrastructure dependencies — pure function

🤖 Generated with [Claude Code](https://claude.com/claude-code)