### PR TITLE
fix(form-data): render nested object form values as JSON, not [object Object]

### DIFF
--- a/frontend/components/__tests__/application-form-data-display.test.tsx
+++ b/frontend/components/__tests__/application-form-data-display.test.tsx
@@ -25,6 +25,26 @@ jest.mock("@/lib/utils/application-helpers", () => ({
   formatFieldValue: jest.fn((fieldName: string, value: any, locale: Locale) =>
     Promise.resolve(value)
   ),
+  // Re-implement the production formatter so the component still
+  // renders objects as JSON (PR #497) under the mock.
+  formatDisplayValue: jest.fn((value: unknown) => {
+    if (value === null || value === undefined) return "";
+    if (typeof value === "string") return value;
+    if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+    if (Array.isArray(value)) {
+      return value.map(String).join(", ");
+    }
+    if (typeof value === "object") {
+      try {
+        return JSON.stringify(value);
+      } catch {
+        return String(value);
+      }
+    }
+    return String(value);
+  }),
 }));
 
 // Mock UI components
@@ -211,8 +231,7 @@ describe("ApplicationFormDataDisplay", () => {
     });
   });
 
-  // TODO: Fix object rendering - component doesn't render nested objects
-  it.skip("should handle nested object values", async () => {
+  it("should handle nested object values by rendering them as JSON", async () => {
     const formData = {
       submitted_form_data: {
         fields: {
@@ -230,8 +249,14 @@ describe("ApplicationFormDataDisplay", () => {
     render(<ApplicationFormDataDisplay formData={formData} locale="zh" />);
 
     await waitFor(() => {
-      // Should display JSON stringified value for complex objects
-      expect(screen.getByText(/123 Main St/)).toBeInTheDocument();
+      // Plain objects render via JSON.stringify (formatDisplayValue) so the
+      // user sees the nested data instead of "[object Object]". The render
+      // happens inside <p>...</p> as a single text node, so the substring
+      // assertion is enough — no need for individual sub-elements.
+      const node = screen.getByText(/123 Main St/);
+      expect(node).toBeInTheDocument();
+      expect(node.textContent).toMatch(/Hsinchu/);
+      expect(node.textContent).toMatch(/Taiwan/);
     });
   });
 

--- a/frontend/components/application-form-data-display.tsx
+++ b/frontend/components/application-form-data-display.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Label } from "@/components/ui/label";
 import { Locale } from "@/lib/validators";
 import {
+  formatDisplayValue,
   formatFieldName,
   formatFieldValue,
 } from "@/lib/utils/application-helpers";
@@ -185,9 +186,12 @@ export function ApplicationFormDataDisplay({
                 <p className="text-sm text-gray-600 mt-1">
                   {key === "scholarship_type"
                     ? "載入中..."
-                    : typeof value === "string" && value.length > 100
-                      ? `${value.substring(0, 100)}...`
-                      : String(value)}
+                    : (() => {
+                        const rendered = formatDisplayValue(value);
+                        return rendered.length > 100
+                          ? `${rendered.substring(0, 100)}...`
+                          : rendered;
+                      })()}
                 </p>
               </div>
             </div>
@@ -221,9 +225,12 @@ export function ApplicationFormDataDisplay({
                 {getFieldLabel(key, locale, fieldLabels)}
               </Label>
               <p className="text-sm text-gray-600 mt-1">
-                {typeof value === "string" && value.length > 100
-                  ? `${value.substring(0, 100)}...`
-                  : String(value)}
+                {(() => {
+                  const rendered = formatDisplayValue(value);
+                  return rendered.length > 100
+                    ? `${rendered.substring(0, 100)}...`
+                    : rendered;
+                })()}
               </p>
             </div>
           </div>

--- a/frontend/lib/utils/__tests__/application-helpers.test.ts
+++ b/frontend/lib/utils/__tests__/application-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   getApplicationTimeline,
   formatFieldName,
   formatFieldValue,
+  formatDisplayValue,
   getDocumentLabel,
   fetchApplicationFiles,
   BadgeVariant,
@@ -408,6 +409,69 @@ describe("Application Helpers", () => {
 
       const result = await fetchApplicationFiles(1);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("formatDisplayValue", () => {
+    // The display formatter is the contract that
+    // application-form-data-display.tsx leans on to avoid rendering
+    // "[object Object]" for nested form-field values.
+    it("returns empty string for null/undefined", () => {
+      expect(formatDisplayValue(null)).toBe("");
+      expect(formatDisplayValue(undefined)).toBe("");
+    });
+
+    it("returns the input unchanged for strings (including empty)", () => {
+      expect(formatDisplayValue("")).toBe("");
+      expect(formatDisplayValue("hello")).toBe("hello");
+      expect(formatDisplayValue("0")).toBe("0");
+    });
+
+    it("stringifies numeric values, preserving 0 and negatives", () => {
+      expect(formatDisplayValue(0)).toBe("0");
+      expect(formatDisplayValue(42)).toBe("42");
+      expect(formatDisplayValue(-1.5)).toBe("-1.5");
+    });
+
+    it("stringifies booleans", () => {
+      expect(formatDisplayValue(true)).toBe("true");
+      expect(formatDisplayValue(false)).toBe("false");
+    });
+
+    it("renders arrays as comma-separated values", () => {
+      // The existing array-rendering test in
+      // application-form-data-display.test.tsx pins this exact shape.
+      expect(formatDisplayValue(["reading", "coding", "music"])).toBe(
+        "reading, coding, music"
+      );
+    });
+
+    it("renders plain objects as JSON instead of [object Object]", () => {
+      // The original bug: String({...}) → "[object Object]".
+      expect(
+        formatDisplayValue({ street: "123 Main St", city: "Hsinchu" })
+      ).toBe('{"street":"123 Main St","city":"Hsinchu"}');
+    });
+
+    it("renders nested objects recursively via JSON.stringify", () => {
+      expect(
+        formatDisplayValue({ address: { city: "Hsinchu" } })
+      ).toBe('{"address":{"city":"Hsinchu"}}');
+    });
+
+    it("recursively formats arrays of objects", () => {
+      expect(
+        formatDisplayValue([{ a: 1 }, { b: 2 }])
+      ).toBe('{"a":1}, {"b":2}');
+    });
+
+    it("falls back to String(value) when JSON.stringify throws (e.g. cycles)", () => {
+      const cyclic: any = { a: 1 };
+      cyclic.self = cyclic;
+      // Should not throw, and should return a defined string.
+      const result = formatDisplayValue(cyclic);
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
     });
   });
 });

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -290,6 +290,42 @@ export const formatFieldName = (fieldName: string, locale: Locale) => {
 };
 
 // 格式化欄位值（從資料庫獲取獎學金類型名稱）
+/**
+ * Render a form-field value as a human-readable string. Used by the
+ * application-form-data-display component to show dynamic-form data
+ * collected from students.
+ *
+ * Why:
+ * - String/number/boolean: use `String(value)` (handles 0, false, etc.).
+ * - null/undefined: return empty string (caller decides placeholder).
+ * - Array: comma-separated stringified items (matches the array-test
+ *   contract from PR #244 and the eye-test of "hobbies: reading, coding").
+ * - Plain object: JSON.stringify so nested data renders as readable JSON
+ *   instead of the default `[object Object]`. (Replaces TODO at
+ *   `application-form-data-display.test.tsx:215`.)
+ *
+ * Truncation is the caller's responsibility — different render paths
+ * use different cap lengths.
+ */
+export const formatDisplayValue = (value: unknown): string => {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => formatDisplayValue(item)).join(", ");
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+};
+
 export const formatFieldValue = async (
   fieldName: string,
   value: any,


### PR DESCRIPTION
## Summary
Form-field values that are nested objects (e.g. bank account JSON, structured addresses) currently render as the literal string \`[object Object]\` to reviewers, because the display component uses \`String(value)\`. Replace with a proper formatter and unskip the test that was sitting behind a \`TODO: Fix object rendering\` since PR #244.

## Changes

### `lib/utils/application-helpers.ts`
New export \`formatDisplayValue(value: unknown): string\`:
- \`null\` / \`undefined\` → \`\"\"\`
- string → unchanged
- number / boolean → \`String(value)\` (so \`0\`/\`false\` survive)
- array → recursive comma-join (preserves the existing array contract)
- plain object → \`JSON.stringify\` with \`String()\` fallback for cycles

### `components/application-form-data-display.tsx`
Replace both \`String(value)\` call-sites (loading branch + post-load branch) with \`formatDisplayValue(value)\`. Truncation cap (100 chars) now applies to the formatted string, so a long JSON payload is also capped.

### Tests
- Unskip \`should handle nested object values\` in \`application-form-data-display.test.tsx\`, rename to make the contract explicit, and assert on both \`street\` and \`city\` substrings.
- Update the in-test \`jest.mock\` to expose the new export.
- Add 8 new \`formatDisplayValue\` unit tests covering null/undefined, primitives, string/object arrays, nested objects, and the cyclic-reference fallback.

## Effect on the frontend jest gate
```
before #497: 538 passed / 126 skipped
after  #497: 548 passed / 125 skipped
```
+9 = 8 new unit tests + 1 newly-unskipped component test. Addresses autonomous-loop hook complaint #5 (\"123 skipped tests across 12 test suites\") with one real product-level bugfix.

## Test plan
- [x] \`jest lib/utils/__tests__/application-helpers.test.ts\` → 36 passed
- [x] \`jest components/__tests__/application-form-data-display.test.tsx\` → 10 passed (was 9 passed / 1 skipped)
- [x] Full jest suite → 548 passed / 125 skipped / 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)