### PR TITLE
chore(backend): preserve tracebacks on admin/configurations error logs (9 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/configurations.py
+++ b/backend/app/api/v1/endpoints/admin/configurations.py
@@ -112,13 +112,13 @@ async def get_all_configurations(
         return {"success": True, "message": "Configurations retrieved successfully", "data": result}
 
     except SQLAlchemyError as e:
-        logger.error(f"Database error retrieving configurations: {str(e)}")
+        logger.exception("Database error retrieving configurations")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve configurations due to a database error.",
         ) from e
     except Exception as e:
-        logger.error(f"Unexpected error retrieving configurations: {str(e)}")
+        logger.exception("Unexpected error retrieving configurations")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve configurations due to an unexpected error.",
@@ -183,13 +183,13 @@ async def create_configuration(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except SQLAlchemyError as e:
-        logger.error(f"Database error creating configuration: {str(e)}")
+        logger.exception("Database error creating configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create configuration due to a database error.",
         ) from e
     except Exception as e:
-        logger.error(f"Unexpected error creating configuration: {str(e)}")
+        logger.exception("Unexpected error creating configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create configuration due to an unexpected error.",
@@ -278,13 +278,13 @@ async def bulk_update_configurations(
     except HTTPException:
         raise
     except SQLAlchemyError as e:
-        logger.error(f"Database error in bulk configuration update: {str(e)}")
+        logger.exception("Database error in bulk configuration update")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update configurations due to a database error.",
         ) from e
     except Exception as e:
-        logger.error(f"Unexpected error in bulk configuration update: {str(e)}")
+        logger.exception("Unexpected error in bulk configuration update")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update configurations due to an unexpected error.",
@@ -332,7 +332,7 @@ async def validate_configuration(
         return {"success": True, "message": "Validation completed", "data": result}
 
     except Exception as e:
-        logger.error(f"Unexpected error validating configuration: {str(e)}")
+        logger.exception("Unexpected error validating configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to validate configuration due to an unexpected error.",
@@ -360,13 +360,13 @@ async def delete_configuration(
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except SQLAlchemyError as e:
-        logger.error(f"Database error deleting configuration: {str(e)}")
+        logger.exception("Database error deleting configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete configuration due to a database error.",
         ) from e
     except Exception as e:
-        logger.error(f"Unexpected error deleting configuration: {str(e)}")
+        logger.exception("Unexpected error deleting configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete configuration due to an unexpected error.",


### PR DESCRIPTION
## Summary
- All 9 error handlers in \`admin/configurations.py\` used \`logger.error(f\"...: {str(e)}\")\` which discards the traceback.
- Switch to \`logger.exception(...)\` so the stack lands in Loki / Sentry. The \`as e\` binding is still consumed by \`from e\` chains on the HTTPException raises.

## Test plan
- [x] \`python3 -c \"import ast; ast.parse(...)\"\`
- [x] \`uvx --from black==26.3.1 black --check\`
- [x] \`flake8 F841\` clean
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)