### PR TITLE
chore(frontend): narrow manual-distribution.ts any-types (19 sites)

### DIFF
--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -170,31 +170,40 @@ describe("createManualDistributionApi", () => {
 
   // ─── getHistory (path-templated scholarship_type_id) ──────────────
 
-  it("getHistory templates scholarship_type_id directly into URL path", async () => {
-    // Pin: scholarship_type_id is in PATH (not query) for history
-    // — uses backtick template string. Pin so refactor moving it
-    // to query breaks the admin history view.
+  it("getHistory uses typed-route path param for scholarship_type_id", async () => {
+    // Pin: scholarship_type_id is in PATH (not query) for history.
+    // Uses openapi-fetch typed-route form: literal {scholarship_type_id}
+    // in the URL string, real value via params.path. Pin so refactor
+    // moving it to query breaks the admin history view.
     mockedRaw.GET.mockResolvedValueOnce({});
     const api = createManualDistributionApi();
     await api.getHistory(7, 114, "first");
     expect(mockedRaw.GET).toHaveBeenCalledWith(
-      "/api/v1/manual-distribution/7/history",
-      { params: { query: { academic_year: 114, semester: "first" } } }
+      "/api/v1/manual-distribution/{scholarship_type_id}/history",
+      {
+        params: {
+          path: { scholarship_type_id: 7 },
+          query: { academic_year: 114, semester: "first" },
+        },
+      }
     );
   });
 
   // ─── restoreFromHistory ───────────────────────────────────────────
 
-  it("restoreFromHistory POSTs /{id}/restore with history_id body", async () => {
+  it("restoreFromHistory POSTs typed-route /{id}/restore with history_id body", async () => {
     // Pin SECURITY: restore replays a historical allocation —
-    // path-templated scholarship_type_id + body with history_id.
-    // Pin so refactor doesn't mismatch scholarship vs. history.
+    // typed-route scholarship_type_id in params.path + body with
+    // history_id. Pin so refactor doesn't mismatch scholarship vs. history.
     mockedRaw.POST.mockResolvedValueOnce({});
     const api = createManualDistributionApi();
     await api.restoreFromHistory(7, { history_id: 42 });
     expect(mockedRaw.POST).toHaveBeenCalledWith(
-      "/api/v1/manual-distribution/7/restore",
-      { body: { history_id: 42 } }
+      "/api/v1/manual-distribution/{scholarship_type_id}/restore",
+      {
+        params: { path: { scholarship_type_id: 7 } },
+        body: { history_id: 42 },
+      }
     );
   });
 

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -188,7 +188,7 @@ export function createManualDistributionApi() {
       ApiResponse<AvailableCombinations>
     > => {
       const response = await typedClient.raw.GET(
-        "/api/v1/manual-distribution/available-combinations" as any,
+        "/api/v1/manual-distribution/available-combinations",
         {}
       );
       return toApiResponse(response) as ApiResponse<AvailableCombinations>;
@@ -204,7 +204,7 @@ export function createManualDistributionApi() {
       college_code?: string
     ): Promise<ApiResponse<DistributionStudent[]>> => {
       const response = await typedClient.raw.GET(
-        "/api/v1/manual-distribution/students" as any,
+        "/api/v1/manual-distribution/students",
         {
           params: {
             query: {
@@ -212,7 +212,7 @@ export function createManualDistributionApi() {
               academic_year,
               semester,
               ...(college_code ? { college_code } : {}),
-            } as any,
+            },
           },
         }
       );
@@ -228,10 +228,10 @@ export function createManualDistributionApi() {
       semester: string
     ): Promise<ApiResponse<QuotaStatus>> => {
       const response = await typedClient.raw.GET(
-        "/api/v1/manual-distribution/quota-status" as any,
+        "/api/v1/manual-distribution/quota-status",
         {
           params: {
-            query: { scholarship_type_id, academic_year, semester } as any,
+            query: { scholarship_type_id, academic_year, semester },
           },
         }
       );
@@ -245,8 +245,8 @@ export function createManualDistributionApi() {
       request: AllocateRequest
     ): Promise<ApiResponse<AllocateResult>> => {
       const response = await typedClient.raw.POST(
-        "/api/v1/manual-distribution/allocate" as any,
-        { body: request as any }
+        "/api/v1/manual-distribution/allocate",
+        { body: request }
       );
       return toApiResponse(response) as ApiResponse<AllocateResult>;
     },
@@ -258,8 +258,8 @@ export function createManualDistributionApi() {
       request: FinalizeRequest
     ): Promise<ApiResponse<FinalizeResult>> => {
       const response = await typedClient.raw.POST(
-        "/api/v1/manual-distribution/finalize" as any,
-        { body: request as any }
+        "/api/v1/manual-distribution/finalize",
+        { body: request }
       );
       return toApiResponse(response) as ApiResponse<FinalizeResult>;
     },
@@ -273,10 +273,11 @@ export function createManualDistributionApi() {
       semester: string
     ): Promise<ApiResponse<DistributionHistoryRecord[]>> => {
       const response = await typedClient.raw.GET(
-        `/api/v1/manual-distribution/${scholarship_type_id}/history` as any,
+        `/api/v1/manual-distribution/{scholarship_type_id}/history`,
         {
           params: {
-            query: { academic_year, semester } as any,
+            path: { scholarship_type_id },
+            query: { academic_year, semester },
           },
         }
       );
@@ -293,8 +294,11 @@ export function createManualDistributionApi() {
       request: RestoreRequest
     ): Promise<ApiResponse<RestoreResult>> => {
       const response = await typedClient.raw.POST(
-        `/api/v1/manual-distribution/${scholarship_type_id}/restore` as any,
-        { body: request as any }
+        `/api/v1/manual-distribution/{scholarship_type_id}/restore`,
+        {
+          params: { path: { scholarship_type_id } },
+          body: request,
+        }
       );
       return toApiResponse(response) as ApiResponse<RestoreResult>;
     },
@@ -308,10 +312,10 @@ export function createManualDistributionApi() {
       semester: string
     ): Promise<ApiResponse<DistributionSummaryResult>> => {
       const response = await typedClient.raw.GET(
-        "/api/v1/manual-distribution/distribution-summary" as any,
+        "/api/v1/manual-distribution/distribution-summary",
         {
           params: {
-            query: { scholarship_type_id, academic_year, semester } as any,
+            query: { scholarship_type_id, academic_year, semester },
           },
         }
       );
@@ -327,14 +331,14 @@ export function createManualDistributionApi() {
       semester: string
     ): Promise<ApiResponse<{ suggestions: AllocationSuggestion[] }>> => {
       const response = await typedClient.raw.GET(
-        "/api/v1/manual-distribution/auto-allocate-preview" as any,
+        "/api/v1/manual-distribution/auto-allocate-preview",
         {
           params: {
             query: {
               scholarship_type_id,
               academic_year,
               semester,
-            } as any,
+            },
           },
         }
       );
@@ -351,8 +355,8 @@ export function createManualDistributionApi() {
       request: GenerateRostersRequest
     ): Promise<ApiResponse<GenerateRostersResult>> => {
       const response = await typedClient.raw.POST(
-        "/api/v1/manual-distribution/generate-rosters-from-distribution" as any,
-        { body: request as any }
+        "/api/v1/manual-distribution/generate-rosters-from-distribution",
+        { body: request as never }
       );
       return toApiResponse(response) as ApiResponse<GenerateRostersResult>;
     },


### PR DESCRIPTION
## Summary

- Drop 18 stale `as any` casts in `manual-distribution.ts` — the 11 underlying endpoints all exist in the generated OpenAPI schema, so typed-route inference works directly.
- 1 site converted from `as any` to `as never` (`generateRostersFromDistribution` body): the generated schema marks `student_verification_enabled` + `force_regenerate` as required (server-default `false`), but the local `GenerateRostersRequest` keeps them optional for callers. `as never` is the openapi-fetch convention for this shape-drift.
- Path-param routes (`{scholarship_type_id}/history`, `{scholarship_type_id}/restore`) moved from interpolated `${id}` strings to typed-route + `params: { path: ... }` form (matching `applications.ts`/`college.ts`).

## Test plan

- [x] `tsc --noEmit` exit 0 against the entire frontend with the symlinked node_modules
- [x] No runtime change — pure type narrowing
- [ ] CI green

Continues the frontend any-cleanup wave (PRs #589–#599, #627–#636, #673–#675, #678, #690, #692). 18 of remaining ~96 `as any` sites cleared (~19% of remaining surface in one file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)