### PR TITLE
chore(backend tests): rename E741 ambiguous loop var l to label/lang (3 sites)

### DIFF
--- a/backend/app/tests/test_github_integration_pure_helpers.py
+++ b/backend/app/tests/test_github_integration_pure_helpers.py
@@ -68,7 +68,7 @@ def test_issue_labels_no_semester_when_none(service):
     """No 'semester-*' label if the distribution is yearly."""
     d = SimpleNamespace(academic_year=113, semester=None, success_rate=95)
     labels = service._generate_issue_labels(d)
-    assert not any(l.startswith("semester-") for l in labels)
+    assert not any(label.startswith("semester-") for label in labels)
 
 
 def test_issue_labels_high_success_rate_above_90(service):
@@ -102,5 +102,5 @@ def test_issue_labels_exactly_one_success_tier_always(service):
     for rate in (0, 50, 70, 89, 90, 100):
         d = SimpleNamespace(academic_year=113, semester=None, success_rate=rate)
         labels = service._generate_issue_labels(d)
-        tier_labels = [l for l in labels if l.endswith("-success-rate")]
+        tier_labels = [label for label in labels if label.endswith("-success-rate")]
         assert len(tier_labels) == 1, f"rate={rate} → {tier_labels}"

--- a/backend/app/tests/test_i18n_utils.py
+++ b/backend/app/tests/test_i18n_utils.py
@@ -97,7 +97,7 @@ def test_supported_languages_returns_two_entries():
     coverage in the TRANSLATIONS dict, so pin this so it's reviewed."""
     langs = ScholarshipI18n.get_supported_languages()
     assert len(langs) == 2
-    codes = [l["code"] for l in langs]
+    codes = [lang["code"] for lang in langs]
     assert codes == ["zh-TW", "en"]
 
 


### PR DESCRIPTION
Rename ambiguous l → label / lang in 3 test comprehension sites. Closes the last open E741 hits. flake8 --select E741 backend/app/ now returns 0.

Test plan:
- [x] flake8 --select E741 clean
- [x] black --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)