### PR TITLE
chore(frontend): narrow getHistoricalApplications filters any → HistoricalApplicationFilters

### DIFF
--- a/frontend/lib/api/modules/admin.ts
+++ b/frontend/lib/api/modules/admin.ts
@@ -17,7 +17,7 @@
 
 import { typedClient } from '../typed-client';
 import { toApiResponse } from '../compat';
-import type { ApiResponse } from '../types';
+import type { ApiResponse, HistoricalApplicationFilters } from '../types';
 
 export function createAdminApi() {
   return {
@@ -90,7 +90,9 @@ export function createAdminApi() {
      * Get historical applications with filters
      * Type-safe: Query parameters validated against OpenAPI
      */
-    getHistoricalApplications: async (filters?: any): Promise<ApiResponse<any>> => {
+    getHistoricalApplications: async (
+      filters?: HistoricalApplicationFilters
+    ): Promise<ApiResponse<any>> => {
       const response = await typedClient.raw.GET('/api/v1/admin/applications/history', {
         params: {
           query: {


### PR DESCRIPTION
## Summary

\`frontend/lib/api/modules/admin.ts:93\` — replace \`filters?: any\` with the canonical \`HistoricalApplicationFilters\` type already exported from \`lib/api/types.ts:1087\`. The function reads exactly the same 7 fields the interface declares (\`page, size, status, scholarship_type, academic_year, semester, search\`) so the narrow surfaces no consumer changes.

Both consumers (\`admin-management-interface.tsx:857\`, \`HistoryPanel.tsx:130\`) pass plain objects that satisfy the interface shape — verified via tsc.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Consumer audit: both callers' filter shapes match the interface
- [ ] CI green on Verify OpenAPI Types + frontend lint + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)