### PR TITLE
fix(roster): stop hardcoding "monthly" roster_cycle when generating from UI

### DIFF
--- a/frontend/components/roster-management-dashboard.tsx
+++ b/frontend/components/roster-management-dashboard.tsx
@@ -289,6 +289,7 @@ export function RosterManagementDashboard() {
                     <RosterListTable
                       periods={cycleData.periods}
                       configId={selectedConfig.id}
+                      rosterCycle={selectedSchedule.roster_cycle}
                       onRosterGenerated={refetchCycleData}
                     />
                   )}

--- a/frontend/components/roster/PeriodDetailDialog.tsx
+++ b/frontend/components/roster/PeriodDetailDialog.tsx
@@ -49,6 +49,13 @@ interface PeriodDetailDialogProps {
   onOpenChange: (open: boolean) => void
   period: Period
   configId: number
+  /**
+   * Roster cycle from the parent schedule (monthly | semi_yearly | yearly).
+   * Required — previously hardcoded to "monthly" when generating rosters,
+   * which silently mislabelled rosters generated against semi-yearly /
+   * yearly schedules. See PR #507.
+   */
+  rosterCycle: string
   onRosterGenerated?: () => void
 }
 
@@ -57,6 +64,7 @@ export function PeriodDetailDialog({
   onOpenChange,
   period,
   configId,
+  rosterCycle,
   onRosterGenerated,
 }: PeriodDetailDialogProps) {
   const [downloading, setDownloading] = useState(false)
@@ -127,14 +135,12 @@ export function PeriodDetailDialog({
   const handleGenerateNow = async () => {
     setGenerating(true)
     try {
-      // TODO: Need to get schedule_id from parent component
-      // For now, we'll use the generate API directly
       const response = await apiClient.request("/payment-rosters/generate", {
         method: "POST",
         body: JSON.stringify({
           scholarship_configuration_id: configId,
           period_label: period.label,
-          roster_cycle: "monthly", // TODO: Get from schedule
+          roster_cycle: rosterCycle,
           academic_year: parseInt(period.label.split("-")[0]),
           student_verification_enabled: true,
           auto_export_excel: true,

--- a/frontend/components/roster/RosterCycleTimeline.tsx
+++ b/frontend/components/roster/RosterCycleTimeline.tsx
@@ -264,12 +264,13 @@ export function RosterCycleTimeline({ configId }: RosterCycleTimelineProps) {
       </Card>
 
       {/* Period Detail Dialog */}
-      {selectedPeriod && (
+      {selectedPeriod && data && (
         <PeriodDetailDialog
           open={dialogOpen}
           onOpenChange={setDialogOpen}
           period={selectedPeriod}
           configId={configId}
+          rosterCycle={data.roster_cycle}
           onRosterGenerated={loadCycleStatus}
         />
       )}

--- a/frontend/components/roster/RosterListTable.tsx
+++ b/frontend/components/roster/RosterListTable.tsx
@@ -52,12 +52,20 @@ interface Period {
 interface RosterListTableProps {
   periods: Period[];
   configId: number;
+  /**
+   * Roster cycle from the parent schedule (monthly | semi_yearly | yearly).
+   * Required — previously this was hardcoded to "monthly" when generating
+   * rosters, which silently mislabelled rosters generated against
+   * semi-yearly / yearly schedules. See PR #507.
+   */
+  rosterCycle: string;
   onRosterGenerated?: () => void;
 }
 
 export function RosterListTable({
   periods,
   configId,
+  rosterCycle,
   onRosterGenerated,
 }: RosterListTableProps) {
   const [selectedPeriod, setSelectedPeriod] = useState<Period | null>(null);
@@ -157,7 +165,7 @@ export function RosterListTable({
         body: JSON.stringify({
           scholarship_configuration_id: configId,
           period_label: period.label,
-          roster_cycle: "monthly", // TODO: Get from schedule
+          roster_cycle: rosterCycle,
           academic_year: parseInt(period.label.split("-")[0]),
           student_verification_enabled: true,
           auto_export_excel: true,


### PR DESCRIPTION
## Summary
The "Generate Now" path in two frontend components hardcoded \`roster_cycle: "monthly"\` in the body of \`POST /payment-rosters/generate\`, regardless of what cycle the parent schedule actually used. Both sites were tagged with \`// TODO: Get from schedule\` since the original implementation.

\`RosterCycle\` (backend enum) has three values: \`monthly\`, \`semi_yearly\`, \`yearly\`. A schedule configured for \`semi_yearly\` or \`yearly\` had its ad-hoc roster generations silently mislabelled as \`monthly\`. Downstream analytics, exports, and period-window calculations that key on \`roster_cycle\` then produced wrong results.

## Changes

Plumb the real value through as a required \`rosterCycle: string\` prop:

### \`RosterListTable\`
- Required prop, used in the regenerate / generate handler.
- Parent (\`roster-management-dashboard.tsx\`) already has the selected schedule in scope and now passes \`selectedSchedule.roster_cycle\`.

### \`PeriodDetailDialog\`
- Required prop, used in \`handleGenerateNow\`.
- Parent (\`RosterCycleTimeline.tsx\`) already has \`data.roster_cycle\` in scope and passes it.
- The dialog now only renders when both \`selectedPeriod\` and \`data\` are present (the latter was already guaranteed by the surrounding code path; the guard makes it explicit so TS knows \`data.roster_cycle\` is non-null).

Both \`// TODO: Get from schedule\` comments removed in favour of structured doc comments on the new prop explaining the contract and pointing back to this PR.

## Compatibility
No backend change. The API already accepted any \`RosterCycle\` value; the frontend just stops lying about which one it's sending.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] Two TODO comments removed; no remaining hardcoded \`"monthly"\` in \`/payment-rosters/generate\` request bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)