### PR TITLE
SECURITY: audit-log scholarship-rule deletions

### DIFF
--- a/backend/app/api/v1/endpoints/admin/rules.py
+++ b/backend/app/api/v1/endpoints/admin/rules.py
@@ -280,8 +280,34 @@ async def delete_scholarship_rule(
     # Check permission to manage this scholarship
     check_scholarship_permission(current_user, rule.scholarship_type_id)
 
+    # Capture audit fields before the row is gone — once the rule row is
+    # deleted, the audit context (which scholarship, which rule, which
+    # academic period) is unrecoverable.
+    target_scholarship_type_id = rule.scholarship_type_id
+    target_rule_code = getattr(rule, "rule_code", None) or getattr(rule, "code", None)
+    target_academic_year = getattr(rule, "academic_year", None)
+    target_semester = getattr(rule, "semester", None)
+    if hasattr(target_semester, "value"):
+        target_semester = target_semester.value
+
     await db.delete(rule)
     await db.commit()
+
+    # Scholarship rules govern eligibility decisions — deletion changes
+    # which students qualify for which awards. Audit trail is required
+    # to investigate disputes after the fact.
+    logger.info(
+        "scholarship rule deleted",
+        extra={
+            "actor_user_id": current_user.id,
+            "actor_role": str(current_user.role),
+            "rule_id": id,
+            "scholarship_type_id": target_scholarship_type_id,
+            "rule_code": target_rule_code,
+            "academic_year": target_academic_year,
+            "semester": target_semester,
+        },
+    )
 
     return {
         "success": True,


### PR DESCRIPTION
## Summary

\`DELETE /api/v1/admin/scholarship-rules/{id}\` hard-deletes eligibility-governing rules with **no logging**. Once a rule row is gone the context (which scholarship, which rule code, which academic period) is unrecoverable from the DB — so the audit trail has to be captured at the application layer before commit.

## Changes (additive, no schema/behavior modification)

1. **Capture pre-delete fields**: \`scholarship_type_id\`, \`rule_code\`, \`academic_year\`, \`semester\` (with enum-value coercion) from the rule row before the delete commits.
2. **logger.info post-commit** with \`{actor_user_id, actor_role, rule_id, ...captured fields...}\` — gives the forensic trail tying the deletion to the admin user and the affected eligibility context.

## Why this matters

Scholarship rules govern who qualifies for which awards. A rule deletion changes eligibility decisions retroactively (for re-evaluations) or going forward — disputes will require the audit trail to investigate "who removed this rule, when, for which year."

Pattern matches prior audit-instrumentation PRs:
- PR #501 (scholarship_rules.py service-level instrumentation)
- PR #502 (users.py destructive endpoints)
- PR #503 (pre_authorization.py access-control logging)
- PR #645 (admin/scholarship-permissions CREATE/DELETE)

## Test plan

- [x] \`black --check --line-length=120\` clean on touched file
- [x] \`flake8\` clean on touched file
- [x] Diff is purely additive (26 insertions, 0 deletions)
- [ ] CI green on Backend Tests + Backend Security + backend-lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)