### PR TITLE
chore(backend): instrument quota_dashboard.py with logger calls

### DIFF
--- a/backend/app/api/v1/endpoints/quota_dashboard.py
+++ b/backend/app/api/v1/endpoints/quota_dashboard.py
@@ -9,6 +9,7 @@ Major changes from original:
 """
 
 import io
+import logging
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -24,6 +25,7 @@ from app.models.user import User
 from app.schemas.response import ApiResponse
 from app.services.quota_service import QuotaService
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
@@ -145,6 +147,16 @@ async def get_detailed_quota_status(
     scholarship_type = scholarship_type_result.scalar_one_or_none()
 
     if not scholarship_type:
+        logger.warning(
+            "Quota detail lookup for missing scholarship_type",
+            extra={
+                "user_id": current_user.id,
+                "scholarship_type_id": scholarship_type_id,
+                "sub_type": sub_type,
+                "academic_year": academic_year,
+                "semester": semester,
+            },
+        )
         raise HTTPException(status_code=404, detail="Scholarship type not found")
 
     # Get quota status
@@ -252,6 +264,20 @@ async def get_quota_alerts(
                         }
                     )
 
+    if alerts:
+        critical_count = sum(1 for a in alerts if a.get("severity") == "critical")
+        if critical_count:
+            logger.warning(
+                "Quota dashboard surfaced critical-severity alerts",
+                extra={
+                    "user_id": current_user.id,
+                    "academic_year": academic_year,
+                    "semester": semester,
+                    "critical_count": critical_count,
+                    "total_alerts": len(alerts),
+                },
+            )
+
     return ApiResponse(
         success=True,
         message=f"Found {len(alerts)} quota alerts",
@@ -268,6 +294,17 @@ async def export_quota_data(
     db: AsyncSession = Depends(get_db),
 ):
     """Export quota data in JSON or CSV format"""
+    # Audit trail: quota export is admin-only and can surface PII-adjacent
+    # totals; log who exported what so Grafana/Loki can correlate.
+    logger.info(
+        "Quota export requested",
+        extra={
+            "user_id": current_user.id,
+            "academic_year": academic_year,
+            "semester": semester,
+            "format": format,
+        },
+    )
     quota_service = QuotaService(db)
 
     # Get all active scholarship types


### PR DESCRIPTION
## Summary
Prior audit found \`quota_dashboard.py\` at 341 LOC with 0 logger calls — any 4xx/5xx from this admin-only dashboard left no trace beyond FastAPI's generic exception handler. This PR adds targeted observability:

- Module-level \`logger = logging.getLogger(__name__)\`.
- **WARNING** before the 404 in \`get_detailed_quota_status\`, with \`user_id\` / \`scholarship_type_id\` / \`sub_type\` / \`academic_year\` / \`semester\` context — unknown-id lookups are now debuggable from Loki.
- **INFO** at the top of \`export_quota_data\` — admin-only export of cross-cohort quota totals; audit trail line.
- **WARNING** when \`get_quota_alerts\` surfaces any critical-severity alert (quota exhausted), with counts. Pairs with the \`payment_rosters_total\` counter wired in #566 — together they let Grafana correlate \"rosters generated\" with \"quotas filling up\".

No request-handler signature or response-shape changes.

## Test plan
- [x] flake8 clean (no new violations)
- [x] Python syntax verified
- [ ] After deploy: confirm Loki ingests \`module=\"app.api.v1.endpoints.quota_dashboard\"\` entries from the three new log sites