### PR TITLE
chore(admin-scholarship-dashboard): type 2 `any` sites + fix latent undefined-pass bug

### DIFF
--- a/frontend/components/admin-scholarship-dashboard.tsx
+++ b/frontend/components/admin-scholarship-dashboard.tsx
@@ -77,6 +77,20 @@ import { useScholarshipData } from "@/hooks/use-scholarship-data";
 import { Application } from "@/lib/api";
 import { User as UserType } from "@/types/user";
 
+// Shape of entries returned by GET /admin/applications/{id}/audit-logs.
+// Co-located here (not exported) because it's only consumed by the audit
+// modal in this component; the fields named are the ones the table renders.
+interface AuditLogEntry {
+  created_at?: string;
+  timestamp?: string;
+  user_name?: string;
+  user?: { name?: string };
+  app_id?: string;
+  student_name?: string;
+  action?: string;
+  description?: string;
+}
+
 interface AdminScholarshipDashboardProps {
   user: UserType;
 }
@@ -302,7 +316,7 @@ export function AdminScholarshipDashboard({
 
   // 操作紀錄相關狀態
   const [showAuditModal, setShowAuditModal] = useState(false);
-  const [auditLogs, setAuditLogs] = useState<any[]>([]);
+  const [auditLogs, setAuditLogs] = useState<AuditLogEntry[]>([]);
   const [auditLoading, setAuditLoading] = useState(false);
 
   // 檢查用戶是否可以指派教授
@@ -1643,7 +1657,7 @@ export function AdminScholarshipDashboard({
                   {auditLogs.map((log, index) => (
                     <TableRow key={index}>
                       <TableCell className="text-sm">
-                        {new Date(log.created_at || log.timestamp).toLocaleString("zh-TW")}
+                        {new Date(log.created_at || log.timestamp || Date.now()).toLocaleString("zh-TW")}
                       </TableCell>
                       <TableCell className="text-sm">
                         {log.user_name || log.user?.name || "系統"}
@@ -1699,7 +1713,10 @@ export function AdminScholarshipDashboard({
       {activeTab && (
         <div className="mt-8">
           <AdminScholarshipManagementInterface
-            type={activeTab as any}
+            // Cast is at the boundary: activeTab is typed as `string` from
+            // useState; the prop's `ScholarshipType` union is enforced by
+            // AdminScholarshipManagementInterface at the call site.
+            type={activeTab as "undergraduate_freshman" | "direct_phd" | "phd"}
             className="border-t pt-6"
           />
         </div>


### PR DESCRIPTION
## Summary

Second bite at the frontend any-type cleanup ledger (task #14).
\`admin-scholarship-dashboard.tsx\` had ~5 \`any\` annotations; this PR
clears the 2 that have a clear single shape and surfaced a latent bug.

## Changes (1 file, +20 / -3)

1. **\`auditLogs: any[]\` → \`auditLogs: AuditLogEntry[]\`**
   New local \`AuditLogEntry\` interface naming the 8 fields the audit
   modal table actually renders (created_at, timestamp, user_name,
   user.name, app_id, student_name, action, description).

2. **\`type={activeTab as any}\` → \`as \"undergraduate_freshman\" | \"direct_phd\" | \"phd\"\`**
   Same runtime, but now the accepted union is visible at the call site
   instead of silently accepting any string.

## Latent bug found by stricter typing

After typing \`auditLogs\`, tsc surfaced this in the audit-modal:

\`\`\`tsx
{new Date(log.created_at || log.timestamp).toLocaleString(\"zh-TW\")}
\`\`\`

Both fields are optional, so the \`||\` chain can yield \`undefined\` —
which \`new Date(undefined)\` returns as \`Invalid Date\`. Added
\`|| Date.now()\` fallback so the rare failure mode is \"current time\"
instead of a broken date string.

This was invisible while \`auditLogs: any[]\` was the type. The PR's
type-tightening is doing what type-tightening is supposed to do.

## Remaining ledger

\`admin-scholarship-dashboard.tsx\` still has 3 \`any\` sites that need
coordinated interface design across DashboardApplication, the API
payload shape, and bank-verification callback contracts. Left for a
later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)