### PR TITLE
feat(backend): instrument file_uploads_total counter (#159)

### DIFF
--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -15,6 +15,7 @@ from minio.error import S3Error
 
 from app.core.config import settings
 from app.core.exceptions import FileStorageError
+from app.core.metrics import file_uploads_total
 
 logger = logging.getLogger(__name__)
 
@@ -236,10 +237,22 @@ class MinIOService:
             )
 
             logger.info(f"Uploaded file {file.filename} as {object_name}")
+
+            # Business metric: count successful application-file uploads.
+            # file_type already discriminates document categories (doc,
+            # transcript, etc.); status "success" pairs with the failure
+            # increment in the except block (issue #159).
+            file_uploads_total.labels(file_type=str(file_type), status="success").inc()
+
             return object_name, file_size
 
         except Exception as e:
             logger.error(f"Failed to upload file {file.filename}: {e}")
+
+            # Business metric: count failures so the dashboard can show
+            # the success-rate ratio without needing log-scraping.
+            file_uploads_total.labels(file_type=str(file_type), status="failed").inc()
+
             from fastapi import HTTPException
 
             raise HTTPException(status_code=500, detail=str(e)) from e

--- a/backend/app/tests/test_file_uploads_metric.py
+++ b/backend/app/tests/test_file_uploads_metric.py
@@ -1,0 +1,39 @@
+"""
+Counter-contract tests for file_uploads_total instrumentation in
+MinIOService.upload_file (issue #159).
+
+Tests the counter dimensions directly — the upload_file path itself
+requires a MinIO client + UploadFile fixture which already has
+coverage in test_minio_service.py.
+"""
+
+from prometheus_client import REGISTRY
+
+from app.core.metrics import file_uploads_total
+
+
+def _sample(file_type: str, status: str) -> float:
+    value = REGISTRY.get_sample_value(
+        "file_uploads_total_total",
+        labels={"file_type": file_type, "status": status},
+    )
+    return value or 0.0
+
+
+class TestFileUploadsCounter:
+    def test_success_label_increments(self):
+        before = _sample("doc", "success")
+        file_uploads_total.labels(file_type="doc", status="success").inc()
+        assert _sample("doc", "success") - before == 1.0
+
+    def test_failed_label_increments(self):
+        before = _sample("doc", "failed")
+        file_uploads_total.labels(file_type="doc", status="failed").inc()
+        assert _sample("doc", "failed") - before == 1.0
+
+    def test_file_type_label_segregates_series(self):
+        before_doc = _sample("doc", "success")
+        before_transcript = _sample("transcript", "success")
+        file_uploads_total.labels(file_type="transcript", status="success").inc()
+        assert _sample("doc", "success") - before_doc == 0.0
+        assert _sample("transcript", "success") - before_transcript == 1.0


### PR DESCRIPTION
## Summary
Wires \`file_uploads_total\` into \`MinIOService.upload_file\`, the entry point for all application file uploads (bank docs, supporting documents, transcripts, etc.).

- **Success path**: \`status=\"success\"\` after \`put_object\` returns.
- **Failure path**: \`status=\"failed\"\` inside the existing \`except Exception\` block (before the HTTPException re-raise) — dashboard can derive an upload success-rate without log scraping.

The \`file_type\` label is the same string discriminator the upload path already uses to route into folder buckets (\"doc\", \"transcript\", etc.), so the counter naturally splits by document category.

## Test plan
- [x] \`test_file_uploads_metric.py\` pins counter contract (success + failed increments independent, file_type segregates series). Counter symbol tested directly — the MinIO put_object integration path is covered by existing \`test_minio_service.py\`.
- [ ] After deploy: confirm \`file_uploads_total{file_type,status}\` panels populate.

Builds on PR #563 (applications) + PR #564 (reviews + emails). **4 of 6 business counters now wired** — only \`payment_rosters_total\` and \`db_query_duration_seconds\` remain.