### PR TITLE
chore(backend): preserve tracebacks on application_fields error logs (4 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/application_fields.py
+++ b/backend/app/api/v1/endpoints/application_fields.py
@@ -237,7 +237,7 @@ async def get_scholarship_form_config(
         logger.info(f"API: Form config retrieved successfully for {scholarship_type}")
         return ApiResponse(success=True, message=f"Form configuration retrieved for {scholarship_type}", data=config)
     except Exception as e:
-        logger.error(f"API: Error getting form config for {scholarship_type}: {str(e)}")
+        logger.exception(f"API: Error getting form config for {scholarship_type}")
         # Return 404 for invalid scholarship types (proper HTTP semantics)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -366,7 +366,7 @@ async def upload_document_example(
         return ApiResponse(success=True, message="範例文件上傳成功", data={"example_file_url": object_name})
 
     except Exception as e:
-        logger.error(f"Failed to upload example file: {str(e)}")
+        logger.exception("Failed to upload example file")
         await db.rollback()
         raise HTTPException(status_code=500, detail=f"範例文件上傳失敗: {str(e)}") from e
 
@@ -426,7 +426,7 @@ async def get_document_example(
         )
 
     except Exception as e:
-        logger.error(f"Failed to get example file: {str(e)}")
+        logger.exception("Failed to get example file")
         raise HTTPException(status_code=500, detail=f"範例文件讀取失敗: {str(e)}") from e
 
 
@@ -472,6 +472,6 @@ async def delete_document_example(
         return ApiResponse(success=True, message="範例文件刪除成功", data=True)
 
     except Exception as e:
-        logger.error(f"Failed to delete example file: {str(e)}")
+        logger.exception("Failed to delete example file")
         await db.rollback()
         raise HTTPException(status_code=500, detail=f"範例文件刪除失敗: {str(e)}") from e


### PR DESCRIPTION
## Summary
- All 4 error handlers in \`application_fields.py\` used \`logger.error(f\"...: {str(e)}\")\` which discards the traceback.
- Switch to \`logger.exception(...)\` so the stack lands in Loki / Sentry. The L240 site retains its f-string so the \`scholarship_type\` interpolation continues to render.

## Test plan
- [x] \`python3 -c \"import ast; ast.parse(...)\"\`
- [x] \`uvx --from black==26.3.1 black --check\`
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)