### PR TITLE
chore(backend): SECURITY logging on files.py + document_requests.py 403 paths

### DIFF
--- a/backend/app/api/v1/endpoints/document_requests.py
+++ b/backend/app/api/v1/endpoints/document_requests.py
@@ -269,6 +269,15 @@ async def fulfill_document_request(
 
     # Verify student owns the application
     if document_request.application.user_id != current_user.id:
+        logger.warning(
+            "SECURITY: student attempted to fulfill another user's document request",
+            extra={
+                "user_id": current_user.id,
+                "request_id": request_id,
+                "application_id": document_request.application_id,
+                "owner_user_id": document_request.application.user_id,
+            },
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You can only fulfill document requests for your own applications",

--- a/backend/app/api/v1/endpoints/files.py
+++ b/backend/app/api/v1/endpoints/files.py
@@ -75,10 +75,28 @@ async def get_file_proxy(
         if current_user.role == UserRole.student:
             # Students can only access their own files
             if application.user_id != current_user.id:
+                logger.warning(
+                    "SECURITY: student attempted to access another user's file",
+                    extra={
+                        "user_id": current_user.id,
+                        "file_id": file_id,
+                        "owner_user_id": application.user_id,
+                        "application_id": application.id,
+                    },
+                )
                 raise HTTPException(status_code=403, detail="Access denied")
         elif current_user.role == UserRole.professor:
             # Professors can access files from their students
             if not current_user.can_access_student_data(application.user_id, "view_applications"):
+                logger.warning(
+                    "SECURITY: professor lacked relationship to access student file",
+                    extra={
+                        "user_id": current_user.id,
+                        "file_id": file_id,
+                        "student_user_id": application.user_id,
+                        "application_id": application.id,
+                    },
+                )
                 raise HTTPException(status_code=403, detail="Access denied - no relationship with student")
         elif current_user.role in [
             UserRole.college,
@@ -89,6 +107,14 @@ async def get_file_proxy(
             pass
         else:
             # Other roles are not allowed
+            logger.warning(
+                "SECURITY: unexpected role attempted file access",
+                extra={
+                    "user_id": current_user.id,
+                    "role": str(current_user.role),
+                    "file_id": file_id,
+                },
+            )
             raise HTTPException(status_code=403, detail="Access denied")
 
         # Get file stream from MinIO
@@ -178,10 +204,28 @@ async def download_file_proxy(
         if current_user.role == UserRole.student:
             # Students can only access their own files
             if application.user_id != current_user.id:
+                logger.warning(
+                    "SECURITY: student attempted to access another user's file",
+                    extra={
+                        "user_id": current_user.id,
+                        "file_id": file_id,
+                        "owner_user_id": application.user_id,
+                        "application_id": application.id,
+                    },
+                )
                 raise HTTPException(status_code=403, detail="Access denied")
         elif current_user.role == UserRole.professor:
             # Professors can access files from their students
             if not current_user.can_access_student_data(application.user_id, "view_applications"):
+                logger.warning(
+                    "SECURITY: professor lacked relationship to access student file",
+                    extra={
+                        "user_id": current_user.id,
+                        "file_id": file_id,
+                        "student_user_id": application.user_id,
+                        "application_id": application.id,
+                    },
+                )
                 raise HTTPException(status_code=403, detail="Access denied - no relationship with student")
         elif current_user.role in [
             UserRole.college,
@@ -192,6 +236,14 @@ async def download_file_proxy(
             pass
         else:
             # Other roles are not allowed
+            logger.warning(
+                "SECURITY: unexpected role attempted file access",
+                extra={
+                    "user_id": current_user.id,
+                    "role": str(current_user.role),
+                    "file_id": file_id,
+                },
+            )
             raise HTTPException(status_code=403, detail="Access denied")
 
         # Get file stream from MinIO


### PR DESCRIPTION
## Summary
Prior audit (and the upstream Stop-hook ledger) called out two access-control endpoint files where 403 \"Access denied\" responses were silent — a brute-force enumeration or a real misuse attempt would leave nothing behind beyond the generic FastAPI 403 in nginx logs.

### \`files.py\` — three SECURITY WARNING entries on the file-serve endpoint
- student attempting to access another student's file (user_id + file_id + owner_user_id context)
- professor lacking relationship to the student whose file they requested
- unexpected role hitting the role-allowlist fallthrough

### \`document_requests.py\` — SECURITY WARNING on \`fulfill_document_request\`
- student attempting to fulfill a request not tied to their own application

Both files already had \`logger = logging.getLogger(__name__)\` and existing logger calls (no import change). All new entries use \`extra={}\` for structured fields so Loki LogQL can filter by \`user_id\`, \`request_id\`, etc.

## Test plan
- [x] Python syntax verified on both files
- [x] No request-handler signature or response-shape changes
- [ ] After deploy: confirm Loki ingests new \`SECURITY:\` lines from the four sites under abnormal access scenarios