### PR TITLE
fix(alembic): handle UNIQUE INDEX vs UNIQUE CONSTRAINT in email_templates migration

### DIFF
--- a/backend/alembic/versions/20260515_email_templates_scholarship_type_id.py
+++ b/backend/alembic/versions/20260515_email_templates_scholarship_type_id.py
@@ -40,20 +40,25 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-def _existing_key_unique_constraint_name(inspector) -> Union[str, None]:
-    """Return the auto-generated name of the existing single-column unique on ``key``.
+def _existing_key_unique_constraint_name(inspector) -> tuple:
+    """Return (name, kind) for the existing single-column unique on ``key``.
 
-    The constraint may have been created either as a real UNIQUE CONSTRAINT
-    or as a UNIQUE INDEX; check both. Returns ``None`` if neither is found
-    (e.g., a fresh DB built directly from the new model).
+    kind is ``"constraint"`` when found via get_unique_constraints (can be
+    dropped with op.drop_constraint), or ``"index"`` when found via
+    get_indexes (must be dropped with op.drop_index). Returns (None, None)
+    if neither is found (fresh DB built from the new model).
+
+    Returning the kind avoids the try/except anti-pattern where
+    op.drop_constraint fails with UndefinedObject, the PostgreSQL transaction
+    enters aborted state, and the fallback op.drop_index also fails.
     """
     for c in inspector.get_unique_constraints("email_templates"):
         if c.get("column_names") == ["key"]:
-            return c["name"]
+            return c["name"], "constraint"
     for ix in inspector.get_indexes("email_templates"):
         if ix.get("unique") and ix.get("column_names") == ["key"]:
-            return ix["name"]
-    return None
+            return ix["name"], "index"
+    return None, None
 
 
 def _fks_targeting_email_templates_key(inspector, table_name: str) -> list:
@@ -111,12 +116,14 @@ def upgrade() -> None:
         )
 
     # 3. Drop the auto-generated single-column unique on ``key``.
-    existing_unique_name = _existing_key_unique_constraint_name(inspector)
+    existing_unique_name, unique_kind = _existing_key_unique_constraint_name(inspector)
     if existing_unique_name:
-        # Try dropping as a unique constraint first; fall back to index drop.
-        try:
+        # Use the correct DDL based on how the unique was created. Mixing them
+        # (e.g., calling op.drop_constraint on a UNIQUE INDEX) raises
+        # UndefinedObject and aborts the transaction before the fallback runs.
+        if unique_kind == "constraint":
             op.drop_constraint(existing_unique_name, "email_templates", type_="unique")
-        except Exception:
+        else:
             op.drop_index(existing_unique_name, table_name="email_templates")
 
     # 4. Add the compound unique constraint.


### PR DESCRIPTION
## Summary

- Fixes the staging deployment failure in migration `email_tpl_scholar_type_001`
- Root cause: `_existing_key_unique_constraint_name()` returned a name found via `get_indexes()` (a UNIQUE INDEX), but the caller always tried `op.drop_constraint(...)` first — which raises `UndefinedObject` because the object is an index, not a constraint
- PostgreSQL then puts the transaction into aborted state, so the fallback `op.drop_index()` in the `except` block also fails
- Fix: return `(name, kind)` tuple from the helper and dispatch to the correct DDL function (`op.drop_constraint` vs `op.drop_index`) without a try/except

## Affected CI run

Deployment Pipeline — Run database migrations (2026-05-17):
```
psycopg2.errors.UndefinedObject: constraint "ix_email_templates_key" of relation "email_templates" does not exist
[SQL: ALTER TABLE email_templates DROP CONSTRAINT ix_email_templates_key]
```

## Test plan

- [x] `uvx --from black==26.3.1 black` — no changes
- [x] `uvx --from flake8==7.1.1 flake8` — clean
- [ ] CI: Deployment Pipeline should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)