### PR TITLE
SECURITY: override transitive postcss to fix 8.4.31 XSS

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13971,33 +13971,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,7 +123,11 @@
   },
   "overrides": {
     "@react-email/preview-server": {
-      "next": "15.5.18"
+      "next": "15.5.18",
+      "postcss": "$postcss"
+    },
+    "next": {
+      "postcss": "$postcss"
     },
     "@isaacs/brace-expansion": ">=5.0.1",
     "glob": ">=13.0.2",


### PR DESCRIPTION
## Summary (SECURITY)

Top-level postcss is already at 8.5.14, but Dependabot still flags an open medium-severity advisory for postcss 8.4.31 — that version is being pulled in transitively by two packages:

- \`@react-email/preview-server\` (nested \`node_modules/@react-email/preview-server/node_modules/postcss\`)
- \`next\` (nested \`node_modules/next/node_modules/postcss\`)

This PR adds \`\$postcss\` overrides for both so they reuse the top-level postcss installation:

\`\`\`json
"overrides": {
  "@react-email/preview-server": { "next": "15.5.18", "postcss": "\$postcss" },
  "next": { "postcss": "\$postcss" }
}
\`\`\`

After rebuild, both nested postcss trees collapse into the single top-level install at 8.5.14.

## CVE closed

- npm:postcss medium — XSS via unescaped \`</style>\` in CSS Stringify Output

This was the last remaining open Dependabot alert after the Next.js 15.5.18 bump in PR #622.

## Test plan

- [ ] CI: frontend lint + tsc + Jest + bundle-size
- [ ] CI: Dependency Check should now show 0 open Dependabot alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)