### PR TITLE
chore(frontend): narrow college mutation any types to unknown

### DIFF
--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -133,7 +133,7 @@ export function createCollegeApi() {
     updateRanking: async (
       rankingId: number,
       data: { ranking_name: string }
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.PUT(
         "/api/v1/college-review/rankings/{ranking_id}" as any,
         {
@@ -141,7 +141,7 @@ export function createCollegeApi() {
           body: data,
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -151,7 +151,7 @@ export function createCollegeApi() {
     updateRankingOrder: async (
       rankingId: number,
       newOrder: Array<{ item_id: number; position: number }>
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.PUT(
         "/api/v1/college-review/rankings/{ranking_id}/order",
         {
@@ -159,35 +159,39 @@ export function createCollegeApi() {
           body: newOrder,
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
      * Finalize ranking (lock and approve)
      * Type-safe: Path parameter validated against OpenAPI
      */
-    finalizeRanking: async (rankingId: number): Promise<ApiResponse<any>> => {
+    finalizeRanking: async (
+      rankingId: number
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.POST(
         "/api/v1/college-review/rankings/{ranking_id}/finalize",
         {
           params: { path: { ranking_id: rankingId } },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
      * Unfinalize ranking (unlock to allow editing)
      * Type-safe: Path parameter validated against OpenAPI
      */
-    unfinalizeRanking: async (rankingId: number): Promise<ApiResponse<any>> => {
+    unfinalizeRanking: async (
+      rankingId: number
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.POST(
         "/api/v1/college-review/rankings/{ranking_id}/unfinalize" as any,
         {
           params: { path: { ranking_id: rankingId } },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -201,7 +205,7 @@ export function createCollegeApi() {
         student_name: string;
         rank_position: number;
       }>
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.POST(
         "/api/v1/college-review/rankings/{ranking_id}/import-excel" as any,
         {
@@ -209,7 +213,7 @@ export function createCollegeApi() {
           body: importData,
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -311,14 +315,16 @@ export function createCollegeApi() {
      * Delete a ranking
      * Type-safe: Path parameter validated against OpenAPI
      */
-    deleteRanking: async (rankingId: number): Promise<ApiResponse<any>> => {
+    deleteRanking: async (
+      rankingId: number
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.DELETE(
         "/api/v1/college-review/rankings/{ranking_id}" as any,
         {
           params: { path: { ranking_id: rankingId } },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**


### PR DESCRIPTION
## Summary

- Narrow 6 college.ts ranking-mutation endpoints from `Promise<ApiResponse<any>>` → `Promise<ApiResponse<unknown>>`:
  - `updateRanking`, `updateRankingOrder`, `finalizeRanking`, `unfinalizeRanking`, `importRankingExcel`, `deleteRanking`
- Leaves `createRanking` and `reviewApplication` untouched — their consumers in `RankingManagementPanel.tsx` access `response.data.id` / `response.data.ranking_name` / `response.data.redistribution_info`, which would require unsafe casts under \`unknown\`.

## Why this is safe

All six narrowed endpoints have a **single consumer** (`frontend/components/college/ranking/RankingManagementPanel.tsx`), and each consumer only checks `response.success` (and `response.message` for the import path). No site reads structured fields off `response.data`. Test mocks in `lib/api/modules/__tests__/college.test.ts` don't access `response.data` at all.

Closes 6 of the 34 remaining \`any\` sites in college.ts. Follows the email-management precedent from PR #624.

## Test plan

- [x] `tsc --noEmit` clean (full strict, run against worktree with symlinked node_modules) — 0 errors
- [x] Diff scope verified — only 6 return types + 6 \`toApiResponse<>\` generics flipped
- [x] Consumer audit — every \`apiClient.college.{updateRanking,updateRankingOrder,finalizeRanking,unfinalizeRanking,importRankingExcel,deleteRanking}\` call inspected via grep across frontend; all use \`response.success\` only
- [ ] CI green on Quick Checks + Verify OpenAPI Types + frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)