### PR TITLE
chore(college-management-context): type 2 of 23 `any` sites (task #14)

### DIFF
--- a/frontend/contexts/college-management-context.tsx
+++ b/frontend/contexts/college-management-context.tsx
@@ -20,6 +20,19 @@ interface AcademicConfig {
 
 type SubTypeQuotaBreakdown = Record<string, { quota?: number; label?: string; label_en?: string }>;
 
+interface AvailableOptions {
+  scholarship_types: Array<{ id: number; code: string; name: string; name_en?: string }>;
+  academic_years: number[];
+  semesters: string[];
+}
+
+interface ManagedCollege {
+  code: string;
+  name: string;
+  name_en: string;
+  scholarship_count: number;
+}
+
 interface RankingData {
   applications: any[];
   totalQuota: number;
@@ -87,12 +100,8 @@ interface CollegeManagementContextType {
   setSelectedScholarshipType: (type: string | undefined) => void;
 
   // Available options
-  availableOptions: {
-    scholarship_types: Array<{ id: number; code: string; name: string; name_en?: string }>;
-    academic_years: number[];
-    semesters: string[];
-  } | null;
-  setAvailableOptions: (options: any) => void;
+  availableOptions: AvailableOptions | null;
+  setAvailableOptions: (options: AvailableOptions | null) => void;
 
   // College quota info (for review panel)
   collegeQuotaInfo: {
@@ -102,13 +111,8 @@ interface CollegeManagementContextType {
   setCollegeQuotaInfo: (info: { collegeQuota: number | null; breakdown: Record<string, number> } | null) => void;
 
   // Managed college
-  managedCollege: {
-    code: string;
-    name: string;
-    name_en: string;
-    scholarship_count: number;
-  } | null;
-  setManagedCollege: (college: any) => void;
+  managedCollege: ManagedCollege | null;
+  setManagedCollege: (college: ManagedCollege | null) => void;
   collegeDisplayName: string;
 
   // Dialog states


### PR DESCRIPTION
## Summary

Fourth bite at the frontend any-type cleanup ledger (task #14). Two
setters in \`college-management-context.tsx\` had their corresponding
read-side fields fully typed inline, but the setters were declared
\`(x: any) => void\` — purely \`any\` widening with no consumer reliance.

## Changes (1 file, +17 / -13)

- Lifted inline object literals to named \`AvailableOptions\` and
  \`ManagedCollege\` interfaces at module top.
- Both \`setAvailableOptions\` and \`setManagedCollege\` now accept the
  matching named type (\`| null\`) instead of \`any\`.

## Why this is safe

\`tsc --noEmit\` passes after the change. No consumer was using the
\`any\` widening — the change just makes explicit what the read side
already documented.

## Remaining in this file

21 \`any\` sites still pending — these need either the canonical
\`Application\` interface from \`@/lib/api\` (for \`selectedApplication\`,
\`applicationToDelete\`, etc.) or a new \`Ranking\` interface that doesn't
yet exist. Those need coordinated type design across consumers; queued
for follow-up.

## Ledger progress (task #14)

| PR | File | Sites cleared |
|---|---|---|
| #518 | scholarship-timeline.tsx | 3 |
| #519 | admin-scholarship-dashboard.tsx | 2 of 5 |
| #520 | admin-management-context.tsx | 2 |
| **this PR** | **college-management-context.tsx** | **2 of 23** |
| | **total** | **9 sites** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)