### PR TITLE
fix(core): preserve exception chains in security + regex_validator

### DIFF
--- a/backend/app/core/regex_validator.py
+++ b/backend/app/core/regex_validator.py
@@ -124,11 +124,11 @@ def validate_regex_pattern(pattern: str, test_string: Optional[str] = None, time
                 signal.alarm(0)
 
     except re.error as e:
-        raise RegexValidationError(f"Invalid regex pattern: {str(e)}")
+        raise RegexValidationError(f"Invalid regex pattern: {str(e)}") from e
     except RegexTimeoutError:
         raise
     except Exception as e:
-        raise RegexValidationError(f"Failed to validate regex pattern: {str(e)}")
+        raise RegexValidationError(f"Failed to validate regex pattern: {str(e)}") from e
 
     # Test the compiled pattern with timeout if test_string provided
     if test_string is not None:
@@ -192,10 +192,10 @@ def safe_regex_match(pattern: str, string: str, flags: int = 0, timeout_seconds:
             if hasattr(signal, "SIGALRM"):
                 signal.alarm(0)
 
-    except RegexTimeoutError:
-        raise RegexValidationError("Regex matching timed out (potential ReDoS)")
+    except RegexTimeoutError as exc:
+        raise RegexValidationError("Regex matching timed out (potential ReDoS)") from exc
     except re.error as e:
-        raise RegexValidationError(f"Regex error: {str(e)}")
+        raise RegexValidationError(f"Regex error: {str(e)}") from e
 
 
 def safe_regex_search(pattern: str, string: str, flags: int = 0, timeout_seconds: int = 1) -> Optional[re.Match]:
@@ -235,7 +235,7 @@ def safe_regex_search(pattern: str, string: str, flags: int = 0, timeout_seconds
             if hasattr(signal, "SIGALRM"):
                 signal.alarm(0)
 
-    except RegexTimeoutError:
-        raise RegexValidationError("Regex search timed out (potential ReDoS)")
+    except RegexTimeoutError as exc:
+        raise RegexValidationError("Regex search timed out (potential ReDoS)") from exc
     except re.error as e:
-        raise RegexValidationError(f"Regex error: {str(e)}")
+        raise RegexValidationError(f"Regex error: {str(e)}") from e

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -52,10 +52,10 @@ def verify_token(token: str) -> Dict[str, Any]:
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
         return payload
-    except jwt.ExpiredSignatureError:
-        raise AuthenticationError("Token has expired")
-    except jwt.PyJWTError:
-        raise AuthenticationError("Invalid token")
+    except jwt.ExpiredSignatureError as exc:
+        raise AuthenticationError("Token has expired") from exc
+    except jwt.PyJWTError as exc:
+        raise AuthenticationError("Invalid token") from exc
 
 
 async def get_current_user(
@@ -74,8 +74,8 @@ async def get_current_user(
         user_id = int(user_id_str)  # Convert string back to int
     except AuthenticationError:
         raise  # Re-raise authentication errors as-is
-    except Exception:
-        raise AuthenticationError("Could not validate credentials")
+    except Exception as exc:
+        raise AuthenticationError("Could not validate credentials") from exc
 
     # Get user from database with relationships that will be used in-request
     stmt = select(User).options(selectinload(User.admin_scholarships)).where(User.id == user_id)


### PR DESCRIPTION
## Summary
8 sites across two security-critical core modules use \`except → raise <NewError>(...)\` without \`from <exc>\`, which drops the underlying cause from the traceback. Switch all of them to explicit chaining so the original exception survives in \`__cause__\`.

## Why
When an auth or regex-validation incident reaches the logs, the operator currently sees only the translated wrapper exception (\`AuthenticationError(\"Invalid token\")\`, \`RegexValidationError(\"Regex error: ...\")\`). The real cause — \`jwt.ExpiredSignatureError\`, \`jwt.InvalidSignatureError\`, \`re.error\`, \`ValueError\` from \`int(user_id_str)\`, etc. — has been silently swallowed by Python's implicit-chaining rules in nested \`except\` blocks. PEP 3134 chaining (\`raise ... from exc\`) is the standard fix.

## Changes

### \`backend/app/core/security.py\` (3 sites)
- \`verify_token\`: \`jwt.ExpiredSignatureError\` and \`jwt.PyJWTError\` now chain into \`AuthenticationError\`. The traceback now shows whether the 401 came from clock skew, key rotation, or a malformed header.
- \`get_current_user\`: the catch-all \`except Exception\` (currently triggered when \`payload.get(\"sub\")\` or \`int(user_id_str)\` blow up) now chains too, so \`ValueError\` from a non-numeric \`sub\` claim is no longer hidden.

### \`backend/app/core/regex_validator.py\` (5 sites)
- \`validate_regex_pattern\`: \`re.error\` and the catch-all \`Exception\` chain.
- \`safe_regex_match\`: \`RegexTimeoutError\` and \`re.error\` chain.
- \`safe_regex_search\`: same two.
- Useful when an admin supplies a malformed validation pattern: the original \`re.error\` (with \`.pattern\` and \`.pos\` attributes) is now reachable from the wrapper.

## Compatibility
No behavior change for callers — the same exception types are raised with the same messages and \`status_code\`s. Only the \`__cause__\` attribute on each raised exception is now populated.

## Test plan
- [x] \`black --check\` clean
- [x] \`flake8 --select=E9,F63,F7,F82,F401\` clean
- [x] Smoke pytest gate green
- [x] \`test_core_security.py\`: 39 passed / 5 failed — the 5 failures are pre-existing on \`origin/main\` (MagicMock JSON-serialization issues in fixture setup), not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)