### PR TITLE
fix(nightly): E2E Full — withdraw NOT NULL crash + 3 spec-level bugs

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2128,8 +2128,13 @@ class ApplicationService:
         if application.status not in [ApplicationStatus.submitted, ApplicationStatus.under_review]:
             raise ValidationError("Only submitted or under-review applications can be withdrawn")
 
+        from app.models.enums import ReviewStage
+
         application.status = ApplicationStatus.draft
-        application.review_stage = None
+        # review_stage is NOT NULL on the column (20251028_add_review_stage_to_applications
+        # set nullable=False); set it back to the canonical draft stage to mirror the
+        # status transition rather than leaving the column null and tripping a 500.
+        application.review_stage = ReviewStage.student_draft.value
         application.professor_id = None
         application.updated_at = datetime.now(timezone.utc)
 

--- a/frontend/e2e/helpers/db.ts
+++ b/frontend/e2e/helpers/db.ts
@@ -79,25 +79,41 @@ export async function dumpRelated(opts: {
 }
 
 export async function deleteApplicationCascade(appId: string): Promise<void> {
-  // Best-effort idempotent cleanup. Order respects FKs:
-  //   application_review_items → application_reviews → audit → application.
-  // The legacy `reviews`/`review_items` table names never existed in this
-  // schema; they came from an early draft of the helper. Each DELETE
-  // tolerates the absence of its table so older branches with partial
-  // schema still drain cleanly.
+  // Best-effort idempotent cleanup covering every FK that points at
+  // `applications` with ON DELETE NO ACTION (the default for most of the
+  // referencing tables in this schema). Order: children first, parent last.
+  //
+  // Tables whose FK to applications was discovered the hard way by previous
+  // E2E flakes (cross-spec dirty state on stuphd001+phd):
+  //   - email_history, scheduled_emails (notification queue)
+  //   - document_requests (deadline tracker)
+  //   - application_files (uploaded supporting docs)
+  //   - college_ranking_items, payment_roster_items (review-stage children)
+  //   - application_review_items → application_reviews (review tree)
+  //   - student_bank_accounts.verification_source_application_id is ON DELETE
+  //     SET NULL, so it cleans itself — left out intentionally.
+  //
+  // Each DELETE tolerates table absence so older/divergent schemas don't
+  // wedge the helper.
   const { rows } = await pool.query("SELECT id FROM applications WHERE app_id = $1", [appId]);
   if (!rows[0]) return;
   const id = rows[0].id as number;
-  await pool.query(
+
+  for (const sql of [
+    "DELETE FROM email_history WHERE application_id = $1",
+    "DELETE FROM scheduled_emails WHERE application_id = $1",
+    "DELETE FROM document_requests WHERE application_id = $1",
+    "DELETE FROM application_files WHERE application_id = $1",
+    "DELETE FROM college_ranking_items WHERE application_id = $1",
+    "DELETE FROM payment_roster_items WHERE application_id = $1",
     `DELETE FROM application_review_items
-     WHERE review_id IN (SELECT id FROM application_reviews WHERE application_id = $1)`,
-    [id],
-  ).catch(() => undefined);
-  await pool.query("DELETE FROM application_reviews WHERE application_id = $1", [id]).catch(() => undefined);
+       WHERE review_id IN (SELECT id FROM application_reviews WHERE application_id = $1)`,
+    "DELETE FROM application_reviews WHERE application_id = $1",
+  ]) {
+    await pool.query(sql, [id]).catch(() => undefined);
+  }
   // The audit table is `audit_logs` (general-purpose), keyed by
-  // (resource_type, resource_id::text). `application_audit_logs` was an
-  // early-draft name that never existed in the schema; the previous query
-  // silently no-op'd via .catch(). Stop pretending to clean it up — the
-  // genuine audit rows are removed by their FK cascade on applications.
+  // (resource_type, resource_id::text). Its rows are removed by the FK
+  // cascade on applications, so no explicit DELETE is needed here.
   await pool.query("DELETE FROM applications WHERE id = $1", [id]);
 }

--- a/frontend/e2e/specs/role-permissions.spec.ts
+++ b/frontend/e2e/specs/role-permissions.spec.ts
@@ -150,6 +150,21 @@ test.describe("Role-permission boundaries on applications endpoints", () => {
     // 3. College user tries to submit a professor-only review → 403
     //    (the endpoint checks current_user.is_professor() inline and
     //    raises 403 if the role is wrong).
+    //
+    // Body must satisfy `ReviewCreate` (application_id + items[]) so Pydantic
+    // doesn't 422 *before* the role guard runs. The role check is what we
+    // want to exercise; a 422 would mask whether the guard exists at all.
+    const validReviewBody = {
+      application_id: appDbId,
+      items: [
+        {
+          sub_type_code: "nstc",
+          recommendation: "approve",
+          comments: "should never be persisted",
+        },
+      ],
+    };
+
     const collegeLogin = await loginAs(browser, COLLEGE_ID);
     pushTrace(runState, collegeLogin.traceId);
 
@@ -157,10 +172,7 @@ test.describe("Role-permission boundaries on applications endpoints", () => {
       collegeLogin.token,
       "POST",
       `/applications/${appDbId}/review`,
-      {
-        recommendation: "yes",
-        comments: "should never be persisted",
-      },
+      validReviewBody,
     );
     pushTrace(runState, collegeReview.traceId);
     expect(
@@ -177,10 +189,7 @@ test.describe("Role-permission boundaries on applications endpoints", () => {
       studentLogin.token,
       "POST",
       `/applications/${appDbId}/review`,
-      {
-        recommendation: "yes",
-        comments: "should never be persisted",
-      },
+      validReviewBody,
     );
     pushTrace(runState, studentReview.traceId);
     expect(

--- a/frontend/e2e/specs/student-withdraw.spec.ts
+++ b/frontend/e2e/specs/student-withdraw.spec.ts
@@ -139,9 +139,11 @@ test.describe("Student withdraws a submitted application", () => {
     expect(afterWithdraw!.status).toBe("draft");
 
     // 3. Second withdraw must be rejected — application is no longer in
-    //    submitted/under_review, so the service raises ValidationError →
-    //    HTTP 400. We pin this so a future change that silently no-ops on
-    //    invalid state transitions fails the test.
+    //    submitted/under_review, so the service raises ValidationError.
+    //    ScholarshipException maps ValidationError → HTTP 422 (see
+    //    backend/app/core/exceptions.py:34). We pin the 4xx outcome so a
+    //    future change that silently no-ops on invalid state transitions
+    //    fails the test.
     const secondWithdrawRes = await apiAs<{ success: boolean; detail?: string }>(
       studentLogin.token,
       "POST",
@@ -151,10 +153,10 @@ test.describe("Student withdraws a submitted application", () => {
     pushTrace(runState, secondWithdrawRes.traceId);
     expect(
       secondWithdrawRes.status,
-      `expected 400 for second withdraw, got ${secondWithdrawRes.status} body=${JSON.stringify(
+      `expected 422 for second withdraw, got ${secondWithdrawRes.status} body=${JSON.stringify(
         secondWithdrawRes.body,
       )}`,
-    ).toBe(400);
+    ).toBe(422);
 
     // Status didn't drift further — still draft.
     const finalState = await getApplication(appId);


### PR DESCRIPTION
## Summary
Resolves the remaining `E2E Full` failures from nightly [#25816259640](https://github.com/anud18/scholarship-system/actions/runs/25816259640). Four independent issues, all surfaced together because each touches the cross-spec `stuphd001 + phd` state.

### 1. Backend — `withdraw_application` crashes with `NotNullViolation` (the only production-impacting bug)
`application_service.py:2132` set `review_stage = None` on withdraw, but migration `20251028_add_review_stage_to_applications` flipped the column to **NOT NULL** (line 88). Every first withdraw 500'd. Mirror the data-migration mapping for `status='draft'` and set it to `ReviewStage.student_draft.value`.

\`\`\`
asyncpg.exceptions.NotNullViolationError: null value in column \"review_stage\"
of relation \"applications\" violates not-null constraint
\`\`\`

### 2. E2E helper — `deleteApplicationCascade` leaks 6 child tables
Cascade only cleaned `application_review_items` + `application_reviews`. Six other FKs to `applications` use ON DELETE NO ACTION (`email_history`, `scheduled_emails`, `document_requests`, `application_files`, `college_ranking_items`, `payment_roster_items`), so the parent DELETE silently failed and stale apps survived across specs. Next test's `purgeStudentApps` couldn't drain them → unique constraint `uq_user_scholarship_academic_term` fired → POST returned 201 with \`{success: false, error_code: \"DUPLICATE_APPLICATION\"}\`. That's what made `student-withdraw.spec.ts:112` look like a create-application bug.

### 3. `role-permissions.spec.ts` — body shape mismatch swallows the 403
Test posted \`{recommendation, comments}\` to \`/applications/{id}/review\`, but the route's body schema is \`ReviewCreate\` (\`application_id\` + \`items[]\`). FastAPI 422'd **before** the inline \`current_user.is_professor()\` guard ran, so the test asserting 403 caught a different bug than the one it claimed to. Send a Pydantic-valid body so the role check is the actual gate being exercised; pinned the reasoning inline.

### 4. `student-withdraw.spec.ts` — pinned 400 but the real contract is 422
Test asserted second-withdraw returned 400, but \`ScholarshipException.ValidationError\` is wired to \`status_code=422\` in \`core/exceptions.py:34\` — has been since before this spec was written. The intent (\"a future change that silently no-ops on invalid state transitions fails the test\") still holds with 422; updated the assertion + docstring to match the real contract.

## Verification (local, clean DB)
\`\`\`
$ npx playwright test --project=chromium --reporter=line
5 passed (27.1s)
\`\`\`
multi-role-phd · role-permissions · roster-generation · student-withdraw · whitelist-grant — same set the nightly E2E Full runs.

## Test plan
- [ ] CI on this PR all green (esp. Backend Tests + E2E Smoke — E2E Full only runs nightly so the post-merge gate is the next scheduled or `workflow_dispatch`-fired nightly)
- [ ] After merge, trigger `nightly.yml` via `workflow_dispatch` and confirm `E2E Full` job exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)