### PR TITLE
fix(application-detail-dialog): render nested form values as JSON (follow-up to #497)

### DIFF
--- a/frontend/components/application-detail-dialog.tsx
+++ b/frontend/components/application-detail-dialog.tsx
@@ -43,6 +43,7 @@ import {
   getDocumentLabel,
   fetchApplicationFiles,
   formatFieldName,
+  formatDisplayValue,
 } from "@/lib/utils/application-helpers";
 import { useReferenceData, getDegreeName } from "@/hooks/use-reference-data";
 import {
@@ -730,9 +731,12 @@ export function ApplicationDetailDialog({
                             {getFieldLabel(key, locale, fieldLabels)}
                           </Label>
                           <p className="text-sm text-gray-800">
-                            {typeof value === "string" && value.length > 50
-                              ? `${value.substring(0, 50)}...`
-                              : String(value)}
+                            {(() => {
+                              const rendered = formatDisplayValue(value);
+                              return rendered.length > 50
+                                ? `${rendered.substring(0, 50)}...`
+                                : rendered;
+                            })()}
                           </p>
                         </div>
                       );


### PR DESCRIPTION
## Summary
Second occurrence of the \`[object Object]\` bug surfaced by #497. \`application-detail-dialog.tsx:735\` iterates \`Object.entries(basicFields)\` from a student's submitted form data and renders each via \`String(value)\`, which produces \`[object Object]\` for any nested-object value.

## Base
This PR targets the \`fix/form-data-object-render\` branch (the head branch of #497) so the new \`formatDisplayValue\` helper is in scope. **Will auto-retarget to \`main\` when #497 merges.**

## Why
Same surface, same user impact: admins and reviewers see \`[object Object]\` instead of structured form data on the application detail page. Without the fix, the bug in #497 only gets cleared on the loading and post-load branches of \`application-form-data-display.tsx\` — leaving the detail-dialog rendering still broken.

## Change
Replace the \`String(value)\` call-site at \`application-detail-dialog.tsx:735\` with the same \`formatDisplayValue\` helper used in #497. Truncation cap (50 chars) now applies to the formatted string instead of just string-typed values, so a long JSON payload also gets capped.

No new tests in this PR — the helper contract is already covered by the 8 unit tests added in #497, and \`application-detail-dialog.tsx\` has no existing test suite to extend.

## Test plan
- [x] \`tsc --noEmit\` clean for the modified file
- [x] Diff against #497 base shows only 1 file, +7/-3
- [x] Helper contract unit-tested in #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)