### PR TITLE
fix(types): remove duplicate UserListResponse interface declaration

### DIFF
--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -800,36 +800,6 @@ export interface UserListResponse {
   student_no?: string;
 }
 
-export interface UserListResponse {
-  id: number;
-  nycu_id: string;
-  email: string;
-  name: string;
-  user_type?: string;
-  status?: string;
-  dept_code?: string;
-  dept_name?: string;
-  college_code?: string; // 系統內學院管理權限
-  role: string;
-  comment?: string;
-  created_at: string;
-  updated_at?: string;
-  last_login_at?: string;
-  raw_data?: {
-    chinese_name?: string;
-    english_name?: string;
-    [key: string]: unknown;
-  };
-  // 向後相容性欄位
-  username?: string;
-  full_name?: string;
-  chinese_name?: string;
-  english_name?: string;
-  is_active?: boolean;
-  is_verified?: boolean;
-  student_no?: string;
-}
-
 export interface UserResponse {
   id: number;
   nycu_id: string;


### PR DESCRIPTION
## Summary

`frontend/lib/api/types.ts` declared `export interface UserListResponse` twice, byte-for-byte identical between the two copies. TypeScript silently merges duplicate interface declarations, so this was hidden clutter — but it broke convention and made the file confusing for future readers (\"which one is canonical?\").

Delete the first copy; the second was equivalent so consumers get identical behavior.

## Stats

- **30 lines deleted**, no behavior change.
- Both copies used the post-narrowing `[key: string]: unknown` shape (from PR #634), so this is purely cleanup.

## Test plan

- [x] Single `export interface UserListResponse` remains in the file (verified via grep)
- [x] Consumers unaffected — TS merged the two copies into one type anyway, this just removes the duplicate source declaration
- [ ] CI green (tsc + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)