### PR TITLE
SECURITY: gate /nycu-employee/* behind require_admin

### DIFF
--- a/backend/app/api/v1/endpoints/nycu_employee.py
+++ b/backend/app/api/v1/endpoints/nycu_employee.py
@@ -4,10 +4,11 @@ NYCU Employee API endpoints.
 
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.core.cache import cached
+from app.core.security import require_admin
 from app.integrations.nycu_emp import (
     NYCUEmpAuthenticationError,
     NYCUEmpConnectionError,
@@ -19,7 +20,10 @@ from app.integrations.nycu_emp import (
     create_nycu_emp_client_from_env,
 )
 
-router = APIRouter()
+# SECURITY: All NYCU employee directory endpoints expose internal staff PII
+# (names, departments, positions, employee numbers). Gate the entire router
+# behind admin authentication — no public access to the directory.
+router = APIRouter(dependencies=[Depends(require_admin)])
 
 
 class EmployeeListResponse(BaseModel):


### PR DESCRIPTION
## Summary

The NYCU employee directory endpoints (\`/api/v1/nycu-employee/employees\`, \`/employees/all\`, \`/employees/search\`, \`/employees/{employee_no}\`) were mounted on a bare \`APIRouter()\` with no auth dependency. **Anonymous internet users could enumerate staff PII** (names, departments, positions, employee numbers) by hitting any of these paths.

## Resolution

Add \`dependencies=[Depends(require_admin)]\` at the router level so every endpoint requires an authenticated admin/super_admin JWT.

The \`admin/cache.py\` (\`refresh_nycu_employee_cache\`) and \`admin/dashboard.py\` (\`debug_nycu_employee_api\`) routes that proxy the same NYCU upstream **already use \`require_admin\` individually** — this aligns the public router with their convention.

## Why safe to ship

- **Frontend impact: zero.** The generated openapi schema references these paths but no \`frontend/lib/api/\` module or component actually calls them. \`grep -rn "nycu-employee\\|nycuEmployee" frontend/\` returns only references in \`schema.d.ts\`.
- **Test impact: zero.** \`backend/app/tests/test_nycu_employee_*.py\` only assert model serialization and don't hit the endpoints via \`TestClient\`, so no test updates required.

## Test plan

- [x] \`black --check --line-length=120\` clean
- [x] \`flake8 --max-line-length=120\` clean
- [x] Consumer audit: zero frontend callers
- [x] Test audit: no TestClient hits on these paths
- [ ] CI green on backend lint + backend tests + Backend Security

🤖 Generated with [Claude Code](https://claude.com/claude-code)