### PR TITLE
fix(endpoints): bulk B904 sweep — clear 78 exception-chain violations

### DIFF
--- a/backend/app/api/v1/endpoints/admin/applications.py
+++ b/backend/app/api/v1/endpoints/admin/applications.py
@@ -385,7 +385,7 @@ async def assign_professor_to_application(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND if isinstance(e, NotFoundError) else status.HTTP_403_FORBIDDEN,
             detail=str(e),
-        )
+        ) from e
     except SQLAlchemyError as e:
         logger.error(f"Database error assigning professor: {str(e)}")
         raise HTTPException(

--- a/backend/app/api/v1/endpoints/admin/configurations.py
+++ b/backend/app/api/v1/endpoints/admin/configurations.py
@@ -181,7 +181,7 @@ async def create_configuration(
         return {"success": True, "message": f"Configuration '{config.key}' created successfully", "data": response_data}
 
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except SQLAlchemyError as e:
         logger.error(f"Database error creating configuration: {str(e)}")
         raise HTTPException(
@@ -358,7 +358,7 @@ async def delete_configuration(
         return {"success": True, "message": f"Configuration '{key}' deleted successfully", "data": key}
 
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except SQLAlchemyError as e:
         logger.error(f"Database error deleting configuration: {str(e)}")
         raise HTTPException(

--- a/backend/app/api/v1/endpoints/admin/students.py
+++ b/backend/app/api/v1/endpoints/admin/students.py
@@ -259,4 +259,4 @@ async def get_student_sis_data(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=f"Failed to fetch student data from SIS: {str(e)}"
-        )
+        ) from e

--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -553,7 +553,7 @@ async def restore_application(
                 else status.HTTP_404_NOT_FOUND if isinstance(e, NotFoundError) else status.HTTP_403_FORBIDDEN
             ),
             detail=str(e),
-        )
+        ) from e
 
 
 @router.get("/{id}/files")
@@ -837,7 +837,7 @@ async def update_student_data(
                 else status.HTTP_404_NOT_FOUND if isinstance(e, NotFoundError) else status.HTTP_403_FORBIDDEN
             ),
             detail=str(e),
-        )
+        ) from e
 
 
 @router.get("/{id}/student-data")

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -186,7 +186,7 @@ async def mock_sso_login(request: Request, request_data: PortalSSORequest, db: A
             },
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 async def get_portal_sso_data(
@@ -274,7 +274,7 @@ async def portal_sso_verify(
             # Return in exact portal format for testing
             return {"status": "success", "message": "jwt pass", "data": portal_data}
         except ValueError as e:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
     # Real Portal SSO flow
     if not final_token:
@@ -328,7 +328,7 @@ async def portal_sso_verify_get(username: str, db: AsyncSession = Depends(get_db
         # Return in exact portal format
         return {"status": "success", "message": "jwt pass", "data": portal_data}
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 # Developer Profile endpoints for personalized testing
@@ -455,7 +455,7 @@ async def create_custom_profile(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid profile data: {str(e)}",
-        )
+        ) from e
 
 
 @router.post("/dev-profiles/{developer_id}/student-suite")

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -138,7 +138,7 @@ async def upload_batch_import_data(
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail=f"檔案結構驗證失敗: {str(e)}",
-        )
+        ) from e
 
     # Parse and validate
     normalized_semester = (semester.strip() if isinstance(semester, str) else semester) or None

--- a/backend/app/api/v1/endpoints/college_review/export_package.py
+++ b/backend/app/api/v1/endpoints/college_review/export_package.py
@@ -56,7 +56,7 @@ async def export_application_package(
             college_code=college_code,
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
     encoded_filename = quote(zip_filename)
 

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -249,9 +249,9 @@ async def create_ranking(
         )
 
     except AuthorizationError as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except NotFoundError as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except ValueError as e:
         logger.warning(f"Invalid ranking creation data: {str(e)}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid ranking data: {str(e)}")
@@ -644,9 +644,9 @@ async def update_ranking_order(
         )
 
     except AuthorizationError as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except NotFoundError as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingNotFoundError as e:
         logger.warning(f"Ranking not found for order update: {str(e)}")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -743,9 +743,9 @@ async def finalize_ranking(
         )
 
     except AuthorizationError as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except NotFoundError as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingNotFoundError as e:
         logger.warning(f"Ranking not found for finalization: {str(e)}")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -837,9 +837,9 @@ async def unfinalize_ranking(
         )
 
     except AuthorizationError as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except NotFoundError as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingNotFoundError as e:
         logger.warning(f"Ranking not found for unfinalization: {str(e)}")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/api/v1/endpoints/email_management.py
+++ b/backend/app/api/v1/endpoints/email_management.py
@@ -154,7 +154,7 @@ async def approve_scheduled_email(
         )
         return {"success": True, "message": "Scheduled email approved successfully", "data": scheduled_email}
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to approve email")
 
@@ -173,7 +173,7 @@ async def cancel_scheduled_email(
         scheduled_email = await email_service.cancel_scheduled_email(db=db, email_id=email_id)
         return {"success": True, "message": "Scheduled email approved successfully", "data": scheduled_email}
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to cancel email")
 
@@ -199,7 +199,7 @@ async def update_scheduled_email(
         )
         return {"success": True, "message": "Scheduled email approved successfully", "data": scheduled_email}
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to update scheduled email")
 
@@ -222,7 +222,7 @@ async def process_due_emails(
         stats = await email_service.process_due_emails(db=db, batch_size=batch_size)
         return {"success": True, "message": "Emails processed successfully", "data": EmailProcessingStats(**stats)}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to process emails: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Failed to process emails: {str(e)}") from e
 
 
 @router.get("/categories")
@@ -288,7 +288,7 @@ async def get_test_mode_status(*, db: AsyncSession = Depends(get_db), current_us
         return ApiResponse(success=True, message="Test mode status retrieved successfully", data=test_config)
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get test mode status: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Failed to get test mode status: {str(e)}") from e
 
 
 @router.post("/test-mode/enable")
@@ -457,7 +457,7 @@ async def get_test_mode_audit_logs(
         )
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get audit logs: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Failed to get audit logs: {str(e)}") from e
 
 
 @router.delete("/test-mode/audit-logs/cleanup")
@@ -548,7 +548,9 @@ async def send_test_email(
                 request.body_override if request.body_override else template.body_template.format(**request.test_data)
             )
         except KeyError as e:
-            raise HTTPException(status_code=400, detail=f"模板變數缺失：{str(e)}。請確保 test_data 包含所有必需的變數")
+            raise HTTPException(
+                status_code=400, detail=f"模板變數缺失：{str(e)}。請確保 test_data 包含所有必需的變數"
+            ) from e
 
         # Initialize email service with database session
         email_service = EmailService(db)
@@ -734,7 +736,7 @@ async def get_email_templates(*, db: AsyncSession = Depends(get_db), current_use
         return ApiResponse(success=True, message=f"成功獲取 {len(template_list)} 個郵件模板", data=template_list)
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"獲取郵件模板失敗: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"獲取郵件模板失敗: {str(e)}") from e
 
 
 # ========== React Email Template Endpoints ==========

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -201,7 +201,7 @@ async def allocate(
             "data": result,
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.post("/finalize")
@@ -225,7 +225,7 @@ async def finalize(
             "data": result,
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.get("/{scholarship_type_id}/history")
@@ -311,7 +311,7 @@ async def restore_from_history(
             "data": restore_result,
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except Exception as e:
         logger.error(f"Error restoring from history: {str(e)}")
         raise HTTPException(
@@ -496,7 +496,7 @@ async def generate_rosters_from_distribution(
             },
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except Exception as e:
         logger.error(f"Error generating rosters from distribution: {str(e)}", exc_info=True)
         raise HTTPException(
@@ -542,7 +542,7 @@ async def import_received_months(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"無法解析 Excel 檔案，請確認格式正確: {type(e).__name__}",
-        )
+        ) from e
 
     if not rows:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Excel 檔案沒有資料列")

--- a/backend/app/api/v1/endpoints/notifications_facebook_demo.py
+++ b/backend/app/api/v1/endpoints/notifications_facebook_demo.py
@@ -82,7 +82,7 @@ async def create_facebook_style_notification(
             "message": "Facebook-style notification created successfully",
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.post("/notifications/batch")
@@ -110,7 +110,7 @@ async def create_batch_notifications(
             "message": "Batch notifications queued successfully",
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.get("/notifications/aggregated/{group_key}")
@@ -171,7 +171,7 @@ async def update_notification_preferences(
             "message": "Preferences updated successfully",
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.get("/notifications/analytics")

--- a/backend/app/api/v1/endpoints/nycu_employee.py
+++ b/backend/app/api/v1/endpoints/nycu_employee.py
@@ -107,17 +107,17 @@ async def get_employees(
         )
 
     except NYCUEmpAuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}") from e
     except NYCUEmpValidationError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}") from e
     except NYCUEmpConnectionError as e:
-        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}")
+        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}") from e
     except NYCUEmpTimeoutError as e:
-        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}")
+        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}") from e
     except NYCUEmpError as e:
-        raise HTTPException(status_code=500, detail=f"API error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"API error: {str(e)}") from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}") from e
 
 
 @router.get("/employees/all")
@@ -154,17 +154,17 @@ async def get_all_employees(status: str = Query("01", description="Employee stat
         return response_pages
 
     except NYCUEmpAuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}") from e
     except NYCUEmpValidationError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}") from e
     except NYCUEmpConnectionError as e:
-        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}")
+        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}") from e
     except NYCUEmpTimeoutError as e:
-        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}")
+        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}") from e
     except NYCUEmpError as e:
-        raise HTTPException(status_code=500, detail=f"API error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"API error: {str(e)}") from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}") from e
 
 
 @router.get("/employees/search")
@@ -227,17 +227,17 @@ async def search_employees(
         )
 
     except NYCUEmpAuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}") from e
     except NYCUEmpValidationError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}") from e
     except NYCUEmpConnectionError as e:
-        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}")
+        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}") from e
     except NYCUEmpTimeoutError as e:
-        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}")
+        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}") from e
     except NYCUEmpError as e:
-        raise HTTPException(status_code=500, detail=f"API error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"API error: {str(e)}") from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}") from e
 
 
 @router.get("/employees/{employee_no}")
@@ -272,14 +272,14 @@ async def get_employee_by_no(
     except HTTPException:
         raise  # Re-raise HTTP exceptions as-is
     except NYCUEmpAuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}") from e
     except NYCUEmpValidationError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}") from e
     except NYCUEmpConnectionError as e:
-        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}")
+        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}") from e
     except NYCUEmpTimeoutError as e:
-        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}")
+        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}") from e
     except NYCUEmpError as e:
-        raise HTTPException(status_code=500, detail=f"API error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"API error: {str(e)}") from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}") from e

--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -205,7 +205,7 @@ async def submit_professor_review(
     except NotFoundError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found")
     except AuthorizationError as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except Exception as e:
         logger.error(f"Error submitting professor review: {str(e)}")
         import traceback
@@ -284,7 +284,7 @@ async def update_professor_review(
         }
 
     except AuthorizationError as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except NotFoundError:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Review not found")
     except Exception as e:

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -518,7 +518,7 @@ async def get_colleges(current_user: User = Depends(require_admin), db: AsyncSes
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve colleges: {str(e)}"
-        )
+        ) from e
 
 
 @router.get("/scholarship-types")
@@ -582,7 +582,7 @@ async def get_scholarship_types(current_user: User = Depends(require_staff), db:
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve scholarship types: {str(e)}"
-        )
+        ) from e
 
 
 @router.get("/overview/{period}")
@@ -718,7 +718,7 @@ async def get_quota_overview(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve quota overview: {str(e)}"
-        )
+        ) from e
 
 
 # CRUD Endpoints for ScholarshipConfiguration Management
@@ -908,7 +908,7 @@ async def get_scholarship_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.put("/configurations/{id}")
@@ -1328,7 +1328,7 @@ async def list_scholarship_configurations(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to list configurations: {str(e)}"
-        )
+        ) from e
 
 
 # Whitelist Management Endpoints

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -80,7 +80,7 @@ async def get_all_configurations(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve configurations: {str(e)}"
-        )
+        ) from e
 
 
 _ALLOWED_DOC_KEYS = {"regulations_url", "sample_document_url"}
@@ -247,7 +247,7 @@ async def get_system_doc_file(
         )
         file_content = response.read()
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"無法取得文件: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"無法取得文件: {str(e)}") from e
 
     content_type = "application/pdf"
     if object_name.endswith(".doc"):
@@ -329,7 +329,7 @@ async def get_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.post("")
@@ -389,7 +389,7 @@ async def create_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to create configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.put("/{id}")
@@ -457,7 +457,7 @@ async def update_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to update configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.delete("/{id}")
@@ -489,7 +489,7 @@ async def delete_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to delete configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.post("/validate")
@@ -520,7 +520,7 @@ async def validate_configuration(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to validate configuration: {str(e)}"
-        )
+        ) from e
 
 
 @router.get("/categories")
@@ -610,4 +610,4 @@ async def get_configuration_audit_logs(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve audit logs: {str(e)}"
-        )
+        ) from e

--- a/backend/app/api/v1/endpoints/user_profiles.py
+++ b/backend/app/api/v1/endpoints/user_profiles.py
@@ -82,7 +82,7 @@ async def create_my_profile(
             "data": UserProfileResponse.model_validate(profile),
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
 
 
 @router.put("/me")
@@ -206,7 +206,7 @@ async def upload_bank_document(
             "data": {"document_url": document_url},
         }
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
 
 @router.post("/me/bank-document/file")

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -211,7 +211,7 @@ async def get_all_users(
             user_roles = [UserRole(r) for r in role_list]
             stmt = stmt.where(User.role.in_(user_roles))
         except ValueError as e:
-            raise HTTPException(status_code=400, detail=f"Invalid role in roles parameter: {e}")
+            raise HTTPException(status_code=400, detail=f"Invalid role in roles parameter: {e}") from e
     elif role:
         # Handle single role (backward compatibility)
         try:


### PR DESCRIPTION
## Summary
A regex-driven sweep across \`backend/app/api/v1/endpoints/**/*.py\` adds \`from <exc_name>\` to every \`except <Type> as <name>: raise HTTPException(...)\` site that wasn't already chained. **78 substitutions across 17 files; no behavior change for callers.**

Same mechanical transformation that PRs #504 / #511 / #512 applied file-by-file, run as a single backend-wide sweep so the B904 CI gate landing in PR #505 won't fail on any of these endpoints.

## Files touched (by sub count)
| subs | file |
|------|------|
| 24 | \`nycu_employee.py\` |
| 8 | \`email_management.py\` |
| 8 | \`system_settings.py\` |
| 8 | \`college_review/ranking_management.py\` |
| 5 | \`manual_distribution.py\` |
| 5 | \`scholarship_configurations.py\` |
| 4 | \`auth.py\` |
| 3 | \`notifications_facebook_demo.py\` |
| 2 | \`admin/configurations.py\` |
| 2 | \`applications.py\` |
| 2 | \`professor.py\` |
| 2 | \`user_profiles.py\` |
| 1 | \`admin/applications.py\` |
| 1 | \`admin/students.py\` |
| 1 | \`batch_import.py\` |
| 1 | \`college_review/export_package.py\` |
| 1 | \`users.py\` |

## What the sweep skipped
- \`except SomeType:\` (no \`as <name>\`)
- Multi-statement except blocks (logger.exception + raise)
- Patterns with the raise inside an inner conditional

Those need targeted human review and remain on the B904 list (~193 sites still). They'll get cleaned in follow-up PRs as we touch those files for other reasons.

```
before: 271 B904 violations across backend/app/api/v1/endpoints
after:  193 (-78 in one mechanical pass, no behavior change)
```

## Compatibility
No behavior change for callers — same exception classes, same status codes, same response shapes. Only \`__cause__\` becomes non-None on each raised exception.

## Test plan
- [x] All 17 files parse clean (\`ast.parse\`)
- [x] \`black --check\` clean (one auto-fix for an \`email_management.py\` line that grew past 120 chars after \`from e\` insertion)
- [x] \`flake8 --select=E9,F63,F7,F82,F401\` — no new violations (3 pre-existing F401 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)