### PR TITLE
test(core-utilities): fix 8 schema-drift failures — backend -m unit now fully green

### DIFF
--- a/backend/app/tests/test_core_utilities.py
+++ b/backend/app/tests/test_core_utilities.py
@@ -139,10 +139,10 @@ class TestSecurityFunctions:
         payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
         assert "exp" in payload
 
-        # Verify expiry is set to default (15 minutes from now)
+        # Verify expiry is set to the configured default (access_token_expire_minutes)
         exp_time = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         now = datetime.now(timezone.utc)
-        expected_exp = now + timedelta(minutes=15)
+        expected_exp = now + timedelta(minutes=settings.access_token_expire_minutes)
 
         # Allow 1 minute tolerance for test execution time
         assert abs((exp_time - expected_exp).total_seconds()) < 60
@@ -172,7 +172,7 @@ class TestSecurityFunctions:
         payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
 
         # Assert
-        exp_time = datetime.fromtimestamp(payload["exp"])
+        exp_time = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
         now = datetime.now(timezone.utc)
         expected_exp = now + custom_expiry
 
@@ -200,46 +200,47 @@ class TestCustomExceptions:
     def test_not_found_error_creation(self):
         """Test NotFoundError creation"""
         # Arrange
-        message = "Resource not found"
-        resource_type = "User"
-        resource_id = "123"
+        resource = "User"
+        identifier = "123"
 
         # Act
-        error = NotFoundError(message, resource_type=resource_type, resource_id=resource_id)
+        error = NotFoundError(resource, identifier)
 
-        # Assert
-        assert str(error) == message
-        assert error.resource_type == resource_type
-        assert error.resource_id == resource_id
+        # Assert: message includes both resource and identifier
+        assert str(error) == f"{resource} not found: {identifier}"
+        assert error.status_code == 404
+        assert error.error_code == "NOT_FOUND"
 
     def test_authorization_error_creation(self):
         """Test AuthorizationError creation"""
         # Arrange
         message = "Insufficient permissions"
-        required_permission = "admin_access"
 
         # Act
-        error = AuthorizationError(message, required_permission=required_permission)
+        error = AuthorizationError(message)
 
         # Assert
         assert str(error) == message
-        assert error.required_permission == required_permission
+        assert error.status_code == 403
+        assert error.error_code == "AUTHORIZATION_ERROR"
 
     def test_business_logic_error_creation(self):
-        """Test BusinessLogicError creation"""
+        """Test BusinessLogicError creation — error code is fixed, custom data goes in details"""
         # Arrange
         message = "Business rule violation"
-        error_code = "DUPLICATE_APPLICATION"
+        details = {"violation_code": "DUPLICATE_APPLICATION"}
 
         # Act
-        error = BusinessLogicError(message, error_code=error_code)
+        error = BusinessLogicError(message, details=details)
 
         # Assert
         assert str(error) == message
-        assert error.error_code == error_code
+        assert error.status_code == 422
+        assert error.error_code == "BUSINESS_LOGIC_ERROR"
+        assert error.details == details
 
     def test_file_storage_error_creation(self):
-        """Test FileStorageError creation"""
+        """Test FileStorageError creation — file metadata stored in details"""
         # Arrange
         message = "File upload failed"
         file_name = "document.pdf"
@@ -250,8 +251,10 @@ class TestCustomExceptions:
 
         # Assert
         assert str(error) == message
-        assert error.file_name == file_name
-        assert error.storage_path == storage_path
+        assert error.status_code == 500
+        assert error.error_code == "FILE_STORAGE_ERROR"
+        assert error.details["file_name"] == file_name
+        assert error.details["storage_path"] == storage_path
 
 
 @pytest.mark.unit
@@ -541,11 +544,14 @@ class TestValidationHelpers:
         ]
 
         # Act & Assert
+        # check_deliverability=False — CI containers have no DNS resolver
+        # so MX-record lookups fail for every domain, making the test
+        # environment, not the validator, decide the outcome.
         from email_validator import validate_email
 
         for email in valid_emails:
             try:
-                validate_email(email)
+                validate_email(email, check_deliverability=False)
                 is_valid = True
             except Exception:
                 is_valid = False
@@ -567,7 +573,7 @@ class TestValidationHelpers:
 
         for email in invalid_emails:
             with pytest.raises(EmailNotValidError):
-                validate_email(email)
+                validate_email(email, check_deliverability=False)
 
     def test_validate_nycu_id_format(self):
         """Test NYCU ID validation"""
@@ -621,11 +627,16 @@ class TestValidationHelpers:
             sanitized = sanitized.strip(" .")
             return sanitized
 
+        # Each `/` becomes a single `_` (one-to-one substitution); leading
+        # dots are stripped by the trailing strip(" ."). For "../../../etc/passwd"
+        # → "../" * 3 + "etc/passwd" becomes "../_../_../_etc_passwd" via re.sub,
+        # i.e. ".._.._.._etc_passwd"; then strip(" .") trims the leading ".."
+        # → "_.._.._etc_passwd".
         test_cases = [
             ("normal_file.pdf", "normal_file.pdf"),
             ("file with spaces.txt", "file with spaces.txt"),
             ("file<>:pipe.doc", "file___pipe.doc"),
-            ("../../../etc/passwd", "..___..___.._etc_passwd"),
+            ("../../../etc/passwd", "_.._.._etc_passwd"),
             ("  .dotfile.txt  ", "dotfile.txt"),
         ]
 


### PR DESCRIPTION
## Summary
Eight independent schema-drift failures in `backend/app/tests/test_core_utilities.py`, all reflecting production changes the tests had not been updated for:

| # | Test | Drift |
|---|------|-------|
| 1 | `test_create_access_token_default_expiry` | Hardcoded `15`-min expiry; production raised it to 30 min (`settings.access_token_expire_minutes`) |
| 2 | `test_token_expiration_format` | Naive `datetime.fromtimestamp(...)` subtracted from tz-aware `now` |
| 3 | `test_not_found_error_creation` | Used `NotFoundError(msg, resource_type=, resource_id=)`; real signature is `(resource, identifier)` |
| 4 | `test_authorization_error_creation` | Passed `required_permission=`; real signature is `(message)` only |
| 5 | `test_business_logic_error_creation` | Passed `error_code=` kwarg; production constants are fixed, custom data goes in `details` |
| 6 | `test_file_storage_error_creation` | Read `.file_name` / `.storage_path`; production stores them in `.details` |
| 7 | `test_validate_email_format_valid` | `email_validator.validate_email()` now defaults to MX-record DNS checks — broken in CI containers; pass `check_deliverability=False` |
| 8 | `test_sanitize_filename` | Expected `..___..___.._etc_passwd` for `../../../etc/passwd`, but the local sanitizer does a 1-to-1 `/` → `_` substitution; real output is `_.._.._etc_passwd` |

## Why
Closes the `-m unit` failure column. Before/after:

```
before #495: 38 passed / 8 failed /  0 errors / 86 skipped
after  #495: 46 passed / 0 failed /  0 errors / 86 skipped
```

Backend `-m unit` gate is now fully green — no failures, no collection errors.

## Test plan
- [x] `pytest app/tests/test_core_utilities.py -q` → `36 passed`
- [x] `pytest -m unit -q` → `46 passed / 0 failed / 0 errors / 86 skipped`
- [x] `pytest -m smoke -q` still 245/245 green
- [x] `black --check` clean
- [x] `flake8 --select=E9,F63,F7,F82,F401` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)