### PR TITLE
chore(backend): preserve tracebacks on 10 endpoint files (54 swaps, bulk)

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -374,7 +374,7 @@ async def portal_sso_verify(
             status_code=302,
         )
     except Exception as e:
-        logger.error(f"Portal SSO error: {str(e)}")
+        logger.exception("Portal SSO error")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Portal SSO verification failed: {str(e)}",

--- a/backend/app/api/v1/endpoints/college_review/application_review.py
+++ b/backend/app/api/v1/endpoints/college_review/application_review.py
@@ -112,12 +112,12 @@ async def get_applications_for_review(
         logger.warning(f"Permission denied for college applications access: {str(e)}")
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except DatabaseError as e:
-        logger.error(f"Database error retrieving applications: {str(e)}")
+        logger.exception("Database error retrieving applications")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Database service temporarily unavailable"
         ) from e
     except Exception as e:
-        logger.error(f"Unexpected error retrieving applications: {str(e)}")
+        logger.exception("Unexpected error retrieving applications")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An unexpected error occurred while retrieving applications",
@@ -219,7 +219,7 @@ async def get_student_preview(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error retrieving student preview for {student_id}: {str(e)}")
+        logger.exception(f"Error retrieving student preview for {student_id}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve student preview: {str(e)}"
         ) from e

--- a/backend/app/api/v1/endpoints/college_review/distribution.py
+++ b/backend/app/api/v1/endpoints/college_review/distribution.py
@@ -61,10 +61,10 @@ async def get_quota_status(
         logger.warning(f"Invalid quota status parameters: {str(e)}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid parameters: {str(e)}") from e
     except CollegeReviewError as e:
-        logger.error(f"College review error retrieving quota status: {str(e)}")
+        logger.exception("College review error retrieving quota status")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Unexpected error retrieving quota status: {str(e)}")
+        logger.exception("Unexpected error retrieving quota status")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve quota status"
         ) from e
@@ -87,7 +87,7 @@ async def get_ranking_roster_status(
         return ApiResponse(success=True, message="Roster status retrieved successfully", data=roster_status)
 
     except Exception as e:
-        logger.error(f"Error retrieving roster status for ranking {ranking_id}: {str(e)}")
+        logger.exception(f"Error retrieving roster status for ranking {ranking_id}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve roster status"
         ) from e
@@ -388,7 +388,7 @@ async def get_distribution_details(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error retrieving distribution details: {str(e)}")
+        logger.exception("Error retrieving distribution details")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to retrieve distribution details: {str(e)}",

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -193,10 +193,10 @@ async def get_rankings(
             status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid query parameters: {str(e)}"
         ) from e
     except CollegeReviewError as e:
-        logger.error(f"College review error retrieving rankings: {str(e)}")
+        logger.exception("College review error retrieving rankings")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Unexpected error retrieving rankings: {str(e)}")
+        logger.exception("Unexpected error retrieving rankings")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve rankings"
         ) from e
@@ -260,10 +260,10 @@ async def create_ranking(
         logger.warning(f"Invalid ranking creation data: {str(e)}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid ranking data: {str(e)}") from e
     except CollegeReviewError as e:
-        logger.error(f"College review error creating ranking: {str(e)}")
+        logger.exception("College review error creating ranking")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Unexpected error creating ranking: {str(e)}")
+        logger.exception("Unexpected error creating ranking")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create ranking") from e
 
 
@@ -565,10 +565,10 @@ async def get_ranking(
         logger.warning(f"Ranking not found: {str(e)}")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except CollegeReviewError as e:
-        logger.error(f"College review error retrieving ranking: {str(e)}")
+        logger.exception("College review error retrieving ranking")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Unexpected error retrieving ranking: {str(e)}")
+        logger.exception("Unexpected error retrieving ranking")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve ranking"
         ) from e
@@ -621,7 +621,7 @@ async def update_ranking(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Unexpected error updating ranking: {str(e)}")
+        logger.exception("Unexpected error updating ranking")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update ranking") from e
 
 
@@ -663,10 +663,10 @@ async def update_ranking_order(
         logger.warning(f"Invalid ranking data: {str(e)}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except CollegeReviewError as e:
-        logger.error(f"College review error during ranking update: {str(e)}")
+        logger.exception("College review error during ranking update")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Unexpected error updating ranking order: {str(e)}")
+        logger.exception("Unexpected error updating ranking order")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update ranking order"
         ) from e
@@ -761,10 +761,10 @@ async def finalize_ranking(
         logger.warning(f"Cannot finalize ranking: {str(e)}")
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
     except CollegeReviewError as e:
-        logger.error(f"College review error during finalization: {str(e)}")
+        logger.exception("College review error during finalization")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Unexpected error finalizing ranking: {str(e)}")
+        logger.exception("Unexpected error finalizing ranking")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to finalize ranking"
         ) from e
@@ -857,10 +857,10 @@ async def unfinalize_ranking(
         logger.warning(f"Cannot unfinalize ranking: {str(e)}")
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
     except CollegeReviewError as e:
-        logger.error(f"College review error during unfinalization: {str(e)}")
+        logger.exception("College review error during unfinalization")
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Unexpected error unfinalizing ranking: {str(e)}")
+        logger.exception("Unexpected error unfinalizing ranking")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to unfinalize ranking"
         ) from e
@@ -955,7 +955,7 @@ async def delete_ranking(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error deleting ranking {ranking_id}: {str(e)}")
+        logger.exception(f"Error deleting ranking {ranking_id}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to delete ranking: {str(e)}"
         ) from e
@@ -1109,7 +1109,7 @@ async def import_ranking_from_excel(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error importing ranking data: {str(e)}")
+        logger.exception("Error importing ranking data")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to import ranking data: {str(e)}",

--- a/backend/app/api/v1/endpoints/college_review/utilities.py
+++ b/backend/app/api/v1/endpoints/college_review/utilities.py
@@ -267,7 +267,7 @@ async def get_available_combinations(current_user: User = Depends(require_colleg
         return ApiResponse(success=True, message="Available combinations retrieved successfully", data=response_data)
 
     except Exception as e:
-        logger.error(f"Error retrieving available combinations: {str(e)}")
+        logger.exception("Error retrieving available combinations")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve available combinations from database",
@@ -333,7 +333,7 @@ async def get_active_config(
             },
         )
     except Exception as e:
-        logger.error(f"Error retrieving active config: {str(e)}")
+        logger.exception("Error retrieving active config")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve active scholarship configuration",
@@ -380,7 +380,7 @@ async def get_sub_type_translations(
         )
 
     except Exception as e:
-        logger.error(f"Error retrieving sub-type translations: {str(e)}")
+        logger.exception("Error retrieving sub-type translations")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to retrieve sub-type translations: {str(e)}",

--- a/backend/app/api/v1/endpoints/document_requests.py
+++ b/backend/app/api/v1/endpoints/document_requests.py
@@ -115,9 +115,9 @@ async def create_document_request(
                 },
             )
             logger.info(f"Document request automation triggered for {student_email}")
-    except Exception as e:
+    except Exception:
         # Log error but don't fail the request creation
-        logger.error(f"Failed to trigger supplement request automation: {e}")
+        logger.exception("Failed to trigger supplement request automation")
 
     # Build response
     response_data = DocumentRequestResponse.model_validate(document_request)

--- a/backend/app/api/v1/endpoints/email_automation.py
+++ b/backend/app/api/v1/endpoints/email_automation.py
@@ -142,7 +142,7 @@ def validate_condition_query(query: Optional[str]) -> None:
 
     except RegexValidationError as e:
         # Regex pattern itself is malicious or causes ReDoS
-        logger.error(f"Regex validation error in condition_query: {e}")
+        logger.exception("Regex validation error in condition_query")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"condition_query contains invalid pattern that cannot be safely validated: {str(e)}",
@@ -231,7 +231,7 @@ async def get_automation_rules(
         return ApiResponse(success=True, message=f"成功獲取 {len(rules_data)} 條自動化規則", data=rules_data)
 
     except Exception as e:
-        logger.error(f"獲取自動化規則失敗: {e}")
+        logger.exception("獲取自動化規則失敗")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"獲取自動化規則失敗: {str(e)}"
         ) from e

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -163,7 +163,7 @@ def _generate_payment_roster_inner(
 
     except RosterGenerationError as e:
         # General roster generation failure (including data consistency errors)
-        logger.error(f"Roster generation error: {e}")
+        logger.exception("Roster generation error")
 
         # 保存 roster ID (如果存在) 用於後續標記
         roster_id_to_mark = roster.id if (roster and hasattr(roster, "id") and roster.id) else None
@@ -361,7 +361,7 @@ def get_available_rankings(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error fetching available rankings: {e}")
+        logger.exception("Error fetching available rankings")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to fetch available rankings"
         ) from e
@@ -445,7 +445,7 @@ async def list_payment_rosters(
         )
 
     except Exception as e:
-        logger.error(f"Failed to list rosters: {e}")
+        logger.exception("Failed to list rosters")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="取得造冊清單失敗") from e
 
 
@@ -752,10 +752,10 @@ async def preview_roster_students(
         raise
     except ValueError as e:
         # Handle validation errors with specific messages (e.g., missing ranking)
-        logger.error(f"Failed to preview students for config {config_id}: {e}")
+        logger.exception(f"Failed to preview students for config {config_id}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Failed to preview students for config {config_id}: {e}")
+        logger.exception(f"Failed to preview students for config {config_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="預覽學生名單失敗") from e
     finally:
         db.close()
@@ -1173,7 +1173,7 @@ async def get_roster_cycle_status(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to get cycle status for config {config_id}: {e}")
+        logger.exception(f"Failed to get cycle status for config {config_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="查詢造冊週期狀態失敗") from e
 
 
@@ -1217,7 +1217,7 @@ async def get_payment_roster(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to get roster {roster_id}: {e}")
+        logger.exception(f"Failed to get roster {roster_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="取得造冊詳情失敗") from e
 
 
@@ -1281,7 +1281,7 @@ async def get_roster_items(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to get roster items for {roster_id}: {e}")
+        logger.exception(f"Failed to get roster items for {roster_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="取得造冊明細失敗") from e
 
 
@@ -1326,7 +1326,7 @@ async def lock_roster(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to lock roster {roster_id}: {e}")
+        logger.exception(f"Failed to lock roster {roster_id}")
         await db.rollback()
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="鎖定造冊失敗") from e
 
@@ -1374,7 +1374,7 @@ async def unlock_roster(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to unlock roster {roster_id}: {e}")
+        logger.exception(f"Failed to unlock roster {roster_id}")
         await db.rollback()
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="解鎖造冊失敗") from e
 
@@ -1428,7 +1428,7 @@ def preview_roster_export(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to preview roster {roster_id}: {e}")
+        logger.exception(f"Failed to preview roster {roster_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="預覽產生失敗") from e
 
 
@@ -1479,7 +1479,7 @@ def dry_run_roster_generation(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to dry run roster generation: {e}")
+        logger.exception("Failed to dry run roster generation")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="預演失敗") from e
 
 
@@ -1564,7 +1564,7 @@ def export_roster_to_excel(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to export roster {roster_id}: {e}")
+        logger.exception(f"Failed to export roster {roster_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Excel匯出失敗") from e
 
 
@@ -1681,7 +1681,7 @@ async def download_roster_excel(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to download roster {roster_id}: {e}")
+        logger.exception(f"Failed to download roster {roster_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="下載造冊失敗") from e
 
 
@@ -1755,7 +1755,7 @@ async def get_roster_statistics(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to get roster statistics for {roster_id}: {e}")
+        logger.exception(f"Failed to get roster statistics for {roster_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="取得造冊統計失敗") from e
 
 
@@ -1902,7 +1902,7 @@ async def exclude_roster_item(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to exclude roster item {item_id}: {e}")
+        logger.exception(f"Failed to exclude roster item {item_id}")
         await db.rollback()
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="排除造冊明細失敗") from e
 
@@ -1948,7 +1948,7 @@ async def delete_roster(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to delete roster {roster_id}: {e}")
+        logger.exception(f"Failed to delete roster {roster_id}")
         await db.rollback()
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="刪除造冊失敗") from e
 
@@ -2015,5 +2015,5 @@ async def get_roster_audit_logs(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to get audit logs for roster {roster_id}: {e}")
+        logger.exception(f"Failed to get audit logs for roster {roster_id}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="查詢稽核日誌失敗") from e

--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -63,7 +63,7 @@ async def get_professor_applications(
         }
 
     except Exception as e:
-        logger.error(f"Error fetching professor applications: {str(e)}")
+        logger.exception("Error fetching professor applications")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while fetching applications",
@@ -124,7 +124,7 @@ async def get_professor_review(
     except NotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Professor review not found") from exc
     except Exception as e:
-        logger.error(f"Error fetching professor review: {str(e)}")
+        logger.exception("Error fetching professor review")
         import traceback
 
         logger.error(f"Full traceback: {traceback.format_exc()}")
@@ -207,7 +207,7 @@ async def submit_professor_review(
     except AuthorizationError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Error submitting professor review: {str(e)}")
+        logger.exception("Error submitting professor review")
         import traceback
 
         logger.error(f"Full traceback: {traceback.format_exc()}")
@@ -288,7 +288,7 @@ async def update_professor_review(
     except NotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Review not found") from exc
     except Exception as e:
-        logger.error(f"Error updating professor review: {str(e)}")
+        logger.exception("Error updating professor review")
         import traceback
 
         logger.error(f"Full traceback: {traceback.format_exc()}")
@@ -320,7 +320,7 @@ async def get_application_sub_types(
         }
 
     except Exception as e:
-        logger.error(f"Error fetching application sub-types: {str(e)}")
+        logger.exception("Error fetching application sub-types")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while fetching sub-types",
@@ -352,7 +352,7 @@ async def get_professor_review_stats(
         }
 
     except Exception as e:
-        logger.error(f"Error fetching professor stats: {str(e)}")
+        logger.exception("Error fetching professor stats")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while fetching statistics",

--- a/backend/app/api/v1/endpoints/student_bank_accounts.py
+++ b/backend/app/api/v1/endpoints/student_bank_accounts.py
@@ -85,8 +85,8 @@ async def get_my_verified_account(
                 ),
             }
 
-    except Exception as e:
-        logger.error(f"Error getting verified account for user {current_user.id}: {str(e)}")
+    except Exception:
+        logger.exception(f"Error getting verified account for user {current_user.id}")
         return {
             "success": False,
             "message": "查詢已驗證帳號時發生錯誤",


### PR DESCRIPTION
## Summary
Final bulk sweep of \`logger.error(f\"...: {e}\")\` → \`logger.exception(...)\` across 10 endpoint files. After this PR, the backend endpoint surface has no remaining traceback-discarding error logs.

| File | Swaps |
|------|-------|
| \`payment_rosters.py\` | 18 |
| \`college_review/ranking_management.py\` | 15 |
| \`professor.py\` | 6 |
| \`college_review/distribution.py\` | 4 |
| \`college_review/utilities.py\` | 3 |
| \`college_review/application_review.py\` | 3 |
| \`email_automation.py\` | 2 |
| \`student_bank_accounts.py\` | 1 |
| \`document_requests.py\` | 1 |
| \`auth.py\` | 1 |
| **Total** | **54** |

Where the original message embedded another interpolation (e.g. \`{id}\` or \`{schedule_id}\`), the f-string is preserved so structured log search still works. The 2 sites where \`as e\` became unused after the swap are demoted to bare \`except Exception:\` to keep flake8 F841 clean.

## Test plan
- [x] \`python3 -c \"import ast; ast.parse(...)\"\` on all 10 files
- [x] \`uvx --from black==26.3.1 black --check\` clean
- [x] \`uvx --from flake8==7.1.1 flake8 --select F841\` clean on edited files
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)