### PR TITLE
chore(frontend): narrow application-fields options + manual-distribution body any

### DIFF
--- a/frontend/lib/api/modules/application-fields.ts
+++ b/frontend/lib/api/modules/application-fields.ts
@@ -34,7 +34,7 @@ type ApplicationField = {
   required: boolean;
   display_order: number;
   is_active: boolean;
-  options?: any;
+  options?: unknown;
 };
 
 type ApplicationFieldCreate = Omit<ApplicationField, 'id'>;

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -389,7 +389,7 @@ export function createManualDistributionApi() {
         }
       );
 
-      let body: any = null;
+      let body: unknown = null;
       try {
         body = await response.json();
       } catch {
@@ -397,11 +397,17 @@ export function createManualDistributionApi() {
       }
 
       if (!response.ok) {
+        const bodyObj =
+          body && typeof body === "object"
+            ? (body as { message?: unknown; detail?: unknown })
+            : null;
+        const message =
+          (typeof bodyObj?.message === "string" && bodyObj.message) ||
+          (typeof bodyObj?.detail === "string" && bodyObj.detail) ||
+          `Upload failed (HTTP ${response.status})`;
         return {
           success: false,
-          message:
-            (body && (body.message || body.detail)) ||
-            `Upload failed (HTTP ${response.status})`,
+          message,
           data: undefined,
         } as ApiResponse<{
           matched: number;


### PR DESCRIPTION
## Summary

Two narrowings:

1. \`application-fields.ts:37\` — \`ApplicationField.options: any\` → \`unknown\`. Internal type alias not re-exported (consumers import the canonical type from \`lib/api/types.ts\`); \`.options\` is opaque metadata.
2. \`manual-distribution.ts:392\` — internal \`let body: any = null\` → \`let body: unknown = null\`. Body holds the JSON of the upload error response; the structured \`.message\` / \`.detail\` access is now gated by an explicit type guard.

## Why fields/documents arrays were left

\`ApplicationField.fields: any[]\` and \`.documents: any[]\` were left as-is because narrowing to \`unknown[]\` broke \`ScholarshipApplicationStep.tsx:712-754\` (consumer destructures \`{ fields, documents }\` from \`response.data\` and reads \`.is_active\`, \`.is_required\`, \`.is_fixed\`, \`.field_name\`, \`.document_name\`). A safer narrow needs to lift the canonical types from \`lib/api/types.ts\` into the module — separate follow-up PR.

## Test plan

- [x] \`tsc --noEmit\` clean across whole frontend
- [x] Consumer audit: \`options\` access pattern verified opaque; manual-distribution body access wrapped in type guards
- [ ] CI green on frontend lint + Verify OpenAPI Types + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)