### PR TITLE
chore(frontend): type 9 any sites across 3 files (task #14)

### DIFF
--- a/frontend/components/batch-import-editor.tsx
+++ b/frontend/components/batch-import-editor.tsx
@@ -24,23 +24,31 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+// One validation error attached to a specific row (and optionally a specific
+// cell) — produced by the backend Excel parser; the editor highlights cells
+// and rows that match.
+interface BatchImportValidationError {
+  row: number;
+  field?: string;
+  message: string;
+}
+
 interface BatchImportEditorProps {
   batchId: number;
-  previewData: Array<Record<string, any>>;
-  validationErrors: Array<{
-    row: number;
-    field?: string;
-    message: string;
-  }>;
-  onDataChange?: (newData: Array<Record<string, any>>) => void;
-  onValidationChange?: (errors: Array<any>) => void;
+  // Each row is an opaque key→value map (cell values can be string/number/
+  // bool/null depending on the column); editor reads keys + values without
+  // assuming a fixed schema, which is why `unknown` is the right level here.
+  previewData: Array<Record<string, unknown>>;
+  validationErrors: BatchImportValidationError[];
+  onDataChange?: (newData: Array<Record<string, unknown>>) => void;
+  onValidationChange?: (errors: BatchImportValidationError[]) => void;
   locale?: "zh" | "en";
 }
 
 interface EditingCell {
   rowIndex: number;
   field: string;
-  value: any;
+  value: unknown;
 }
 
 export function BatchImportEditor({
@@ -75,7 +83,11 @@ export function BatchImportEditor({
     return errors.find((e) => e.row === rowIndex + 2 && e.field === field);
   };
 
-  const handleStartEdit = (rowIndex: number, field: string, value: any) => {
+  const handleStartEdit = (
+    rowIndex: number,
+    field: string,
+    value: unknown
+  ) => {
     setEditingCell({ rowIndex, field, value });
   };
 
@@ -321,7 +333,11 @@ export function BatchImportEditor({
                         {isEditing ? (
                           <div className="flex items-center gap-2">
                             <Input
-                              value={editingCell.value}
+                              value={
+                                editingCell.value == null
+                                  ? ""
+                                  : String(editingCell.value)
+                              }
                               onChange={(e) =>
                                 setEditingCell({
                                   ...editingCell,

--- a/frontend/components/email-test-mode-panel.tsx
+++ b/frontend/components/email-test-mode-panel.tsx
@@ -45,8 +45,11 @@ interface AuditLog {
   event_type: string;
   timestamp: string;
   user_id: number | null;
-  config_before: any;
-  config_after: any;
+  // Free-form JSON snapshots of test-mode config before/after the audit event.
+  // The UI never inspects these (only renders presence indicators), so we keep
+  // them as opaque records.
+  config_before: Record<string, unknown> | null;
+  config_after: Record<string, unknown> | null;
   original_recipient: string | null;
   actual_recipient: string | null;
   email_subject: string | null;

--- a/frontend/components/reviewer-dashboard.tsx
+++ b/frontend/components/reviewer-dashboard.tsx
@@ -66,7 +66,28 @@ export function ReviewerDashboard({
   const t = (key: string) => getTranslation(locale, key);
 
   const [viewMode, setViewMode] = useState<"card" | "table">("card");
-  const [selectedApplication, setSelectedApplication] = useState<any>(null);
+
+  // Mock-data row shape consumed by this demo dashboard. Real production
+  // version pulls from the Application type via the API; this component is
+  // wired to a hard-coded fixture below.
+  interface MockApplicationRow {
+    id: string;
+    studentName: string;
+    studentNameEn: string;
+    studentId: string;
+    nationality: string;
+    type: string;
+    typeName: string;
+    status: string;
+    statusName: string;
+    submittedAt: string;
+    gpa: number;
+    amount: number;
+    priority: string;
+    daysWaiting: number;
+  }
+  const [selectedApplication, setSelectedApplication] =
+    useState<MockApplicationRow | null>(null);
 
   const [applications] = useState([
     {
@@ -119,24 +140,26 @@ export function ReviewerDashboard({
     },
   ]);
 
-  const getStatusColor = (status: string) => {
-    const statusMap = {
+  type BadgeVariant = "default" | "secondary" | "destructive" | "outline";
+
+  const getStatusColor = (status: string): BadgeVariant => {
+    const statusMap: Record<string, BadgeVariant> = {
       pending_review: "destructive",
       under_review: "outline",
       approved: "default",
       partial_approved: "outline",
       rejected: "secondary",
     };
-    return statusMap[status as keyof typeof statusMap] || "secondary";
+    return statusMap[status] || "secondary";
   };
 
-  const getPriorityColor = (priority: string) => {
-    const priorityMap = {
+  const getPriorityColor = (priority: string): BadgeVariant => {
+    const priorityMap: Record<string, BadgeVariant> = {
       high: "destructive",
       medium: "outline",
       low: "secondary",
     };
-    return priorityMap[priority as keyof typeof priorityMap] || "secondary";
+    return priorityMap[priority] || "secondary";
   };
 
   const handleApprove = (appId: string) => {
@@ -163,7 +186,7 @@ export function ReviewerDashboard({
                   showLabel={false}
                 />
               </div>
-              <Badge variant={getPriorityColor(app.priority) as any}>
+              <Badge variant={getPriorityColor(app.priority)}>
                 {app.priority === "high"
                   ? locale === "zh"
                     ? "高"


### PR DESCRIPTION
## Summary
9 sites cleared across 3 files:

**reviewer-dashboard.tsx (4 sites)**: extracted \`MockApplicationRow\` interface for the local-fixture state; narrowed \`getStatusColor\`/\`getPriorityColor\` return type to \`BadgeVariant\` (proper union), which eliminates the 3× \`as any\` at <Badge variant={...}>.

**batch-import-editor.tsx (3 sites)**: \`previewData: Array<Record<string, any>>\` -> \`Record<string, unknown>[]\`; \`onValidationChange: Array<any>\` -> \`BatchImportValidationError[]\` (extracted inline shape); \`handleStartEdit value: any\` + \`EditingCell.value\` -> \`unknown\` with Input binding coercing via \`editingCell.value == null ? "" : String(editingCell.value)\`.

**email-test-mode-panel.tsx (2 sites)**: \`AuditLog.config_before\` / \`config_after\` -> \`Record<string, unknown> | null\` (free-form snapshots, never inspected by UI).

Pure type narrowing. \`bunx tsc --noEmit\` exits 0.

## Test plan
- [x] tsc clean
- [ ] CI: backend + frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)