### PR TITLE
chore(frontend): type 4 Select onValueChange callbacks in relationship management (task #14)

### DIFF
--- a/frontend/components/professor-student-relationship-management.tsx
+++ b/frontend/components/professor-student-relationship-management.tsx
@@ -353,10 +353,10 @@ export default function ProfessorStudentRelationshipManagement() {
                   <Label htmlFor="relationship_type">關係類型</Label>
                   <Select
                     value={newRelationship.relationship_type}
-                    onValueChange={(value: any) =>
+                    onValueChange={(value: string) =>
                       setNewRelationship(prev => ({
                         ...prev,
-                        relationship_type: value,
+                        relationship_type: value as RelationshipType,
                       }))
                     }
                   >
@@ -381,10 +381,10 @@ export default function ProfessorStudentRelationshipManagement() {
                   <Label htmlFor="status">狀態</Label>
                   <Select
                     value={newRelationship.status}
-                    onValueChange={(value: any) =>
+                    onValueChange={(value: string) =>
                       setNewRelationship(prev => ({
                         ...prev,
-                        status: value,
+                        status: value as RelationshipStatus,
                       }))
                     }
                   >
@@ -764,12 +764,12 @@ export default function ProfessorStudentRelationshipManagement() {
                   <Label htmlFor="edit-relationship_type">關係類型</Label>
                   <Select
                     value={editingRelationship.relationship_type}
-                    onValueChange={(value: any) =>
+                    onValueChange={(value: string) =>
                       setEditingRelationship(prev =>
                         prev
                           ? {
                               ...prev,
-                              relationship_type: value,
+                              relationship_type: value as RelationshipType,
                             }
                           : null
                       )
@@ -791,12 +791,12 @@ export default function ProfessorStudentRelationshipManagement() {
                   <Label htmlFor="edit-status">狀態</Label>
                   <Select
                     value={editingRelationship.status}
-                    onValueChange={(value: any) =>
+                    onValueChange={(value: string) =>
                       setEditingRelationship(prev =>
                         prev
                           ? {
                               ...prev,
-                              status: value,
+                              status: value as RelationshipStatus,
                             }
                           : null
                       )


### PR DESCRIPTION
## Summary
\`professor-student-relationship-management.tsx\` had 4 \`(value: any) => ...\` callbacks for the \`relationship_type\` / \`status\` Select fields (twice in the create dialog, twice in the edit dialog). Replaced with \`(value: string) => ...\` (matches Radix Select's actual onValueChange contract) plus narrowing \`as RelationshipType\` / \`as RelationshipStatus\` casts at the field assignment, preserving the typed \`ProfessorStudentRelationshipCreate\` shape.

Pure type narrowing. \`bunx tsc --noEmit\` exits 0.

## Test plan
- [x] tsc clean
- [ ] CI: backend + frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)