### PR TITLE
chore(frontend): batch migrate 9 console-heavy components to logger

### DIFF
--- a/frontend/app/admin/test-users/page.tsx
+++ b/frontend/app/admin/test-users/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { apiClient, UserListResponse, UserStats, UserCreate } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 
 export default function TestUsersPage() {
   const [users, setUsers] = useState<UserListResponse[]>([]);
@@ -16,13 +17,13 @@ export default function TestUsersPage() {
     setError(null);
 
     try {
-      console.log("🧪 測試獲取用戶列表...");
+      logger.debug("🧪 測試獲取用戶列表...");
       const response = await apiClient.users.getAll({ page: 1, size: 10 });
-      console.log("📥 用戶列表響應:", response);
+      logger.debug("📥 用戶列表響應:", response);
 
       if (response.success && response.data) {
         setUsers(response.data.items || []);
-        console.log(
+        logger.debug(
           "✅ 用戶列表獲取成功，數量:",
           response.data.items?.length || 0
         );
@@ -30,7 +31,7 @@ export default function TestUsersPage() {
         setError("獲取用戶失敗: " + (response.message || "未知錯誤"));
       }
     } catch (err) {
-      console.error("❌ 獲取用戶異常:", err);
+      logger.error("❌ 獲取用戶異常", { err: err });
       setError(
         "網絡錯誤: " + (err instanceof Error ? err.message : "未知錯誤")
       );
@@ -41,18 +42,18 @@ export default function TestUsersPage() {
 
   const testGetStats = async () => {
     try {
-      console.log("🧪 測試獲取用戶統計...");
+      logger.debug("🧪 測試獲取用戶統計...");
       const response = await apiClient.users.getStats();
-      console.log("📥 用戶統計響應:", response);
+      logger.debug("📥 用戶統計響應:", response);
 
       if (response.success && response.data) {
         setUserStats(response.data);
-        console.log("✅ 用戶統計獲取成功");
+        logger.debug("✅ 用戶統計獲取成功");
       } else {
         setError("獲取統計失敗: " + (response.message || "未知錯誤"));
       }
     } catch (err) {
-      console.error("❌ 獲取統計異常:", err);
+      logger.error("❌ 獲取統計異常", { err: err });
       setError(
         "網絡錯誤: " + (err instanceof Error ? err.message : "未知錯誤")
       );
@@ -61,7 +62,7 @@ export default function TestUsersPage() {
 
   const testCreateUser = async () => {
     try {
-      console.log("🧪 測試創建用戶...");
+      logger.debug("🧪 測試創建用戶...");
       const newUser: UserCreate = {
         nycu_id: `test-${Date.now()}`,
         name: "測試用戶",
@@ -79,16 +80,16 @@ export default function TestUsersPage() {
       };
 
       const response = await apiClient.users.create(newUser);
-      console.log("📥 創建用戶響應:", response);
+      logger.debug("📥 創建用戶響應:", response);
 
       if (response.success) {
-        console.log("✅ 用戶創建成功");
+        logger.debug("✅ 用戶創建成功");
         testGetUsers(); // 重新獲取用戶列表
       } else {
         setError("創建用戶失敗: " + (response.message || "未知錯誤"));
       }
     } catch (err) {
-      console.error("❌ 創建用戶異常:", err);
+      logger.error("❌ 創建用戶異常", { err: err });
       setError(
         "網絡錯誤: " + (err instanceof Error ? err.message : "未知錯誤")
       );

--- a/frontend/components/admin-rule-management.tsx
+++ b/frontend/components/admin-rule-management.tsx
@@ -23,6 +23,7 @@ import {
   Upload,
 } from "lucide-react";
 import { ScholarshipType, ScholarshipRule, api } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 import { ScholarshipRuleModal } from "./scholarship-rule-modal";
 import { CopyRulesModal } from "./copy-rules-modal";
 import { toast } from "sonner";
@@ -79,7 +80,7 @@ export function AdminRuleManagement({
           throw new Error(response.message || "獲取可用年份失敗");
         }
       } catch (error) {
-        console.error("獲取可用年份失敗:", error);
+        logger.error("獲取可用年份失敗", { error: error });
         toast.error("無法載入可用年份，將使用預設年份範圍");
         // Set a default range of years if API fails
         const currentYear = new Date().getFullYear() - 1911;
@@ -170,18 +171,18 @@ export function AdminRuleManagement({
           params.semester = semester;
         }
 
-        console.log("[RULES] Fetching rules with params:", params);
+        logger.debug("[RULES] Fetching rules with params:", params);
         const response = await api.admin.getScholarshipRules(params);
-        console.log("[RULES] API response:", response);
+        logger.debug("[RULES] API response:", response);
 
         if (response.success && response.data) {
-          console.log("[RULES] Setting rules:", response.data.length, "rules found");
+          logger.debug("[RULES] Setting rules:", response.data.length, "rules found");
           setRules(response.data);
         } else {
           throw new Error(response.message || "載入規則失敗");
         }
       } catch (error) {
-        console.error("載入規則失敗:", error);
+        logger.error("載入規則失敗", { error: error });
         toast.error("載入規則失敗: " + (error as Error).message);
         // Set empty rules on error
         setRules([]);
@@ -230,7 +231,7 @@ export function AdminRuleManagement({
       await loadRules(selectedScholarshipType!, selectedYear, selectedSemester);
       toast.success("規則刪除成功");
     } catch (error) {
-      console.error("刪除規則失敗:", error);
+      logger.error("刪除規則失敗", { error: error });
       toast.error("刪除規則失敗: " + (error as Error).message);
     }
   };
@@ -250,7 +251,7 @@ export function AdminRuleManagement({
       await loadRules(selectedScholarshipType, selectedYear, selectedSemester);
       toast.success(isCreating ? "規則創建成功" : "規則更新成功");
     } catch (error) {
-      console.error("提交規則失敗:", error);
+      logger.error("提交規則失敗", { error: error });
       toast.error("提交規則失敗: " + (error as Error).message);
     }
   };
@@ -272,14 +273,14 @@ export function AdminRuleManagement({
     overwriteExisting: boolean = false
   ) => {
     try {
-      console.log("[COPY RULES] Starting copy process...");
-      console.log("[COPY RULES] Source:", {
+      logger.debug("[COPY RULES] Starting copy process...");
+      logger.debug("[COPY RULES] Source:", {
         year: selectedYear,
         semester: selectedSemester,
         rulesCount: selectedRulesForCopy.length,
         ruleIds: selectedRulesForCopy.map(rule => rule.id),
       });
-      console.log("[COPY RULES] Target:", {
+      logger.debug("[COPY RULES] Target:", {
         year: targetYear,
         semester: targetSemester,
         overwriteExisting,
@@ -298,18 +299,18 @@ export function AdminRuleManagement({
         overwrite_existing: overwriteExisting,
       };
 
-      console.log("[COPY RULES] Request payload:", copyRequest);
+      logger.debug("[COPY RULES] Request payload:", copyRequest);
 
       const response = await api.admin.copyRulesBetweenPeriods(copyRequest);
 
-      console.log("[COPY RULES] Response:", response);
-      console.log("[COPY RULES] Response data:", response.data);
+      logger.debug("[COPY RULES] Response:", response);
+      logger.debug("[COPY RULES] Response data:", response.data);
 
       if (response.success) {
         const copiedCount = response.data?.length || 0;
         const skippedCount = selectedRulesForCopy.length - copiedCount;
 
-        console.log("[COPY RULES] Results:", {
+        logger.debug("[COPY RULES] Results:", {
           totalRules: selectedRulesForCopy.length,
           copiedCount,
           skippedCount,
@@ -321,12 +322,12 @@ export function AdminRuleManagement({
           message += `，跳過 ${skippedCount} 條重複規則`;
         }
 
-        console.log("[COPY RULES] Alert message:", message);
+        logger.debug("[COPY RULES] Alert message:", message);
         alert(message);
 
         // 如果複製到新的年份（不在現有列表中），重新載入可用年份
         if (!availableYears.includes(targetYear)) {
-          console.log(
+          logger.debug(
             "[COPY RULES] New year detected, reloading available years..."
           );
           try {
@@ -335,7 +336,7 @@ export function AdminRuleManagement({
               setAvailableYears(response.data);
             }
           } catch (error) {
-            console.error("Failed to reload available years:", error);
+            logger.error("Failed to reload available years", { error: error });
             toast.error("重新載入可用年份失敗");
           }
         }
@@ -346,7 +347,7 @@ export function AdminRuleManagement({
           ((!targetSemester && !selectedSemester) ||
             targetSemester === selectedSemester)
         ) {
-          console.log("[COPY RULES] Reloading rules for current period...");
+          logger.debug("[COPY RULES] Reloading rules for current period...");
           await loadRules(
             selectedScholarshipType!,
             selectedYear,
@@ -354,12 +355,12 @@ export function AdminRuleManagement({
           );
         }
       } else {
-        console.error("[COPY RULES] Copy failed:", response.message);
+        logger.error("[COPY RULES] Copy failed:", response.message);
         throw new Error(response.message || "複製失敗");
       }
     } catch (error) {
-      console.error("[COPY RULES] Error in copy process:", error);
-      console.error("複製規則失敗:", error);
+      logger.error("[COPY RULES] Error in copy process", { error: error });
+      logger.error("複製規則失敗", { error: error });
       toast.error("複製規則失敗: " + (error as Error).message);
     }
   };

--- a/frontend/components/admin-scholarship-dashboard.tsx
+++ b/frontend/components/admin-scholarship-dashboard.tsx
@@ -42,6 +42,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useScholarshipSpecificApplications } from "@/hooks/use-admin";
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 import { Locale } from "@/lib/validators";
 import { getDisplayStatusInfo } from "@/lib/utils/application-helpers";
 import {
@@ -199,8 +200,8 @@ interface DashboardApplication {
 // loose rather than re-declare the entire transform.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const transformApplicationData = (app: any): DashboardApplication => {
-  console.log("🔍 Transforming application data:", app.app_id);
-  console.log("📊 Professor data in raw API response:", app.professor);
+  logger.debug("🔍 Transforming application data:", app.app_id);
+  logger.debug("📊 Professor data in raw API response:", app.professor);
 
   // Ensure submitted_form_data has the correct structure for file preview
   let submittedFormData = app.submitted_form_data;
@@ -270,11 +271,11 @@ const transformApplicationData = (app: any): DashboardApplication => {
     scholarship_configuration: app.scholarship_configuration,
   };
 
-  console.log("✅ Transformed result:", transformed.app_id);
-  console.log("📋 Professor in transformed data:", transformed.professor);
-  console.log("🎯 Professor name in transformed:", transformed.professor?.name);
-  console.log("🔢 Professor ID in transformed:", transformed.professor_id);
-  console.log("⚙️ Scholarship configuration:", app.scholarship_configuration);
+  logger.debug("✅ Transformed result:", transformed.app_id);
+  logger.debug("📋 Professor in transformed data:", transformed.professor);
+  logger.debug("🎯 Professor name in transformed:", transformed.professor?.name);
+  logger.debug("🔢 Professor ID in transformed:", transformed.professor_id);
+  logger.debug("⚙️ Scholarship configuration:", app.scholarship_configuration);
   return transformed;
 };
 
@@ -306,7 +307,7 @@ export function AdminScholarshipDashboard({
   const { subTypeTranslations } = useScholarshipData();
 
   // Debug logging
-  console.log("ScholarshipSpecificDashboard render:", {
+  logger.debug("ScholarshipSpecificDashboard render:", {
     scholarshipTypes,
     scholarshipStats,
     applicationsByType,
@@ -372,7 +373,7 @@ export function AdminScholarshipDashboard({
 
     // Debug logging
     if (transformedApplications.length > 0) {
-      console.log(
+      logger.debug(
         `Transformed applications for ${type}:`,
         transformedApplications[0]
       );
@@ -478,9 +479,9 @@ export function AdminScholarshipDashboard({
     newStatus: string
   ) => {
     try {
-      console.log("Status update request:", { applicationId, newStatus });
+      logger.debug("Status update request:", { applicationId, newStatus });
       const result = await updateApplicationStatus(applicationId, newStatus);
-      console.log("Status update result:", result);
+      logger.debug("Status update result:", result);
 
       // 檢查是否成功（即使拋出錯誤，實際上也可能成功了）
       toast.success(`申請狀態已更新為${newStatus === "approved" ? "已核准" : newStatus === "rejected" ? "已駁回" : newStatus}`);
@@ -488,7 +489,7 @@ export function AdminScholarshipDashboard({
       // 重新載入數據
       refetch();
     } catch (error) {
-      console.error("Failed to update application status:", error);
+      logger.error("Failed to update application status", { error: error });
       // 嘗試重新載入以檢查狀態是否實際上已更新
       await new Promise(resolve => setTimeout(resolve, 500));
       refetch();
@@ -509,7 +510,7 @@ export function AdminScholarshipDashboard({
         toast.error("無法載入申請詳情");
       }
     } catch (error) {
-      console.error("Failed to fetch application details:", error);
+      logger.error("Failed to fetch application details", { error: error });
       toast.error("載入申請詳情時發生錯誤");
     } finally {
       setLoadingApplicationDetail(false);
@@ -537,7 +538,7 @@ export function AdminScholarshipDashboard({
         toast.error(response.message || "無法完成郵局帳戶驗證");
       }
     } catch (error) {
-      console.error("Post office verification error:", error);
+      logger.error("Post office verification error", { error: error });
       toast.error("郵局帳戶驗證過程中發生錯誤");
     } finally {
       setBankVerificationLoading(prev => ({ ...prev, [applicationId]: false }));
@@ -558,7 +559,7 @@ export function AdminScholarshipDashboard({
         toast.error(response.message || "無法載入驗證資料");
       }
     } catch (error) {
-      console.error("Failed to load post office verification data:", error);
+      logger.error("Failed to load post office verification data", { error: error });
       toast.error("載入驗證資料時發生錯誤");
     } finally {
       setBankVerificationLoading(prev => ({ ...prev, [applicationId]: false }));
@@ -583,7 +584,7 @@ export function AdminScholarshipDashboard({
         toast.error(response.message || "無法執行郵局帳號驗證");
       }
     } catch (error) {
-      console.error("Failed to verify post office account:", error);
+      logger.error("Failed to verify post office account", { error: error });
       toast.error("執行驗證時發生錯誤");
     } finally {
       setBankVerificationLoading(prev => ({ ...prev, [applicationId]: false }));
@@ -610,7 +611,7 @@ export function AdminScholarshipDashboard({
         toast.error(response.message || "無法完成批量郵局帳戶驗證");
       }
     } catch (error) {
-      console.error("Batch post office verification error:", error);
+      logger.error("Batch post office verification error", { error: error });
       toast.error("批量郵局帳戶驗證過程中發生錯誤");
     } finally {
       setBatchVerificationLoading(false);
@@ -725,7 +726,7 @@ export function AdminScholarshipDashboard({
         toast.error(response.message || "無法載入操作紀錄");
       }
     } catch (error) {
-      console.error("Failed to fetch audit logs:", error);
+      logger.error("Failed to fetch audit logs", { error: error });
       toast.error("無法載入操作紀錄，請稍後再試");
     } finally {
       setAuditLoading(false);
@@ -1000,26 +1001,26 @@ export function AdminScholarshipDashboard({
                                   <CheckCircle className="h-4 w-4 text-green-600" />
                                     <span className="text-sm font-medium text-green-800 whitespace-nowrap">
                                     {(() => {
-                                      console.log(
+                                      logger.debug(
                                         "🎯 Display logic - App:",
                                         app.app_id
                                       );
-                                      console.log(
+                                      logger.debug(
                                         "📋 Professor object:",
                                         app.professor
                                       );
-                                      console.log(
+                                      logger.debug(
                                         "📝 Professor name:",
                                         app.professor?.name
                                       );
-                                      console.log(
+                                      logger.debug(
                                         "🔢 Professor ID:",
                                         app.professor_id
                                       );
                                       const displayName =
                                         app.professor?.name ||
                                         `教授 #${app.professor_id}`;
-                                      console.log(
+                                      logger.debug(
                                         "✨ Final display name:",
                                         displayName
                                       );
@@ -1087,26 +1088,26 @@ export function AdminScholarshipDashboard({
                             <div className="flex items-center gap-1">
                               <span className="text-sm font-medium text-green-800 whitespace-nowrap">
                                 {(() => {
-                                  console.log(
+                                  logger.debug(
                                     "🎯 Display logic (readonly) - App:",
                                     app.app_id
                                   );
-                                  console.log(
+                                  logger.debug(
                                     "📋 Professor object:",
                                     app.professor
                                   );
-                                  console.log(
+                                  logger.debug(
                                     "📝 Professor name:",
                                     app.professor?.name
                                   );
-                                  console.log(
+                                  logger.debug(
                                     "🔢 Professor ID:",
                                     app.professor_id
                                   );
                                   const displayName =
                                     app.professor?.name ||
                                     `教授 #${app.professor_id}`;
-                                  console.log(
+                                  logger.debug(
                                     "✨ Final display name:",
                                     displayName
                                   );

--- a/frontend/components/admin-scholarship-management-interface.tsx
+++ b/frontend/components/admin-scholarship-management-interface.tsx
@@ -49,6 +49,7 @@ import { ApplicationFieldForm } from "@/components/application-field-form";
 import { ApplicationDocumentForm } from "@/components/application-document-form";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { api } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 import type {
   ApplicationField,
   ApplicationDocument,
@@ -181,7 +182,7 @@ export function AdminScholarshipManagementInterface({
         setError("尚未設定表單配置，請先於後台建立。");
       }
     } catch (err) {
-      console.error("Failed to load form configuration:", err);
+      logger.error("Failed to load form configuration", { err: err });
       setApplicationFields([]);
       setDocumentRequirements([]);
       setFormConfig(null);
@@ -220,7 +221,7 @@ export function AdminScholarshipManagementInterface({
         }
       }
     } catch (err) {
-      console.error("Failed to load scholarship data:", err);
+      logger.error("Failed to load scholarship data", { err: err });
       toast.error("無法載入獎學金資料");
     } finally {
       setLoadingWhitelist(false);
@@ -235,7 +236,7 @@ export function AdminScholarshipManagementInterface({
         setWhitelist(response.data as WhitelistResponse[]);
       }
     } catch (err: unknown) {
-      console.error("Failed to load whitelist:", err);
+      logger.error("Failed to load whitelist", { err: err });
       toast.error((err instanceof Error ? err.message : "無法載入白名單"));
     } finally {
       setLoadingWhitelist(false);
@@ -324,7 +325,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "保存設定時發生錯誤");
       }
     } catch (err) {
-      console.error("Failed to save configuration:", err);
+      logger.error("Failed to save configuration", { err: err });
       setError("保存設定時發生錯誤，請稍後再試");
     } finally {
       setIsSaving(false);
@@ -374,7 +375,7 @@ export function AdminScholarshipManagementInterface({
         setError(errorData.message || "上傳申請條款文件失敗");
       }
     } catch (err) {
-      console.error("Failed to upload terms document:", err);
+      logger.error("Failed to upload terms document", { err: err });
       setError("上傳申請條款文件失敗，請稍後再試");
     } finally {
       setIsUploadingTerms(false);
@@ -406,7 +407,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "新增欄位失敗");
       }
     } catch (err) {
-      console.error("Failed to create field:", err);
+      logger.error("Failed to create field", { err: err });
       setError("新增欄位失敗，請稍後再試");
     }
   };
@@ -433,7 +434,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "更新欄位失敗");
       }
     } catch (err) {
-      console.error("Failed to update field:", err);
+      logger.error("Failed to update field", { err: err });
       setError("更新欄位失敗，請稍後再試");
     }
   };
@@ -450,7 +451,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "刪除欄位失敗");
       }
     } catch (err) {
-      console.error("Failed to delete field:", err);
+      logger.error("Failed to delete field", { err: err });
       setError("刪除欄位失敗，請稍後再試");
     }
   };
@@ -475,7 +476,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "新增文件要求失敗");
       }
     } catch (err) {
-      console.error("Failed to create document:", err);
+      logger.error("Failed to create document", { err: err });
       setError("新增文件要求失敗，請稍後再試");
     }
   };
@@ -524,7 +525,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "更新文件要求失敗");
       }
     } catch (err) {
-      console.error("Failed to update document:", err);
+      logger.error("Failed to update document", { err: err });
       setError("更新文件要求失敗，請稍後再試");
     }
   };
@@ -541,7 +542,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "刪除文件要求失敗");
       }
     } catch (err) {
-      console.error("Failed to delete document:", err);
+      logger.error("Failed to delete document", { err: err });
       setError("刪除文件要求失敗，請稍後再試");
     }
   };
@@ -578,7 +579,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "範例文件上傳失敗");
       }
     } catch (err: unknown) {
-      console.error("Failed to upload example:", err);
+      logger.error("Failed to upload example", { err: err });
       setError((err instanceof Error ? err.message : "範例文件上傳失敗，請稍後再試"));
     } finally {
       setUploadingExampleDocId(null);
@@ -630,7 +631,7 @@ export function AdminScholarshipManagementInterface({
         setError(response.message || "範例文件刪除失敗");
       }
     } catch (err) {
-      console.error("Failed to delete example:", err);
+      logger.error("Failed to delete example", { err: err });
       setError("範例文件刪除失敗，請稍後再試");
     }
   };
@@ -696,7 +697,7 @@ export function AdminScholarshipManagementInterface({
         const message = `成功: ${result.success_count} 筆，失敗: ${result.failed_items.length} 筆`;
         if (result.failed_items.length > 0) {
           toast.error(message);
-          console.error("Import errors:", result.failed_items);
+          logger.error("Import errors:", result.failed_items);
         } else {
           toast.success(message);
         }

--- a/frontend/components/application-detail-dialog.tsx
+++ b/frontend/components/application-detail-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Dialog,
   DialogContent,
@@ -194,7 +195,7 @@ export function ApplicationDetailDialog({
         );
       }
     } catch (error) {
-      console.error("Bank verification error:", error);
+      logger.error("Bank verification error", { error: error });
       toast.error(t("dialogs.application_detail.bank_verification_error"));
     } finally {
       setBankVerificationLoading(false);
@@ -295,7 +296,7 @@ export function ApplicationDetailDialog({
             scholarshipType = scholarshipResponse.data.code;
           } else {
             const errorMsg = `${t("dialogs.application_detail.scholarship_type_fetch_failed")}: ${scholarshipResponse.message}`;
-            console.error(errorMsg);
+            logger.error(errorMsg);
             setError(errorMsg);
             setDocumentLabels({});
             setFieldLabels({});
@@ -306,7 +307,7 @@ export function ApplicationDetailDialog({
           }
         } catch (error) {
           const errorMsg = `${t("dialogs.application_detail.scholarship_type_fetch_error")}: ${error instanceof Error ? error.message : "未知錯誤"}`;
-          console.error(errorMsg);
+          logger.error(errorMsg);
           setError(errorMsg);
           setDocumentLabels({});
           setFieldLabels({});
@@ -321,7 +322,7 @@ export function ApplicationDetailDialog({
         const errorMsg = t(
           "dialogs.application_detail.scholarship_type_undetermined"
         );
-        console.error(errorMsg);
+        logger.error(errorMsg);
         setError(errorMsg);
         setDocumentLabels({});
         setFieldLabels({});
@@ -365,7 +366,7 @@ export function ApplicationDetailDialog({
         }
       } else {
         const errorMsg = `${t("dialogs.application_detail.form_config_load_failed")}: ${response.message}`;
-        console.error(errorMsg);
+        logger.error(errorMsg);
         setError(errorMsg);
         setDocumentLabels({});
         setFieldLabels({});
@@ -373,7 +374,7 @@ export function ApplicationDetailDialog({
       }
     } catch (error) {
       const errorMsg = `${t("dialogs.application_detail.form_config_load_error")}: ${error instanceof Error ? error.message : "未知錯誤"}`;
-      console.error(errorMsg);
+      logger.error(errorMsg);
       setError(errorMsg);
       setDocumentLabels({});
       setFieldLabels({});
@@ -414,7 +415,7 @@ export function ApplicationDetailDialog({
         setApplicationFiles(files);
       }
     } catch (error) {
-      console.error("Failed to load application files:", error);
+      logger.error("Failed to load application files", { error: error });
       setApplicationFiles([]);
     } finally {
       setIsLoadingFiles(false);
@@ -427,20 +428,20 @@ export function ApplicationDetailDialog({
     // with a console error rather than producing an invalid preview URL.
     const filename = file.filename || file.original_filename;
     if (!filename) {
-      console.error("No filename available for preview");
+      logger.error("No filename available for preview");
       return;
     }
 
     // 檢查是否有文件路徑
     if (!file.file_path) {
-      console.error("No file path available for preview");
+      logger.error("No file path available for preview");
       return;
     }
 
     // 從後端URL中提取token
     const urlParts = file.file_path.split("?");
     if (urlParts.length < 2) {
-      console.error("Invalid file URL format");
+      logger.error("Invalid file URL format");
       return;
     }
 
@@ -448,7 +449,7 @@ export function ApplicationDetailDialog({
     const token = urlParams.get("token");
 
     if (!token) {
-      console.error("No token found in file URL");
+      logger.error("No token found in file URL");
       return;
     }
 
@@ -467,7 +468,7 @@ export function ApplicationDetailDialog({
       fileType = "image";
     }
 
-    console.log("Opening file preview:", {
+    logger.debug("Opening file preview:", {
       filename,
       fileType,
       previewUrl,

--- a/frontend/components/application-form-data-display.tsx
+++ b/frontend/components/application-form-data-display.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Label } from "@/components/ui/label";
 import { Locale } from "@/lib/validators";
+import { logger } from "@/lib/utils/logger";
 import {
   formatDisplayValue,
   formatFieldName,
@@ -19,7 +20,7 @@ const getFieldLabel = (
     const label = locale === "zh"
       ? fieldLabels[fieldName].zh
       : fieldLabels[fieldName].en || fieldLabels[fieldName].zh || fieldName;
-    console.log(
+    logger.debug(
       `🏷️ Found label for "${fieldName}":`,
       label,
       "from:",
@@ -28,7 +29,7 @@ const getFieldLabel = (
     return label;
   }
   const fallbackLabel = formatFieldName(fieldName, locale);
-  console.log(
+  logger.debug(
     `🏷️ No label found for "${fieldName}", using fallback:`,
     fallbackLabel
   );
@@ -57,22 +58,22 @@ export function ApplicationFormDataDisplay({
 
   // Debug logging
 
-    console.log(
+    logger.debug(
     "📋 fields 是物件:",
     typeof formData?.submitted_form_data?.fields === "object"
   );
-  console.log(
+  logger.debug(
     "📋 fields 鍵值:",
     formData?.submitted_form_data?.fields
       ? Object.keys(formData.submitted_form_data.fields)
       : "N/A"
   );
-  console.log(
+  logger.debug(
     "📋 原始 fields 物件:",
     formData?.submitted_form_data?.fields
   );
-  console.log("🏷️ 接收到的 fieldLabels:", fieldLabels);
-  console.log(
+  logger.debug("🏷️ 接收到的 fieldLabels:", fieldLabels);
+  logger.debug(
     "🏷️ fieldLabels 鍵值:",
     fieldLabels ? Object.keys(fieldLabels) : "沒有標籤"
   );
@@ -91,9 +92,9 @@ export function ApplicationFormDataDisplay({
       const fields = formData?.submitted_form_data?.fields || {};
 
 
-      console.log("🔄 Processing fields:", fields);
-      console.log("🔄 Fields entries count:", Object.entries(fields).length);
-      console.log("🔄 All field keys:", Object.keys(fields));
+      logger.debug("🔄 Processing fields:", fields);
+      logger.debug("🔄 Fields entries count:", Object.entries(fields).length);
+      logger.debug("🔄 All field keys:", Object.keys(fields));
 
       for (const [fieldId, fieldData] of Object.entries(fields)) {
         if (
@@ -119,7 +120,7 @@ export function ApplicationFormDataDisplay({
                   locale
                 );
               } catch (error) {
-                console.warn(
+                logger.warn(
                   `Failed to format scholarship type: ${value}`,
                   error
                 );
@@ -132,7 +133,7 @@ export function ApplicationFormDataDisplay({
         }
       }
 
-      console.log("✅ Formatted data:", formatted);
+      logger.debug("✅ Formatted data:", formatted);
       setFormattedData(formatted);
       setIsLoading(false);
     };

--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -18,6 +18,7 @@ import { RankingCardList } from "../shared/RankingCardList";
 import { Plus, Loader2, Clock, AlertTriangle, Lock } from "lucide-react";
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
 
 // #63: surface the college-review deadline visibly on the ranking page
 // and warn / lock once the deadline approaches or passes.
@@ -233,7 +234,7 @@ export function RankingManagementPanel({
           });
         }
       } catch (error) {
-        console.error("Failed to fetch ranking details:", error);
+        logger.error("Failed to fetch ranking details", { error: error });
       } finally {
         setIsRankingLoading(false);
       }
@@ -247,7 +248,7 @@ export function RankingManagementPanel({
     // 1. Current tab is "ranking"
     // 2. Not currently loading
     if (activeTab === "ranking") {
-      console.log(
+      logger.debug(
         `[RankingManagementPanel] Auto-refreshing (dataVersion: ${dataVersion})`
       );
 
@@ -326,7 +327,7 @@ export function RankingManagementPanel({
               : `Ranking "${response.data.ranking_name || "New Ranking"}" has been created successfully`
           );
         } catch (fetchError) {
-          console.error("Failed to load ranking after creation:", fetchError);
+          logger.error("Failed to load ranking after creation", { fetchError: fetchError });
           toast.error(
             locale === "zh"
               ? "排名已建立，但無法自動載入。請手動重新整理頁面。"
@@ -341,7 +342,7 @@ export function RankingManagementPanel({
         );
       }
     } catch (error) {
-      console.error("Failed to create ranking:", error);
+      logger.error("Failed to create ranking", { error: error });
       toast.error(
         error instanceof Error
           ? error.message
@@ -410,7 +411,7 @@ export function RankingManagementPanel({
             setSaveStatus("error");
           }
         } catch (error) {
-          console.error("Failed to save ranking:", error);
+          logger.error("Failed to save ranking", { error: error });
           setSaveStatus("error");
         }
       }, 500);
@@ -476,11 +477,11 @@ export function RankingManagementPanel({
 
         // Increment data version to notify other panels to refresh
         incrementDataVersion();
-        console.log(
+        logger.debug(
           "[RankingManagementPanel] Data version incremented after review"
         );
       } catch (error) {
-        console.error("Failed to review application:", error);
+        logger.error("Failed to review application", { error: error });
         toast.error("審核提交失敗");
       }
     },
@@ -516,7 +517,7 @@ export function RankingManagementPanel({
           );
         }
       } catch (error) {
-        console.error("Failed to finalize ranking:", error);
+        logger.error("Failed to finalize ranking", { error: error });
       }
     },
     [
@@ -548,7 +549,7 @@ export function RankingManagementPanel({
           );
         }
       } catch (error) {
-        console.error("Failed to unfinalize ranking:", error);
+        logger.error("Failed to unfinalize ranking", { error: error });
       }
     },
     [
@@ -593,7 +594,7 @@ export function RankingManagementPanel({
           throw new Error(response.message || "Failed to import");
         }
       } catch (error) {
-        console.error("Failed to import Excel:", error);
+        logger.error("Failed to import Excel", { error: error });
         throw error;
       }
     },
@@ -619,7 +620,7 @@ export function RankingManagementPanel({
         setRankingToDelete(null);
       }
     } catch (error) {
-      console.error("Failed to delete ranking:", error);
+      logger.error("Failed to delete ranking", { error: error });
     }
   }, [
     rankingToDelete,
@@ -662,7 +663,7 @@ export function RankingManagementPanel({
           );
         }
       } catch (error) {
-        console.error("Failed to update ranking name:", error);
+        logger.error("Failed to update ranking name", { error: error });
         toast.error(
           locale === "zh" ? "無法更新排名名稱" : "Failed to update ranking name"
         );

--- a/frontend/components/common/ApplicationReviewDialog.tsx
+++ b/frontend/components/common/ApplicationReviewDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Dialog,
   DialogContent,
@@ -751,7 +752,7 @@ export function ApplicationReviewDialog({
         );
       }
     } catch (error) {
-      console.error("Post office verification error:", error);
+      logger.error("Post office verification error", { error: error });
       toast.error(
         locale === "zh" ? "郵局驗證錯誤" : "Post Office Verification Error",
         {
@@ -955,7 +956,7 @@ export function ApplicationReviewDialog({
             });
 
             // Debug logging
-            console.log('📋 Loaded existing review:', {
+            logger.debug('📋 Loaded existing review:', {
               reviewId: reviewResponse.data.id,
               reviewedAt: reviewResponse.data.reviewed_at,
               existingItemsCount: existingItems.length,
@@ -976,7 +977,7 @@ export function ApplicationReviewDialog({
         }
       }
     } catch (err) {
-      console.error("Error loading sub-types and review:", err);
+      logger.error("Error loading sub-types and review", { err: err });
     } finally {
       setIsLoadingSubTypes(false);
     }
@@ -1034,12 +1035,12 @@ export function ApplicationReviewDialog({
             scholarshipType = scholarshipResponse.data.code;
           }
         } catch (error) {
-          console.error("Failed to get scholarship type:", error);
+          logger.error("Failed to get scholarship type", { error: error });
         }
       }
 
       if (!scholarshipType) {
-        console.error("Cannot determine scholarship type");
+        logger.error("Cannot determine scholarship type");
         setDocumentLabels({});
         setFieldLabels({});
         setApplicationFields([]);
@@ -1080,7 +1081,7 @@ export function ApplicationReviewDialog({
         }
       }
     } catch (error) {
-      console.error("Failed to load form config:", error);
+      logger.error("Failed to load form config", { error: error });
       setDocumentLabels({});
       setFieldLabels({});
       setApplicationFields([]);
@@ -1118,7 +1119,7 @@ export function ApplicationReviewDialog({
         setApplicationFiles(files);
       }
     } catch (error) {
-      console.error("Failed to load application files:", error);
+      logger.error("Failed to load application files", { error: error });
       setApplicationFiles([]);
     } finally {
       setIsLoadingFiles(false);
@@ -1129,18 +1130,18 @@ export function ApplicationReviewDialog({
   const handleFilePreview = (file: DocumentPayload) => {
     const filename = file.filename || file.original_filename;
     if (!filename) {
-      console.error("No filename available for preview");
+      logger.error("No filename available for preview");
       return;
     }
 
     if (!file.file_path) {
-      console.error("No file path available for preview");
+      logger.error("No file path available for preview");
       return;
     }
 
     const urlParts = file.file_path.split("?");
     if (urlParts.length < 2) {
-      console.error("Invalid file URL format");
+      logger.error("Invalid file URL format");
       return;
     }
 
@@ -1148,7 +1149,7 @@ export function ApplicationReviewDialog({
     const token = urlParams.get("token");
 
     if (!token) {
-      console.error("No token found in file URL");
+      logger.error("No token found in file URL");
       return;
     }
 
@@ -1306,7 +1307,7 @@ export function ApplicationReviewDialog({
         throw new Error(safeErrorMessage(response.message) || "Failed to submit review");
       }
     } catch (err: unknown) {
-      console.error("Failed to submit review:", err);
+      logger.error("Failed to submit review", { err: err });
 
       // Extract detailed error message from various possible locations.
       // Use a focused axios+Error shape cast rather than `any` so each
@@ -1356,7 +1357,7 @@ export function ApplicationReviewDialog({
         // Close dialog after successful approval
         onOpenChange(false);
       } catch (error) {
-        console.error('Failed to approve application:', error);
+        logger.error('Failed to approve application:', error);
         // Error handling is done in the parent component (toast notification)
       } finally {
         setIsSubmitting(false);
@@ -1372,7 +1373,7 @@ export function ApplicationReviewDialog({
         // Close dialog after successful rejection
         onOpenChange(false);
       } catch (error) {
-        console.error('Failed to reject application:', error);
+        logger.error('Failed to reject application:', error);
         // Error handling is done in the parent component (toast notification)
       } finally {
         setIsSubmitting(false);
@@ -1806,15 +1807,15 @@ export function ApplicationReviewDialog({
                         <>
                           {/* Debug logging for form data */}
                           {(() => {
-                            console.log(
+                            logger.debug(
                               "🔍 Form Tab - detailedApplication:",
                               detailedApplication
                             );
-                            console.log(
+                            logger.debug(
                               "🔍 Form Tab - submitted_form_data:",
                               detailedApplication?.submitted_form_data
                             );
-                            console.log(
+                            logger.debug(
                               "🔍 Form Tab - fields:",
                               detailedApplication?.submitted_form_data?.fields
                             );

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Card,
   CardContent,
@@ -222,11 +223,11 @@ export function EnhancedStudentPortal({
 
   // Debug authentication status
   useEffect(() => {
-    console.log("EnhancedStudentPortal mounted with user:", user);
+    logger.debug("EnhancedStudentPortal mounted with user:", user);
     const token =
       typeof window !== "undefined" ? localStorage.getItem("auth_token") : null;
-    console.log("Current auth token exists:", !!token);
-    console.log(
+    logger.debug("Current auth token exists:", !!token);
+    logger.debug(
       "Token preview:",
       token ? token.substring(0, 20) + "..." : "No token"
     );
@@ -267,9 +268,9 @@ export function EnhancedStudentPortal({
         const response = await api.scholarships.getEligible();
 
         // Debug: Check the raw API response
-        console.log("Debug: Raw API response:", response);
-        console.log("Debug: API response success:", response.success);
-        console.log("Debug: API response data:", response.data);
+        logger.debug("Debug: Raw API response:", response);
+        logger.debug("Debug: API response success:", response.success);
+        logger.debug("Debug: API response data:", response.data);
 
         let scholarshipData: ScholarshipType[] = [];
         if (response.success && response.data) {
@@ -286,11 +287,11 @@ export function EnhancedStudentPortal({
           setScholarshipsError(t("messages.no_eligible_scholarships"));
         } else {
           // Debug: Check the structure of scholarship data
-          console.log(
+          logger.debug(
             "Debug: First scholarship data structure:",
             scholarshipData[0]
           );
-          console.log(
+          logger.debug(
             "Debug: All scholarship configuration_ids:",
             scholarshipData.map(s => ({
               code: s.code,
@@ -307,7 +308,7 @@ export function EnhancedStudentPortal({
           });
         }
       } catch (error) {
-        console.error("Error fetching scholarships:", error); // Debug log
+        logger.error("Error fetching scholarships", { error: error }); // Debug log
         setScholarshipsError(
           error instanceof Error ? error.message : t("messages.unknown_error")
         );
@@ -331,11 +332,11 @@ export function EnhancedStudentPortal({
         if (response.success && response.data) {
           setDocumentRequests(response.data);
         } else {
-          console.error("Failed to fetch document requests:", response.message);
+          logger.error("Failed to fetch document requests:", response.message);
           setDocumentRequests([]);
         }
       } catch (error) {
-        console.error("Error fetching document requests:", error);
+        logger.error("Error fetching document requests", { error: error });
         setDocumentRequests([]);
       } finally {
         setIsLoadingDocumentRequests(false);
@@ -361,7 +362,7 @@ export function EnhancedStudentPortal({
         );
       }
     } catch (error: unknown) {
-      console.error("Failed to fulfill document request:", error);
+      logger.error("Failed to fulfill document request", { error: error });
       const errShape = error as { response?: { data?: { message?: string } } };
       alert(
         errShape.response?.data?.message ||
@@ -417,7 +418,7 @@ export function EnhancedStudentPortal({
         }));
       }
     } catch (error) {
-      console.error(
+      logger.error(
         `Failed to fetch application info for ${scholarshipType}:`,
         error
       );
@@ -586,7 +587,7 @@ export function EnhancedStudentPortal({
         const progress = Math.round((completedItems / totalRequired) * 100);
         setFormProgress(progress);
       } catch (error) {
-        console.error("Error calculating progress:", error);
+        logger.error("Error calculating progress", { error: error });
         setFormProgress(0);
       }
     };
@@ -621,16 +622,16 @@ export function EnhancedStudentPortal({
       setIsSubmitting(true);
 
       // Debug: Log current state before submission
-      console.log("Debug: handleSubmitApplication called");
-      console.log(
+      logger.debug("Debug: handleSubmitApplication called");
+      logger.debug(
         "Debug: newApplicationData at submission:",
         newApplicationData
       );
-      console.log(
+      logger.debug(
         "Debug: selectedScholarship at submission:",
         selectedScholarship
       );
-      console.log(
+      logger.debug(
         "Debug: configuration_id at submission:",
         newApplicationData.configuration_id
       );
@@ -686,15 +687,15 @@ export function EnhancedStudentPortal({
         },
       };
 
-      console.log("Debug: Final applicationData being sent:", applicationData);
-      console.log(
+      logger.debug("Debug: Final applicationData being sent:", applicationData);
+      logger.debug(
         "Debug: Final configuration_id being sent:",
         applicationData.configuration_id
       );
 
       if (editingApplication) {
         // 編輯模式 - 更新草稿然後提交
-        console.log("Updating application with data:", applicationData);
+        logger.debug("Updating application with data:", applicationData);
         await updateApplication(editingApplication.id, applicationData);
 
         // 上傳新文件
@@ -710,7 +711,7 @@ export function EnhancedStudentPortal({
         await submitApplicationApi(editingApplication.id);
       } else {
         // 新建模式 - 先創建草稿，然後提交
-        console.log(
+        logger.debug(
           "Creating application as draft with data:",
           applicationData
         );
@@ -760,7 +761,7 @@ export function EnhancedStudentPortal({
 
       alert(t("messages.application_success"));
     } catch (error) {
-      console.error("Failed to submit application:", error);
+      logger.error("Failed to submit application", { error: error });
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
       alert(`${t("applications.submit_failed")}: ${errorMessage}`);
@@ -831,7 +832,7 @@ export function EnhancedStudentPortal({
 
       if (editingApplication) {
         // 編輯模式 - 更新現有申請
-        console.log("Updating draft application with data:", applicationData);
+        logger.debug("Updating draft application with data:", applicationData);
         await updateApplication(editingApplication.id, applicationData);
 
         // 上傳新文件
@@ -846,7 +847,7 @@ export function EnhancedStudentPortal({
         alert(t("messages.draft_updated"));
       } else {
         // 新建模式 - 創建新草稿
-        console.log("Saving new draft with data:", applicationData);
+        logger.debug("Saving new draft with data:", applicationData);
         const application = await saveApplicationDraft(applicationData);
 
         if (application && application.id) {
@@ -886,7 +887,7 @@ export function EnhancedStudentPortal({
         setSelectedSubTypes({});
       }
     } catch (error) {
-      console.error("Failed to save draft:", error);
+      logger.error("Failed to save draft", { error: error });
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
       alert(`${t("messages.save_failed")}: ${errorMessage}`);
@@ -899,7 +900,7 @@ export function EnhancedStudentPortal({
     try {
       await withdrawApplication(applicationId);
     } catch (error) {
-      console.error("Failed to withdraw application:", error);
+      logger.error("Failed to withdraw application", { error: error });
     }
   };
 
@@ -918,7 +919,7 @@ export function EnhancedStudentPortal({
 
       alert(t("messages.draft_deleted"));
     } catch (error) {
-      console.error("Failed to delete application:", error);
+      logger.error("Failed to delete application", { error: error });
       alert(t("messages.delete_error"));
     }
   };
@@ -937,7 +938,7 @@ export function EnhancedStudentPortal({
         setSelectedApplicationForDetails(application);
       }
     } catch (error) {
-      console.error("Failed to fetch application details:", error);
+      logger.error("Failed to fetch application details", { error: error });
       // 如果獲取失敗，使用原始的申請資料
       setSelectedApplicationForDetails(application);
     }


### PR DESCRIPTION
## Summary

Continues the components/ tier of the frontend console-cleanup wave (PRs #608-#618). Bulk-migrates 9 console-heavy components in one batch using the regex transform validated across the wave:

- \`components/enhanced-student-portal.tsx\` (29 sites)
- \`components/admin-scholarship-dashboard.tsx\` (28 sites)
- \`components/admin-rule-management.tsx\` (21 sites)
- \`components/common/ApplicationReviewDialog.tsx\` (17 sites)
- \`components/admin-scholarship-management-interface.tsx\` (14 sites)
- \`components/college/ranking/RankingManagementPanel.tsx\` (12 sites)
- \`components/application-form-data-display.tsx\` (12 sites)
- \`components/application-detail-dialog.tsx\` (12 sites)
- \`app/admin/test-users/page.tsx\` (12 sites)

Total: ~157 sites in one PR.

Pure refactor — public render flow, useState/useEffect deps, and exported identifiers unchanged. Logger import inserted at top of each file after the React import.

## Test plan

- [ ] CI: lint + tsc + bundle-size
- [ ] CI: existing component tests should not regress
- [ ] Manual: visit admin / college / student dashboards in dev — flows continue to work with logger.debug output visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)