### PR TITLE
fix(api): implement ApplicationService.get_application_available_sub_types (closes #649 — 2 of 3 endpoints)

### DIFF
--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -305,16 +305,19 @@ async def get_application_sub_types(
     current_user: User = Depends(require_professor),
     db: AsyncSession = Depends(get_db),
 ):
-    """[Not implemented - see issue #649] Get available sub-types for an application.
+    """Get available sub-types for an application (config-driven, role-filtered).
 
-    Calls ``ApplicationService.get_application_available_sub_types`` which is
-    not defined on the service. Returns 501 to stop the false 500 spike until
-    the role-filtering rules are designed (tracked in issue #649).
+    Implementation landed in ``ApplicationService.get_application_available_sub_types``;
+    closes issue #649 for the professor route. For professors this returns
+    every active sub-type configured on the scholarship.
     """
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="Per-application sub-type listing is not currently implemented (tracked in issue #649).",
-    )
+    service = ApplicationService(db)
+    try:
+        sub_types = await service.get_application_available_sub_types(application_id, current_user)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found") from exc
+
+    return {"success": True, "message": "查詢成功", "data": sub_types}
 
 
 @router.get("/stats")

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -639,15 +639,24 @@ async def get_application_reviewable_sub_types(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """[Not implemented - see issue #649] Get reviewable sub-types for an application.
+    """Get reviewable sub-types for an application (multi-role, role-filtered).
 
-    Intended to return sub-types filtered by reviewer role (professor: all;
-    college: not rejected by professor; admin: not rejected by professor or
-    college). Calls ``ApplicationService.get_application_available_sub_types``
-    which is not defined on the service. Returns 501 until the role-filtering
-    rules are designed (tracked in issue #649).
+    Returns sub-types that the current user is authorized to review:
+
+    - Professor: all active sub-types.
+    - College: sub-types not rejected by any professor.
+    - Admin / super_admin: sub-types not rejected by any professor or college.
+
+    Implementation lives in ``ApplicationService.get_application_available_sub_types``
+    (closes issue #649 for the multi-role review route).
     """
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="Per-application reviewable sub-type listing is not currently implemented (tracked in issue #649).",
-    )
+    from app.core.exceptions import NotFoundError
+    from app.services.application_service import ApplicationService
+
+    service = ApplicationService(db)
+    try:
+        sub_types = await service.get_application_available_sub_types(application_id, current_user)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="申請不存在") from exc
+
+    return {"success": True, "message": "查詢成功", "data": sub_types}

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2666,6 +2666,87 @@ class ApplicationService:
             "overdue_reviews": 0,
         }
 
+    async def get_application_available_sub_types(
+        self, application_id: int, current_user: User
+    ) -> List[Dict[str, Any]]:
+        """Return sub-types the given user is authorized to review on this application.
+
+        The shape matches the frontend's ``SubTypeOption`` interface
+        (see ``frontend/components/professor-review-component.tsx:81``):
+            ``{"value": str, "label": str, "label_en": str, "is_default": bool}``
+
+        Filtering rules (additive — stricter as the role moves through the
+        review chain):
+
+        - All callers: only ``is_active=True`` sub-type configs.
+        - ``professor``: returns every active sub-type (full set).
+        - ``college``: also excludes sub-types where any professor has
+          recommended ``reject`` on the application.
+        - ``admin`` / ``super_admin``: also excludes sub-types where any
+          college reviewer has recommended ``reject``.
+
+        The result is sorted by ``(display_order, sub_type_code)`` so the
+        frontend list rendering is stable across calls.
+
+        Raises ``NotFoundError`` when the application doesn't exist.
+        """
+        # Load application + its scholarship + that scholarship's sub-type configs
+        # in one round trip so we can iterate ``application.scholarship.sub_type_configs``
+        # without a lazy fetch on the AsyncSession.
+        stmt = (
+            select(Application)
+            .where(Application.id == application_id)
+            .options(selectinload(Application.scholarship).selectinload(ScholarshipType.sub_type_configs))
+        )
+        result = await self.db.execute(stmt)
+        application = result.scalar_one_or_none()
+        if application is None:
+            raise NotFoundError(f"Application {application_id} not found")
+
+        # Empty scholarship or no configured sub-types -> empty list.
+        # The frontend already falls back to a synthetic "default" sub-type
+        # in that case (FALLBACK_SUB_TYPE), so we don't need to return one.
+        if not application.scholarship or not application.scholarship.sub_type_configs:
+            return []
+
+        active_configs = [c for c in application.scholarship.sub_type_configs if c.is_active]
+
+        async def _rejected_by_role(role: UserRole) -> set[str]:
+            """sub_type_codes rejected by any reviewer of the given role on this application."""
+            stmt_rejected = (
+                select(ApplicationReviewItem.sub_type_code)
+                .join(ApplicationReview, ApplicationReviewItem.review_id == ApplicationReview.id)
+                .join(User, ApplicationReview.reviewer_id == User.id)
+                .where(
+                    ApplicationReview.application_id == application_id,
+                    User.role == role,
+                    ApplicationReviewItem.recommendation == "reject",
+                )
+            )
+            res = await self.db.execute(stmt_rejected)
+            return set(res.scalars().all())
+
+        # Professors see everything. College sees what professors didn't reject.
+        # Admin sees what neither professors nor college rejected.
+        excluded_codes: set[str] = set()
+        if current_user.role != UserRole.professor:
+            excluded_codes |= await _rejected_by_role(UserRole.professor)
+        if current_user.role in (UserRole.admin, UserRole.super_admin):
+            excluded_codes |= await _rejected_by_role(UserRole.college)
+
+        available = [c for c in active_configs if c.sub_type_code not in excluded_codes]
+        available.sort(key=lambda c: (c.display_order or 0, c.sub_type_code))
+
+        return [
+            {
+                "value": c.sub_type_code,
+                "label": c.name,
+                "label_en": c.name_en or c.name,
+                "is_default": c.sub_type_code == "default",
+            }
+            for c in available
+        ]
+
     async def get_available_professors(self, user: User, search: Optional[str] = None) -> List[Dict[str, Any]]:
         """
         Get professors based on user role:

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4369,11 +4369,11 @@ export interface paths {
         };
         /**
          * Get Application Sub Types
-         * @description [Not implemented - see issue #649] Get available sub-types for an application.
+         * @description Get available sub-types for an application (config-driven, role-filtered).
          *
-         *     Calls ``ApplicationService.get_application_available_sub_types`` which is
-         *     not defined on the service. Returns 501 to stop the false 500 spike until
-         *     the role-filtering rules are designed (tracked in issue #649).
+         *     Implementation landed in ``ApplicationService.get_application_available_sub_types``;
+         *     closes issue #649 for the professor route. For professors this returns
+         *     every active sub-type configured on the scholarship.
          */
         get: operations["get_application_sub_types_api_v1_professor_applications__application_id__sub_types_get"];
         put?: never;
@@ -5078,13 +5078,16 @@ export interface paths {
         };
         /**
          * Get Application Reviewable Sub Types
-         * @description [Not implemented - see issue #649] Get reviewable sub-types for an application.
+         * @description Get reviewable sub-types for an application (multi-role, role-filtered).
          *
-         *     Intended to return sub-types filtered by reviewer role (professor: all;
-         *     college: not rejected by professor; admin: not rejected by professor or
-         *     college). Calls ``ApplicationService.get_application_available_sub_types``
-         *     which is not defined on the service. Returns 501 until the role-filtering
-         *     rules are designed (tracked in issue #649).
+         *     Returns sub-types that the current user is authorized to review:
+         *
+         *     - Professor: all active sub-types.
+         *     - College: sub-types not rejected by any professor.
+         *     - Admin / super_admin: sub-types not rejected by any professor or college.
+         *
+         *     Implementation lives in ``ApplicationService.get_application_available_sub_types``
+         *     (closes issue #649 for the multi-role review route).
          */
         get: operations["get_application_reviewable_sub_types_api_v1_reviews_applications__application_id__sub_types_get"];
         put?: never;


### PR DESCRIPTION
## Summary

**Permanent fix** for two of the three endpoints stubbed at 501 in PR #650. Both raised 501 because \`ApplicationService.get_application_available_sub_types\` didn't exist on the service.

Adds the method and swaps the 501 stubs for live calls. Closes the bulk of issue #649.

## What the method does

Returns the sub-types the current user is authorized to review on a given application, in the shape the frontend already consumes (\`SubTypeOption\` interface in \`frontend/components/professor-review-component.tsx:81\`):

\`\`\`json
{"value": "nstc", "label": "國科會", "label_en": "NSTC", "is_default": false}
\`\`\`

Filtering rules (additive — stricter as the role moves through the review chain):

- All callers: only \`is_active=True\` sub-type configs.
- \`professor\`: every active sub-type (full set).
- \`college\`: excludes sub-types where any professor has recommended \`reject\` on the application.
- \`admin\` / \`super_admin\`: also excludes sub-types where any college reviewer has recommended \`reject\`.

Result is sorted by \`(display_order, sub_type_code)\` so list rendering is stable across calls.

## How the two endpoints use it

| Endpoint | Auth | Returns |
|----------|------|---------|
| \`GET /api/v1/professor/applications/{id}/sub-types\` | \`require_professor\` | Full active set |
| \`GET /api/v1/reviews/applications/{id}/sub-types\` | \`get_current_user\` | Role-filtered based on \`current_user.role\` |

Both raise 404 when the application doesn't exist (via \`NotFoundError\`); other exceptions bubble up to the global handler.

## Schema sync

\`frontend/lib/api/generated/schema.d.ts\` updated so the \`Verify OpenAPI Types\` CI check passes against the new docstrings.

## Closes

Closes 2/3 of issue **#649**:
- ✅ \`professor.py:313\` — now calls the live method
- ✅ \`reviews.py:659\` — now calls the live method
- ⏸ \`scholarship_management.py:57\` (\`create_application\` on \`ScholarshipApplicationService\`) — **not addressed here**; that's a different bug with a more substantial architectural mismatch (the service method was deliberately removed; the endpoint contract has no surviving counterpart). Stays 501 per PR #650.

## Test plan

- [ ] CI green (black 26.3.1, flake8 F4xx/B904, Verify OpenAPI Types)
- [ ] Manual sanity: hit both endpoints from frontend; confirm the sub-types list renders in the existing review dialog (already wired against the same response shape).