### PR TITLE
fix(test): correct 15-vs-14-digit off-by-one in postal-account test

### DIFF
--- a/backend/app/tests/test_bank_verification_service_helpers.py
+++ b/backend/app/tests/test_bank_verification_service_helpers.py
@@ -54,11 +54,23 @@ class TestValidatePostalAccountFormat:
         assert err is None
 
     def test_valid_with_dashes_and_spaces(self, service: BankVerificationService) -> None:
-        """Real-world bank pamphlets format as '0001234-5678901-2' or similar
-        — the validator strips non-digits before counting."""
-        ok, err = service.validate_postal_account_format("0001234-5678901-2")
+        """Real-world bank pamphlets format as '0001234-5678901' (7-7 split,
+        14 digits) — the validator strips non-digits before counting.
+
+        Previously this test asserted "0001234-5678901-2" (15 digits) was
+        valid, but the validator correctly requires exactly 14 digits; the
+        test input had an extra trailing "-2" by mistake.
+        """
+        ok, err = service.validate_postal_account_format("0001234-5678901")
         assert ok is True
         assert err is None
+
+    def test_15_digit_input_rejected(self, service: BankVerificationService) -> None:
+        """Pin: 15 digits (one too many) → rejected with explicit count.
+        Regression guard for the off-by-one fix above."""
+        ok, err = service.validate_postal_account_format("0001234-5678901-2")
+        assert ok is False
+        assert err is not None and "15 位" in err
 
     def test_empty_string_rejected(self, service: BankVerificationService) -> None:
         ok, err = service.validate_postal_account_format("")


### PR DESCRIPTION
## Bug
\`test_valid_with_dashes_and_spaces\` in \`test_bank_verification_service_helpers.py:56\` asserts that \`"0001234-5678901-2"\` is a valid postal account, but that input has **15 digits** after dash-stripping (7+7+1) and the validator correctly requires exactly **14 digits**.

The test was always failing — it just wasn't running in CI end-to-end because:
1. Backend smoke suite has been blocked by a missing \`hypothesis\` dev-only dependency (collection error)
2. CI workflow runs the relevant pytest with markers that select-around the failure
3. Only when the smoke suite is actually run from end-to-end does the assertion fail

## Discovered via
Running the full smoke suite locally after installing \`hypothesis\` in the test container:

\`\`\`
docker exec scholarship_backend_dev pip install hypothesis==6.112.0
docker exec scholarship_backend_dev python -m pytest app/tests/ --override-ini='addopts=' -m smoke --tb=no -q
# 243 passed, 5 failed, 2965 deselected
\`\`\`

The other 4 failures are environmental (\`test_reference_data_response_shape.py\` needs a seeded DB; the SQLite fixture lacks the reference tables) and will be tracked separately.

## Fix
- Correct happy-path input to \`"0001234-5678901"\` (14 digits — 7 + 7 split, standard pamphlet format)
- Add \`test_15_digit_input_rejected\` as a regression guard pinning the explicit \`"15 位"\` error message for the original buggy input

After fix: \`TestValidatePostalAccountFormat\` = **9/9 pass**.

## Test plan
- [x] Black 26.3.1 formatting clean
- [x] 9 cases pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)