### PR TITLE
chore(ci): wire flake8-bugbear into backend lint gate + clear B014

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,19 @@ jobs:
           }
           echo "::endgroup::"
 
+          # flake8-bugbear is installed via requirements-lint.txt. Gate hard
+          # on B904 (exception chain loss) and B014 (redundant exception
+          # types); both reached 0 in PRs #504 / #505 and must stay there.
+          # B008 (function-call default) is intentionally NOT gated because
+          # FastAPI's `Depends(...)` pattern is the project-standard idiom
+          # for argument-default injection.
+          echo "::group::Flake8 Bugbear Gate (B904, B014)"
+          flake8 app --select=B904,B014 --max-line-length=120 || {
+            echo "::error::flake8-bugbear B904/B014 violations found. See PR #504/#505 for the established pattern."
+            exit 1
+          }
+          echo "::endgroup::"
+
           echo "::group::MyPy Type Checking"
           mypy app \
             --ignore-missing-imports \

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -239,7 +239,7 @@ class Settings(BaseSettings):
         try:
             if "alembic" not in sys.argv:
                 os.makedirs(v, exist_ok=True)
-        except (OSError, PermissionError):
+        except OSError:
             # If we can't create the directory, just skip it
             # This happens during Alembic migrations when running as non-root user
             pass
@@ -277,7 +277,7 @@ class Settings(BaseSettings):
         """Ensure roster template directory exists"""
         try:
             os.makedirs(v, exist_ok=True)
-        except (OSError, PermissionError):
+        except OSError:
             pass
         return v
 
@@ -287,7 +287,7 @@ class Settings(BaseSettings):
         """Ensure roster export directory exists"""
         try:
             os.makedirs(v, exist_ok=True)
-        except (OSError, PermissionError):
+        except OSError:
             pass
         return v
 

--- a/backend/requirements-lint.txt
+++ b/backend/requirements-lint.txt
@@ -1,5 +1,6 @@
 black==26.3.1  # Security: fixes arbitrary file writes from unsanitized cache filename (<26.3.1)
-flake8
+flake8==7.1.1
+flake8-bugbear==24.12.12  # B-rules: B904 (exception chaining), B014 (redundant excepts)
 mypy
 pylint
 types-requests


### PR DESCRIPTION
## Summary
Locks in the invariant from PR #504. With backend B904 (exception chain loss) at 0 from #504 and B014 (redundant exception types) at 0 from this PR, both rules are now enforced as a **hard** CI gate on every PR — replacing the per-PR cleanup pattern (#499/#500/#503/#504) with a one-time-enforce-once contract.

**Targets the #504 branch** so the diff stays clean. **Will auto-retarget to \`main\` once #504 merges.**

## Changes

### 1. \`backend/core/config.py\` — fix 3 B014 violations
\`except (OSError, PermissionError):\` is redundant because \`PermissionError\` is a subclass of \`OSError\` — the tuple catches exactly the same exceptions as \`except OSError:\` alone. Three filesystem-fallback sites collapsed.

### 2. \`backend/requirements-lint.txt\`
Add \`flake8-bugbear==24.12.12\`. Pin \`flake8==7.1.1\` to match the version used in the local uvx-driven checks during this session.

### 3. \`.github/workflows/ci.yml\`
Add a second flake8 invocation immediately after the existing soft-warning one:
\`\`\`
flake8 app --select=B904,B014 --max-line-length=120 || exit 1
\`\`\`
The existing soft-warning block is left in place so style noise keeps surfacing without blocking PRs. The new gate is hard-fail.

**B008 (function-call-in-default) is intentionally NOT gated** — it would fire on every FastAPI \`Depends(...)\` argument default (~15 sites across the codebase), which is the project-standard DI pattern.

## Status going forward
| rule | violations | gated? |
|------|------------|--------|
| B904 (exception chain loss) | 0 | ✅ hard-fail |
| B014 (redundant excepts) | 0 | ✅ hard-fail |
| B008 (FastAPI Depends default) | 15 | ❌ intentional |

## Test plan
- [x] \`flake8 app --select=B904,B014\` against this branch → 0 violations
- [x] \`black --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)