### PR TITLE
feat(backend): instrument scholarship_reviews_total + email_sent_total (#159)

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import selectinload
 
 from app.core.cache import invalidate as cache_invalidate
 from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFoundError, ValidationError
-from app.core.metrics import scholarship_applications_total
+from app.core.metrics import scholarship_applications_total, scholarship_reviews_total
 from app.core.schema_validation import serialize_value
 from app.models.application import Application, ApplicationStatus, ReviewStatus
 from app.models.enums import Semester
@@ -1728,6 +1728,15 @@ class ApplicationService:
         application.updated_at = datetime.now(timezone.utc)
 
         await self.db.commit()
+
+        # Business metric: count professor review actions for the
+        # Scholarship System Overview dashboard. Action is derived from
+        # the overall recommendation so dashboards can split approve vs
+        # reject (issue #159).
+        scholarship_reviews_total.labels(
+            reviewer_type="professor",
+            action=str(overall_recommendation) if overall_recommendation else "unknown",
+        ).inc()
 
         # 觸發教授審查提交事件（會觸發自動化郵件規則）
         try:

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.dynamic_config import dynamic_config
+from app.core.metrics import email_sent_total
 from app.models.email_management import EmailCategory, EmailHistory, EmailStatus, EmailTestModeAudit, ScheduledEmail
 from app.services.system_setting_service import EmailTemplateService
 
@@ -404,6 +405,22 @@ class EmailService:
             raise
 
         finally:
+            # Business metric: count every send attempt so the Scholarship
+            # System Overview dashboard's email panel reflects real traffic
+            # (issue #159). Category comes from caller-supplied metadata; we
+            # fall back to "uncategorized" so the counter is never skipped.
+            category_value = metadata.get("email_category")
+            if hasattr(category_value, "value"):
+                category_label = category_value.value
+            else:
+                category_label = category_value or "uncategorized"
+            email_sent_total.labels(
+                category=str(category_label),
+                status=(
+                    status.value if isinstance(status, EmailStatus) else str(status)
+                ),
+            ).inc()
+
             # Log email history if database session provided
             if db:
                 try:

--- a/backend/app/tests/test_business_metrics_instrumentation.py
+++ b/backend/app/tests/test_business_metrics_instrumentation.py
@@ -1,0 +1,135 @@
+"""
+Counter-contract tests for the additional business-metric instrumentation
+added in the scholarship_reviews_total / email_sent_total wave (#159).
+
+These mirror test_application_metrics_instrumentation.py — they verify
+that the counter symbols imported from app.core.metrics are real
+Counter instances, that .inc() advances the value, and that the label
+dimensions segregate series. The end-to-end paths that drive the
+counters live in application_service.py / email_service.py and are
+covered by existing service-level suites.
+"""
+
+from prometheus_client import REGISTRY
+
+from app.core.metrics import email_sent_total, scholarship_reviews_total
+
+
+def _sample(metric_name: str, **labels: str) -> float:
+    value = REGISTRY.get_sample_value(metric_name, labels=labels)
+    return value or 0.0
+
+
+class TestScholarshipReviewsCounter:
+    def test_increment_for_professor_approve(self):
+        before = _sample(
+            "scholarship_reviews_total_total",
+            reviewer_type="professor",
+            action="approve",
+        )
+        scholarship_reviews_total.labels(
+            reviewer_type="professor", action="approve"
+        ).inc()
+        after = _sample(
+            "scholarship_reviews_total_total",
+            reviewer_type="professor",
+            action="approve",
+        )
+        assert after - before == 1.0
+
+    def test_increment_for_professor_reject_is_independent(self):
+        before_approve = _sample(
+            "scholarship_reviews_total_total",
+            reviewer_type="professor",
+            action="approve",
+        )
+        before_reject = _sample(
+            "scholarship_reviews_total_total",
+            reviewer_type="professor",
+            action="reject",
+        )
+        scholarship_reviews_total.labels(
+            reviewer_type="professor", action="reject"
+        ).inc()
+        assert (
+            _sample(
+                "scholarship_reviews_total_total",
+                reviewer_type="professor",
+                action="approve",
+            )
+            - before_approve
+            == 0.0
+        )
+        assert (
+            _sample(
+                "scholarship_reviews_total_total",
+                reviewer_type="professor",
+                action="reject",
+            )
+            - before_reject
+            == 1.0
+        )
+
+    def test_increment_for_college_reviewer_type(self):
+        before = _sample(
+            "scholarship_reviews_total_total",
+            reviewer_type="college",
+            action="approve",
+        )
+        scholarship_reviews_total.labels(
+            reviewer_type="college", action="approve"
+        ).inc()
+        after = _sample(
+            "scholarship_reviews_total_total",
+            reviewer_type="college",
+            action="approve",
+        )
+        assert after - before == 1.0
+
+
+class TestEmailSentCounter:
+    def test_increment_for_success_path(self):
+        before = _sample(
+            "email_sent_total_total",
+            category="notification",
+            status="sent",
+        )
+        email_sent_total.labels(category="notification", status="sent").inc()
+        after = _sample(
+            "email_sent_total_total",
+            category="notification",
+            status="sent",
+        )
+        assert after - before == 1.0
+
+    def test_increment_for_failed_path(self):
+        before = _sample(
+            "email_sent_total_total",
+            category="notification",
+            status="failed",
+        )
+        email_sent_total.labels(category="notification", status="failed").inc()
+        after = _sample(
+            "email_sent_total_total",
+            category="notification",
+            status="failed",
+        )
+        assert after - before == 1.0
+
+    def test_uncategorized_label_used_when_no_category(self):
+        # email_service falls back to "uncategorized" when metadata
+        # doesn't carry an email_category — ensure the literal label
+        # works on the counter so the dashboard isn't surprised by a
+        # validation error at runtime.
+        before = _sample(
+            "email_sent_total_total",
+            category="uncategorized",
+            status="sent",
+        )
+        email_sent_total.labels(category="uncategorized", status="sent").inc()
+        after = _sample(
+            "email_sent_total_total",
+            category="uncategorized",
+            status="sent",
+        )
+        assert after - before == 1.0


### PR DESCRIPTION
## Summary
Continues issue #159 — wires two more business counters that were defined but never incremented.

**\`scholarship_reviews_total\`**: incremented at end of \`ApplicationService.create_professor_review\`, labelled \`reviewer_type="professor"\` + \`action=<overall_recommendation>\`. The most common review write-path; college-review increments will follow separately to keep scope manageable.

**\`email_sent_total\`**: incremented inside \`EmailService.send_email\`'s \`finally\` block so the counter advances on both success (status="sent") and failure (status="failed") without changing existing exception semantics (re-raise still happens). Category comes from caller-supplied metadata.email_category with an \"uncategorized\" fallback so the counter is never skipped.

## Test plan
- [x] \`test_business_metrics_instrumentation.py\` pins counter contracts (import, label dimensions, segregation between approve/reject and sent/failed). No DB fixture required.
- [ ] After deploy: confirm Prometheus scrapes \`scholarship_reviews_total{reviewer_type=\"professor\",action=\"approve\"}\` and \`email_sent_total{category,status}\` go from 0→real values.

Related: PR #563 (applications counter, same pattern).