### PR TITLE
fix(test): r-prefix docstring to clear SyntaxWarning on regex pattern

### DIFF
--- a/backend/app/tests/test_user_profile_schemas.py
+++ b/backend/app/tests/test_user_profile_schemas.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Tests for `app/schemas/user_profile.py`.
 
 The advisor + bank + privacy schemas are what every student fills out
@@ -12,7 +12,7 @@ non-obvious behaviour:
     surface as students unable to clear advisor email once set.
 
   - **Email regex validation**: the duplicated raw-string pattern
-    `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$`
+    `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
     is duplicated across BankInfoBase/AdvisorInfoBase/Create/Update.
     All four duplicates must agree — a drift would let one entry
     point accept invalid emails another rejects.
@@ -21,6 +21,10 @@ non-obvious behaviour:
     account_number (50), preferred_language (10).
 
 19 cases pinning the 8 schemas in the module.
+
+Note: this docstring is a raw string (r-prefix) because the regex
+pattern above quotes a literal `\.` — without the r-prefix Python
+emits a SyntaxWarning that blocks any `-W error::SyntaxWarning` CI gate.
 """
 
 import pytest


### PR DESCRIPTION
## Bug
\`test_user_profile_schemas.py:14\` quotes the production email-validation regex pattern \`\\.\` inside its module docstring. Without an r-prefix, Python emits:

\`\`\`
SyntaxWarning: invalid escape sequence '\.'
\`\`\`

This is a recurring warning during every pytest collection and blocks any future \`-W error::SyntaxWarning\` CI gate.

## Discovery
Promoting SyntaxWarning to error during smoke-suite audit:

\`\`\`
docker exec scholarship_backend_dev python -m pytest app/tests/ \\
  --override-ini='addopts=' -m smoke -W error::SyntaxWarning ...
# Interrupted: 1 error during collection
\`\`\`

## Fix
Prefix the module docstring with \`r\` (raw string) so the backslash isn't parsed as an escape sequence. Write the regex pattern in its actual single-backslash form to match production.

## Verification
- 24/24 tests in this file still pass
- \`-W error::SyntaxWarning\` no longer blocks collection

## Test plan
- [x] Black 26.3.1 clean (1 file unchanged)
- [x] 24 tests still pass
- [x] No SyntaxWarning when collecting
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)