### PR TITLE
chore(frontend): type 6 any sites across professor-review + workflow-mermaid (task #14)

### DIFF
--- a/frontend/components/ScholarshipWorkflowMermaid.tsx
+++ b/frontend/components/ScholarshipWorkflowMermaid.tsx
@@ -58,6 +58,34 @@ interface WorkflowStats {
   nextDeadline?: Date;
 }
 
+interface WorkflowStage {
+  name: string;
+  type: string;
+  status: "completed" | "active" | "pending" | "expired";
+  period?: string;
+}
+
+// Application list-row shape returned by GET /admin/applications when the
+// component requests applications for a specific workflow stage. Only the
+// fields rendered by the stage-details table are typed; backend returns more.
+interface StageApplicationRow {
+  id?: number;
+  app_id?: string;
+  student?: {
+    name?: string;
+    nycu_id?: string;
+  };
+  student_name?: string;
+  student_id?: string;
+  status?: string;
+  status_zh?: string;
+  scholarship_type_zh?: string;
+  scholarship_name?: string;
+  created_at?: string;
+  submitted_at?: string;
+  [key: string]: unknown;
+}
+
 export function ScholarshipWorkflowMermaid({
   configurations,
   selectedConfigId,
@@ -68,7 +96,9 @@ export function ScholarshipWorkflowMermaid({
   const [stats, setStats] = useState<WorkflowStats | null>(null);
   const [loading, setLoading] = useState(false);
   const [selectedStage, setSelectedStage] = useState<string | null>(null);
-  const [stageApplications, setStageApplications] = useState<any[]>([]);
+  const [stageApplications, setStageApplications] = useState<
+    StageApplicationRow[]
+  >([]);
   const [showStageDetails, setShowStageDetails] = useState(false);
 
   // Tab 功能相關狀態
@@ -301,14 +331,7 @@ export function ScholarshipWorkflowMermaid({
   };
 
   // 準備工作流程階段數據
-  const getWorkflowStages = (config: ScholarshipConfiguration) => {
-    interface WorkflowStage {
-      name: string;
-      type: string;
-      status: "completed" | "active" | "pending" | "expired";
-      period?: string;
-    }
-
+  const getWorkflowStages = (config: ScholarshipConfiguration): WorkflowStage[] => {
     const stages: WorkflowStage[] = [
       {
         name: "開始",
@@ -683,7 +706,11 @@ export function ScholarshipWorkflowMermaid({
 
                             <div className="space-y-4">
                               {getWorkflowStages(selectedConfig).map(
-                                (stage: any, index: number, array: any[]) => (
+                                (
+                                  stage: WorkflowStage,
+                                  index: number,
+                                  array: WorkflowStage[]
+                                ) => (
                                   <div
                                     key={index}
                                     className="flex items-center"
@@ -819,7 +846,7 @@ export function ScholarshipWorkflowMermaid({
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {stageApplications.map((app: any) => (
+                  {stageApplications.map((app: StageApplicationRow) => (
                     <TableRow key={app.id}>
                       <TableCell className="font-medium">#{app.id}</TableCell>
                       <TableCell>{app.student?.name || "N/A"}</TableCell>
@@ -851,7 +878,7 @@ export function ScholarshipWorkflowMermaid({
                             "college_review_pending",
                             "approved",
                             "rejected",
-                          ].includes(app.status) && app.status}
+                          ].includes(app.status ?? "") && app.status}
                         </Badge>
                       </TableCell>
                       <TableCell>

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -96,6 +96,18 @@ interface ReviewData {
   items: ReviewItem[];
 }
 
+// Existing-review payload returned by GET /professor/.../review.
+// Only fields the component reads are typed; backend may attach more.
+interface ExistingReviewPayload {
+  id: number;
+  items?: ReviewItem[];
+  [key: string]: unknown;
+}
+
+// Response shape from professor.submitReview / .updateReview — opaque
+// success/message envelope; we never inspect `data` content here.
+type ProfessorReviewResponse = ApiResponse<{ [key: string]: unknown } | null>;
+
 function ProfessorReviewComponentInner({
   user,
 }: ProfessorReviewComponentProps) {
@@ -130,7 +142,8 @@ function ProfessorReviewComponentInner({
     recommendation: "",
     items: [],
   });
-  const [existingReview, setExistingReview] = useState<any>(null);
+  const [existingReview, setExistingReview] =
+    useState<ExistingReviewPayload | null>(null);
   const [reviewModalOpen, setReviewModalOpen] = useState(false);
 
   // Regulations state
@@ -369,7 +382,7 @@ function ProfessorReviewComponentInner({
     setSuccess(null);
 
     try {
-      let response: ApiResponse<any>;
+      let response: ProfessorReviewResponse;
 
       // Filter out pending items - only send approve/reject items to API
       const filteredItems = reviewData.items
@@ -438,7 +451,11 @@ function ProfessorReviewComponentInner({
   };
 
   // Update review item
-  const updateReviewItem = (subTypeCode: string, field: string, value: any) => {
+  const updateReviewItem = (
+    subTypeCode: string,
+    field: keyof ReviewItem,
+    value: ReviewItem[keyof ReviewItem]
+  ) => {
     setReviewData(prev => {
       const newData = {
         ...prev,


### PR DESCRIPTION
## Summary

**professor-review-component.tsx (3 sites)**:
- \`existingReview\` state: \`any\` -> new \`ExistingReviewPayload\` interface (id + items + passthrough)
- \`let response: ApiResponse<any>\` -> \`ProfessorReviewResponse\` type alias
- \`updateReviewItem (..., field: string, value: any)\` -> typed via \`keyof ReviewItem\` + \`ReviewItem[keyof ReviewItem]\`

**ScholarshipWorkflowMermaid.tsx (3 sites)**:
- Extracted \`WorkflowStage\` interface from inside the helper closure to module scope
- Defined \`StageApplicationRow\` view-model for the stage-details table
- \`stageApplications: any[]\` -> \`StageApplicationRow[]\`
- Inline \`(stage: any, ..., array: any[])\` -> typed map callback
- \`.includes(app.status)\` narrowed via \`?? ""\` since \`status\` is now optional in the view-model

Pure type narrowing. \`bunx tsc --noEmit\` exits 0.

## Test plan
- [x] tsc clean
- [ ] CI: backend + frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)