### PR TITLE
fix(core): drop unused asyncio import in cache.py

### DIFF
--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -35,7 +35,6 @@ Notes for future maintainers:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import random


### PR DESCRIPTION
## Summary
Last remaining F401 violation backend-wide. \`grep -n "asyncio\\." backend/app/core/cache.py\` returns zero matches — the \`import asyncio\` at line 38 was dead.

## Gate impact
After this PR, the comprehensive lint sweep is clean:

\`\`\`
uvx --from flake8==7.1.1 flake8 backend/app/ --select=E9,F63,F7,F82,F401
# (no output, clean exit)
\`\`\`

Combined with #484 (F821 `func`), #485 (F821 dead-code refs), this completes the multi-PR F-class cleanup started during the production-readiness audit.

## Verification
- Module imports cleanly: \`from app.core.cache import *\`
- Black 26.3.1 formatting passes
- No F401 backend-wide after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)