### PR TITLE
SECURITY: bump PyJWT 2.9.0 -> 2.12.0 in pyproject.toml

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -122,7 +122,7 @@ dependencies = [
     "greenlet>=3.0,<4",  # Required by SQLAlchemy sync engine
     
     # Authentication and Security
-    "PyJWT[crypto]==2.9.0",
+    "PyJWT[crypto]==2.12.0",  # Match requirements.txt; closes Dependabot alert #40 (high)
     "passlib[bcrypt]==1.7.4",
     "bcrypt==4.2.1",
     "cryptography==46.0.7",


### PR DESCRIPTION
## Summary

Closes Dependabot alert **#40** (high severity): \"PyJWT accepts unknown \`crit\` header extensions\" (vulnerable_version_range \`<= 2.11.0\`, first_patched_version \`2.12.0\`).

## Why pyproject.toml only

The runtime install pins \`PyJWT==2.12.0\` in \`backend/requirements.txt\` (the file actually used at deploy and CI install time), so production already runs the patched version. But Dependabot scans \`backend/pyproject.toml\`, which still listed \`2.9.0\` from an earlier pyproject migration. The alert has stayed open against the repo despite the runtime being fine.

Bumping the pyproject pin to match closes the alert without any runtime behavior change (the resolved version is already \`2.12.0\` via requirements.txt). Documented inline with a pointer to the alert so future drift between the two pin sites is visible.

## Test plan

- [ ] CI green (no install or test changes needed since requirements.txt is unchanged)
- [ ] Dependabot alert #40 auto-closes after merge