### PR TITLE
SECURITY: audit-log admin/system-setting PUT mutations

### DIFF
--- a/backend/app/api/v1/endpoints/admin/system_settings.py
+++ b/backend/app/api/v1/endpoints/admin/system_settings.py
@@ -4,6 +4,8 @@ Admin System Settings API Endpoints
 Handles system-level configuration settings
 """
 
+import logging
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,6 +14,8 @@ from app.db.deps import get_db
 from app.models.user import User
 from app.schemas.common import SystemSettingSchema
 from app.services.system_setting_service import SystemSettingService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -41,8 +45,33 @@ async def get_system_setting(
 async def set_system_setting(
     data: SystemSettingSchema, current_user: User = Depends(require_admin), db: AsyncSession = Depends(get_db)
 ):
-    """Update system setting (admin only)"""
+    """Update system setting (admin only).
+
+    SECURITY: System-config mutation. Audit-logged with actor_user_id /
+    actor_role / key / value-length so any unexpected change to runtime
+    settings (e.g., feature flags, integration toggles) is traceable
+    back to an admin actor.
+    """
+    # Capture pre-existing value so the audit row can show old -> new.
+    previous = await SystemSettingService.get_setting(db, data.key)
+    previous_value = previous.value if previous is not None else None
+
     setting = await SystemSettingService.set_setting(db, key=data.key, value=data.value)
+
+    logger.info(
+        "system-setting updated: key=%s by user_id=%s",
+        data.key,
+        current_user.id,
+        extra={
+            "actor_user_id": current_user.id,
+            "actor_role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            "setting_key": data.key,
+            "previous_value_len": len(previous_value) if previous_value is not None else None,
+            "new_value_len": len(data.value) if data.value is not None else 0,
+            "previous_existed": previous is not None,
+        },
+    )
+
     return {
         "success": True,
         "message": "System setting updated successfully",

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -1193,7 +1193,12 @@ export interface paths {
         get: operations["get_system_setting_api_v1_admin_system_setting_get"];
         /**
          * Set System Setting
-         * @description Update system setting (admin only)
+         * @description Update system setting (admin only).
+         *
+         *     SECURITY: System-config mutation. Audit-logged with actor_user_id /
+         *     actor_role / key / value-length so any unexpected change to runtime
+         *     settings (e.g., feature flags, integration toggles) is traceable
+         *     back to an admin actor.
          */
         put: operations["set_system_setting_api_v1_admin_system_setting_put"];
         post?: never;


### PR DESCRIPTION
## Summary

\`backend/app/api/v1/endpoints/admin/system_settings.py\` defines a \`PUT /system-setting\` endpoint that lets an admin mutate any system-config row by key. The file had **zero observability**:

- No logger configured at module level.
- No log on the success path → no audit trail for "who changed which setting from what to what."
- The read path (GET) is similarly silent, but reads are low-stakes — only the mutation path is in scope for this PR.

## What changed

1. Module-level \`logger = logging.getLogger(__name__)\`.
2. Pre-read of the existing setting via \`SystemSettingService.get_setting\` so the audit row captures whether a previous value existed and how long it was — **without dumping the raw value** (settings can hold integration tokens or other sensitive material).
3. \`logger.info(...)\` on the success path with:
   - \`actor_user_id\`, \`actor_role\`
   - \`setting_key\`, \`previous_value_len\`, \`new_value_len\`, \`previous_existed\`

   The key is the audit primitive; values stay log-redacted by virtue of only logging their length.

The GET path is intentionally left without per-call logging — read operations on admin config are not the same audit-trail signal as mutations.

## Behavior change

None. Same response shape, same status codes.

## Test plan

- [ ] CI green (black 26.3.1, flake8 with F4xx/B904)
- [ ] Manual sanity (post-merge): \`PUT /api/v1/admin/system-setting\` → look for \`system-setting updated: key=... by user_id=...\` log row