### PR TITLE
feat(backend): instrument payment_rosters_total counter (#159)

### DIFF
--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -11,6 +11,7 @@ from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
 from app.core.exceptions import RosterAlreadyExistsError, RosterGenerationError, RosterLockedError, RosterNotFoundError
+from app.core.metrics import payment_rosters_total
 from app.core.pii_crypto import redact_dict_pii
 from app.models.application import Application
 from app.models.enums import QuotaManagementMode
@@ -172,6 +173,11 @@ class RosterService:
                 self.db.flush()  # 取得ID
 
                 logger.info(f"Creating new roster {roster_code}")
+
+                # Business metric: count roster creations so the
+                # Scholarship System Overview dashboard reflects when
+                # admins kick off a new payment cycle (issue #159).
+                payment_rosters_total.labels(status="processing").inc()
 
             # 記錄稽核日誌
             user = self.db.query(User).filter(User.id == created_by_user_id).first()
@@ -1690,6 +1696,11 @@ class RosterService:
         roster.verification_api_failures = verification_failures
         roster.status = RosterStatus.COMPLETED
         roster.completed_at = datetime.now(timezone.utc)
+
+        # Business metric: roster reached the completed state. Pairs
+        # with the "processing" increment at creation so dashboards can
+        # show completion ratio over time (issue #159).
+        payment_rosters_total.labels(status="completed").inc()
 
         self.db.flush()
 

--- a/backend/app/tests/test_payment_rosters_metric.py
+++ b/backend/app/tests/test_payment_rosters_metric.py
@@ -1,0 +1,38 @@
+"""
+Counter-contract test for payment_rosters_total instrumentation in
+RosterService (issue #159).
+
+Verifies that the counter symbol responds to .inc() with the labels
+the service emits ("processing" at creation, "completed" at finalize).
+"""
+
+from prometheus_client import REGISTRY
+
+from app.core.metrics import payment_rosters_total
+
+
+def _sample(status: str) -> float:
+    value = REGISTRY.get_sample_value(
+        "payment_rosters_total_total",
+        labels={"status": status},
+    )
+    return value or 0.0
+
+
+class TestPaymentRostersCounter:
+    def test_processing_label_increments(self):
+        before = _sample("processing")
+        payment_rosters_total.labels(status="processing").inc()
+        assert _sample("processing") - before == 1.0
+
+    def test_completed_label_increments(self):
+        before = _sample("completed")
+        payment_rosters_total.labels(status="completed").inc()
+        assert _sample("completed") - before == 1.0
+
+    def test_processing_and_completed_segregate(self):
+        before_proc = _sample("processing")
+        before_done = _sample("completed")
+        payment_rosters_total.labels(status="processing").inc()
+        assert _sample("processing") - before_proc == 1.0
+        assert _sample("completed") - before_done == 0.0


### PR DESCRIPTION
## Summary
Wires \`payment_rosters_total\` into \`RosterService.generate_roster\` at the two state transitions:

- New roster created → \`status=\"processing\"\` (paired with the existing PROCESSING-state assignment after \`self.db.flush()\`).
- Roster finalized inside the roster-item qualify/disqualify loop → \`status=\"completed\"\` (immediately after the \`status=RosterStatus.COMPLETED\` assignment).

This pair lets the dashboard derive both the rate of new payment cycles and the completion ratio without running a separate query against the rosters table.

## Test plan
- [x] \`test_payment_rosters_metric.py\` pins the counter contract for \"processing\" + \"completed\" labels.
- [ ] After deploy: confirm \`payment_rosters_total{status}\` panels populate.

**5 of 6 business counters now wired** — only \`db_query_duration_seconds\` remains (that needs SQLAlchemy event-listener integration rather than service-layer increments; separate PR).

Builds on PRs #563, #564, #565 (applications / reviews+emails / file uploads).