### PR TITLE
chore(frontend): final sweep — migrate remaining components/+app console.* → logger (64 files)

### DIFF
--- a/frontend/app/api/email/render/route.ts
+++ b/frontend/app/api/email/render/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/utils/logger";
 /**
  * Email Rendering API Endpoint
  *
@@ -79,7 +80,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<RenderEma
     });
 
   } catch (error: unknown) {
-    console.error('[Email Render API] Error rendering email:', error);
+    logger.error('[Email Render API] Error rendering email:', error);
 
     return NextResponse.json(
       {

--- a/frontend/app/api/v1/download/route.ts
+++ b/frontend/app/api/v1/download/route.ts
@@ -141,7 +141,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    console.log("Download API called:", {
+    logger.debug("Download API called:", {
       fileId,
       applicationId,
       userId,

--- a/frontend/app/api/v1/preview-document-example/route.ts
+++ b/frontend/app/api/v1/preview-document-example/route.ts
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
     // Construct URL with validated components only
     const backendUrl = new URL(`/api/v1/application-fields/documents/${documentId}/example`, baseUrl).toString();
 
-    console.log("Document example preview API called:", {
+    logger.debug("Document example preview API called:", {
       documentId,
       backendUrl,
     });

--- a/frontend/app/api/v1/preview-terms/route.ts
+++ b/frontend/app/api/v1/preview-terms/route.ts
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
     // Construct URL with validated components only
     const backendUrl = new URL(`/api/v1/scholarships/${scholarshipType}/terms`, baseUrl).toString();
 
-    console.log("Terms preview API called:", {
+    logger.debug("Terms preview API called:", {
       scholarshipType,
       backendUrl,
     });

--- a/frontend/app/api/v1/preview/route.ts
+++ b/frontend/app/api/v1/preview/route.ts
@@ -210,7 +210,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    console.log("Preview API called:", {
+    logger.debug("Preview API called:", {
       fileId,
       applicationId,
       userId,
@@ -339,7 +339,7 @@ async function handleRosterPreview(
     backendUrl.searchParams.set("max_preview_rows", String(max_preview_rows));
     backendUrl.searchParams.set("include_excluded", String(include_excluded));
 
-    console.log(`[Roster Preview] Fetching: ${backendUrl.toString()}`);
+    logger.debug(`[Roster Preview] Fetching: ${backendUrl.toString()}`);
 
     // 調用後端 API
     const response = await fetch(backendUrl, {

--- a/frontend/app/api/v1/scholarships/[type]/upload-terms/route.ts
+++ b/frontend/app/api/v1/scholarships/[type]/upload-terms/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { logger } from "@/lib/utils/logger";
 
 const INTERNAL_API_URL = process.env.INTERNAL_API_URL || "http://backend:8000";
 
@@ -48,7 +49,7 @@ export async function POST(
     // Construct backend URL using INTERNAL_API_URL (Docker internal network)
     const backendUrl = `${INTERNAL_API_URL}/api/v1/scholarships/${encodeURIComponent(type)}/upload-terms`;
 
-    console.log(`[Upload Terms Proxy] Forwarding file "${file.name}" to: ${backendUrl}`);
+    logger.debug(`[Upload Terms Proxy] Forwarding file "${file.name}" to: ${backendUrl}`);
 
     // Create a fresh FormData instance to avoid stream consumption issues
     const backendFormData = new FormData();
@@ -70,7 +71,7 @@ export async function POST(
     // Return response with same status code
     return NextResponse.json(data, { status: response.status });
   } catch (error) {
-    console.error("[Upload Terms Proxy] Error:", error);
+    logger.error("[Upload Terms Proxy] Error", { error: error });
     return NextResponse.json(
       {
         success: false,

--- a/frontend/components/ScholarshipWorkflowMermaid.tsx
+++ b/frontend/components/ScholarshipWorkflowMermaid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import { format } from "date-fns";
 import {
   Card,
@@ -203,7 +204,7 @@ export function ScholarshipWorkflowMermaid({
     try {
       const config = configurations.find(c => c.id === configId);
       if (!config) {
-        console.warn("Configuration not found for id:", configId);
+        logger.warn("Configuration not found for id:", configId);
         setStats(null);
         return;
       }
@@ -288,7 +289,7 @@ export function ScholarshipWorkflowMermaid({
           nextDeadline,
         });
       } else {
-        console.warn("Failed to load applications:", response.message);
+        logger.warn("Failed to load applications:", response.message);
         setStats({
           totalApplications: 0,
           pendingReviews: 0,
@@ -297,7 +298,7 @@ export function ScholarshipWorkflowMermaid({
         });
       }
     } catch (error) {
-      console.error("Failed to load workflow stats:", error);
+      logger.error("Failed to load workflow stats", { error: error });
       setStats({
         totalApplications: 0,
         pendingReviews: 0,
@@ -460,7 +461,7 @@ export function ScholarshipWorkflowMermaid({
         setShowStageDetails(true);
       }
     } catch (error) {
-      console.error("Failed to load stage details:", error);
+      logger.error("Failed to load stage details", { error: error });
     } finally {
       setLoading(false);
     }

--- a/frontend/components/admin-configuration-management.tsx
+++ b/frontend/components/admin-configuration-management.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -126,7 +127,7 @@ export function AdminConfigurationManagement({
           setAcademyCodes(codesMap);
         }
       } catch (error) {
-        console.error("載入學院代碼失敗:", error);
+        logger.error("載入學院代碼失敗", { error: error });
         toast.error("載入學院代碼失敗: " + (error as Error).message);
       }
     };
@@ -223,7 +224,7 @@ export function AdminConfigurationManagement({
 
         setConfigurations(allConfigurations);
       } catch (error) {
-        console.error("載入配置失敗:", error);
+        logger.error("載入配置失敗", { error: error });
         toast.error("載入配置失敗: " + (error as Error).message);
         setConfigurations([]);
         setFilteredConfigurations([]);
@@ -527,7 +528,7 @@ export function AdminConfigurationManagement({
       const date = new Date(dateString);
       // 檢查日期是否有效
       if (isNaN(date.getTime())) {
-        console.warn("Invalid date string:", dateString);
+        logger.warn("Invalid date string:", dateString);
         return "";
       }
 

--- a/frontend/components/admin-dashboard.tsx
+++ b/frontend/components/admin-dashboard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { logger } from "@/lib/utils/logger";
 import {
   Card,
   CardContent,
@@ -120,7 +121,7 @@ export function AdminDashboard({
             <div className="flex gap-2">
               <button
                 onClick={async () => {
-                  console.log("Manual retry triggered");
+                  logger.debug("Manual retry triggered");
                   fetchRecentApplications();
                 }}
                 className="px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700"
@@ -131,17 +132,17 @@ export function AdminDashboard({
               <button
                 onClick={async () => {
                   try {
-                    console.log("Testing super_admin login...");
+                    logger.debug("Testing super_admin login...");
                     const response = await api.auth.mockSSOLogin("super_admin");
-                    console.log("Mock login response:", response);
+                    logger.debug("Mock login response:", response);
 
                     if (response.success && response.data) {
                       const { access_token, user: userData } = response.data;
                       login(access_token, userData);
-                      console.log("Super admin login successful");
+                      logger.debug("Super admin login successful");
                     }
                   } catch (e) {
-                    console.error("Test login failed:", e);
+                    logger.error("Test login failed", { e: e });
                   }
                 }}
                 className="px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700"

--- a/frontend/components/admin/AdminManagementShell.tsx
+++ b/frontend/components/admin/AdminManagementShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { logger } from "@/lib/utils/logger";
 import { AdminManagementProvider, useAdminManagement } from "@/contexts/admin-management-context";
 import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
@@ -78,7 +79,7 @@ function AdminManagementContent({ user }: AdminManagementShellProps) {
           setHasQuotaPermission(hasQuota);
         }
       } catch (error) {
-        console.error("Failed to check quota permissions:", error);
+        logger.error("Failed to check quota permissions", { error: error });
       }
     };
 

--- a/frontend/components/admin/batch-bank-verification.tsx
+++ b/frontend/components/admin/batch-bank-verification.tsx
@@ -10,6 +10,7 @@
 
 'use client';
 
+import { logger } from "@/lib/utils/logger";
 import { useState, useEffect } from 'react';
 import { AlertCircle, CheckCircle, Clock, XCircle, Eye } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -65,7 +66,7 @@ export function BatchBankVerification({
           }
         }
       } catch (err) {
-        console.error('Failed to fetch task status:', err);
+        logger.error('Failed to fetch task status:', err);
       }
     }, 2000); // Poll every 2 seconds
 
@@ -85,7 +86,7 @@ export function BatchBankVerification({
       }
     } catch (err) {
       setError('啟動批次驗證時發生錯誤');
-      console.error(err);
+      logger.error(err);
     } finally {
       setIsStarting(false);
     }

--- a/frontend/components/admin/configurations/ConfigurationsPanel.tsx
+++ b/frontend/components/admin/configurations/ConfigurationsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AdminConfigurationManagement } from "@/components/admin-configuration-management";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent } from "@/components/ui/card";
 import { AlertCircle } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -26,7 +27,7 @@ export function ConfigurationsPanel() {
         setScholarshipTypes(response.data);
       }
     } catch (error) {
-      console.error("Failed to load scholarship types:", error);
+      logger.error("Failed to load scholarship types", { error: error });
     } finally {
       setLoadingScholarshipTypes(false);
     }

--- a/frontend/components/admin/history/HistoryPanel.tsx
+++ b/frontend/components/admin/history/HistoryPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
+import { logger } from "@/lib/utils/logger";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -144,7 +145,7 @@ export function HistoryPanel({ user }: HistoryPanelProps) {
         setHistoricalApplicationsError(errorMsg);
       }
     } catch (error: unknown) {
-      console.error("獲取歷史申請資料失敗:", error);
+      logger.error("獲取歷史申請資料失敗", { error: error });
       const errShape = error as { message?: string; response?: { data?: { message?: string } } };
       const errorMsg =
         errShape.message ||
@@ -210,7 +211,7 @@ export function HistoryPanel({ user }: HistoryPanelProps) {
         setActiveHistoricalTab("all"); // 保持全部為默認
       }
     } catch (error) {
-      console.error("獲取歷史申請 tab 資料失敗:", error);
+      logger.error("獲取歷史申請 tab 資料失敗", { error: error });
     }
   }, [user, activeHistoricalTab]);
 

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import { useCollegeManagement } from "@/contexts/college-management-context";
 import { useReferenceData } from "@/hooks/use-reference-data";
 import { apiClient } from "@/lib/api";
@@ -423,7 +424,7 @@ export function ManualDistributionPanel({
         setSaveMessage({ type: "error", text: resp.message || "確認分發失敗" });
       }
     } catch (error) {
-      console.error("Finalize error:", error);
+      logger.error("Finalize error", { error: error });
       setSaveMessage({ type: "error", text: "確認分發時發生錯誤" });
     } finally {
       setIsFinalizing(false);
@@ -454,7 +455,7 @@ export function ManualDistributionPanel({
         setSaveMessage({ type: "error", text: resp.message || "造冊產生失敗" });
       }
     } catch (error) {
-      console.error("Generate rosters error:", error);
+      logger.error("Generate rosters error", { error: error });
       setSaveMessage({ type: "error", text: "造冊產生時發生錯誤" });
     } finally {
       setIsGeneratingRosters(false);
@@ -482,7 +483,7 @@ export function ManualDistributionPanel({
         });
       }
     } catch (error) {
-      console.error("Load distribution summary error:", error);
+      logger.error("Load distribution summary error", { error: error });
       setSaveMessage({ type: "error", text: "載入分發名單時發生錯誤" });
     } finally {
       setIsLoadingSummary(false);
@@ -509,7 +510,7 @@ export function ManualDistributionPanel({
         });
       }
     } catch (error) {
-      console.error("Load history error:", error);
+      logger.error("Load history error", { error: error });
       setSaveMessage({ type: "error", text: "載入歷史記錄失敗" });
     } finally {
       setIsLoadingHistory(false);
@@ -565,7 +566,7 @@ export function ManualDistributionPanel({
         setSaveMessage({ type: "error", text: resp.message || "還原失敗" });
       }
     } catch (error) {
-      console.error("Restore error:", error);
+      logger.error("Restore error", { error: error });
       setSaveMessage({ type: "error", text: "還原時發生錯誤" });
     } finally {
       setIsRestoring(false);

--- a/frontend/components/admin/rules/RulesPanel.tsx
+++ b/frontend/components/admin/rules/RulesPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AdminRuleManagement } from "@/components/admin-rule-management";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent } from "@/components/ui/card";
 import { AlertCircle } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -26,7 +27,7 @@ export function RulesPanel() {
         setScholarshipTypes(response.data);
       }
     } catch (error) {
-      console.error("Failed to load scholarship types:", error);
+      logger.error("Failed to load scholarship types", { error: error });
     } finally {
       setLoadingScholarshipTypes(false);
     }

--- a/frontend/components/admin/students/StudentDetailModal.tsx
+++ b/frontend/components/admin/students/StudentDetailModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { apiClient } from "@/lib/api";
 import type { Student, StudentSISData } from "@/lib/api";
 import {
@@ -57,7 +58,7 @@ export function StudentDetailModal({ student, open, onClose }: StudentDetailModa
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : "網絡錯誤";
       setError(errorMsg);
-      console.error("Error fetching SIS data:", err);
+      logger.error("Error fetching SIS data", { err: err });
     } finally {
       setLoading(false);
     }

--- a/frontend/components/admin/students/StudentListManagement.tsx
+++ b/frontend/components/admin/students/StudentListManagement.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { apiClient } from "@/lib/api";
 import type { Student, StudentStats } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -91,7 +92,7 @@ export function StudentListManagement() {
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : "網絡錯誤";
       setError(errorMsg);
-      console.error("Error fetching students:", err);
+      logger.error("Error fetching students", { err: err });
     } finally {
       setLoading(false);
     }
@@ -107,7 +108,7 @@ export function StudentListManagement() {
         setStats(response.data);
       }
     } catch (error) {
-      console.error("獲取學生統計失敗:", error);
+      logger.error("獲取學生統計失敗", { error: error });
     }
   };
 

--- a/frontend/components/application-audit-trail.tsx
+++ b/frontend/components/application-audit-trail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -44,7 +45,7 @@ export function ApplicationAuditTrail({
       }
     } catch (err) {
       setError("Error loading audit trail");
-      console.error("Failed to fetch audit trail:", err);
+      logger.error("Failed to fetch audit trail", { err: err });
     } finally {
       setIsLoading(false);
     }

--- a/frontend/components/bank-verification-review-dialog.tsx
+++ b/frontend/components/bank-verification-review-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { logger } from "@/lib/utils/logger";
 import React, { useState, useEffect } from "react"
 import {
   Dialog,
@@ -85,7 +86,7 @@ export function BankVerificationReviewDialog({
       // 從 file_path URL 參數中提取 token（參考 ApplicationReviewDialog 的做法）
       const urlParts = doc.file_path.split("?")
       if (urlParts.length < 2) {
-        console.error("Invalid file URL format")
+        logger.error("Invalid file URL format")
         return
       }
 
@@ -93,7 +94,7 @@ export function BankVerificationReviewDialog({
       const token = urlParams.get("token")
 
       if (!token) {
-        console.error("No token found in file URL")
+        logger.error("No token found in file URL")
         return
       }
 

--- a/frontend/components/batch-application-file-upload.tsx
+++ b/frontend/components/batch-application-file-upload.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useMemo } from "react";
+import { logger } from "@/lib/utils/logger";
 import { apiClient } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -95,7 +96,7 @@ export function BatchApplicationFileUpload({
             });
           }
         } catch (err) {
-          console.error(`Failed to fetch application ${appId}:`, err);
+          logger.error(`Failed to fetch application ${appId}:`, err);
           setApplicationStates((prev) => {
             const updated = new Map(prev);
             const state = updated.get(appId);
@@ -151,7 +152,7 @@ export function BatchApplicationFileUpload({
           setScholarshipDocuments([]);
         }
       } catch (err) {
-        console.error("Failed to fetch scholarship documents:", err);
+        logger.error("Failed to fetch scholarship documents", { err: err });
         setScholarshipDocuments([]);
       } finally {
         setDocumentsLoading(false);
@@ -227,7 +228,7 @@ export function BatchApplicationFileUpload({
           });
         }
       } catch (err) {
-        console.error(`Failed to refresh application ${applicationToDelete.id}:`, err);
+        logger.error(`Failed to refresh application ${applicationToDelete.id}:`, err);
       }
 
       // Notify completion (optional - refresh parent data)
@@ -273,7 +274,7 @@ export function BatchApplicationFileUpload({
         );
       }
     } catch (err) {
-      console.error(`Failed to restore application ${appId}:`, err);
+      logger.error(`Failed to restore application ${appId}:`, err);
       setError(
         locale === "zh"
           ? "恢復申請失敗，請稍後再試"

--- a/frontend/components/batch-import-panel.tsx
+++ b/frontend/components/batch-import-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useCallback, useEffect, useTransition } from "react";
+import { logger } from "@/lib/utils/logger";
 import { apiClient } from "@/lib/api";
 
 /**
@@ -166,7 +167,7 @@ export function BatchImportPanel({ locale = "zh" }: BatchImportPanelProps) {
         setScholarships(response.data);
       }
     } catch (error) {
-      console.error("Failed to fetch scholarships:", error);
+      logger.error("Failed to fetch scholarships", { error: error });
       setError(locale === "zh" ? "無法載入獎學金列表" : "Failed to load scholarships");
     } finally {
       setIsLoadingScholarships(false);
@@ -189,7 +190,7 @@ export function BatchImportPanel({ locale = "zh" }: BatchImportPanelProps) {
         }
       }
     } catch (error) {
-      console.error("Failed to fetch periods:", error);
+      logger.error("Failed to fetch periods", { error: error });
       setError(locale === "zh" ? "無法載入學年學期選項" : "Failed to load period options");
     } finally {
       setIsLoadingPeriods(false);
@@ -203,7 +204,7 @@ export function BatchImportPanel({ locale = "zh" }: BatchImportPanelProps) {
         setHistory(response.data.items);
       }
     } catch (error) {
-      console.error("Failed to fetch import history:", error);
+      logger.error("Failed to fetch import history", { error: error });
     }
   };
 

--- a/frontend/components/college-ranking-table.tsx
+++ b/frontend/components/college-ranking-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   DndContext,
   closestCenter,
@@ -713,7 +714,7 @@ export function CollegeRankingTable({
         setIsImportDialogOpen(false);
       }
     } catch (error) {
-      console.error("Excel import error:", error);
+      logger.error("Excel import error", { error: error });
       toast.error(
         error instanceof Error ? error.message : "無法讀取 Excel 檔案"
       );
@@ -764,7 +765,7 @@ export function CollegeRankingTable({
 
       toast.success(`已下載範本檔案：${filename}`);
     } catch (error) {
-      console.error("Template download error:", error);
+      logger.error("Template download error", { error: error });
       toast.error(error instanceof Error ? error.message : "無法產生範本檔案");
     }
   };
@@ -786,7 +787,7 @@ export function CollegeRankingTable({
       URL.revokeObjectURL(url);
       toast.success(`已下載 ${filename}`);
     } catch (error) {
-      console.error("Export error:", error);
+      logger.error("Export error", { error: error });
       toast.error(error instanceof Error ? error.message : "無法匯出排名資料");
     }
   };

--- a/frontend/components/college/CollegeManagementShell.tsx
+++ b/frontend/components/college/CollegeManagementShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import dynamic from "next/dynamic";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CollegeManagementProvider, useCollegeManagement } from "@/contexts/college-management-context";
@@ -91,7 +92,7 @@ function CollegeManagementContent({ user }: { user: User }) {
           setManagedCollege(response.data);
         }
       } catch (error) {
-        console.error("Failed to fetch managed college:", error);
+        logger.error("Failed to fetch managed college", { error: error });
       }
     };
     fetchManagedCollege();

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { logger } from "@/lib/utils/logger";
 import { User } from "@/types/user";
 import { useCollegeManagement } from "@/contexts/college-management-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -149,7 +150,7 @@ export function ApplicationReviewPanel({
       );
 
       if (!scholarshipType || !scholarshipType.id) {
-        console.warn(
+        logger.warn(
           "Scholarship type ID not found for:",
           activeScholarshipTab
         );
@@ -157,7 +158,7 @@ export function ApplicationReviewPanel({
         return;
       }
 
-      console.log("Fetching college quota for:", {
+      logger.debug("Fetching college quota for:", {
         scholarshipTypeId: scholarshipType.id,
         academicYear: selectedAcademicYear,
         semester: selectedSemester,
@@ -174,12 +175,12 @@ export function ApplicationReviewPanel({
           collegeQuota: response.data.college_quota ?? null,
           breakdown: response.data.college_quota_breakdown ?? {},
         });
-        console.log("College quota fetched:", response.data.college_quota);
+        logger.debug("College quota fetched:", response.data.college_quota);
       } else {
         setCollegeQuotaInfo(null);
       }
     } catch (error) {
-      console.error("Failed to fetch college quota:", error);
+      logger.error("Failed to fetch college quota", { error: error });
       setCollegeQuotaInfo(null);
     }
   }, [
@@ -201,7 +202,7 @@ export function ApplicationReviewPanel({
     // 1. Current tab is "review"
     // 2. Data version has changed (indicating updates from other tabs)
     if (activeTab === "review") {
-      console.log(
+      logger.debug(
         `[ApplicationReviewPanel] Auto-refreshing applications (dataVersion: ${dataVersion})`
       );
       fetchCollegeApplications(
@@ -253,7 +254,7 @@ export function ApplicationReviewPanel({
         "approved",
         comments || "學院核准通過"
       );
-      console.log(`College approved application ${appId}`, result);
+      logger.debug(`College approved application ${appId}`, result);
 
       // 檢查是否自動重新執行了分發
       const redistribution = result?.redistribution_info;
@@ -287,7 +288,7 @@ export function ApplicationReviewPanel({
       // 觸發 dataVersion 更新，通知其他 tab 重新載入數據
       incrementDataVersion();
     } catch (error) {
-      console.error("Failed to approve application:", error);
+      logger.error("Failed to approve application", { error: error });
       toast.error(locale === "zh" ? "核准失敗" : "Approval Failed", {
         description:
           error instanceof Error
@@ -306,7 +307,7 @@ export function ApplicationReviewPanel({
         "rejected",
         comments || "學院駁回申請"
       );
-      console.log(`College rejected application ${appId}`, result);
+      logger.debug(`College rejected application ${appId}`, result);
 
       // 檢查是否自動重新執行了分發
       const redistribution = result?.redistribution_info;
@@ -340,7 +341,7 @@ export function ApplicationReviewPanel({
       // 觸發 dataVersion 更新，通知其他 tab 重新載入數據
       incrementDataVersion();
     } catch (error) {
-      console.error("Failed to reject application:", error);
+      logger.error("Failed to reject application", { error: error });
       toast.error(locale === "zh" ? "駁回失敗" : "Rejection Failed", {
         description:
           error instanceof Error
@@ -470,7 +471,7 @@ export function ApplicationReviewPanel({
             : `Exported ${exportData.length} applications`,
       });
     } catch (error) {
-      console.error("Export error:", error);
+      logger.error("Export error", { error: error });
       toast.error(locale === "zh" ? "匯出失敗" : "Export failed", {
         description:
           error instanceof Error

--- a/frontend/components/copy-rules-modal.tsx
+++ b/frontend/components/copy-rules-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -85,7 +86,7 @@ export function CopyRulesModal({
       }
 
       setError(errorMessage);
-      console.error("複製失敗:", error);
+      logger.error("複製失敗", { error: error });
     } finally {
       setIsLoading(false);
     }

--- a/frontend/components/create-schedule-dialog.tsx
+++ b/frontend/components/create-schedule-dialog.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { toast } from "sonner";
+import { logger } from "@/lib/utils/logger";
 import { Calendar, Plus } from "lucide-react"
 
 interface ScholarshipConfiguration {
@@ -61,7 +62,7 @@ export function CreateScheduleDialog({
       const configs = Array.isArray(response.data) ? response.data : (response.data?.data || [])
       setScholarshipConfigs(configs)
     } catch (error) {
-      console.error("獲取獎學金設定失敗:", error)
+      logger.error("獲取獎學金設定失敗", { error: error })
       toast.error("無法載入獎學金設定")
     }
   }
@@ -108,7 +109,7 @@ export function CreateScheduleDialog({
       setOpen(false)
       onScheduleCreated()
     } catch (error) {
-      console.error("建立排程失敗:", error)
+      logger.error("建立排程失敗", { error: error })
       toast.error(error instanceof Error ? error.message : "無法建立排程")
     } finally {
       setLoading(false)

--- a/frontend/components/delete-application-dialog.tsx
+++ b/frontend/components/delete-application-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -71,7 +72,7 @@ export function DeleteApplicationDialog({
         );
       }
     } catch (error: unknown) {
-      console.error("Failed to delete application:", error);
+      logger.error("Failed to delete application", { error: error });
       const errShape = error as { response?: { data?: { message?: string } } };
       toast.error(
         errShape.response?.data?.message ||

--- a/frontend/components/document-request-form.tsx
+++ b/frontend/components/document-request-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Dialog,
   DialogContent,
@@ -101,7 +102,7 @@ export function DocumentRequestForm({
         );
       }
     } catch (error: unknown) {
-      console.error("Failed to create document request:", error);
+      logger.error("Failed to create document request", { error: error });
       const errShape = error as { response?: { data?: { message?: string } } };
       toast.error(
         errShape.response?.data?.message ||

--- a/frontend/components/edit-schedule-dialog.tsx
+++ b/frontend/components/edit-schedule-dialog.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { toast } from "sonner";
+import { logger } from "@/lib/utils/logger";
 import { Calendar } from "lucide-react"
 
 interface RosterSchedule {
@@ -68,7 +69,7 @@ export function EditScheduleDialog({
       const data = await response.json()
       setScholarshipConfigs(data.configurations || [])
     } catch (error) {
-      console.error("獲取獎學金設定失敗:", error)
+      logger.error("獲取獎學金設定失敗", { error: error })
       toast.error("無法載入獎學金設定")
     }
   }
@@ -116,7 +117,7 @@ export function EditScheduleDialog({
 
       onScheduleUpdated()
     } catch (error) {
-      console.error("更新排程失敗:", error)
+      logger.error("更新排程失敗", { error: error })
       toast.error(error instanceof Error ? error.message : "無法更新排程")
     } finally {
       setLoading(false)

--- a/frontend/components/email-automation-management.tsx
+++ b/frontend/components/email-automation-management.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Card,
   CardContent,
@@ -137,7 +138,7 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
         setTriggerEvents(response.data);
       }
     } catch (error: unknown) {
-      console.error("Failed to fetch trigger events:", error);
+      logger.error("Failed to fetch trigger events", { error: error });
     }
   };
 
@@ -156,7 +157,7 @@ export function EmailAutomationManagement() {  const [rules, setRules] = useStat
         setEmailTemplates(templates);
       }
     } catch (error: unknown) {
-      console.error("Failed to fetch email templates:", error);
+      logger.error("Failed to fetch email templates", { error: error });
     }
   };
 

--- a/frontend/components/email-history-table.tsx
+++ b/frontend/components/email-history-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -124,7 +125,7 @@ export function EmailHistoryTable({ className }: EmailHistoryTableProps) {
         }));
       }
     } catch (error) {
-      console.error("Failed to load email history:", error);
+      logger.error("Failed to load email history", { error: error });
     } finally {
       setLoading(false);
     }

--- a/frontend/components/email-test-mode-banner.tsx
+++ b/frontend/components/email-test-mode-banner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import { AlertTriangle, X } from "lucide-react";
 import { api } from "@/lib/api";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -35,7 +36,7 @@ export function EmailTestModeBanner() {
         }
       }
     } catch (error) {
-      console.error("Failed to load test mode status:", error);
+      logger.error("Failed to load test mode status", { error: error });
     } finally {
       setLoading(false);
     }

--- a/frontend/components/enhanced-admin-dashboard.tsx
+++ b/frontend/components/enhanced-admin-dashboard.tsx
@@ -5,6 +5,7 @@
 
 "use client";
 
+import { logger } from "@/lib/utils/logger";
 import React, { useState, useEffect } from "react";
 import {
   Card,
@@ -130,7 +131,7 @@ export function EnhancedAdminDashboard({
         setFilteredApplications(applicationsResponse.data);
       }
     } catch (error) {
-      console.error("Error fetching filtered data:", error);
+      logger.error("Error fetching filtered data", { error: error });
       // 如果API不支援篩選，使用原始資料
       setFilteredStats(stats);
       setFilteredApplications(recentApplications);

--- a/frontend/components/examples/scholarship-data-example.tsx
+++ b/frontend/components/examples/scholarship-data-example.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { logger } from "@/lib/utils/logger";
 /**
  * Example component demonstrating useScholarshipData hook usage
  *
@@ -310,7 +311,7 @@ export function ScholarshipDataExamples() {
       <section>
         <h2 className="text-2xl font-bold mb-4">Example 5: Selector</h2>
         <div className="max-w-sm">
-          <ScholarshipSelectorExample onChange={id => console.log('Selected:', id)} />
+          <ScholarshipSelectorExample onChange={id => logger.debug('Selected:', id)} />
         </div>
       </section>
 

--- a/frontend/components/mock-sso-login.tsx
+++ b/frontend/components/mock-sso-login.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Card,
   CardContent,
@@ -138,7 +139,7 @@ export function MockSSOLogin() {
             }
           }
         } catch (err) {
-          console.warn(
+          logger.warn(
             `Failed to fetch profiles for developer ${developerId}:`,
             err
           );
@@ -147,7 +148,7 @@ export function MockSSOLogin() {
 
       setDeveloperProfiles(allProfiles);
     } catch (err) {
-      console.warn("Failed to fetch developer profiles:", err);
+      logger.warn("Failed to fetch developer profiles:", err);
     }
   };
 

--- a/frontend/components/notification-panel.tsx
+++ b/frontend/components/notification-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -90,7 +91,7 @@ export function NotificationPanel({
         throw new Error(response.message || "獲取通知失敗");
       }
     } catch (err) {
-      console.error("獲取通知錯誤:", err);
+      logger.error("獲取通知錯誤", { err: err });
       setError(err instanceof Error ? err.message : "獲取通知失敗");
     } finally {
       setIsLoading(false);
@@ -112,7 +113,7 @@ export function NotificationPanel({
       // 透過 context 標記已讀 (會自動更新 unreadCount)
       await markAsRead(notificationId);
     } catch (err) {
-      console.error("標記已讀失敗:", err);
+      logger.error("標記已讀失敗", { err: err });
     }
   };
 
@@ -131,7 +132,7 @@ export function NotificationPanel({
       // 透過 context 標記全部已讀
       await markAllAsRead();
     } catch (err) {
-      console.error("標記全部已讀失敗:", err);
+      logger.error("標記全部已讀失敗", { err: err });
     }
   };
 

--- a/frontend/components/payment-roster-list.tsx
+++ b/frontend/components/payment-roster-list.tsx
@@ -11,6 +11,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog"
 import { toast } from "sonner";
+import { logger } from "@/lib/utils/logger";
 import { Search, MoreHorizontal, Download, Eye, RefreshCw, Trash2, FileSpreadsheet } from "lucide-react"
 import { formatDateTime, getStatusBadgeVariant } from "@/lib/utils"
 import { buildSecurePreviewUrl, getAuthToken } from "@/lib/utils/url-validation"
@@ -72,7 +73,7 @@ export function PaymentRosterList({ onRosterChange }: PaymentRosterListProps) {
         setPagination(prev => ({ ...prev, total: data.total }))
       }
     } catch (error) {
-      console.error("獲取造冊列表失敗:", error)
+      logger.error("獲取造冊列表失敗", { error: error })
       toast.error("無法載入造冊列表")
     } finally {
       setLoading(false)
@@ -95,7 +96,7 @@ export function PaymentRosterList({ onRosterChange }: PaymentRosterListProps) {
 
       toast.success("造冊檔案已下載")
     } catch (error) {
-      console.error("下載造冊失敗:", error)
+      logger.error("下載造冊失敗", { error: error })
       toast.error("無法下載造冊檔案")
     } finally {
       setActionLoading(prev => ({ ...prev, [rosterId]: false }))
@@ -115,7 +116,7 @@ export function PaymentRosterList({ onRosterChange }: PaymentRosterListProps) {
       fetchRosters()
       onRosterChange()
     } catch (error) {
-      console.error("重新產生造冊失敗:", error)
+      logger.error("重新產生造冊失敗", { error: error })
       toast.error("無法重新產生造冊")
     } finally {
       setActionLoading(prev => ({ ...prev, [rosterId]: false }))
@@ -137,7 +138,7 @@ export function PaymentRosterList({ onRosterChange }: PaymentRosterListProps) {
       setDeleteDialogOpen(false)
       setSelectedRoster(null)
     } catch (error) {
-      console.error("刪除造冊失敗:", error)
+      logger.error("刪除造冊失敗", { error: error })
       toast.error("無法刪除造冊")
     }
   }
@@ -327,7 +328,7 @@ export function PaymentRosterList({ onRosterChange }: PaymentRosterListProps) {
                                 });
                                 window.open(safeUrl, '_blank');
                               } catch (error) {
-                                console.error('Failed to build preview URL:', error);
+                                logger.error('Failed to build preview URL:', error);
                                 toast.error('無法開啟預覽，請稍後再試');
                               }
                             }}

--- a/frontend/components/professor-assignment-dropdown.tsx
+++ b/frontend/components/professor-assignment-dropdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { Check, ChevronsUpDown, Search, User } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -74,7 +75,7 @@ function ProfessorAssignmentDropdownInner({
         setProfessors(response.data);
       }
     } catch (error) {
-      console.error("Failed to fetch professors:", error);
+      logger.error("Failed to fetch professors", { error: error });
     } finally {
       setLoading(false);
     }
@@ -109,7 +110,7 @@ function ProfessorAssignmentDropdownInner({
         onAssigned?.(professor);
       }
     } catch (error) {
-      console.error("Failed to assign professor:", error);
+      logger.error("Failed to assign professor", { error: error });
     } finally {
       setAssigning(false);
     }
@@ -204,7 +205,7 @@ export function ProfessorAssignmentDropdown(
   return (
     <ErrorBoundary
       onError={(error, errorInfo) => {
-        console.error("Professor Assignment Dropdown Error:", error, errorInfo);
+        logger.error("Professor Assignment Dropdown Error:", error, errorInfo);
       }}
     >
       <ProfessorAssignmentDropdownInner {...props} />

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { ErrorBoundary, useErrorHandler } from "@/components/error-boundary";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -366,7 +367,7 @@ function ProfessorReviewComponentInner({
 
       setReviewModalOpen(true);
     } catch (e: unknown) {
-      console.error("Error opening review modal:", e);
+      logger.error("Error opening review modal", { e: e });
       setError((e instanceof Error ? e.message : "Failed to load review data"));
     } finally {
       setLoading(false);
@@ -1026,7 +1027,7 @@ export function ProfessorReviewComponent({
   return (
     <ErrorBoundary
       onError={(error, errorInfo) => {
-        console.error("Professor Review Component Error:", error, errorInfo);
+        logger.error("Professor Review Component Error:", error, errorInfo);
         // In production, send to error reporting service
       }}
     >

--- a/frontend/components/quota-management.tsx
+++ b/frontend/components/quota-management.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/utils/logger";
 /**
  * Main quota management component for admin interface
  */
@@ -100,12 +101,12 @@ export function QuotaManagement() {  const { user } = useAuth();
 
   const checkUserPermission = async () => {
     setCheckingPermission(true);
-    console.log("🔍 Checking quota management permissions for user:", user);
+    logger.debug("🔍 Checking quota management permissions for user:", user);
 
     try {
       // First check if user is super_admin - they always have access
       if (user?.role === "super_admin") {
-        console.log("✅ User is super_admin, granting access");
+        logger.debug("✅ User is super_admin, granting access");
         setHasPermission(true);
         setCheckingPermission(false);
         return;
@@ -113,40 +114,40 @@ export function QuotaManagement() {  const { user } = useAuth();
 
       // For admin users, check their scholarship permissions
       if (user?.role === "admin") {
-        console.log(
+        logger.debug(
           "🔍 Checking admin permissions via scholarship permissions API"
         );
         try {
           const response =
             await apiClient.admin.getCurrentUserScholarshipPermissions();
-          console.log("📊 Scholarship permissions response:", response);
+          logger.debug("📊 Scholarship permissions response:", response);
 
           if (response.success && response.data) {
             const hasPerms = response.data.length > 0;
-            console.log(
+            logger.debug(
               hasPerms
                 ? "✅ Admin has scholarship permissions"
                 : "❌ Admin has no scholarship permissions"
             );
             setHasPermission(hasPerms);
           } else {
-            console.log("❌ Admin permission check failed:", response.message);
+            logger.debug("❌ Admin permission check failed:", response.message);
             setHasPermission(false);
           }
         } catch (permError) {
-          console.error("❌ Admin permission check error:", permError);
+          logger.error("❌ Admin permission check error", { permError: permError });
           setHasPermission(false);
         }
       } else {
         // Other roles don't have access
-        console.log(
+        logger.debug(
           "❌ User role not authorized for quota management:",
           user?.role
         );
         setHasPermission(false);
       }
     } catch (error) {
-      console.error("❌ Overall permission check failed:", error);
+      logger.error("❌ Overall permission check failed", { error: error });
       setHasPermission(false);
     } finally {
       setCheckingPermission(false);
@@ -166,7 +167,7 @@ export function QuotaManagement() {  const { user } = useAuth();
         throw new Error(response.message || "無法載入可用學期");
       }
     } catch (error) {
-      console.error("Error fetching available periods:", error);
+      logger.error("Error fetching available periods", { error: error });
       setError("無法載入可用學期資料");
       toast.error("無法載入可用學期資料");
     }

--- a/frontend/components/react-email-template-viewer.tsx
+++ b/frontend/components/react-email-template-viewer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -73,7 +74,7 @@ function PreviewDialog({ template, open, onClose }: PreviewDialogProps) {
         setError(result.error || "渲染模板失敗");
       }
     } catch (err) {
-      console.error("Failed to render template:", err);
+      logger.error("Failed to render template", { err: err });
       setError(err instanceof Error ? err.message : "渲染模板失敗");
     } finally {
       setIsLoadingPreview(false);
@@ -112,7 +113,7 @@ function PreviewDialog({ template, open, onClose }: PreviewDialogProps) {
       setSuccess(`測試郵件已發送至 ${testEmail}`);
       setTimeout(() => setSuccess(null), 5000);
     } catch (err) {
-      console.error("Failed to send test email:", err);
+      logger.error("Failed to send test email", { err: err });
       setError(err instanceof Error ? err.message : "發送測試郵件失敗");
     } finally {
       setIsSendingTest(false);
@@ -267,22 +268,22 @@ export function ReactEmailTemplateViewer() {
 
     try {
       const response = await api.emailManagement.getReactEmailTemplates();
-      console.log("📧 React Email Templates API response:", response);
+      logger.debug("📧 React Email Templates API response:", response);
 
       // Check if data is an array
       if (Array.isArray(response.data)) {
-        console.log(`✅ Found ${response.data.length} React Email templates`);
+        logger.debug(`✅ Found ${response.data.length} React Email templates`);
         setTemplates(response.data);
       } else if (response.success && response.data) {
-        console.warn("⚠️ Unexpected response data format:", response.data);
+        logger.warn("⚠️ Unexpected response data format:", response.data);
         setTemplates([]);
         setError("回應格式錯誤：無法解析模板列表");
       } else {
-        console.warn("⚠️ No templates data in response:", response);
+        logger.warn("⚠️ No templates data in response:", response);
         setTemplates([]);
       }
     } catch (err) {
-      console.error("❌ Failed to fetch React Email templates:", err);
+      logger.error("❌ Failed to fetch React Email templates", { err: err });
       setError(err instanceof Error ? err.message : "載入模板失敗");
     } finally {
       setIsLoading(false);
@@ -318,7 +319,7 @@ export function ReactEmailTemplateViewer() {
         sourceWindow.document.close();
       }
     } catch (err) {
-      console.error("Failed to fetch source:", err);
+      logger.error("Failed to fetch source", { err: err });
       setError(err instanceof Error ? err.message : "載入源碼失敗");
     }
   };

--- a/frontend/components/reviewer-dashboard.tsx
+++ b/frontend/components/reviewer-dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Card,
   CardContent,
@@ -163,11 +164,11 @@ export function ReviewerDashboard({
   };
 
   const handleApprove = (appId: string) => {
-    console.log(`Approving application ${appId}`);
+    logger.debug(`Approving application ${appId}`);
   };
 
   const handleReject = (appId: string) => {
-    console.log(`Rejecting application ${appId}`);
+    logger.debug(`Rejecting application ${appId}`);
   };
 
   const renderCardView = () => (

--- a/frontend/components/roster-management-dashboard.tsx
+++ b/frontend/components/roster-management-dashboard.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { logger } from "@/lib/utils/logger";
 import React, { useState, useEffect } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -70,7 +71,7 @@ export function RosterManagementDashboard() {
         schedulerRunning: schedulerData.scheduler_running || false
       })
     } catch (error) {
-      console.error("獲取儀表板統計失敗:", error)
+      logger.error("獲取儀表板統計失敗", { error: error })
     } finally {
       setLoading(false)
     }
@@ -91,7 +92,7 @@ export function RosterManagementDashboard() {
         setSelectedSchedule(null)
       }
     } catch (error) {
-      console.error("Failed to load schedule:", error)
+      logger.error("Failed to load schedule", { error: error })
       setSelectedSchedule(null)
     } finally {
       setLoadingSchedule(false)
@@ -110,7 +111,7 @@ export function RosterManagementDashboard() {
         setCycleData(null)
       }
     } catch (error) {
-      console.error("Failed to load cycle status:", error)
+      logger.error("Failed to load cycle status", { error: error })
       setCycleData(null)
     } finally {
       setLoadingCycle(false)
@@ -133,7 +134,7 @@ export function RosterManagementDashboard() {
         setCycleData(null)
       }
     } catch (error) {
-      console.error("Failed to refetch cycle status:", error)
+      logger.error("Failed to refetch cycle status", { error: error })
       setCycleData(null)
     } finally {
       setLoadingCycle(false)

--- a/frontend/components/roster-schedule-list.tsx
+++ b/frontend/components/roster-schedule-list.tsx
@@ -10,6 +10,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog"
 import { toast } from "sonner";
+import { logger } from "@/lib/utils/logger";
 import { Search, MoreHorizontal, Play, Pause, Square, Trash2, Edit, Calendar, FileText } from "lucide-react"
 import { EditScheduleDialog } from "./edit-schedule-dialog"
 import { formatDateTime, getStatusBadgeVariant } from "@/lib/utils"
@@ -83,7 +84,7 @@ export function RosterScheduleList({ onScheduleChange, onRosterGenerated }: Rost
         setPagination(prev => ({ ...prev, total: data.total }))
       }
     } catch (error) {
-      console.error("獲取排程列表失敗:", error)
+      logger.error("獲取排程列表失敗", { error: error })
       toast.error("無法載入排程列表")
     } finally {
       setLoading(false)
@@ -104,7 +105,7 @@ export function RosterScheduleList({ onScheduleChange, onRosterGenerated }: Rost
       fetchSchedules()
       onScheduleChange()
     } catch (error) {
-      console.error("狀態更新失敗:", error)
+      logger.error("狀態更新失敗", { error: error })
       toast.error("無法更新排程狀態")
     } finally {
       setActionLoading(prev => ({ ...prev, [scheduleId]: false }))
@@ -125,7 +126,7 @@ export function RosterScheduleList({ onScheduleChange, onRosterGenerated }: Rost
       onScheduleChange()
       onRosterGenerated?.()
     } catch (error) {
-      console.error("執行排程失敗:", error)
+      logger.error("執行排程失敗", { error: error })
       toast.error("無法執行排程")
     } finally {
       setActionLoading(prev => ({ ...prev, [scheduleId]: false }))
@@ -147,7 +148,7 @@ export function RosterScheduleList({ onScheduleChange, onRosterGenerated }: Rost
       setDeleteDialogOpen(false)
       setSelectedSchedule(null)
     } catch (error) {
-      console.error("刪除排程失敗:", error)
+      logger.error("刪除排程失敗", { error: error })
       toast.error("無法刪除排程")
     }
   }

--- a/frontend/components/roster/CompactConfigSelector.tsx
+++ b/frontend/components/roster/CompactConfigSelector.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { logger } from "@/lib/utils/logger";
 import { useState, useEffect } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { api } from "@/lib/api"
@@ -118,11 +119,11 @@ export function CompactConfigSelector({ onConfigSelect, disabled = false }: Comp
 
         setScholarshipTypes(types)
       } else {
-        console.error("Failed to load scholarship types")
+        logger.error("Failed to load scholarship types")
         setScholarshipTypes([])
       }
     } catch (error) {
-      console.error("Failed to load scholarship types:", error)
+      logger.error("Failed to load scholarship types", { error: error })
       setScholarshipTypes([])
     } finally {
       setIsLoadingTypes(false)
@@ -184,7 +185,7 @@ export function CompactConfigSelector({ onConfigSelect, disabled = false }: Comp
         setPeriodOptions([])
       }
     } catch (error) {
-      console.error("Failed to load configurations:", error)
+      logger.error("Failed to load configurations", { error: error })
       setConfigurations([])
       setPeriodOptions([])
     } finally {

--- a/frontend/components/roster/ConfigSelector.tsx
+++ b/frontend/components/roster/ConfigSelector.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { logger } from "@/lib/utils/logger";
 import { useState, useEffect } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Button } from "@/components/ui/button"
@@ -85,7 +86,7 @@ export function ConfigSelector({ onConfigSelect, disabled = false }: ConfigSelec
         setConfigurations([])
       }
     } catch (error) {
-      console.error("Failed to load configurations:", error)
+      logger.error("Failed to load configurations", { error: error })
       setConfigurations([])
     } finally {
       setIsLoadingConfigs(false)

--- a/frontend/components/roster/PeriodDetailDialog.tsx
+++ b/frontend/components/roster/PeriodDetailDialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { logger } from "@/lib/utils/logger";
 import { useState } from "react"
 import {
   Dialog,
@@ -125,7 +126,7 @@ export function PeriodDetailDialog({
 
       toast.success("造冊檔案已下載")
     } catch (error) {
-      console.error("Failed to download roster:", error)
+      logger.error("Failed to download roster", { error: error })
       toast.error("下載失敗: 無法下載造冊檔案")
     } finally {
       setDownloading(false)
@@ -158,7 +159,7 @@ export function PeriodDetailDialog({
         throw new Error(response.message || "產生造冊失敗")
       }
     } catch (error: unknown) {
-      console.error("Failed to generate roster:", error)
+      logger.error("Failed to generate roster", { error: error })
       toast.error(`產生造冊失敗: ${(error instanceof Error ? error.message : "無法產生造冊")}`)
     } finally {
       setGenerating(false)

--- a/frontend/components/roster/RosterCycleTimeline.tsx
+++ b/frontend/components/roster/RosterCycleTimeline.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { logger } from "@/lib/utils/logger";
 import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -69,7 +70,7 @@ export function RosterCycleTimeline({ configId }: RosterCycleTimelineProps) {
         setError("無法載入造冊週期資料")
       }
     } catch (err) {
-      console.error("Failed to load cycle status:", err)
+      logger.error("Failed to load cycle status", { err: err })
       setError("載入造冊週期時發生錯誤")
     } finally {
       setLoading(false)

--- a/frontend/components/roster/RosterDetailDialog.tsx
+++ b/frontend/components/roster/RosterDetailDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Dialog,
   DialogContent,
@@ -173,7 +174,7 @@ export function RosterDetailDialog({
         }
       }
     } catch (error) {
-      console.error("Failed to load roster items:", error);
+      logger.error("Failed to load roster items", { error: error });
     } finally {
       setLoading(false);
     }

--- a/frontend/components/roster/RosterListTable.tsx
+++ b/frontend/components/roster/RosterListTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -147,7 +148,7 @@ export function RosterListTable({
 
       toast.success("造冊檔案已下載");
     } catch (error) {
-      console.error("Failed to download roster:", error);
+      logger.error("Failed to download roster", { error: error });
       toast.error("下載失敗: 無法下載造冊檔案");
     } finally {
       setDownloading(null);
@@ -183,7 +184,7 @@ export function RosterListTable({
         throw new Error(response.message || "產生造冊失敗");
       }
     } catch (error: unknown) {
-      console.error("Failed to generate roster:", error);
+      logger.error("Failed to generate roster", { error: error });
       toast.error(`產生造冊失敗: ${(error instanceof Error ? error.message : "無法產生造冊")}`);
     } finally {
       setGenerating(null);

--- a/frontend/components/roster/ScheduleSettingDialog.tsx
+++ b/frontend/components/roster/ScheduleSettingDialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { logger } from "@/lib/utils/logger";
 import { useState, useEffect } from "react"
 import {
   Dialog,
@@ -100,7 +101,7 @@ export function ScheduleSettingDialog({
         throw new Error(response.message || "更新失敗")
       }
     } catch (error: unknown) {
-      console.error("Failed to update schedule:", error)
+      logger.error("Failed to update schedule", { error: error })
       toast.error(`儲存失敗: ${(error instanceof Error ? error.message : "無法更新排程設定")}`)
     } finally {
       setSaving(false)

--- a/frontend/components/roster/StudentRosterPreview.tsx
+++ b/frontend/components/roster/StudentRosterPreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -137,7 +138,7 @@ export function StudentRosterPreview({
         setError("無法載入學生資料");
       }
     } catch (err) {
-      console.error("Failed to load student data:", err);
+      logger.error("Failed to load student data", { err: err });
       // Try to extract error message from different error sources
       let errorMessage = "載入學生資料時發生錯誤";
 

--- a/frontend/components/scheduled-emails-table.tsx
+++ b/frontend/components/scheduled-emails-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -145,7 +146,7 @@ export function ScheduledEmailsTable({
         }));
       }
     } catch (error) {
-      console.error("Failed to load scheduled emails:", error);
+      logger.error("Failed to load scheduled emails", { error: error });
     } finally {
       setLoading(false);
     }
@@ -162,7 +163,7 @@ export function ScheduledEmailsTable({
         await loadScheduledEmails();
       }
     } catch (error) {
-      console.error("Failed to approve email:", error);
+      logger.error("Failed to approve email", { error: error });
     }
   };
 
@@ -175,7 +176,7 @@ export function ScheduledEmailsTable({
         await loadScheduledEmails();
       }
     } catch (error) {
-      console.error("Failed to cancel email:", error);
+      logger.error("Failed to cancel email", { error: error });
     }
   };
 
@@ -287,7 +288,7 @@ export function ScheduledEmailsTable({
       );
       setIsEditMode(false);
     } catch (error) {
-      console.error("Failed to update scheduled email:", error);
+      logger.error("Failed to update scheduled email", { error: error });
     }
   };
 

--- a/frontend/components/scheduler-status.tsx
+++ b/frontend/components/scheduler-status.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { toast } from "sonner";
+import { logger } from "@/lib/utils/logger";
 import { Play, Pause, Square, Clock, Activity, AlertTriangle, CheckCircle, XCircle, RefreshCw } from "lucide-react"
 import { formatDateTime } from "@/lib/utils"
 
@@ -68,7 +69,7 @@ export function SchedulerStatus() {
       setSchedulerInfo(statusData)
       setJobs(statusData.jobs || [])
     } catch (error) {
-      console.error("獲取排程器狀態失敗:", error)
+      logger.error("獲取排程器狀態失敗", { error: error })
       toast.error("無法載入排程器狀態")
     } finally {
       setLoading(false)
@@ -95,7 +96,7 @@ export function SchedulerStatus() {
       // 稍等一下再刷新狀態
       setTimeout(fetchSchedulerStatus, 1000)
     } catch (error) {
-      console.error(`排程器${action}操作失敗:`, error)
+      logger.error(`排程器${action}操作失敗:`, error)
       toast.error(`無法${action}排程器`)
     } finally {
       setActionLoading(false)

--- a/frontend/components/scholarship-rule-modal.tsx
+++ b/frontend/components/scholarship-rule-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -216,7 +217,7 @@ export function ScholarshipRuleModal({
         if (response.success && response.data && Array.isArray(response.data)) {
           setSubTypeOptions(response.data);
         } else {
-          console.error("Failed to load sub-types:", response.message);
+          logger.error("Failed to load sub-types:", response.message);
           // Keep default options on error
           setSubTypeOptions([
             {
@@ -228,7 +229,7 @@ export function ScholarshipRuleModal({
           ]);
         }
       } catch (error) {
-        console.error("Error loading sub-types:", error);
+        logger.error("Error loading sub-types", { error: error });
         // Keep default options on error
         setSubTypeOptions([
           { value: null, label: "通用", label_en: "General", is_default: true },
@@ -294,7 +295,7 @@ export function ScholarshipRuleModal({
       await onSubmit(submitData);
       onClose();
     } catch (error) {
-      console.error("提交規則失敗:", error);
+      logger.error("提交規則失敗", { error: error });
     }
   };
 

--- a/frontend/components/scholarship-timeline.tsx
+++ b/frontend/components/scholarship-timeline.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Card,
   CardContent,
@@ -160,7 +161,7 @@ export function ScholarshipTimeline({ user }: ScholarshipTimelineProps) {
       setIsLoading(true);
       setError(null);
 
-      console.log(
+      logger.debug(
         "ScholarshipTimeline: Starting fetch for user:",
         user.role,
         user.id
@@ -177,7 +178,7 @@ export function ScholarshipTimeline({ user }: ScholarshipTimelineProps) {
       let response;
       if (user.role === "super_admin") {
         // Super admin 可以看到所有獎學金
-        console.log(
+        logger.debug(
           "ScholarshipTimeline: Fetching all scholarships for super_admin",
           { academicYear, semester }
         );
@@ -189,7 +190,7 @@ export function ScholarshipTimeline({ user }: ScholarshipTimelineProps) {
         response = await apiClient.request(url);
       } else if (user.role === "admin" || user.role === "college") {
         // Admin 和 College 可以看到他們有權限的獎學金
-        console.log(
+        logger.debug(
           "ScholarshipTimeline: Fetching scholarships for admin/college user",
           { academicYear, semester }
         );
@@ -201,7 +202,7 @@ export function ScholarshipTimeline({ user }: ScholarshipTimelineProps) {
         response = await apiClient.request(url);
       } else {
         // 其他角色不顯示此功能
-        console.log(
+        logger.debug(
           "ScholarshipTimeline: User role not eligible for timeline:",
           user.role
         );
@@ -211,7 +212,7 @@ export function ScholarshipTimeline({ user }: ScholarshipTimelineProps) {
       }
 
       if (response.success && response.data) {
-        console.log(
+        logger.debug(
           "ScholarshipTimeline: Raw scholarships data:",
           response.data
         );
@@ -220,14 +221,14 @@ export function ScholarshipTimeline({ user }: ScholarshipTimelineProps) {
         const filteredScholarships = filterScholarshipsByPermission(
           response.data as ScholarshipApiPayload[]
         );
-        console.log(
+        logger.debug(
           "ScholarshipTimeline: Filtered scholarships based on permissions:",
           filteredScholarships
         );
 
         const timelineData: ScholarshipTimelineData[] =
           filteredScholarships.map((scholarship: ScholarshipApiPayload) => {
-            console.log(
+            logger.debug(
               `ScholarshipTimeline: Processing ${scholarship.name}, application_cycle:`,
               scholarship.application_cycle
             );
@@ -269,7 +270,7 @@ export function ScholarshipTimeline({ user }: ScholarshipTimelineProps) {
         }
       }
     } catch (err) {
-      console.error("Failed to fetch scholarship timelines:", err);
+      logger.error("Failed to fetch scholarship timelines", { err: err });
       setError("載入獎學金時間軸失敗");
     } finally {
       setIsLoading(false);

--- a/frontend/components/semester-selector.tsx
+++ b/frontend/components/semester-selector.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@/lib/utils/logger";
 /**
  * 學期選擇器組件 - 提供學年學期的 dropdown 選擇功能
  */
@@ -217,7 +218,7 @@ export const SemesterSelector: React.FC<SemesterSelectorProps> = ({
         }
       }
     } catch (error) {
-      console.error("Error loading scholarship period data:", error);
+      logger.error("Error loading scholarship period data", { error: error });
       // 發生錯誤時顯示空列表
       setCombinations([]);
       setDetectedCycle("semester");
@@ -245,7 +246,7 @@ export const SemesterSelector: React.FC<SemesterSelectorProps> = ({
       });
       setActualMode("separate");
     } catch (error) {
-      console.error("Error loading semester data:", error);
+      logger.error("Error loading semester data", { error: error });
     } finally {
       setLoading(false);
     }
@@ -310,14 +311,14 @@ export const SemesterSelector: React.FC<SemesterSelectorProps> = ({
 
         setCombinations(combinationOptions);
       } else {
-        console.error(
+        logger.error(
           "Failed to fetch available combinations:",
           response.message
         );
         setCombinations([]);
       }
     } catch (error) {
-      console.error("Error loading combination data:", error);
+      logger.error("Error loading combination data", { error: error });
       setCombinations([]);
     } finally {
       setLoading(false);

--- a/frontend/components/system-configuration-management.tsx
+++ b/frontend/components/system-configuration-management.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import {
   Card,
   CardContent,
@@ -120,7 +121,7 @@ export default function SystemConfigurationManagement() {
       }
     } catch (err) {
       setError("載入配置時發生錯誤");
-      console.error("Error loading configurations:", err);
+      logger.error("Error loading configurations", { err: err });
     } finally {
       setLoading(false);
     }
@@ -133,7 +134,7 @@ export default function SystemConfigurationManagement() {
         setAuditLogs(response.data);
       }
     } catch (err) {
-      console.error("Error loading audit logs:", err);
+      logger.error("Error loading audit logs", { err: err });
     }
   };
 
@@ -170,7 +171,7 @@ export default function SystemConfigurationManagement() {
       }
     } catch (err) {
       setError("更新配置時發生錯誤");
-      console.error("Error updating configuration:", err);
+      logger.error("Error updating configuration", { err: err });
     }
   };
 

--- a/frontend/components/text-template-editor.tsx
+++ b/frontend/components/text-template-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
@@ -63,7 +64,7 @@ function EditDialog({ template, open, onClose, onSave }: EditDialogProps) {
       }
       onClose();
     } catch (err) {
-      console.error("Failed to save template:", err);
+      logger.error("Failed to save template", { err: err });
       setError(err instanceof Error ? err.message : "保存模板失敗");
     } finally {
       setIsSaving(false);
@@ -338,7 +339,7 @@ export function TextTemplateEditor() {
       const response = await api.emailManagement.getEmailTemplates();
       setTemplates(response.data || []);
     } catch (err) {
-      console.error("Failed to fetch templates:", err);
+      logger.error("Failed to fetch templates", { err: err });
       setError(err instanceof Error ? err.message : "載入模板失敗");
     } finally {
       setIsLoading(false);

--- a/frontend/components/user-permission-management.tsx
+++ b/frontend/components/user-permission-management.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { logger } from "@/lib/utils/logger";
 import { useAuth } from "@/hooks/use-auth";
 import { apiClient } from "@/lib/api";
 import type { UserStats, UserCreate as UserCreateType } from "@/lib/api";
@@ -189,7 +190,7 @@ export function UserPermissionManagement() {
         setUserStats(response.data);
       }
     } catch (error) {
-      console.error("獲取使用者統計失敗:", error);
+      logger.error("獲取使用者統計失敗", { error: error });
     }
   };
 
@@ -202,7 +203,7 @@ export function UserPermissionManagement() {
         setScholarshipPermissions(response.data);
       }
     } catch (error) {
-      console.error("Error fetching permissions:", error);
+      logger.error("Error fetching permissions", { error: error });
     } finally {
       setLoadingPermissions(false);
     }
@@ -215,7 +216,7 @@ export function UserPermissionManagement() {
         setAvailableScholarships(response.data);
       }
     } catch (error) {
-      console.error("獲取獎學金列表失敗:", error);
+      logger.error("獲取獎學金列表失敗", { error: error });
     }
   };
 
@@ -226,7 +227,7 @@ export function UserPermissionManagement() {
         setAcademies(response.data);
       }
     } catch (error) {
-      console.error("獲取學院列表失敗:", error);
+      logger.error("獲取學院列表失敗", { error: error });
     }
   };
 

--- a/frontend/components/user-profile-management.tsx
+++ b/frontend/components/user-profile-management.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -118,7 +119,7 @@ export default function UserProfileManagement() {
   const loadProfile = async () => {
     try {
       const response = await api.userProfiles.getMyProfile();
-      console.log("Profile response:", response); // 調試用
+      logger.debug("Profile response:", response); // 調試用
 
       if (response.success && response.data) {
         setProfile(response.data as unknown as CompleteUserProfile);
@@ -132,7 +133,7 @@ export default function UserProfileManagement() {
         }
       } else {
         // 如果 API 返回失敗，顯示錯誤但不阻止頁面渲染
-        console.warn("Profile API returned error:", response.message);
+        logger.warn("Profile API returned error:", response.message);
         toast(response.message || t("profile_management.profile_may_not_exist"));
 
         // 設置基本的用戶資料結構，即使沒有完整的個人資料
@@ -158,7 +159,7 @@ export default function UserProfileManagement() {
         });
       }
     } catch (error: unknown) {
-      console.error("Load profile error:", error);
+      logger.error("Load profile error", { error: error });
 
       // 網絡錯誤或其他嚴重錯誤
       if (error instanceof Error && error.name === "TypeError" && error.message.includes("fetch")) {
@@ -406,7 +407,7 @@ export default function UserProfileManagement() {
     // 建立預覽 URL，使用前端路由而不是完整的外部 URL
     const previewUrl = `/api/v1/preview?fileId=${fileId}&filename=${encodeURIComponent(filename)}&type=${fileType}&userId=${userId}&token=${token}`;
 
-    console.log("Preview URL:", previewUrl); // 用於調試
+    logger.debug("Preview URL:", previewUrl); // 用於調試
 
     // 判斷文件類型
     let fileType_display = "other";

--- a/frontend/components/whitelist-management-dialog.tsx
+++ b/frontend/components/whitelist-management-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { logger } from "@/lib/utils/logger";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -153,7 +154,7 @@ export function WhitelistManagementDialog({
         }
 
         if (result.failed_items.length > 0) {
-          console.error("Import errors:", result.failed_items);
+          logger.error("Import errors:", result.failed_items);
         }
 
         await loadWhitelist();


### PR DESCRIPTION
## Summary

Closes out the components/+app tier of the frontend console-cleanup wave (PRs #607-#619). Applies the same regex transform validated across the wave to **64 files** with **~190 sites** in one batch:

- \`console.error("msg:", err)\` → \`logger.error("msg", { err: err })\`
- \`console.log(...)\` → \`logger.debug(...)\`
- Multi-line \`console.error\` collapsed to single-line \`logger.error\`

Logger import inserted at top of each file after the first single-line import statement (improved heuristic avoids the multi-line brace-block insertion bug seen in earlier iterations; smart detection skips files where a clean insertion point isn't found).

## After this PR

The only remaining \`console.*\` sites in \`components/+app\` are the 24 in \`components/debug-panel.tsx\` — that file is a dev-only debug tool whose console output IS the feature, intentionally left as-is.

Frontend \`hooks/\`, \`lib/\`, \`contexts/\`, \`components/\`, and \`app/\` trees are now ~99% migrated to the centralized logger.

## Test plan

- [ ] CI: lint + tsc + bundle-size + frontend tests
- [ ] CI: existing component tests should not regress (this is a pure logging refactor; render output unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)