### PR TITLE
fix(core): clear all 13 remaining B904 exception-chain violations (backend → 0)

### DIFF
--- a/backend/app/core/regex_validator.py
+++ b/backend/app/core/regex_validator.py
@@ -143,8 +143,8 @@ def validate_regex_pattern(pattern: str, test_string: Optional[str] = None, time
                 if hasattr(signal, "SIGALRM"):
                     signal.alarm(0)
 
-        except RegexTimeoutError:
-            raise RegexValidationError("Regex pattern causes excessive backtracking (ReDoS vulnerability)")
+        except RegexTimeoutError as exc:
+            raise RegexValidationError("Regex pattern causes excessive backtracking (ReDoS vulnerability)") from exc
         except Exception:
             # Other exceptions during matching are acceptable
             pass

--- a/backend/app/core/schema_validation.py
+++ b/backend/app/core/schema_validation.py
@@ -49,7 +49,9 @@ def validate_response_data(data: Any, schema: Type[BaseModel]) -> bool:
             field_path = " -> ".join(str(loc) for loc in error["loc"])
             error_details.append(f"Field '{field_path}': {error['msg']}")
 
-        raise SchemaValidationError(f"Schema validation failed for {schema.__name__}:\n" + "\n".join(error_details))
+        raise SchemaValidationError(
+            f"Schema validation failed for {schema.__name__}:\n" + "\n".join(error_details)
+        ) from e
 
 
 def convert_sqlalchemy_to_response_dict(

--- a/backend/app/integrations/nycu_emp/client_http.py
+++ b/backend/app/integrations/nycu_emp/client_http.py
@@ -176,14 +176,14 @@ class NYCUEmpHttpClient(NYCUEmpClientBase):
 
         except httpx.TimeoutException as e:
             logger.error(f"Request timeout: {e}")
-            raise NYCUEmpTimeoutError(f"Request timed out after {self.timeout}s")
+            raise NYCUEmpTimeoutError(f"Request timed out after {self.timeout}s") from e
 
         except httpx.ConnectError as e:
             logger.error(f"Connection error: {e}")
-            raise NYCUEmpConnectionError(f"Failed to connect to {self.endpoint}")
+            raise NYCUEmpConnectionError(f"Failed to connect to {self.endpoint}") from e
 
         except Exception as e:
             if isinstance(e, NYCUEmpError):
                 raise
             logger.error(f"Unexpected error: {e}")
-            raise NYCUEmpError(f"Unexpected error: {str(e)}")
+            raise NYCUEmpError(f"Unexpected error: {str(e)}") from e

--- a/backend/app/utils/date_utils.py
+++ b/backend/app/utils/date_utils.py
@@ -54,7 +54,7 @@ def parse_date_field(date_input: Optional[Union[str, datetime]]) -> Optional[dat
                 return dateutil.parser.parse(date_input)
             except Exception as e2:
                 logger.error(f"Could not parse date '{date_input}' with any method: {e2}")
-                raise ValueError(f"Invalid date format: {date_input}")
+                raise ValueError(f"Invalid date format: {date_input}") from e2
 
     return None
 

--- a/backend/app/utils/endpoint_decorators.py
+++ b/backend/app/utils/endpoint_decorators.py
@@ -48,48 +48,48 @@ def handle_college_review_errors(func: Callable) -> Callable:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=str(e),
-            )
+            ) from e
 
         except RankingNotFoundError as e:
             logger.warning(f"Ranking not found: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=str(e),
-            )
+            ) from e
 
         except RankingModificationError as e:
             logger.warning(f"Ranking modification error: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=str(e),
-            )
+            ) from e
 
         except ValueError as e:
             logger.warning(f"Invalid value: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid request data: {str(e)}",
-            )
+            ) from e
 
         except IntegrityError as e:
             logger.error(f"Database integrity error: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="The request conflicts with existing data",
-            )
+            ) from e
 
         except DatabaseError as e:
             logger.error(f"Database error: {str(e)}")
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Database service temporarily unavailable",
-            )
+            ) from e
 
         except Exception as e:
             logger.error(f"Unexpected error in {func.__name__}: {str(e)}", exc_info=True)
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="An unexpected error occurred",
-            )
+            ) from e
 
     return wrapper


### PR DESCRIPTION
## Summary
Systematic pass. After PR #499 (8 sites in security + regex_validator) and PR #503 (3 sites in pre_authorization), a \`flake8-bugbear B904\` sweep across \`backend/app\` reveals exactly **13 remaining** \`raise SomeError(...)\` sites inside \`except\` blocks that drop the original cause from the traceback. This PR clears all of them.

```
before: 13 B904 violations across 5 files
after:  0 B904 violations backend-wide
```

## Files and what each site translates

### \`core/regex_validator.py:147\` — 1 site
\`RegexTimeoutError\` → \`RegexValidationError\`. Last hold-out from #499; missed because it lives inside a nested try in \`validate_regex_pattern\` that #499 didn't touch.

### \`core/schema_validation.py:52\` — 1 site
\`pydantic.ValidationError\` → \`SchemaValidationError\`. Preserves the structured \`error_details\` on \`__cause__\` for traceback consumers.

### \`integrations/nycu_emp/client_http.py:179, 183, 189\` — 3 sites
- \`httpx.TimeoutException\` → \`NYCUEmpTimeoutError\`
- \`httpx.ConnectError\` → \`NYCUEmpConnectionError\`
- \`Exception\` → \`NYCUEmpError\`

External-API failures; preserving \`__cause__\` is especially valuable since the wrapping just renames the error class without adding diagnostic info.

### \`utils/date_utils.py:57\` — 1 site
\`Exception\` from \`dateutil.parser.parse\` → \`ValueError(\"Invalid date format: ...\")\`. The dateutil error often has the more useful \"Unknown string format\" message.

### \`utils/endpoint_decorators.py:48, 55, 62, 69, 76, 83, 90\` — 7 sites
Seven sites in the \`handle_college_review_errors\` decorator, mapping each domain exception class to an \`HTTPException\` with the right status code. All seven now chain through \`__cause__\`. **Critical** because this decorator wraps every college-review endpoint — losing chains here hides root causes from operators across an entire feature area.

## Why this matters as a checkpoint

- This was the recurring drift class behind PR #499, #500, #503.
- Each missed site is a future debugging session running blind.
- With B904 at 0, a follow-up PR can wire \`flake8-bugbear\` into CI so the count *stays* at 0 — that's a separate decision because adding bugbear may surface other rule violations worth a triage-and-cleanup pass first.

## Compatibility
No behavior change for callers — same exception classes raised with the same messages and (for HTTPException) status codes. Only \`__cause__\` becomes non-None.

## Test plan
- [x] \`uvx --from flake8==7.1.1 --with flake8-bugbear flake8 --select=B904 backend/app\` → 0 results
- [x] \`black --check\` clean
- [x] \`flake8 --select=E9,F63,F7,F82,F401\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)