### PR TITLE
SECURITY: require auth + ownership/role check on bank document serving

### DIFF
--- a/backend/app/api/v1/endpoints/user_profiles.py
+++ b/backend/app/api/v1/endpoints/user_profiles.py
@@ -8,14 +8,14 @@ import logging
 import os
 from typing import Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import FileResponse, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.path_security import validate_filename_strict
-from app.core.security import get_current_user, require_admin
+from app.core.security import get_current_user, require_admin, verify_token
 from app.db.deps import get_db
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.schemas.user_profile import (
     AdvisorInfoUpdate,
     BankDocumentPhotoUpload,
@@ -25,6 +25,7 @@ from app.schemas.user_profile import (
     UserProfileResponse,
     UserProfileUpdate,
 )
+from app.services.auth_service import AuthService
 from app.services.ocr_service import get_ocr_service
 from app.services.user_profile_service import UserProfileService
 
@@ -319,10 +320,40 @@ async def delete_my_profile(current_user: User = Depends(get_current_user), db: 
 
 
 @router.get("/files/bank_documents/{filename}")
-async def get_bank_document(filename: str, db: AsyncSession = Depends(get_db)):
-    """Serve bank documents from MinIO"""
+async def get_bank_document(
+    filename: str,
+    # JWTs from this system are dot-separated base64url segments. Constrain
+    # length + charset at the FastAPI layer so malformed / oversized strings
+    # 422 before they reach verify_token().
+    token: Optional[str] = Query(None, description="Access token", max_length=2048, pattern=r"^[A-Za-z0-9._-]+$"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Serve bank documents from MinIO.
+
+    SECURITY: Bank passbook photos are highly sensitive PII (account
+    numbers, holder names). Requires:
+    1. A valid JWT (passed via ?token=... since browsers can't set
+       Authorization headers on <img src> / <iframe src>).
+    2. The requesting user must own the document OR be an authorized
+       reviewer (professor with student relationship, college, admin,
+       super_admin).
+    """
     # SECURITY: Comprehensive filename validation (CLAUDE.md triple validation)
     validate_filename_strict(filename, allow_unicode=True)
+
+    # SECURITY: Verify JWT before any database lookups or filesystem access.
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Access token required")
+    try:
+        payload = verify_token(token)
+        user_id = int(payload.get("sub"))
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+
+    auth_service = AuthService(db)
+    current_user = await auth_service.get_user_by_id(user_id)
+    if not current_user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
 
     try:
         # Try to serve from MinIO first (new approach)
@@ -339,6 +370,24 @@ async def get_bank_document(filename: str, db: AsyncSession = Depends(get_db)):
         profile = result.scalar_one_or_none()
 
         if profile:
+            # SECURITY: Ownership / role gate. Owners pass; reviewers and admins pass.
+            is_owner = profile.user_id == current_user.id
+            is_admin = current_user.role in (UserRole.admin, UserRole.super_admin, UserRole.college)
+            is_authorized_professor = current_user.role == UserRole.professor and current_user.can_access_student_data(
+                profile.user_id, "view_applications"
+            )
+            if not (is_owner or is_admin or is_authorized_professor):
+                logger.warning(
+                    "SECURITY: unauthorized bank document access attempt",
+                    extra={
+                        "requester_user_id": current_user.id,
+                        "requester_role": str(current_user.role),
+                        "owner_user_id": profile.user_id,
+                        "filename": filename,
+                    },
+                )
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
             # Try to construct the MinIO object path
             # Format: user-profiles/{user_id}/bank-documents/{filename}
             object_name = f"user-profiles/{profile.user_id}/bank-documents/{filename}"
@@ -371,7 +420,22 @@ async def get_bank_document(filename: str, db: AsyncSession = Depends(get_db)):
                 # If MinIO fails, try fallback to local storage
                 pass
 
-        # Fallback to local storage (backward compatibility)
+        # Fallback to local storage (backward compatibility for legacy files
+        # uploaded before MinIO migration). The MinIO path above performed
+        # explicit ownership / role checks via the matching UserProfile row;
+        # the legacy local-storage path has no per-file ownership metadata,
+        # so SECURITY: only admin/college/super_admin reviewers may reach it.
+        if current_user.role not in (UserRole.admin, UserRole.super_admin, UserRole.college):
+            logger.warning(
+                "SECURITY: non-admin role attempted legacy bank document access",
+                extra={
+                    "requester_user_id": current_user.id,
+                    "requester_role": str(current_user.role),
+                    "filename": filename,
+                },
+            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="證明文件不存在")
+
         upload_base = os.environ.get("UPLOAD_BASE_DIR", "uploads")
         bank_docs_dir = os.environ.get("BANK_DOCUMENTS_DIR", "bank_documents")
         storage_directory = os.path.join(upload_base, bank_docs_dir)

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4022,7 +4022,15 @@ export interface paths {
         };
         /**
          * Get Bank Document
-         * @description Serve bank documents from MinIO
+         * @description Serve bank documents from MinIO.
+         *
+         *     SECURITY: Bank passbook photos are highly sensitive PII (account
+         *     numbers, holder names). Requires:
+         *     1. A valid JWT (passed via ?token=... since browsers can't set
+         *        Authorization headers on <img src> / <iframe src>).
+         *     2. The requesting user must own the document OR be an authorized
+         *        reviewer (professor with student relationship, college, admin,
+         *        super_admin).
          */
         get: operations["get_bank_document_api_v1_user_profiles_files_bank_documents__filename__get"];
         put?: never;
@@ -17014,7 +17022,10 @@ export interface operations {
     };
     get_bank_document_api_v1_user_profiles_files_bank_documents__filename__get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Access token */
+                token?: string | null;
+            };
             header?: never;
             path: {
                 filename: string;


### PR DESCRIPTION
## Summary

\`GET /api/v1/user-profiles/files/bank_documents/{filename}\` previously had **NO authentication or authorization**. Anyone who knew or guessed a filename could retrieve another user's bank passbook photo (account number, holder name) — a serious PII leak.

The frontend Next.js proxies at \`/api/v1/download\` and \`/api/v1/preview\` already pass \`?token=...\` for this endpoint (matching the \`files.py\` pattern), so adding the token verification surfaces no client-side change.

## Resolution

Mirrors the pattern in \`backend/app/api/v1/endpoints/files.py\`:

1. **Token validation** via \`verify_token\` + \`AuthService.get_user_by_id\` (401 on missing/invalid)
2. **Ownership / role gate** on the MinIO path: \`profile.user_id == current_user.id\` OR \`admin/super_admin/college\` OR \`professor\` with student relationship via \`can_access_student_data()\`
3. **Legacy local-storage fallback path** also gated (admin/super_admin/college only) since it has no per-file ownership metadata
4. **SECURITY warning log** on unauthorized attempts with requester/owner IDs for audit-trail correlation

## Test plan

- [x] \`black --check --line-length=120\` clean
- [x] \`flake8 --max-line-length=120\` clean
- [x] Frontend audit: confirmed \`Authorization: Bearer\` + \`?token=\` already sent by \`frontend/app/api/v1/download/route.ts\` and \`/preview/route.ts\`
- [x] Test audit: no TestClient hits on this endpoint
- [ ] CI green on backend lint + backend tests + Backend Security

🤖 Generated with [Claude Code](https://claude.com/claude-code)