### PR TITLE
fix(logging): drop redundant logger.error(traceback.format_exc()) (6 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -296,10 +296,6 @@ async def create_application(
         ) from e
     except Exception as e:
         logger.exception("Unexpected error during application creation")
-        import traceback
-
-        error_trace = traceback.format_exc()
-        logger.debug(f"Full traceback: {error_trace}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={

--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -125,9 +125,6 @@ async def get_professor_review(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Professor review not found") from exc
     except Exception as e:
         logger.exception("Error fetching professor review")
-        import traceback
-
-        logger.error(f"Full traceback: {traceback.format_exc()}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while fetching review",
@@ -208,9 +205,6 @@ async def submit_professor_review(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except Exception as e:
         logger.exception("Error submitting professor review")
-        import traceback
-
-        logger.error(f"Full traceback: {traceback.format_exc()}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while submitting review",
@@ -289,9 +283,6 @@ async def update_professor_review(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Review not found") from exc
     except Exception as e:
         logger.exception("Error updating professor review")
-        import traceback
-
-        logger.error(f"Full traceback: {traceback.format_exc()}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while updating review",

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -623,9 +623,6 @@ async def get_user_application_review(
 
     except Exception as e:
         logger.exception("Error fetching user review")
-        import traceback
-
-        logger.error(f"Full traceback: {traceback.format_exc()}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An internal error occurred while fetching review",

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -179,11 +179,9 @@ async def get_available_semesters(
 
     except Exception as e:
         import logging
-        import traceback
 
         logger = logging.getLogger(__name__)
         logger.error(f"Error in get_available_semesters: {type(e).__name__}: {str(e)}", exc_info=True)
-        logger.error(f"Full traceback: {traceback.format_exc()}")
 
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Summary

Six sites across 4 endpoint files emitted a follow-up `logger.error(f\"Full traceback: {traceback.format_exc()}\")` (or debug-level equivalent) **immediately after** a `logger.exception(...)` or `logger.error(..., exc_info=True)` call. The trailing line is purely redundant — Python's `logging` module already captures the full stack trace through `exc_info=True` (and `logger.exception` is just a shortcut for that). Stringifying it into the message again creates duplicate trace data in Loki and obscures structured-log analysis.

## Sites cleaned up

| File | Sites | Surrounding log |
|---|---|---|
| `reviews.py` | 1 | `logger.exception` above |
| `professor.py` | 3 | `logger.exception` above each |
| `applications.py` | 1 (debug-level) | `logger.exception` above |
| `scholarship_configurations.py` | 1 | `logger.error(..., exc_info=True)` above |

Also removes the local `import traceback` inside each except block (no longer used after the redundant log line goes).

## Stats

18 lines deleted, 0 added. No behavior change — loggers still emit the full trace via `exc_info`, just without duplication.

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741
- [x] Black formatted (pinned 26.3.1, no diff after edit)
- [x] All 6 sites verified removed via post-edit grep
- [x] Surrounding `logger.exception` / `exc_info=True` preserved on every site so the trace still lands in logs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)