### PR TITLE
chore(frontend): narrow ApiResponse any to unknown in user-profiles.ts (6 sites)

### DIFF
--- a/frontend/lib/api/modules/user-profiles.ts
+++ b/frontend/lib/api/modules/user-profiles.ts
@@ -102,11 +102,11 @@ export function createUserProfilesApi() {
      */
     updateBankInfo: async (
       bankData: BankInfoUpdate
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.PUT('/api/v1/user-profiles/me/bank-info', {
         body: bankData as any, // Frontend allows optional fields that may not match exact schema
       });
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -115,7 +115,7 @@ export function createUserProfilesApi() {
      */
     updateAdvisorInfo: async (
       advisorData: AdvisorInfoUpdate
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.PUT('/api/v1/user-profiles/me/advisor-info', {
         body: advisorData,
       });
@@ -162,7 +162,7 @@ export function createUserProfilesApi() {
      * Delete bank document
      * Type-safe: Response type inferred from OpenAPI
      */
-    deleteBankDocument: async (): Promise<ApiResponse<any>> => {
+    deleteBankDocument: async (): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.DELETE('/api/v1/user-profiles/me/bank-document');
       return toApiResponse(response);
     },
@@ -180,7 +180,7 @@ export function createUserProfilesApi() {
      * Delete entire profile
      * Type-safe: Response type inferred from OpenAPI
      */
-    deleteProfile: async (): Promise<ApiResponse<any>> => {
+    deleteProfile: async (): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.DELETE('/api/v1/user-profiles/me');
       return toApiResponse(response);
     },
@@ -193,7 +193,7 @@ export function createUserProfilesApi() {
        * Get incomplete profiles
        * Type-safe: Response type inferred from OpenAPI
        */
-      getIncompleteProfiles: async (): Promise<ApiResponse<any>> => {
+      getIncompleteProfiles: async (): Promise<ApiResponse<unknown>> => {
         const response = await typedClient.raw.GET('/api/v1/user-profiles/admin/incomplete');
         return toApiResponse(response);
       },


### PR DESCRIPTION
## Summary
- 6 \`Promise<ApiResponse<any>>\` return types + their inner \`toApiResponse<any>()\` generics narrowed to \`<unknown>\`. Callers must type-narrow before using the data.
- The 3 \`[key: string]: any\` index signatures and 2 \`body: ... as any\` casts are intentional per the frontend any-type cleanup ledger (openapi-fetch body schemas are \`Record<string, never>\` for this module).

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [ ] CI: frontend lint + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)