### PR TITLE
chore(frontend): 9 more `catch (err: any)` sites across 7 files (task #14)

### DIFF
--- a/frontend/components/admin/history/HistoryPanel.tsx
+++ b/frontend/components/admin/history/HistoryPanel.tsx
@@ -143,11 +143,12 @@ export function HistoryPanel({ user }: HistoryPanelProps) {
         const errorMsg = response.message || "獲取歷史申請失敗";
         setHistoricalApplicationsError(errorMsg);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("獲取歷史申請資料失敗:", error);
+      const errShape = error as { message?: string; response?: { data?: { message?: string } } };
       const errorMsg =
-        error?.message ||
-        error?.response?.data?.message ||
+        errShape.message ||
+        errShape.response?.data?.message ||
         "網路錯誤或伺服器未回應";
       setHistoricalApplicationsError(errorMsg);
     } finally {

--- a/frontend/components/application-file-upload-dialog.tsx
+++ b/frontend/components/application-file-upload-dialog.tsx
@@ -95,9 +95,9 @@ export function ApplicationFileUploadDialog({
         setUploadStatus("error");
         setUploadMessage(t("form_dialog.partial_upload_failed"));
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       setUploadStatus("error");
-      setUploadMessage(err.message || t("form_dialog.upload_failed"));
+      setUploadMessage((err instanceof Error ? err.message : t("form_dialog.upload_failed")));
     } finally {
       setUploading(false);
     }

--- a/frontend/components/batch-document-upload.tsx
+++ b/frontend/components/batch-document-upload.tsx
@@ -125,12 +125,13 @@ export function BatchDocumentUpload({
             (locale === "zh" ? "上傳失敗" : "Upload failed")
         );
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       setError(
-        error.message ||
-          (locale === "zh"
+        error instanceof Error
+          ? error.message
+          : locale === "zh"
             ? "上傳時發生錯誤"
-            : "Error during upload")
+            : "Error during upload"
       );
     } finally {
       setIsUploading(false);

--- a/frontend/components/batch-import-editor.tsx
+++ b/frontend/components/batch-import-editor.tsx
@@ -117,10 +117,10 @@ export function BatchImportEditor({
           text: response.message || (locale === "zh" ? "更新失敗" : "Update failed"),
         });
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       setMessage({
         type: "error",
-        text: error.message || (locale === "zh" ? "更新時發生錯誤" : "Error during update"),
+        text: (error instanceof Error ? error.message : (locale === "zh" ? "更新時發生錯誤" : "Error during update")),
       });
     } finally {
       setIsSaving(false);
@@ -169,10 +169,10 @@ export function BatchImportEditor({
           text: response.message || (locale === "zh" ? "刪除失敗" : "Delete failed"),
         });
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       setMessage({
         type: "error",
-        text: error.message || (locale === "zh" ? "刪除時發生錯誤" : "Error during deletion"),
+        text: (error instanceof Error ? error.message : (locale === "zh" ? "刪除時發生錯誤" : "Error during deletion")),
       });
     } finally {
       setIsDeleting(null);
@@ -205,10 +205,10 @@ export function BatchImportEditor({
           text: response.message || (locale === "zh" ? "驗證失敗" : "Validation failed"),
         });
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       setMessage({
         type: "error",
-        text: error.message || (locale === "zh" ? "驗證時發生錯誤" : "Error during validation"),
+        text: (error instanceof Error ? error.message : (locale === "zh" ? "驗證時發生錯誤" : "Error during validation")),
       });
     } finally {
       setIsRevalidating(false);

--- a/frontend/components/delete-application-dialog.tsx
+++ b/frontend/components/delete-application-dialog.tsx
@@ -70,10 +70,11 @@ export function DeleteApplicationDialog({
           response.message || t("dialogs.delete_application.delete_failed")
         );
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to delete application:", error);
+      const errShape = error as { response?: { data?: { message?: string } } };
       toast.error(
-        error?.response?.data?.message ||
+        errShape.response?.data?.message ||
           t("dialogs.delete_application.delete_error")
       );
     } finally {

--- a/frontend/components/document-request-form.tsx
+++ b/frontend/components/document-request-form.tsx
@@ -100,10 +100,11 @@ export function DocumentRequestForm({
             (locale === "zh" ? "送出失敗" : "Failed to send request")
         );
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to create document request:", error);
+      const errShape = error as { response?: { data?: { message?: string } } };
       toast.error(
-        error?.response?.data?.message ||
+        errShape.response?.data?.message ||
           (locale === "zh" ? "建立文件要求時發生錯誤" : "Error creating document request")
       );
     } finally {

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -360,10 +360,11 @@ export function EnhancedStudentPortal({
           response.message || t("portal.document_request.operation_failed")
         );
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to fulfill document request:", error);
+      const errShape = error as { response?: { data?: { message?: string } } };
       alert(
-        error?.response?.data?.message ||
+        errShape.response?.data?.message ||
           t("portal.document_request.mark_complete_error")
       );
     }


### PR DESCRIPTION
## Summary

Eleventh bite at the frontend any-type cleanup ledger (task #14).
Continues the \`instanceof Error\` + axios-shape narrowing patterns
from PRs #522–#527.

## Coverage (7 files, 9 sites)

| File | Sites | Pattern |
|---|---|---|
| batch-import-editor.tsx | 3 | locale-ternary fallback |
| batch-document-upload.tsx | 1 | locale-ternary fallback |
| application-file-upload-dialog.tsx | 1 | i18n \`t()\` fallback |
| enhanced-student-portal.tsx | 1 | axios shape |
| admin/history/HistoryPanel.tsx | 1 | mixed message + axios |
| document-request-form.tsx | 1 | axios |
| delete-application-dialog.tsx | 1 | axios |

\`error.message \\|\\| X\` → \`(error instanceof Error ? error.message : X)\`
\`error?.response?.data?.message\` → \`errShape\` cast with proper shape

## Verification

\`bunx tsc --noEmit\` clean on all modified files.

## Ledger progress (task #14)

| PR | Files | Sites |
|---|---|---|
| #518–#527 | 18 files | 52 |
| **this PR** | **7 files** | **9** |
| | **total** | **61** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)