### PR TITLE
fix(types): reconcile DashboardStats / SystemStats type drift (closes #642)

### DIFF
--- a/frontend/components/admin-management-interface.tsx
+++ b/frontend/components/admin-management-interface.tsx
@@ -243,8 +243,16 @@ export function AdminManagementInterface({
     number | undefined
   >();
 
-  // 系統統計狀態
+  // 系統統計狀態 — initialized with placeholder values for all DashboardStats
+  // fields (canonical snake_case + legacy camelCase aliases). See issue #642.
   const [systemStats, setSystemStats] = useState<SystemStats>({
+    // Canonical snake_case fields
+    total_applications: 0,
+    pending_review: 0,
+    approved: 0,
+    rejected: 0,
+    avg_processing_time: "0ms",
+    // Legacy camelCase aliases
     totalUsers: 0,
     activeApplications: 0,
     completedReviews: 0,

--- a/frontend/lib/api/modules/admin.ts
+++ b/frontend/lib/api/modules/admin.ts
@@ -17,19 +17,22 @@
 
 import { typedClient } from '../typed-client';
 import { toApiResponse } from '../compat';
-import type { ApiResponse, HistoricalApplicationFilters } from '../types';
+import type { ApiResponse, DashboardStats, HistoricalApplicationFilters } from '../types';
 
 export function createAdminApi() {
   return {
     // ========== Dashboard and Statistics ==========
 
     /**
-     * Get dashboard statistics
-     * Type-safe: Response type inferred from OpenAPI
+     * Get dashboard statistics.
+     *
+     * Returns the unified DashboardStats shape (snake_case canonical fields
+     * + legacy camelCase aliases for the admin-management-interface UI).
+     * See issue #642 for the reconciliation.
      */
-    getDashboardStats: async (): Promise<ApiResponse<any>> => {
+    getDashboardStats: async (): Promise<ApiResponse<DashboardStats>> => {
       const response = await typedClient.raw.GET('/api/v1/admin/dashboard/stats');
-      return toApiResponse(response) as ApiResponse<any>;
+      return toApiResponse(response) as ApiResponse<DashboardStats>;
     },
 
     /**
@@ -55,12 +58,14 @@ export function createAdminApi() {
     },
 
     /**
-     * Get system stats (alias for getDashboardStats)
-     * Type-safe: Response type inferred from OpenAPI
+     * Get system stats — alias for getDashboardStats.
+     *
+     * Returns the same DashboardStats shape (legacy SystemStats is a type
+     * alias for DashboardStats). See issue #642.
      */
-    getSystemStats: async (): Promise<ApiResponse<any>> => {
+    getSystemStats: async (): Promise<ApiResponse<DashboardStats>> => {
       const response = await typedClient.raw.GET('/api/v1/admin/dashboard/stats');
-      return toApiResponse(response) as ApiResponse<any>;
+      return toApiResponse(response) as ApiResponse<DashboardStats>;
     },
 
     // ========== Application Management ==========

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -407,12 +407,33 @@ export interface ApplicationCreate {
   [key: string]: unknown; // 允許動態欄位
 }
 
+// Backend `GET /api/v1/admin/dashboard/stats` returns both the canonical
+// snake_case fields and a set of camelCase aliases for the legacy
+// admin-management-interface UI. Until that UI is migrated off the alias
+// shape, the canonical type exposes both. `storageUsed` is optional because
+// the backend does not currently compute it.
+//
+// Both `apiClient.admin.getDashboardStats()` and the legacy alias
+// `apiClient.admin.getSystemStats()` resolve to this same shape.
+//
+// Closes #642 (DashboardStats / SystemStats type drift).
 export interface DashboardStats {
+  // Canonical snake_case fields
   total_applications: number;
   pending_review: number;
   approved: number;
   rejected: number;
   avg_processing_time: string;
+  // Legacy camelCase aliases also returned by the same endpoint
+  totalUsers: number;
+  activeApplications: number;
+  completedReviews: number;
+  systemUptime: string;
+  avgResponseTime: string;
+  pendingReviews: number;
+  totalScholarships: number;
+  // Optional — not currently populated by backend; UI renders empty if absent.
+  storageUsed?: string;
 }
 
 export interface RecipientOption {
@@ -1220,16 +1241,10 @@ export interface Workflow {
   updated_at: string;
 }
 
-export interface SystemStats {
-  totalUsers: number;
-  activeApplications: number;
-  completedReviews: number;
-  systemUptime: string;
-  avgResponseTime: string;
-  storageUsed: string;
-  pendingReviews: number;
-  totalScholarships: number;
-}
+// Legacy alias. Both DashboardStats and SystemStats describe the same
+// `GET /api/v1/admin/dashboard/stats` response (see issue #642). New code
+// should use DashboardStats directly.
+export type SystemStats = DashboardStats;
 
 export interface ScholarshipPermission {
   id: number;


### PR DESCRIPTION
## Summary

Two consumers of the same backend endpoint ``GET /api/v1/admin/dashboard/stats`` declared incompatible local types:

| Consumer | Type | Fields |
|---|---|---|
| ``hooks/use-admin.ts`` | ``DashboardStats`` | ``total_applications``, ``pending_review``, ``approved``, ``rejected``, ``avg_processing_time`` |
| ``components/admin-management-interface.tsx`` | ``SystemStats`` | ``totalUsers``, ``activeApplications``, ``pendingReviews``, ``systemUptime``, ``avgResponseTime``, ``storageUsed``, ``completedReviews``, ``totalScholarships`` |

with **zero field overlap**, and ``apiClient.admin.getDashboardStats()`` / ``getSystemStats()`` typed as ``ApiResponse<any>`` so TypeScript silently accepted both views.

The backend already returns both shapes in one payload (see ``backend/app/api/v1/endpoints/admin/dashboard.py:121-140``), so the canonical type can simply express the full union.

## Changes

- ``DashboardStats`` widened to include all 12 fields the backend returns. ``storageUsed`` is optional because the backend doesn't compute it (the UI already tolerates ``undefined``).
- ``SystemStats`` is now a deprecated alias: ``export type SystemStats = DashboardStats``.
- ``getDashboardStats()`` / ``getSystemStats()`` return ``ApiResponse<DashboardStats>`` — future drift now fails TypeScript.
- ``admin-management-interface.tsx``'s ``useState<SystemStats>`` initializer adds the snake_case seeds (since they're now required by the unified type).

## Test plan

- [ ] frontend type-check passes
- [ ] admin dashboard still renders the camelCase tiles (Total Users / Active Applications / etc.)
- [ ] ``use-admin.ts`` consumer still reads ``total_applications`` correctly

Closes #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)