### PR TITLE
fix(user-edit-modal): break useEffect array-prop render loop (same root cause as #509)

### DIFF
--- a/frontend/components/user-edit-modal.tsx
+++ b/frontend/components/user-edit-modal.tsx
@@ -107,17 +107,34 @@ export function UserEditModal({
   }, [isOpen]);
 
   // 初始化已選擇的獎學金 ID
+  //
+  // INFINITE-LOOP FIX (PR #510): same root cause as the FileUpload fix in
+  // PR #509. The default `scholarshipPermissions = []` parameter creates
+  // a fresh array reference on every render, so the useEffect dependency
+  // `[scholarshipPermissions, ...]` always sees a "changed" prop and
+  // re-runs the effect. Without a content-aware bailout, `setSelectedScholarshipIds`
+  // schedules a new array each render and the cycle never stops. Compare
+  // contents before scheduling state updates; rely on React's bailout when
+  // the previous reference is returned.
   React.useEffect(() => {
-    if (scholarshipPermissions.length > 0 && editingUser?.id) {
-      // 只顯示當前編輯用戶的權限
-      const userPermissions = scholarshipPermissions.filter(
-        p => p.user_id === Number(editingUser.id)
-      );
-      const selectedIds = userPermissions.map(p => p.scholarship_id);
-      setSelectedScholarshipIds(selectedIds);
-    } else {
-      setSelectedScholarshipIds([]);
-    }
+    setSelectedScholarshipIds((prev) => {
+      let nextIds: number[];
+      if (scholarshipPermissions.length > 0 && editingUser?.id) {
+        const userPermissions = scholarshipPermissions.filter(
+          p => p.user_id === Number(editingUser.id)
+        );
+        nextIds = userPermissions.map(p => p.scholarship_id);
+      } else {
+        nextIds = [];
+      }
+      if (
+        prev.length === nextIds.length &&
+        prev.every((id, i) => id === nextIds[i])
+      ) {
+        return prev;
+      }
+      return nextIds;
+    });
   }, [scholarshipPermissions, editingUser?.id]);
 
   // 當角色改變時，清除獎學金權限


### PR DESCRIPTION
## Summary
\`UserEditModal\` declares \`scholarshipPermissions: ScholarshipPermission[] = []\` as a defaulted prop. Same antipattern PR #509 hit on \`FileUpload\`: the default-parameter expression creates a fresh \`[]\` reference per render, which makes the useEffect with \`[scholarshipPermissions, editingUser?.id]\` dependency fire on every render. Inside, \`setSelectedScholarshipIds(...)\` allocates a new array → state change → re-render → useEffect fires again → loop.

In practice the modal is gated by \`isOpen\` so the loop only spins while the dialog is mounted. But while it is mounted with \`editingUser\` set, every render allocates a fresh result array even if the underlying permission list didn't change.

## Fix
Same content-comparison + setState-bailout pattern as PR #509:

\`\`\`tsx
React.useEffect(() => {
  setSelectedScholarshipIds((prev) => {
    let nextIds: number[];
    if (scholarshipPermissions.length > 0 && editingUser?.id) {
      const userPermissions = scholarshipPermissions.filter(
        p => p.user_id === Number(editingUser.id)
      );
      nextIds = userPermissions.map(p => p.scholarship_id);
    } else {
      nextIds = [];
    }
    if (
      prev.length === nextIds.length &&
      prev.every((id, i) => id === nextIds[i])
    ) {
      return prev;        // bail — React skips the re-render
    }
    return nextIds;
  });
}, [scholarshipPermissions, editingUser?.id]);
\`\`\`

## Compatibility
No visible behavior change for callers — the modal renders the same selected IDs, just without the wasted re-render cycle.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] Full jest suite → 559 passed / 114 skipped / 0 failed (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)