### PR TITLE
sec(logging): preserve traceback for 28 logger.warning sites in endpoints/

### DIFF
--- a/backend/app/api/v1/endpoints/application_fields.py
+++ b/backend/app/api/v1/endpoints/application_fields.py
@@ -355,8 +355,8 @@ async def upload_document_example(
                 minio_service.client.remove_object(
                     bucket_name=minio_service.default_bucket, object_name=document.example_file_url
                 )
-            except Exception as e:
-                logger.warning(f"Failed to delete old example file: {str(e)}")
+            except Exception:
+                logger.warning("Failed to delete old example file", exc_info=True)
 
         # Update database with new object name
         document.example_file_url = object_name

--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -998,12 +998,12 @@ async def upload_application_document(
     if previous_object and previous_object != object_name:
         try:
             minio_service.client.remove_object(minio_service.default_bucket, previous_object)
-        except Exception as exc:
+        except Exception:
             logger.warning(
-                "Failed to remove orphaned MinIO object %s for application %s: %s",
+                "Failed to remove orphaned MinIO object %s for application %s",
                 previous_object,
                 application_id,
-                exc,
+                exc_info=True,
             )
 
     return {
@@ -1136,12 +1136,12 @@ async def delete_application_document(
     if previous_object:
         try:
             minio_service.client.remove_object(minio_service.default_bucket, previous_object)
-        except Exception as exc:
+        except Exception:
             logger.warning(
-                "Failed to remove MinIO object %s after delete for application %s: %s",
+                "Failed to remove MinIO object %s after delete for application %s",
                 previous_object,
                 application_id,
-                exc,
+                exc_info=True,
             )
 
     return {"success": True, "message": "申請文件已刪除", "data": None}

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -1433,8 +1433,8 @@ async def delete_batch_import(
         try:
             minio_service = MinIOService()
             minio_service.delete_file(bucket_name=settings.minio_bucket, object_name=batch_import.file_path)
-        except Exception as e:
-            logger.warning(f"Failed to delete batch import file from MinIO: {e}")
+        except Exception:
+            logger.warning("Failed to delete batch import file from MinIO", exc_info=True)
             # Continue with batch deletion even if MinIO deletion fails
 
     # Delete batch import record

--- a/backend/app/api/v1/endpoints/college_review/application_review.py
+++ b/backend/app/api/v1/endpoints/college_review/application_review.py
@@ -104,10 +104,10 @@ async def get_applications_for_review(
     except HTTPException:
         raise
     except ValueError as e:
-        logger.warning(f"Invalid request parameters for college applications: {str(e)}")
+        logger.warning("Invalid request parameters for college applications", exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid request parameters") from e
     except ReviewPermissionError as e:
-        logger.warning(f"Permission denied for college applications access: {str(e)}")
+        logger.warning("Permission denied for college applications access", exc_info=True)
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except DatabaseError as e:
         logger.exception("Database error retrieving applications")

--- a/backend/app/api/v1/endpoints/college_review/distribution.py
+++ b/backend/app/api/v1/endpoints/college_review/distribution.py
@@ -58,7 +58,7 @@ async def get_quota_status(
         return ApiResponse(success=True, message="Quota status retrieved successfully", data=quota_status)
 
     except ValueError as e:
-        logger.warning(f"Invalid quota status parameters: {str(e)}")
+        logger.warning("Invalid quota status parameters", exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid parameters") from e
     except CollegeReviewError as e:
         logger.exception("College review error retrieving quota status")

--- a/backend/app/api/v1/endpoints/college_review/export_package.py
+++ b/backend/app/api/v1/endpoints/college_review/export_package.py
@@ -74,7 +74,7 @@ async def export_application_package(
             college_code=college_code,
         )
     except ValueError as e:
-        logger.warning("export-package rejected: %s", e, extra=log_extra)
+        logger.warning("export-package rejected: %s", extra=log_extra, exc_info=True)
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.exception("export-package zip generation failed", extra=log_extra)

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -188,7 +188,7 @@ async def get_rankings(
         )
 
     except ValueError as e:
-        logger.warning(f"Invalid query parameters for rankings: {str(e)}")
+        logger.warning("Invalid query parameters for rankings", exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid query parameters") from e
     except CollegeReviewError as e:
         logger.exception("College review error retrieving rankings")
@@ -255,7 +255,7 @@ async def create_ranking(
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except ValueError as e:
-        logger.warning(f"Invalid ranking creation data: {str(e)}")
+        logger.warning("Invalid ranking creation data", exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid ranking data") from e
     except CollegeReviewError as e:
         logger.exception("College review error creating ranking")
@@ -560,7 +560,7 @@ async def get_ranking(
     except HTTPException:
         raise
     except RankingNotFoundError as e:
-        logger.warning(f"Ranking not found: {str(e)}")
+        logger.warning("Ranking not found", exc_info=True)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except CollegeReviewError as e:
         logger.exception("College review error retrieving ranking")
@@ -652,13 +652,13 @@ async def update_ranking_order(
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingNotFoundError as e:
-        logger.warning(f"Ranking not found for order update: {str(e)}")
+        logger.warning("Ranking not found for order update", exc_info=True)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingModificationError as e:
-        logger.warning(f"Cannot modify ranking: {str(e)}")
+        logger.warning("Cannot modify ranking", exc_info=True)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
     except InvalidRankingDataError as e:
-        logger.warning(f"Invalid ranking data: {str(e)}")
+        logger.warning("Invalid ranking data", exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except CollegeReviewError as e:
         logger.exception("College review error during ranking update")
@@ -753,10 +753,10 @@ async def finalize_ranking(
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingNotFoundError as e:
-        logger.warning(f"Ranking not found for finalization: {str(e)}")
+        logger.warning("Ranking not found for finalization", exc_info=True)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingModificationError as e:
-        logger.warning(f"Cannot finalize ranking: {str(e)}")
+        logger.warning("Cannot finalize ranking", exc_info=True)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
     except CollegeReviewError as e:
         logger.exception("College review error during finalization")
@@ -849,10 +849,10 @@ async def unfinalize_ranking(
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingNotFoundError as e:
-        logger.warning(f"Ranking not found for unfinalization: {str(e)}")
+        logger.warning("Ranking not found for unfinalization", exc_info=True)
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except RankingModificationError as e:
-        logger.warning(f"Cannot unfinalize ranking: {str(e)}")
+        logger.warning("Cannot unfinalize ranking", exc_info=True)
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
     except CollegeReviewError as e:
         logger.exception("College review error during unfinalization")

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -145,19 +145,19 @@ def _generate_payment_roster_inner(
 
     except RosterAlreadyExistsError as e:
         # Roster already exists for this configuration/period
-        logger.warning(f"Roster already exists: {e}")
+        logger.warning("Roster already exists", exc_info=True)
         db.rollback()
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
 
     except RosterLockedError as e:
         # Trying to regenerate a locked roster
-        logger.warning(f"Roster is locked: {e}")
+        logger.warning("Roster is locked", exc_info=True)
         db.rollback()
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
 
     except RosterNotFoundError as e:
         # Referenced roster not found (for regeneration)
-        logger.warning(f"Roster not found: {e}")
+        logger.warning("Roster not found", exc_info=True)
         db.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
@@ -196,7 +196,7 @@ def _generate_payment_roster_inner(
 
     except ValueError as e:
         # Validation errors (missing data, invalid parameters)
-        logger.warning(f"Roster generation validation error: {e}")
+        logger.warning("Roster generation validation error", exc_info=True)
         db.rollback()
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
@@ -665,7 +665,7 @@ async def preview_roster_students(
                         student_info["has_fresh_data"] = bool(fresh_student_data)
 
                 except Exception as e:
-                    logger.warning(f"Verification failed for student {student_id_number}: {e}")
+                    logger.warning(f"Verification failed for student {student_id_number}", exc_info=True)
                     student_info["verification_status"] = "error"
                     student_info["verification_message"] = str(e)
                     summary["verification_stats"]["api_errors"] += 1
@@ -680,8 +680,8 @@ async def preview_roster_students(
                 student_info["is_eligible"] = eligibility_result.get("is_eligible", True)
                 student_info["failed_rules"] = eligibility_result.get("failed_rules", [])
                 student_info["warning_rules"] = eligibility_result.get("warning_rules", [])
-            except Exception as e:
-                logger.warning(f"Eligibility validation failed for application {application.id}: {e}")
+            except Exception:
+                logger.warning(f"Eligibility validation failed for application {application.id}", exc_info=True)
                 student_info["is_eligible"] = True  # Don't exclude on validation error
 
             # Validation Step 4: Bank account check
@@ -1635,8 +1635,8 @@ async def download_roster_excel(
                     },
                 )
 
-            except Exception as e:
-                logger.warning(f"MinIO download failed, falling back to local file: {e}")
+            except Exception:
+                logger.warning("MinIO download failed, falling back to local file", exc_info=True)
                 use_minio = False
 
         if not use_minio or not (hasattr(roster, "minio_object_name") and roster.minio_object_name):

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -540,10 +540,10 @@ async def submit_application_review(
         # Re-raise FastAPI HTTPException as-is (preserves status code and detail)
         raise
     except ValueError as e:
-        logger.warning(f"Invalid review data for application {application_id}: {str(e)}")
+        logger.warning(f"Invalid review data for application {application_id}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid review data") from e
     except PermissionError as e:
-        logger.warning(f"Permission denied for review creation by user {current_user.id}: {str(e)}")
+        logger.warning(f"Permission denied for review creation by user {current_user.id}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to review this application"
         ) from e

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -196,11 +196,11 @@ async def upload_system_doc(
     if previous_object and previous_object != object_name:
         try:
             minio_service.client.remove_object(minio_service.default_bucket, previous_object)
-        except Exception as exc:
+        except Exception:
             logger.warning(
-                "Failed to remove orphaned MinIO system doc %s: %s",
+                "Failed to remove orphaned MinIO system doc %s",
                 previous_object,
-                exc,
+                exc_info=True,
             )
 
     return {


### PR DESCRIPTION
## Summary

Completes the WARNING-level traceback-loss sweep across the entire `backend/app/` tree. After this lands, the only retained instances are the **4 sites in `utils/endpoint_decorators.py::wrapper`** — intentional recoverable-business-error mappings (HTTP 403/404/400) documented in PR #698's commit.

## Sweep totals across the WARNING-level wave

| PR | Scope | Sites |
|---|---|---|
| #698 | utils/core/db (f-string) | 5 |
| #699 | services/ (f-string) | 14 |
| #701 | core/cache.py (positional) | 8 |
| **this** | **endpoints/ (mixed)** | **28** |
| **Total** | | **55** |

## Per-file in this PR

| File | Sites | Variant |
|---|---|---|
| `college_review/ranking_management.py` | 10 | fstring |
| `payment_rosters.py` | 7 | fstring |
| `reviews.py` | 2 | fstring |
| `college_review/application_review.py` | 2 | fstring |
| `applications.py` | 2 | positional, multi-line (manual fix) |
| `system_settings.py` | 1 | positional, multi-line (manual fix) |
| `batch_import.py` | 1 | fstring |
| `application_fields.py` | 1 | fstring |
| `college_review/distribution.py` | 1 | fstring |
| `college_review/export_package.py` | 1 | positional |

The AST batch-rewrite handled 25 single-line cases automatically; the 3 multi-line positional-arg cases (MinIO orphan cleanup paths in `applications.py` + `system_settings.py`) were edited manually.

Each conversion preserves non-leak contextual `%s`/`%r` arguments (object names, application IDs, etc.) and adds `exc_info=True`. Four `except Exception as e:` bindings became unused (F841) and were converted to bare `except Exception:`.

## After this lands

A WARNING-level AST invariant (mirror of #695's ERROR-level one with allowlist for `endpoint_decorators.wrapper`) becomes shippable in a follow-up PR. The combined ERROR + WARNING invariant pair will then fully CI-guard the entire backend traceback-preservation property.

## Test plan

- [x] Lint clean under E9/F63/F7/F82/F401/F811/F841/B904/E712/E741 on all 10 touched files
- [x] Black formatted (pinned 26.3.1)
- [x] AST scan confirms 0 WARNING traceback-loss sites remain in endpoints/ (excluding the documented endpoint_decorators allowlist)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)