### PR TITLE
chore(frontend): migrate utility console.* to logger (4 files, 8 sites)

### DIFF
--- a/frontend/contexts/session-expired-context.tsx
+++ b/frontend/contexts/session-expired-context.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
 import { SessionExpiredModal } from "@/components/session-expired-modal";
 import { Locale } from "@/lib/validators";
+import { logger } from "@/lib/utils/logger";
 
 interface SessionExpiredContextType {
   isSessionExpired: boolean;
@@ -27,7 +28,7 @@ export function SessionExpiredProvider({ children }: { children: ReactNode }) {
     const handleSessionExpired = (event: CustomEvent) => {
       const { type, status, endpoint } = event.detail;
 
-      console.warn(`Session expired event received:`, {
+      logger.warn("Session expired event received", {
         type,
         status,
         endpoint,
@@ -58,7 +59,7 @@ export function SessionExpiredProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const handleRelogin = useCallback(() => {
-    console.log("Session expired - redirecting to login");
+    logger.info("Session expired - redirecting to login");
 
     // Clear session expired state
     setIsSessionExpired(false);

--- a/frontend/hooks/use-scholarship-data.ts
+++ b/frontend/hooks/use-scholarship-data.ts
@@ -15,6 +15,7 @@
 
 import useSWR from 'swr';
 import { apiClient } from '@/lib/api';
+import { logger } from '@/lib/utils/logger';
 import type { ApiResponse } from '@/lib/api/types';
 
 type ScholarshipData = Array<{
@@ -91,7 +92,7 @@ const fetchAllScholarshipData = async (userRole?: string): Promise<ScholarshipDa
         }
       }
     } catch (translationError) {
-      console.warn('Failed to fetch sub-type translations, using empty translations', translationError);
+      logger.warn('Failed to fetch sub-type translations, using empty translations', { translationError });
       // Continue with empty translations rather than failing the whole request
     }
 
@@ -100,7 +101,7 @@ const fetchAllScholarshipData = async (userRole?: string): Promise<ScholarshipDa
       subTypeTranslations,
     };
   } catch (error) {
-    console.error('Failed to fetch scholarship data:', error);
+    logger.error('Failed to fetch scholarship data', { error });
     // Return empty data instead of throwing
     return {
       scholarships: [],
@@ -154,7 +155,7 @@ export function useScholarshipData(autoDetectRole: boolean = true, explicitRole?
       userRole = explicitRole || 'admin';
     }
   } catch (error) {
-    console.warn('Failed to detect user role, using default API', error);
+    logger.warn('Failed to detect user role, using default API', { error });
     userRole = explicitRole || 'admin';
   }
 

--- a/frontend/lib/email-renderer.tsx
+++ b/frontend/lib/email-renderer.tsx
@@ -16,6 +16,7 @@
  */
 
 import { render } from '@react-email/render';
+import { logger } from '@/lib/utils/logger';
 import ApplicationSubmitted from '@/emails/application-submitted';
 import ProfessorReviewRequest from '@/emails/professor-review-request';
 import CollegeReviewRequest from '@/emails/college-review-request';
@@ -114,7 +115,7 @@ export function emailToPlainText(html: string): string {
       return text.split(' ').filter(Boolean).join(' ').trim();
     } catch (error) {
       // If DOMParser fails, return empty rather than use unsafe fallback
-      console.error('DOMParser failed to parse HTML:', error);
+      logger.error('DOMParser failed to parse HTML', { error });
       return '';
     }
   }

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -1,5 +1,6 @@
 import { Locale } from "@/lib/validators";
 import { api } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 import {
   ApplicationStatus,
   ReviewStage,
@@ -366,10 +367,10 @@ export const formatFieldValue = async (
         }
       }
     } catch (error) {
-      console.warn(
-        `Failed to fetch scholarship type for code: ${value}`,
-        error
-      );
+      logger.warn("Failed to fetch scholarship type for code", {
+        code: value,
+        error,
+      });
     }
     // API 失敗時直接顯示 code
     return value;
@@ -454,7 +455,7 @@ export const fetchApplicationFiles = async (applicationId: number) => {
 
     return [];
   } catch (error) {
-    console.error("Failed to fetch application files:", error);
+    logger.error("Failed to fetch application files", { error });
     return [];
   }
 };


### PR DESCRIPTION
## Summary

Third batch of the frontend console→logger migration (continuation of #608/#609). Switches the remaining context, lib, and SWR-hook modules to structured logging.

Files touched:
- \`frontend/contexts/session-expired-context.tsx\` — 1 warn (event received) + 1 info (redirect)
- \`frontend/lib/email-renderer.tsx\` — 1 error (DOMParser failure path)
- \`frontend/lib/utils/application-helpers.ts\` — 1 warn (scholarship lookup) + 1 error (file fetch)
- \`frontend/hooks/use-scholarship-data.ts\` — 2 warns + 1 error (translation/data/role-detect paths)

All structured-context arguments now match logger's \`LogContext\` shape so the eventual external-logger sink picks up error/code/timestamp fields cleanly.

## Test plan

- [ ] CI: \`npm run lint\` & TypeScript checks
- [ ] CI: existing frontend unit tests should not regress (logger module already tested separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)