### PR TITLE
chore(frontend): type ScholarshipPermission props + ocr_data record (task #14)

### DIFF
--- a/frontend/components/bank-verification-review-dialog.tsx
+++ b/frontend/components/bank-verification-review-dialog.tsx
@@ -41,7 +41,7 @@ interface BankVerificationData {
     account_holder?: VerificationFieldData
   }
   form_data?: { [key: string]: string }
-  ocr_data?: { [key: string]: any }
+  ocr_data?: { [key: string]: unknown }
   passbook_document?: {
     file_path: string
     original_filename: string

--- a/frontend/components/user-edit-modal.tsx
+++ b/frontend/components/user-edit-modal.tsx
@@ -6,7 +6,12 @@ import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Modal } from "./ui/modal";
-import { UserListResponse, UserCreate, apiClient } from "@/lib/api";
+import {
+  UserListResponse,
+  UserCreate,
+  ScholarshipPermission,
+  apiClient,
+} from "@/lib/api";
 import { Badge } from "./ui/badge";
 
 interface Academy {
@@ -24,14 +29,14 @@ interface UserEditModalProps {
   onSubmit: () => void;
   isLoading?: boolean;
   // 獎學金權限相關
-  scholarshipPermissions?: any[];
+  scholarshipPermissions?: ScholarshipPermission[];
   availableScholarships?: Array<{
     id: number;
     name: string;
     name_en?: string;
     code: string;
   }>;
-  onPermissionChange?: (permissions: any[]) => void;
+  onPermissionChange?: (permissions: ScholarshipPermission[]) => void;
 }
 
 export function UserEditModal({

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -1238,8 +1238,10 @@ export interface ScholarshipPermission {
   scholarship_name: string;
   scholarship_name_en?: string;
   comment?: string;
-  created_at: string;
-  updated_at: string;
+  // Optional because callers (e.g., admin user-edit modal) construct temporary
+  // permission objects in-memory before the server assigns timestamps.
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface ScholarshipPermissionCreate {


### PR DESCRIPTION
## Summary
- bank-verification-review-dialog.tsx: \`ocr_data?: { [key: string]: any }\` -> \`{ [key: string]: unknown }\`
- user-edit-modal.tsx: \`scholarshipPermissions?: any[]\` and \`onPermissionChange?: (permissions: any[]) => void\` -> typed with the existing \`ScholarshipPermission\` from \`@/lib/api\`
- types.ts: marked \`ScholarshipPermission.created_at\` / \`updated_at\` optional, because the admin modal constructs temp permission objects in-memory before the server assigns timestamps

Pure type narrowing; no runtime behavior change. tsc --noEmit clean.

## Test plan
- [x] \`bunx tsc --noEmit\` exits 0
- [x] \`bun run lint\` shows only pre-existing img-element warnings
- [ ] CI: smoke + unit + integration + frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)