### PR TITLE
chore(frontend): narrow any-types in Next.js API route handlers

### DIFF
--- a/frontend/app/api/v1/download/route.ts
+++ b/frontend/app/api/v1/download/route.ts
@@ -97,12 +97,13 @@ export async function GET(request: NextRequest) {
           { status: 400 }
         );
       }
-    } catch (validationError: any) {
+    } catch (validationError: unknown) {
       logger.error("Input validation error", {});
-      return NextResponse.json(
-        { error: validationError.message },
-        { status: 400 }
-      );
+      const message =
+        validationError instanceof Error
+          ? validationError.message
+          : "Invalid input";
+      return NextResponse.json({ error: message }, { status: 400 });
     }
 
     if (!token) {

--- a/frontend/app/api/v1/preview/route.ts
+++ b/frontend/app/api/v1/preview/route.ts
@@ -166,12 +166,13 @@ export async function GET(request: NextRequest) {
           { status: 400 }
         );
       }
-    } catch (validationError: any) {
+    } catch (validationError: unknown) {
       logger.error("Input validation error", {});
-      return NextResponse.json(
-        { error: validationError.message },
-        { status: 400 }
-      );
+      const message =
+        validationError instanceof Error
+          ? validationError.message
+          : "Invalid input";
+      return NextResponse.json({ error: message }, { status: 400 });
     }
 
     if (!token) {
@@ -400,7 +401,20 @@ async function handleRosterPreview(
 }
 
 // 生成造冊預覽 HTML
-function generateRosterPreviewHTML(data: any): string {
+interface RosterPreviewPayload {
+  roster_code: string;
+  preview_data: (string | number | null)[][];
+  total_rows: number;
+  column_headers: string[];
+  validation_result?: {
+    is_valid?: boolean;
+    errors?: string[];
+    warnings?: string[];
+    [key: string]: unknown;
+  };
+}
+
+function generateRosterPreviewHTML(data: RosterPreviewPayload): string {
   const { roster_code, preview_data, total_rows, column_headers, validation_result } = data;
 
   return `
@@ -556,11 +570,20 @@ function generateRosterPreviewHTML(data: any): string {
           </tr>
         </thead>
         <tbody>
-          ${preview_data.map((row: any[]) => `
+          ${preview_data
+            .map(
+              row => `
             <tr>
-              ${row.map((cell: any) => `<td>${cell !== null && cell !== undefined ? cell : '-'}</td>`).join('')}
+              ${row
+                .map(
+                  cell =>
+                    `<td>${cell !== null && cell !== undefined ? cell : '-'}</td>`
+                )
+                .join('')}
             </tr>
-          `).join('')}
+          `
+            )
+            .join('')}
         </tbody>
       </table>
       ` : `


### PR DESCRIPTION
## Summary
Three \`any\` sites across two Next.js route handlers:

- \`app/api/v1/download/route.ts\` + \`app/api/v1/preview/route.ts\`: the validation-error \`catch\` now uses \`unknown\` with an \`instanceof Error\` narrowing rather than \`validationError: any\` directly accessing \`.message\`. Mirrors the established frontend pattern.
- \`app/api/v1/preview/route.ts\`: introduced a \`RosterPreviewPayload\` interface for \`generateRosterPreviewHTML\`; the \`.map((row: any[]))\` and inner \`.map((cell: any))\` inside the HTML template literal now infer from the typed \`preview_data\` field (\`(string | number | null)[][]\`).

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime behavior changes