### PR TITLE
fix(backend): clear unbound-except B904 sites (follow-up to #514)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/bank_verification.py
+++ b/backend/app/api/v1/endpoints/admin/bank_verification.py
@@ -553,11 +553,11 @@ async def list_verification_tasks(
         if status:
             try:
                 status_filter = BankVerificationTaskStatus(status)
-            except ValueError:
+            except ValueError as exc:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"無效的狀態值: {status}",
-                )
+                ) from exc
 
         tasks = await task_service.list_tasks(
             status=status_filter,

--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -895,8 +895,8 @@ async def get_application_audit_trail(
     service = ApplicationService(db)
     try:
         await service.get_application_by_id(id, current_user)
-    except Exception:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found")
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found") from exc
 
     # Get audit trail
     audit_service = ApplicationAuditService(db)

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -562,5 +562,5 @@ async def delete_specific_profile(developer_id: str, role: str, db: AsyncSession
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Profile not found: {developer_id}/{role}",
             )
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid role: {role}")
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid role: {role}") from exc

--- a/backend/app/api/v1/endpoints/email_automation.py
+++ b/backend/app/api/v1/endpoints/email_automation.py
@@ -252,10 +252,10 @@ async def create_automation_rule(
         # Validate trigger event
         try:
             trigger_enum = TriggerEvent(rule_data.trigger_event)
-        except ValueError:
+        except ValueError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=f"無效的觸發事件: {rule_data.trigger_event}"
-            )
+            ) from exc
 
         # SECURITY: Validate condition_query to prevent SQL injection
         validate_condition_query(rule_data.condition_query)
@@ -331,10 +331,10 @@ async def update_automation_rule(
         if rule_data.trigger_event is not None:
             try:
                 rule.trigger_event = TriggerEvent(rule_data.trigger_event)
-            except ValueError:
+            except ValueError as exc:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST, detail=f"無效的觸發事件: {rule_data.trigger_event}"
-                )
+                ) from exc
         if rule_data.template_key is not None:
             rule.template_key = rule_data.template_key
         if rule_data.delay_hours is not None:

--- a/backend/app/api/v1/endpoints/email_management.py
+++ b/backend/app/api/v1/endpoints/email_management.py
@@ -155,8 +155,8 @@ async def approve_scheduled_email(
         return {"success": True, "message": "Scheduled email approved successfully", "data": scheduled_email}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception:
-        raise HTTPException(status_code=500, detail="Failed to approve email")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to approve email") from exc
 
 
 @router.patch("/scheduled/{email_id}/cancel")
@@ -174,8 +174,8 @@ async def cancel_scheduled_email(
         return {"success": True, "message": "Scheduled email approved successfully", "data": scheduled_email}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception:
-        raise HTTPException(status_code=500, detail="Failed to cancel email")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to cancel email") from exc
 
 
 @router.patch("/scheduled/{email_id}")
@@ -200,8 +200,8 @@ async def update_scheduled_email(
         return {"success": True, "message": "Scheduled email approved successfully", "data": scheduled_email}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception:
-        raise HTTPException(status_code=500, detail="Failed to update scheduled email")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to update scheduled email") from exc
 
 
 @router.post("/scheduled/process")

--- a/backend/app/api/v1/endpoints/files.py
+++ b/backend/app/api/v1/endpoints/files.py
@@ -44,8 +44,8 @@ async def get_file_proxy(
         try:
             payload = verify_token(token)
             user_id = int(payload.get("sub"))
-        except Exception:
-            raise HTTPException(status_code=401, detail="Invalid token")
+        except Exception as exc:
+            raise HTTPException(status_code=401, detail="Invalid token") from exc
 
         # Get user from token
         auth_service = AuthService(db)
@@ -147,8 +147,8 @@ async def download_file_proxy(
         try:
             payload = verify_token(token)
             user_id = int(payload.get("sub"))
-        except Exception:
-            raise HTTPException(status_code=401, detail="Invalid token")
+        except Exception as exc:
+            raise HTTPException(status_code=401, detail="Invalid token") from exc
 
         # Get user from token
         auth_service = AuthService(db)

--- a/backend/app/api/v1/endpoints/notifications_facebook_demo.py
+++ b/backend/app/api/v1/endpoints/notifications_facebook_demo.py
@@ -59,11 +59,11 @@ async def create_facebook_style_notification(
         for channel_str in request.channels:
             try:
                 channels.append(NotificationChannel(channel_str))
-            except ValueError:
+            except ValueError as exc:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Invalid channel: {channel_str}",
-                )
+                ) from exc
 
     try:
         notification = await service.create_notification(

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -271,14 +271,14 @@ def generate_payment_roster(
     try:
         with with_lock_sync(lock_key, ttl_seconds=300):
             return _generate_payment_roster_inner(request, db, current_user)
-    except LockBusy:
+    except LockBusy as exc:
         # Concurrent generation in flight — fail fast rather than queue.
         # UI already handles 409 from RosterAlreadyExistsError, so the
         # path is well-trodden.
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="造冊產生中，請稍候再試",
-        )
+        ) from exc
 
 
 @router.get("/available-rankings")
@@ -1596,11 +1596,11 @@ async def download_roster_excel(
             # SECURITY: Validate MinIO object name (CLAUDE.md requirement)
             try:
                 validate_object_name_minio(roster.minio_object_name)
-            except HTTPException:
+            except HTTPException as exc:
                 logger.error(f"Invalid minio_object_name from database: {roster.minio_object_name}")
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="MinIO object name驗證失敗"
-                )
+                ) from exc
 
             # 使用MinIO下載
             try:

--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -121,8 +121,8 @@ async def get_professor_review(
             "data": review_response.model_dump(),
         }
 
-    except NotFoundError:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Professor review not found")
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Professor review not found") from exc
     except Exception as e:
         logger.error(f"Error fetching professor review: {str(e)}")
         import traceback
@@ -202,8 +202,8 @@ async def submit_professor_review(
             "data": review_response.model_dump(),
         }
 
-    except NotFoundError:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found")
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found") from exc
     except AuthorizationError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except Exception as e:
@@ -285,8 +285,8 @@ async def update_professor_review(
 
     except AuthorizationError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
-    except NotFoundError:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Review not found")
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Review not found") from exc
     except Exception as e:
         logger.error(f"Error updating professor review: {str(e)}")
         import traceback

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -365,8 +365,8 @@ async def get_matrix_quota_status(
 
         return ApiResponse(success=True, message="Matrix quota status retrieved successfully", data=response_data)
 
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid period format: {period}")
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid period format: {period}") from exc
     except Exception as e:
         import logging
 
@@ -713,8 +713,8 @@ async def get_quota_overview(
 
         return ApiResponse(success=True, message="Quota overview retrieved successfully", data=overview_data)
 
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid period format: {period}")
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid period format: {period}") from exc
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve quota overview: {str(e)}"

--- a/backend/app/api/v1/endpoints/scholarship_rules.py
+++ b/backend/app/api/v1/endpoints/scholarship_rules.py
@@ -77,8 +77,8 @@ async def list_scholarship_rules(
                     ScholarshipRule.semester.is_(None),  # Include generic rules
                 )
             )
-        except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid semester: {semester}")
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid semester: {semester}") from exc
 
     if sub_type:
         stmt = stmt.filter(

--- a/backend/app/api/v1/endpoints/user_profiles.py
+++ b/backend/app/api/v1/endpoints/user_profiles.py
@@ -384,8 +384,8 @@ async def get_bank_document(filename: str, db: AsyncSession = Depends(get_db)):
         # 2. List all available files (untainted source from filesystem)
         try:
             available_files = os.listdir(storage_directory)
-        except OSError:
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="無法讀取儲存目錄")
+        except OSError as exc:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="無法讀取儲存目錄") from exc
 
         # 3. Find matching file from filesystem listing (breaks taint flow)
         # Search for the requested filename in the filesystem-provided list
@@ -407,8 +407,8 @@ async def get_bank_document(filename: str, db: AsyncSession = Depends(get_db)):
 
     except HTTPException:
         raise
-    except Exception:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="檔案服務發生錯誤")
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="檔案服務發生錯誤") from exc
 
 
 # ==================== Admin endpoints ====================

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -217,8 +217,8 @@ async def get_all_users(
         try:
             user_role = UserRole(role.lower())
             stmt = stmt.where(User.role == user_role)
-        except ValueError:
-            raise HTTPException(status_code=400, detail=f"Invalid role: {role}")
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid role: {role}") from exc
 
     if search:
         stmt = stmt.where(

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -50,8 +50,8 @@ async def get_current_user(token: str = Depends(oauth2_scheme), db: AsyncSession
         user_id: str = payload.get("sub")
         if user_id is None:
             raise credentials_exception
-    except jwt.PyJWTError:
-        raise credentials_exception
+    except jwt.PyJWTError as exc:
+        raise credentials_exception from exc
 
     stmt = select(User).options(selectinload(User.admin_scholarships)).where(User.id == int(user_id))
     result = await db.execute(stmt)

--- a/backend/app/schemas/college_review.py
+++ b/backend/app/schemas/college_review.py
@@ -154,8 +154,8 @@ class RankingImportItem(BaseModel):
                 return "N"
             try:
                 v = int(v)
-            except ValueError:
-                raise ValueError(f"排名格式無效：'{v}'，只接受正整數或 'N'")
+            except ValueError as exc:
+                raise ValueError(f"排名格式無效：'{v}'，只接受正整數或 'N'") from exc
         if isinstance(v, float):
             if not v.is_integer():
                 raise ValueError(f"排名必須為整數，收到：{v}")

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -694,11 +694,11 @@ class BatchImportService:
         if semester:
             try:
                 semester_enum = Semester(semester)
-            except ValueError:
+            except ValueError as exc:
                 raise BatchImportError(
                     message=f"無效的學期值: {semester}",
                     batch_id=batch_import.id,
-                )
+                ) from exc
 
         # Find scholarship configuration for this academic period
         config_stmt = select(ScholarshipConfiguration).where(

--- a/backend/app/services/bulk_approval_service.py
+++ b/backend/app/services/bulk_approval_service.py
@@ -369,8 +369,8 @@ class BulkApprovalService:
             # Validate status
             try:
                 _ = ApplicationStatus(new_status)
-            except ValueError:
-                raise ValueError(f"Invalid status: {new_status}")
+            except ValueError as exc:
+                raise ValueError(f"Invalid status: {new_status}") from exc
 
             stmt = select(Application).where(Application.id.in_(application_ids))
             result = await self.db.execute(stmt)

--- a/backend/app/services/portal_sso_service.py
+++ b/backend/app/services/portal_sso_service.py
@@ -101,15 +101,15 @@ class PortalSSOService:
                     logger.error(f"Invalid portal response format: {portal_data}")
                     raise AuthenticationError("Invalid portal response format")
 
-        except httpx.TimeoutException:
+        except httpx.TimeoutException as exc:
             logger.error("Portal JWT verification timeout")
-            raise AuthenticationError("Portal verification timeout")
+            raise AuthenticationError("Portal verification timeout") from exc
         except httpx.RequestError as e:
             logger.error(f"Portal JWT verification request error: {e}")
             raise AuthenticationError("Portal verification failed") from e
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
             logger.error("Portal JWT verification returned invalid JSON")
-            raise AuthenticationError("Invalid portal response")
+            raise AuthenticationError("Invalid portal response") from exc
 
     def _validate_portal_response(self, data: Dict) -> bool:
         """Validate portal response contains required fields"""

--- a/backend/app/services/student_service.py
+++ b/backend/app/services/student_service.py
@@ -112,9 +112,9 @@ class StudentService:
                     logger.error(f"Student API request failed: {response.status_code}")
                     raise ServiceUnavailableError("Student API is unavailable")
 
-        except httpx.TimeoutException:
+        except httpx.TimeoutException as exc:
             logger.error(f"Student API request timed out for {student_code}")
-            raise ServiceUnavailableError("Student API request timed out")
+            raise ServiceUnavailableError("Student API request timed out") from exc
         except httpx.RequestError as e:
             logger.error(f"Student API request error: {str(e)}")
             raise ServiceUnavailableError(f"Student API request failed: {str(e)}") from e
@@ -192,9 +192,9 @@ class StudentService:
                     logger.error(f"Student term API request failed: {response.status_code}")
                     raise ServiceUnavailableError("Student API is unavailable")
 
-        except httpx.TimeoutException:
+        except httpx.TimeoutException as exc:
             logger.error(f"Student term API request timed out for {student_code}")
-            raise ServiceUnavailableError("Student API request timed out")
+            raise ServiceUnavailableError("Student API request timed out") from exc
         except httpx.RequestError as e:
             logger.error(f"Student term API request error: {str(e)}")
             raise ServiceUnavailableError(f"Student API request failed: {str(e)}") from e

--- a/backend/app/services/student_verification_service.py
+++ b/backend/app/services/student_verification_service.py
@@ -202,16 +202,16 @@ class StudentVerificationService:
                     student_id=student_id_number,
                 )
 
-        except requests.exceptions.Timeout:
+        except requests.exceptions.Timeout as exc:
             raise StudentVerificationError(
                 "Student verification API timeout",
                 student_id=student_id_number,
-            )
-        except requests.exceptions.ConnectionError:
+            ) from exc
+        except requests.exceptions.ConnectionError as exc:
             raise StudentVerificationError(
                 "Cannot connect to student verification API",
                 student_id=student_id_number,
-            )
+            ) from exc
         except requests.exceptions.RequestException as e:
             raise StudentVerificationError(
                 f"API request failed: {str(e)}",


### PR DESCRIPTION
## Summary

Follow-up to PR #514. Clears all remaining backend B904 violations by
handling the symmetric pattern #514 missed: `except X:` (no name binding)
containing `raise Y(...)`.

## Why this surfaced after #514 said "0 B904"

CI's flake8 gate runs from `backend/` directory using `setup.cfg`, which
has no exclude list. Local runs from repo root pick up `.flake8` which
excludes `app/api/`, `app/services/`, `app/models/`, `app/schemas/`, and
`app/tests/`. Most of #514's 297 substitutions landed in core/integrations/
utils — outside the locally-excluded paths. The unbound pattern in the
excluded paths was never visible locally.

PR #505's `flake8-bugbear B904/B014` gate is what made the discrepancy
visible: that gate runs without exclude rules, so CI's run from `backend/`
revealed 35+ remaining sites.

## Mechanism

AST-driven, byte-offset based (the source contains Chinese characters in
i18n strings, and Python AST `col_offset` is byte-based for UTF-8 — char
offsets would corrupt those lines, which I discovered during a first draft).

For each `except X:` (type set, name None) that contains a top-level
`raise Y(...)` with no existing `from` clause, the sweep:

1. Inserts ` as exc` after the exception type → `except X as exc:`
2. Inserts ` from exc` after each enclosed raise expression

Nested except handlers and re-raises (`raise` with no expr) are correctly
skipped — only the immediately-enclosing handler claims its raises.

## Coverage

64 edits across 20 files:

- 13 endpoint files (auth, applications, professor, payment_rosters,
  email_automation, email_management, files, user_profiles, etc.)
- 5 service files (batch_import, bulk_approval, portal_sso, student_service,
  student_verification_service)
- 1 schema (college_review)
- 1 core (deps)

## Verification

```
cd backend
uvx --from flake8==7.1.1 --with flake8-bugbear==24.12.12 \
  flake8 app --select=B904 --max-line-length=120
# 0 lines

uvx --from black==26.3.1 black --check --line-length=120 app
# All done! 469 files would be left unchanged.
```

After this PR + rebased #505, the bugbear gate will hold the invariant
going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)