### PR TITLE
sec(nycu_employee): stop leaking exception detail to HTTP client (24 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/nycu_employee.py
+++ b/backend/app/api/v1/endpoints/nycu_employee.py
@@ -111,17 +111,17 @@ async def get_employees(
         )
 
     except NYCUEmpAuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}") from e
+        raise HTTPException(status_code=401, detail="Authentication failed") from e
     except NYCUEmpValidationError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}") from e
+        raise HTTPException(status_code=400, detail="Invalid request") from e
     except NYCUEmpConnectionError as e:
-        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}") from e
+        raise HTTPException(status_code=503, detail="Service unavailable") from e
     except NYCUEmpTimeoutError as e:
-        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}") from e
+        raise HTTPException(status_code=504, detail="Request timeout") from e
     except NYCUEmpError as e:
-        raise HTTPException(status_code=500, detail=f"API error: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="API error") from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Unexpected error") from e
 
 
 @router.get("/employees/all")
@@ -158,17 +158,17 @@ async def get_all_employees(status: str = Query("01", description="Employee stat
         return response_pages
 
     except NYCUEmpAuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}") from e
+        raise HTTPException(status_code=401, detail="Authentication failed") from e
     except NYCUEmpValidationError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}") from e
+        raise HTTPException(status_code=400, detail="Invalid request") from e
     except NYCUEmpConnectionError as e:
-        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}") from e
+        raise HTTPException(status_code=503, detail="Service unavailable") from e
     except NYCUEmpTimeoutError as e:
-        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}") from e
+        raise HTTPException(status_code=504, detail="Request timeout") from e
     except NYCUEmpError as e:
-        raise HTTPException(status_code=500, detail=f"API error: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="API error") from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Unexpected error") from e
 
 
 @router.get("/employees/search")
@@ -231,17 +231,17 @@ async def search_employees(
         )
 
     except NYCUEmpAuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}") from e
+        raise HTTPException(status_code=401, detail="Authentication failed") from e
     except NYCUEmpValidationError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}") from e
+        raise HTTPException(status_code=400, detail="Invalid request") from e
     except NYCUEmpConnectionError as e:
-        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}") from e
+        raise HTTPException(status_code=503, detail="Service unavailable") from e
     except NYCUEmpTimeoutError as e:
-        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}") from e
+        raise HTTPException(status_code=504, detail="Request timeout") from e
     except NYCUEmpError as e:
-        raise HTTPException(status_code=500, detail=f"API error: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="API error") from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Unexpected error") from e
 
 
 @router.get("/employees/{employee_no}")
@@ -276,14 +276,14 @@ async def get_employee_by_no(
     except HTTPException:
         raise  # Re-raise HTTP exceptions as-is
     except NYCUEmpAuthenticationError as e:
-        raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}") from e
+        raise HTTPException(status_code=401, detail="Authentication failed") from e
     except NYCUEmpValidationError as e:
-        raise HTTPException(status_code=400, detail=f"Invalid request: {str(e)}") from e
+        raise HTTPException(status_code=400, detail="Invalid request") from e
     except NYCUEmpConnectionError as e:
-        raise HTTPException(status_code=503, detail=f"Service unavailable: {str(e)}") from e
+        raise HTTPException(status_code=503, detail="Service unavailable") from e
     except NYCUEmpTimeoutError as e:
-        raise HTTPException(status_code=504, detail=f"Request timeout: {str(e)}") from e
+        raise HTTPException(status_code=504, detail="Request timeout") from e
     except NYCUEmpError as e:
-        raise HTTPException(status_code=500, detail=f"API error: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="API error") from e
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Unexpected error") from e


### PR DESCRIPTION
## Summary

24 sites in `nycu_employee.py` raised `HTTPException` with `detail=f\"<message>: {str(e)}\"`, echoing the internal NYCU employee client wrapper's exception messages back to the caller. Sanitize each to `detail=\"<message>\"`, keeping `from e` so the traceback chain still lands in structured logs.

The exception messages from the wrapped NYCU client are particularly sensitive: they can include API endpoint URLs, internal IDs, authentication tokens (in error contexts where the wrapper echoes the failing request), and stack-frame fragments from the NYCU SDK. Even though `/nycu-employee/*` is gated behind `require_admin` (PR #637), **defense-in-depth dictates not echoing them to the wire** — admin sessions can be compromised too.

24 insertions, 24 deletions. Status codes and human-readable messages preserved as-is; only the `: {str(e)}` tail removed.

**Second file** in the exception-leak sweep (PR #684 was notifications.py, 13 sites). ~22 sites remain across other endpoint files.

## Sites covered (24 total)

Spans `Authentication failed`, `Invalid request`, `Service unavailable`, `Request timeout`, `API error`, `Unexpected error` patterns across the 6 NYCU employee proxy endpoints — each had the same 6-branch except chain leaking `str(e)` to the caller.

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741
- [x] Black formatted (pinned 26.3.1, no diff)
- [x] All 24 sites verified via grep — none remain with `{str(e)}` or `{e}` in `detail=`
- [x] `from e` preserved on all sites so traceback chain still lands in logs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)