### PR TITLE
chore(admin-scholarship-management-interface): clear 7 `catch (err: any)` sites (task #14)

### DIFF
--- a/frontend/components/admin-scholarship-management-interface.tsx
+++ b/frontend/components/admin-scholarship-management-interface.tsx
@@ -219,9 +219,9 @@ export function AdminScholarshipManagementInterface({
       if (response.success && response.data) {
         setWhitelist(response.data as WhitelistResponse[]);
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Failed to load whitelist:", err);
-      toast.error(err.message || "無法載入白名單");
+      toast.error((err instanceof Error ? err.message : "無法載入白名單"));
     } finally {
       setLoadingWhitelist(false);
     }
@@ -552,9 +552,9 @@ export function AdminScholarshipManagementInterface({
       } else {
         setError(response.message || "範例文件上傳失敗");
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Failed to upload example:", err);
-      setError(err.message || "範例文件上傳失敗，請稍後再試");
+      setError((err instanceof Error ? err.message : "範例文件上傳失敗，請稍後再試"));
     } finally {
       setUploadingExampleDocId(null);
       // Reset file input
@@ -633,8 +633,8 @@ export function AdminScholarshipManagementInterface({
         const batchResult = response.data as { success_count: number; failed_items: Array<{ nycu_id: string; reason: string; }>; };
         toast.error(batchResult.failed_items[0].reason);
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法新增學生到白名單");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法新增學生到白名單"));
     } finally {
       setAddingStudent(false);
     }
@@ -653,8 +653,8 @@ export function AdminScholarshipManagementInterface({
         setSelectedStudents(new Set());
         await loadWhitelist(activeConfigId);
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法刪除學生");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法刪除學生"));
     }
   };
 
@@ -678,8 +678,8 @@ export function AdminScholarshipManagementInterface({
 
         await loadWhitelist(activeConfigId);
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法匯入 Excel 檔案");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法匯入 Excel 檔案"));
     } finally {
       setLoadingWhitelist(false);
       if (fileInputRef.current) {
@@ -702,8 +702,8 @@ export function AdminScholarshipManagementInterface({
       window.URL.revokeObjectURL(url);
 
       toast.success("白名單已下載為 Excel 檔案");
-    } catch (error: any) {
-      toast.error(error.message || "無法匯出白名單");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法匯出白名單"));
     }
   };
 
@@ -720,8 +720,8 @@ export function AdminScholarshipManagementInterface({
       window.URL.revokeObjectURL(url);
 
       toast.success("匯入模板已下載");
-    } catch (error: any) {
-      toast.error(error.message || "無法下載模板");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法下載模板"));
     }
   };
 


### PR DESCRIPTION
## Summary

Fifth bite at the frontend any-type cleanup ledger (task #14). All
7 catch clauses in \`admin-scholarship-management-interface.tsx\` had
\`(err: any)\` / \`(error: any)\` annotations. Converted to
\`(err: unknown)\` + \`err instanceof Error ? err.message : \"...\"\` —
removes implicit \`any\` widening while preserving runtime behavior on
\`Error\` instances.

## Why this is a real improvement

Pre-change pattern: \`err.message || \"fallback\"\`. When the rejected
value isn't an \`Error\` (plain string, non-Error object, number),
\`err.message\` is \`undefined\` → the fallback fires but the original
cause info is lost AND the type system was lying.

Post-change: \`err instanceof Error ? err.message : \"fallback\"\`.
Same Error-input behavior, but the narrowing is now explicit and
removes the implicit \`any\`.

## Sites cleared (7)

| Line | Operation |
|---|---|
| 224 | whitelist load |
| 557 | example doc upload |
| 637 | whitelist add-student |
| 657 | whitelist delete-students |
| 682 | whitelist import-excel |
| 706 | whitelist export |
| 724 | whitelist template download |

## Verification

\`bunx tsc --noEmit\` passes — no consumer relied on the \`any\` widening.

## Ledger progress (task #14)

| PR | File | Sites cleared |
|---|---|---|
| #518 | scholarship-timeline.tsx | 3 |
| #519 | admin-scholarship-dashboard.tsx | 2 of 5 |
| #520 | admin-management-context.tsx | 2 |
| #521 | college-management-context.tsx | 2 of 23 |
| **this PR** | **admin-scholarship-management-interface.tsx** | **7 of 11** |
| | **total** | **16 sites** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)