### PR TITLE
chore(lint): clear F841 + F811 flake8 violations in endpoint files

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -473,7 +473,7 @@ async def delete_application(
                 else deleted_app.model_dump() if hasattr(deleted_app, "model_dump") else {"id": id}
             ),
         }
-    except Exception as e:
+    except Exception:
         logger.exception(f"Error deleting application {id}")
         raise
 

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -14,7 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_admin_user, get_db
 from app.db.deps import get_sync_db
-from app.models.college_review import CollegeRanking, ManualDistributionHistory
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.services.manual_distribution_service import ManualDistributionService
 
@@ -334,8 +335,6 @@ async def get_distribution_summary(
     """
     from sqlalchemy import and_, or_
     from sqlalchemy.orm import selectinload
-    from app.models.college_review import CollegeRanking, CollegeRankingItem
-    from app.models.application import Application
 
     try:
         # 取得已完成分發的排名
@@ -517,9 +516,6 @@ async def import_received_months(
     """Import received months from Excel for students in a distribution."""
     import openpyxl
     from io import BytesIO
-
-    from app.models.college_review import CollegeRanking, CollegeRankingItem
-    from app.models.application import Application
 
     # Validate file type
     if not file.filename or not file.filename.endswith(".xlsx"):


### PR DESCRIPTION
## Summary

flake8 with `F401,F811,F821,F823,F841` selectors flagged 3 production-code violations across 2 endpoint files (rest were in tests).

## What changed

- `applications.py:476`  F841 — `except Exception as e` where `e` is never used (the bare `raise` rethrows the active exception). Drop `as e`.
- `manual_distribution.py:337, 521`  F811 — redundant function-local imports of `CollegeRanking` that shadow the module-level import on line 17. Promote `CollegeRankingItem` and `Application` to module-level imports (they were only imported inside the two affected functions) and remove the duplicated local imports.

## Why

These are dead-code lint warnings that would normally be suppressed but indicate either:
1. A missing logger call (would have been `logger.error(f\"...{e}\")` — but the code uses bare `raise` correctly), or
2. Drift between repeated function-local imports — easy for refactors to miss one site and leave inconsistencies.

Promoting to module-level imports gives a single source of truth for the model imports in `manual_distribution.py`.

## Test plan

- [ ] black 26.3.1 clean
- [ ] flake8 `--select=F401,F811,F821,F823,F841` clean on the two files
- [ ] CI green