### PR TITLE
sec(logging): preserve traceback for 5 logger.warning sites in utils/core/db

### DIFF
--- a/backend/app/core/rate_limiting.py
+++ b/backend/app/core/rate_limiting.py
@@ -73,8 +73,8 @@ def get_rate_limiter() -> RateLimiter:
 
             redis_url = settings.redis_url
             _rate_limiter = RateLimiter(redis_url)
-        except Exception as e:
-            logger.warning(f"Could not initialize rate limiter: {e}")
+        except Exception:
+            logger.warning("Could not initialize rate limiter", exc_info=True)
             # Create with default URL as fallback
             _rate_limiter = RateLimiter()
     return _rate_limiter

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -92,12 +92,12 @@ async def handle_cached_statement_error(session: AsyncSession, operation_func, *
 
     try:
         return await operation_func(*args, **kwargs)
-    except InvalidCachedStatementError as e:
+    except InvalidCachedStatementError:
         # Log the error for monitoring
         import logging
 
         logger = logging.getLogger(__name__)
-        logger.warning(f"Cached statement plan invalidated, retrying operation: {e}")
+        logger.warning("Cached statement plan invalidated, retrying operation", exc_info=True)
 
         # Invalidate the connection and get a fresh one
         await session.invalidate()

--- a/backend/app/utils/audit_helpers.py
+++ b/backend/app/utils/audit_helpers.py
@@ -68,8 +68,8 @@ async def log_college_review_action(
         try:
             ip_address = request.client.host if request.client else None
             user_agent = request.headers.get("user-agent")
-        except Exception as e:
-            logger.warning(f"Failed to extract request metadata: {e}")
+        except Exception:
+            logger.warning("Failed to extract request metadata", exc_info=True)
 
     # Create and save audit log
     audit_log = AuditLog.create_log(
@@ -143,8 +143,8 @@ async def log_college_review_action_with_changes(
         try:
             ip_address = request.client.host if request.client else None
             user_agent = request.headers.get("user-agent")
-        except Exception as e:
-            logger.warning(f"Failed to extract request metadata: {e}")
+        except Exception:
+            logger.warning("Failed to extract request metadata", exc_info=True)
 
     # Create and save audit log
     audit_log = AuditLog.create_log(

--- a/backend/app/utils/date_utils.py
+++ b/backend/app/utils/date_utils.py
@@ -47,8 +47,8 @@ def parse_date_field(date_input: Optional[Union[str, datetime]]) -> Optional[dat
             # Fallback to dateutil parser for other formats
             else:
                 return dateutil.parser.parse(date_input)
-        except (ValueError, TypeError) as e:
-            logger.warning(f"Failed to parse date string '{date_input}': {e}")
+        except (ValueError, TypeError):
+            logger.warning("Failed to parse date string %r", date_input, exc_info=True)
             # Try dateutil as last resort
             try:
                 return dateutil.parser.parse(date_input)


### PR DESCRIPTION
## Summary

Targets the highest-value subset of the ~47 `logger.warning(f\"...{e}\")` sites identified during PR #695's invariant scan (the WARNING-level scope explicitly deferred there).

## Five sites cleared

All in `except Exception as e:` blocks where the trace is the only diagnostic signal when the path fires in production:

| File | Line | Context |
|---|---|---|
| `backend/app/utils/date_utils.py` | 51 | date-parse fallback failure |
| `backend/app/utils/audit_helpers.py` | 72 | request metadata extract |
| `backend/app/utils/audit_helpers.py` | 147 | same in alternate path |
| `backend/app/core/rate_limiting.py` | 77 | Redis-backed rate-limiter init fallback |
| `backend/app/db/session.py` | 100 | `InvalidCachedStatementError` retry path |

Each conversion drops the `{e}` interpolation (redundant once `exc_info=True` is present) and uses `%s`-style placeholders for contextual variables that aid log filtering.

## Intentionally not in scope

- `endpoint_decorators.py` (4 WARNING sites) — business-error mappings (`ReviewPermissionError`, `RankingNotFoundError`, `RankingModificationError`, `ValueError`) where the message names what failed and the trace would be noise. Same recoverable-error pattern is also why those handlers map to specific HTTP responses (403/404/400) rather than 500.
- `services/**` WARNING sites (~40 sites across 15+ files) — cover diverse failure modes including some genuinely recoverable retries. Triage deferred to follow-up.

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741
- [x] Black formatted (pinned 26.3.1)
- [x] 5 sites verified via post-edit grep
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)