### PR TITLE
chore(scholarships): instrument whitelist toggle + reset; clear 2 B904 sites

### DIFF
--- a/backend/app/api/v1/endpoints/scholarships.py
+++ b/backend/app/api/v1/endpoints/scholarships.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -15,6 +16,8 @@ from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User
 from app.schemas.response import ApiResponse
 from app.schemas.scholarship import EligibleScholarshipResponse, ScholarshipTypeResponse, WhitelistToggleRequest
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -349,6 +352,21 @@ async def reset_application_periods(current_user: User = Depends(require_admin),
         scholarship.application_start_date = start_date
         scholarship.application_end_date = end_date
     await db.commit()
+
+    logger.warning(
+        "Application periods reset for %d scholarship(s) by admin user_id=%s (start=%s end=%s)",
+        len(scholarships),
+        current_user.id,
+        start_date.isoformat(),
+        end_date.isoformat(),
+        extra={
+            "scholarships_updated": len(scholarships),
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "actor_user_id": current_user.id,
+        },
+    )
+
     return ApiResponse(
         success=True,
         message=f"Reset {len(scholarships)} scholarship application periods",
@@ -541,7 +559,11 @@ async def upload_terms_document(
 
     except Exception as e:
         await db.rollback()
-        raise HTTPException(status_code=500, detail=f"Failed to upload terms document: {str(e)}")
+        logger.exception(
+            "Failed to upload terms document",
+            extra={"scholarship_type": scholarship_type, "actor_user_id": current_user.id},
+        )
+        raise HTTPException(status_code=500, detail=f"Failed to upload terms document: {str(e)}") from e
 
 
 @router.get("/{scholarship_type}/terms")
@@ -600,7 +622,11 @@ async def get_terms_document(
         )
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve terms document: {str(e)}")
+        logger.exception(
+            "Failed to retrieve terms document",
+            extra={"scholarship_type": scholarship_type},
+        )
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve terms document: {str(e)}") from e
 
 
 @router.patch("/{id}/whitelist")
@@ -631,11 +657,28 @@ async def toggle_scholarship_whitelist(
         raise HTTPException(status_code=404, detail=f"找不到ID為 {id} 的獎學金類型")
 
     # Update whitelist_enabled
+    previous_state = scholarship.whitelist_enabled
     scholarship.whitelist_enabled = request.enabled
     scholarship.updated_by = current_user.id
 
     await db.commit()
     await db.refresh(scholarship)
+
+    logger.warning(
+        "Scholarship whitelist %s → %s for scholarship_id=%d (%s) by admin user_id=%s",
+        previous_state,
+        scholarship.whitelist_enabled,
+        id,
+        scholarship.code,
+        current_user.id,
+        extra={
+            "scholarship_id": id,
+            "scholarship_code": scholarship.code,
+            "previous_whitelist_enabled": previous_state,
+            "new_whitelist_enabled": scholarship.whitelist_enabled,
+            "actor_user_id": current_user.id,
+        },
+    )
 
     # Get active configuration for amount and other details
     config_stmt = (


### PR DESCRIPTION
## Summary
\`backend/app/api/v1/endpoints/scholarships.py\` (706 LOC, the main scholarship CRUD module) was another plan-flagged 0-logger file. On top of the observability gap, it harboured 2 \`raise HTTPException(500)\` sites without \`from e\` that would block the B904 CI gate from PR #505.

This PR closes both.

## Observability

- Add module-level \`logger\`.
- **\`PATCH /{id}/whitelist\`** (\`toggle_scholarship_whitelist\`) — production endpoint that flips whether a scholarship is whitelist-gated. \`logger.warning\` (warning-level because flipping this changes who can apply) with previous + new state, scholarship_id, scholarship_code, actor_user_id.
- **\`POST /dev/reset-application-periods\`** (dev-only) — \`logger.warning\` capturing number of scholarships touched and the start/end window. Dev-only but mass period reset is the kind of action worth tracking in the test environment.

## Exception chain preservation (2 sites)

- \`POST /{scholarship_type}/upload-terms\`: existing catch-all now gets \`logger.exception\` + \`raise ... from e\`. Carries scholarship_type and actor_user_id in extras.
- \`GET /{scholarship_type}/terms\`: existing catch-all now gets \`logger.exception\` + \`raise ... from e\`. Carries scholarship_type.

After this PR, \`flake8 --select=B904,B014\` on this file is 0 — pre-empts the gate added in PR #505.

## Compatibility
No behavior change for callers — same status codes, response shapes, exception classes.

## Test plan
- [x] AST parse clean
- [x] \`black --check\` clean
- [x] \`flake8 --select=B904,B014\` → 0 in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)