### PR TITLE
chore(frontend): narrow any-types in lib/api/compat + form-data-helpers

### DIFF
--- a/frontend/lib/api/compat.ts
+++ b/frontend/lib/api/compat.ts
@@ -7,6 +7,14 @@
 
 import type { ApiResponse } from './types';
 
+// FastAPI validation error row — emitted in error.detail arrays.
+interface FastApiValidationErrorRow {
+  loc?: (string | number)[];
+  msg?: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
 /**
  * openapi-fetch response type
  * Flexible definition to handle various error structures from FastAPI
@@ -14,9 +22,10 @@ import type { ApiResponse } from './types';
 export interface FetchResponse<T> {
   data?: T;
   error?: {
-    detail?: string | any[] | any; // FastAPI can return string, validation errors array, or other structures
+    // FastAPI can return string, validation errors array, or other structures
+    detail?: string | FastApiValidationErrorRow[] | Record<string, unknown>;
     message?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   response: Response;
 }
@@ -24,22 +33,23 @@ export interface FetchResponse<T> {
 /**
  * Helper function to safely convert any value to a string message
  */
-function safeStringify(value: any): string {
+function safeStringify(value: unknown): string {
   if (typeof value === 'string') {
     return value;
   }
   if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
     // Handle Error objects
-    if (value.message && typeof value.message === 'string') {
-      return value.message;
+    if (typeof obj.message === 'string') {
+      return obj.message;
     }
     // Handle arrays
     if (Array.isArray(value)) {
       return value.map(v => safeStringify(v)).join(', ');
     }
     // Handle objects with detail field
-    if (value.detail) {
-      return safeStringify(value.detail);
+    if (obj.detail) {
+      return safeStringify(obj.detail);
     }
     // Fallback: stringify the object
     try {
@@ -76,7 +86,10 @@ export function toApiResponse<T>(
     } else if (Array.isArray(response.error.detail)) {
       // FastAPI validation errors
       errorMessage = response.error.detail
-        .map((err: any) => `${err.loc?.join('.')}: ${err.msg}`)
+        .map(
+          (err: FastApiValidationErrorRow) =>
+            `${err.loc?.join('.')}: ${err.msg}`
+        )
         .join(', ');
     } else if (response.error.detail) {
       // Handle object detail - use safeStringify
@@ -129,7 +142,7 @@ export function toApiResponse<T>(
  * @param response - openapi-fetch response object
  * @returns Error message string
  */
-export function extractErrorMessage(response: FetchResponse<any>): string {
+export function extractErrorMessage(response: FetchResponse<unknown>): string {
   if (response.error) {
     // Handle different error detail formats
     if (typeof response.error.detail === 'string') {
@@ -137,7 +150,10 @@ export function extractErrorMessage(response: FetchResponse<any>): string {
     } else if (Array.isArray(response.error.detail)) {
       // FastAPI validation errors
       return response.error.detail
-        .map((err: any) => `${err.loc?.join('.')}: ${err.msg}`)
+        .map(
+          (err: FastApiValidationErrorRow) =>
+            `${err.loc?.join('.')}: ${err.msg}`
+        )
         .join(', ');
     } else if (response.error.detail) {
       // Handle object detail - use safeStringify

--- a/frontend/lib/api/form-data-helpers.ts
+++ b/frontend/lib/api/form-data-helpers.ts
@@ -57,7 +57,7 @@ export function createFileUploadFormData(data: {
 /**
  * Type guard to check if a value is FormData
  */
-export function isFormData(value: any): value is FormData {
+export function isFormData(value: unknown): value is FormData {
   return value instanceof FormData;
 }
 


### PR DESCRIPTION
## Summary
Two foundational API-client modules had \`any\` in shared contracts. This PR replaces them with structural types:

- **\`lib/api/compat.ts\`**: extracted a \`FastApiValidationErrorRow\` interface (\`loc + msg + type\`, plus index sig for forward-compat fields). Used to type the two \`.map((err: any) => ...)\` sites and tightens \`FetchResponse\`'s \`error.detail\` union. \`safeStringify\` now takes \`unknown\` and narrows via a \`Record<string, unknown>\` cast inside the object branch. \`extractErrorMessage\`: \`FetchResponse<any>\` → \`FetchResponse<unknown>\`.
- **\`lib/api/form-data-helpers.ts\`**: \`isFormData\` guard now takes \`unknown\`.

**Left intentionally**:
- \`toApiResponse(response: any)\` — must accept the union of openapi-fetch responses across many generic Ts; \`any\` is more honest than a fragile variadic shape.
- \`TypedFormData<T extends Record<string, any>>\` generic + \`.append\`'s \`value: any\` — file-or-primitive heterogeneity makes structural narrowing worse than the current \`any\`.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime behavior changes