### PR TITLE
chore(frontend): narrow application-helpers any → structural types

### DIFF
--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -80,9 +80,26 @@ const hasReachedStage = (currentStage: string | undefined, targetStage: string):
   return currentOrder >= targetOrder;
 };
 
+// Structural shape consumed by the helpers below. Matches the canonical
+// Application interface plus the review-stage extensions surfaced by the
+// /applications/{id} backend response.
+type ApplicationTimelineInput = {
+  status: string;
+  review_stage?: string;
+  professor_reviews?: Array<{ reviewed_at?: string }>;
+  application_reviews?: Array<{ review_stage?: string; reviewed_at?: string }>;
+  professor?: { name?: string; nycu_id?: string };
+  requires_professor_recommendation?: boolean;
+  requires_college_review?: boolean;
+  submitted_at?: string;
+  created_at?: string;
+  approved_at?: string;
+  reviewed_at?: string;
+};
+
 // 獲取申請時間軸
 export const getApplicationTimeline = (
-  application: any,
+  application: ApplicationTimelineInput,
   locale: Locale
 ): TimelineStep[] => {
   const status = application.status as ApplicationStatus;
@@ -172,7 +189,7 @@ export const getApplicationTimeline = (
         id: "professor_submitted",
         title: locale === "zh" ? "教授已送出審核" : "Professor Review Submitted",
         status: getStepStatus("professor_reviewed", afterProfessorStage, hasProfessorReview),
-        date: hasProfessorReview ? formatDate(professorReview.reviewed_at, locale) : "",
+        date: hasProfessorReview ? formatDate(professorReview?.reviewed_at, locale) : "",
       },
     );
   }
@@ -196,7 +213,7 @@ export const getApplicationTimeline = (
         id: "college_submitted",
         title: locale === "zh" ? "學院已送出審核" : "College Review Submitted",
         status: getStepStatus("college_reviewed", "admin_review", hasCollegeReview),
-        date: hasCollegeReview ? formatDate(collegeReview.reviewed_at, locale) : "",
+        date: hasCollegeReview ? formatDate(collegeReview?.reviewed_at, locale) : "",
       },
     );
   }
@@ -246,7 +263,7 @@ export const shouldShowReviewStage = (
 
 // 獲取顯示狀態 - 返回狀態和階段的組合資訊
 export const getDisplayStatusInfo = (
-  application: any,
+  application: { status: string; review_stage?: string },
   locale: Locale
 ): {
   showStatus: boolean;
@@ -351,7 +368,7 @@ export const formatDisplayValue = (value: unknown): string => {
 
 export const formatFieldValue = async (
   fieldName: string,
-  value: any,
+  value: unknown,
   locale: Locale
 ) => {
   if (fieldName === "scholarship_type") {


### PR DESCRIPTION
## Summary

Three \`any\` narrowings in \`frontend/lib/utils/application-helpers.ts\`:

1. \`getApplicationTimeline(application: any)\` → typed \`ApplicationTimelineInput\` shape covering all 9 accessed fields (status, review_stage, professor_reviews[], application_reviews[], professor.name/nycu_id, requires_professor_recommendation, requires_college_review, submitted_at / created_at / approved_at / reviewed_at).

2. \`getDisplayStatusInfo(application: any)\` → typed \`{ status: string; review_stage?: string }\`.

3. \`formatFieldValue(value: any)\` → \`value: unknown\`. Comparison \`s.code === value\` works on unknown and the fallback returns value as-is.

## Latent-bug fix

Added optional chaining on \`professorReview?.reviewed_at\` and \`collegeReview?.reviewed_at\` since the new types make these properly nullable. The previous \`any\` silently swallowed the possibility — these were both \`Array.find()\` results that can be undefined.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`jest\` 1138 tests pass (no regressions)
- [ ] CI green on Verify OpenAPI Types + frontend lint + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)