### PR TITLE
sec(logging): preserve traceback for 8 logger.warning sites in core/cache.py

### DIFF
--- a/backend/app/core/cache.py
+++ b/backend/app/core/cache.py
@@ -151,24 +151,24 @@ def cached(key_fn: Callable[..., str], ttl: int, jitter: float = 0.1):
                     exc,
                 )
                 return await fn(*args, **kwargs)
-            except Exception as exc:  # noqa: BLE001
+            except Exception:  # noqa: BLE001
                 # Redis init failure: fail open, retry on next call.
-                logger.warning("cache: key build / redis init failed: %s", exc)
+                logger.warning("cache: key build / redis init failed", exc_info=True)
                 return await fn(*args, **kwargs)
 
             # Lookup
             try:
                 hit = await client.get(key)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("cache: GET failed (%s); falling through", exc)
+            except Exception:  # noqa: BLE001
+                logger.warning("cache: GET failed; falling through", exc_info=True)
                 return await fn(*args, **kwargs)
 
             if hit is not None:
                 try:
                     return _loads(hit)
-                except Exception as exc:  # noqa: BLE001
+                except Exception:  # noqa: BLE001
                     # Corrupt cache entry — drop it and recompute.
-                    logger.warning("cache: parse failed (%s); recomputing", exc)
+                    logger.warning("cache: parse failed; recomputing", exc_info=True)
                     try:
                         await client.delete(key)
                     except Exception:
@@ -187,8 +187,8 @@ def cached(key_fn: Callable[..., str], ttl: int, jitter: float = 0.1):
                     key,
                     exc,
                 )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("cache: SET failed (%s); not cached", exc)
+            except Exception:  # noqa: BLE001
+                logger.warning("cache: SET failed; not cached", exc_info=True)
             return value
 
         return wrapper
@@ -204,8 +204,8 @@ async def invalidate(prefix: str) -> int:
     """
     try:
         client = get_cache()
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("invalidate: redis init failed (%s)", exc)
+    except Exception:  # noqa: BLE001
+        logger.warning("invalidate: redis init failed", exc_info=True)
         return 0
 
     pattern = (KEY_PREFIX + prefix + "*").encode("utf-8")
@@ -218,8 +218,8 @@ async def invalidate(prefix: str) -> int:
                 deleted += await client.delete(*keys)
             if cursor == 0:
                 break
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("invalidate: SCAN/DEL failed for %r: %s", pattern, exc)
+    except Exception:  # noqa: BLE001
+        logger.warning("invalidate: SCAN/DEL failed for %r", pattern, exc_info=True)
     return deleted
 
 
@@ -265,8 +265,8 @@ async def with_lock(key: str, ttl_seconds: int = 60):
     finally:
         try:
             await client.eval(_RELEASE_LUA, 1, full, token)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("with_lock: release failed for %s: %s", key, exc)
+        except Exception:  # noqa: BLE001
+            logger.warning("with_lock: release failed for %s", key, exc_info=True)
 
 
 @contextmanager
@@ -284,8 +284,8 @@ def with_lock_sync(key: str, ttl_seconds: int = 60):
     finally:
         try:
             client.eval(_RELEASE_LUA, 1, full, token)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("with_lock_sync: release failed for %s: %s", key, exc)
+        except Exception:  # noqa: BLE001
+            logger.warning("with_lock_sync: release failed for %s", key, exc_info=True)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Continues the WARNING-level traceback-loss sweep after **#698** (utils/core/db) and **#699** (services/). Eight sites in `core/cache.py` used `logger.warning(\"...\", exc)` (positional-arg form — **different syntactic shape from #698's f-string form**, which is why they were missed by the first scan). All inside `except Exception as exc:` blocks for Redis cache init/GET/SET/parse/SCAN-DEL/lock-release failures.

## Sites cleared

| Line | Function | Pattern |
|---|---|---|
| 156 | `wrapper` (cache decorator) | Redis init failure |
| 163 | `wrapper` | GET failure |
| 171 | `wrapper` | parse (corrupt entry) failure |
| 191 | `wrapper` | SET failure |
| 208 | `invalidate` | redis init failure |
| 222 | `invalidate` | SCAN/DEL failure for pattern |
| 269 | `with_lock` | lock release failure |
| 288 | `with_lock_sync` | lock release failure (sync variant) |

Each call converted from `logger.warning(\"...: %s\", exc)` to `logger.warning(\"...\", exc_info=True)`. Where the message had multiple `%s` placeholders (e.g. `\"SCAN/DEL failed for %r: %s\"` with `pattern, exc`), preserved the non-exc `%r` arg as positional with `exc_info=True`.

Five `except Exception as exc:` bindings became unused after the edit (F841) and were converted to bare `except Exception:`. The single `except TypeError as exc:` at line 182 was preserved — it uses `exc` legitimately for a JSON-serialisation debug log (separate codepath, no exc_info needed).

## Sweep totals after this PR

- **#698**: 5 sites (utils/core/db, f-string form)
- **#699**: 14 sites (services/, f-string form)
- **#701**: 8 sites (core/cache.py, positional-arg form) ← this PR
- Remaining: ~21 sites in `api/v1/endpoints/` (positional + f-string mix) — slated for follow-up

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741
- [x] Black formatted (pinned 26.3.1)
- [x] AST scan confirms 0 WARNING traceback-loss sites remain in core/cache.py
- [x] `except TypeError as exc:` legitimate usage at line 182 preserved
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)