### PR TITLE
sec(logging): AST invariant against logger.error traceback-loss + sweep 6 sites

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/utilities.py
+++ b/backend/app/api/v1/endpoints/college_review/utilities.py
@@ -447,9 +447,11 @@ async def get_managed_college(
         return ApiResponse(success=True, message="Managed college retrieved successfully", data=managed_college_data)
 
     except Exception as e:
-        logger.error(
-            f"Error retrieving managed college for user {current_user.nycu_id} (ID: {current_user.id}): {str(e)}"
+        logger.exception(
+            "Error retrieving managed college for user %s (ID: %s)",
+            current_user.nycu_id,
+            current_user.id,
         )
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to retrieve managed college: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve managed college"
         ) from e

--- a/backend/app/services/application_audit_service.py
+++ b/backend/app/services/application_audit_service.py
@@ -619,9 +619,10 @@ class ApplicationAuditService:
 
             return enriched_logs
 
-        except Exception as e:
-            logger.error(
-                f"Failed to retrieve scholarship audit trail for scholarship_type_id {scholarship_type_id}: {e}"
+        except Exception:
+            logger.exception(
+                "Failed to retrieve scholarship audit trail for scholarship_type_id %s",
+                scholarship_type_id,
             )
             return []
 

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -624,9 +624,10 @@ class BatchImportService:
                         logger.warning(
                             f"SIS API unavailable for student {student_id}. Creating user with batch import data."
                         )
-                    except Exception as e:
-                        logger.error(
-                            f"Error fetching SIS data for student {student_id}: {e}. Creating user with batch import data."
+                    except Exception:
+                        logger.exception(
+                            "Error fetching SIS data for student %s. Creating user with batch import data.",
+                            student_id,
                         )
 
                     new_user = User(
@@ -800,10 +801,10 @@ class BatchImportService:
                         f"SIS API unavailable or student not found for {student_id}: {e}. "
                         "Creating application without student snapshot."
                     )
-                except Exception as e:
-                    logger.error(
-                        f"Error fetching student snapshot for {student_id}: {e}. "
-                        "Creating application without student snapshot."
+                except Exception:
+                    logger.exception(
+                        "Error fetching student snapshot for %s. Creating application without student snapshot.",
+                        student_id,
                     )
 
                 # Construct submitted_form_data, primarily from batch import, but override dept_code if SIS has it

--- a/backend/app/services/frontend_email_renderer.py
+++ b/backend/app/services/frontend_email_renderer.py
@@ -97,10 +97,11 @@ async def render_email_via_frontend(
         logger.error(f"Timeout calling frontend email renderer at {render_endpoint} " f"(template: {template_name})")
         return None
 
-    except httpx.ConnectError as e:
-        logger.error(
-            f"Connection error calling frontend at {render_endpoint}: {e}. "
-            f"Make sure frontend container is running and FRONTEND_URL is correct."
+    except httpx.ConnectError:
+        logger.exception(
+            "Connection error calling frontend at %s. "
+            "Make sure frontend container is running and FRONTEND_URL is correct.",
+            render_endpoint,
         )
         return None
 

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -1235,9 +1235,12 @@ class RosterService:
                 logger.warning(f"Unknown operator: {operator}")
                 return False
 
-        except (ValueError, TypeError) as e:
-            logger.error(
-                f"Error evaluating condition: actual={actual_value}, operator={operator}, expected={expected_value}, error={e}"
+        except (ValueError, TypeError):
+            logger.exception(
+                "Error evaluating condition: actual=%s, operator=%s, expected=%s",
+                actual_value,
+                operator,
+                expected_value,
             )
             return False
 

--- a/backend/app/tests/test_no_logger_error_traceback_loss.py
+++ b/backend/app/tests/test_no_logger_error_traceback_loss.py
@@ -1,0 +1,136 @@
+"""
+Source-level regression for the traceback-preservation sweep
+(PRs #574-#588 + #681 + service-layer follow-ups).
+
+The sweep replaced every `logger.error(f"...{e}")` (no exc_info) in
+backend/app/ with `logger.exception(...)` or `logger.error(...,
+exc_info=True)` so structured logs capture the full stack trace
+instead of just str(exc). If a future PR re-introduces the pattern
+at ERROR level, this test fails before the change ships.
+
+The check is an AST walk: it finds every `logger.error(...)` call
+and verifies that if the first positional arg is an f-string
+referencing `{e}` / `{exc}` / `{str(e)}` / etc., then `exc_info=`
+is also passed (or the call is `logger.exception(...)` which
+implicitly carries exc_info).
+
+Scope: ERROR level only. The same pattern at WARNING level is a
+separate (larger, ~47-site) cleanup tracked for a follow-up — for
+many warnings the missing trace is less load-bearing because the
+exception is recoverable and the message itself names the failure
+mode adequately. Tightening WARNING is out of scope here.
+
+The check runs in <1s. No DB, no fixtures, no HTTP client.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Module-relative path to backend/app — derived from this file's
+# own location to stay stable across worktree paths.
+APP_DIR = Path(__file__).resolve().parent.parent
+
+LEAK_VARS = {"e", "exc", "e2", "ex", "err", "error"}
+
+
+def _is_leak_fstring(node: ast.AST) -> bool:
+    """True iff `node` is an f-string referencing an exception variable."""
+    if not isinstance(node, ast.JoinedStr):
+        return False
+    for part in node.values:
+        if not isinstance(part, ast.FormattedValue):
+            continue
+        if isinstance(part.value, ast.Name) and part.value.id in LEAK_VARS:
+            return True
+        if (
+            isinstance(part.value, ast.Call)
+            and isinstance(part.value.func, ast.Name)
+            and part.value.func.id == "str"
+            and len(part.value.args) == 1
+            and isinstance(part.value.args[0], ast.Name)
+            and part.value.args[0].id in LEAK_VARS
+        ):
+            return True
+    return False
+
+
+def _has_exc_info_truthy(call: ast.Call) -> bool:
+    """True iff `exc_info=` keyword is present and not literally False."""
+    for kw in call.keywords:
+        if kw.arg != "exc_info":
+            continue
+        # `exc_info=False` doesn't count
+        if isinstance(kw.value, ast.Constant) and kw.value.value is False:
+            return False
+        return True
+    return False
+
+
+def _is_logger_error_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "error"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "logger"
+    )
+
+
+def _enclosing_function(node: ast.AST, tree: ast.AST) -> str:
+    target_line = getattr(node, "lineno", 0)
+    candidates = [
+        fn
+        for fn in ast.walk(tree)
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and fn.lineno <= target_line <= getattr(fn, "end_lineno", target_line)
+    ]
+    if not candidates:
+        return "<module>"
+    return min(candidates, key=lambda fn: target_line - fn.lineno).name
+
+
+def _iter_app_files() -> list[Path]:
+    """Backend application source files, excluding tests and __pycache__."""
+    return sorted(p for p in APP_DIR.rglob("*.py") if "__pycache__" not in p.parts and p.parts[-2] != "tests")
+
+
+def _scan_file(path: Path) -> list[tuple[str, int, str]]:
+    src = path.read_text()
+    tree = ast.parse(src)
+    findings = []
+    for node in ast.walk(tree):
+        if not _is_logger_error_call(node):
+            continue
+        if _has_exc_info_truthy(node):
+            continue
+        if not node.args or not _is_leak_fstring(node.args[0]):
+            continue
+        handler = _enclosing_function(node, tree)
+        excerpt = ast.unparse(node).splitlines()[0][:120]
+        findings.append((handler, node.lineno, excerpt))
+    return findings
+
+
+def test_no_logger_error_with_exception_fstring_lacks_exc_info():
+    """Every `logger.error(f"...{e}")` call in backend/app/ must also
+    pass `exc_info=True`, or be converted to `logger.exception(...)`.
+    Without one of those, the traceback is discarded — only str(exc)
+    reaches Loki."""
+    violations = []
+    for path in _iter_app_files():
+        rel = path.relative_to(APP_DIR.parent)
+        for handler, lineno, excerpt in _scan_file(path):
+            violations.append(f"{rel}:{lineno}  {handler}()  {excerpt!r}")
+
+    if violations:
+        msg = (
+            'Found `logger.error(f"...{e/exc/str(e)}")` calls lacking '
+            "`exc_info=True`. PRs #574-#588 + #681 swept this pattern; "
+            "do not re-introduce it. Use `logger.exception(...)` (which "
+            "implicitly carries exc_info=True) so the full traceback "
+            "lands in structured logs instead of just str(exc).\n\n"
+            "Violations:\n  " + "\n  ".join(violations)
+        )
+        pytest.fail(msg)


### PR DESCRIPTION
## Why now

PRs #574-#588 + #681 swept `logger.error(f\"...{e}\")` → `logger.exception(...)`, but six ERROR-level sites slipped through (mostly nested-brace f-strings the regex didn't match, plus a few new ones). This PR fixes them and adds a CI-enforced invariant to prevent regression — same shape as #694's invariant test, applied to the traceback-preservation sweep.

## Part 1 — invariant test (the durable fix)

`backend/app/tests/test_no_logger_error_traceback_loss.py` walks every `logger.error(...)` call in `backend/app/` and asserts that if the first positional arg is an f-string referencing an exception variable (`{e}` / `{exc}` / `{str(e)}` / `{e2}` / etc.), the call also passes `exc_info=` (truthy). Otherwise structured logs get just `str(exc)` instead of the full traceback.

**Scope is ERROR level only.** WARNING-level uses of the pattern (~47 sites identified) are a separate, larger cleanup tracked for a follow-up — many WARNING sites recover gracefully and the message itself names the failure mode adequately.

## Part 2 — 6 sites surfaced by the invariant (cleared so the test passes today)

| File | Line | Fix |
|---|---|---|
| `services/roster_service.py` | 1239 | → `logger.exception` |
| `services/frontend_email_renderer.py` | 101 | → `logger.exception` |
| `services/application_audit_service.py` | 623 | → `logger.exception` |
| `services/batch_import_service.py` | 628 | → `logger.exception` |
| `services/batch_import_service.py` | 804 | → `logger.exception` |
| `api/v1/endpoints/college_review/utilities.py` | 450 | → `logger.exception` (+ sanitized HTTPException detail leak at line 454) |

Each conversion preserves contextual variables via `%s`-style args (e.g. `logger.exception(\"Error for student %s\", student_id)`) so structured-log filters by user_id / ranking_id / student_id still work. Exception variable removed from the message text since `logger.exception` captures it natively.

## Session invariant coverage cumulative

| PR | Invariant pinned |
|---|---|
| #683 + #689 | 20 SECURITY audit-log handlers |
| #694 | HTTPException-detail-leak (endpoints, 106 sites cleared + permanent guard) |
| **this** | logger.error traceback-loss (6 sites cleared + ERROR-level permanent guard) |

## Test plan

- [x] Inline AST scan confirmed 0 violations remain
- [x] Lint clean on all 6 touched files
- [x] Black formatted (pinned 26.3.1)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)