### PR TITLE
chore(frontend): narrow any-types across admin shell + notification + lib types

### DIFF
--- a/frontend/components/admin/AdminManagementShell.tsx
+++ b/frontend/components/admin/AdminManagementShell.tsx
@@ -50,7 +50,7 @@ interface User {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 
@@ -74,9 +74,7 @@ function AdminManagementContent({ user }: AdminManagementShellProps) {
         const response = await apiClient.admin.getCurrentUserScholarshipPermissions();
         if (response.success && response.data) {
           const permissions = response.data as ScholarshipPermission[];
-          const hasQuota = permissions.some(
-            (p: any) => p.can_manage_quota
-          );
+          const hasQuota = permissions.some(p => p.can_manage_quota);
           setHasQuotaPermission(hasQuota);
         }
       } catch (error) {

--- a/frontend/components/admin/batch-bank-verification.tsx
+++ b/frontend/components/admin/batch-bank-verification.tsx
@@ -24,7 +24,10 @@ const api = createBankVerificationApi();
 
 interface BatchBankVerificationProps {
   applicationIds: number[];
-  onComplete?: (taskId: string, results: any) => void;
+  onComplete?: (
+    taskId: string,
+    results: BankVerificationTask["results"]
+  ) => void;
   onNeedsReview?: (applicationIds: number[]) => void;
 }
 

--- a/frontend/components/admin/email/EmailPanel.tsx
+++ b/frontend/components/admin/email/EmailPanel.tsx
@@ -33,7 +33,7 @@ interface User {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 

--- a/frontend/components/admin/history/HistoryPanel.tsx
+++ b/frontend/components/admin/history/HistoryPanel.tsx
@@ -60,7 +60,7 @@ interface User {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
 }
 

--- a/frontend/components/admin/students/StudentListManagement.tsx
+++ b/frontend/components/admin/students/StudentListManagement.tsx
@@ -59,7 +59,13 @@ export function StudentListManagement() {
     setError(null);
 
     try {
-      const params: any = {
+      const params: {
+        page: number;
+        size: number;
+        search?: string;
+        dept_code?: string;
+        status?: string;
+      } = {
         page: pagination.page,
         size: pagination.size,
       };

--- a/frontend/components/notification-panel.tsx
+++ b/frontend/components/notification-panel.tsx
@@ -46,7 +46,7 @@ interface NotificationData {
   expires_at?: string;
   read_at?: string;
   created_at: string;
-  metadata?: any;
+  metadata?: Record<string, unknown> | null;
 }
 
 interface NotificationPanelProps {

--- a/frontend/components/student-preview-card.tsx
+++ b/frontend/components/student-preview-card.tsx
@@ -89,7 +89,9 @@ export function StudentPreviewCard({
     label,
     value,
   }: {
-    icon?: any;
+    // lucide-react icons are React components — use a typed alias rather
+    // than `any`.
+    icon?: React.ComponentType<{ className?: string }>;
     label: string;
     value?: string;
   }) => {

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -1238,6 +1238,10 @@ export interface ScholarshipPermission {
   scholarship_name: string;
   scholarship_name_en?: string;
   comment?: string;
+  // Optional quota-management gate emitted by
+  // /admin/scholarship-permissions/me; admin shell uses it to decide
+  // whether to surface the quota tab.
+  can_manage_quota?: boolean;
   // Optional because callers (e.g., admin user-edit modal) construct temporary
   // permission objects in-memory before the server assigns timestamps.
   created_at?: string;


### PR DESCRIPTION
## Summary
Seven small components plus one shared API type. Mix of \`any -> unknown\` widening for opaque index-signature fields and structural narrowing for callbacks/params.

- \`admin/AdminManagementShell\`: raw_data index sig \`any -> unknown\`; the \`(p: any) => p.can_manage_quota\` was load-bearing because the canonical \`ScholarshipPermission\` type omitted that field.
- \`admin/batch-bank-verification\`: \`onComplete\` callback now uses \`BankVerificationTask[\"results\"]\` from the shared API type.
- \`admin/email/EmailPanel\` + \`admin/history/HistoryPanel\`: raw_data index sig narrowed to \`unknown\`.
- \`admin/students/StudentListManagement\`: typed inline params object for \`apiClient.students.getAll\`.
- \`notification-panel\`: metadata \`any -> Record<string, unknown> | null\`.
- \`student-preview-card\`: \`InfoRow\`'s icon prop now typed \`React.ComponentType<{className?: string}>\` instead of \`any\`.

**Shared type fix**: added \`can_manage_quota?: boolean\` to \`ScholarshipPermission\` in \`lib/api/types.ts\` — the field was already populated at runtime by \`/admin/scholarship-permissions/me\` but missing from the canonical TypeScript shape, forcing the consumer to use \`(p: any)\`.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime behavior changes