### PR TITLE
test(observability): WARNING-level traceback-loss AST invariant + sweep 3 stragglers

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -70,8 +70,8 @@ class ApplicationService:
         try:
             await cache_invalidate("dashboard:")
             await cache_invalidate("quota:")
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("cache invalidation failed (non-fatal): %s", exc)
+        except Exception:  # noqa: BLE001
+            logger.warning("cache invalidation failed (non-fatal)", exc_info=True)
 
     def _serialize_for_json(self, data: Any) -> Any:
         """Serialize data for JSON response"""
@@ -1115,7 +1115,7 @@ class ApplicationService:
         logger.info(f"Cloning bank account proof document for application {application.app_id}")
         try:
             await self._clone_user_profile_documents(application, current_user)
-        except Exception as e:
+        except Exception:
             logger.warning(
                 f"Failed to clone bank account proof document for application {application.app_id}", exc_info=True
             )

--- a/backend/app/services/bank_verification_task_service.py
+++ b/backend/app/services/bank_verification_task_service.py
@@ -341,13 +341,13 @@ class BankVerificationTaskService:
             )
             result = await self.db.execute(stmt)
             return result.scalar_one_or_none() is not None
-        except Exception as exc:  # noqa: BLE001
+        except Exception:  # noqa: BLE001
             # Fall through to normal verification on any lookup error — this is
             # an optimisation, not a correctness boundary, so we don't want it
             # to mask real verification work.
             logger.warning(
-                "Skip-check failed for application %s; falling through to full verification: %s",
+                "Skip-check failed for application %s; falling through to full verification",
                 application_id,
-                exc,
+                exc_info=True,
             )
             return False

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -453,8 +453,12 @@ class BatchImportService:
                         )
                         api_failed = True
                     break
-                except Exception as exc:  # pylint: disable=broad-except
-                    logger.warning("Student API unexpected error for %s: %s", student_id, exc)
+                except Exception:  # pylint: disable=broad-except
+                    logger.warning(
+                        "Student API unexpected error for %s",
+                        student_id,
+                        exc_info=True,
+                    )
                     add_warning(
                         student_id,
                         "student_api_error",

--- a/backend/app/tests/test_no_logger_warning_traceback_loss.py
+++ b/backend/app/tests/test_no_logger_warning_traceback_loss.py
@@ -1,0 +1,172 @@
+"""
+Source-level regression for the WARNING-level traceback-preservation
+sweep (PRs #698 + #699 + #701 + #702).
+
+Mirrors `test_no_logger_error_traceback_loss.py` but for `logger.warning(...)`.
+WARNING is swept *with one documented exception*: the four business-error
+handlers in `utils/endpoint_decorators.py::wrapper` intentionally retain
+f-string form because they map known recoverable errors
+(ReviewPermissionError, RankingNotFoundError, RankingModificationError,
+ValueError) to specific HTTP 4xx responses — the trace would be noise
+since the exception is already understood and routed.
+
+Two syntactic variants are guarded:
+1. **f-string** — `logger.warning(f"...: {e}")` (caught by PRs #698/#699/#702)
+2. **positional** — `logger.warning("...: %s", e)` (caught by PRs #701/#702)
+
+If a future PR re-introduces either pattern at WARNING level without
+`exc_info=True`, this test fails before the change ships.
+
+The check runs in <1s. No DB, no fixtures, no HTTP client.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+APP_DIR = Path(__file__).resolve().parent.parent
+
+LEAK_VARS = {"e", "exc", "e2", "ex", "err", "error"}
+
+# Allowlist: (relative-to-app posix path, enclosing function name)
+# Documented in source via a SECURITY comment so future readers can find it.
+ALLOWLIST = {
+    ("utils/endpoint_decorators.py", "wrapper"),
+}
+
+
+def _is_leak_fstring(node: ast.AST) -> bool:
+    if not isinstance(node, ast.JoinedStr):
+        return False
+    for part in node.values:
+        if not isinstance(part, ast.FormattedValue):
+            continue
+        if isinstance(part.value, ast.Name) and part.value.id in LEAK_VARS:
+            return True
+        if (
+            isinstance(part.value, ast.Call)
+            and isinstance(part.value.func, ast.Name)
+            and part.value.func.id == "str"
+            and len(part.value.args) == 1
+            and isinstance(part.value.args[0], ast.Name)
+            and part.value.args[0].id in LEAK_VARS
+        ):
+            return True
+    return False
+
+
+def _has_exc_info_truthy(call: ast.Call) -> bool:
+    for kw in call.keywords:
+        if kw.arg != "exc_info":
+            continue
+        if isinstance(kw.value, ast.Constant) and kw.value.value is False:
+            return False
+        return True
+    return False
+
+
+def _is_logger_warning_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "warning"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "logger"
+    )
+
+
+def _enclosing_function(node: ast.AST, tree: ast.AST) -> str:
+    target_line = getattr(node, "lineno", 0)
+    candidates = [
+        fn
+        for fn in ast.walk(tree)
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and fn.lineno <= target_line <= getattr(fn, "end_lineno", target_line)
+    ]
+    if not candidates:
+        return "<module>"
+    return min(candidates, key=lambda fn: target_line - fn.lineno).name
+
+
+def _iter_app_files() -> list[Path]:
+    return sorted(p for p in APP_DIR.rglob("*.py") if "__pycache__" not in p.parts and p.parts[-2] != "tests")
+
+
+def _has_exception_positional_arg(call: ast.Call) -> bool:
+    for arg in call.args[1:]:
+        if isinstance(arg, ast.Name) and arg.id in LEAK_VARS:
+            return True
+        if (
+            isinstance(arg, ast.Call)
+            and isinstance(arg.func, ast.Name)
+            and arg.func.id == "str"
+            and len(arg.args) == 1
+            and isinstance(arg.args[0], ast.Name)
+            and arg.args[0].id in LEAK_VARS
+        ):
+            return True
+    return False
+
+
+def _scan_file(path: Path) -> list[tuple[str, int, str, str]]:
+    src = path.read_text()
+    tree = ast.parse(src)
+    findings = []
+    for node in ast.walk(tree):
+        if not _is_logger_warning_call(node):
+            continue
+        if _has_exc_info_truthy(node):
+            continue
+        if not node.args:
+            continue
+        kind = None
+        if _is_leak_fstring(node.args[0]):
+            kind = "fstring"
+        elif _has_exception_positional_arg(node):
+            kind = "positional"
+        if kind is None:
+            continue
+        handler = _enclosing_function(node, tree)
+        excerpt = ast.unparse(node).splitlines()[0][:120]
+        findings.append((handler, node.lineno, excerpt, kind))
+    return findings
+
+
+def test_no_logger_warning_traceback_loss():
+    """Every `logger.warning(...)` call that interpolates an exception
+    variable (either as f-string `{e}` or as positional `%s`-style arg)
+    must also pass `exc_info=True`, or be converted to
+    `logger.exception(...)`. Otherwise the trace gets discarded.
+
+    PRs #698 + #699 + #701 + #702 swept the WARNING-level surface
+    across utils/core/db/services/cache/endpoints. The four sites in
+    `utils/endpoint_decorators.py::wrapper` are intentionally retained
+    (HTTP-mapped business errors — trace would be noise) and live in
+    the ALLOWLIST."""
+    violations = []
+    for path in _iter_app_files():
+        rel = path.relative_to(APP_DIR.parent)
+        rel_to_app = path.relative_to(APP_DIR).as_posix()
+        for handler, lineno, excerpt, kind in _scan_file(path):
+            if (rel_to_app, handler) in ALLOWLIST:
+                continue
+            violations.append(f"{rel}:{lineno}  [{kind}]  {handler}()  {excerpt!r}")
+
+    if violations:
+        msg = (
+            "Found `logger.warning(...)` calls that interpolate an exception "
+            "variable but lack `exc_info=True`. The trace gets discarded — "
+            "only str(exc) reaches structured logs. Two variants both "
+            "forbidden:\n"
+            '  - [fstring]    logger.warning(f"...: {e}")    → '
+            "logger.exception(...) (drop the {e}) — or logger.warning(..., exc_info=True)\n"
+            '  - [positional] logger.warning("...: %s", e)   → '
+            "logger.exception(...) (drop the e) — or logger.warning(..., exc_info=True)\n"
+            "If a site needs to stay at WARNING level without a trace "
+            "(e.g. recoverable business-error mapper in endpoint_decorators.py), "
+            "add it to the ALLOWLIST in this test file with a SECURITY "
+            "comment at the source site documenting why.\n\n"
+            "Violations:\n  " + "\n  ".join(violations)
+        )
+        pytest.fail(msg)

--- a/backend/app/utils/endpoint_decorators.py
+++ b/backend/app/utils/endpoint_decorators.py
@@ -40,6 +40,15 @@ def handle_college_review_errors(func: Callable) -> Callable:
 
     @functools.wraps(func)
     async def wrapper(*args, **kwargs):
+        # SECURITY: the four logger.warning(f"...: {str(e)}") calls in this
+        # function intentionally interpolate the exception variable without
+        # exc_info=True. These are recoverable business errors that map to
+        # specific HTTP 4xx responses — the trace would be noise. The
+        # CI invariant test_no_logger_warning_traceback_loss allowlists
+        # ("utils/endpoint_decorators.py", "wrapper") to permit this. If
+        # adding new branches here that follow the same pattern, no
+        # invariant update is needed; if a branch needs a real trace,
+        # add exc_info=True at that single call site.
         try:
             return await func(*args, **kwargs)
 


### PR DESCRIPTION
## Summary

- New CI invariant `test_no_logger_warning_traceback_loss.py` mirrors the ERROR-level guard from PR #695/#700, locking in the WARNING-level sweep completed by PRs #698/#699/#701/#702.
- Catches both syntactic shapes: f-string (`logger.warning(f\"...{e}\")`) and positional (`logger.warning(\"...%s\", exc)`).
- ALLOWLIST: `(\"utils/endpoint_decorators.py\", \"wrapper\")` — 4 sites mapping ReviewPermissionError / RankingNotFoundError / RankingModificationError / ValueError to HTTP 4xx where the trace would be noise. SECURITY comment added at the source so future readers can find the allowlist by grepping the function.
- Swept 3 stragglers (positional form, escaped earlier fstring-targeted sweeps): `application_service.py:74`, `bank_verification_task_service.py:348`, `batch_import_service.py:457`.
- Drive-by F841 fix on `application_service.py:1118` (unused `as e:` binding from a prior incomplete WARNING fix).

## Test plan

- [x] AST scan against the worktree (origin/main + this PR) returns 0 violations
- [x] `uvx --from black==26.3.1 black ...` no-op
- [x] `uvx --from flake8==7.1.1 flake8 ... --select=E9,F63,F7,F82,F841,F401,F811,B904,B014` exit 0
- [ ] CI green

Closes the WARNING-level traceback-loss thread. With this merged, the entire backend `app/` tree is CI-guarded against both ERROR-level and WARNING-level traceback discards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)