### PR TITLE
chore(frontend): narrow notifications metadata any → unknown

### DIFF
--- a/frontend/lib/api/modules/notifications.ts
+++ b/frontend/lib/api/modules/notifications.ts
@@ -32,7 +32,7 @@ type NotificationResponse = {
   expires_at?: string;
   read_at?: string;
   created_at: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 };
 
 type AnnouncementCreate = {
@@ -40,7 +40,7 @@ type AnnouncementCreate = {
   message: string;
   notification_type?: string;
   target_roles?: string[];
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 };
 
 export function createNotificationsApi() {


### PR DESCRIPTION
## Summary

Two \`any\` narrowings in \`frontend/lib/api/modules/notifications.ts\`:

- \`NotificationResponse.metadata\`: \`Record<string, any>\` → \`Record<string, unknown>\`
- \`AnnouncementCreate.metadata\`: \`any\` → \`Record<string, unknown>\`

## Why this is safe

The only structured consumer of \`NotificationResponse.metadata\` is \`admin-management-interface.tsx:1019\` which assigns it to \`AnnouncementCreate.metadata\` for the edit form. Both sides narrow together, so the assignment stays well-typed.

No site reads typed fields off metadata (verified via grep for \`.metadata.<identifier>\` across components/app/hooks/lib — the only match is \`roster.metadata.total_records\` which is a different roster.metadata field).

## Test plan

- [x] \`tsc --noEmit\` clean across whole frontend
- [x] Consumer audit complete
- [ ] CI green on frontend lint + Verify OpenAPI Types + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)