### PR TITLE
SECURITY: audit-log bulk PII export endpoint (college_review/export-package)

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/export_package.py
+++ b/backend/app/api/v1/endpoints/college_review/export_package.py
@@ -5,6 +5,7 @@ Generates and streams a ZIP file containing application materials
 organized by department for college review.
 """
 
+import logging
 from typing import Optional
 from urllib.parse import quote
 
@@ -20,6 +21,8 @@ from app.services.minio_service import MinIOService
 
 from ._helpers import _check_academic_year_permission, _check_scholarship_permission, normalize_semester_value
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 
@@ -31,16 +34,31 @@ async def export_application_package(
     current_user: User = Depends(require_roles(UserRole.college, UserRole.admin, UserRole.super_admin)),
     db: AsyncSession = Depends(get_db),
 ):
-    """Download a ZIP package of all application materials for a scholarship period."""
+    """Download a ZIP package of all application materials for a scholarship period.
 
+    SECURITY: Bulk PII export. Every call is audit-logged with the actor's
+    user_id and role, scholarship/period filters, and the resulting file
+    size. 403 (permission-denied) paths are also logged at warning level
+    so repeated denials can be flagged as potential bypass attempts.
+    """
     # Normalize semester using shared helper (handles "yearly" → None, enum values, etc.)
     semester = normalize_semester_value(semester)
 
+    log_extra = {
+        "actor_user_id": current_user.id,
+        "actor_role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+        "scholarship_type_id": scholarship_type_id,
+        "academic_year": academic_year,
+        "semester": semester,
+    }
+
     # Permission checks
     if not await _check_scholarship_permission(current_user, scholarship_type_id, db):
+        logger.warning("export-package denied: scholarship permission missing", extra=log_extra)
         raise HTTPException(status_code=403, detail="無權限存取此獎學金類型")
 
     if not await _check_academic_year_permission(current_user, academic_year, db):
+        logger.warning("export-package denied: academic-year permission missing", extra=log_extra)
         raise HTTPException(status_code=403, detail="無權限存取此學年度")
 
     # Determine college_code for filtering
@@ -56,7 +74,20 @@ async def export_application_package(
             college_code=college_code,
         )
     except ValueError as e:
+        logger.warning("export-package rejected: %s", e, extra=log_extra)
         raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.exception("export-package zip generation failed", extra=log_extra)
+        raise HTTPException(status_code=500, detail="匯出檔案產生失敗") from e
+
+    file_size = zip_buffer.getbuffer().nbytes
+    logger.info(
+        "export-package issued: filename=%s size_bytes=%d college_code=%s",
+        zip_filename,
+        file_size,
+        college_code,
+        extra={**log_extra, "filename": zip_filename, "size_bytes": file_size, "college_code": college_code},
+    )
 
     encoded_filename = quote(zip_filename)
 
@@ -65,6 +96,6 @@ async def export_application_package(
         media_type="application/zip",
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
-            "Content-Length": str(zip_buffer.getbuffer().nbytes),
+            "Content-Length": str(file_size),
         },
     )

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4875,6 +4875,11 @@ export interface paths {
         /**
          * Export Application Package
          * @description Download a ZIP package of all application materials for a scholarship period.
+         *
+         *     SECURITY: Bulk PII export. Every call is audit-logged with the actor's
+         *     user_id and role, scholarship/period filters, and the resulting file
+         *     size. 403 (permission-denied) paths are also logged at warning level
+         *     so repeated denials can be flagged as potential bypass attempts.
          */
         get: operations["export_application_package_api_v1_college_review_export_package_get"];
         put?: never;


### PR DESCRIPTION
## Summary

The \`/college-review/export-package\` endpoint streams a ZIP of every applicant's review materials for a given scholarship/year/semester. It's a **bulk PII export** gated only by role + per-scholarship + per-academic-year permission checks. Until now it had **zero observability**:

- No \`logger\` configured.
- No log on the 200 success path → no audit trail for who downloaded which package.
- No log on the two 403 permission-denied paths → no signal for bypass-attempt patterns.
- No catch-all \`except\` → any non-\`ValueError\` raised by \`ExportPackageService\` or \`MinIOService\` would bubble up to the global handler with no endpoint-local context.

## What changed

1. Module-level \`logger = logging.getLogger(__name__)\`.
2. \`logger.warning(...)\` on both 403 paths with \`actor_user_id\`, \`actor_role\`, \`scholarship_type_id\`, \`academic_year\`, \`semester\` — SOC can now flag repeated denials.
3. \`logger.warning(...)\` on 400 (ValueError from the service) and \`logger.exception(...) + 500\` on any other exception, both with the same audit context and traceback preservation.
4. \`logger.info(...)\` on the success path with \`filename\`, \`size_bytes\`, \`college_code\` — the canonical "who exported what" audit row.

The 500-path exception preserves the chain via \`from e\` (B904 clean).

## Behavior change

None. Same response codes, same body, same headers — just observability that was missing.

## Test plan

- [ ] CI green (black 26.3.1, flake8 with F4xx/B904)
- [ ] Manual sanity (post-merge, staging): hit the endpoint as college role → look for `export-package issued` log row with the matching `actor_user_id` and `size_bytes`