### PR TITLE
chore(frontend): start components/ console.* → logger (3 files, 8 sites)

### DIFF
--- a/frontend/components/dynamic-application-form.tsx
+++ b/frontend/components/dynamic-application-form.tsx
@@ -37,6 +37,7 @@ import {
   CheckCircle,
 } from "lucide-react";
 import { api } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 import { getTranslation } from "@/lib/i18n";
 import type {
   ApplicationField,
@@ -148,7 +149,7 @@ export function DynamicApplicationForm({
         setError(t("form_upload.load_form_config_failed"));
       }
     } catch (err) {
-      console.error("Failed to load form configuration:", err);
+      logger.error("Failed to load form configuration", { err });
       setError(t("form_upload.load_form_config_error"));
     } finally {
       setIsLoading(false);
@@ -193,7 +194,7 @@ export function DynamicApplicationForm({
         "";
 
       if (!token) {
-        console.error("No authentication token available");
+        logger.error("No authentication token available");
         return null;
       }
     }
@@ -650,7 +651,7 @@ export function DynamicApplicationForm({
                   link.rel = "noopener noreferrer";
                   link.click();
                 } catch (error) {
-                  console.error("Failed to build preview URL:", error);
+                  logger.error("Failed to build preview URL", { error });
                   alert(t("form_upload.preview_open_failed"));
                 }
               }}

--- a/frontend/components/email-test-mode-panel.tsx
+++ b/frontend/components/email-test-mode-panel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { AlertCircle, CheckCircle, Clock, Mail, RefreshCw, Shield, ChevronDown, ChevronUp, Send } from "lucide-react";
 import { api } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
@@ -103,7 +104,7 @@ export function EmailTestModePanel() {  const [status, setStatus] = useState<Tes
         setStatus(response.data);
       }
     } catch (error) {
-      console.error("Failed to load test mode status:", error);
+      logger.error("Failed to load test mode status", { error });
       toast.error("無法載入測試模式狀態",
       );
     } finally {
@@ -118,7 +119,7 @@ export function EmailTestModePanel() {  const [status, setStatus] = useState<Tes
         setAuditLogs(response.data.items);
       }
     } catch (error) {
-      console.error("Failed to load audit logs:", error);
+      logger.error("Failed to load audit logs", { error });
     }
   };
 
@@ -130,7 +131,7 @@ export function EmailTestModePanel() {  const [status, setStatus] = useState<Tes
         setEmailHistory(response.data.items);
       }
     } catch (error) {
-      console.error("Failed to load email history:", error);
+      logger.error("Failed to load email history", { error });
       toast.error("無法載入郵件歷史紀錄",
       );
     } finally {

--- a/frontend/components/user-edit-modal.tsx
+++ b/frontend/components/user-edit-modal.tsx
@@ -12,6 +12,7 @@ import {
   ScholarshipPermission,
   apiClient,
 } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 import { Badge } from "./ui/badge";
 
 interface Academy {
@@ -85,7 +86,7 @@ export function UserEditModal({
           setAcademies(response.data);
         }
       } catch (error) {
-        console.error("Failed to fetch academies:", error);
+        logger.error("Failed to fetch academies", { error });
       } finally {
         setLoadingAcademies(false);
       }
@@ -105,7 +106,7 @@ export function UserEditModal({
           setDepartments(response.data);
         }
       } catch (error) {
-        console.error("Failed to fetch departments:", error);
+        logger.error("Failed to fetch departments", { error });
       }
     };
 


### PR DESCRIPTION
## Summary

Begins the \`components/\` tier of the frontend console-cleanup wave (continues PRs #608-#613 which finished \`hooks/\`/\`lib/\`/\`contexts/\`).

Files migrated:
- \`components/user-edit-modal.tsx\` (2 catch-block errors: academy/department lookups)
- \`components/email-test-mode-panel.tsx\` (3 catch-block errors: status/audit/history fetches)
- \`components/dynamic-application-form.tsx\` (3 sites: form-config load, missing-token guard, preview URL build)

Pure refactor — render flow and behaviour unchanged.

## Out of scope

Remaining \`components/\`+\`app/\` console sites total ~480, concentrated in:
- \`app/page.tsx\` (55), \`components/admin-management-interface.tsx\` (31), \`app/auth/sso-callback/page.tsx\` (30), \`components/enhanced-student-portal.tsx\` (29), \`components/admin-scholarship-dashboard.tsx\` (28), \`components/debug-panel.tsx\` (24, intentional dev tool)

These will be picked up in follow-up PRs.

## Test plan

- [ ] CI: lint + tsc
- [ ] CI: existing component tests should not regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)