### PR TITLE
chore(types/user): tighten raw_data index signature `any` → `unknown` (task #14)

### DIFF
--- a/frontend/types/user.ts
+++ b/frontend/types/user.ts
@@ -18,7 +18,7 @@ export interface User {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   // 向後相容性欄位
   username?: string;


### PR DESCRIPTION
## Summary

Seventeenth bite at the frontend any-type cleanup ledger (task #14).
The User interface's \`raw_data\` index signature was \`[key: string]: any\`
— wide-open dynamic property access. Switched to \`unknown\`. The known
keys (\`chinese_name\`, \`english_name\`) keep their \`string\` typing.

## Verification

\`bunx tsc --noEmit\` clean. No consumer relied on the \`any\` widening.

## Ledger progress

| PR | Coverage |
|---|---|
| #518–#533 | 80 sites |
| **this PR** | **1 \`unknown\` swap** |
| | **total: 81** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)