### PR TITLE
chore(frontend): narrow user-profiles index sigs + changes audit any → unknown

### DIFF
--- a/frontend/lib/api/modules/user-profiles.ts
+++ b/frontend/lib/api/modules/user-profiles.ts
@@ -26,18 +26,18 @@ type CompleteUserProfile = {
   bank_document_url?: string;
   advisor_name?: string;
   advisor_email?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 type UserProfile = {
   id: number;
   user_id: number;
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 type UserProfileUpdate = {
   phone?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 type BankInfoUpdate = {
@@ -56,7 +56,7 @@ type ProfileHistory = {
   user_id: number;
   changed_at: string;
   changed_by: number;
-  changes: Record<string, any>;
+  changes: Record<string, unknown>;
 };
 
 export function createUserProfilesApi() {


### PR DESCRIPTION
## Summary

Four \`any\` narrowings in \`frontend/lib/api/modules/user-profiles.ts\`:

- \`CompleteUserProfile.[key: string]: any\` → \`unknown\`
- \`UserProfile.[key: string]: any\` → \`unknown\`
- \`UserProfileUpdate.[key: string]: any\` → \`unknown\`
- \`ProfileHistory.changes: Record<string, any>\` → \`Record<string, unknown>\`

## Why safe

The two real consumers (\`components/user-profile-management.tsx\` and \`hooks/use-student-profile.ts\`) declare their own local \`CompleteUserProfile\` shape and cast via \`as unknown as CompleteUserProfile\`, so the narrowing surfaces no consumer change.

\`ProfileHistory.changes\` is rendered as opaque audit data; no structured access.

The \`profileData as any\` body cast on \`createProfile\`/\`updateProfile\` is retained — it's required because openapi-fetch generates \`Record<string, never>\` for these flexible-shape endpoints (separate openapi generator issue).

## Test plan

- [x] \`tsc --noEmit\` clean across whole frontend
- [x] Consumer audit complete
- [ ] CI green on Verify OpenAPI Types + frontend lint + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)