### PR TITLE
fix(admin): return 501 for broken scholarship-email-templates endpoints (#647)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/email_templates.py
+++ b/backend/app/api/v1/endpoints/admin/email_templates.py
@@ -120,20 +120,45 @@ async def get_email_templates(
     return [EmailTemplateSchema.model_validate(template) for template in templates]
 
 
+# NOTE (issue #647): the scholarship-email-templates endpoint family was
+# wired up against a service API that does not exist. Each handler below
+# calls a method (get_scholarship_templates, get_template/2-arg,
+# create_template, update_template, delete_template) that is NOT defined
+# on EmailTemplateService — only get_template/1-arg, set_template, and
+# get_or_create_template exist. Worse, EmailTemplate has no
+# scholarship_type_id column, so a per-scholarship template row cannot
+# even be persisted under the current schema.
+#
+# Until a follow-up PR adds (a) the scholarship_type_id column via Alembic
+# migration and (b) the missing service methods, return a clean
+# 501 Not Implemented instead of a confusing 500 AttributeError. This:
+#   - stops the false 5xx spike on the BackendErrorSpike alert
+#   - gives clients an actionable response code instead of a stack trace
+#   - leaves the API surface visible in the OpenAPI schema so the
+#     frontend can flag callsites at design time
+
+
+_SCHOLARSHIP_TEMPLATES_NOT_IMPLEMENTED_DETAIL = (
+    "Per-scholarship email templates are not currently implemented " "(tracked in issue #647)."
+)
+
+
+def _raise_scholarship_email_templates_not_implemented() -> None:
+    """Single source for the 501 raise so all six endpoints agree."""
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail=_SCHOLARSHIP_TEMPLATES_NOT_IMPLEMENTED_DETAIL,
+    )
+
+
 @router.get("/scholarship-email-templates/{scholarship_type_id}")
 async def get_scholarship_email_templates(
     scholarship_type_id: int,
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get all email templates for a scholarship type"""
-    service = EmailTemplateService(db)
-    templates = await service.get_scholarship_templates(scholarship_type_id)
-    return {
-        "success": True,
-        "message": "Email templates retrieved successfully",
-        "data": templates,
-    }
+    """[Not implemented — see issue #647] Get all email templates for a scholarship type."""
+    _raise_scholarship_email_templates_not_implemented()
 
 
 @router.get("/scholarship-email-templates/{scholarship_type_id}/{template_key}")
@@ -143,14 +168,8 @@ async def get_scholarship_email_template(
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get a specific email template"""
-    service = EmailTemplateService(db)
-    template = await service.get_template(scholarship_type_id, template_key)
-    return {
-        "success": True,
-        "message": "Email template retrieved successfully",
-        "data": template,
-    }
+    """[Not implemented — see issue #647] Get a specific email template."""
+    _raise_scholarship_email_templates_not_implemented()
 
 
 @router.post("/scholarship-email-templates")
@@ -159,14 +178,8 @@ async def create_scholarship_email_template(
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Create a new email template"""
-    service = EmailTemplateService(db)
-    template = await service.create_template(template_data)
-    return {
-        "success": True,
-        "message": "Email template created successfully",
-        "data": template,
-    }
+    """[Not implemented — see issue #647] Create a new email template."""
+    _raise_scholarship_email_templates_not_implemented()
 
 
 @router.put("/scholarship-email-templates/{scholarship_type_id}/{template_key}")
@@ -177,14 +190,8 @@ async def update_scholarship_email_template(
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update an email template"""
-    service = EmailTemplateService(db)
-    template = await service.update_template(scholarship_type_id, template_key, template_data)
-    return {
-        "success": True,
-        "message": "Email template updated successfully",
-        "data": template,
-    }
+    """[Not implemented — see issue #647] Update an email template."""
+    _raise_scholarship_email_templates_not_implemented()
 
 
 @router.delete("/scholarship-email-templates/{scholarship_type_id}/{template_key}")
@@ -194,13 +201,8 @@ async def delete_scholarship_email_template(
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Delete an email template"""
-    service = EmailTemplateService(db)
-    await service.delete_template(scholarship_type_id, template_key)
-    return {
-        "success": True,
-        "message": "Email template deleted successfully",
-    }
+    """[Not implemented — see issue #647] Delete an email template."""
+    _raise_scholarship_email_templates_not_implemented()
 
 
 @router.post("/scholarship-email-templates/{scholarship_type_id}/bulk-create")
@@ -210,17 +212,8 @@ async def bulk_create_scholarship_email_templates(
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Bulk create email templates"""
-    service = EmailTemplateService(db)
-    created_templates = []
-    for template_data in templates:
-        template = await service.create_template(template_data)
-        created_templates.append(template)
-    return {
-        "success": True,
-        "message": f"{len(created_templates)} email templates created successfully",
-        "data": created_templates,
-    }
+    """[Not implemented — see issue #647] Bulk create email templates."""
+    _raise_scholarship_email_templates_not_implemented()
 
 
 @router.get("/scholarship-email-templates/{scholarship_type_id}/available")

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -1874,7 +1874,7 @@ export interface paths {
         };
         /**
          * Get Scholarship Email Templates
-         * @description Get all email templates for a scholarship type
+         * @description [Not implemented — see issue #647] Get all email templates for a scholarship type.
          */
         get: operations["get_scholarship_email_templates_api_v1_admin_scholarship_email_templates__scholarship_type_id__get"];
         put?: never;
@@ -1894,18 +1894,18 @@ export interface paths {
         };
         /**
          * Get Scholarship Email Template
-         * @description Get a specific email template
+         * @description [Not implemented — see issue #647] Get a specific email template.
          */
         get: operations["get_scholarship_email_template_api_v1_admin_scholarship_email_templates__scholarship_type_id___template_key__get"];
         /**
          * Update Scholarship Email Template
-         * @description Update an email template
+         * @description [Not implemented — see issue #647] Update an email template.
          */
         put: operations["update_scholarship_email_template_api_v1_admin_scholarship_email_templates__scholarship_type_id___template_key__put"];
         post?: never;
         /**
          * Delete Scholarship Email Template
-         * @description Delete an email template
+         * @description [Not implemented — see issue #647] Delete an email template.
          */
         delete: operations["delete_scholarship_email_template_api_v1_admin_scholarship_email_templates__scholarship_type_id___template_key__delete"];
         options?: never;
@@ -1924,7 +1924,7 @@ export interface paths {
         put?: never;
         /**
          * Create Scholarship Email Template
-         * @description Create a new email template
+         * @description [Not implemented — see issue #647] Create a new email template.
          */
         post: operations["create_scholarship_email_template_api_v1_admin_scholarship_email_templates_post"];
         delete?: never;
@@ -1944,7 +1944,7 @@ export interface paths {
         put?: never;
         /**
          * Bulk Create Scholarship Email Templates
-         * @description Bulk create email templates
+         * @description [Not implemented — see issue #647] Bulk create email templates.
          */
         post: operations["bulk_create_scholarship_email_templates_api_v1_admin_scholarship_email_templates__scholarship_type_id__bulk_create_post"];
         delete?: never;


### PR DESCRIPTION
## Summary

The \`scholarship-email-templates\` endpoint family (6 routes) is **architecturally broken**:

| Endpoint | Calls method | Status |
|---|---|---|
| \`GET /scholarship-email-templates/{scholarship_type_id}\` | \`service.get_scholarship_templates\` | missing |
| \`GET /scholarship-email-templates/{scholarship_type_id}/{template_key}\` | \`service.get_template(2-arg)\` | missing (only \`get_template(db, key)\` exists) |
| \`POST /scholarship-email-templates\` | \`service.create_template\` | missing |
| \`PUT /scholarship-email-templates/{scholarship_type_id}/{template_key}\` | \`service.update_template\` | missing |
| \`DELETE /scholarship-email-templates/{scholarship_type_id}/{template_key}\` | \`service.delete_template\` | missing |
| \`POST /scholarship-email-templates/{scholarship_type_id}/bulk-create\` | \`service.create_template\` (in loop) | missing |

Worse, \`EmailTemplate\` has **no \`scholarship_type_id\` column**, so per-scholarship rows can't be persisted under the current schema. Every call currently 500s with an \`AttributeError\` stack trace.

## What this PR does

Converts all 6 broken handlers to return a clean **\`501 Not Implemented\`** with a single-source detail message pointing at issue #647 for the real fix (Alembic migration + service-method implementation).

## Why ship 501 now rather than wait for full fix

- **Stops admins seeing internal Python tracebacks** in the response body
- **Stops false-positive 5xx spikes** from polluting the \`BackendErrorSpike\` alert noise floor
- **Preserves the API surface** in OpenAPI for frontend type generation
- **Gives a discoverable, actionable response code** — clients can branch on 501

## Out of scope (for issue #647 to handle)

- \`scholarship_type_id\` column migration on \`email_templates\` table
- Real \`EmailTemplateService.{create,update,delete,get,get_scholarship}\_template\` implementations
- Audit logging on the destructive paths (will follow PR #645 / #646 pattern)

## Endpoints NOT affected

- \`GET /scholarship-email-templates/{scholarship_type_id}/available\` — returns a static list, works correctly, untouched.
- All non-scholarship template endpoints (\`/email-template\`, \`/email-templates\`, \`/scholarship-email-templates/{scholarship_type_id}/available\`) — untouched.

## Test plan

- [x] \`black --check --line-length=120\` clean
- [x] \`flake8 --max-line-length=120\` clean
- [x] Diff is purely safe-replacement (no new imports, no schema changes)
- [ ] CI green on Backend Tests + Backend Security + backend-lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)