### PR TITLE
chore(frontend): narrow application_reviews.find callback in application-helpers

### DIFF
--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -93,7 +93,8 @@ export const getApplicationTimeline = (
 
   // 獲取學院審核資訊
   const collegeReview = application.application_reviews?.find(
-    (r: any) => r.review_stage === "college_review"
+    (r: { review_stage?: string; reviewed_at?: string }) =>
+      r.review_stage === "college_review"
   );
   const hasCollegeReview = Boolean(collegeReview?.reviewed_at);
 


### PR DESCRIPTION
## Summary
\`getApplicationTimeline\` looked up the college review via \`application.application_reviews?.find((r: any) => r.review_stage === \"college_review\")\`. Replaces \`any\` with \`{review_stage?, reviewed_at?}\` — the minimal shape the predicate and the downstream \`hasCollegeReview\` check actually read.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime changes