### PR TITLE
chore(frontend): narrow scholarships.getAll() any[] to ScholarshipType[]

### DIFF
--- a/frontend/lib/api/modules/scholarships.ts
+++ b/frontend/lib/api/modules/scholarships.ts
@@ -40,9 +40,9 @@ export function createScholarshipsApi() {
      * Get all scholarships
      * Type-safe: Response array inferred from OpenAPI
      */
-    getAll: async (): Promise<ApiResponse<any[]>> => {
+    getAll: async (): Promise<ApiResponse<ScholarshipType[]>> => {
       const response = await typedClient.raw.GET('/api/v1/scholarships');
-      return toApiResponse(response);
+      return toApiResponse<ScholarshipType[]>(response);
     },
 
     /**


### PR DESCRIPTION
## Summary
- \`scholarships.getAll()\` returned \`ApiResponse<any[]>\` while sibling \`getCombined()\` already returned \`ApiResponse<ScholarshipType[]>\`. Match the existing pattern.
- Consumers (college-management-context, use-scholarship-data, admin-scholarship-management-interface, application-helpers) already treat the result as \`ScholarshipType\`-shaped.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [ ] CI: frontend lint + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)