### PR TITLE
chore(backend): preserve tracebacks on roster_schedules error logs

### DIFF
--- a/backend/app/api/v1/endpoints/roster_schedules.py
+++ b/backend/app/api/v1/endpoints/roster_schedules.py
@@ -104,7 +104,7 @@ async def list_roster_schedules(
         )
 
     except Exception as e:
-        logger.error(f"Error listing roster schedules: {e}")
+        logger.exception("Error listing roster schedules")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list roster schedules"
         ) from e
@@ -199,7 +199,7 @@ async def create_roster_schedule(
         raise
     except Exception as e:
         await db.rollback()
-        logger.error(f"Error creating roster schedule: {e}")
+        logger.exception("Error creating roster schedule")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create roster schedule"
         ) from e
@@ -311,7 +311,7 @@ async def update_roster_schedule(
         raise
     except Exception as e:
         await db.rollback()
-        logger.error(f"Error updating roster schedule {schedule_id}: {e}")
+        logger.exception("Error updating roster schedule %s", schedule_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update roster schedule"
         ) from e
@@ -386,7 +386,7 @@ async def update_schedule_status(
         raise
     except Exception as e:
         await db.rollback()
-        logger.error(f"Error updating schedule status {schedule_id}: {e}")
+        logger.exception("Error updating schedule status %s", schedule_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update schedule status"
         ) from e
@@ -427,7 +427,7 @@ async def delete_roster_schedule(
         raise
     except Exception as e:
         await db.rollback()
-        logger.error(f"Error deleting roster schedule {schedule_id}: {e}")
+        logger.exception("Error deleting roster schedule %s", schedule_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete roster schedule"
         ) from e
@@ -471,7 +471,7 @@ async def execute_schedule_now(
         )
 
     except Exception as e:
-        logger.error(f"Error executing schedule {schedule_id}: {e}")
+        logger.exception("Error executing schedule %s", schedule_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to execute schedule"
         ) from e
@@ -524,7 +524,7 @@ async def get_schedule_by_config(
         )
 
     except Exception as e:
-        logger.error(f"Error getting schedule by config {config_id}: {e}")
+        logger.exception("Error getting schedule by config %s", config_id)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to get schedule by config"
         ) from e
@@ -574,7 +574,7 @@ async def get_scheduler_status(
         )
 
     except Exception as e:
-        logger.error(f"Error getting scheduler status: {e}")
+        logger.exception("Error getting scheduler status")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to get scheduler status"
         ) from e


### PR DESCRIPTION
## Summary
- All 8 error handlers in \`roster_schedules.py\` used \`logger.error(f\"...: {e}\")\` which throws away the traceback — only the str(exc) message reached Loki.
- Switch to \`logger.exception(...)\` so the full stack is captured alongside the message, with the schedule identifier rendered as a \`%-style\` arg so log search remains structured.

## Test plan
- [x] \`python3 -c \"import ast; ast.parse(...)\"\`
- [x] \`uvx --from black==26.3.1 black --check\`
- [x] \`flake8 F401,F841\` clean — \`as e\` is still consumed by \`from e\` chains
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)