### PR TITLE
chore(frontend): narrow any-types in use-admin + use-student-profile

### DIFF
--- a/frontend/hooks/use-admin.ts
+++ b/frontend/hooks/use-admin.ts
@@ -297,16 +297,27 @@ export function useCollegeApplications() {
 
         if (response.success && response.data) {
           // Transform data to ensure consistent field mapping
-          const transformedApplications = response.data.map((app: any) => ({
-            ...app,
-            // Ensure student fields are correctly mapped
-            student_name:
-              app.student_name ||
-              app.student_info?.display_name ||
-              "未提供姓名",
-            student_id:
-              app.student_id || app.student_info?.student_id_masked || "N/A",
-          }));
+          const transformedApplications = response.data.map(app => {
+            // Loose typing for fields not on the canonical Application
+            // type (the college-review endpoint includes a denormalized
+            // `student_info` block plus already-flattened student_name /
+            // student_id strings). We narrow only the read fields.
+            const a = app as Application & {
+              student_info?: {
+                display_name?: string;
+                student_id_masked?: string;
+              };
+            };
+            return {
+              ...a,
+              student_name:
+                a.student_name ||
+                a.student_info?.display_name ||
+                "未提供姓名",
+              student_id:
+                a.student_id || a.student_info?.student_id_masked || "N/A",
+            };
+          });
           setApplications(transformedApplications);
         } else {
           throw new Error(

--- a/frontend/hooks/use-student-profile.ts
+++ b/frontend/hooks/use-student-profile.ts
@@ -33,7 +33,7 @@ type CompleteUserProfile = {
     user_type?: string;
     status?: string;
     role?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   student_info?: {
     std_stdcode?: string;
@@ -41,8 +41,11 @@ type CompleteUserProfile = {
     std_degree?: string;
     std_studingstatus?: string;
     std_enrollyear?: string;
+    std_enrollterm?: string;
     std_termcount?: string;
-    [key: string]: any;
+    std_nation?: string;
+    std_identity?: string;
+    [key: string]: unknown;
   };
   profile?: {
     id?: number;
@@ -52,9 +55,9 @@ type CompleteUserProfile = {
     advisor_nycu_id?: string;
     account_number?: string;
     bank_document_photo_url?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 /**


### PR DESCRIPTION
## Summary
- \`use-student-profile.ts\`: 4 \`[key: string]: any\` index signatures inside the \`CompleteUserProfile\` type narrowed to \`[key: string]: unknown\`. Added the missing \`student_info\` fields the \`StudentDataReviewStep\` consumer reads (\`std_enrollterm\`, \`std_nation\`, \`std_identity\`) so widening the index sig doesn't poison those access sites.
- \`use-admin.ts\`: replaced the \`(app: any) => ...\` transform in the college-review \`applications\` mapper with a documented intersection cast \`Application & {student_info?: ...}\` for the denormalized endpoint shape (the college-review endpoint adds a flattened \`student_info\` block on top of the canonical \`Application\`).

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime changes — pure type narrowings + one intersection cast