### PR TITLE
chore(frontend): narrow college.getSubTypes() any[] to string[] (1 site)

### DIFF
--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -418,14 +418,14 @@ export function createCollegeApi() {
      * Uses multi-role review API endpoint
      * Type-safe: Path parameter validated against OpenAPI
      */
-    getSubTypes: async (applicationId: number): Promise<ApiResponse<any[]>> => {
+    getSubTypes: async (applicationId: number): Promise<ApiResponse<string[]>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/reviews/applications/{application_id}/sub-types" as any,
         {
           params: { path: { application_id: applicationId } },
         }
       );
-      return toApiResponse<any[]>(response);
+      return toApiResponse<string[]>(response);
     },
 
     /**


### PR DESCRIPTION
## Summary
- Narrow \`college.getSubTypes()\` from \`ApiResponse<any[]>\` to \`ApiResponse<string[]>\`. The consumer at \`hooks/use-admin.ts:356\` already maps the result as \`(subType: string) => ...\`, so this just makes the contract honest.
- The other 34 \`ApiResponse<any>\` sites in college.ts are deferred — a bulk \`<unknown>\` narrow broke 23 consumer call sites across RankingManagementPanel, ApplicationReviewPanel, college-management-context, and use-admin.ts. Needs either canonical shared interfaces for the ranking/review payloads or consumer-side schema validation before setState.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [ ] CI: frontend lint + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)