### PR TITLE
chore(frontend): type 9 any sites in file-upload + roster-preview (task #14)

### DIFF
--- a/frontend/components/file-upload.tsx
+++ b/frontend/components/file-upload.tsx
@@ -12,6 +12,17 @@ import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { Locale } from "@/lib/validators";
 import { getTranslation } from "@/lib/i18n";
 
+// Files passed as `initialFiles` may have been previously uploaded — the
+// caller attaches server-side metadata (id, url, file_path, originalSize)
+// onto the File-shaped object. We narrow each access site via this type
+// instead of widening File globally.
+type UploadedFileLike = File & {
+  id?: string | number;
+  url?: string;
+  file_path?: string;
+  originalSize?: number;
+};
+
 interface FileUploadProps {
   onFilesChange: (files: File[]) => void;
   acceptedTypes?: string[];
@@ -58,7 +69,8 @@ export function FileUpload({
 
   // 檢查文件是否為已上傳的文件
   const isUploadedFile = (file: File) => {
-    return (file as any).id || (file as any).file_path || (file as any).url;
+    const f = file as UploadedFileLike;
+    return f.id || f.file_path || f.url;
   };
 
   // 初始化和同步外部文件
@@ -184,9 +196,10 @@ export function FileUpload({
 
   // 獲取文件的顯示大小
   const getFileDisplaySize = (file: File) => {
+    const uploaded = file as UploadedFileLike;
     // 如果是已上傳的文件，優先使用 originalSize
-    if (isUploadedFile(file) && (file as any).originalSize) {
-      return formatFileSize((file as any).originalSize);
+    if (isUploadedFile(file) && uploaded.originalSize) {
+      return formatFileSize(uploaded.originalSize);
     }
     return formatFileSize(file.size);
   };
@@ -194,11 +207,10 @@ export function FileUpload({
   // 獲取文件的預覽URL
   const getFilePreviewUrl = (file: File) => {
     if (isUploadedFile(file)) {
+      const uploaded = file as UploadedFileLike;
       // 如果是已上傳的文件，使用其URL
       return (
-        (file as any).url ||
-        (file as any).file_path ||
-        URL.createObjectURL(file)
+        uploaded.url || uploaded.file_path || URL.createObjectURL(file)
       );
     }
     // 如果是本地文件，創建臨時URL

--- a/frontend/components/roster/StudentRosterPreview.tsx
+++ b/frontend/components/roster/StudentRosterPreview.tsx
@@ -35,7 +35,9 @@ interface StudentInfo {
   sub_type: string;
   amount: number;
   rank_position: number | null;
-  backup_info: any[];
+  // backup_info is rendered via the BackupInfoBadges helper which accepts
+  // an opaque list — never inspected here, so we keep it as unknown[].
+  backup_info: unknown[];
   allocated_sub_type?: string | null;
   allocation_year?: number | null;
   // Validation fields
@@ -106,7 +108,9 @@ export function StudentRosterPreview({
     setError(null);
 
     try {
-      const params: any = { config_id: configId };
+      const params: { config_id: number; ranking_id?: number | null } = {
+        config_id: configId,
+      };
       if (rankingId) {
         params.ranking_id = rankingId;
       }
@@ -140,10 +144,11 @@ export function StudentRosterPreview({
       if (err instanceof Error) {
         errorMessage = err.message;
       } else if (typeof err === "object" && err !== null) {
-        if ("detail" in err) {
-          errorMessage = (err as any).detail;
-        } else if ("message" in err) {
-          errorMessage = (err as any).message;
+        const errObj = err as { detail?: unknown; message?: unknown };
+        if (typeof errObj.detail === "string") {
+          errorMessage = errObj.detail;
+        } else if (typeof errObj.message === "string") {
+          errorMessage = errObj.message;
         }
       }
 


### PR DESCRIPTION
## Summary
Cleared 9 \`any\` sites across two files using local view-model interfaces:

**file-upload.tsx (5 sites)**: Added \`UploadedFileLike = File & { id?, url?, file_path?, originalSize? }\` to model the optional server-side metadata that callers attach to File-shaped objects via \`initialFiles\`. Replaced 5 \`(file as any).<field>\` casts with a single per-function \`as UploadedFileLike\` narrowing.

**roster/StudentRosterPreview.tsx (4 sites)**:
- \`StudentInfo.backup_info: any[]\` -> \`unknown[]\` (only \`.length\` is read inside the preview)
- \`params: any\` -> precise object-literal type \`{ config_id: number; ranking_id?: number | null }\`
- Two \`(err as any).<field>\` accesses replaced with object narrowing + \`typeof === 'string'\` guards

Pure type narrowing. \`bunx tsc --noEmit\` exits 0.

## Test plan
- [x] tsc clean
- [ ] CI: backend + frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)