### PR TITLE
fix(system-settings): clear 8 B904 exception-chain violations

### DIFF
--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -80,7 +80,7 @@ async def get_all_configurations(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve configurations: {str(e)}"
-        )
+        ) from e
 
 
 _ALLOWED_DOC_KEYS = {"regulations_url", "sample_document_url"}
@@ -247,7 +247,7 @@ async def get_system_doc_file(
         )
         file_content = response.read()
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"無法取得文件: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"無法取得文件: {str(e)}") from e
 
     content_type = "application/pdf"
     if object_name.endswith(".doc"):
@@ -329,7 +329,7 @@ async def get_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.post("")
@@ -389,7 +389,7 @@ async def create_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to create configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.put("/{id}")
@@ -457,7 +457,7 @@ async def update_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to update configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.delete("/{id}")
@@ -489,7 +489,7 @@ async def delete_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to delete configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.post("/validate")
@@ -520,7 +520,7 @@ async def validate_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to validate configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.get("/categories")
@@ -610,4 +610,4 @@ async def get_configuration_audit_logs(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve audit logs: {str(e)}"
-        )
+        ) from e


### PR DESCRIPTION
## Summary
\`backend/app/api/v1/endpoints/system_settings.py\` had the **largest** single-file B904 count remaining (8 sites — more than any other file in the codebase). All 8 share the same shape:

\`\`\`python
except Exception as e:
    raise HTTPException(
        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
        detail=f"... {str(e)}",
    )
\`\`\`

Drop the original cause from the traceback every time. Mechanical sweep adds \`from e\` to each so the wrapped \`HTTPException\` carries the real underlying exception in \`__cause__\` — operators tracing a 500 in Loki now reach the original DB error / serialization error / etc. instead of an opaque \"Failed to retrieve configurations: <repr>\".

## Sites
- L81 — \`get_all_configurations\` catch-all → 500
- L250 — \`get_system_doc_file\` MinIO read → 500
- L330 — \`get_configuration\` catch-all → 500
- L390 — \`create_configuration\` catch-all → 500
- L458 — \`update_configuration\` catch-all → 500
- L490 — \`delete_configuration\` catch-all → 500
- L521 — \`validate_configuration\` catch-all → 500
- L611 — audit-log read catch-all → 500

After this PR:
\`\`\`
flake8 --select=B904 system_settings.py → 0 (was 8)
\`\`\`

Pre-empts the B904 CI gate added in PR #505.

## Compatibility
No behavior change for callers — same status codes, same response shape, same exception class. Only \`__cause__\` becomes non-None.

## Test plan
- [x] AST parse clean
- [x] \`black --check\` clean
- [x] \`flake8 --select=E9,F63,F7,F82,F401\` clean
- [x] \`flake8 --select=B904\` → 0 violations in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)