### PR TITLE
chore(frontend): narrow lib/utils any + fix getTranslation return-type bug

### DIFF
--- a/frontend/lib/__tests__/i18n.test.ts
+++ b/frontend/lib/__tests__/i18n.test.ts
@@ -49,13 +49,10 @@ describe("getTranslation", () => {
 
   it("returns the key when partial path resolves to an object (not a string)", () => {
     /** Truncated dot-path lands on a nested object (e.g., "nav" resolves
-     * to the whole nav dict). The `|| key` fallback applies because
-     * an object is truthy and would otherwise be returned. Pin actual
-     * behavior: object IS returned (the implementation accepts that). */
+     * to the whole nav dict). The function now enforces its declared
+     * `string` return type — non-string resolutions fall back to the key. */
     const result = getTranslation("zh", "nav");
-    // The function returns the truthy intermediate object — pin this
-    // current behavior so a future "must be string" guard surfaces here.
-    expect(typeof result).toBe("object");
+    expect(result).toBe("nav");
   });
 
   it("resolves English equivalent paths", () => {

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -1032,11 +1032,15 @@ export const translations = {
 
 export function getTranslation(locale: "zh" | "en", key: string): string {
   const keys = key.split(".");
-  let value: any = translations[locale];
+  let value: unknown = translations[locale];
 
   for (const k of keys) {
-    value = value?.[k];
+    if (value && typeof value === "object") {
+      value = (value as Record<string, unknown>)[k];
+    } else {
+      value = undefined;
+    }
   }
 
-  return value || key;
+  return typeof value === "string" ? value : key;
 }

--- a/frontend/lib/utils/jwt.ts
+++ b/frontend/lib/utils/jwt.ts
@@ -9,7 +9,7 @@ export interface JWTPayload {
   role: string;
   exp?: number;
   iat?: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related narrowings in the frontend \`lib/\` tier:

1. **lib/utils/jwt.ts:12** — \`JWTPayload.[key: string]: any\` → \`unknown\`. The interface is exported but has no external consumers; the index sig is opaque overflow for unknown JWT claim fields.

2. **lib/i18n.ts:1035** — \`getTranslation()\` declared a \`string\` return but could leak nested-object values when a partial dot-path resolved to an intermediate node. Replaced \`let value: any\` with a type-guarded \`unknown\` traversal that returns the key when value is non-string.

## Test fix

The previous "returns intermediate object" behavior was pinned by a test docstring that explicitly said *"a future 'must be string' guard surfaces here"*. The test now asserts the now-correct key fallback:

\`\`\`typescript
// before: expect(typeof result).toBe("object");
expect(result).toBe("nav");  // getTranslation("zh", "nav") returns "nav" key
\`\`\`

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`jest\` 1138 tests pass (no regressions outside the updated test)
- [ ] CI green on Verify OpenAPI Types + frontend lint + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)