### PR TITLE
chore(backend): sweep 30 test-wishlist TODOs from 6 test files

### DIFF
--- a/backend/app/tests/test_admin_endpoints.py
+++ b/backend/app/tests/test_admin_endpoints.py
@@ -770,9 +770,3 @@ class TestAdminEndpoints:
             json={"reason": "x"},
         )
         assert response.status_code == 403
-
-    # TODO: Add tests for rate limiting on admin endpoints
-    # TODO: Add tests for admin action logging and audit trail
-    # TODO: Add tests for admin permission inheritance and delegation
-    # TODO: Add performance tests for bulk operations
-    # TODO: Add tests for data export in different formats (Excel, JSON)

--- a/backend/app/tests/test_application_service_comprehensive.py
+++ b/backend/app/tests/test_application_service_comprehensive.py
@@ -638,9 +638,3 @@ class TestGetStudentDataFromUser:
 
         # Assert
         assert result is None
-
-    # TODO: Add tests for external API failure handling
-    # TODO: Add tests for student data caching mechanism
-    # TODO: Add tests for student data validation and sanitization
-    # TODO: Add performance tests for bulk application operations
-    # TODO: Add tests for application archiving functionality

--- a/backend/app/tests/test_core_utilities.py
+++ b/backend/app/tests/test_core_utilities.py
@@ -644,9 +644,3 @@ class TestValidationHelpers:
         for input_filename, expected_output in test_cases:
             result = sanitize_filename(input_filename)
             assert result == expected_output
-
-    # TODO: Add tests for rate limiting utilities
-    # TODO: Add tests for data encryption/decryption helpers
-    # TODO: Add tests for API response formatting utilities
-    # TODO: Add tests for pagination helpers
-    # TODO: Add performance tests for utility functions with large inputs

--- a/backend/app/tests/test_email_management_service.py
+++ b/backend/app/tests/test_email_management_service.py
@@ -439,9 +439,3 @@ class TestEmailManagementService:
         # Act & Assert
         with pytest.raises(Exception, match="Database connection failed"):
             await email_service.get_email_history(db=mock_db_session, user=admin_user)
-
-    # TODO: Add tests for email retry mechanism when implemented
-    # TODO: Add tests for email template system integration
-    # TODO: Add tests for email delivery status webhook handling
-    # TODO: Add performance tests for large email history queries
-    # TODO: Add tests for email content sanitization

--- a/backend/app/tests/test_minio_service.py
+++ b/backend/app/tests/test_minio_service.py
@@ -521,9 +521,3 @@ class TestMinIOService:
         # Assert
         assert cleaned_count == 2
         assert mock_minio_client.remove_object.call_count == 2
-
-    # TODO: Add tests for concurrent file operations
-    # TODO: Add tests for file encryption/decryption
-    # TODO: Add tests for file versioning support
-    # TODO: Add tests for bandwidth limiting
-    # TODO: Add performance tests for large file operations

--- a/backend/app/tests/test_models_comprehensive.py
+++ b/backend/app/tests/test_models_comprehensive.py
@@ -665,9 +665,3 @@ class TestModelTimestamps:
 
         # Assert
         assert user.updated_at > original_updated_at
-
-    # TODO: Add tests for model validation methods
-    # TODO: Add tests for model serialization to dict/JSON
-    # TODO: Add tests for complex query scenarios
-    # TODO: Add tests for model inheritance relationships
-    # TODO: Add performance tests for large dataset operations


### PR DESCRIPTION
## Summary

Backend production code has **zero** TODO/FIXME/HACK comments today. The 34 \`TODO\` mentions in \`backend/app/\` were all in \`tests/\` files — wishlist comments at the end of test files like:

\`\`\`python
# TODO: Add tests for rate limiting on admin endpoints
# TODO: Add tests for admin action logging and audit trail
# TODO: Add performance tests for bulk operations
\`\`\`

Per CLAUDE.md "Don't add comments that don't matter" — these are clutter. They've sat untouched for months. Sweep them so the codebase reflects what is actually tested vs not.

After sweep:
- **30** wishlist TODO lines removed across 6 files (5 each)
- **4** mentions remain that are documentation pointers (e.g., \`# this is a TODO comment in the source\`) explaining test rationale — left as-is

Pure deletion; no test logic changed.

## Test plan

- [ ] CI: backend lint + tests should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)