### PR TITLE
fix(ci): unbreak main — black-format 4 files + drop bogus email test case

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/_helpers.py
+++ b/backend/app/api/v1/endpoints/college_review/_helpers.py
@@ -190,9 +190,9 @@ async def load_export_aux_data(
     profile_advisor_by_user: dict[int, str] = {}
 
     if user_ids:
-        profile_stmt = select(
-            UserProfile.user_id, UserProfile.account_number, UserProfile.advisor_name
-        ).where(UserProfile.user_id.in_(user_ids))
+        profile_stmt = select(UserProfile.user_id, UserProfile.account_number, UserProfile.advisor_name).where(
+            UserProfile.user_id.in_(user_ids)
+        )
         for uid, acct, adv in (await db.execute(profile_stmt)).all():
             if acct:
                 account_number_by_user[uid] = acct

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -82,9 +82,7 @@ async def export_department_summary_single(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="無權限存取此學年度")
 
     # Resolve department row + auth check
-    dept = (
-        await db.execute(select(Department).where(Department.code == department_code))
-    ).scalar_one_or_none()
+    dept = (await db.execute(select(Department).where(Department.code == department_code))).scalar_one_or_none()
     if dept is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -129,15 +127,14 @@ async def export_department_summary_single(
         stmt = stmt.where(Application.semester == normalised_semester)
 
     raw_apps = list((await db.execute(stmt)).scalars().all())
-    apps = [
-        a for a in raw_apps
-        if ((a.student_data or {}).get("std_depno") or "").strip() == department_code
-    ]
+    apps = [a for a in raw_apps if ((a.student_data or {}).get("std_depno") or "").strip() == department_code]
     apps.sort(key=_sort_key)
 
     # Aux data
     dynamic_fields, sub_type_labels, account_by_user, advisor_by_user = await load_export_aux_data(
-        db, scholarship_type=stype, applications=apps,
+        db,
+        scholarship_type=stype,
+        applications=apps,
     )
 
     # Build rows with rank_position=None — empty cell in column 2
@@ -156,8 +153,7 @@ async def export_department_summary_single(
     title = f"{academic_year}學年度{scholarship_name}學生資料彙整表 - {dept_name}"
     sheet_name = f"{academic_year}學年"
     base_filename = (
-        f"{academic_year}學年度{scholarship_name}學生資料彙整表"
-        f"_{_sanitise_filename_part(dept_name)}.xlsx"
+        f"{academic_year}學年度{scholarship_name}學生資料彙整表" f"_{_sanitise_filename_part(dept_name)}.xlsx"
     )
     encoded = _url_quote(base_filename, safe="")
 
@@ -214,10 +210,8 @@ async def export_department_summary_bulk(
                 detail="未設定學院，無法使用本學院範圍",
             )
         dept_rows = (
-            await db.execute(
-                select(Department).where(Department.academy_code == college_code)
-            )
-        ).scalars().all()
+            (await db.execute(select(Department).where(Department.academy_code == college_code))).scalars().all()
+        )
         target_dept_codes = [d.code for d in dept_rows if d.code]
     else:  # scope == "all"
         target_dept_codes = None  # no dept filter
@@ -258,10 +252,7 @@ async def export_department_summary_bulk(
     raw_apps = list((await db.execute(stmt)).scalars().all())
     if target_dept_codes is not None:
         allowed = set(target_dept_codes)
-        apps = [
-            a for a in raw_apps
-            if ((a.student_data or {}).get("std_depno") or "").strip() in allowed
-        ]
+        apps = [a for a in raw_apps if ((a.student_data or {}).get("std_depno") or "").strip() in allowed]
     else:
         apps = raw_apps
 
@@ -281,14 +272,14 @@ async def export_department_summary_bulk(
 
     # Department name lookup
     dept_codes = list(groups.keys())
-    dept_name_rows = (
-        await db.execute(select(Department).where(Department.code.in_(dept_codes)))
-    ).scalars().all()
+    dept_name_rows = (await db.execute(select(Department).where(Department.code.in_(dept_codes)))).scalars().all()
     name_by_code = {d.code: d.name for d in dept_name_rows}
 
     # Aux data — loaded once over the union of applicants
     dynamic_fields, sub_type_labels, account_by_user, advisor_by_user = await load_export_aux_data(
-        db, scholarship_type=stype, applications=apps,
+        db,
+        scholarship_type=stype,
+        applications=apps,
     )
 
     scholarship_name = stype.name or "獎學金"

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -1149,12 +1149,10 @@ async def export_ranking_excel(
     items_sorted = sorted(ranking.items or [], key=lambda x: x.rank_position)
     apps_in_ranking = [item.application for item in items_sorted if item.application is not None]
 
-    dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user = (
-        await load_export_aux_data(
-            db,
-            scholarship_type=ranking.scholarship_type,
-            applications=apps_in_ranking,
-        )
+    dynamic_fields, sub_type_labels, account_number_by_user, advisor_string_by_user = await load_export_aux_data(
+        db,
+        scholarship_type=ranking.scholarship_type,
+        applications=apps_in_ranking,
     )
 
     export_rows = [

--- a/backend/app/tests/test_application_summary_export_endpoint.py
+++ b/backend/app/tests/test_application_summary_export_endpoint.py
@@ -57,6 +57,7 @@ _AsyncSession = async_sessionmaker(_async_engine, class_=AsyncSession, expire_on
 
 def _run_async(coro):
     import asyncio
+
     return asyncio.run(coro)
 
 
@@ -64,6 +65,7 @@ def _create_tables():
     async def _impl():
         async with _async_engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
+
     _run_async(_impl())
 
 
@@ -71,6 +73,7 @@ def _drop_tables():
     async def _impl():
         async with _async_engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
+
     _run_async(_impl())
 
 

--- a/frontend/lib/validations/__tests__/user-profile.test.ts
+++ b/frontend/lib/validations/__tests__/user-profile.test.ts
@@ -47,7 +47,11 @@ describe("validateAdvisorEmail", () => {
   it("accepts valid email formats", () => {
     expect(validateAdvisorEmail("prof@nycu.edu.tw").isValid).toBe(true);
     expect(validateAdvisorEmail("user+tag@example.co").isValid).toBe(true);
-    expect(validateAdvisorEmail("a.b.c@d.e").isValid).toBe(true);
+    /* Pin: multi-dot local part with 2-char TLD — the EMAIL_PATTERN
+     * regex requires `[a-zA-Z]{2,}` after the final dot, so the
+     * original `a.b.c@d.e` (1-char TLD) is correctly rejected. Keep
+     * the multi-dot-local-part intent by using a 2-char TLD. */
+    expect(validateAdvisorEmail("a.b.c@d.ee").isValid).toBe(true);
   });
 
   it("rejects malformed emails with localized error message", () => {


### PR DESCRIPTION
## Summary
Unblocks `Main CI/CD Pipeline` on `main`, which has been red on consecutive merges. Two independent failures, both narrow surface:

### 1. `Quick Checks (backend-lint)` — black 26.3.1 wants 4 files reformatted
\`\`\`
reformatted backend/app/api/v1/endpoints/college_review/_helpers.py
reformatted backend/app/api/v1/endpoints/college_review/application_summary_export.py
reformatted backend/app/api/v1/endpoints/college_review/ranking_management.py
reformatted backend/app/tests/test_application_summary_export_endpoint.py
```
`ranking_management.py` was partly fixed by 475cc40; black re-reformatted it. The other three landed via the application-summary-export feature with a different black version. Same `black==26.3.1 --line-length=120` invocation `ci.yml` runs.

### 2. `Frontend Tests` — bogus 1-char TLD fixture in `user-profile.test.ts`
`validateAdvisorEmail("a.b.c@d.e")` was asserted to be valid, but the regex (`[a-zA-Z]{2,}` after the final dot) correctly rejects 1-char TLDs. This fixture (added in #340 / `38f1031`) never actually ran on `main` — every recent run had backend-lint fail first, and Frontend Tests is gated `if: !failure()`, so the bug stayed hidden until this PR un-gates that path.

Kept the test's intent (multi-dot local part) by switching to `"a.b.c@d.ee"` and pinned the reasoning inline so it doesn't regress.

## Test plan
- [ ] CI on this PR: `Quick Checks (backend-lint)` AND `Frontend Tests` both pass
- [ ] After merge, `Main CI/CD Pipeline` returns to `success` conclusion on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)