### PR TITLE
fix(nightly): repair 3 broken test imports + matching production import

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -88,7 +88,7 @@ async def handle_cached_statement_error(session: AsyncSession, operation_func, *
     This function addresses the PostgreSQL asyncpg cached statement plan invalidation
     issue that occurs after schema or configuration changes.
     """
-    from sqlalchemy.dialects.postgresql.asyncpg import InvalidCachedStatementError
+    from asyncpg.exceptions import InvalidCachedStatementError
 
     try:
         return await operation_func(*args, **kwargs)

--- a/backend/app/tests/test_analytics_service_overview_metrics.py
+++ b/backend/app/tests/test_analytics_service_overview_metrics.py
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.models.application import ApplicationStatus
-from app.services.analytics_service import AnalyticsService
+from app.services.analytics_service import ScholarshipAnalyticsService
 
 
 def _app(*, status, submitted_at=None, decision_date=None) -> SimpleNamespace:
@@ -32,7 +32,7 @@ def _app(*, status, submitted_at=None, decision_date=None) -> SimpleNamespace:
 
 @pytest.fixture
 def service():
-    return AnalyticsService(db=None)  # type: ignore[arg-type]
+    return ScholarshipAnalyticsService(db=None)  # type: ignore[arg-type]
 
 
 def test_empty_list_returns_zero_values(service):

--- a/backend/app/tests/test_application_audit_service_deep.py
+++ b/backend/app/tests/test_application_audit_service_deep.py
@@ -22,7 +22,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.audit import AuditAction, AuditLog
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.user import User, UserRole, UserType
 from app.services.application_audit_service import ApplicationAuditService
 

--- a/backend/app/tests/test_handle_cached_statement_error.py
+++ b/backend/app/tests/test_handle_cached_statement_error.py
@@ -21,7 +21,7 @@ Bugs cause:
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy.dialects.postgresql.asyncpg import InvalidCachedStatementError
+from asyncpg.exceptions import InvalidCachedStatementError
 
 from app.db.session import handle_cached_statement_error
 


### PR DESCRIPTION
## Summary
Fixes nightly run [#25816259640](https://github.com/anud18/scholarship-system/actions/runs/25816259640) — `Backend Slow + Performance` was red at collection time on three test modules added by the 2026-05-13 test wave (#279–#303), each importing a symbol that doesn't exist. The third one also surfaced an identical latent bug in the production handler.

### Three renames
| File | Was | Now |
|---|---|---|
| `test_analytics_service_overview_metrics.py` | `AnalyticsService` | `ScholarshipAnalyticsService` |
| `test_application_audit_service_deep.py` | `app.models.audit` | `app.models.audit_log` |
| `test_handle_cached_statement_error.py` | `sqlalchemy.dialects.postgresql.asyncpg.InvalidCachedStatementError` | `asyncpg.exceptions.InvalidCachedStatementError` |
| **`backend/app/db/session.py:91`** (production) | same wrong SQLAlchemy import | `asyncpg.exceptions.InvalidCachedStatementError` |

### Why the production bug stayed latent
The bad import sits *inside* `handle_cached_statement_error`'s function body, so Python only evaluates it when the function is **called** — and the existing test suite never called it. The new module-level test attempted to collect, evaluated the import at parse time, and tripped the same wall.

In SQLAlchemy 2.0.44 (`backend/requirements.txt`), the class `InvalidCachedStatementError` lives as a **nested** class on `AsyncAdapt_asyncpg_dbapi` inside `sqlalchemy/dialects/postgresql/asyncpg.py` line 993 — not a module-level export. The public symbol is `asyncpg.exceptions.InvalidCachedStatementError` (asyncpg's native exception, which SQLAlchemy wraps). Both production and test now reference that public one — same logical behavior, valid import.

### Not in scope
The same nightly run also failed `E2E Full` (two Playwright assertion failures on `role-permissions.spec` and `student-withdraw.spec`). Those are real spec/contract drift, not import errors, and warrant their own diagnostic loop — separate PR.

## Test plan
- [ ] CI `Quick Checks (backend-lint)` passes (black-clean)
- [ ] CI on this PR shows all 4 backend-test matrix entries (smoke/unit/integration/critical-workflows) staying green
- [ ] After merge, the next nightly `Backend Slow + Performance` job reaches actual test execution (no `ImportError` during collection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)