### PR TITLE
chore(frontend): narrow scattered any sites across admin/audit/roster/sso

### DIFF
--- a/frontend/components/admin-rule-management.tsx
+++ b/frontend/components/admin-rule-management.tsx
@@ -154,7 +154,12 @@ export function AdminRuleManagement({
       setLoading(true);
       try {
         // 根據獎學金類型決定是否包含學期參數
-        const params: any = {
+        const params: {
+          scholarship_type_id: number;
+          academic_year: number;
+          is_active: boolean;
+          semester?: string | null;
+        } = {
           scholarship_type_id: scholarshipType.id,
           academic_year: year,
           is_active: true, // Explicitly filter for active rules

--- a/frontend/components/audit-trail/JsonDiffViewer.tsx
+++ b/frontend/components/audit-trail/JsonDiffViewer.tsx
@@ -4,8 +4,10 @@ import { useMemo } from "react";
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
 
 interface JsonDiffViewerProps {
-  oldValue: any;
-  newValue: any;
+  // Audit-log diffs ship arbitrary JSON payloads (rows from many tables),
+  // so the values are typed as `unknown` and stringified at use-site.
+  oldValue: unknown;
+  newValue: unknown;
   locale?: "zh" | "en";
 }
 

--- a/frontend/components/email-automation-management.tsx
+++ b/frontend/components/email-automation-management.tsx
@@ -146,11 +146,13 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
       const response = await apiClient.admin.getEmailTemplatesBySendingType();
       if (response.success && response.data) {
         // Use subject_template from database as label
-        const templates = response.data.map((t: any) => ({
-          key: t.key,
-          label: t.subject_template || t.key, // Use subject as label, fallback to key
-          subject_template: t.subject_template,
-        }));
+        const templates = response.data.map(
+          (t: { key: string; subject_template?: string }) => ({
+            key: t.key,
+            label: t.subject_template || t.key, // Use subject as label, fallback to key
+            subject_template: t.subject_template,
+          })
+        );
         setEmailTemplates(templates);
       }
     } catch (error: unknown) {

--- a/frontend/components/mock-sso-login.tsx
+++ b/frontend/components/mock-sso-login.tsx
@@ -128,7 +128,9 @@ export function MockSSOLogin() {
           if (profilesResponse.ok) {
             const profilesData = await profilesResponse.json();
             if (profilesData.success) {
-              const profiles = profilesData.data.map((profile: any) => ({
+              const profiles = (
+                profilesData.data as Omit<DeveloperProfile, "developer_id">[]
+              ).map(profile => ({
                 ...profile,
                 developer_id: developerId,
               }));

--- a/frontend/components/roster-schedule-list.tsx
+++ b/frontend/components/roster-schedule-list.tsx
@@ -62,7 +62,12 @@ export function RosterScheduleList({ onScheduleChange, onRosterGenerated }: Rost
   const fetchSchedules = async () => {
     try {
       setLoading(true)
-      const params: any = {
+      const params: {
+        skip: number
+        limit: number
+        search?: string
+        status?: string
+      } = {
         skip: pagination.skip,
         limit: pagination.limit,
       }

--- a/frontend/components/user-edit-modal.tsx
+++ b/frontend/components/user-edit-modal.tsx
@@ -25,7 +25,10 @@ interface UserEditModalProps {
   onClose: () => void;
   editingUser: UserListResponse | null;
   userForm: UserCreate;
-  onUserFormChange: (field: keyof UserCreate, value: any) => void;
+  onUserFormChange: <K extends keyof UserCreate>(
+    field: K,
+    value: UserCreate[K]
+  ) => void;
   onSubmit: () => void;
   isLoading?: boolean;
   // 獎學金權限相關
@@ -230,7 +233,7 @@ export function UserEditModal({
               <select
                 value={userForm.role}
                 onChange={(e) => {
-                  const newRole = e.target.value;
+                  const newRole = e.target.value as UserCreate["role"];
                   const oldRole = userForm.role;
 
                   onUserFormChange("role", newRole);


### PR DESCRIPTION
## Summary
Targets six low-coupling components where the \`any\` was load-bearing for a single object literal or callback, and replaces each with a typed structural shape derived from how the value is used:

- \`admin-rule-management\`: inline params object passed to \`api.admin.getScholarshipRules\`.
- \`audit-trail/JsonDiffViewer\`: \`oldValue\` / \`newValue\` -> \`unknown\` (arbitrary JSON payloads).
- \`email-automation-management\`: \`.map((t: any) => ...)\` -> \`{key, subject_template?}\`.
- \`mock-sso-login\`: profile spread typed via \`Omit<DeveloperProfile, \"developer_id\">\` using the existing local interface.
- \`roster-schedule-list\`: inline params accumulator with optional search/status fields.
- \`user-edit-modal\`: \`onUserFormChange\` now uses the generic \`<K extends keyof UserCreate>(field: K, value: UserCreate[K])\` shape; the role select cast at call-site to \`UserCreate[\"role\"]\`.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime behavior changes — pure type narrowings + one role-string cast