### PR TITLE
chore(frontend): replace any with keyof-indexed generics in form handlers

### DIFF
--- a/frontend/components/admin-management-interface.tsx
+++ b/frontend/components/admin-management-interface.tsx
@@ -1290,13 +1290,16 @@ export function AdminManagementInterface({
     }
   };
 
-  const handleUserFormChange = (field: keyof UserCreate, value: any) => {
+  const handleUserFormChange = <K extends keyof UserCreate>(
+    field: K,
+    value: UserCreate[K]
+  ) => {
     setUserForm(prev => ({ ...prev, [field]: value }));
 
     // 當角色改變時，處理獎學金權限
     if (field === "role") {
       // 如果角色不是 college 或 admin，清除該用戶的所有獎學金權限
-      if (!["college", "admin"].includes(value)) {
+      if (!["college", "admin"].includes(value as string)) {
         if (editingUser) {
           // 編輯現有用戶時，清除該用戶的權限
           setScholarshipPermissions(prev =>

--- a/frontend/components/batch-application-file-upload.tsx
+++ b/frontend/components/batch-application-file-upload.tsx
@@ -139,11 +139,13 @@ export function BatchApplicationFileUpload({
         const response = await apiClient.applicationFields.getFormConfig(scholarshipType);
         if (response.success && response.data?.documents && response.data.documents.length > 0) {
           // Transform API response to DocumentType format
-          const transformedDocs: DocumentType[] = response.data.documents.map((doc: any) => ({
-            value: doc.document_name.toLowerCase().replace(/\s+/g, "_"),
-            label_zh: doc.document_name,
-            label_en: doc.document_name_en || doc.document_name,
-          }));
+          const transformedDocs: DocumentType[] = response.data.documents.map(
+            (doc: { document_name: string; document_name_en?: string }) => ({
+              value: doc.document_name.toLowerCase().replace(/\s+/g, "_"),
+              label_zh: doc.document_name,
+              label_en: doc.document_name_en || doc.document_name,
+            })
+          );
           setScholarshipDocuments(transformedDocs);
         } else {
           setScholarshipDocuments([]);

--- a/frontend/components/scholarship-rule-modal.tsx
+++ b/frontend/components/scholarship-rule-modal.tsx
@@ -241,7 +241,10 @@ export function ScholarshipRuleModal({
     loadSubTypes();
   }, [isOpen, scholarshipTypeId]);
 
-  const handleChange = (field: keyof ScholarshipRule, value: any) => {
+  const handleChange = <K extends keyof ScholarshipRule>(
+    field: K,
+    value: ScholarshipRule[K]
+  ) => {
     setFormData(prev => {
       const newData = { ...prev, [field]: value };
 
@@ -356,7 +359,10 @@ export function ScholarshipRuleModal({
             <Select
               value={formData.sub_type || "__general__"}
               onValueChange={value =>
-                handleChange("sub_type", value === "__general__" ? null : value)
+                handleChange(
+                  "sub_type",
+                  value === "__general__" ? undefined : value
+                )
               }
               disabled={loadingSubTypes}
             >

--- a/frontend/components/user-permission-management.tsx
+++ b/frontend/components/user-permission-management.tsx
@@ -246,11 +246,14 @@ export function UserPermissionManagement() {
     }
   }, [userSearch, userRoleFilter]);
 
-  const handleUserFormChange = (field: keyof UserCreateForm, value: any) => {
+  const handleUserFormChange = <K extends keyof UserCreateForm>(
+    field: K,
+    value: UserCreateForm[K]
+  ) => {
     setUserForm((prev) => ({ ...prev, [field]: value }));
 
     if (field === "role") {
-      if (!["college", "admin"].includes(value)) {
+      if (!["college", "admin"].includes(value as string)) {
         if (editingUser) {
           setScholarshipPermissions((prev) =>
             prev.filter((p) => p.user_id !== Number(editingUser.id))


### PR DESCRIPTION
## Summary
- Four components used the \`handleChange = (field: keyof T, value: any)\` pattern, which defeats type-safety on the value side. This PR upgrades all four to the generic form \`<K extends keyof T>(field: K, value: T[K])\`, which TypeScript can actually narrow.
- Replaces \`(doc: any)\` in \`batch-application-file-upload\` with the minimal \`{document_name, document_name_en?}\` shape that the .map callback actually reads.
- Fixes a pre-existing latent issue surfaced by the new narrowing: \`scholarship-rule-modal\` was passing \`null\` to a field typed as \`string | undefined\`. Switched to \`undefined\`.

## Changed files
- \`frontend/components/scholarship-rule-modal.tsx\` — generic handleChange + sub_type call-site null→undefined
- \`frontend/components/admin-management-interface.tsx\` — generic handleUserFormChange + role-string cast
- \`frontend/components/user-permission-management.tsx\` — same as admin-management
- \`frontend/components/batch-application-file-upload.tsx\` — narrow doc-transform callback shape

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime behavior changes (the null→undefined sub_type change is functionally equivalent: existing API code in the parent dispatcher treats both as \"unset\")