### PR TITLE
chore(frontend): enable tsc + eslint build errors in next.config

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,10 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // SECURITY / PRODUCTION-READINESS: Surface ESLint warnings and TypeScript
+  // errors at build time so they fail the deploy pipeline instead of
+  // silently shipping. The repo's CI also runs `tsc --noEmit` in the
+  // "Verify OpenAPI Types are Up-to-Date" workflow as a backstop, but
+  // these flags add a second guardrail directly to the `next build` path
+  // (used by the "Build Frontend with Generated Types" CI job).
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary

\`frontend/next.config.mjs\` had **\`ignoreDuringBuilds: true\` (eslint)** and **\`ignoreBuildErrors: true\` (typescript)** — both silenced production-build failures. \`next build\` would happily ship type errors and ESLint violations.

## Why safe to flip

Verified locally before changing the flags:
- \`./node_modules/.bin/tsc --noEmit\` → **0 errors**
- \`next lint\` → "No ESLint warnings or errors"

So the current main is already clean enough to build under strict mode. Flipping both to \`false\` adds a second guardrail inside the build path itself, catching any regression that slips past the existing "Verify OpenAPI Types are Up-to-Date" CI workflow (which runs strict \`tsc --noEmit\`).

## Production-readiness impact

| Before | After |
|---|---|
| TS errors silent in build | TS errors fail \`next build\` |
| ESLint warnings silent in build | ESLint warnings fail \`next build\` |
| Single CI checkpoint (\`Verify OpenAPI Types\`) | Two CI checkpoints |

## Test plan

- [x] \`tsc --noEmit\` clean on main HEAD
- [x] \`next lint\` clean on main HEAD
- [ ] CI green on Build Frontend with Generated Types + Verify OpenAPI Types + frontend lint + Frontend Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)