### PR TITLE
fix(backend): clear remaining bugbear violations — B007, B010, B017 (6 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/announcements.py
+++ b/backend/app/api/v1/endpoints/admin/announcements.py
@@ -243,7 +243,7 @@ async def update_announcement(
         for field, value in update_data.items():
             if field in allowed_fields:
                 if field == "metadata":
-                    setattr(announcement, "meta_data", value)
+                    announcement.meta_data = value
                 elif hasattr(announcement, field):
                     setattr(announcement, field, value)
 

--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -503,7 +503,7 @@ class ExcelExportService:
         # STD_UP_MIXLISTA必填欄位檢查
         required_fields = ["身分證字號", "姓名"]  # 第1、2欄必填
 
-        for idx, row in enumerate(excel_data, start=1):
+        for _idx, row in enumerate(excel_data, start=1):
             # 檢查必填欄位
             missing_required = False
             for field in required_fields:

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -1067,7 +1067,7 @@ class ManualDistributionService:
 
         # Determine all years to load configs for
         all_prior_years: set[int] = set()
-        for sub_type, years_list in prior_years_map.items():
+        for years_list in prior_years_map.values():
             if isinstance(years_list, list):
                 all_prior_years.update(years_list)
         years_to_check = sorted([academic_year] + list(all_prior_years), reverse=True)

--- a/backend/app/services/scholarship_configuration_service.py
+++ b/backend/app/services/scholarship_configuration_service.py
@@ -156,7 +156,7 @@ class ScholarshipConfigurationService:
             reason = "Passed all screening rules"
 
             # Apply each screening rule
-            for rule_name, rule_config in screening_rules.items():
+            for rule_config in screening_rules.values():
                 rule_type = rule_config.get("type")
                 threshold = rule_config.get("threshold")
                 field = rule_config.get("field")

--- a/backend/app/tests/test_critical_workflows.py
+++ b/backend/app/tests/test_critical_workflows.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from sqlalchemy.exc import IntegrityError
+
 from app.core.exceptions import AuthorizationError, ConflictError, ValidationError
 from app.models.application import Application, ApplicationStatus
 from app.models.enums import QuotaManagementMode, Semester
@@ -423,5 +425,5 @@ class TestCriticalDataIntegrity:
         db.add(config2)
 
         # Should raise integrity error
-        with pytest.raises(Exception):  # SQLAlchemy IntegrityError
+        with pytest.raises(IntegrityError):
             await db.commit()

--- a/backend/app/tests/test_rate_limiting.py
+++ b/backend/app/tests/test_rate_limiting.py
@@ -217,7 +217,7 @@ class TestRateLimitIntegration:
         limiter = RateLimiter("redis://localhost:6379")
 
         # Test multiple requests within limit
-        for i in range(5):
+        for _ in range(5):
             is_limited, remaining = await limiter.is_rate_limited("test_integration", 10, 60)
             assert is_limited is False
             assert remaining >= 0


### PR DESCRIPTION
## Summary

After PRs #514 (AST B904) and #516 (unbound-except B904), only 6 other
bugbear-rule violations remained on backend:

- **B017** ×1: overly-broad `pytest.raises(Exception)` 
- **B010** ×1: `setattr(obj, "constant", value)` (pointless indirection)
- **B007** ×4: unused loop control variables

This PR clears all of them.

## Why these matter

- **B017** is a legitimate test-quality bug — the test would pass for
  *any* exception, including ones caused by test setup bugs. The comment
  beside it documented the actual expected `IntegrityError`; the code
  was just lying. Now narrowed.
- **B010** is harmless but signals confusion about Python's attribute
  protocol; the static analyzer flags it as such.
- **B007** unused loop variables can mask intent — readers reasonably
  assume the index is used somewhere in the body.

## Changes (6 files, 8 insertions, 6 deletions)

| File | Line | Rule | Fix |
|---|---|---|---|
| test_critical_workflows.py | 426 | B017 | `pytest.raises(Exception)` → `pytest.raises(IntegrityError)` |
| admin/announcements.py | 246 | B010 | `setattr(announcement, "meta_data", v)` → `announcement.meta_data = v` |
| excel_export_service.py | 506 | B007 | `for idx, row in ...` → `for _idx, row in ...` |
| manual_distribution_service.py | 1070 | B007 | `for sub_type, years_list in .items()` → `for years_list in .values()` |
| scholarship_configuration_service.py | 159 | B007 | `for rule_name, rule_config in .items()` → `for rule_config in .values()` |
| test_rate_limiting.py | 220 | B007 | `for i in range(5)` → `for _ in range(5)` |

## Verification

```
cd backend
uvx --from flake8==7.1.1 --with flake8-bugbear==24.12.12 \
  flake8 app --select=B007,B010,B017 --max-line-length=120
# 0 violations

uvx --from black==26.3.1 black --check --line-length=120 app
# All done!
```

After this PR, the only remaining bugbear violations are 15× B008
(FastAPI `Depends()` defaults — intentional, not gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)