### PR TITLE
chore(frontend): narrow remaining any-type sites in admin + roster + profile

### DIFF
--- a/frontend/components/admin-scholarship-dashboard.tsx
+++ b/frontend/components/admin-scholarship-dashboard.tsx
@@ -3,7 +3,10 @@
 import { AdminScholarshipManagementInterface } from "@/components/admin-scholarship-management-interface";
 import { ApplicationReviewDialog } from "@/components/common/ApplicationReviewDialog";
 import { ApplicationAuditTrail } from "@/components/application-audit-trail";
-import { BankVerificationReviewDialog } from "@/components/bank-verification-review-dialog";
+import {
+  BankVerificationReviewDialog,
+  type BankVerificationData,
+} from "@/components/bank-verification-review-dialog";
 import { DeleteApplicationDialog } from "@/components/delete-application-dialog";
 import { ProfessorAssignmentDropdown } from "@/components/professor-assignment-dropdown";
 import { SemesterSelector } from "@/components/semester-selector";
@@ -175,7 +178,7 @@ interface DashboardApplication {
   approved_at?: string;
   academic_year?: string;
   semester?: string;
-  meta_data?: any;
+  meta_data?: Record<string, unknown>;
   // Scholarship configuration for professor review requirements
   scholarship_configuration?: {
     requires_professor_recommendation: boolean;
@@ -184,10 +187,17 @@ interface DashboardApplication {
   };
   // Student data snapshot from SIS API (see backend/app/schemas/student_snapshot.py)
   // Fields follow pattern: std_* (basic), trm_* (term), com_* (contact)
-  student_data?: Record<string, any>;
+  student_data?: Record<string, unknown>;
 }
 
-// Data transformation function to map API response to expected format
+// Data transformation function to map API response to expected format.
+// Accepts the loose Application shape from useScholarshipSpecificApplications
+// (which mirrors the admin /applications endpoint) and normalises it into a
+// DashboardApplication. The upstream Application type has fields that diverge
+// from DashboardApplication (e.g. professor_id is string | number, while
+// DashboardApplication narrows it to number), so we keep this parameter
+// loose rather than re-declare the entire transform.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const transformApplicationData = (app: any): DashboardApplication => {
   console.log("🔍 Transforming application data:", app.app_id);
   console.log("📊 Professor data in raw API response:", app.professor);
@@ -323,7 +333,8 @@ export function AdminScholarshipDashboard({
   const [selectedApplicationsForBatch, setSelectedApplicationsForBatch] =
     useState<number[]>([]);
   const [bankReviewDialogOpen, setBankReviewDialogOpen] = useState(false);
-  const [currentBankVerification, setCurrentBankVerification] = useState<any | null>(null);
+  const [currentBankVerification, setCurrentBankVerification] =
+    useState<BankVerificationData | null>(null);
   // 學期選擇相關狀態
   const [selectedAcademicYear, setSelectedAcademicYear] = useState<number>();
   const [selectedSemester, setSelectedSemester] = useState<string>();
@@ -344,7 +355,10 @@ export function AdminScholarshipDashboard({
     user && ["admin", "super_admin", "college"].includes(user.role);
 
   // 處理教授指派回調
-  const handleProfessorAssigned = (applicationId: number, professor: any) => {
+  const handleProfessorAssigned = (
+    _applicationId: number,
+    _professor: unknown
+  ) => {
     // 刷新相應的申請資料
     refetch();
   };
@@ -638,7 +652,9 @@ export function AdminScholarshipDashboard({
   // 獲取郵局驗證狀態的顯示組件（簡化版：僅顯示 icon）
   const getBankVerificationStatus = (app: DashboardApplication) => {
     // 新版：檢查 bank_verification 物件中的分開狀態
-    const bankVerification = app.meta_data?.bank_verification;
+    const bankVerification = app.meta_data?.bank_verification as
+      | { account_number_status?: string; account_holder_status?: string }
+      | undefined;
     const accountNumberStatus = bankVerification?.account_number_status;
     const accountHolderStatus = bankVerification?.account_holder_status;
 

--- a/frontend/components/bank-verification-review-dialog.tsx
+++ b/frontend/components/bank-verification-review-dialog.tsx
@@ -30,7 +30,7 @@ interface VerificationFieldData {
   needs_manual_review?: boolean
 }
 
-interface BankVerificationData {
+export interface BankVerificationData {
   application_id: number
   verification_status: string
   account_number_status?: string

--- a/frontend/components/college/shared/RankingCard.tsx
+++ b/frontend/components/college/shared/RankingCard.tsx
@@ -17,21 +17,24 @@ import {
   Award,
 } from "lucide-react";
 
+export interface RankingCardData {
+  id: number;
+  ranking_name: string;
+  is_finalized: boolean;
+  distribution_executed: boolean;
+  total_applications: number;
+  allocated_count?: number;
+  distribution_date?: string;
+  [key: string]: unknown;
+}
+
 interface RankingCardProps {
-  ranking: {
-    id: number;
-    ranking_name: string;
-    is_finalized: boolean;
-    distribution_executed: boolean;
-    total_applications: number;
-    allocated_count?: number;
-    distribution_date?: string;
-  };
+  ranking: RankingCardData;
   isSelected?: boolean;
   showActions?: boolean;
   onSelect: (rankingId: number) => void;
-  onEdit?: (ranking: any) => void;
-  onDelete?: (ranking: any) => void;
+  onEdit?: (ranking: RankingCardData) => void;
+  onDelete?: (ranking: RankingCardData) => void;
   onToggleLock?: (rankingId: number) => void;
   editingId?: number | null;
   editingName?: string;

--- a/frontend/components/roster/CompactConfigSelector.tsx
+++ b/frontend/components/roster/CompactConfigSelector.tsx
@@ -15,8 +15,15 @@ interface ScholarshipConfiguration {
     name: string
   }
   is_active: boolean
-  quotas?: any
+  quotas?: Record<string, unknown>
   has_college_quota?: boolean
+}
+
+interface ScholarshipTypeConfigRow {
+  scholarship_type_id?: number
+  scholarship_type_name?: string
+  scholarship_type_code?: string
+  [key: string]: unknown
 }
 
 interface ScholarshipType {
@@ -95,7 +102,7 @@ export function CompactConfigSelector({ onConfigSelect, disabled = false }: Comp
         // Extract unique scholarship types from configurations
         const typesMap = new Map<number, ScholarshipType>()
 
-        response.data.forEach((config: any) => {
+        ;(response.data as ScholarshipTypeConfigRow[]).forEach(config => {
           if (config.scholarship_type_id && config.scholarship_type_name) {
             typesMap.set(config.scholarship_type_id, {
               id: config.scholarship_type_id,

--- a/frontend/components/user-profile-management.tsx
+++ b/frontend/components/user-profile-management.tsx
@@ -61,10 +61,18 @@ interface UserProfile {
   updated_at: string;
 }
 
+interface StudentInfoSnapshot {
+  std_degree?: string;
+  std_studingstatus?: string;
+  std_enrollyear?: string | number;
+  std_termcount?: string | number;
+  [key: string]: unknown;
+}
+
 interface CompleteUserProfile {
   user_info: UserResponse;
   profile: UserProfile | null;
-  student_info?: any;
+  student_info?: StudentInfoSnapshot | null;
 }
 
 interface ProfileHistory {
@@ -249,7 +257,7 @@ export default function UserProfileManagement() {
     setSaving(true);
     try {
       let endpoint = "/user-profiles/me";
-      let data: any = {};
+      let data: Record<string, unknown> = {};
 
       switch (section) {
         case "bank":
@@ -275,16 +283,20 @@ export default function UserProfileManagement() {
           };
           break;
         default:
-          data = editingProfile;
+          data = { ...editingProfile };
       }
 
       let response;
       switch (section) {
         case "bank":
-          response = await api.userProfiles.updateBankInfo(data);
+          response = await api.userProfiles.updateBankInfo(
+            data as Parameters<typeof api.userProfiles.updateBankInfo>[0]
+          );
           break;
         case "advisor":
-          response = await api.userProfiles.updateAdvisorInfo(data);
+          response = await api.userProfiles.updateAdvisorInfo(
+            data as Parameters<typeof api.userProfiles.updateAdvisorInfo>[0]
+          );
           break;
         default:
           response = await api.userProfiles.updateProfile(editingProfile);


### PR DESCRIPTION
## Summary
- Replaces 7 \`any\` annotations across five components with typed view-model interfaces or \`unknown\`/\`Record<string, unknown>\`, restoring TypeScript checking around the affected code.
- Exports \`BankVerificationData\` from \`bank-verification-review-dialog\` so the admin dashboard's bank-verification state can share the same prop contract instead of an opaque record.
- Documents one remaining \`any\` (\`transformApplicationData\`) with an eslint-disable comment: the upstream Application type has divergent field types (e.g. \`professor_id: string | number\`) that don't intersect cleanly with the internal DashboardApplication, so tightening it would balloon the PR.

## Changed files
- \`frontend/components/admin-scholarship-dashboard.tsx\` — meta_data/student_data → \`Record<string, unknown>\`; currentBankVerification → \`BankVerificationData | null\`; handleProfessorAssigned param → \`unknown\` (return-value unused).
- \`frontend/components/bank-verification-review-dialog.tsx\` — export the local \`BankVerificationData\` interface.
- \`frontend/components/college/shared/RankingCard.tsx\` — extracted \`RankingCardData\` view-model (with index signature) and used for \`ranking\` + \`onEdit\` + \`onDelete\` (was \`any\`).
- \`frontend/components/roster/CompactConfigSelector.tsx\` — \`quotas?: Record<string, unknown>\`; \`forEach\` row typed via a local \`ScholarshipTypeConfigRow\` view-model.
- \`frontend/components/user-profile-management.tsx\` — added a \`StudentInfoSnapshot\` view-model for the SIS API snapshot; the legacy \`data: any\` save buffer narrowed to \`Record<string, unknown>\` with \`Parameters<typeof api.x>[0]\` casts at the update call sites.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime behavior changes — pure type narrowings + one cross-file type-export