### PR TITLE
fix(deploy): wire PII_ENCRYPTION_KEYS into staging container env (#284)

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -219,8 +219,18 @@ jobs:
           STUDENT_API_ACCOUNT: ${{ secrets.STUDENT_API_ACCOUNT }}
           STUDENT_API_HMAC_KEY: ${{ secrets.STUDENT_API_HMAC_KEY }}
           SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
         run: |
           cd ~/scholarship-staging
+          if [ -z "$PII_ENCRYPTION_KEYS" ]; then
+            echo "::error::secrets.PII_ENCRYPTION_KEYS is not configured. The"
+            echo "::error::20260512_encrypt_std_pid migration will hard-fail because"
+            echo "::error::ENVIRONMENT=production on staging. Generate a key with:"
+            echo "::error::  python -c 'import os,base64;print(base64.urlsafe_b64encode(os.urandom(32)).rstrip(b\"=\").decode())'"
+            echo "::error::then: gh secret set PII_ENCRYPTION_KEYS --body '{\"v1\":\"<KEY>\"}'"
+            exit 1
+          fi
           docker compose up -d
 
       - name: Run database migrations


### PR DESCRIPTION
## Summary
- Fixes #284 — the post-#202 staging deploy died at `alembic upgrade head` running the new `20260512_encrypt_std_pid` migration, because `PII_ENCRYPTION_KEYS` was never plumbed from GitHub Secrets into the backend container.
- `docker-compose.staging.yml:51` already references `${PII_ENCRYPTION_KEYS}`. The gap was in `.github/workflows/deploy-pipeline.yml`'s `Start new containers` step — its `env:` block was missing both `PII_ENCRYPTION_KEYS` and `PII_ENCRYPTION_ACTIVE_VERSION`, so compose interpolated empty strings and the backend booted with no key. Since staging has `ENVIRONMENT=production` (intentional, to mirror prod auth rules), `pii_crypto._load_keys()` then refused the dev fallback and the migration hard-crashed on the first row touching `encrypt_pii_idempotent`.

## What changed
\`\`\`yaml
PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
\`\`\`
Plus a pre-flight guard in the same step that fails the job with an actionable message (secret name + key-generation recipe) if the secret hasn't been set yet — better than letting an alembic stack trace be the operator's first signal.

## Operator follow-up required (one-time)
The repo doesn't yet have `secrets.PII_ENCRYPTION_KEYS` set. Without it this PR turns the failure mode from \"opaque alembic crash\" into \"explicit fast-fail with instructions\" — but the deploy will still fail. Run:

\`\`\`bash
# Generate a fresh AES-256 key
KEY=\$(python3 -c \"import os,base64;print(base64.urlsafe_b64encode(os.urandom(32)).rstrip(b'=').decode())\")
gh secret set PII_ENCRYPTION_KEYS --body \"{\\\"v1\\\":\\\"\$KEY\\\"}\"
# (PII_ENCRYPTION_ACTIVE_VERSION can be left unset — pii_crypto.py defaults to \"v1\")
\`\`\`

Then re-run the failed deploy on \`main\` (or merge this PR, which itself fires a fresh deploy).

## Test plan
- [ ] Operator sets \`secrets.PII_ENCRYPTION_KEYS\` per recipe above
- [ ] Merge this PR → \`Deploy to Staging\` job's \`Start new containers\` step no longer errors with \"PII_ENCRYPTION_KEYS env var is required\"
- [ ] \`Run database migrations\` step completes the \`20260512_encrypt_std_pid\` upgrade successfully
- [ ] On staging, \`SELECT student_data->>'std_pid' FROM applications LIMIT 1\` returns a \`pii:v1:...\` envelope rather than a raw Taiwan ID
- [ ] Issue #284 closes via the \`Fixes #284\` reference

Fixes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)