### PR TITLE
fix(api): 501 for scholarship_management.py async-on-sync-session endpoints (#651)

### DIFF
--- a/backend/app/api/v1/endpoints/scholarship_management.py
+++ b/backend/app/api/v1/endpoints/scholarship_management.py
@@ -23,7 +23,6 @@ from app.models.application import Application, ApplicationStatus
 from app.models.scholarship import ScholarshipStatus, ScholarshipType
 from app.models.user import User
 from app.schemas.response import ApiResponse
-from app.services.scholarship_service import ScholarshipApplicationService
 from app.utils.scholarship_helpers import get_distinct_sub_types
 
 logger = logging.getLogger(__name__)
@@ -62,24 +61,21 @@ async def submit_comprehensive_application(
     current_user: User = Depends(require_student),
     db: AsyncSession = Depends(get_db),
 ):
-    """Submit application with comprehensive workflow management"""
-    from sqlalchemy.orm import sessionmaker
+    """[Not implemented - see issue #651] Submit application with comprehensive workflow management.
 
-    sync_session = sessionmaker(bind=db.bind)()
-
-    try:
-        service = ScholarshipApplicationService(sync_session)
-        success, message = service.submit_application(application_id)
-
-        if not success:
-            raise HTTPException(status_code=400, detail=message)
-
-        return ApiResponse(success=True, message=message, data={"application_id": application_id})
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Submission failed: {str(e)}") from e
-    finally:
-        sync_session.close()
+    Calls ``ScholarshipApplicationService.submit_application`` (async) on a
+    synchronously-constructed session, without ``await``. The service body
+    uses ``await self.db.execute(...)`` / ``await self.db.commit()`` which
+    fails against a sync session, and the missing ``await`` would yield a
+    coroutine that cannot be tuple-unpacked into ``(success, message)``.
+    Returns 501 until the service interface is reconciled with the endpoint
+    (tracked in issue #651). Use ``POST /api/v1/applications/{id}/submit``
+    on ``ApplicationService`` instead.
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="The comprehensive submit endpoint is not currently implemented (tracked in issue #651). Use POST /api/v1/applications/{id}/submit instead.",
+    )
 
 
 @router.get("/applications/by-priority")
@@ -91,74 +87,19 @@ async def get_applications_by_priority(
     current_user: User = Depends(require_staff),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get applications ordered by priority score"""
-    from sqlalchemy.orm import sessionmaker
+    """[Not implemented - see issue #651] Get applications ordered by priority score.
 
-    sync_session = sessionmaker(bind=db.bind)()
-
-    try:
-        service = ScholarshipApplicationService(sync_session)
-
-        # Convert string status to enum if provided
-        status_enum = None
-        if status:
-            try:
-                status_enum = ApplicationStatus(status)
-            except ValueError as e:
-                raise HTTPException(status_code=400, detail=f"Invalid status: {status}") from e
-
-        applications = service.get_applications_by_priority(
-            scholarship_type_id=scholarship_type_id,
-            semester=semester,
-            status=status_enum,
-            limit=limit,
-        )
-
-        application_data = []
-        for app in applications:
-            application_data.append(
-                {
-                    "id": app.id,
-                    "app_id": app.app_id,
-                    "student_id": app.student_id,
-                    "scholarship_type_id": app.scholarship_type_id,
-                    "sub_type": app.sub_scholarship_type,
-                    "is_renewal": app.is_renewal,
-                    "status": app.status,
-                    "submitted_at": app.submitted_at.isoformat() if app.submitted_at else None,
-                    "review_deadline": app.review_deadline.isoformat() if app.review_deadline else None,
-                    "is_overdue": app.is_overdue,
-                }
-            )
-
-        return ApiResponse(
-            success=True,
-            message=f"Retrieved {len(applications)} applications",
-            data={
-                "applications": application_data,
-                "total": len(applications),
-                "filters": {
-                    "scholarship_type_id": scholarship_type_id,
-                    "semester": semester,
-                    "status": status,
-                },
-            },
-        )
-
-    except Exception as e:
-        logger.exception(
-            "Failed to retrieve applications by priority",
-            extra={
-                "scholarship_type_id": scholarship_type_id,
-                "semester": semester,
-                "status": status,
-                "limit": limit,
-                "actor_user_id": current_user.id,
-            },
-        )
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve applications: {str(e)}") from e
-    finally:
-        sync_session.close()
+    Calls ``ScholarshipApplicationService.get_applications_by_priority`` (async)
+    on a synchronously-constructed session, without ``await``. The service body
+    uses ``await self.db.execute(...)`` which fails against a sync session, and
+    the missing ``await`` would yield a coroutine that cannot be iterated.
+    Returns 501 until the service interface is reconciled with the endpoint
+    (tracked in issue #651).
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="The applications-by-priority endpoint is not currently implemented (tracked in issue #651).",
+    )
 
 
 # Renewal Processing Endpoints
@@ -170,41 +111,19 @@ async def process_renewal_applications(
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Process renewal applications with priority"""
-    from sqlalchemy.orm import sessionmaker
+    """[Not implemented - see issue #651] Process renewal applications with priority.
 
-    sync_session = sessionmaker(bind=db.bind)()
-
-    try:
-        service = ScholarshipApplicationService(sync_session)
-        result = service.process_renewal_applications_first(semester)
-
-        logger.warning(
-            "Renewal applications processed for semester=%s by admin user_id=%s",
-            semester,
-            current_user.id,
-            extra={
-                "semester": semester,
-                "actor_user_id": current_user.id,
-                "result_summary": result if isinstance(result, (dict, list)) else str(result),
-            },
-        )
-
-        return ApiResponse(
-            success=True,
-            message="Renewal applications processed successfully",
-            data=result,
-        )
-
-    except Exception as e:
-        logger.exception(
-            "Renewal-applications processing failed for semester=%s",
-            semester,
-            extra={"semester": semester, "actor_user_id": current_user.id},
-        )
-        raise HTTPException(status_code=500, detail=f"Failed to process renewals: {str(e)}") from e
-    finally:
-        sync_session.close()
+    Calls ``ScholarshipApplicationService.process_renewal_applications_first``
+    (async) on a synchronously-constructed session, without ``await``. The
+    service body uses ``await self.db.execute(...)`` which fails against a
+    sync session, and the missing ``await`` would yield a coroutine that is
+    serialized in place of the expected result dict. Returns 501 until the
+    service interface is reconciled with the endpoint (tracked in issue #651).
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="The renewal-priority processing endpoint is not currently implemented (tracked in issue #651).",
+    )
 
 
 # Analytics and Dashboard Endpoints

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -2616,7 +2616,16 @@ export interface paths {
         put?: never;
         /**
          * Submit Comprehensive Application
-         * @description Submit application with comprehensive workflow management
+         * @description [Not implemented - see issue #651] Submit application with comprehensive workflow management.
+         *
+         *     Calls ``ScholarshipApplicationService.submit_application`` (async) on a
+         *     synchronously-constructed session, without ``await``. The service body
+         *     uses ``await self.db.execute(...)`` / ``await self.db.commit()`` which
+         *     fails against a sync session, and the missing ``await`` would yield a
+         *     coroutine that cannot be tuple-unpacked into ``(success, message)``.
+         *     Returns 501 until the service interface is reconciled with the endpoint
+         *     (tracked in issue #651). Use ``POST /api/v1/applications/{id}/submit``
+         *     on ``ApplicationService`` instead.
          */
         post: operations["submit_comprehensive_application_api_v1_scholarship_management_applications__application_id__submit_comprehensive_post"];
         delete?: never;
@@ -2634,7 +2643,14 @@ export interface paths {
         };
         /**
          * Get Applications By Priority
-         * @description Get applications ordered by priority score
+         * @description [Not implemented - see issue #651] Get applications ordered by priority score.
+         *
+         *     Calls ``ScholarshipApplicationService.get_applications_by_priority`` (async)
+         *     on a synchronously-constructed session, without ``await``. The service body
+         *     uses ``await self.db.execute(...)`` which fails against a sync session, and
+         *     the missing ``await`` would yield a coroutine that cannot be iterated.
+         *     Returns 501 until the service interface is reconciled with the endpoint
+         *     (tracked in issue #651).
          */
         get: operations["get_applications_by_priority_api_v1_scholarship_management_applications_by_priority_get"];
         put?: never;
@@ -2656,7 +2672,14 @@ export interface paths {
         put?: never;
         /**
          * Process Renewal Applications
-         * @description Process renewal applications with priority
+         * @description [Not implemented - see issue #651] Process renewal applications with priority.
+         *
+         *     Calls ``ScholarshipApplicationService.process_renewal_applications_first``
+         *     (async) on a synchronously-constructed session, without ``await``. The
+         *     service body uses ``await self.db.execute(...)`` which fails against a
+         *     sync session, and the missing ``await`` would yield a coroutine that is
+         *     serialized in place of the expected result dict. Returns 501 until the
+         *     service interface is reconciled with the endpoint (tracked in issue #651).
          */
         post: operations["process_renewal_applications_api_v1_scholarship_management_renewals_process_priority_post"];
         delete?: never;


### PR DESCRIPTION
## Summary

Audit follow-up to PR #650 / issue #651. An AST pass that flags `var.method(...)` calls where `method` is `async def` on the service class but the call site lacks `await` surfaced three endpoints in `scholarship_management.py` that are double-broken:

1. The service methods (`submit_application`, `get_applications_by_priority`, `process_renewal_applications_first`) are `async def` on `ScholarshipApplicationService` and internally use `await self.db.execute(...)` plus `await self.db.commit()`.
2. The endpoints construct a synchronous `Session` via `sessionmaker(bind=db.bind)()` and pass that to the service.
3. The endpoints call `service.method(...)` without `await`.

Runtime consequences:
- Tuple-unpacking a coroutine raises `TypeError`.
- `len(applications)` on a coroutine raises `TypeError`.
- Sync sessions cannot drive `await self.db.execute(...)` anyway.
- Every call lands in the generic `except -> 500` path.

Converts each handler to `501 Not Implemented` with a docstring explaining the breakage and linking to #651 — same mitigation pattern as PR #648/#650.

## Affected endpoints

| File:line (pre-fix) | Endpoint | Service method |
|---------------------|----------|----------------|
| `scholarship_management.py:72` | `POST /scholarship-management/applications/{id}/submit-comprehensive` | `submit_application` |
| `scholarship_management.py:110` | `GET /scholarship-management/applications/by-priority` | `get_applications_by_priority` |
| `scholarship_management.py:180` | `POST /scholarship-management/renewals/process-priority` | `process_renewal_applications_first` |

## What changed

- 3 endpoint handlers replaced with `raise HTTPException(status_code=501, detail=...)`.
- Unused `from app.services.scholarship_service import ScholarshipApplicationService` import dropped (no live call sites remain after this PR).
- `frontend/lib/api/generated/schema.d.ts` pre-synced so `Verify OpenAPI Types` stays green.

## Why 501 instead of fix-in-place

The fix is not mechanical:
- Drop the sync session and use the injected `AsyncSession db` directly.
- Add `await` in 3 call sites.
- **Audit service internals** — methods like `_validate_application_documents` and `_create_initial_review` may themselves invoke sync helpers on what is now an async session.

That third bullet is the catch: until a service-internals audit confirms the whole call tree is async-clean, swapping in `await db.execute(...)` would just move the breakage one level deeper.

## Test plan

- [ ] CI green (black 26.3.1, flake8, pytest)
- [ ] Verify OpenAPI Types check passes (schema.d.ts pre-synced)
- [ ] Build Frontend with Generated Types check passes
- [ ] CodeQL clean
- [ ] Manual: hit each endpoint -> expect `501 Not Implemented` with `#651` link in detail