### PR TITLE
chore(backend): convert SQLAlchemy  to  (24 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -353,8 +353,8 @@ async def get_distribution_summary(
                 CollegeRanking.scholarship_type_id == scholarship_type_id,
                 CollegeRanking.academic_year == academic_year,
                 sem_filter,
-                CollegeRanking.is_finalized == True,
-                CollegeRanking.distribution_executed == True,
+                CollegeRanking.is_finalized.is_(True),
+                CollegeRanking.distribution_executed.is_(True),
             )
         )
         ranking_result = await db.execute(ranking_stmt)
@@ -375,7 +375,7 @@ async def get_distribution_summary(
             .where(
                 and_(
                     CollegeRankingItem.ranking_id.in_(ranking_ids),
-                    CollegeRankingItem.is_allocated == True,
+                    CollegeRankingItem.is_allocated.is_(True),
                 )
             )
             .options(selectinload(CollegeRankingItem.application))

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -320,7 +320,7 @@ def get_available_rankings(
             and_(
                 CollegeRanking.scholarship_type_id == config.scholarship_type_id,
                 CollegeRanking.academic_year == academic_year,
-                CollegeRanking.distribution_executed == True,  # 必須已執行分配
+                CollegeRanking.distribution_executed.is_(True),  # 必須已執行分配
             )
         )
 
@@ -531,7 +531,7 @@ async def preview_roster_students(
                 .filter(
                     and_(
                         CollegeRanking.scholarship_type_id == config.scholarship_type_id,
-                        CollegeRanking.distribution_executed == True,
+                        CollegeRanking.distribution_executed.is_(True),
                     )
                 )
                 .order_by(CollegeRanking.created_at.desc())
@@ -566,7 +566,7 @@ async def preview_roster_students(
                 .filter(
                     and_(
                         CollegeRankingItem.application_id.in_(app_ids),
-                        CollegeRankingItem.is_allocated == True,
+                        CollegeRankingItem.is_allocated.is_(True),
                         CollegeRanking.academic_year == academic_year,
                     )
                 )

--- a/backend/app/api/v1/endpoints/reference_data.py
+++ b/backend/app/api/v1/endpoints/reference_data.py
@@ -193,7 +193,7 @@ async def _get_all_reference_data_cached(session: AsyncSession) -> dict:
         .join(ScholarshipType)
         .where(
             ScholarshipType.status == ScholarshipStatus.active.value,
-            ScholarshipSubTypeConfig.is_active == True,
+            ScholarshipSubTypeConfig.is_active.is_(True),
         )
         .order_by(ScholarshipSubTypeConfig.display_order)
     )

--- a/backend/app/api/v1/endpoints/student_bank_accounts.py
+++ b/backend/app/api/v1/endpoints/student_bank_accounts.py
@@ -39,7 +39,7 @@ async def get_my_verified_account(
             select(StudentBankAccount)
             .where(
                 StudentBankAccount.user_id == current_user.id,
-                StudentBankAccount.is_active == True,
+                StudentBankAccount.is_active.is_(True),
                 StudentBankAccount.verification_status == "verified",
             )
             .order_by(StudentBankAccount.verified_at.desc())

--- a/backend/app/services/bank_verification_service.py
+++ b/backend/app/services/bank_verification_service.py
@@ -758,7 +758,7 @@ class BankVerificationService:
                         # Create new verified account record
                         # First, deactivate any other active accounts for this user
                         deactivate_stmt = select(StudentBankAccount).where(
-                            StudentBankAccount.user_id == application.user_id, StudentBankAccount.is_active == True
+                            StudentBankAccount.user_id == application.user_id, StudentBankAccount.is_active.is_(True)
                         )
                         deactivate_result = await self.db.execute(deactivate_stmt)
                         active_accounts = deactivate_result.scalars().all()

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -270,7 +270,7 @@ class ManualDistributionService:
                 CollegeRanking.scholarship_type_id == scholarship_type_id,
                 CollegeRanking.academic_year == academic_year,
                 _ranking_semester_condition(semester),
-                CollegeRanking.is_finalized == True,
+                CollegeRanking.is_finalized.is_(True),
             )
         )
         result = await self.db.execute(ranking_query)
@@ -446,7 +446,7 @@ class ManualDistributionService:
             .where(
                 and_(
                     ScholarshipSubTypeConfig.scholarship_type_id == scholarship_type_id,
-                    ScholarshipSubTypeConfig.is_active == True,
+                    ScholarshipSubTypeConfig.is_active.is_(True),
                 )
             )
             .order_by(ScholarshipSubTypeConfig.display_order)
@@ -459,7 +459,7 @@ class ManualDistributionService:
         all_rankings_query = select(CollegeRanking).where(
             and_(
                 CollegeRanking.scholarship_type_id == scholarship_type_id,
-                CollegeRanking.is_finalized == True,
+                CollegeRanking.is_finalized.is_(True),
             )
         )
         result = await self.db.execute(all_rankings_query)
@@ -473,7 +473,7 @@ class ManualDistributionService:
                 .where(
                     and_(
                         CollegeRankingItem.ranking_id.in_(all_ranking_ids),
-                        CollegeRankingItem.is_allocated == True,
+                        CollegeRankingItem.is_allocated.is_(True),
                     )
                 )
             )
@@ -698,7 +698,7 @@ class ManualDistributionService:
                 CollegeRanking.scholarship_type_id == scholarship_type_id,
                 CollegeRanking.academic_year == academic_year,
                 _ranking_semester_condition(semester),
-                CollegeRanking.is_finalized == True,
+                CollegeRanking.is_finalized.is_(True),
             )
         )
         result = await self.db.execute(ranking_query)
@@ -946,7 +946,7 @@ class ManualDistributionService:
             .where(
                 and_(
                     ScholarshipSubTypeConfig.scholarship_type_id == scholarship_type_id,
-                    ScholarshipSubTypeConfig.is_active == True,
+                    ScholarshipSubTypeConfig.is_active.is_(True),
                 )
             )
             .order_by(ScholarshipSubTypeConfig.display_order)
@@ -1008,7 +1008,7 @@ class ManualDistributionService:
                 CollegeRanking.scholarship_type_id == scholarship_type_id,
                 CollegeRanking.academic_year == academic_year,
                 _ranking_semester_condition(semester),
-                CollegeRanking.is_finalized == True,
+                CollegeRanking.is_finalized.is_(True),
             )
         )
         result = await self.db.execute(ranking_query)

--- a/backend/app/services/quota_service.py
+++ b/backend/app/services/quota_service.py
@@ -39,7 +39,7 @@ class QuotaService:
             and_(
                 ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
                 ScholarshipConfiguration.academic_year == academic_year,
-                ScholarshipConfiguration.is_active == True,
+                ScholarshipConfiguration.is_active.is_(True),
             )
         )
 

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -643,8 +643,8 @@ class RosterService:
                         and_(
                             CollegeRanking.scholarship_type_id == config.scholarship_type_id,
                             CollegeRanking.academic_year == academic_year,
-                            CollegeRanking.is_finalized == True,  # 必須已完成
-                            CollegeRanking.distribution_executed == True,  # 必須已執行分發
+                            CollegeRanking.is_finalized.is_(True),  # 必須已完成
+                            CollegeRanking.distribution_executed.is_(True),  # 必須已執行分發
                         )
                     )
                     .order_by(CollegeRanking.finalized_at.desc())
@@ -667,7 +667,7 @@ class RosterService:
             query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(
                 and_(
                     CollegeRankingItem.ranking_id == ranking_id,
-                    CollegeRankingItem.is_allocated == True,  # 只選正取學生
+                    CollegeRankingItem.is_allocated.is_(True),  # 只選正取學生
                 )
             )
         else:
@@ -835,7 +835,7 @@ class RosterService:
                 .filter(
                     and_(
                         CollegeRankingItem.application_id == application.id,
-                        CollegeRankingItem.is_allocated == True,
+                        CollegeRankingItem.is_allocated.is_(True),
                         CollegeRanking.academic_year == roster.academic_year,
                     )
                 )
@@ -1448,8 +1448,8 @@ class RosterService:
                     CollegeRanking.scholarship_type_id == scholarship_type_id,
                     CollegeRanking.academic_year == academic_year,
                     sem_filter,
-                    CollegeRanking.is_finalized == True,
-                    CollegeRanking.distribution_executed == True,
+                    CollegeRanking.is_finalized.is_(True),
+                    CollegeRanking.distribution_executed.is_(True),
                 )
             )
             .all()
@@ -1487,7 +1487,7 @@ class RosterService:
             .filter(
                 and_(
                     CollegeRankingItem.ranking_id.in_(ranking_ids),
-                    CollegeRankingItem.is_allocated == True,
+                    CollegeRankingItem.is_allocated.is_(True),
                 )
             )
             .all()

--- a/backend/app/tests/test_business_metrics_instrumentation.py
+++ b/backend/app/tests/test_business_metrics_instrumentation.py
@@ -27,9 +27,7 @@ class TestScholarshipReviewsCounter:
             reviewer_type="professor",
             action="approve",
         )
-        scholarship_reviews_total.labels(
-            reviewer_type="professor", action="approve"
-        ).inc()
+        scholarship_reviews_total.labels(reviewer_type="professor", action="approve").inc()
         after = _sample(
             "scholarship_reviews_total_total",
             reviewer_type="professor",
@@ -48,9 +46,7 @@ class TestScholarshipReviewsCounter:
             reviewer_type="professor",
             action="reject",
         )
-        scholarship_reviews_total.labels(
-            reviewer_type="professor", action="reject"
-        ).inc()
+        scholarship_reviews_total.labels(reviewer_type="professor", action="reject").inc()
         assert (
             _sample(
                 "scholarship_reviews_total_total",
@@ -76,9 +72,7 @@ class TestScholarshipReviewsCounter:
             reviewer_type="college",
             action="approve",
         )
-        scholarship_reviews_total.labels(
-            reviewer_type="college", action="approve"
-        ).inc()
+        scholarship_reviews_total.labels(reviewer_type="college", action="approve").inc()
         after = _sample(
             "scholarship_reviews_total_total",
             reviewer_type="college",


### PR DESCRIPTION
## Summary
24 SQLAlchemy column-comparison sites across 8 files used the Python-equality operator. Replaced with \`.is_(True)\`/\`.is_(False)\` — same generated SQL, but silences flake8 E712 and makes the SQLAlchemy intent unambiguous.

| Module | Sites |
|--------|-------|
| \`services/manual_distribution_service.py\` | 7 |
| \`services/roster_service.py\` | 7 |
| \`api/v1/endpoints/manual_distribution.py\` | 3 |
| \`api/v1/endpoints/payment_rosters.py\` | 3 |
| \`api/v1/endpoints/reference_data.py\` | 1 |
| \`api/v1/endpoints/student_bank_accounts.py\` | 1 |
| \`services/bank_verification_service.py\` | 1 |
| \`services/quota_service.py\` | 1 |
| **Total** | **24** |

After this PR \`flake8 --select E712 backend/app/\` returns 0 hits, eliminating the non-blocking E712 warnings that previously cluttered CI workflow logs.

## Test plan
- [x] AST parse all touched files
- [x] \`flake8 --select E712\` clean
- [x] \`uvx --from black==26.3.1 black\` clean
- [ ] CI: backend tests + lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)