### PR TITLE
chore(student-wizard): clear last 6 catch sites — frontend ledger complete (task #14)

### DIFF
--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -454,8 +454,8 @@ export function ScholarshipApplicationStep({
       await refreshProfile();
       setPersonalInfoSaved(true);
       toast.success(text.personalInfoSaved);
-    } catch (err: any) {
-      toast.error(err.message || text.personalInfoSaveFailed);
+    } catch (err: unknown) {
+      toast.error((err instanceof Error ? err.message : text.personalInfoSaveFailed));
     } finally {
       setSavingPersonalInfo(false);
     }
@@ -520,8 +520,8 @@ export function ScholarshipApplicationStep({
       } else {
         throw new Error(response.message || "Delete failed");
       }
-    } catch (err: any) {
-      toast.error(err.message || text.deleteFailed);
+    } catch (err: unknown) {
+      toast.error((err instanceof Error ? err.message : text.deleteFailed));
     }
   };
 
@@ -537,8 +537,8 @@ export function ScholarshipApplicationStep({
       } else {
         throw new Error(response.message || "Delete failed");
       }
-    } catch (err: any) {
-      toast.error(err.message || text.deleteFailed);
+    } catch (err: unknown) {
+      toast.error((err instanceof Error ? err.message : text.deleteFailed));
     }
   };
 
@@ -657,8 +657,8 @@ export function ScholarshipApplicationStep({
       } else {
         setError(response.message || text.loadError);
       }
-    } catch (err: any) {
-      setError(err.message || text.loadError);
+    } catch (err: unknown) {
+      setError((err instanceof Error ? err.message : text.loadError));
     } finally {
       setLoading(false);
     }
@@ -944,8 +944,8 @@ export function ScholarshipApplicationStep({
           toast.success(text.draftSaved);
         }
       }
-    } catch (error: any) {
-      toast.error(text.submitError + ": " + error.message);
+    } catch (error: unknown) {
+      toast.error(text.submitError + ": " + (error instanceof Error ? error.message : String(error)));
     } finally {
       setSubmitting(false);
     }
@@ -1049,8 +1049,8 @@ export function ScholarshipApplicationStep({
 
       toast.success(text.submitSuccess);
       onComplete();
-    } catch (error: any) {
-      toast.error(text.submitError + ": " + error.message);
+    } catch (error: unknown) {
+      toast.error(text.submitError + ": " + (error instanceof Error ? error.message : String(error)));
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Summary

Thirteenth (and final) bite at the frontend any-type cleanup ledger
(task #14). All 6 catch sites in
\`student-wizard/steps/ScholarshipApplicationStep.tsx\` cleared.

## Sites (6)

| Line | Pattern | Fix |
|---|---|---|
| 457 | \`err.message \\|\\| text.personalInfoSaveFailed\` | instanceof guard |
| 523, 540 | \`err.message \\|\\| text.deleteFailed\` | same |
| 660 | \`err.message \\|\\| text.loadError\` | same |
| 947, 1052 | \`text.submitError + \": \" + error.message\` | \`String(error)\` fallback |

## Ledger COMPLETE

After this PR + #518-#529:
\`\`\`
grep -rn 'catch (err: any\\|catch (error: any\\|catch (e: any' frontend
# → 0 matches
\`\`\`

**74 sites cleared across 32 files**. Original task #14 inventory
estimated ~50; the sweep was tighter than estimated.

## Runtime bugs surfaced by type-tightening

| PR | Bug | Severity |
|---|---|---|
| #519 | \`new Date(undefined).toLocaleString()\` in admin-dashboard | display: \"Invalid Date\" |
| #529 | raw \`error.response\` access in copy-rules-modal | runtime throw on non-axios |
| **this PR** | \`text.submitError + \": \" + undefined\` concat | \"submit error: undefined\" toast |

## Verification

\`bunx tsc --noEmit\` clean on the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)