### PR TITLE
chore(scholarship-mgmt): instrument bulk admin endpoints + clear 6 B904 sites

### DIFF
--- a/backend/app/api/v1/endpoints/scholarship_management.py
+++ b/backend/app/api/v1/endpoints/scholarship_management.py
@@ -10,6 +10,7 @@ Major changes:
 - Dashboard and types endpoints now use ScholarshipType table
 """
 
+import logging
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
@@ -24,6 +25,8 @@ from app.models.user import User
 from app.schemas.response import ApiResponse
 from app.services.scholarship_service import ScholarshipApplicationService
 from app.utils.scholarship_helpers import get_distinct_sub_types
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -76,9 +79,9 @@ async def create_comprehensive_application(
         )
 
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Application creation failed: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Application creation failed: {str(e)}") from e
     finally:
         sync_session.close()
 
@@ -104,7 +107,7 @@ async def submit_comprehensive_application(
         return ApiResponse(success=True, message=message, data={"application_id": application_id})
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Submission failed: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Submission failed: {str(e)}") from e
     finally:
         sync_session.close()
 
@@ -131,8 +134,8 @@ async def get_applications_by_priority(
         if status:
             try:
                 status_enum = ApplicationStatus(status)
-            except ValueError:
-                raise HTTPException(status_code=400, detail=f"Invalid status: {status}")
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=f"Invalid status: {status}") from e
 
         applications = service.get_applications_by_priority(
             scholarship_type_id=scholarship_type_id,
@@ -173,7 +176,17 @@ async def get_applications_by_priority(
         )
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve applications: {str(e)}")
+        logger.exception(
+            "Failed to retrieve applications by priority",
+            extra={
+                "scholarship_type_id": scholarship_type_id,
+                "semester": semester,
+                "status": status,
+                "limit": limit,
+                "actor_user_id": current_user.id,
+            },
+        )
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve applications: {str(e)}") from e
     finally:
         sync_session.close()
 
@@ -196,6 +209,17 @@ async def process_renewal_applications(
         service = ScholarshipApplicationService(sync_session)
         result = service.process_renewal_applications_first(semester)
 
+        logger.warning(
+            "Renewal applications processed for semester=%s by admin user_id=%s",
+            semester,
+            current_user.id,
+            extra={
+                "semester": semester,
+                "actor_user_id": current_user.id,
+                "result_summary": result if isinstance(result, (dict, list)) else str(result),
+            },
+        )
+
         return ApiResponse(
             success=True,
             message="Renewal applications processed successfully",
@@ -203,7 +227,12 @@ async def process_renewal_applications(
         )
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to process renewals: {str(e)}")
+        logger.exception(
+            "Renewal-applications processing failed for semester=%s",
+            semester,
+            extra={"semester": semester, "actor_user_id": current_user.id},
+        )
+        raise HTTPException(status_code=500, detail=f"Failed to process renewals: {str(e)}") from e
     finally:
         sync_session.close()
 
@@ -288,7 +317,15 @@ async def get_scholarship_dashboard(
         )
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get dashboard data: {str(e)}")
+        logger.exception(
+            "Failed to get scholarship dashboard data",
+            extra={
+                "academic_year": academic_year,
+                "semester": semester,
+                "actor_user_id": current_user.id,
+            },
+        )
+        raise HTTPException(status_code=500, detail=f"Failed to get dashboard data: {str(e)}") from e
 
 
 @router.get("/types/available")
@@ -379,6 +416,25 @@ async def simulate_priority_processing(
 
     # Sort by submission date (renewal applications first)
     simulation_results.sort(key=lambda x: (not x["is_renewal"], x["submission_date"] or ""))
+
+    logger.info(
+        "Priority-processing simulated for %d applications by admin user_id=%s "
+        "(AY=%d semester=%s scholarship_type_id=%d sub_type=%s)",
+        len(simulation_results),
+        current_user.id,
+        academic_year,
+        semester,
+        scholarship_type_id,
+        sub_type,
+        extra={
+            "application_count": len(simulation_results),
+            "academic_year": academic_year,
+            "semester": semester,
+            "scholarship_type_id": scholarship_type_id,
+            "sub_type": sub_type,
+            "actor_user_id": current_user.id,
+        },
+    )
 
     return ApiResponse(
         success=True,


### PR DESCRIPTION
## Summary
\`scholarship_management.py\` was a plan-flagged 0-logger file (395 LOC, no \`logger.X()\` calls). On top of the observability gap, it harboured 6 \`raise HTTPException(...)\` sites inside \`except\` blocks that drop the original cause — these would block the B904 CI gate landing in PR #505.

This PR closes both problems at once.

## Observability

- Add module-level \`logger\`.
- \`process_renewal_applications\` (\`POST /renewals/process-priority\`) — \`logger.warning\` on success with semester + actor_user_id + result_summary; \`logger.exception\` on the 500 path. Renewal processing flips application state for an entire semester worth of records, so warning-level + structured extras keep it searchable in Loki.
- \`simulate_priority_processing\` (\`POST /dev/simulate-priority-processing\`) — \`logger.info\` with application_count, AY/semester/scholarship_type, actor_user_id. Dev-only but still useful in the test environment.

## Exception chain preservation (6 sites)

- \`create_comprehensive_application\` — \`ValueError\` and catch-all both chain.
- \`submit_comprehensive_application\` — catch-all chains.
- \`get_applications_by_priority\` — invalid-status \`ValueError\` and outer catch-all chain; the latter gets \`logger.exception\` so the failed-call's filters survive in Loki.
- \`process_renewal_applications\` — catch-all chains and gets \`logger.exception\`.
- \`get_scholarship_dashboard\` — catch-all chains and gets \`logger.exception\` carrying academic_year + semester.

After this PR, the file has **0 B904 violations** — pre-empts the CI gate added in PR #505.

## Compatibility
No behavior change for callers — same status codes, response shapes, and exception types.

## Test plan
- [x] AST parse clean
- [x] \`black --check\` clean
- [x] \`flake8 --select=B904,B014\` → 0 violations in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)