### PR TITLE
fix(staging): harden cadvisor against restart loop (closes #152)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -268,6 +268,18 @@ services:
     networks:
       - scholarship_prod_network
     restart: unless-stopped
+    # Match the staging hardening from issue #152: bounded memory so the
+    # host's OOM-killer doesn't go after other prod services if cadvisor
+    # ever leaks, plus a real healthcheck so Docker restarts it before it
+    # ends up in a half-dead state that drags every container into a
+    # false-positive ContainerDown alert.
+    mem_limit: 256m
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -183,6 +183,22 @@ services:
     networks:
       - scholarship_staging_network
     restart: unless-stopped
+    # Stability hardening for issue #152. cadvisor on staging was
+    # restart-looping (136 alert cycles between 2026-05-08 and 2026-05-14
+    # — see issue comments) and dragging the staging ContainerDown alert
+    # with it, because when cadvisor goes down the scrape stops and every
+    # container in the env looks "down" to the alert rule. mem_limit lets
+    # Docker kill it cleanly before the host OOM-killer does, and the
+    # healthcheck makes the swarm-side restart trigger fire on first
+    # unhealthy probe (rather than waiting for a SIGSEGV). cadvisor's
+    # /healthz returns 200 once the scraper is responsive.
+    mem_limit: 256m
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
cadvisor on staging has been restart-looping for ~6 days (**136 alert cycles** between 2026-05-08 and 2026-05-14 in issue #152 — bridge re-fires + auto-resolves every few minutes). When cadvisor itself goes down the metric scrape stops cold, and the \`ContainerDown\` rule (\`time() - container_last_seen > 60\`) lights up for every container in the env — that's the recurring \"9 alert(s) in this batch\" noise.

## Two changes, identical for staging + prod

1. **\`mem_limit: 256m\`** — cadvisor on both envs has no memory cap today. If it ever leaks, the host OOM-killer picks a victim essentially at random; with a cap, Docker takes cadvisor down cleanly and \`restart: unless-stopped\` brings it back. 256MB matches typical sizing docs and is well above observed RSS (~80–120 MB locally).

2. **\`healthcheck\` hitting \`/healthz\` on :8080** — verified the image ships \`/usr/bin/wget\` and the endpoint returns \`200 OK\` once the scraper is responsive. Without this, Docker only knows cadvisor is \"alive\" via the entrypoint process; a half-dead state where the HTTP listener has hung but the binary hasn't crashed produces exactly the symptom we've seen.

## Why prod too

The compose pattern, image, and risk are identical. Cheaper to ship the hardening across both at once than to wait for prod to flap.

## What this doesn't touch

- Alert rule PromQL — fine as-is, the container is what's misbehaving.
- No SSH access from this session to capture the actual cadvisor crash logs from staging; if the alert pattern persists post-deploy, we'll need a deeper dive into the cadvisor container's stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)