### PR TITLE
fix(tests): clear 5 F821 errors from schema-cleanup dead code

### DIFF
--- a/backend/app/tests/test_college_review_endpoints.py
+++ b/backend/app/tests/test_college_review_endpoints.py
@@ -9,7 +9,7 @@ Tests critical API functionality including:
 - Data filtering and security
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -90,10 +90,13 @@ class TestCollegeReviewEndpoints:
         mock_session = AsyncMock()
         mock_db.return_value = mock_session
 
-        # Mock service
+        # Mock service. CollegeReview model was removed in schema cleanup;
+        # since the test body ends with `pass` (placeholder), the mock
+        # return value is never inspected — a generic MagicMock is enough.
         with patch.object(CollegeReviewService, "create_or_update_review") as mock_create:
-            mock_review = CollegeReview(id=1, application_id=1, reviewer_id=college_user.id, **sample_review_data)
-            mock_create.return_value = mock_review
+            mock_create.return_value = MagicMock(
+                id=1, application_id=1, reviewer_id=college_user.id, **sample_review_data
+            )
 
             # Mock permission check
             with patch(

--- a/backend/app/tests/test_college_review_service.py
+++ b/backend/app/tests/test_college_review_service.py
@@ -46,19 +46,8 @@ class TestCollegeReviewService:
             sub_scholarship_type="phd_research",
         )
 
-    @pytest.fixture
-    def sample_college_review(self):
-        """Sample college review for testing"""
-        return CollegeReview(
-            id=1,
-            application_id=1,
-            reviewer_id=2001,
-            academic_score=85.0,
-            professor_review_score=90.0,
-            college_criteria_score=88.0,
-            ranking_score=87.5,
-            review_status="completed",
-        )
+    # NOTE: `sample_college_review` fixture removed alongside the CollegeReview
+    # model in the schema cleanup. No collected test consumed it.
 
     @pytest.fixture
     def sample_ranking(self):

--- a/backend/app/tests/test_professor_endpoints.py
+++ b/backend/app/tests/test_professor_endpoints.py
@@ -236,24 +236,12 @@ class TestProfessorReviewEndpoints:
         request.client.host = "127.0.0.1"
         return request
 
-    @pytest.fixture
-    def sample_review_create(self):
-        """Sample review creation data"""
-        return ProfessorReviewCreate(
-            recommendation="Student demonstrates excellent academic performance",
-            items=[
-                ProfessorReviewItemCreate(
-                    sub_type_code="nstc",
-                    is_recommended=True,
-                    comments="Highly recommended for NSTC scholarship",
-                ),
-                ProfessorReviewItemCreate(
-                    sub_type_code="moe_1w",
-                    is_recommended=False,
-                    comments="Does not meet MOE requirements",
-                ),
-            ],
-        )
+    # NOTE: `sample_review_create` fixture removed alongside the
+    # ProfessorReviewCreate / ProfessorReviewItemCreate schemas during the
+    # unified-review-schema refactor (see app.schemas.review). The
+    # `test_create_professor_review_success` test that consumed it has
+    # already been removed; the fixture itself was the only remaining F821
+    # reference.
 
     @pytest.mark.asyncio
     async def test_get_professor_review_success(self, mock_professor, mock_db_session, mock_request):


### PR DESCRIPTION
## Summary
After PR #484 fixed the production F821 in admin/email_templates.py, a full backend-wide `flake8 --select=F821` sweep flagged 5 remaining dead-code references in three test files.

## What was wrong
Three test files retained references to schema classes that were removed in earlier refactors:

| File | Line | Symbol | Status |
|---|---|---|---|
| test_college_review_endpoints.py | 95 | `CollegeReview(...)` | Inside test body that ends with `pass`; never reached |
| test_college_review_service.py | 52 | `CollegeReview(...)` | Inside fixture; never consumed by any test |
| test_professor_endpoints.py | 242,245,250 | `ProfessorReviewCreate/ItemCreate(...)` | Inside fixture; consuming test was already deleted |

These are all dead references — none would crash at runtime because the bodies / fixtures aren't actually executed. They were silent lint warnings preventing clean `flake8` sweeps.

## Fix
- College review endpoints: replace `CollegeReview(...)` with `MagicMock(...)` (the value is never inspected — test body is `pass`)
- College review service: delete the unused `sample_college_review` fixture entirely
- Professor endpoints: delete the unused `sample_review_create` fixture entirely

After fix: **0 F821 errors backend-wide**. All 39 tests across the 3 files still collect.

## Why
The full backend F821 sweep is the foundation of the production-level audit operationalization started in PR #484. Combined: PR #484 + this PR mean `flake8 --select=E9,F63,F7,F82` is now clean on origin/main.

## Test plan
- [x] `flake8 --select=F821` exits clean on origin/main + this branch
- [x] All 39 tests in the 3 files still collect
- [x] Black 26.3.1 formatting check passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)