### PR TITLE
chore(alembic): merge 5 unmerged heads into single head (closes #668, unblocks #647)

### DIFF
--- a/backend/alembic/versions/20260515_merge_5_heads.py
+++ b/backend/alembic/versions/20260515_merge_5_heads.py
@@ -1,0 +1,44 @@
+"""Empty merge: collapse the 5 unmerged alembic heads into a single head.
+
+The migration graph had drifted to 5 open heads, which makes
+``alembic upgrade head`` and ``./scripts/reset_database.sh`` ambiguous
+and blocks any new schema change from landing without compounding the
+branch count. See issue #668.
+
+The 5 heads are independent — they touch disjoint tables, so the merge
+order is irrelevant for correctness:
+
+- ``add_college_rejected_001``        → adds column to ``college_ranking_items``
+- ``add_renewal_year_001``            → adds column to ``applications``
+- ``add_roster_sub_type_001``         → adds columns to ``payment_rosters`` + ``scholarship_configurations``
+- ``20260513_doc_req_deadline``       → adds column to ``document_requests``
+- ``seed_phd_college_export_001``     → data-only seed (no schema changes)
+
+No-op upgrade/downgrade — alembic just collapses the DAG.
+
+Revision ID: merge_20260515_heads
+Revises: add_college_rejected_001, add_renewal_year_001, add_roster_sub_type_001, 20260513_doc_req_deadline, seed_phd_college_export_001
+Create Date: 2026-05-15
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "merge_20260515_heads"
+down_revision: Union[str, Sequence[str], None] = (
+    "add_college_rejected_001",
+    "add_renewal_year_001",
+    "add_roster_sub_type_001",
+    "20260513_doc_req_deadline",
+    "seed_phd_college_export_001",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """No schema change — this migration only collapses the DAG."""
+
+
+def downgrade() -> None:
+    """No-op: downgrading past the merge would re-expose the 5-head state."""


### PR DESCRIPTION
## Summary

The migration graph had drifted to **5 open heads** (verified via AST scan of \`backend/alembic/versions/*.py\` in issue #668). This makes \`alembic upgrade head\` ambiguous, breaks \`./scripts/reset_database.sh\`, and blocks any new schema change from landing without compounding the branch count — in particular, it blocks issue #647's \`email_templates.scholarship_type_id\` migration.

## Heads collapsed

| Head | Table(s) touched |
|---|---|
| \`add_college_rejected_001\` | \`college_ranking_items\` |
| \`add_renewal_year_001\` | \`applications\` |
| \`add_roster_sub_type_001\` | \`payment_rosters\` + \`scholarship_configurations\` |
| \`20260513_doc_req_deadline\` | \`document_requests\` |
| \`seed_phd_college_export_001\` | no schema (data-only seed) |

**Zero overlap** — verified by AST inspection of each migration's \`op.add_column\` / \`op.create_table\` calls. Merge order is therefore irrelevant for correctness.

## What changed

Adds \`backend/alembic/versions/20260515_merge_5_heads.py\` — a standard empty merge migration with all 5 as \`down_revision\` and no-op \`upgrade()\` / \`downgrade()\`. Alembic just collapses the DAG; no DB writes.

## Verification

Re-running the AST head-detection script after this PR shows exactly 1 head:

\`\`\`
Heads (1):
  merge_20260515_heads: 20260515_merge_5_heads.py
\`\`\`

## Unblocks

- #647 (email_templates feature build can now branch from a clean single head)
- Any future schema-change PR

Closes #668.

## Test plan

- [ ] CI green (black, flake8)
- [ ] \`docker compose -f docker-compose.dev.yml exec backend alembic upgrade head\` succeeds (post-merge sanity)
- [ ] \`./scripts/reset_database.sh\` end-to-end succeeds (post-merge sanity)