### PR TITLE
chore(frontend): type APScheduler job args/kwargs (task #14)

### DIFF
--- a/frontend/components/scheduler-status.tsx
+++ b/frontend/components/scheduler-status.tsx
@@ -38,8 +38,10 @@ interface JobInfo {
   misfire_grace_time?: number
   max_instances: number
   coalesce: boolean
-  args: any[]
-  kwargs: any
+  // APScheduler job args/kwargs are inherently dynamic — only opaque JSON
+  // values, never inspected by the UI (we only render counts).
+  args: unknown[]
+  kwargs: Record<string, unknown>
 }
 
 export function SchedulerStatus() {


### PR DESCRIPTION
## Summary
\`scheduler-status.tsx::JobInfo.args: any[]\` / \`kwargs: any\` -> \`unknown[]\` / \`Record<string, unknown>\`. APScheduler args/kwargs are inherently dynamic opaque JSON; the UI never inspects values (only renders counts), so \`unknown\` is sufficient and forces explicit narrowing if any future code reads them.

## Test plan
- [x] tsc --noEmit clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)