### PR TITLE
chore(backend): preserve tracebacks on professor_student error logs

### DIFF
--- a/backend/app/api/v1/endpoints/professor_student.py
+++ b/backend/app/api/v1/endpoints/professor_student.py
@@ -101,7 +101,7 @@ async def get_professor_student_relationships(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error fetching professor-student relationships: {str(e)}")
+        logger.exception("Error fetching professor-student relationships")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while fetching relationships",
@@ -192,7 +192,7 @@ async def create_professor_student_relationship(
         raise
     except Exception as e:
         await db.rollback()
-        logger.error(f"Error creating professor-student relationship: {str(e)}")
+        logger.exception("Error creating professor-student relationship")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while creating relationship",
@@ -263,7 +263,7 @@ async def update_professor_student_relationship(
         raise
     except Exception as e:
         await db.rollback()
-        logger.error(f"Error updating professor-student relationship: {str(e)}")
+        logger.exception("Error updating professor-student relationship")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while updating relationship",
@@ -308,7 +308,7 @@ async def delete_professor_student_relationship(
         raise
     except Exception as e:
         await db.rollback()
-        logger.error(f"Error deleting professor-student relationship: {str(e)}")
+        logger.exception("Error deleting professor-student relationship")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while deleting relationship",


### PR DESCRIPTION
## Summary
- All 4 error handlers in \`professor_student.py\` used \`logger.error(f\"...: {str(e)}\")\` which discards the traceback.
- Switch to \`logger.exception(...)\` so the stack lands in Loki / Sentry alongside the message.

## Test plan
- [x] \`python3 -c \"import ast; ast.parse(...)\"\`
- [x] \`uvx --from black==26.3.1 black --check\`
- [x] \`flake8 F401,F841\` clean — \`as e\` is still consumed by \`from e\` chains
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)