### PR TITLE
chore(frontend): silence next/no-img-element on 2 passbook-preview sites

### DIFF
--- a/frontend/components/bank-verification-review-dialog.tsx
+++ b/frontend/components/bank-verification-review-dialog.tsx
@@ -253,6 +253,7 @@ export function BankVerificationReviewDialog({
                   {imageLoading && (
                     <Skeleton className="absolute inset-4 rounded" />
                   )}
+                  {/* eslint-disable-next-line @next/next/no-img-element -- user-uploaded passbook scan, unknown aspect ratio; next/image gives no benefit with images.unoptimized */}
                   <img
                     src={previewUrl}
                     alt="存摺封面"

--- a/frontend/components/student/verified-account-alert.tsx
+++ b/frontend/components/student/verified-account-alert.tsx
@@ -70,6 +70,7 @@ export function VerifiedAccountAlert({
         {showDetails && account.passbook_cover_url && (
           <div className="mt-3 p-3 bg-white rounded border border-green-200">
             <p className="text-sm font-medium mb-2">帳本封面照片</p>
+            {/* eslint-disable-next-line @next/next/no-img-element -- user-uploaded passbook scan, unknown aspect ratio; next/image gives no benefit with images.unoptimized */}
             <img
               src={account.passbook_cover_url}
               alt="已驗證的帳本封面"


### PR DESCRIPTION
## Summary

- Adds `eslint-disable-next-line @next/next/no-img-element` to the two remaining ESLint warning sites:
  - `frontend/components/bank-verification-review-dialog.tsx:256` — passbook preview inside the reviewer dialog
  - `frontend/components/student/verified-account-alert.tsx:73` — verified-account passbook display
- Inline comments explain why \`<img>\` is intentional: user-uploaded passbook scans have unknown aspect ratios, and `images.unoptimized: true` in `next.config.mjs` already disables the optimization step that `next/image` would otherwise provide.

## Test plan

- [ ] CI: `npm run lint` should now exit clean (no warnings)
- [ ] CI: `bunx tsc --noEmit` (or whichever the pipeline runs) — comment-only change, no type impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)