### PR TITLE
chore(admin-management-interface): clear 2 axios-shape `catch (error: any)` sites (task #14)

### DIFF
--- a/frontend/components/admin-management-interface.tsx
+++ b/frontend/components/admin-management-interface.tsx
@@ -638,12 +638,16 @@ export function AdminManagementInterface({
       if (response.success && response.data) {
         setScholarshipEmailTemplates(response.data.items);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to load scholarship email templates:", error);
-      // If it's a permission error, switch back to system mode
+      // If it's a permission error, switch back to system mode.
+      // Errors from axios-style clients carry `.response.status`; plain
+      // Error subclasses carry `.message`. Narrow to a focused shape rather
+      // than `any` so the access path is documented.
+      const errShape = error as { response?: { status?: number }; message?: string };
       if (
-        error?.response?.status === 400 ||
-        error?.message?.includes("permission")
+        errShape.response?.status === 400 ||
+        errShape.message?.includes("permission")
       ) {
         setScholarshipEmailTab("system");
         alert("您沒有權限存取此獎學金的郵件模板");
@@ -857,9 +861,11 @@ export function AdminManagementInterface({
         const errorMsg = response.message || "獲取歷史申請失敗";
         setHistoricalApplicationsError(errorMsg);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("獲取歷史申請資料失敗:", error);
-      const errorMsg = error?.message || error?.response?.data?.message || "網路錯誤或伺服器未回應";
+      const errShape = error as { message?: string; response?: { data?: { message?: string } } };
+      const errorMsg =
+        errShape.message || errShape.response?.data?.message || "網路錯誤或伺服器未回應";
       setHistoricalApplicationsError(errorMsg);
     } finally {
       setLoadingHistoricalApplications(false);


### PR DESCRIPTION
## Summary

Seventh bite at the frontend any-type cleanup ledger (task #14). The
2 catch sites in \`admin-management-interface.tsx\` were deferred from
PR #523 because their consumers reach into \`error.response.status\` /
\`error.response.data.message\` (axios-style error shape) rather than
the simple \`.message || \"fallback\"\` pattern that #523 swept.

## Pattern

\`\`\`ts
} catch (error: unknown) {
  const errShape = error as { response?: { status?: number }; message?: string };
  if (errShape.response?.status === 400 || errShape.message?.includes(\"permission\")) {
    // permission-error fallback
  }
}
\`\`\`

The named-shape cast is a documented, focused type assertion — the
\`any\` widening is gone and the optional chains do safe property
access. Doesn't depend on axios's typed surface so it survives an HTTP
client swap.

## Sites cleared (2)

| Line | Operation | Consumed shape |
|---|---|---|
| 641 | Load scholarship email templates | \`response.status === 400\`, \`message.includes('permission')\` |
| 860 | Load historical applications | \`message\` then \`response.data.message\` then fallback |

## Why not just \`instanceof Error\`?

\`error.response\` is from axios's \`AxiosError\`, not \`Error\`. Importing
\`AxiosError\` to narrow would couple the module to axios's type
surface; the localized cast is a smaller change.

## Verification

\`bunx tsc --noEmit\` passes. Same runtime behavior.

## Ledger progress (task #14)

| PR | Files | Sites |
|---|---|---|
| #518 | scholarship-timeline | 3 |
| #519 | admin-scholarship-dashboard | 2 |
| #520 | admin-management-context | 2 |
| #521 | college-management-context | 2 |
| #522 | admin-scholarship-management-interface | 7 |
| #523 | 9 simpler files | 16 |
| **this PR** | **admin-management-interface (axios pattern)** | **2** |
| | **total** | **34** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)