### PR TITLE
chore(email-automation-management): clear 7 `catch (error: any)` sites (task #14)

### DIFF
--- a/frontend/components/email-automation-management.tsx
+++ b/frontend/components/email-automation-management.tsx
@@ -123,8 +123,8 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
       if (response.success && response.data) {
         setRules(response.data);
       }
-    } catch (error: any) {
-      toast.error(error.message || "無法載入自動化規則");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "無法載入自動化規則"));
     } finally {
       setIsLoading(false);
     }
@@ -136,7 +136,7 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
       if (response.success && response.data) {
         setTriggerEvents(response.data);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to fetch trigger events:", error);
     }
   };
@@ -153,7 +153,7 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
         }));
         setEmailTemplates(templates);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to fetch email templates:", error);
     }
   };
@@ -204,8 +204,8 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
         setIsCreateDialogOpen(false);
         fetchRules();
       }
-    } catch (error: any) {
-      toast.error(error.message || "創建規則失敗");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "創建規則失敗"));
     } finally {
       setIsSubmitting(false);
     }
@@ -230,8 +230,8 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
         setIsEditDialogOpen(false);
         fetchRules();
       }
-    } catch (error: any) {
-      toast.error(error.message || "更新規則失敗");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "更新規則失敗"));
     } finally {
       setIsSubmitting(false);
     }
@@ -248,8 +248,8 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
         setIsDeleteDialogOpen(false);
         fetchRules();
       }
-    } catch (error: any) {
-      toast.error(error.message || "刪除規則失敗");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "刪除規則失敗"));
     } finally {
       setIsSubmitting(false);
     }
@@ -262,8 +262,8 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
         toast.success(rule.is_active ? "規則已停用" : "規則已啟用");
         fetchRules();
       }
-    } catch (error: any) {
-      toast.error(error.message || "切換規則狀態失敗");
+    } catch (error: unknown) {
+      toast.error((error instanceof Error ? error.message : "切換規則狀態失敗"));
     }
   };
 


### PR DESCRIPTION
## Summary

Ninth bite at the frontend any-type cleanup ledger (task #14). All
7 catch sites in \`email-automation-management.tsx\` converted to
\`catch (error: unknown)\`:

- **5 sites** use the \`error instanceof Error ? error.message : \"X\"\`
  narrowing pattern (lines 126, 207, 233, 251, 265)
- **2 sites** only \`console.error(...)\` the value, so just need the
  \`: any\` widening removed (lines 139, 156)

## Verification

\`bunx tsc --noEmit\` passes.

## Ledger progress (task #14)

| PR | Files | Sites |
|---|---|---|
| #518–#525 | 16 files | 40 |
| **this PR** | **email-automation-management** | **7** |
| | **total** | **47** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)