### PR TITLE
chore(imports): clear 6 F401 stragglers across 3 files

### DIFF
--- a/backend/app/api/v1/endpoints/admin/_helpers.py
+++ b/backend/app/api/v1/endpoints/admin/_helpers.py
@@ -15,7 +15,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import require_admin
-from app.db.deps import get_db
 from app.models.user import AdminScholarship, User, UserRole
 
 logger = logging.getLogger(__name__)

--- a/backend/app/api/v1/endpoints/admin/permissions.py
+++ b/backend/app/api/v1/endpoints/admin/permissions.py
@@ -8,8 +8,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import func, select
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -18,7 +17,6 @@ from app.core.security import check_scholarship_permission, get_current_user, re
 from app.db.deps import get_db
 from app.models.scholarship import ScholarshipType
 from app.models.user import AdminScholarship, User, UserRole
-from app.schemas.common import ApiResponse
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -21,12 +21,11 @@ from sqlalchemy.orm import selectinload
 from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFoundError
 from app.core.metrics import scholarship_reviews_total
 from app.models.application import Application, ApplicationStatus
-from app.models.college_review import CollegeRanking, CollegeRankingItem, QuotaDistribution
+from app.models.college_review import CollegeRanking, CollegeRankingItem
 from app.models.enums import Semester
 from app.models.review import ApplicationReview  # Unified review system
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User, UserRole
-from app.services.email_automation_service import email_automation_service
 
 func: Any = sa_func
 


### PR DESCRIPTION
## Summary

PR #489 declared \"entire backend now clean under E9/F63/F7/F82/F401\", but six unused imports have crept back in across 3 files. The project-root `.flake8` excludes most of `backend/app/` (api/, models/, schemas/, services/, tests/, static/), so these violations were **hidden from the default `flake8 backend/app/` scan** — flake8 only surfaces them when invoked with an explicit file path. The lint config masks regressions; clean the underlying code rather than extend the mask.

## Imports removed (each verified truly unused via grep)

| File | Import |
|---|---|
| `admin/_helpers.py:18` | `from app.db.deps import get_db` |
| `admin/permissions.py:11` | `func` from `sqlalchemy import func, select` |
| `admin/permissions.py:12` | `from sqlalchemy.exc import SQLAlchemyError` |
| `admin/permissions.py:21` | `from app.schemas.common import ApiResponse` |
| `college_review_service.py:24` | `QuotaDistribution` from college_review model |
| `college_review_service.py:29` | `from app.services.email_automation_service import email_automation_service` |

## Stats

6 deletions, 2 insertions (rewritten import lines). No behavior change.

## Note on lint config

This PR fixes the underlying code; the `.flake8` directory exclude that masked the regressions is left in place. A follow-up could narrow that exclude list (e.g. drop `backend/app/services/`, `backend/app/api/`), but doing so would surface a much larger backlog and is out of scope here.

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741 on all 3 touched files (explicit file paths)
- [x] Each removed import verified unused via `grep` across the file
- [x] Black formatted (pinned 26.3.1, no diff)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)