### PR TITLE
chore(types): narrow ApplicationCreate index signature any → unknown

### DIFF
--- a/frontend/lib/api/modules/applications.ts
+++ b/frontend/lib/api/modules/applications.ts
@@ -26,7 +26,12 @@ type ApplicationCreate = {
   expected_graduation_date?: string;
   research_topic?: string;
   gpa?: number;
-  [key: string]: any;
+  // Dynamic application fields (bank_account, contact_phone, ...) are bag-passed
+  // through this index signature. Tightened from `any` to `unknown` so the
+  // typed-client `body: applicationData as any` cast at the call site (lines
+  // ~85 / ~274) is the only remaining widening — `unknown` here means callers
+  // can't accidentally read a dynamic field as a typed value without checking.
+  [key: string]: unknown;
 };
 
 export function createApplicationsApi() {


### PR DESCRIPTION
## Summary

Narrows the local \`ApplicationCreate.[key: string]: any\` index signature in \`frontend/lib/api/modules/applications.ts\` to \`unknown\`. Named members (\`scholarship_type: string\`, \`gpa?: number\`, …) keep their declared types — only the unnamed dynamic-field reads (bank_account, contact_phone, etc.) become \`unknown\`, forcing callers to narrow before reading.

The two intentional \`body: applicationData as any\` casts at lines ~85 / ~274 remain, per the ledger: the typed-client's generated body schema is \`Record<string, never>\` so widening at the call site is the only way through until backend OpenAPI emits real body schemas.

## Test plan

- [ ] \`bunx tsc --noEmit\` clean (Verify OpenAPI Types CI job)
- [ ] application submission flow still saves dynamic fields (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)