### PR TITLE
chore(frontend): narrow lib/api/types.ts [key: string]: any → unknown (7 sites)

### DIFF
--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -50,7 +50,7 @@ export interface User {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   // Backward compatibility fields
   username?: string; // Maps to nycu_id
@@ -404,7 +404,7 @@ export interface ApplicationCreate {
   agree_terms?: boolean;
   is_renewal?: boolean; // 是否為續領申請
   sub_type_preferences?: string[];
-  [key: string]: any; // 允許動態欄位
+  [key: string]: unknown; // 允許動態欄位
 }
 
 export interface DashboardStats {
@@ -767,7 +767,7 @@ export interface UserListResponse {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   // 向後相容性欄位
   username?: string;
@@ -797,7 +797,7 @@ export interface UserListResponse {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   // 向後相容性欄位
   username?: string;
@@ -826,7 +826,7 @@ export interface UserResponse {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   // 向後相容性欄位
   username?: string;
@@ -857,7 +857,7 @@ export interface UserCreate {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   // 向後相容性欄位
   username?: string;
@@ -881,7 +881,7 @@ export interface UserUpdate {
   raw_data?: {
     chinese_name?: string;
     english_name?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
   // 向後相容性欄位
   username?: string;


### PR DESCRIPTION
## Summary

Narrowed all 7 \`[key: string]: any\` index signatures in \`frontend/lib/api/types.ts\` to \`unknown\`:

| Interface | Field |
|---|---|
| \`User\` | \`raw_data.[key: string]\` |
| \`UserListResponse\` | \`raw_data.[key: string]\` |
| \`UserResponse\` | \`raw_data.[key: string]\` |
| \`UserCreate\` | \`raw_data.[key: string]\` |
| \`UserUpdate\` | \`raw_data.[key: string]\` |
| \`ApplicationCreate\` | top-level \`[key: string]: any // 允許動態欄位\` |

All consumers across the frontend tree only access the explicit typed fields (\`chinese_name\`, \`english_name\`); the \`[key: string]\` overflow is opaque metadata. Narrowing to \`unknown\` forces type guards on any future structured access.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`jest\` 1138 tests pass (no regressions)
- [ ] CI green on Verify OpenAPI Types + frontend lint + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)