### PR TITLE
sec(logging): preserve traceback for 3 logger.error sites passing exception as positional arg

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -295,7 +295,7 @@ async def health_check():
         # Get logger instance for this function
         health_logger = logging.getLogger(__name__)
         try:
-            health_logger.error("Health check failed: %s", exc)
+            health_logger.exception("Health check failed")
         except Exception:
             # Fallback logging if logger fails
             print(

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -400,7 +400,7 @@ class EmailService:
         except Exception as e:
             status = EmailStatus.failed
             error_message = str(e)
-            logger.error("Failed to send email to %s: %s", primary_recipient, e)
+            logger.exception("Failed to send email to %s", primary_recipient)
             # Re-raise the exception so callers can handle it
             raise
 
@@ -484,8 +484,8 @@ class EmailService:
                 await audit_db.commit()
                 logger.debug(f"Email history logged for {recipient_email}")
 
-            except Exception as e:
-                logger.error("Failed to log email history: %s", e)
+            except Exception:
+                logger.exception("Failed to log email history")
                 await audit_db.rollback()
                 # Don't re-raise - audit logging failure shouldn't break email sending
 


### PR DESCRIPTION
## Summary

PR #695 added an AST invariant for `logger.error(f\"...{e}\")` patterns (f-string interpolation). A **related** anti-pattern is `logger.error(\"...: %s\", exc)` — using `%s`-format with the exception passed as positional arg, no `exc_info=True`. This still loses the traceback even though the syntactic shape is different.

## Three sites cleared

| File | Line | Fix |
|---|---|---|
| `services/email_service.py` | 403 | → `logger.exception(\"Failed to send email to %s\", primary_recipient)` |
| `services/email_service.py` | 488 | → `logger.exception(\"Failed to log email history\")` |
| `main.py` | 298 | → `health_logger.exception(\"Health check failed\")` (health check fallback) |

Each conversion preserves contextual variables (recipient, etc.) via remaining `%s` placeholders. Exception arg removed since `logger.exception` captures it natively.

## Note on the invariant

Follow-up to #695 — the AST invariant in `test_no_logger_error_traceback_loss.py` could be extended to catch this `logger.error(\"...\", exc_var)` shape too. Left as separate work to keep merge surface small while #695 is in CI. The invariant extension would look at the *positional args* of `logger.error()` calls and flag any whose value is a `Name` node referencing one of `LEAK_VARS`.

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741
- [x] Black formatted (pinned 26.3.1)
- [x] All 3 sites verified converted via grep
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)