### PR TITLE
chore(frontend): `catch (err: any)` → `catch (err: unknown)` sweep across 9 files (task #14)

### DIFF
--- a/frontend/components/bank-verification-review-dialog.tsx
+++ b/frontend/components/bank-verification-review-dialog.tsx
@@ -209,8 +209,8 @@ export function BankVerificationReviewDialog({
       } else {
         setError(response.message || "提交審核失敗")
       }
-    } catch (err: any) {
-      setError(err.message || "提交審核時發生錯誤")
+    } catch (err: unknown) {
+      setError((err instanceof Error ? err.message : "提交審核時發生錯誤"))
     } finally {
       setSubmitting(false)
     }

--- a/frontend/components/email-test-mode-panel.tsx
+++ b/frontend/components/email-test-mode-panel.tsx
@@ -163,8 +163,8 @@ export function EmailTestModePanel() {  const [status, setStatus] = useState<Tes
       } else {
         throw new Error(response.data?.error || "無法發送測試郵件");
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法發送測試郵件",
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法發送測試郵件"),
       );
     } finally {
       setSendingTestEmail(false);
@@ -192,8 +192,8 @@ export function EmailTestModePanel() {  const [status, setStatus] = useState<Tes
         setRedirectEmails([]);
         toast.success(`所有郵件將重定向到 ${redirectEmails.length} 個測試信箱，將於 ${durationHours} 小時後自動關閉`);
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法啟用測試模式",
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法啟用測試模式"),
       );
     } finally {
       setLoading(false);
@@ -210,8 +210,8 @@ export function EmailTestModePanel() {  const [status, setStatus] = useState<Tes
         setShowDisableDialog(false);
         toast.success("郵件將正常發送至實際收件人");
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法停用測試模式",
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法停用測試模式"),
       );
     } finally {
       setLoading(false);

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -185,8 +185,8 @@ function ProfessorReviewComponentInner({
         setApplications([]);
         setFilteredApplications([]);
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to load applications");
+    } catch (e: unknown) {
+      setError((e instanceof Error ? e.message : "Failed to load applications"));
       setApplications([]);
       setFilteredApplications([]);
     } finally {
@@ -352,9 +352,9 @@ function ProfessorReviewComponentInner({
       }
 
       setReviewModalOpen(true);
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("Error opening review modal:", e);
-      setError(e.message || "Failed to load review data");
+      setError((e instanceof Error ? e.message : "Failed to load review data"));
     } finally {
       setLoading(false);
     }
@@ -430,8 +430,8 @@ function ProfessorReviewComponentInner({
       } else {
         setError(response.message || "Failed to submit review");
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to submit review");
+    } catch (e: unknown) {
+      setError((e instanceof Error ? e.message : "Failed to submit review"));
     } finally {
       setLoading(false);
     }

--- a/frontend/components/roster/PeriodDetailDialog.tsx
+++ b/frontend/components/roster/PeriodDetailDialog.tsx
@@ -157,9 +157,9 @@ export function PeriodDetailDialog({
       } else {
         throw new Error(response.message || "產生造冊失敗")
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to generate roster:", error)
-      toast.error(`產生造冊失敗: ${error.message || "無法產生造冊"}`)
+      toast.error(`產生造冊失敗: ${(error instanceof Error ? error.message : "無法產生造冊")}`)
     } finally {
       setGenerating(false)
     }

--- a/frontend/components/roster/RosterListTable.tsx
+++ b/frontend/components/roster/RosterListTable.tsx
@@ -182,9 +182,9 @@ export function RosterListTable({
       } else {
         throw new Error(response.message || "產生造冊失敗");
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to generate roster:", error);
-      toast.error(`產生造冊失敗: ${error.message || "無法產生造冊"}`);
+      toast.error(`產生造冊失敗: ${(error instanceof Error ? error.message : "無法產生造冊")}`);
     } finally {
       setGenerating(null);
     }

--- a/frontend/components/roster/ScheduleSettingDialog.tsx
+++ b/frontend/components/roster/ScheduleSettingDialog.tsx
@@ -99,9 +99,9 @@ export function ScheduleSettingDialog({
       } else {
         throw new Error(response.message || "更新失敗")
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to update schedule:", error)
-      toast.error(`儲存失敗: ${error.message || "無法更新排程設定"}`)
+      toast.error(`儲存失敗: ${(error instanceof Error ? error.message : "無法更新排程設定")}`)
     } finally {
       setSaving(false)
     }

--- a/frontend/components/whitelist-management-dialog.tsx
+++ b/frontend/components/whitelist-management-dialog.tsx
@@ -80,8 +80,8 @@ export function WhitelistManagementDialog({
       if (response.success && response.data) {
         setWhitelist(response.data);
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法載入申請白名單");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法載入申請白名單"));
     } finally {
       setLoading(false);
     }
@@ -107,8 +107,8 @@ export function WhitelistManagementDialog({
       } else if (response.data?.failed_items && response.data.failed_items.length > 0) {
         toast.error(response.data.failed_items[0].reason);
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法新增學生到申請白名單");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法新增學生到申請白名單"));
     } finally {
       setAddingStudent(false);
     }
@@ -129,8 +129,8 @@ export function WhitelistManagementDialog({
         setSelectedStudents(new Set());
         await loadWhitelist();
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法刪除學生");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法刪除學生"));
     }
   };
 
@@ -158,8 +158,8 @@ export function WhitelistManagementDialog({
 
         await loadWhitelist();
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法匯入 Excel 檔案");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法匯入 Excel 檔案"));
     } finally {
       setLoading(false);
       if (fileInputRef.current) {
@@ -181,8 +181,8 @@ export function WhitelistManagementDialog({
       window.URL.revokeObjectURL(url);
 
       toast.success("申請白名單已下載為 Excel 檔案");
-    } catch (error: any) {
-      toast.error(error.message || "無法匯出申請白名單");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法匯出申請白名單"));
     }
   };
 
@@ -198,8 +198,8 @@ export function WhitelistManagementDialog({
       window.URL.revokeObjectURL(url);
 
       toast.success("匯入模板已下載");
-    } catch (error: any) {
-      toast.error(error.message || "無法下載模板");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法下載模板"));
     }
   };
 

--- a/frontend/hooks/use-student-preview.ts
+++ b/frontend/hooks/use-student-preview.ts
@@ -124,14 +124,14 @@ export function useStudentPreview(): UseStudentPreviewReturn {
       } else {
         throw new Error(result.message || 'Failed to load student preview');
       }
-    } catch (err: any) {
-      if (err.name === 'AbortError') {
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') {
         // Request was cancelled, ignore
         return;
       }
 
       console.error('Error fetching student preview:', err);
-      setError(err.message || 'Failed to load student preview');
+      setError((err instanceof Error ? err.message : 'Failed to load student preview'));
       setPreviewData(null);
     } finally {
       setIsLoading(false);

--- a/frontend/lib/api/modules/professor.ts
+++ b/frontend/lib/api/modules/professor.ts
@@ -54,10 +54,10 @@ export function createProfessorApi() {
             "Failed to load applications - unexpected response format",
           data: [],
         };
-      } catch (error: any) {
+      } catch (error: unknown) {
         return {
           success: false,
-          message: error.message || "Failed to load applications",
+          message: (error instanceof Error ? error.message : "Failed to load applications"),
           data: [],
         };
       }


### PR DESCRIPTION
## Summary

Sixth bite at the frontend any-type cleanup ledger (task #14). The
\`instanceof Error\` guard pattern from PR #522 proved out — applied
mechanically across 9 more files where the consumer pattern was
exclusively \`err.message || \"fallback\"\`.

## Coverage (9 files, 16 catch sites)

| File | Sites |
|---|---|
| bank-verification-review-dialog.tsx | 1 |
| email-test-mode-panel.tsx | 3 |
| professor-review-component.tsx | 3 |
| roster/PeriodDetailDialog.tsx | 1 |
| roster/RosterListTable.tsx | 1 |
| roster/ScheduleSettingDialog.tsx | 1 |
| whitelist-management-dialog.tsx | 6 |
| hooks/use-student-preview.ts | 1 + AbortError guard |
| lib/api/modules/professor.ts | 1 |

## Files deferred

Other matched files had consumer patterns beyond \`.message || \"fallback\"\`
(\`err.response.data\`, raw \`error.message\` without fallback, etc.) and
need per-site narrowing to avoid breaking consumers. Those will land
in follow-up PRs.

Deferred: admin-configuration-management.tsx, admin-management-interface.tsx,
email-automation-management.tsx, batch-import-editor.tsx, plus 4 Next.js
route handlers and a few more components.

## Verification

\`bunx tsc --noEmit\` clean. The one non-message-pattern site in
\`use-student-preview.ts\` was \`err.name === 'AbortError'\` — converted
to \`err instanceof Error && err.name === 'AbortError'\` for proper narrowing.

## Ledger progress (task #14)

| PR | Files | Sites cleared |
|---|---|---|
| #518 | scholarship-timeline | 3 |
| #519 | admin-scholarship-dashboard | 2 |
| #520 | admin-management-context | 2 |
| #521 | college-management-context | 2 |
| #522 | admin-scholarship-management-interface | 7 |
| **this PR** | **9 components/hooks/lib files** | **16** |
| | **total** | **32** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)