### PR TITLE
feat(backend): instrument college-review reviewer_type for scholarship_reviews_total

### DIFF
--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFoundError
+from app.core.metrics import scholarship_reviews_total
 from app.models.application import Application, ApplicationStatus
 from app.models.college_review import CollegeRanking, CollegeRankingItem, QuotaDistribution
 from app.models.enums import Semester
@@ -796,6 +797,14 @@ class CollegeReviewService:
             ranking.ranking_status = "finalized"
 
             await self.db.flush()  # Flush within transaction context
+
+            # Business metric: count college finalize actions to complete
+            # the reviewer_type dimension of scholarship_reviews_total
+            # (professor counterpart wired in PR #564, follow-up from #159).
+            scholarship_reviews_total.labels(
+                reviewer_type="college",
+                action="finalize",
+            ).inc()
 
             return ranking
 


### PR DESCRIPTION
## Summary
Completes the \`reviewer_type\` dimension of \`scholarship_reviews_total\` (issue #159 follow-up). The professor reviewer_type was wired in PR #564; this PR wires the college reviewer_type at the natural college write-path: \`CollegeReviewService.finalize_ranking\`.

Increment fires after the ranking transitions to \`is_finalized=True\` and the existing flush, with \`action=\"finalize\"\` so dashboards can distinguish college finalize actions from professor approve/reject without changing the existing counter shape.

## Test plan
- [x] Counter symbol contract already pinned by \`test_business_metrics_instrumentation.py::TestScholarshipReviewsCounter::test_increment_for_college_reviewer_type\` (added in PR #564).
- [ ] After deploy: confirm \`scholarship_reviews_total{reviewer_type=\"college\",action=\"finalize\"}\` panels populate when admins finalize rankings.