### PR TITLE
fix(services): replace nonexistent UserRole.processor with super_admin (closes #462)

### DIFF
--- a/backend/app/services/roster_notification_service.py
+++ b/backend/app/services/roster_notification_service.py
@@ -44,7 +44,7 @@ class RosterNotificationService:
             List[int]: 已發送通知的使用者ID清單
         """
         if notify_roles is None:
-            notify_roles = [UserRole.admin, UserRole.processor]
+            notify_roles = [UserRole.admin, UserRole.super_admin]
 
         try:
             # 取得要通知的使用者
@@ -113,7 +113,7 @@ class RosterNotificationService:
             List[int]: 已發送通知的使用者ID清單
         """
         if notify_roles is None:
-            notify_roles = [UserRole.admin, UserRole.processor]
+            notify_roles = [UserRole.admin, UserRole.super_admin]
 
         try:
             target_users = self._get_users_by_roles(notify_roles)
@@ -241,7 +241,7 @@ class RosterNotificationService:
             List[int]: 已發送通知的使用者ID清單
         """
         if notify_roles is None:
-            notify_roles = [UserRole.admin, UserRole.processor]
+            notify_roles = [UserRole.admin, UserRole.super_admin]
 
         try:
             target_users = self._get_users_by_roles(notify_roles)

--- a/backend/app/tests/test_roster_notification_defaults.py
+++ b/backend/app/tests/test_roster_notification_defaults.py
@@ -40,31 +40,30 @@ def _stub_user(user_id):
 
 
 class TestNotifyRosterGeneratedDefaults:
-    """Pin: notify_roster_generated with default args is CURRENTLY
-    BROKEN due to UserRole.processor typo (no such enum value;
-    UserRole has admin/student/professor/college/super_admin).
+    """Pin: notify_roster_generated defaults to [admin, super_admin].
 
-    The top-level try/except catches the AttributeError and
-    returns []. Pin actual behavior here — see issue tracking
-    the underlying bug for the fix path."""
+    Issue #462 fix — previously referenced nonexistent
+    UserRole.processor enum value which crashed AttributeError.
+    Now defaults to admin + super_admin (escalation pairing,
+    matching the elevated-privilege intent of roster events)."""
 
     @pytest.mark.asyncio
-    async def test_default_args_raises_attribute_error_due_to_typo(self):
-        # Pin BUG: default `notify_roles=None` branch references
-        # UserRole.processor (does NOT exist; only admin / student /
-        # professor / college / super_admin exist per CLAUDE.md §4).
-        # The default-assignment line (47) is OUTSIDE the try/except
-        # so the AttributeError PROPAGATES out of the method —
-        # crashing whichever roster orchestrator called it.
-        # Pin so refactor fixing the typo can confidently change
-        # the contract from "raises" to "returns []".
+    async def test_default_args_targets_admin_and_super_admin(self):
+        # Pin Issue #462 FIX: default `notify_roles=None` now
+        # resolves to [UserRole.admin, UserRole.super_admin].
+        # Pin so refactor doesn't regress to the broken
+        # UserRole.processor reference.
         service = RosterNotificationService(db=MagicMock())
         service._get_users_by_roles = MagicMock(return_value=[_stub_user(1)])
         service.notification_service = MagicMock()
         service.notification_service.createUserNotification = AsyncMock()
 
-        with pytest.raises(AttributeError, match="processor"):
-            await service.notify_roster_generated(_stub_roster())
+        result = await service.notify_roster_generated(_stub_roster())
+        assert result == [1]
+
+        called_roles = service._get_users_by_roles.call_args.args[0]
+        assert UserRole.admin in called_roles
+        assert UserRole.super_admin in called_roles
 
     @pytest.mark.asyncio
     async def test_explicit_roles_override_defaults(self):
@@ -165,24 +164,29 @@ class TestNotifyRosterErrorDefaults:
 
 
 class TestNotifyRosterCompletedDefaults:
-    """Pin: notify_roster_completed default args ALSO broken
-    (same UserRole.processor typo). See issue."""
+    """Pin: notify_roster_completed defaults to [admin, super_admin]
+    (same fix path as notify_roster_generated — see Issue #462)."""
 
     @pytest.mark.asyncio
-    async def test_completed_default_args_raises_due_to_typo(self):
-        # Pin BUG: same UserRole.processor typo in
-        # notify_roster_completed default branch. AttributeError
-        # propagates (default-assignment is OUTSIDE try/except).
+    async def test_completed_default_args_targets_admin_and_super_admin(self):
+        # Pin Issue #462 FIX: previously crashed with AttributeError
+        # because UserRole.processor doesn't exist. Now uses
+        # UserRole.super_admin instead. Pin so refactor doesn't
+        # regress.
         service = RosterNotificationService(db=MagicMock())
         service._get_users_by_roles = MagicMock(return_value=[_stub_user(1)])
         service.notification_service = MagicMock()
         service.notification_service.createUserNotification = AsyncMock()
 
-        with pytest.raises(AttributeError, match="processor"):
-            await service.notify_roster_completed(
-                roster=_stub_roster(),
-                statistics={"qualified_count": 25, "total_amount": 250000},
-            )
+        result = await service.notify_roster_completed(
+            roster=_stub_roster(),
+            statistics={"qualified_count": 25, "total_amount": 250000},
+        )
+        assert result == [1]
+
+        called_roles = service._get_users_by_roles.call_args.args[0]
+        assert UserRole.admin in called_roles
+        assert UserRole.super_admin in called_roles
 
     @pytest.mark.asyncio
     async def test_completed_with_explicit_admin_role_works(self):


### PR DESCRIPTION
## Summary
Fixes **#462** — \`backend/app/services/roster_notification_service.py\` references the nonexistent \`UserRole.processor\` enum value on lines 47/116/244, crashing 3 \`notify_*\` methods with AttributeError whenever called with default \`notify_roles=None\`.

## Why
Per CLAUDE.md §4, \`UserRole\` enum has exactly 5 valid values: student / professor / college / admin / super_admin. \`UserRole.processor\` does **not** exist. Calling \`notify_roster_generated()\` / \`notify_roster_completed()\` / \`notify_roster_status_changed()\` with default args propagates AttributeError to the upstream roster-generation orchestrator.

Per CLAUDE.md §2 (NO BACKWARD COMPATIBILITY), the broken references are replaced with \`[UserRole.admin, UserRole.super_admin]\` — escalation pairing matches the elevated-privilege intent of roster events.

## What
- 3 instances of \`UserRole.processor\` → \`UserRole.super_admin\` in roster_notification_service.py
- Updated test_roster_notification_defaults.py (PR #463 / wave 6a142): the AttributeError-pinning tests are flipped to pin the correct \`[admin, super_admin]\` contract so a regression to the broken state surfaces immediately.

## Test plan
- [x] \`pytest app/tests/test_roster_notification_defaults.py\` — 10/10 pass
- [x] \`from app.services.roster_notification_service import RosterNotificationService\` imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)