### PR TITLE
chore(batch-import): audit logging on confirm/delete + clear 5 B904 sites

### DIFF
--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -138,7 +138,7 @@ async def upload_batch_import_data(
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail=f"檔案結構驗證失敗: {str(e)}",
-        )
+        ) from e
 
     # Parse and validate
     normalized_semester = (semester.strip() if isinstance(semester, str) else semester) or None
@@ -694,11 +694,11 @@ async def upload_batch_documents(
     # Validate ZIP file
     try:
         zip_file = zipfile.ZipFile(BytesIO(zip_content))
-    except zipfile.BadZipFile:
+    except zipfile.BadZipFile as e:
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail="無效的 ZIP 檔案",
-        )
+        ) from e
 
     # ZIP bomb protection
     # 1. Check file count limit (max 1000 files)
@@ -1105,6 +1105,20 @@ async def confirm_batch_import(
             created_application_ids=created_ids,
         )
 
+        logger.warning(
+            "Batch import %d confirmed by user_id=%s: %d applications created, %d errors",
+            batch_id,
+            current_user.id,
+            len(created_ids),
+            len(creation_errors),
+            extra={
+                "batch_id": batch_id,
+                "created_application_count": len(created_ids),
+                "creation_error_count": len(creation_errors),
+                "actor_user_id": current_user.id,
+            },
+        )
+
         return {
             "success": True,
             "message": (
@@ -1118,10 +1132,14 @@ async def confirm_batch_import(
     except BatchImportError as e:
         # Re-raise to let the global exception handler deal with it
         # Batch status has already been updated to 'failed' in the service
+        logger.exception(
+            "Batch import confirmation failed",
+            extra={"batch_id": batch_id, "actor_user_id": current_user.id},
+        )
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=e.message,
-        )
+        ) from e
 
 
 @router.get("/history")
@@ -1319,12 +1337,12 @@ async def download_batch_import_file(
     # SECURITY: Validate MinIO object name (CLAUDE.md requirement)
     try:
         validate_object_name_minio(batch_import.file_path)
-    except HTTPException:
+    except HTTPException as exc:
         logger.error(f"Invalid file_path from database: {batch_import.file_path}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="檔案路徑驗證失敗",
-        )
+        ) from exc
 
     # Get file from MinIO
     try:
@@ -1353,13 +1371,14 @@ async def download_batch_import_file(
             headers={"Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"},
         )
     except Exception as e:
-        import logging
-
-        logging.error(f"Failed to download batch import file from MinIO: {e}")
+        logger.exception(
+            "Failed to download batch import file from MinIO",
+            extra={"batch_id": batch_id, "file_path": batch_import.file_path},
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="下載檔案時發生錯誤",
-        )
+        ) from e
 
 
 @router.delete("/{batch_id}")
@@ -1373,12 +1392,11 @@ async def delete_batch_import(
 
     **權限**: College 角色僅能刪除自己上傳的批次，Admin/Super Admin 可刪除所有批次
     """
-    import logging
-
     from app.core.config import settings
     from app.services.minio_service import MinIOService
 
-    logger = logging.getLogger(__name__)
+    # Note: `logger` is already configured at module top (line 44); the
+    # local re-import shadowed it for no reason — removed in PR #511.
 
     # Get batch import with related applications
     stmt = select(BatchImport).where(BatchImport.id == batch_id)
@@ -1425,6 +1443,20 @@ async def delete_batch_import(
     # Delete batch import record
     await db.delete(batch_import)
     await db.commit()
+
+    logger.warning(
+        "Batch import %d (%s) deleted by user_id=%s; %d related applications removed",
+        batch_id,
+        batch_import.file_name,
+        current_user.id,
+        application_count,
+        extra={
+            "batch_id": batch_id,
+            "file_name": batch_import.file_name,
+            "deleted_application_count": application_count,
+            "actor_user_id": current_user.id,
+        },
+    )
 
     return {
         "success": True,


### PR DESCRIPTION
## Summary
\`batch_import.py\` (1645 LOC) was the second-biggest of the remaining low-observability endpoint files: only 2 \`logger.X()\` calls covering an unused error-log and a stale local shadowed-logger. The two most consequential admin operations (\`POST /{batch_id}/confirm\` and \`DELETE /{batch_id}\`) had **no audit breadcrumbs at all**.

This PR fixes observability + exception chains in one pass.

## Observability

- **\`POST /{batch_id}/confirm\` (success path)** — \`logger.warning\` on commit with batch_id, created_application_count, creation_error_count, actor_user_id. Warning level because confirming a batch persists imported records permanently — exactly what operators need to reconstruct from logs after an incident.
- **\`POST /{batch_id}/confirm\` (error path)** — \`logger.exception\` before the 422 conversion so the underlying \`BatchImportError\` chain reaches Loki even though the response only carries the user-visible message.
- **\`DELETE /{batch_id}\` (success path)** — \`logger.warning\` capturing batch_id, file_name, deleted_application_count, actor_user_id. Cascading delete of applications is high-impact.
- **\`GET /{batch_id}/download\` (error path)** — replace the misleading inline \`logging.error(...)\` (used root logger, missed module context) with \`logger.exception(...)\` carrying batch_id + file_path.
- Drop the redundant local \`logger = logging.getLogger(__name__)\` inside \`delete_batch_import\` — it shadowed the module-level logger from line 44 for no reason.

## Exception chain preservation (5 sites)

\`\`\`
before this PR: 5 B904 violations on this file
after this PR:  0
\`\`\`

- L138 — pandas \`read_csv\` failure → 415, chains.
- L698 — \`zipfile.BadZipFile\` → 415, chains.
- L1121 — \`BatchImportError\` → 422, chains.
- L1324 — \`validate_object_name_minio\` HTTPException → 500, chains.
- L1359 — MinIO download Exception → 500, chains and uses module logger.

Pre-empts the B904 CI gate added in PR #505.

## Compatibility
No behavior change for callers — same status codes, response shapes, exception classes. Only \`__cause__\` and the new structured log lines change.

## Test plan
- [x] AST parse clean
- [x] \`black --check\` clean
- [x] \`flake8 --select=B904,B014\` → 0 on this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)