### PR TITLE
chore(users-endpoint): instrument destructive admin endpoints with structured logging

### DIFF
--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -386,9 +386,28 @@ async def delete_user(
     if user.id == current_user.id:
         raise HTTPException(status_code=400, detail="Cannot delete your own account")
 
+    # Capture identity *before* the delete so the audit log survives the
+    # SQLAlchemy cascade. After db.delete(user) the attached object's
+    # attributes may be expired.
+    deleted_email = user.email
+    deleted_role = user.role.value if hasattr(user.role, "value") else str(user.role)
+
     await db.delete(user)
     await db.commit()
     await cache_invalidate("dashboard:")
+
+    logger.warning(
+        "User %s (role=%s) hard-deleted by admin user_id=%s",
+        id,
+        deleted_role,
+        current_user.id,
+        extra={
+            "deleted_user_id": id,
+            "deleted_email": deleted_email,
+            "deleted_role": deleted_role,
+            "actor_user_id": current_user.id,
+        },
+    )
 
     return {
         "success": True,
@@ -443,10 +462,25 @@ async def update_user_college(
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
+    previous_college_code = user.college_code
     user.college_code = college_code
     await db.commit()
     await db.refresh(user)
     await cache_invalidate("dashboard:")
+
+    logger.info(
+        "User %s college_code changed %r → %r by super-admin user_id=%s",
+        id,
+        previous_college_code,
+        college_code,
+        current_user.id,
+        extra={
+            "target_user_id": id,
+            "previous_college_code": previous_college_code,
+            "new_college_code": college_code,
+            "actor_user_id": current_user.id,
+        },
+    )
 
     return {
         "success": True,
@@ -544,6 +578,25 @@ async def bulk_assign_scholarships(
         removed_count=removed_count,
         total_scholarships=len(scholarships),
         scholarships=[{"id": s.id, "code": s.code, "name": s.name} for s in scholarships],
+    )
+
+    logger.info(
+        "Bulk scholarship %s on user %s by super-admin user_id=%s: assigned=%d removed=%d total=%d",
+        request.operation,
+        id,
+        current_user.id,
+        assigned_count,
+        removed_count,
+        len(scholarships),
+        extra={
+            "target_user_id": id,
+            "operation": request.operation,
+            "requested_scholarship_ids": request.scholarship_ids,
+            "assigned_count": assigned_count,
+            "removed_count": removed_count,
+            "total_after": len(scholarships),
+            "actor_user_id": current_user.id,
+        },
     )
 
     return {


### PR DESCRIPTION
## Summary
\`backend/app/api/v1/endpoints/users.py\` had a configured \`logger\` at module top but **zero** \`logger.X()\` calls across 601 LOC. Any audit of \"who deleted which user, who changed college assignment, who toggled scholarship permissions\" had to be reconstructed from indirect evidence (DB diffs, frontend session traces). Same plan-Wave-1 gap as #501.

## Changes — three destructive admin endpoints now log structured audit breadcrumbs

### \`DELETE /users/{id}\` — \`logger.warning\`
- Hard delete, so the log level is **warning** not info — these calls should stand out in Loki.
- Captures \`deleted_user_id\`, \`deleted_email\`, \`deleted_role\`, \`actor_user_id\`.
- Email + role captured **before** \`db.delete(user)\` to survive the SQLAlchemy cascade (attached objects can have expired attributes after delete).

### \`PATCH /users/{id}/college\` — \`logger.info\`
- Captures \`target_user_id\`, \`previous_college_code\`, \`new_college_code\`, \`actor_user_id\`.
- Pre/post values let an auditor reconstruct the timeline of college re-assignments after a permissions incident.

### \`POST /users/{id}/scholarships/bulk\` — \`logger.info\`
- Captures \`target_user_id\`, \`operation\` (set|add), \`requested_scholarship_ids\`, \`assigned_count\`, \`removed_count\`, \`total_after\`, \`actor_user_id\`.
- The count fields differentiate \"this run was a no-op\" from \"this run cleared every existing assignment\".

## Compatibility
No behavior change. Same status codes, same response shapes. Log volume grows only on the success path of these three endpoints; volume is bounded by admin activity (low-traffic).

## Test plan
- [x] AST parse clean
- [x] \`black --check\` clean
- [x] \`flake8 --select=E9,F63,F7,F82,F401\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)