### PR TITLE
SECURITY: audit-log admin/email-template PUT mutations

### DIFF
--- a/backend/app/api/v1/endpoints/admin/email_templates.py
+++ b/backend/app/api/v1/endpoints/admin/email_templates.py
@@ -89,6 +89,25 @@ async def update_email_template(
     # Fetch updated template
     updated_template = await EmailTemplateService.get_template(db, template.key)
 
+    logger.info(
+        "email-template updated: key=%s by user_id=%s sending_type=%s",
+        template.key,
+        current_user.id,
+        template.sending_type,
+        extra={
+            "actor_user_id": current_user.id,
+            "actor_role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+            "template_key": template.key,
+            "sending_type": template.sending_type,
+            "subject_template_len": len(template.subject_template) if template.subject_template else 0,
+            "body_template_len": len(template.body_template) if template.body_template else 0,
+            "cc_count": len(template.cc) if template.cc else 0,
+            "bcc_count": len(template.bcc) if template.bcc else 0,
+            "requires_approval": template.requires_approval,
+            "max_recipients": template.max_recipients,
+        },
+    )
+
     return {
         "success": True,
         "message": "Email template updated successfully",


### PR DESCRIPTION
## Summary

\`backend/app/api/v1/endpoints/admin/email_templates.py\` declared a module-level \`logger\` but never called it. After PR #648 most of the file is 501 stubs (issue #647 — per-scholarship template family is unimplemented), but **PUT /email-template (super-admin only)** is a live mutation path that rewrites a transactional email template — exactly the kind of change where "who changed what when" needs an audit trail.

## What changed

\`logger.info(...)\` after commit + refetch with:
- \`actor_user_id\`, \`actor_role\` (super_admin)
- \`template_key\`, \`sending_type\`
- \`subject_template_len\`, \`body_template_len\` — **lengths, not bodies**, since templates can contain admin-supplied HTML/text that shouldn't end up in log aggregation
- \`cc_count\`, \`bcc_count\`
- \`requires_approval\`, \`max_recipients\`

GET /email-template and GET /email-templates (list) remain log-free — they're read-only and high-volume.

No behavior change for callers.

## Test plan

- [ ] CI green (black 26.3.1, flake8 with F4xx/B904)
- [ ] Manual sanity (post-merge): \`PUT /api/v1/admin/email-template\` → look for \`email-template updated: key=... by user_id=... sending_type=...\` log row