### PR TITLE
test(frontend): contiguousRuns column-grouping helper

### DIFF
--- a/frontend/lib/constants/__tests__/allocation-matrix-layout.test.ts
+++ b/frontend/lib/constants/__tests__/allocation-matrix-layout.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for `contiguousRuns` in `lib/constants/allocation-matrix-layout.ts`.
+ *
+ * This helper groups student-allocation column indexes into contiguous
+ * runs for rendering the run-level pill UI in the AllocationMatrix.
+ * Each run becomes a single styled pill spanning multiple cells; a bug
+ * here would either:
+ * - Render separate pills for adjacent columns → broken visual unity
+ * - Merge non-adjacent columns into one pill → wrong students appear
+ *   grouped together (allocation misrepresentation in the UI)
+ *
+ * 10 cases. Pure function, no DOM / no React.
+ */
+
+import { contiguousRuns } from "../allocation-matrix-layout";
+
+describe("contiguousRuns", () => {
+  it("returns empty array for empty input", () => {
+    expect(contiguousRuns([])).toEqual([]);
+  });
+
+  it("returns single run for single index", () => {
+    expect(contiguousRuns([3])).toEqual([[3, 3]]);
+  });
+
+  it("groups a fully-contiguous range as one run", () => {
+    expect(contiguousRuns([0, 1, 2, 3])).toEqual([[0, 3]]);
+  });
+
+  it("splits non-contiguous indexes into separate runs", () => {
+    // From the JSDoc example
+    expect(contiguousRuns([0, 1, 2, 5, 6])).toEqual([
+      [0, 2],
+      [5, 6],
+    ]);
+  });
+
+  it("treats every isolated index as its own run", () => {
+    // From the JSDoc example
+    expect(contiguousRuns([0, 2, 4])).toEqual([
+      [0, 0],
+      [2, 2],
+      [4, 4],
+    ]);
+  });
+
+  it("handles unsorted input by sorting first", () => {
+    /* Pin: input is sorted internally — caller doesn't need to pre-sort.
+     * Without this, a user-clicked-out-of-order selection would render
+     * incorrectly. */
+    expect(contiguousRuns([3, 1, 2, 5])).toEqual([
+      [1, 3],
+      [5, 5],
+    ]);
+  });
+
+  it("deduplicates input via Set", () => {
+    /* Pin: duplicate indexes collapsed. Defensive against double-add
+     * bugs in the caller. */
+    expect(contiguousRuns([1, 1, 2, 2, 3])).toEqual([[1, 3]]);
+  });
+
+  it("handles multiple separated runs", () => {
+    expect(contiguousRuns([0, 1, 3, 4, 7])).toEqual([
+      [0, 1],
+      [3, 4],
+      [7, 7],
+    ]);
+  });
+
+  it("does not mutate the input array", () => {
+    /* Pin: function uses spread + sort, so the caller's array is
+     * untouched. Otherwise UI state held in React would silently
+     * mutate during a render. */
+    const input = [5, 2, 1];
+    contiguousRuns(input);
+    expect(input).toEqual([5, 2, 1]);
+  });
+
+  it("handles negative indexes and zero correctly", () => {
+    /* Pin: not strictly used in production but defensive. Contiguity
+     * still works around zero. */
+    expect(contiguousRuns([-2, -1, 0, 1])).toEqual([[-2, 1]]);
+  });
+});


### PR DESCRIPTION
## Summary

10 cases for `contiguousRuns` in `lib/constants/allocation-matrix-layout.ts` — the helper that groups student-allocation column indexes into runs for the AllocationMatrix run-level pill UI.

A bug would either render separate pills for adjacent columns (broken visual unity) or merge non-adjacent columns into one pill (wrong students grouped — allocation misrepresented).

## What's covered

- Empty input → `[]`
- Single index → one `[n,n]` run
- Fully-contiguous range → one `[start,end]` run
- Non-contiguous → split into multiple runs
- Isolated indexes → each its own `[n,n]` run
- Unsorted input → sorted internally (caller doesn't need to pre-sort)
- Duplicates collapsed via `Set`
- **Input array NOT mutated** (caller's array untouched after call)
- Negative indexes + zero handled correctly

## Test plan

- [x] Pure function, no DOM / no React
- [x] 10 cases
- [x] Lives in `frontend/lib/constants/__tests__/` per project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)