### PR TITLE
chore(scholarship-rules): instrument bulk + copy with structured logging

### DIFF
--- a/backend/app/api/v1/endpoints/scholarship_rules.py
+++ b/backend/app/api/v1/endpoints/scholarship_rules.py
@@ -4,7 +4,7 @@ Handles CRUD operations for scholarship eligibility rules
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, asc, desc, or_, select
@@ -290,47 +290,74 @@ async def bulk_rule_operation(
 ):
     """Perform bulk operations on scholarship rules"""
 
-    # Get rules by IDs
-    stmt = select(ScholarshipRule).filter(ScholarshipRule.id.in_(operation.rule_ids))
-    result = await db.execute(stmt)
-    rules = result.scalars().all()
+    try:
+        # Get rules by IDs
+        stmt = select(ScholarshipRule).filter(ScholarshipRule.id.in_(operation.rule_ids))
+        result = await db.execute(stmt)
+        rules = result.scalars().all()
 
-    if len(rules) != len(operation.rule_ids):
-        raise HTTPException(status_code=404, detail="Some rules not found")
+        if len(rules) != len(operation.rule_ids):
+            raise HTTPException(status_code=404, detail="Some rules not found")
 
-    processed_count = 0
+        processed_count = 0
 
-    if operation.operation == "activate":
-        for rule in rules:
-            rule.is_active = True
-            rule.updated_by = current_user.id
-            processed_count += 1
+        if operation.operation == "activate":
+            for rule in rules:
+                rule.is_active = True
+                rule.updated_by = current_user.id
+                processed_count += 1
 
-    elif operation.operation == "deactivate":
-        for rule in rules:
-            rule.is_active = False
-            rule.updated_by = current_user.id
-            processed_count += 1
+        elif operation.operation == "deactivate":
+            for rule in rules:
+                rule.is_active = False
+                rule.updated_by = current_user.id
+                processed_count += 1
 
-    elif operation.operation == "delete":
-        for rule in rules:
-            await db.delete(rule)
-            processed_count += 1
+        elif operation.operation == "delete":
+            for rule in rules:
+                await db.delete(rule)
+                processed_count += 1
 
-    else:
-        raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.operation}")
+        else:
+            raise HTTPException(status_code=400, detail=f"Unknown operation: {operation.operation}")
 
-    await db.commit()
+        await db.commit()
 
-    return ApiResponse(
-        success=True,
-        message=f"Bulk {operation.operation} completed for {processed_count} rules",
-        data={
-            "operation": operation.operation,
-            "processed_count": processed_count,
-            "rule_ids": operation.rule_ids,
-        },
-    )
+        logger.info(
+            "Bulk scholarship rule %s by user_id=%s processed %d rule(s)",
+            operation.operation,
+            current_user.id,
+            processed_count,
+            extra={
+                "operation": operation.operation,
+                "rule_ids": operation.rule_ids,
+                "processed_count": processed_count,
+                "actor_user_id": current_user.id,
+            },
+        )
+
+        return ApiResponse(
+            success=True,
+            message=f"Bulk {operation.operation} completed for {processed_count} rules",
+            data={
+                "operation": operation.operation,
+                "processed_count": processed_count,
+                "rule_ids": operation.rule_ids,
+            },
+        )
+
+    except HTTPException:
+        raise  # Re-raise client/server errors with their intended status code
+    except Exception:
+        logger.exception(
+            "Bulk scholarship rule operation failed",
+            extra={
+                "operation": operation.operation,
+                "rule_ids": operation.rule_ids,
+                "actor_user_id": current_user.id,
+            },
+        )
+        raise
 
 
 @router.post("/copy")
@@ -438,6 +465,28 @@ async def copy_rules(
             copied_count += 1
 
     await db.commit()
+
+    logger.info(
+        "Scholarship rules copied by user_id=%s: copied=%d skipped=%d (AY%s sem=%s → AY%s sem=%s)",
+        current_user.id,
+        copied_count,
+        skipped_count,
+        copy_request.source_academic_year,
+        copy_request.source_semester.value if copy_request.source_semester else "All",
+        copy_request.target_academic_year,
+        copy_request.target_semester.value if copy_request.target_semester else "All",
+        extra={
+            "copied_count": copied_count,
+            "skipped_count": skipped_count,
+            "source_academic_year": copy_request.source_academic_year,
+            "source_semester": copy_request.source_semester.value if copy_request.source_semester else None,
+            "target_academic_year": copy_request.target_academic_year,
+            "target_semester": copy_request.target_semester.value if copy_request.target_semester else None,
+            "scholarship_type_ids": copy_request.scholarship_type_ids,
+            "overwrite_existing": copy_request.overwrite_existing,
+            "actor_user_id": current_user.id,
+        },
+    )
 
     return ApiResponse(
         success=True,


### PR DESCRIPTION
## Summary
\`backend/app/api/v1/endpoints/scholarship_rules.py\` declared \`logger = logging.getLogger(__name__)\` (line 28) but had **zero** \`logger.X()\` calls across 500 LOC and 8 endpoints. Any 5xx from these admin endpoints surfaced in Loki/Grafana as an opaque 500 with no actor, no rule IDs, and no operation context. Plan-flagged observability gap (audit Wave 1).

## Changes

### \`bulk_rule_operation\` (\`POST /scholarship-rules/bulk\`)
- Wrap body in \`try / except HTTPException / except Exception\`.
- On success: \`logger.info\` with operation + processed_count + rule_ids + actor_user_id (structured extras).
- On 5xx: \`logger.exception\` with the same extras so Loki queries can pivot from a traceback to the rules touched by the failed call.
- \`HTTPException\` re-raised unchanged (preserves 400/404 status codes).

### \`copy_rules\` (\`POST /scholarship-rules/copy\`)
- \`logger.info\` on success with copied/skipped counts, source/target period (academic_year + semester), scholarship_type_ids, overwrite_existing, actor_user_id.
- No try/except wrap here — the function does single-step DB writes via \`db.commit()\` and FastAPI's default 500 handler captures the traceback. The value-add is the success audit breadcrumb.

### Misc
- Drop unused \`typing.Any, Dict, List\` imports (pre-existing F401 noise on this file).

## Why
The hook's repeated complaint includes \"no systematic audit of error handling\". These two endpoints are the most consequential write operations in the rules module — \`bulk\` deletes/toggles arbitrary rule sets, \`copy\` clones across academic periods. Without structured logging, post-incident audits have nothing to pivot from. This PR adds the minimum useful set without changing behavior.

## Compatibility
No behavior change for callers; same response shapes, same status codes. \`HTTPException\` re-raise preserves 400/404 path. Catch-all logs and re-raises the exception so FastAPI's 500 handler still runs.

## Test plan
- [x] \`black --check\` clean
- [x] \`flake8 --select=E9,F63,F7,F82,F401\` clean (the 3 pre-existing F401 errors removed by this PR)
- [x] Python AST parse clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)