### PR TITLE
chore(frontend): narrow professor_review_items map callback in ApplicationReviewPanel

### DIFF
--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -1078,7 +1078,15 @@ export function ApplicationReviewPanel({
                       <TableCell>
                         {app.professor_review_items?.length > 0 ? (
                           <div className="flex flex-col gap-0.5">
-                            {app.professor_review_items.map((item: any, idx: number) => (
+                            {app.professor_review_items.map(
+                              (
+                                item: {
+                                  sub_type_code: string;
+                                  recommendation: string;
+                                  comments?: string;
+                                },
+                                idx: number
+                              ) => (
                               <TooltipProvider key={`${item.sub_type_code}-${idx}`}>
                                 <Tooltip>
                                   <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
The professor-review badges in the college review table iterated over \`app.professor_review_items\` with a \`(item: any, idx: number)\` callback. Narrows the callback param to the \`{sub_type_code, recommendation, comments?}\` shape the badge renderer actually reads (\`sub_type_code\` + \`recommendation\` are required; \`comments\` is optional and only rendered inside a Tooltip).

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime behavior changes