### PR TITLE
chore(backend): SECURITY logging on notifications admin 403 guards

### DIFF
--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -225,6 +225,14 @@ async def createSystemAnnouncement(
     """
     # 檢查管理員權限
     if not current_user.is_admin() and not current_user.is_super_admin():
+        logger.warning(
+            "SECURITY: non-admin attempted access to notifications admin endpoint",
+            extra={
+                "user_id": current_user.id,
+                "nycu_id": current_user.nycu_id,
+                "role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            },
+        )
         raise HTTPException(status_code=403, detail="需要管理員權限")
 
     try:
@@ -283,6 +291,14 @@ async def createTestNotifications(current_user: User = Depends(get_current_user)
     """
     # 檢查管理員權限
     if not current_user.is_admin() and not current_user.is_super_admin():
+        logger.warning(
+            "SECURITY: non-admin attempted access to notifications admin endpoint",
+            extra={
+                "user_id": current_user.id,
+                "nycu_id": current_user.nycu_id,
+                "role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            },
+        )
         raise HTTPException(status_code=403, detail="需要管理員權限")
 
     try:
@@ -357,6 +373,14 @@ async def getAllAnnouncements(
     """
     # 檢查管理員權限
     if not current_user.is_admin() and not current_user.is_super_admin():
+        logger.warning(
+            "SECURITY: non-admin attempted access to notifications admin endpoint",
+            extra={
+                "user_id": current_user.id,
+                "nycu_id": current_user.nycu_id,
+                "role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            },
+        )
         raise HTTPException(status_code=403, detail="需要管理員權限")
 
     try:
@@ -438,6 +462,14 @@ async def getAnnouncement(
     """
     # 檢查管理員權限
     if not current_user.is_admin() and not current_user.is_super_admin():
+        logger.warning(
+            "SECURITY: non-admin attempted access to notifications admin endpoint",
+            extra={
+                "user_id": current_user.id,
+                "nycu_id": current_user.nycu_id,
+                "role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            },
+        )
         raise HTTPException(status_code=403, detail="需要管理員權限")
 
     try:
@@ -500,6 +532,14 @@ async def createAnnouncement(
     """
     # 檢查管理員權限
     if not current_user.is_admin() and not current_user.is_super_admin():
+        logger.warning(
+            "SECURITY: non-admin attempted access to notifications admin endpoint",
+            extra={
+                "user_id": current_user.id,
+                "nycu_id": current_user.nycu_id,
+                "role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            },
+        )
         raise HTTPException(status_code=403, detail="需要管理員權限")
 
     try:
@@ -563,6 +603,14 @@ async def updateAnnouncement(
     """
     # 檢查管理員權限
     if not current_user.is_admin() and not current_user.is_super_admin():
+        logger.warning(
+            "SECURITY: non-admin attempted access to notifications admin endpoint",
+            extra={
+                "user_id": current_user.id,
+                "nycu_id": current_user.nycu_id,
+                "role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            },
+        )
         raise HTTPException(status_code=403, detail="需要管理員權限")
 
     try:
@@ -649,6 +697,14 @@ async def deleteAnnouncement(
     """
     # 檢查管理員權限
     if not current_user.is_admin() and not current_user.is_super_admin():
+        logger.warning(
+            "SECURITY: non-admin attempted access to notifications admin endpoint",
+            extra={
+                "user_id": current_user.id,
+                "nycu_id": current_user.nycu_id,
+                "role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            },
+        )
         raise HTTPException(status_code=403, detail="需要管理員權限")
 
     try:


### PR DESCRIPTION
## Summary
- 7 admin endpoints in \`notifications.py\` raise \`HTTPException(403, '需要管理員權限')\` silently. With no log line, probes against the admin surface never show up in Loki.
- Emit a structured \`logger.warning\` with \`user_id + nycu_id + role\` before each raise so SOC can correlate permission-denied bursts with the offending account.

## Test plan
- [x] \`python3 -c \"import ast; ast.parse(...)\"\`
- [x] \`uvx --from black==26.3.1 black\`
- [x] \`grep -c\` confirms all 7 sites instrumented
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)