### PR TITLE
fix(frontend): merge duplicate experimental blocks in next.config.mjs

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -21,12 +21,6 @@ const nextConfig = {
     removeConsole: process.env.NODE_ENV === 'production' ? true : false,
   },
 
-  // Experimental features for better performance
-  experimental: {
-    // Enable optimizePackageImports for faster dev builds
-    optimizePackageImports: ['lucide-react', '@radix-ui/react-icons'],
-  },
-
   // Webpack optimization for development performance
   webpack: (config, { dev, isServer }) => {
     if (dev) {
@@ -60,10 +54,12 @@ const nextConfig = {
     return config;
   },
 
-  // Enable experimental features for better performance
+  // Experimental features for better performance
   experimental: {
     // Use worker threads for webpack builds (faster compilation)
     webpackBuildWorker: true,
+    // Faster dev builds via package-level import optimization
+    optimizePackageImports: ['lucide-react', '@radix-ui/react-icons'],
   },
 
   // API Proxy for development environment


### PR DESCRIPTION
## Summary

\`frontend/next.config.mjs\` declared \`experimental\` twice (L25-28 and L64-67). JS object literal evaluation keeps only the last duplicate key, so the **first** \`experimental\` block — containing \`optimizePackageImports: ['lucide-react', '@radix-ui/react-icons']\` — was silently dropped at config load. The intended dev-build speedup **never took effect** since whenever \`webpackBuildWorker\` was added later.

## Fix

Merged both into a single \`experimental\` block:

\`\`\`javascript
experimental: {
  webpackBuildWorker: true,
  optimizePackageImports: ['lucide-react', '@radix-ui/react-icons'],
},
\`\`\`

## Verification

\`\`\`bash
$ node -e "import('./next.config.mjs').then(m => console.log(JSON.stringify(m.default.experimental)))"
{"webpackBuildWorker":true,"optimizePackageImports":["lucide-react","@radix-ui/react-icons"]}
\`\`\`

Both keys now land on the final \`experimental\` object (previously the bottom block won and \`optimizePackageImports\` was \`undefined\`).

## Impact

Dev-time imports of \`lucide-react\` and \`@radix-ui/react-icons\` will now be tree-shaken per-icon rather than pulling the full barrel — measurable rebuild-speed improvement.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Config import verified — both flags merged
- [ ] CI green on Frontend Tests + frontend-lint + Build Frontend with Generated Types

🤖 Generated with [Claude Code](https://claude.com/claude-code)