### PR TITLE
chore(frontend): DocumentPayload across 3 more files + 3 latent preview bugs (task #14)

### DIFF
--- a/frontend/components/admin-scholarship-dashboard.tsx
+++ b/frontend/components/admin-scholarship-dashboard.tsx
@@ -91,6 +91,26 @@ interface AuditLogEntry {
   description?: string;
 }
 
+// Shape of document entries in `submitted_form_data.documents` from
+// the backend. All fields optional because the upstream JSON can come
+// from several sources (form_data, submitted_form_data, SIS upload).
+interface DocumentPayload {
+  file_id?: string | number;
+  id?: string | number;
+  filename?: string;
+  original_filename?: string;
+  file_size?: number;
+  mime_type?: string;
+  document_type?: string;
+  file_type?: string;
+  file_path?: string;
+  download_url?: string;
+  is_verified?: boolean;
+  upload_time?: string;
+  uploaded_at?: string;
+  document_id?: string;
+}
+
 interface AdminScholarshipDashboardProps {
   user: UserType;
 }
@@ -178,7 +198,7 @@ const transformApplicationData = (app: any): DashboardApplication => {
     // Transform documents to include necessary file properties for preview
     submittedFormData = {
       ...submittedFormData,
-      documents: submittedFormData.documents.map((doc: any) => ({
+      documents: submittedFormData.documents.map((doc: DocumentPayload) => ({
         ...doc,
         // Map API response fields to expected format for ApplicationDetailDialog
         id: doc.file_id || doc.id,

--- a/frontend/components/common/ApplicationReviewDialog.tsx
+++ b/frontend/components/common/ApplicationReviewDialog.tsx
@@ -73,6 +73,26 @@ import {
 } from "@/lib/utils/application-helpers";
 import { getCurrentSemesterROC, toROCYear } from "@/src/utils/dateUtils";
 
+// Shape of document entries in `submitted_form_data.documents` from
+// the backend. All fields optional because the upstream JSON can come
+// from several sources (form_data, submitted_form_data, SIS upload).
+interface DocumentPayload {
+  file_id?: string | number;
+  id?: string | number;
+  filename?: string;
+  original_filename?: string;
+  file_size?: number;
+  mime_type?: string;
+  document_type?: string;
+  file_type?: string;
+  file_path?: string;
+  download_url?: string;
+  is_verified?: boolean;
+  upload_time?: string;
+  uploaded_at?: string;
+  document_id?: string;
+}
+
 interface ApplicationReviewDialogProps {
   application: Application | HistoricalApplication | null;
   role: "college" | "admin" | "super_admin";
@@ -1006,7 +1026,7 @@ export function ApplicationReviewDialog({
       const appData = detailedApplication;
       // Try to get files from submitted_form_data.documents
       if (appData.submitted_form_data?.documents) {
-        const files = appData.submitted_form_data.documents.map((doc: any) => ({
+        const files = appData.submitted_form_data.documents.map((doc: DocumentPayload) => ({
           id: doc.file_id || doc.id,
           filename: doc.filename,
           original_filename: doc.original_filename,
@@ -1033,8 +1053,12 @@ export function ApplicationReviewDialog({
   };
 
   // Handle file preview
-  const handleFilePreview = (file: any) => {
+  const handleFilePreview = (file: DocumentPayload) => {
     const filename = file.filename || file.original_filename;
+    if (!filename) {
+      console.error("No filename available for preview");
+      return;
+    }
 
     if (!file.file_path) {
       console.error("No file path available for preview");
@@ -1055,7 +1079,7 @@ export function ApplicationReviewDialog({
       return;
     }
 
-    const previewUrl = `/api/v1/preview?fileId=${file.id}&filename=${encodeURIComponent(filename)}&type=${encodeURIComponent(file.file_type)}&applicationId=${detailedApplication?.id}&token=${token}`;
+    const previewUrl = `/api/v1/preview?fileId=${file.id ?? ""}&filename=${encodeURIComponent(filename)}&type=${encodeURIComponent(file.file_type ?? "")}&applicationId=${detailedApplication?.id}&token=${token}`;
 
     let fileType = "other";
     if (filename.toLowerCase().endsWith(".pdf")) {

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -9,6 +9,27 @@ import {
   getReviewStageBadgeVariant,
 } from "@/lib/enums";
 
+// Shape of document entries in `submitted_form_data.documents` from
+// the backend. All fields optional because the upstream JSON can come
+// from several sources (form_data, submitted_form_data, SIS upload).
+interface DocumentPayload {
+  file_id?: string | number;
+  id?: string | number;
+  filename?: string;
+  original_filename?: string;
+  file_size?: number;
+  mime_type?: string;
+  document_type?: string;
+  file_type?: string;
+  file_path?: string;
+  download_url?: string;
+  is_verified?: boolean;
+  upload_time?: string;
+  uploaded_at?: string;
+  document_id?: string;
+}
+
+
 export type BadgeVariant = "secondary" | "default" | "outline" | "destructive";
 
 // 時間軸步驟類型
@@ -409,7 +430,7 @@ export const fetchApplicationFiles = async (applicationId: number) => {
       appResponse.data?.submitted_form_data?.documents
     ) {
       // 將 documents 轉換為 ApplicationFile 格式以保持向後兼容
-      return appResponse.data.submitted_form_data.documents.map((doc: any) => ({
+      return appResponse.data.submitted_form_data.documents.map((doc: DocumentPayload) => ({
         id: doc.file_id,
         filename: doc.filename,
         original_filename: doc.original_filename,


### PR DESCRIPTION
## Summary

Fifteenth bite at the frontend any-type cleanup ledger (task #14).
Replicates \`DocumentPayload\` interface from PR #531 across the 3
other files mapping documents from \`submitted_form_data.documents\`,
and applies the same null-guard hardening to a duplicate
\`handleFilePreview\` in \`ApplicationReviewDialog.tsx\`.

## Coverage

| File | Sites | Notes |
|---|---|---|
| admin-scholarship-dashboard.tsx | 1 \`(doc: any)\` | Local DocumentPayload |
| common/ApplicationReviewDialog.tsx | 2 (doc + file) | + 3 latent runtime bugs (parity with #531) |
| lib/utils/application-helpers.ts | 1 \`(doc: any)\` | Local DocumentPayload |

## Latent bugs surfaced (3, same pattern as #531)

\`ApplicationReviewDialog.handleFilePreview\` had the same shape of bug
that #531 fixed in \`application-detail-dialog.tsx\`:

1. \`filename.toLowerCase()\` would throw when both \`filename\` and
   \`original_filename\` are undefined.
2. URL template embedded \`\"undefined\"\` when \`file.file_type\` was missing.
3. Same for \`file.id\`.

All three caught by tsc once the type tightened, fixed with the same
pattern as PR #531 (early-return guard + \`?? \"\"\` defaults).

## Verification

\`bunx tsc --noEmit\` clean on all 3 modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)