### PR TITLE
fix(api): return 501 for 3 endpoints calling missing service methods (#649)

### DIFF
--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -305,26 +305,16 @@ async def get_application_sub_types(
     current_user: User = Depends(require_professor),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get available sub-types for an application (config-driven)"""
-    logger.info("Professor {current_user.id} requesting sub-types for application {application_id}")
+    """[Not implemented - see issue #649] Get available sub-types for an application.
 
-    try:
-        service = ApplicationService(db)
-        sub_types = await service.get_application_available_sub_types(application_id)
-
-        logger.info("Found {len(sub_types)} sub-types for application {application_id}")
-        return {
-            "success": True,
-            "message": "查詢成功",
-            "data": sub_types,
-        }
-
-    except Exception as e:
-        logger.exception("Error fetching application sub-types")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="An internal error occurred while fetching sub-types",
-        ) from e
+    Calls ``ApplicationService.get_application_available_sub_types`` which is
+    not defined on the service. Returns 501 to stop the false 500 spike until
+    the role-filtering rules are designed (tracked in issue #649).
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Per-application sub-type listing is not currently implemented (tracked in issue #649).",
+    )
 
 
 @router.get("/stats")

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -639,35 +639,15 @@ async def get_application_reviewable_sub_types(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    """[Not implemented - see issue #649] Get reviewable sub-types for an application.
+
+    Intended to return sub-types filtered by reviewer role (professor: all;
+    college: not rejected by professor; admin: not rejected by professor or
+    college). Calls ``ApplicationService.get_application_available_sub_types``
+    which is not defined on the service. Returns 501 until the role-filtering
+    rules are designed (tracked in issue #649).
     """
-    Get reviewable sub-types for an application (multi-role)
-
-    Returns sub-types that the current user is authorized to review,
-    with localized labels (zh/en) from database configuration.
-
-    Role-based filtering:
-    - Professor: all sub-types
-    - College: sub-types not rejected by professor
-    - Admin: sub-types not rejected by professor or college
-    """
-    logger.info(f"User {current_user.id} ({current_user.role}) requesting sub-types for application {application_id}")
-
-    try:
-        from app.services.application_service import ApplicationService
-
-        service = ApplicationService(db)
-        sub_types = await service.get_application_available_sub_types(application_id)
-
-        logger.info(f"Found {len(sub_types)} sub-types for application {application_id}")
-        return {
-            "success": True,
-            "message": "查詢成功",
-            "data": sub_types,
-        }
-
-    except Exception as e:
-        logger.exception("Error fetching application sub-types")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="An internal error occurred while fetching sub-types",
-        ) from e
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Per-application reviewable sub-type listing is not currently implemented (tracked in issue #649).",
+    )

--- a/backend/app/api/v1/endpoints/scholarship_management.py
+++ b/backend/app/api/v1/endpoints/scholarship_management.py
@@ -13,7 +13,7 @@ Major changes:
 import logging
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,51 +39,21 @@ async def create_comprehensive_application(
     current_user: User = Depends(require_student),
     db: AsyncSession = Depends(get_db),
 ):
-    """Create a comprehensive scholarship application with all new features"""
-    from sqlalchemy.orm import sessionmaker
+    """[Not implemented - see issue #649] Create a comprehensive scholarship application.
 
-    from app.services.application_service import get_student_data_from_user
-
-    # Convert AsyncSession to regular Session for our service
-    sync_session = sessionmaker(bind=db.bind)()
-
-    try:
-        student = await get_student_data_from_user(current_user)
-        if not student:
-            raise HTTPException(status_code=404, detail="Student profile not found")
-
-        service = ScholarshipApplicationService(sync_session)
-
-        application, message = service.create_application(
-            user_id=current_user.id,
-            student_id=current_user.id,
-            scholarship_type_id=application_data["scholarship_type_id"],
-            scholarship_type_code=application_data["scholarship_type_code"],
-            semester=application_data["semester"],
-            academic_year=application_data["academic_year"],
-            application_data=application_data.get("form_data", {}),
-            is_renewal=application_data.get("is_renewal", False),
-            previous_application_id=application_data.get("previous_application_id"),
-        )
-
-        return ApiResponse(
-            success=True,
-            message=message,
-            data={
-                "application_id": application.id,
-                "app_id": application.app_id,
-                "scholarship_type_id": application.scholarship_type_id,
-                "sub_type": application.sub_scholarship_type,
-                "is_renewal": application.is_renewal,
-            },
-        )
-
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Application creation failed: {str(e)}") from e
-    finally:
-        sync_session.close()
+    Calls ``ScholarshipApplicationService.create_application`` which has been
+    commented out (see ``app/services/scholarship_service.py:385``) with the
+    note that application creation moved to ``ApplicationService`` with
+    external API integration. The new signature is incompatible with this
+    endpoint's renewal-aware contract, so callers must migrate to
+    ``POST /api/v1/applications/`` and the renewal flow on
+    ``ApplicationService`` instead. Returns 501 until a migration plan is
+    decided (tracked in issue #649).
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="The comprehensive create endpoint is not currently implemented (tracked in issue #649). Use POST /api/v1/applications/ instead.",
+    )
 
 
 @router.post("/applications/{application_id}/submit-comprehensive")

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -2587,7 +2587,16 @@ export interface paths {
         put?: never;
         /**
          * Create Comprehensive Application
-         * @description Create a comprehensive scholarship application with all new features
+         * @description [Not implemented - see issue #649] Create a comprehensive scholarship application.
+         *
+         *     Calls ``ScholarshipApplicationService.create_application`` which has been
+         *     commented out (see ``app/services/scholarship_service.py:385``) with the
+         *     note that application creation moved to ``ApplicationService`` with
+         *     external API integration. The new signature is incompatible with this
+         *     endpoint's renewal-aware contract, so callers must migrate to
+         *     ``POST /api/v1/applications/`` and the renewal flow on
+         *     ``ApplicationService`` instead. Returns 501 until a migration plan is
+         *     decided (tracked in issue #649).
          */
         post: operations["create_comprehensive_application_api_v1_scholarship_management_applications_create_comprehensive_post"];
         delete?: never;
@@ -4332,7 +4341,11 @@ export interface paths {
         };
         /**
          * Get Application Sub Types
-         * @description Get available sub-types for an application (config-driven)
+         * @description [Not implemented - see issue #649] Get available sub-types for an application.
+         *
+         *     Calls ``ApplicationService.get_application_available_sub_types`` which is
+         *     not defined on the service. Returns 501 to stop the false 500 spike until
+         *     the role-filtering rules are designed (tracked in issue #649).
          */
         get: operations["get_application_sub_types_api_v1_professor_applications__application_id__sub_types_get"];
         put?: never;
@@ -5032,15 +5045,13 @@ export interface paths {
         };
         /**
          * Get Application Reviewable Sub Types
-         * @description Get reviewable sub-types for an application (multi-role)
+         * @description [Not implemented - see issue #649] Get reviewable sub-types for an application.
          *
-         *     Returns sub-types that the current user is authorized to review,
-         *     with localized labels (zh/en) from database configuration.
-         *
-         *     Role-based filtering:
-         *     - Professor: all sub-types
-         *     - College: sub-types not rejected by professor
-         *     - Admin: sub-types not rejected by professor or college
+         *     Intended to return sub-types filtered by reviewer role (professor: all;
+         *     college: not rejected by professor; admin: not rejected by professor or
+         *     college). Calls ``ApplicationService.get_application_available_sub_types``
+         *     which is not defined on the service. Returns 501 until the role-filtering
+         *     rules are designed (tracked in issue #649).
          */
         get: operations["get_application_reviewable_sub_types_api_v1_reviews_applications__application_id__sub_types_get"];
         put?: never;


### PR DESCRIPTION
## Summary

Following PR #648 (issue #647 mitigation for scholarship-email-templates), an AST-based audit surfaced three more endpoints that raise `AttributeError` at runtime because the service methods they call do not exist. Converts each handler to return `501 Not Implemented` so the false 5xx spike stops, callers see a clear response code, and the endpoints remain visible in the OpenAPI schema for design-time flagging. Tracked in issue #649.

## Affected endpoints

- `GET /professor/applications/{application_id}/sub-types` calls `ApplicationService.get_application_available_sub_types` — method is not defined on the service.
- `GET /reviews/applications/{application_id}/sub-types` — same missing method on `ApplicationService`.
- `POST /scholarship-management/applications/create-comprehensive` calls `ScholarshipApplicationService.create_application` — the method has been commented out (see `backend/app/services/scholarship_service.py:385`) and the replacement on `ApplicationService` has a different, renewal-incompatible signature. Mechanical swap is unsafe.

## What changed

- 3 endpoint handlers replaced with single `raise HTTPException(status_code=501, detail=...)` plus a docstring linking to #649.
- `frontend/lib/api/generated/schema.d.ts` updated to match the new docstrings so the Verify OpenAPI Types CI check stays green.
- Added `status` to the fastapi import in `scholarship_management.py` (was previously only used inside function scope via a Query alias).

## Why 501 instead of fix-in-place

- The two `*/sub-types` endpoints have a complete handler design (role-filtering for professor/college/admin reviewers) but no service implementation — that is a feature to build, not a bug to fix.
- The comprehensive-create endpoint depended on a renewal-aware service API that has been deliberately removed in favor of the external-API-integrated flow on `ApplicationService`. The endpoint contract has no surviving counterpart.

Mirrors the mitigation pattern from PR #648.

## Test plan

- [ ] CI green (black 26.3.1, flake8, pytest)
- [ ] Verify OpenAPI Types check passes (schema.d.ts pre-synced in this PR)
- [ ] Build Frontend with Generated Types check passes
- [ ] CodeQL clean
- [ ] Manual: hit each endpoint -> expect `501 Not Implemented` with issue link in detail