### PR TITLE
fix(security): rate limit /portal-sso/verify (closes #641)

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -283,6 +283,7 @@ async def get_portal_sso_data(
 
 
 @router.post("/portal-sso/verify")
+@rate_limit(requests=30, window_seconds=60)  # 30 SSO verifications / min per IP — slows token-replay / brute attempts
 async def portal_sso_verify(
     request: Request,
     db: AsyncSession = Depends(get_db),

--- a/backend/app/tests/test_auth_rate_limit_invariants.py
+++ b/backend/app/tests/test_auth_rate_limit_invariants.py
@@ -54,3 +54,12 @@ def test_mock_sso_login_has_rate_limit_decorator():
     assert any(d.startswith("@rate_limit") for d in decorators), (
         "auth.mock_sso_login must have @rate_limit decorator (commit 001b14b). " f"Found decorators: {decorators}"
     )
+
+
+def test_portal_sso_verify_has_rate_limit_decorator():
+    # The real public SSO entry point — must be rate-limited.
+    # Closes issue #641: rate-limiter built but not applied to /portal-sso/verify.
+    decorators = _function_decorators(auth, "portal_sso_verify")
+    assert any(d.startswith("@rate_limit") for d in decorators), (
+        "auth.portal_sso_verify must have @rate_limit decorator (issue #641). " f"Found decorators: {decorators}"
+    )


### PR DESCRIPTION
## Summary

Issue #641 reported that the Redis-backed rate-limiter built at `backend/app/core/rate_limiting.py` was not applied to any endpoint. Most of the gap has already been closed in earlier work — `/register`, `/login` and `/mock-sso/login` all have `@rate_limit(...)` decorators today.

What's still missing is the real public SSO entry point: **`POST /portal-sso/verify`**. That endpoint:

- accepts a JWT token from anonymous callers
- triggers a synchronous call to NYCU's upstream Portal JWT verification service
- creates a new user record on first successful verification

so an unthrottled probe can both DoS the upstream Portal and harvest first-login events.

This PR wraps `portal_sso_verify` with `@rate_limit(requests=30, window_seconds=60)`, sized to leave room for legitimate retries while rejecting token-replay / brute attempts.

The existing AST-style invariant test in `test_auth_rate_limit_invariants.py` is extended with `test_portal_sso_verify_has_rate_limit_decorator`, matching the pattern that already locks the decorator on `register` / `login` / `mock_sso_login`.

## Test plan

- [ ] `pytest backend/app/tests/test_auth_rate_limit_invariants.py -v` (4 of 4 pass)
- [ ] backend boots cleanly with the decorator applied
- [ ] manual: `for i in $(seq 1 35); do curl -s -o /dev/null -w "%{http_code}\n" -XPOST localhost:8000/api/v1/auth/portal-sso/verify -d 'token=x'; done` — last few requests return 429

Closes #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)