### PR TITLE
chore(backend): preserve tracebacks on email_management error logs (3 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/email_management.py
+++ b/backend/app/api/v1/endpoints/email_management.py
@@ -758,7 +758,7 @@ async def get_react_email_templates(*, current_user: User = Depends(require_admi
         return ApiResponse(success=True, message=f"成功獲取 {len(templates)} 個 React Email 模板", data=templates)
 
     except Exception as e:
-        logger.error(f"Failed to scan React Email templates: {e}")
+        logger.exception("Failed to scan React Email templates")
         raise HTTPException(status_code=500, detail=f"獲取 React Email 模板失敗: {str(e)}") from e
 
 
@@ -786,7 +786,7 @@ async def get_react_email_template(*, template_name: str, current_user: User = D
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to get React Email template {template_name}: {e}")
+        logger.exception(f"Failed to get React Email template {template_name}")
         raise HTTPException(status_code=500, detail=f"獲取模板失敗: {str(e)}") from e
 
 
@@ -818,5 +818,5 @@ async def get_react_email_template_source(*, template_name: str, current_user: U
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to get React Email template source {template_name}: {e}")
+        logger.exception(f"Failed to get React Email template source {template_name}")
         raise HTTPException(status_code=500, detail=f"獲取模板源碼失敗: {str(e)}") from e


### PR DESCRIPTION
## Summary
- 3 React Email template handlers in \`email_management.py\` used \`logger.error(f\"...: {e}\")\` which discards the traceback.
- Switch to \`logger.exception(...)\` so the stack lands in Loki / Sentry. The two template-named sites retain their f-string so \`{template_name}\` renders.

## Test plan
- [x] \`python3 -c \"import ast; ast.parse(...)\"\`
- [x] \`uvx --from black==26.3.1 black --check\`
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)