### PR TITLE
chore(backend): preserve tracebacks on admin/applications error logs (3 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/applications.py
+++ b/backend/app/api/v1/endpoints/admin/applications.py
@@ -387,13 +387,13 @@ async def assign_professor_to_application(
             detail=str(e),
         ) from e
     except SQLAlchemyError as e:
-        logger.error(f"Database error assigning professor: {str(e)}")
+        logger.exception("Database error assigning professor")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to assign professor due to a database error.",
         ) from e
     except Exception as e:
-        logger.error(f"Unexpected error assigning professor: {str(e)}")
+        logger.exception("Unexpected error assigning professor")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to assign professor due to an unexpected error.",
@@ -519,7 +519,7 @@ async def delete_application(
         await db.commit()
     except SQLAlchemyError as e:
         await db.rollback()
-        logger.error(f"Database error deleting application {id}: {str(e)}")
+        logger.exception(f"Database error deleting application {id}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete application due to a database error.",


### PR DESCRIPTION
## Summary
- 3 error handlers in \`admin/applications.py\` used \`logger.error(f\"...: {str(e)}\")\` which discards the traceback.
- Switch to \`logger.exception(...)\` so the stack lands in Loki / Sentry.

## Test plan
- [x] \`python3 -c \"import ast; ast.parse(...)\"\`
- [x] \`uvx --from black==26.3.1 black --check\`
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)