### PR TITLE
chore(frontend): migrate small-file console.* to logger (5 files, 10 sites)

### DIFF
--- a/frontend/contexts/notification-context.tsx
+++ b/frontend/contexts/notification-context.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useContext, useCallback, useEffect } from "react"
 import { apiClient } from "@/lib/api";
 import { useAuth } from "@/hooks/use-auth";
 import { useNotificationCount } from "@/hooks/use-notification-count";
+import { logger } from "@/lib/utils/logger";
 
 interface NotificationContextValue {
   unreadCount: number;
@@ -33,7 +34,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     try {
       await mutate();
     } catch (err) {
-      console.error("獲取未讀通知數量錯誤:", err);
+      logger.error("Failed to fetch unread notification count", { err });
     }
   }, [mutate, user]);
 
@@ -51,7 +52,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         }));
       }
     } catch (err) {
-      console.error("標記已讀失敗:", err);
+      logger.error("Failed to mark notification as read", { err });
     }
   }, [mutate]);
 
@@ -66,7 +67,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         window.dispatchEvent(new CustomEvent("notifications-all-read"));
       }
     } catch (err) {
-      console.error("標記全部已讀失敗:", err);
+      logger.error("Failed to mark all notifications as read", { err });
     }
   }, [mutate]);
 

--- a/frontend/hooks/use-applications.ts
+++ b/frontend/hooks/use-applications.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { apiClient, Application, ApplicationCreate } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 import { useAuth } from "./use-auth";
 
 export function useApplications() {
@@ -11,7 +12,7 @@ export function useApplications() {
   const fetchApplications = useCallback(
     async (status?: string) => {
       if (!isAuthenticated) {
-        console.log("User not authenticated, skipping application fetch");
+        logger.debug("User not authenticated, skipping application fetch");
         return;
       }
 
@@ -29,7 +30,7 @@ export function useApplications() {
           throw new Error(response.message || "Failed to fetch applications");
         }
       } catch (err) {
-        console.error("Error fetching applications:", err);
+        logger.error("Error fetching applications", { err });
         setError(
           err instanceof Error ? err.message : "Failed to fetch applications"
         );

--- a/frontend/hooks/use-student-preview.ts
+++ b/frontend/hooks/use-student-preview.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { createCollegeApi } from '@/lib/api/modules/college';
+import { logger } from '@/lib/utils/logger';
 
 interface StudentPreviewBasic {
   // === 學籍資料 ===
@@ -130,7 +131,7 @@ export function useStudentPreview(): UseStudentPreviewReturn {
         return;
       }
 
-      console.error('Error fetching student preview:', err);
+      logger.error('Error fetching student preview', { err });
       setError((err instanceof Error ? err.message : 'Failed to load student preview'));
       setPreviewData(null);
     } finally {

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -70,11 +70,11 @@ export class ApiClient {
       // Browser environment - always use relative path
       // Nginx reverse proxy will handle routing /api/* to backend
       this.baseURL = "";
-      console.log("🌐 API Client Browser mode - using relative path (Nginx proxy)");
+      logger.debug("API Client browser mode (Nginx proxy via relative path)");
     } else {
       // Server-side environment - use internal Docker network or localhost
       this.baseURL = process.env.INTERNAL_API_URL || "http://localhost:8000";
-      console.log("🖥️ API Client Server-side mode - using:", this.baseURL);
+      logger.debug("API Client server-side mode", { baseURL: this.baseURL });
     }
 
     // Try to get token from localStorage on client side with safe access

--- a/frontend/lib/api/typed-client.ts
+++ b/frontend/lib/api/typed-client.ts
@@ -13,6 +13,7 @@
 
 import createClient from 'openapi-fetch';
 import type { paths } from './generated/schema';
+import { logger } from '../utils/logger';
 
 /**
  * Type-safe API client with authentication and environment-aware routing
@@ -29,11 +30,10 @@ class TypedApiClient {
       ? '' // Browser: relative path
       : process.env.INTERNAL_API_URL || 'http://localhost:8000';
 
-    console.log(
-      typeof window !== 'undefined'
-        ? '🌐 Typed API Client (Browser mode - Nginx proxy)'
-        : `🖥️ Typed API Client (Server mode - ${baseUrl})`
-    );
+    logger.debug('Typed API Client initialized', {
+      mode: typeof window !== 'undefined' ? 'browser' : 'server',
+      baseUrl,
+    });
 
     // Create typed client
     this.client = createClient<paths>({ baseUrl });
@@ -60,7 +60,7 @@ class TypedApiClient {
       onResponse: ({ response }) => {
         // Clear token on 401 Unauthorized
         if (response.status === 401) {
-          console.error('Authentication failed - clearing token');
+          logger.error('Authentication failed - clearing token');
           this.clearToken();
         }
         return undefined; // No modification needed


### PR DESCRIPTION
## Summary

Continuation of PR #608. Migrate the remaining console.* calls in five low-churn modules to the shared logger so production builds stop emitting unstructured chatter and so error context arrives in the same envelope as the rest of the frontend.

Files & sites:
- `frontend/contexts/notification-context.tsx` — 3 unstructured error logs (zh-TW prefixes preserved as English message + `{ err }`)
- `frontend/hooks/use-applications.ts` — 1 debug, 1 error
- `frontend/hooks/use-student-preview.ts` — 1 error
- `frontend/lib/api/client.ts` — 2 emoji-prefixed boot messages (logger already imported)
- `frontend/lib/api/typed-client.ts` — 1 emoji boot, 1 auth-failure error

## Test plan

- [ ] CI: `npm run lint` should remain clean
- [ ] CI: TypeScript — logger signature `(message: string, context?: LogContext)` matches all new call sites
- [ ] Manual: dev-mode console still shows the debug messages (logger gates on NODE_ENV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)