### PR TITLE
chore(frontend): narrow 2 callback any-types in college-management-context

### DIFF
--- a/frontend/contexts/college-management-context.tsx
+++ b/frontend/contexts/college-management-context.tsx
@@ -372,7 +372,12 @@ export function CollegeManagementProvider({
 
         for (const collegeType of currentAvailableOptions.scholarship_types) {
           const fullScholarship = allScholarshipsResponse.data.find(
-            (scholarship: any) =>
+            (scholarship: {
+              id: number;
+              code?: string;
+              name?: string;
+              name_en?: string;
+            }) =>
               scholarship.code === collegeType.code ||
               scholarship.name === collegeType.name ||
               scholarship.name_en === collegeType.name
@@ -466,17 +471,19 @@ export function CollegeManagementProvider({
         console.log(`[Context] Fetched ${response.data.length} rankings`);
 
         // Normalize semester values (consistent with RankingManagementPanel logic)
-        const normalizedRankings = response.data.map((ranking: any) => {
-          const rawSemester =
-            typeof ranking.semester === "string" && ranking.semester.length > 0
-              ? ranking.semester.toLowerCase()
-              : null;
-          const safeSemester =
-            rawSemester && rawSemester !== "yearly"
-              ? rawSemester
-              : null;
-          return { ...ranking, semester: safeSemester };
-        });
+        const normalizedRankings = response.data.map(
+          (ranking: { semester?: string | null; [key: string]: unknown }) => {
+            const rawSemester =
+              typeof ranking.semester === "string" && ranking.semester.length > 0
+                ? ranking.semester.toLowerCase()
+                : null;
+            const safeSemester =
+              rawSemester && rawSemester !== "yearly"
+                ? rawSemester
+                : null;
+            return { ...ranking, semester: safeSemester };
+          }
+        );
 
         setRankings(normalizedRankings);
       }


### PR DESCRIPTION
## Summary
The college-management-context exposes ~20 \`any\` annotations on its public surface (dialog state, \`selectedApplication\` handles), which would need a broader refactor to type cleanly. This PR clears the two **isolated callback** any sites inside the helper functions that don't touch the public type contract:

- \`scholarship\` lookup \`.find((scholarship: any))\` → \`{id, code?, name?, name_en?}\`
- \`rankings.map((ranking: any))\` → \`{semester?, [key: string]: unknown}\`

These were the lowest-risk wins inside this file. The remaining any-state setters require coordinated changes with the consumers (RankingCard, ApplicationDeleteDialog, etc.) and stay deferred.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] No runtime changes