### PR TITLE
test(backend): pin Facebook-style notification request schemas

### DIFF
--- a/backend/app/tests/test_facebook_notification_request_schemas.py
+++ b/backend/app/tests/test_facebook_notification_request_schemas.py
@@ -1,0 +1,154 @@
+"""
+Tests for the inline Pydantic request schemas in
+`app.api.v1.endpoints.notifications_facebook_demo`:
+
+  - CreateNotificationRequest
+  - BatchNotificationRequest
+  - PreferenceUpdateRequest
+
+Module had ZERO test coverage. These schemas drive the Facebook-
+style notification demo endpoints. While the endpoints themselves
+are DB-coupled, the schemas are pure Pydantic with carefully-
+chosen defaults that affect:
+
+  - Notification priority routing (default "normal")
+  - Batch send rate-limiting (batch_size=100, delay_minutes=5 —
+    SECURITY: too-large batch_size could be used to spam users)
+  - User notification preference defaults (in_app/email ON,
+    sms/push OFF — privacy-respecting defaults)
+
+Wave 6a112 pins these defaults so a refactor doesn't silently
+change rollout behaviour or default privacy posture.
+
+13 cases.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.v1.endpoints.notifications_facebook_demo import (
+    BatchNotificationRequest,
+    CreateNotificationRequest,
+    PreferenceUpdateRequest,
+)
+
+# ─── CreateNotificationRequest ──────────────────────────────────────
+
+
+def test_create_request_minimal_required_fields():
+    # Pin: required = notification_type + data. user_id, channels,
+    # group_key, href are all optional.
+    req = CreateNotificationRequest(notification_type="app_status_change", data={"app_id": 1})
+    assert req.notification_type == "app_status_change"
+    assert req.data == {"app_id": 1}
+    assert req.user_id is None
+    assert req.channels is None
+
+
+def test_create_request_priority_default_is_normal():
+    # Pin: default priority "normal". Pin so a refactor to "high"
+    # doesn't accidentally make every demo notification urgent.
+    req = CreateNotificationRequest(notification_type="x", data={})
+    assert req.priority == "normal"
+
+
+def test_create_request_data_is_required():
+    # Pin: data field has no default — missing → ValidationError.
+    with pytest.raises(ValidationError):
+        CreateNotificationRequest(notification_type="x")
+
+
+def test_create_request_notification_type_is_required():
+    with pytest.raises(ValidationError):
+        CreateNotificationRequest(data={})
+
+
+def test_create_request_accepts_full_payload():
+    # Pin: all fields settable when explicitly provided.
+    req = CreateNotificationRequest(
+        user_id=1,
+        notification_type="info",
+        data={"k": "v"},
+        channels=["in_app", "email"],
+        priority="high",
+        href="/x",
+        group_key="g1",
+    )
+    assert req.user_id == 1
+    assert req.channels == ["in_app", "email"]
+    assert req.priority == "high"
+
+
+# ─── BatchNotificationRequest ───────────────────────────────────────
+
+
+def test_batch_request_required_fields():
+    # Pin: user_ids + notification_type + data are required.
+    req = BatchNotificationRequest(user_ids=[1, 2, 3], notification_type="ann", data={})
+    assert req.user_ids == [1, 2, 3]
+    assert req.notification_type == "ann"
+
+
+def test_batch_request_batch_size_default_is_100():
+    # Pin: default batch_size 100. SECURITY-relevant — too-large
+    # default could be misused to spam users. Pin so a refactor
+    # raising the default (e.g., to 1000) forces explicit review.
+    req = BatchNotificationRequest(user_ids=[1], notification_type="x", data={})
+    assert req.batch_size == 100
+
+
+def test_batch_request_delay_minutes_default_is_5():
+    # Pin: default 5-minute rate-limit between batches. Pin so a
+    # refactor to 0 doesn't accidentally send a burst.
+    req = BatchNotificationRequest(user_ids=[1], notification_type="x", data={})
+    assert req.delay_minutes == 5
+
+
+def test_batch_request_accepts_empty_user_ids():
+    # Pin: empty user_ids accepted (no min_length=1). The endpoint
+    # may treat empty as a noop — pinned so a refactor to forbid
+    # empty doesn't silently break that code path.
+    req = BatchNotificationRequest(user_ids=[], notification_type="x", data={})
+    assert req.user_ids == []
+
+
+# ─── PreferenceUpdateRequest ────────────────────────────────────────
+
+
+def test_preference_request_defaults_privacy_respecting():
+    # Pin: in_app + email default TRUE; sms + push default FALSE.
+    # SECURITY/PRIVACY-relevant — pin so a refactor flipping sms/
+    # push to True-by-default doesn't accidentally enable channels
+    # the user never opted into.
+    req = PreferenceUpdateRequest(notification_type="app_status_change")
+    assert req.in_app_enabled is True
+    assert req.email_enabled is True
+    assert req.sms_enabled is False
+    assert req.push_enabled is False
+
+
+def test_preference_request_frequency_default_is_immediate():
+    # Pin: default frequency "immediate". Pin so a refactor to
+    # "daily" doesn't silently batch user notifications.
+    req = PreferenceUpdateRequest(notification_type="x")
+    assert req.frequency == "immediate"
+
+
+def test_preference_request_notification_type_required():
+    # Pin: notification_type is required.
+    with pytest.raises(ValidationError):
+        PreferenceUpdateRequest()
+
+
+def test_preference_request_all_fields_overridable():
+    req = PreferenceUpdateRequest(
+        notification_type="x",
+        in_app_enabled=False,
+        email_enabled=False,
+        sms_enabled=True,
+        push_enabled=True,
+        frequency="daily",
+    )
+    assert req.in_app_enabled is False
+    assert req.sms_enabled is True
+    assert req.frequency == "daily"


### PR DESCRIPTION
## Summary
- 13 pytest cases for the **previously-untested** inline Pydantic schemas in \`app/api/v1/endpoints/notifications_facebook_demo.py\`.

## Why
- Default values affect production behaviour:
  - **Priority routing** — default \`\"normal\"\` (a refactor to \`\"high\"\` would silently elevate every demo notification)
  - **Batch rate-limiting** — SECURITY: \`batch_size=100\` / \`delay_minutes=5\` defaults pinned (raising defaults could be misused to spam users)
  - **PRIVACY-respecting preference defaults** — \`in_app_enabled=True\`, \`email_enabled=True\`, \`sms_enabled=False\`, \`push_enabled=False\`. Pin so a refactor flipping sms/push to True-by-default doesn't silently enable channels users never opted into.
  - **Notification frequency** — default \`\"immediate\"\` (refactor to \`\"daily\"\` would silently batch user notifications)

Coverage: 3 schemas × required-field validation + default values + overridability.

## Test plan
- [x] \`docker exec scholarship_backend_dev python -m pytest app/tests/test_facebook_notification_request_schemas.py\` — 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)