### PR TITLE
chore(frontend): type 9 any sites across 3 small files (task #14)

### DIFF
--- a/frontend/components/admin/announcements/AnnouncementsPanel.tsx
+++ b/frontend/components/admin/announcements/AnnouncementsPanel.tsx
@@ -43,7 +43,7 @@ interface User {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 
@@ -204,8 +204,12 @@ export function AnnouncementsPanel({ user }: AnnouncementsPanelProps) {
       title_en: announcement.title_en,
       message: announcement.message,
       message_en: announcement.message_en,
-      notification_type: announcement.notification_type as any,
-      priority: announcement.priority as any,
+      // NotificationResponse types these as widened `string`; AnnouncementCreate
+      // requires the canonical enum literal. Server-provided values are
+      // guaranteed to match the enum, so this is a safe narrowing.
+      notification_type:
+        announcement.notification_type as AnnouncementCreate["notification_type"],
+      priority: announcement.priority as AnnouncementCreate["priority"],
       action_url: announcement.action_url,
       expires_at: announcement.expires_at,
       metadata: announcement.metadata,

--- a/frontend/components/college/shared/RankingCardList.tsx
+++ b/frontend/components/college/shared/RankingCardList.tsx
@@ -5,8 +5,24 @@ import { RankingCard } from "./RankingCard";
 import { Trophy, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
+// View-model shape for ranking cards. Mirrors the RankingCard prop contract
+// (so this list can pass items through directly). Optional fields are
+// optional in the underlying CollegeRanking type but are required by the
+// downstream RankingCard renderer; the API guarantees they are present on
+// every row returned by /college-review/rankings.
+interface RankingCardItem {
+  id: number;
+  ranking_name: string;
+  is_finalized: boolean;
+  distribution_executed: boolean;
+  total_applications: number;
+  allocated_count?: number;
+  distribution_date?: string;
+  [key: string]: unknown;
+}
+
 interface RankingCardListProps {
-  rankings: any[];
+  rankings: RankingCardItem[];
   selectedRankingId: number | null;
   onRankingSelect: (id: number) => void;
   showActions?: boolean;
@@ -22,11 +38,11 @@ interface RankingCardListProps {
   };
   editingId?: number | null;
   editingName?: string;
-  onEdit?: (ranking: any) => void;
+  onEdit?: (ranking: RankingCardItem) => void;
   onEditNameChange?: (name: string) => void;
   onEditNameSave?: (id: number) => void;
   onEditNameCancel?: () => void;
-  onDelete?: (ranking: any) => void;
+  onDelete?: (ranking: RankingCardItem) => void;
   onToggleLock?: (id: number, isLocked: boolean) => void;
   locale?: "zh" | "en";
 }

--- a/frontend/components/roster/ConfigSelector.tsx
+++ b/frontend/components/roster/ConfigSelector.tsx
@@ -65,20 +65,20 @@ export function ConfigSelector({ onConfigSelect, disabled = false }: ConfigSelec
 
         // Filter by academic year
         if (selectedYear) {
-          filtered = filtered.filter((config: any) =>
+          filtered = filtered.filter((config: ScholarshipConfiguration) =>
             config.academic_year === parseInt(selectedYear)
           )
         }
 
         // Filter by semester
         if (selectedSemester && selectedSemester !== "all") {
-          filtered = filtered.filter((config: any) =>
+          filtered = filtered.filter((config: ScholarshipConfiguration) =>
             config.semester === selectedSemester || !config.semester
           )
         }
 
         // Filter by active status
-        filtered = filtered.filter((config: any) => config.is_active !== false)
+        filtered = filtered.filter((config: ScholarshipConfiguration) => config.is_active !== false)
 
         setConfigurations(filtered)
       } else {


### PR DESCRIPTION
## Summary
Cleared 9 \`any\` sites across 3 small files:

**ConfigSelector.tsx (3 sites)**: 3× \`.filter((config: any))\` callbacks typed via the already-declared local \`ScholarshipConfiguration\` interface.

**RankingCardList.tsx (3 sites)**: Defined \`RankingCardItem\` view-model interface mirroring the downstream RankingCard's required prop shape (id, ranking_name, is_finalized, distribution_executed, total_applications + optional allocated_count, distribution_date). Replaced \`rankings: any[]\` + 2× \`(ranking: any)\` callbacks.

**AnnouncementsPanel.tsx (3 sites)**:
- \`raw_data\` index signature: \`any\` -> \`unknown\`
- 2× \`announcement.notification_type as any\` / \`priority as any\` -> explicit \`as AnnouncementCreate["notification_type"]\` / \`["priority"]\`. The cast is necessary because NotificationResponse types these fields as widened \`string\`, but AnnouncementCreate requires the canonical enum literal (safe narrowing — server-provided values are guaranteed to match the enum).

Pure type narrowing. \`bunx tsc --noEmit\` exits 0.

## Test plan
- [x] tsc clean
- [ ] CI: backend + frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)