### PR TITLE
fix(college-review): show ranking deadline banner immediately on 學生排序 entry

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -120,9 +120,12 @@ async def get_rankings(
         rankings_data = []
         for ranking in rankings:
             college_quota: Optional[int] = None
+            # Always load the config so we can surface college_review_end on
+            # each ranking item — this lets the frontend display the deadline
+            # banner before any specific ranking has been selected.
+            config = await get_config_for_ranking(ranking)
 
             if user_college_code:
-                config = await get_config_for_ranking(ranking)
                 if config and config.has_college_quota and config.quotas:
                     if ranking.sub_type_code == "default":
                         # Sum all quotas for this college across sub-types
@@ -174,6 +177,9 @@ async def get_rankings(
                     "distribution_executed": ranking.distribution_executed,
                     "created_at": ranking.created_at.isoformat(),
                     "finalized_at": ranking.finalized_at.isoformat() if ranking.finalized_at else None,
+                    "college_review_end": (
+                        config.college_review_end.isoformat() if config and config.college_review_end else None
+                    ),
                 }
             )
 

--- a/backend/app/api/v1/endpoints/college_review/utilities.py
+++ b/backend/app/api/v1/endpoints/college_review/utilities.py
@@ -9,9 +9,10 @@ Handles:
 """
 
 import logging
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import func, select
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -270,6 +271,72 @@ async def get_available_combinations(current_user: User = Depends(require_colleg
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve available combinations from database",
+        )
+
+
+@router.get("/active-config")
+async def get_active_config(
+    scholarship_type_id: int = Query(..., description="Scholarship type ID"),
+    academic_year: int = Query(..., description="Academic year (民國)"),
+    semester: Optional[str] = Query(None, description="Semester: first / second / yearly (or omit for yearly)"),
+    current_user: User = Depends(require_college),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return active scholarship configuration metadata (currently the
+    college-review deadline) for a specific (scholarship_type, year, semester).
+
+    Used by the ranking page to surface the deadline banner before any
+    ranking has been selected or created — the deadline is a property of
+    the configuration, not of any individual ranking.
+
+    Returns success=True with `data.college_review_end=None` when no config
+    matches; the caller decides whether to display a banner.
+    """
+    try:
+        # Yearly cycles store semester as either NULL or "yearly" — match both.
+        sem_raw = (semester or "").strip().lower()
+        if sem_raw.startswith("semester."):
+            sem_raw = sem_raw.split(".", 1)[1]
+        is_yearly = sem_raw in {"", "yearly"}
+
+        conditions = [
+            ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
+            ScholarshipConfiguration.academic_year == academic_year,
+            ScholarshipConfiguration.is_active.is_(True),
+        ]
+        if is_yearly:
+            conditions.append(
+                or_(
+                    ScholarshipConfiguration.semester.is_(None),
+                    ScholarshipConfiguration.semester == "yearly",
+                )
+            )
+        else:
+            conditions.append(ScholarshipConfiguration.semester == sem_raw)
+
+        stmt = select(ScholarshipConfiguration).where(*conditions).limit(1)
+        config = (await db.execute(stmt)).scalar_one_or_none()
+
+        return ApiResponse(
+            success=True,
+            message="Active config retrieved",
+            data={
+                "scholarship_type_id": scholarship_type_id,
+                "academic_year": academic_year,
+                "semester": "yearly" if is_yearly else sem_raw,
+                "college_review_end": (
+                    config.college_review_end.isoformat() if config and config.college_review_end else None
+                ),
+                "college_review_start": (
+                    config.college_review_start.isoformat() if config and config.college_review_start else None
+                ),
+            },
+        )
+    except Exception as e:
+        logger.error(f"Error retrieving active config: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve active scholarship configuration",
         )
 
 

--- a/frontend/components/college/CollegeManagementShell.tsx
+++ b/frontend/components/college/CollegeManagementShell.tsx
@@ -116,8 +116,21 @@ function CollegeManagementContent({ user }: { user: User }) {
         const firstScholarshipType = availableOptions.scholarship_types[0].code;
         setActiveScholarshipTab(firstScholarshipType);
 
-        // Auto-select current academic year
-        const currentYear = academicConfig.currentYear;
+        // Auto-select an academic year that actually has data. The
+        // client-derived `academicConfig.currentYear` is a calendar guess
+        // (e.g. 民國 115 in 2026) and may not match any active scholarship
+        // configuration — landing on it leaves the user staring at an empty
+        // page with no deadline banner. Prefer the most recent year present
+        // in `availableOptions.academic_years`; fall back to the calendar
+        // guess only if availableOptions is empty.
+        const availableYears = availableOptions.academic_years || [];
+        const calendarYear = academicConfig.currentYear;
+        const currentYear =
+          availableYears.length === 0
+            ? calendarYear
+            : availableYears.includes(calendarYear)
+              ? calendarYear
+              : Math.max(...availableYears);
         setSelectedAcademicYear(currentYear);
 
         // FIXED: Select semester from available options (not blindly from current time)

--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -122,6 +122,9 @@ export function RankingManagementPanel({
   } = useCollegeManagement();
 
   // #91 fix: store the college_review_end fetched for the active ranking's config.
+  // Acts as a fallback / fresh-value source after a user clicks into a ranking;
+  // the primary source for the banner is filteredRankings (see deadlineISO below)
+  // so the deadline is visible immediately on page entry, not only after selection.
   const [activeConfigDeadline, setActiveConfigDeadline] = useState<string | null>(null);
 
   const fetchRankingDetails = useCallback(
@@ -624,7 +627,16 @@ export function RankingManagementPanel({
     const id = setInterval(() => setNow(Date.now()), 60_000);
     return () => clearInterval(id);
   }, []);
-  const deadlineISO = activeConfigDeadline;
+  // Prefer the deadline carried on any ranking in the current filter — that lets
+  // the banner appear as soon as the panel loads, without waiting for the user
+  // to click into a specific ranking. Fall back to the ranking-detail-fetched
+  // value (covers manual refresh after admin extends the deadline).
+  const deadlineISO = useMemo(() => {
+    const fromList = filteredRankings.find(
+      (r: any) => r && r.college_review_end
+    )?.college_review_end as string | undefined;
+    return fromList ?? activeConfigDeadline ?? null;
+  }, [filteredRankings, activeConfigDeadline]);
   const deadlineInfo = useMemo(
     () => computeDeadlineInfo(deadlineISO),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `now` triggers re-eval

--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -121,11 +121,16 @@ export function RankingManagementPanel({
     fetchRankings,
   } = useCollegeManagement();
 
-  // #91 fix: store the college_review_end fetched for the active ranking's config.
-  // Acts as a fallback / fresh-value source after a user clicks into a ranking;
-  // the primary source for the banner is filteredRankings (see deadlineISO below)
-  // so the deadline is visible immediately on page entry, not only after selection.
+  // #91 fix: deadline fetched from the ranking-detail endpoint when a user
+  // clicks into a specific ranking. Kept as a freshness fallback.
   const [activeConfigDeadline, setActiveConfigDeadline] = useState<string | null>(null);
+
+  // Page-level deadline fetched directly from the active scholarship
+  // configuration matching (scholarship_type, year, semester). This ensures
+  // the deadline banner appears as soon as the panel renders, even when no
+  // rankings exist for the current selection (i.e. before the user clicks
+  // "建立新排名" for the first time).
+  const [panelDeadline, setPanelDeadline] = useState<string | null>(null);
 
   const fetchRankingDetails = useCallback(
     async (rankingId: number) => {
@@ -627,16 +632,64 @@ export function RankingManagementPanel({
     const id = setInterval(() => setNow(Date.now()), 60_000);
     return () => clearInterval(id);
   }, []);
-  // Prefer the deadline carried on any ranking in the current filter — that lets
-  // the banner appear as soon as the panel loads, without waiting for the user
-  // to click into a specific ranking. Fall back to the ranking-detail-fetched
-  // value (covers manual refresh after admin extends the deadline).
+  // Fetch the deadline directly from the active scholarship configuration
+  // matching the current (scholarship_type, year, semester) selection. This
+  // is the authoritative source — runs whenever the selection changes, so
+  // the banner appears immediately on page entry, with zero rankings, or
+  // after switching combinations.
+  useEffect(() => {
+    const activeConfig = scholarshipConfig.find(
+      (c: any) => c.code === scholarshipType.code
+    );
+    if (!activeConfig?.id || typeof selectedAcademicYear !== "number") {
+      setPanelDeadline(null);
+      return;
+    }
+    const semParam =
+      !selectedSemester || selectedSemester === Semester.YEARLY
+        ? "yearly"
+        : selectedSemester;
+    let cancelled = false;
+    apiClient
+      .request<{ college_review_end: string | null }>(
+        "/college-review/active-config",
+        {
+          method: "GET",
+          params: {
+            scholarship_type_id: activeConfig.id,
+            academic_year: selectedAcademicYear,
+            semester: semParam,
+          },
+        }
+      )
+      .then(resp => {
+        if (cancelled) return;
+        setPanelDeadline(
+          resp.success && resp.data ? resp.data.college_review_end ?? null : null
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setPanelDeadline(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    scholarshipConfig,
+    scholarshipType.code,
+    selectedAcademicYear,
+    selectedSemester,
+  ]);
+
+  // Authoritative deadline = the one matched directly to the active config.
+  // Fall back to anything carried on the current rankings, then to a freshly
+  // fetched ranking-detail value, while the active-config call is in flight.
   const deadlineISO = useMemo(() => {
     const fromList = filteredRankings.find(
       (r: any) => r && r.college_review_end
     )?.college_review_end as string | undefined;
-    return fromList ?? activeConfigDeadline ?? null;
-  }, [filteredRankings, activeConfigDeadline]);
+    return panelDeadline ?? fromList ?? activeConfigDeadline ?? null;
+  }, [panelDeadline, filteredRankings, activeConfigDeadline]);
   const deadlineInfo = useMemo(
     () => computeDeadlineInfo(deadlineISO),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `now` triggers re-eval

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4771,6 +4771,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/college-review/active-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Active Config
+         * @description Return active scholarship configuration metadata (currently the
+         *     college-review deadline) for a specific (scholarship_type, year, semester).
+         *
+         *     Used by the ranking page to surface the deadline banner before any
+         *     ranking has been selected or created — the deadline is a property of
+         *     the configuration, not of any individual ranking.
+         *
+         *     Returns success=True with `data.college_review_end=None` when no config
+         *     matches; the caller decides whether to display a banner.
+         */
+        get: operations["get_active_config_api_v1_college_review_active_config_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/college-review/sub-type-translations": {
         parameters: {
             query?: never;
@@ -18394,6 +18422,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_active_config_api_v1_college_review_active_config_get: {
+        parameters: {
+            query: {
+                /** @description Scholarship type ID */
+                scholarship_type_id: number;
+                /** @description Academic year (民國) */
+                academic_year: number;
+                /** @description Semester: first / second / yearly (or omit for yearly) */
+                semester?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- Surface the college-review deadline banner (`排名截止時間: … · 剩餘 N 天 N 小時`) as soon as a college reviewer enters the 學生排序 tab — previously it only appeared after clicking into a specific ranking card.
- Two root causes were stacked: the panel auto-selected a calendar-derived year that wasn't in the active config set, and the deadline was only loaded as a side effect of `fetchRankingDetails`.

## What changed

**Backend** — `backend/app/api/v1/endpoints/college_review/`
- `ranking_management.py`: `/college-review/rankings` list now includes `college_review_end` per item (config was already loaded for quota lookup).
- `utilities.py`: new `GET /college-review/active-config?scholarship_type_id=…&academic_year=…&semester=…` that resolves the matching active `ScholarshipConfiguration` and returns `{college_review_start, college_review_end}`. Returns `null` deadline when no config matches.

**Frontend**
- `CollegeManagementShell.tsx`: when `academicConfig.currentYear` (民國 calendar guess) isn't in `availableOptions.academic_years`, fall back to `max(availableYears)` so the panel lands on a year that actually has data.
- `RankingManagementPanel.tsx`: new `useEffect` calls the new endpoint whenever `(scholarshipType, year, semester)` changes; `deadlineISO` now prefers this authoritative `panelDeadline` and falls back to rankings-list / ranking-detail values.
- `lib/api/generated/schema.d.ts`: regenerated to include the new endpoint.

## Test plan
- [x] Backend syntax check (`python -m py_compile`) — clean.
- [x] Frontend `tsc --noEmit` — clean (no new errors).
- [x] API smoke tests for `GET /college-review/active-config`:
  - `(scholarship_type=2, year=114, semester=yearly)` → returns `college_review_end: 2026-07-05T18:18:25Z` ✅
  - `(scholarship_type=2, year=115, semester=yearly)` → returns `null` (no config) ✅
  - `(scholarship_type=1, year=114, semester=first)` → returns `null` (config exists, deadline unset) ✅
- [x] Browser E2E as `cs_college` on `localhost:3000`:
  - Landing on 學生排序 with default selection renders `排名截止時間: 2026/7/6 上午2:18:25 · 剩餘 53 天 13 小時` immediately.
  - `[role="combobox"]` defaults to `114 全年` (the only year with active data) instead of `115 全年`.
  - 5 ranking cards visible.
  - Confirmed `配額分配` / `排序預覽` ranking-detail panel is NOT opened (count = 0) — banner appears purely from the page-level fetch, not from clicking into a ranking.

## Screenshots
- Before fix (default `115 全年`, no rankings, no banner)
- After fix (default `114 全年`, banner shown immediately)

(See live verification output in commit `5b33c87` body.)