### PR TITLE
sec(services): stop leaking exception detail through ValueError/BusinessLogicError (9 sites)

### DIFF
--- a/backend/app/services/bank_verification_service.py
+++ b/backend/app/services/bank_verification_service.py
@@ -817,4 +817,4 @@ class BankVerificationService:
         except Exception as e:
             # Rollback on any error
             await self.db.rollback()
-            raise ValueError(f"Failed to process manual review: {str(e)}") from e
+            raise ValueError("Failed to process manual review") from e

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -811,7 +811,7 @@ class CollegeReviewService:
         except (RankingNotFoundError, RankingModificationError):
             raise  # Re-raise specific exceptions
         except Exception as e:
-            raise BusinessLogicError(f"Failed to finalize ranking {ranking_id}: {str(e)}") from e
+            raise BusinessLogicError(f"Failed to finalize ranking {ranking_id}") from e
 
     async def unfinalize_ranking(self, ranking_id: int) -> CollegeRanking:
         """Unfinalize a ranking (makes it editable again)"""
@@ -842,7 +842,7 @@ class CollegeReviewService:
         except (RankingNotFoundError, RankingModificationError):
             raise  # Re-raise specific exceptions
         except Exception as e:
-            raise BusinessLogicError(f"Failed to unfinalize ranking {ranking_id}: {str(e)}") from e
+            raise BusinessLogicError(f"Failed to unfinalize ranking {ranking_id}") from e
 
     async def get_quota_status(
         self,

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -1395,7 +1395,7 @@ class RosterService:
 
         except Exception as e:
             logger.exception("Dry run failed")
-            raise ValueError(f"預演失敗: {str(e)}") from e
+            raise ValueError("預演失敗") from e
 
     def generate_rosters_from_distribution(
         self,

--- a/backend/app/services/user_profile_service.py
+++ b/backend/app/services/user_profile_service.py
@@ -203,7 +203,7 @@ class UserProfileService:
             try:
                 image_data = base64.b64decode(document_upload.photo_data)
             except Exception as e:
-                raise ValueError(f"Invalid base64 data: {str(e)}") from e
+                raise ValueError("Invalid base64 data") from e
 
             # Verify actual size after decoding
             if len(image_data) > self.MAX_FILE_SIZE:
@@ -261,7 +261,7 @@ class UserProfileService:
                 preview_url = f"/api/v1/user-profiles/files/bank_documents/{object_name.split('/')[-1]}"
 
             except Exception as e:
-                raise ValueError(f"Failed to upload to MinIO: {str(e)}") from e
+                raise ValueError("Failed to upload to MinIO") from e
 
             # Update profile with new document URL
             profile = await self.get_user_profile(user_id)
@@ -289,7 +289,7 @@ class UserProfileService:
             return profile.bank_document_photo_url
 
         except Exception as e:
-            raise ValueError(f"Failed to upload bank document: {str(e)}") from e
+            raise ValueError("Failed to upload bank document") from e
 
     async def upload_bank_document(
         self,
@@ -322,7 +322,7 @@ class UserProfileService:
             try:
                 image_data = base64.b64decode(document_upload.photo_data)
             except Exception as e:
-                raise ValueError(f"Invalid base64 data: {str(e)}") from e
+                raise ValueError("Invalid base64 data") from e
 
             # Verify actual size after decoding (final check)
             if len(image_data) > self.MAX_FILE_SIZE:
@@ -420,7 +420,7 @@ class UserProfileService:
             return profile.bank_document_photo_url
 
         except Exception as e:
-            raise ValueError(f"Failed to upload bank document: {str(e)}") from e
+            raise ValueError("Failed to upload bank document") from e
 
     async def delete_bank_document(self, user_id: int) -> bool:
         """Delete bank document"""


### PR DESCRIPTION
## Summary

Extends the HTTPException-detail-leak sweep (PRs #684-#687) **into the service layer**. Nine sites across 4 service files raised `ValueError` / `BusinessLogicError` with `f\"<message>: {str(e)}\"` in the message — which bubbles up to the endpoint layer where FastAPI's exception handler echoes it back to the client. The same leak vector as the endpoint-layer sweep, just one frame deeper.

Sanitize each to a clean `<message>` (preserving the contextual identifier like `ranking_id` where present), keeping `from e` so the traceback chain still lands in structured logs.

## Files / sites

| File | Sites |
|---|---|
| `user_profile_service.py` | 5 (Invalid base64 data ×2, Failed to upload to MinIO, Failed to upload bank document ×2) |
| `bank_verification_service.py` | 1 (Failed to process manual review) |
| `college_review_service.py` | 2 (Failed to finalize ranking, Failed to unfinalize ranking — both preserve `ranking_id` in the message but drop the exception-detail tail) |
| `roster_service.py` | 1 (預演失敗) |

## Why service-layer matters

These messages can leak internal context — **MinIO bucket / object paths, S3 error codes, SQL fragments from SQLAlchemy errors, file-system paths from PIL / binascii errors**. The endpoint layer returns the `ValueError` message verbatim in most catch sites, so the leak does reach the wire.

## Intentionally retained (1 site)

`config_management_service.py:144` (`Invalid validation pattern: {str(e)}`) is **intentionally retained** — admin-provided regex pattern, the `str(e)` is the regex compilation error the admin needs to fix their pattern. Same pattern as `email_management.py:552` template KeyError retained in PR #686.

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741 on all 4 touched files
- [x] Black formatted (pinned 26.3.1, no diff)
- [x] All 9 sweep sites verified via post-edit grep (9 → 0 outside config_management)
- [x] `from e` preserved on every site so traceback chain still lands in logs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)