### PR TITLE
sec(email_management): stop leaking exception detail (10 of 11 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/email_management.py
+++ b/backend/app/api/v1/endpoints/email_management.py
@@ -222,7 +222,7 @@ async def process_due_emails(
         stats = await email_service.process_due_emails(db=db, batch_size=batch_size)
         return {"success": True, "message": "Emails processed successfully", "data": EmailProcessingStats(**stats)}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to process emails: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Failed to process emails") from e
 
 
 @router.get("/categories")
@@ -288,7 +288,7 @@ async def get_test_mode_status(*, db: AsyncSession = Depends(get_db), current_us
         return ApiResponse(success=True, message="Test mode status retrieved successfully", data=test_config)
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get test mode status: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Failed to get test mode status") from e
 
 
 @router.post("/test-mode/enable")
@@ -356,7 +356,7 @@ async def enable_test_mode(
 
     except Exception as e:
         await db.rollback()
-        raise HTTPException(status_code=500, detail=f"Failed to enable test mode: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Failed to enable test mode") from e
 
 
 @router.post("/test-mode/disable")
@@ -407,7 +407,7 @@ async def disable_test_mode(
 
     except Exception as e:
         await db.rollback()
-        raise HTTPException(status_code=500, detail=f"Failed to disable test mode: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Failed to disable test mode") from e
 
 
 @router.get("/test-mode/audit")
@@ -457,7 +457,7 @@ async def get_test_mode_audit_logs(
         )
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get audit logs: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Failed to get audit logs") from e
 
 
 @router.delete("/test-mode/audit-logs/cleanup")
@@ -507,7 +507,7 @@ async def cleanup_old_audit_logs(
 
     except Exception as e:
         await db.rollback()
-        raise HTTPException(status_code=500, detail=f"Failed to cleanup audit logs: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="Failed to cleanup audit logs") from e
 
 
 # ========== Manual Test Email Endpoints ==========
@@ -548,6 +548,12 @@ async def send_test_email(
                 request.body_override if request.body_override else template.body_template.format(**request.test_data)
             )
         except KeyError as e:
+            # SECURITY: intentional exception detail in client response.
+            # KeyError.args[0] is the missing template-variable name (e.g.
+            # 'student_name'). The user needs that name to fix their
+            # test_data payload — generic "missing variable" gives them
+            # nothing actionable. The exception is from str.format() so
+            # there's no path-traversal / DB / auth context to leak.
             raise HTTPException(
                 status_code=400, detail=f"模板變數缺失：{str(e)}。請確保 test_data 包含所有必需的變數"
             ) from e
@@ -736,7 +742,7 @@ async def get_email_templates(*, db: AsyncSession = Depends(get_db), current_use
         return ApiResponse(success=True, message=f"成功獲取 {len(template_list)} 個郵件模板", data=template_list)
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"獲取郵件模板失敗: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="獲取郵件模板失敗") from e
 
 
 # ========== React Email Template Endpoints ==========
@@ -759,7 +765,7 @@ async def get_react_email_templates(*, current_user: User = Depends(require_admi
 
     except Exception as e:
         logger.exception("Failed to scan React Email templates")
-        raise HTTPException(status_code=500, detail=f"獲取 React Email 模板失敗: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="獲取 React Email 模板失敗") from e
 
 
 @router.get("/react-email-templates/{template_name}")
@@ -787,7 +793,7 @@ async def get_react_email_template(*, template_name: str, current_user: User = D
         raise
     except Exception as e:
         logger.exception(f"Failed to get React Email template {template_name}")
-        raise HTTPException(status_code=500, detail=f"獲取模板失敗: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="獲取模板失敗") from e
 
 
 @router.get("/react-email-templates/{template_name}/source")
@@ -819,4 +825,4 @@ async def get_react_email_template_source(*, template_name: str, current_user: U
         raise
     except Exception as e:
         logger.exception(f"Failed to get React Email template source {template_name}")
-        raise HTTPException(status_code=500, detail=f"獲取模板源碼失敗: {str(e)}") from e
+        raise HTTPException(status_code=500, detail="獲取模板源碼失敗") from e


### PR DESCRIPTION
## Summary

10 sites in `email_management.py` raised `HTTPException` with `detail=f\"<message>: {str(e)}\"` (or `{e}`), echoing the email service's internal exception messages back to the caller. Sanitize each to `detail=\"<message>\"`, keeping `from e` so the traceback chain still lands in structured logs.

**1 site intentionally retained** (line 552, template-variable KeyError path) — now carries a SECURITY comment explaining why: the KeyError message contains the missing template-variable name (e.g. `'student_name'`), which the user needs to fix their `test_data` input. A generic \"missing variable\" message gives the user nothing actionable, and the exception source is `str.format()` — no path traversal, DB, or auth context to leak.

**Third file** in the exception-leak sweep:
- #684 — notifications.py (13 sites) ✓ pending
- #685 — nycu_employee.py (24 sites) ✓ pending
- #686 — email_management.py (10 sites + 1 intentionally retained) ← this PR

~11 sites remain across 9 files (application_fields 3, scholarships 2, plus 1 each in users, system_settings, scholarship_management, reviews, payment_rosters, college_review/ranking_management).

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741
- [x] Black formatted (pinned 26.3.1, no diff)
- [x] 10 sanitized sites verified via grep
- [x] 1 retained site has SECURITY comment explaining the deliberate exposure
- [x] `from e` preserved on all sites so traceback chain still lands in logs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)