### PR TITLE
fix(admin): add missing sqlalchemy.func import in email_templates endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/admin/email_templates.py
+++ b/backend/app/api/v1/endpoints/admin/email_templates.py
@@ -11,7 +11,7 @@ import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import require_admin


### PR DESCRIPTION
## Bug
\`update_email_template\` at \`backend/app/api/v1/endpoints/admin/email_templates.py:82\` calls \`func.now()\` to stamp \`updated_at\` on the SQLAlchemy update statement, but \`func\` was never imported.

Any admin who hits \`PUT /admin/email-templates/{id}\` will get:

\`\`\`
NameError: name 'func' is not defined
\`\`\`

## Root cause
Production runtime crash discovered by flake8 F821 (undefined name) — running the gate as part of the comprehensive coverage audit the wave loop is producing.

## Fix
Extend \`from sqlalchemy import select\` → \`from sqlalchemy import func, select\`. No behavior change beyond making the endpoint non-crashing.

## Discovery method
\`\`\`
uvx --from flake8==7.1.1 flake8 backend/app/ --select=F821
# app/api/v1/endpoints/admin/email_templates.py:82:24: F821 undefined name 'func'
\`\`\`

## Verification
\`\`\`
python -c "from app.api.v1.endpoints.admin.email_templates import router; print('routes:', len(router.routes))"
# module imports OK, routes: 10
\`\`\`

Same lint sweep also flagged 5 F821s in test files (\`CollegeReview\`, \`ProfessorReviewCreate\`, \`ProfessorReviewItemCreate\`) — those are in dead-code branches and don't crash production, will address separately.

## Test plan
- [x] Black 26.3.1 formatting check passes
- [x] Module imports cleanly with `from sqlalchemy import func, select`
- [x] F821 cleared on this file
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)