### PR TITLE
SECURITY: audit-log admin/announcements mutations (CREATE / UPDATE / DELETE)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/announcements.py
+++ b/backend/app/api/v1/endpoints/admin/announcements.py
@@ -128,6 +128,19 @@ async def create_announcement(
     await db.commit()
     await db.refresh(announcement)
 
+    logger.info(
+        "system-announcement created: id=%s title=%r by user_id=%s",
+        announcement.id,
+        announcement.title,
+        current_user.id,
+        extra={
+            "actor_user_id": current_user.id,
+            "actor_role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            "announcement_id": announcement.id,
+            "announcement_title": announcement.title,
+        },
+    )
+
     # 修正 meta_data 字段以確保序列化正常
     announcement_dict = {
         "id": announcement.id,
@@ -250,6 +263,21 @@ async def update_announcement(
     await db.commit()
     await db.refresh(announcement)
 
+    logger.info(
+        "system-announcement updated: id=%s title=%r by user_id=%s fields=%s",
+        announcement.id,
+        announcement.title,
+        current_user.id,
+        sorted(update_data.keys()) if update_data else [],
+        extra={
+            "actor_user_id": current_user.id,
+            "actor_role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            "announcement_id": announcement.id,
+            "announcement_title": announcement.title,
+            "updated_fields": sorted(update_data.keys()) if update_data else [],
+        },
+    )
+
     # 修正 meta_data 字段以確保序列化正常
     announcement_dict = {
         "id": announcement.id,
@@ -301,8 +329,25 @@ async def delete_announcement(id: int, current_user: User = Depends(require_admi
     if not announcement:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="System announcement not found")
 
+    # Capture pre-delete fields so the audit row remains meaningful after commit.
+    deleted_id = announcement.id
+    deleted_title = announcement.title
+
     # Delete announcement
     await db.delete(announcement)
     await db.commit()
+
+    logger.info(
+        "system-announcement deleted: id=%s title=%r by user_id=%s",
+        deleted_id,
+        deleted_title,
+        current_user.id,
+        extra={
+            "actor_user_id": current_user.id,
+            "actor_role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            "announcement_id": deleted_id,
+            "announcement_title": deleted_title,
+        },
+    )
 
     return {"success": True, "message": "系統公告已成功刪除", "data": None}


### PR DESCRIPTION
## Summary

\`backend/app/api/v1/endpoints/admin/announcements.py\` declared a module-level \`logger\` but never called it — even on the three mutation paths (POST create, PUT update, DELETE) that change visible system announcements for every user.

## What changed

\`logger.info(...)\` audit rows on each mutation path with \`actor_user_id\`, \`actor_role\`, \`announcement_id\`, and \`announcement_title\`.

- **CREATE**: logs id + title after commit + refresh.
- **UPDATE**: additionally records \`sorted(updated_fields)\` so downstream audit consumers can tell whether the change was content vs. metadata (priority, expires_at, etc.).
- **DELETE**: captures id + title **before** \`db.delete\` + commit so the audit row remains meaningful after the row is gone.

No behavior change — same response codes / shapes. Just observability on three admin-only mutation paths that were previously silent. Pattern matches PRs #645 / #646 / #658.

## Test plan

- [ ] CI green (black 26.3.1, flake8 with F4xx/B904)
- [ ] Manual sanity (post-merge): hit each endpoint as admin → look for \`system-announcement created|updated|deleted\` log row with matching \`actor_user_id\` and \`announcement_id\`