### PR TITLE
chore(frontend): narrow bank-verification any types

### DIFF
--- a/frontend/lib/api/modules/bank-verification.ts
+++ b/frontend/lib/api/modules/bank-verification.ts
@@ -32,7 +32,7 @@ export type BankVerificationResult = {
     };
   };
   form_data?: { [key: string]: string };
-  ocr_data?: { [key: string]: any };
+  ocr_data?: { [key: string]: unknown };
   passbook_document?: {
     file_path: string;
     original_filename: string;
@@ -84,7 +84,12 @@ export type BankVerificationTask = {
   is_completed: boolean;
   is_running: boolean;
   error_message?: string;
-  results?: { [appId: number]: any };
+  results?: { [appId: number]: BankVerificationTaskResult };
+};
+
+export type BankVerificationTaskResult = {
+  status?: string;
+  [key: string]: unknown;
 };
 
 export type BatchVerificationAsyncResponse = {
@@ -194,7 +199,7 @@ export function createBankVerificationApi() {
       status?: string,
       limit: number = 50,
       offset: number = 0
-    ): Promise<ApiResponse<{ tasks: BankVerificationTask[]; pagination: any }>> => {
+    ): Promise<ApiResponse<{ tasks: BankVerificationTask[]; pagination: Record<string, unknown> }>> => {
       const response = await typedClient.raw.GET('/api/v1/admin/bank-verification/tasks', {
         params: {
           query: {
@@ -204,7 +209,7 @@ export function createBankVerificationApi() {
           },
         },
       });
-      return toApiResponse<{ tasks: BankVerificationTask[]; pagination: any }>(response);
+      return toApiResponse<{ tasks: BankVerificationTask[]; pagination: Record<string, unknown> }>(response);
     },
 
     /**


### PR DESCRIPTION
## Summary

Three \`any\` → tighter-type narrowings in \`frontend/lib/api/modules/bank-verification.ts\`:

1. \`BankVerificationResult.ocr_data\`: \`{ [key: string]: any }\` → \`{ [key: string]: unknown }\` — the only consumer (\`bank-verification-review-dialog.tsx:45\`) already declares its local \`ocr_data\` as \`{ [key: string]: unknown }\`, so this just tightens the api-module declaration to match.
2. \`BankVerificationTask.results\`: \`{ [appId: number]: any }\` → new exported \`BankVerificationTaskResult\` type with a known optional \`status\` field plus an index signature for the rest. The sole consumer at \`batch-bank-verification.tsx:62-63\` reads \`.status\`, now typed.
3. \`listVerificationTasks\` return: \`pagination: any\` → \`Record<string, unknown>\`. Function has zero call sites outside the module itself (verified via grep), so this is paper-only.

## Test plan

- [x] \`tsc --noEmit\` clean across the whole frontend
- [x] Consumer audit: \`ocr_data\` (1 site, already unknown), \`results\` (1 site reading \`.status\`), \`listVerificationTasks\` (0 sites)
- [ ] CI green on frontend lint + Verify OpenAPI Types + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)