### PR TITLE
chore(frontend): narrow roster-management filter callbacks (2 sites)

### DIFF
--- a/frontend/components/roster-management-dashboard.tsx
+++ b/frontend/components/roster-management-dashboard.tsx
@@ -64,9 +64,9 @@ export function RosterManagementDashboard() {
 
       setStats({
         totalSchedules: scheduleData.total || 0,
-        activeSchedules: scheduleData.items?.filter((s: any) => s.status === "active").length || 0,
+        activeSchedules: scheduleData.items?.filter((s: { status: string }) => s.status === "active").length || 0,
         totalRosters: rosterData.total || 0,
-        pendingRosters: rosterData.items?.filter((r: any) => r.status === "pending").length || 0,
+        pendingRosters: rosterData.items?.filter((r: { status: string }) => r.status === "pending").length || 0,
         schedulerRunning: schedulerData.scheduler_running || false
       })
     } catch (error) {


### PR DESCRIPTION
## Summary
- 2 \`.filter((s: any) => s.status === "active")\` / \`(r: any) => r.status === "pending"\` callbacks narrowed to \`{ status: string }\`. Only \`.status\` is read.
- Surfaces a real bug if backend renames the field.
- The other 4 \`any\` sites (useState × 3 + \`config: any\` param) remain documented as intentional in the frontend any-cleanup ledger (strict child-component prop contracts).

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [ ] CI: frontend lint + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)