### PR TITLE
chore(tests): drop 14 unused-variable bindings (F841) across 6 test files

### DIFF
--- a/backend/app/tests/test_application_audit_service_deep.py
+++ b/backend/app/tests/test_application_audit_service_deep.py
@@ -129,19 +129,19 @@ async def test_multiple_audits_for_same_application_are_distinct_rows(db: AsyncS
     admin = await _seed_user(db, nycu_id="audit_multi")
     service = ApplicationAuditService(db)
 
-    log1 = await service.log_application_operation(
+    await service.log_application_operation(
         application_id=15,
         action=AuditAction.submit,
         user=admin,
         description="first",
     )
-    log2 = await service.log_application_operation(
+    await service.log_application_operation(
         application_id=15,
         action=AuditAction.approve,
         user=admin,
         description="second",
     )
-    log3 = await service.log_application_operation(
+    await service.log_application_operation(
         application_id=15,
         action=AuditAction.update,
         user=admin,

--- a/backend/app/tests/test_bank_verification_task_state_machine.py
+++ b/backend/app/tests/test_bank_verification_task_state_machine.py
@@ -73,7 +73,7 @@ class TestCreateTask:
 
         with patch("app.services.bank_verification_task_service.BankVerificationTask") as task_cls:
             task_cls.side_effect = lambda **kw: SimpleNamespace(**kw)
-            result = await service.create_task(application_ids=[1, 2, 3], created_by_user_id=42)
+            await service.create_task(application_ids=[1, 2, 3], created_by_user_id=42)
             # task_id passed to BankVerificationTask ctor must be a UUID string
             kwargs = task_cls.call_args.kwargs
             assert len(kwargs["task_id"]) == 36  # uuid4 string format

--- a/backend/app/tests/test_get_user_notifications_deep.py
+++ b/backend/app/tests/test_get_user_notifications_deep.py
@@ -91,8 +91,8 @@ async def _seed_system(
 @pytest.mark.asyncio
 async def test_returns_both_personal_and_system_notifications(db: AsyncSession):
     user = await _seed_user(db, nycu_id="getnotif_mix")
-    p = await _seed_personal(db, user_id=user.id, title="personal-mix")
-    s = await _seed_system(db, title="system-mix")
+    await _seed_personal(db, user_id=user.id, title="personal-mix")
+    await _seed_system(db, title="system-mix")
 
     service = NotificationService(db)
     result = await service.getUserNotifications(user.id)
@@ -120,10 +120,10 @@ async def test_unread_only_excludes_read_personal_and_announcements(db: AsyncSes
     user = await _seed_user(db, nycu_id="getnotif_unread")
     # Personal: 1 unread, 1 read.
     await _seed_personal(db, user_id=user.id, title="p_unread")
-    p_read = await _seed_personal(db, user_id=user.id, title="p_read", is_read=True)
+    await _seed_personal(db, user_id=user.id, title="p_read", is_read=True)
 
     # System: 1 unread, 1 marked read via NotificationRead.
-    s_unread = await _seed_system(db, title="s_unread")
+    await _seed_system(db, title="s_unread")
     s_marked = await _seed_system(db, title="s_marked")
     db.add(NotificationRead(notification_id=s_marked.id, user_id=user.id))
     await db.commit()
@@ -167,9 +167,9 @@ async def test_excludes_expired_notifications(db: AsyncSession):
 async def test_is_read_field_reflects_underlying_state(db: AsyncSession):
     """Personal: is_read column. System: NotificationRead row presence."""
     user = await _seed_user(db, nycu_id="getnotif_isread")
-    p_unread = await _seed_personal(db, user_id=user.id, title="p_isread_no")
-    p_read = await _seed_personal(db, user_id=user.id, title="p_isread_yes", is_read=True)
-    s_unread = await _seed_system(db, title="s_isread_no")
+    await _seed_personal(db, user_id=user.id, title="p_isread_no")
+    await _seed_personal(db, user_id=user.id, title="p_isread_yes", is_read=True)
+    await _seed_system(db, title="s_isread_no")
     s_read = await _seed_system(db, title="s_isread_yes")
     db.add(NotificationRead(notification_id=s_read.id, user_id=user.id))
     await db.commit()

--- a/backend/app/tests/test_manual_distribution_finalize.py
+++ b/backend/app/tests/test_manual_distribution_finalize.py
@@ -114,7 +114,7 @@ async def test_finalize_keeps_status_for_non_allocated_apps(db: AsyncSession):
 
     # Act
     service = ManualDistributionService(db)
-    summary = await service.finalize(sch.id, 114, Semester.first.value)
+    await service.finalize(sch.id, 114, Semester.first.value)
 
     # Assert — allocated path
     await db.refresh(app_a)

--- a/backend/app/tests/test_professor_review_stats.py
+++ b/backend/app/tests/test_professor_review_stats.py
@@ -165,7 +165,7 @@ async def test_stats_reviewed_app_moves_from_pending_to_completed(db: AsyncSessi
         status=ApplicationStatus.submitted.value,
         suffix="s1",
     )
-    app2 = await _seed_app(
+    await _seed_app(
         db,
         student=student,
         professor=professor,

--- a/backend/app/tests/test_settings_schemas.py
+++ b/backend/app/tests/test_settings_schemas.py
@@ -52,7 +52,7 @@ def test_system_setting_is_public_defaults_to_false():
 def test_system_setting_create_inherits_base_fields():
     # Pin: Create is a thin alias of Base (no extra fields). Don't
     # widen silently.
-    fields = set(SystemSettingCreate_fields := SystemSettingBase.model_fields.keys())
+    fields = set(SystemSettingBase.model_fields.keys())
     assert fields == {"key", "value", "description", "is_public", "category"}
 
 


### PR DESCRIPTION
## Summary

flake8 with `--select=F841` flagged 14 unused local bindings in pure-test code. Each binding's right-hand side has the side effect the test relies on (DB insert via the helper's commit, or mock setup via the constructor), so dropping the binding leaves behavior identical and the test contracts unchanged.

After this PR, `flake8 --select=F841 app/tests/` is clean.

## What changed

| File | Count | Notes |
|------|-------|-------|
| `test_application_audit_service_deep.py` | 3 | `log1/log2/log3 = await service.log_application_operation(...)` — assertions read AuditLog rows via `select()`, not the bindings |
| `test_bank_verification_task_state_machine.py` | 1 | `result = await service.create_task(...)` — assertions use `task_cls.call_args.kwargs`, not `result` |
| `test_get_user_notifications_deep.py` | 7 | `p`, `s`, `p_read`, `s_unread`, `p_unread`, `p_read`, `s_unread` — assertions use `titles` / `by_title` lookups |
| `test_manual_distribution_finalize.py` | 1 | `summary = await service.finalize(...)` — assertions read `app_a.status`, `app_a.quota_allocation_status` after refresh |
| `test_professor_review_stats.py` | 1 | `app2 = await _seed_app(...)` — second seeded app never referenced |
| `test_settings_schemas.py` | 1 | `set(SystemSettingCreate_fields := ...)` walrus — the walrus binding is dead; the outer `set(...)` is captured into `fields` |

## Why

Companion to PR #653 (production F841/F811 in endpoint files). With both PRs landed, `flake8 --select=F401,F811,F821,F823,F841` is clean across `backend/app/`.

## Test plan

- [ ] flake8 `--select=F841` clean on `app/tests/`
- [ ] black 26.3.1 unchanged
- [ ] All affected tests still pass