### PR TITLE
chore(backend): SECURITY logging on auth.py register + login endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -2,6 +2,7 @@
 Authentication API endpoints
 """
 
+import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
@@ -18,7 +19,21 @@ from app.services.developer_profile_service import DeveloperProfile, DeveloperPr
 from app.services.mock_sso_service import MockSSOService
 from app.services.portal_sso_service import PortalSSOService
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _client_ip(request: Request) -> str:
+    """
+    Extract client IP for SECURITY audit logs.
+    Honours X-Forwarded-For (set by ingress / nginx) so logs reflect the
+    real client behind a reverse proxy rather than the proxy itself.
+    """
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        # First entry in the chain is the originating client.
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
 
 
 async def populate_college_info(user_data: UserResponse, db: AsyncSession, user: User):
@@ -40,8 +55,33 @@ async def populate_college_info(user_data: UserResponse, db: AsyncSession, user:
 @rate_limit(requests=10, window_seconds=600)  # 10 registrations / 10 min per IP
 async def register(request: Request, user_data: UserCreate, db: AsyncSession = Depends(get_db)):
     """Register a new user"""
-    auth_service = AuthService(db)
-    user = await auth_service.register_user(user_data)
+    client_ip = _client_ip(request)
+    try:
+        auth_service = AuthService(db)
+        user = await auth_service.register_user(user_data)
+    except Exception:
+        # SECURITY audit: capture every failed registration with the
+        # attempted nycu_id + client IP so brute-force / enumeration
+        # attempts are visible in Loki even when AuthService swallows
+        # the surface-level reason.
+        logger.warning(
+            "SECURITY: registration attempt failed",
+            extra={
+                "attempted_nycu_id": getattr(user_data, "nycu_id", None),
+                "ip": client_ip,
+            },
+        )
+        raise
+
+    logger.info(
+        "User registered",
+        extra={
+            "user_id": user.id,
+            "nycu_id": user.nycu_id,
+            "role": user.role.value if hasattr(user.role, "value") else str(user.role),
+            "ip": client_ip,
+        },
+    )
 
     # Convert to dict for response
     user_dict = {
@@ -64,13 +104,43 @@ async def register(request: Request, user_data: UserCreate, db: AsyncSession = D
 @rate_limit(requests=20, window_seconds=300)  # 20 attempts / 5 min per IP — slows brute force
 async def login(request: Request, login_data: UserLogin, db: AsyncSession = Depends(get_db)):
     """Login user and return access token"""
-    auth_service = AuthService(db)
-    token_response = await auth_service.login(login_data)
+    client_ip = _client_ip(request)
+    try:
+        auth_service = AuthService(db)
+        token_response = await auth_service.login(login_data)
+    except Exception:
+        # SECURITY audit: log every failed login. nycu_id (not the
+        # password — never the password) plus client IP lets ops detect
+        # credential-stuffing patterns from the log layer. The rate-
+        # limit decorator throttles, but auth failures still need to
+        # be tracked individually.
+        logger.warning(
+            "SECURITY: login attempt failed",
+            extra={
+                "attempted_nycu_id": getattr(login_data, "nycu_id", None),
+                "ip": client_ip,
+            },
+        )
+        raise
 
     # Populate college_name from Academy table
     user = await db.get(User, token_response.user.id)
     if user:
         await populate_college_info(token_response.user, db, user)
+
+    logger.info(
+        "User logged in",
+        extra={
+            "user_id": token_response.user.id,
+            "nycu_id": token_response.user.nycu_id,
+            "role": (
+                token_response.user.role.value
+                if hasattr(token_response.user.role, "value")
+                else str(token_response.user.role)
+            ),
+            "ip": client_ip,
+        },
+    )
 
     # Return wrapped in standard ApiResponse format
     return {
@@ -240,10 +310,6 @@ async def portal_sso_verify(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Portal SSO is disabled")
 
     # Debug logging to see what parameters are being sent
-    import logging
-
-    logger = logging.getLogger(__name__)
-
     received_params = {
         "token": token,
         "nycu_id": nycu_id,


### PR DESCRIPTION
## Summary
\`auth.py\` had 3 logger calls in 566 LOC — and **zero** of them on the two endpoints that matter most: \`register\` + \`login\`. Brute-force / credential-stuffing attacks against \`/login\` left no trace beyond the generic FastAPI exception in nginx logs.

This PR adds:

- **Module-level** \`import logging\` + \`logger = logging.getLogger(__name__)\` (also lifts the in-function \`import logging\` from the portal-SSO handler so the module follows one pattern).
- **\`_client_ip()\`** helper that honours \`X-Forwarded-For\` so logs reflect the real client when the app sits behind nginx, not the proxy IP.
- **\`/register\`**: try/except wrapping \`AuthService.register_user\` — emits SECURITY WARNING with \`attempted_nycu_id\` + \`ip\` on failure, INFO with new \`user_id\` + \`role\` + \`ip\` on success. Never logs the password.
- **\`/login\`**: same shape — SECURITY WARNING on failure (\`attempted_nycu_id\` + \`ip\` — **never** password), INFO on success (\`user_id\` + \`nycu_id\` + \`role\` + \`ip\`). Pairs with the existing \`@rate_limit(20/5min)\` decorator: the decorator throttles, this PR catches the individual events.

**Net**: from 3 → 7 logger calls on the most security-critical endpoint file. Brute-force / credential-stuffing patterns are now visible from the log layer via LogQL on \`SECURITY:\` + \`extra.ip\` / \`extra.attempted_nycu_id\`.

## Test plan
- [x] Python syntax verified
- [x] Existing AuthService re-raise semantics preserved (the try/except re-raises after logging)
- [x] No request-handler signature or response-shape changes
- [ ] After deploy: confirm Loki ingests \`SECURITY:\` entries from failed login attempts