### PR TITLE
chore(college): type 2 `(item: any)` callback args (task #14)

### DIFF
--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -139,8 +139,35 @@ export function RankingManagementPanel({
         const response = await apiClient.college.getRanking(rankingId);
         if (response.success && response.data) {
           // Transform the API response
+          // Shape from GET /college-review/rankings/{id} — backend's
+          // CollegeRankingItemResponse. Inline because the API client doesn't
+          // export a named type for this nested payload.
+          interface RankingItemPayload {
+            id: number;
+            sub_type?: string;
+            rank_position?: number;
+            is_allocated?: boolean;
+            college_rejected?: boolean;
+            student_name?: string;
+            student_id?: string;
+            application?: {
+              id?: number;
+              app_id?: string;
+              academy_name?: string;
+              academy_code?: string;
+              department_name?: string;
+              department_code?: string;
+              scholarship_type?: string;
+              eligible_subtypes?: string[];
+              is_renewal?: boolean;
+              renewal_year?: number | null;
+              status?: string;
+              review_status?: string;
+              student_info?: { display_name?: string; student_id?: string };
+            };
+          }
           const transformedApplications = (response.data.items || []).map(
-            (item: any) => ({
+            (item: RankingItemPayload) => ({
               id: item.application?.id || item.id,
               ranking_item_id: item.id,
               app_id:

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -403,7 +403,7 @@ export function ApplicationReviewPanel({
             : "-";
 
         const professorRecommendation = (app.professor_review_items || [])
-          .map((item: any) => {
+          .map((item: { sub_type_code?: string; recommendation?: string; comments?: string }) => {
             const label = getSubTypeName(item.sub_type_code, locale);
             const rec = item.recommendation === "approve"
               ? (locale === "zh" ? "推薦" : "Approve")


### PR DESCRIPTION
## Summary

Sixteenth bite at the frontend any-type cleanup ledger (task #14).
Two \`(item: any)\` callback args in the college panels replaced with
named/inline shapes.

| File | Site | Type |
|---|---|---|
| college/review/ApplicationReviewPanel.tsx:406 | \`professor_review_items.map\` | Inline 3-field shape |
| college/ranking/RankingManagementPanel.tsx:143 | rankings items map | New \`RankingItemPayload\` interface |

\`RankingItemPayload\` matches backend's \`CollegeRankingItemResponse\`;
declared inline since the API client doesn't export a named type for
the nested payload.

## Verification

\`bunx tsc --noEmit\` clean. Both callbacks already used optional
chaining + \`||\` fallbacks, so no latent bugs surfaced this PR.

## Ledger progress (task #14)

| PR | Coverage |
|---|---|
| #518–#532 | 78 sites cleared (catch + 6 callbacks) |
| **this PR** | **2 \`(item: any)\` callbacks** |
| | **total: 80 sites, 7 latent bugs caught** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)