### PR TITLE
chore(app/page): replace debug `as any` with focused cast (task #14)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -188,7 +188,7 @@ export default function ScholarshipManagementSystem() {
       console.log("LocalStorage token exists:", !!token);
       console.log("LocalStorage user exists:", !!userJson);
       try {
-        console.log("API client has token:", !!(apiClient as any).token);
+        console.log("API client has token:", !!(apiClient as unknown as { token?: string }).token);
       } catch (e) {
         console.log("Could not access apiClient token");
       }


### PR DESCRIPTION
Debug `console.log` accessing private `apiClient.token` field. Replaced `(apiClient as any).token` with `(apiClient as unknown as { token?: string }).token` — same privacy-bypass, documented shape. Ledger: 81 → 82 sites.