### PR TITLE
chore(frontend): type 7 any sites in college-ranking-table (task #14)

### DIFF
--- a/frontend/components/college-ranking-table.tsx
+++ b/frontend/components/college-ranking-table.tsx
@@ -8,6 +8,7 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
+  type DragEndEvent,
 } from "@dnd-kit/core";
 import {
   arrayMove,
@@ -146,6 +147,19 @@ interface Application {
   review_status?: string;
 }
 
+// Excel import row shape produced by handleFileUpload before being passed up
+// via onImportExcel — three columns (學號/姓名/排名) parsed and normalized.
+interface ExcelRankingImportRow {
+  student_id: string;
+  student_name: string;
+  rank_position: number | string;
+}
+
+// Per-application review scratch state, keyed by application id. Each entry is
+// a free-form field map written by handleScoreUpdate; the values are opaque
+// to this component (the parent reads them via the onRankingChange flow).
+type ReviewScoresState = Record<number, Record<string, unknown>>;
+
 interface CollegeRankingTableProps {
   applications: Application[];
   totalQuota: number;
@@ -166,7 +180,7 @@ interface CollegeRankingTableProps {
     comments?: string
   ) => void;
   onFinalizeRanking: () => void;
-  onImportExcel?: (data: any[]) => Promise<void>;
+  onImportExcel?: (data: ExcelRankingImportRow[]) => Promise<void>;
   locale?: "zh" | "en";
   subTypeMeta?: Record<
     string,
@@ -199,8 +213,8 @@ function SortableItem({
     action: "approve" | "reject",
     comments?: string
   ) => void;
-  reviewScores: { [key: number]: any };
-  handleScoreUpdate: (appId: number, field: string, value: any) => void;
+  reviewScores: ReviewScoresState;
+  handleScoreUpdate: (appId: number, field: string, value: unknown) => void;
   subTypeMeta?: Record<
     string,
     { label: string; label_en: string; code?: string }
@@ -487,7 +501,7 @@ export function CollegeRankingTable({
     useState<Application[]>(applications);
   const [selectedApplication, setSelectedApplication] =
     useState<Application | null>(null);
-  const [reviewScores, setReviewScores] = useState<{ [key: number]: any }>({});
+  const [reviewScores, setReviewScores] = useState<ReviewScoresState>({});
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [selectedAppForDialog, setSelectedAppForDialog] =
@@ -508,7 +522,7 @@ export function CollegeRankingTable({
     setLocalApplications(sortedApps);
   }, [applications]);
 
-  const handleDragEnd = (event: any) => {
+  const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
 
     if (!over || active.id === over.id || editingLocked) {
@@ -537,7 +551,11 @@ export function CollegeRankingTable({
     onRankingChange(updatedItems);
   };
 
-  const handleScoreUpdate = (appId: number, field: string, value: any) => {
+  const handleScoreUpdate = (
+    appId: number,
+    field: string,
+    value: unknown
+  ) => {
     setReviewScores(prev => ({
       ...prev,
       [appId]: {
@@ -578,13 +596,13 @@ export function CollegeRankingTable({
 
       // Parse Excel data - expected columns: 學號, 姓名, 排名
       const errors: string[] = [];
-      const importData: Array<{
-        student_id: string;
-        student_name: string;
-        rank_position: number | string;
-      }> = [];
+      const importData: ExcelRankingImportRow[] = [];
 
-      jsonData.forEach((row: any, index: number) => {
+      // XLSX.utils.sheet_to_json returns a heterogeneous record per row keyed by
+      // column header — the cell values are inherently dynamic (Excel allows
+      // strings/numbers/dates/etc per cell), so `unknown` here is correct and
+      // the field-by-field coercion below narrows for use.
+      (jsonData as Array<Record<string, unknown>>).forEach((row, index) => {
         const rowNum = index + 2; // Excel row (header = row 1)
         const studentId = String(row["學號"] || row["student_id"] || "").trim();
         const studentName = String(


### PR DESCRIPTION
## Summary
Cleared all 7 \`any\` sites in \`components/college-ranking-table.tsx\` by defining two local view-model types:

- \`ExcelRankingImportRow\` — { student_id, student_name, rank_position } shape produced by handleFileUpload
- \`ReviewScoresState = Record<number, Record<string, unknown>>\` — per-application review-scratch state

Replaced:
- \`onImportExcel?: (data: any[]) => Promise<void>\` -> typed array
- \`reviewScores: { [key: number]: any }\` (×2) -> \`ReviewScoresState\`
- \`handleScoreUpdate: ... value: any\` (×2) -> \`value: unknown\`
- \`handleDragEnd = (event: any)\` -> \`DragEndEvent\` (imported from @dnd-kit/core)
- \`jsonData.forEach((row: any, ...))\` -> typed iteration over \`Array<Record<string, unknown>>\` (the actual XLSX.utils.sheet_to_json contract)

Pure type narrowing. \`bunx tsc --noEmit\` exits 0.

## Test plan
- [x] tsc clean
- [ ] CI: backend + frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)