### PR TITLE
fix(SECURITY): sanitize IntegrityError + raw form-data leaks in applications.py (3 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -118,14 +118,11 @@ async def create_application(
             logger.debug("Form data validated successfully")
         except Exception as e:
             logger.exception("Form data validation failed")
-            # Do not log raw form data as it may contain sensitive information
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail={
                     "message": "Invalid form data structure",
                     "error_code": "INVALID_FORM_DATA",
-                    "error": str(e),
-                    "received_form_data": str(application_data.form_data),
                 },
             ) from e
 
@@ -276,14 +273,12 @@ async def create_application(
         raise
     except IntegrityError as e:
         logger.exception("Database integrity error during application creation")
-        # Check for specific constraint violations if needed, e.g., unique constraint
         if "duplicate key value violates unique constraint" in str(e):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "message": "Duplicate entry: An application with these details already exists.",
                     "error_code": "DUPLICATE_ENTRY",
-                    "detail": str(e),
                 },
             ) from e
         raise HTTPException(
@@ -291,7 +286,6 @@ async def create_application(
             detail={
                 "message": "A database integrity error occurred.",
                 "error_code": "DATABASE_INTEGRITY_ERROR",
-                "detail": str(e),
             },
         ) from e
     except Exception as e:

--- a/backend/app/tests/test_no_exception_leak_in_endpoints.py
+++ b/backend/app/tests/test_no_exception_leak_in_endpoints.py
@@ -23,6 +23,11 @@ A second check (added in the same file) catches bare `detail=str(e)`
 the original sweep and was sanitized in the payment_rosters.py
 RosterGenerationError handler.
 
+A third check catches `detail={"key": str(e)}` — dict-form detail
+containing str(e) values on 5xx responses. This pattern was sanitized
+in applications.py (PR #721) and evaded both prior checks because
+the dict wrapper hides the str(e) call from the top-level keyword scan.
+
 The checks run in <1s. No DB, no fixtures, no HTTP client.
 """
 
@@ -146,6 +151,7 @@ def test_no_endpoint_raises_http_exception_leaking_exception_detail():
             "Violations:\n  " + "\n  ".join(violations)
         )
         pytest.fail(msg)
+        pytest.fail(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +232,76 @@ def test_no_5xx_endpoint_leaks_bare_str_exception():
             "Found HTTPException(status_code=5xx, detail=str(e)) regressions.\n"
             "5xx responses must use a static detail string: "
             'detail="<static message>" + raise ... from e\n'
+            "The traceback is captured by logger.exception() / exc_info=True "
+            "and must NOT be echoed verbatim to the HTTP client.\n\n"
+            "Violations:\n  " + "\n  ".join(violations)
+        )
+        pytest.fail(msg)
+        pytest.fail(msg)
+
+
+# ---------------------------------------------------------------------------
+# Third check: dict-form detail containing str(e) values
+# ---------------------------------------------------------------------------
+
+
+def _detail_dict_contains_str_exception(call: ast.Call) -> bool:
+    """Return True iff detail={"key": str(<exception-name>), ...} in any value."""
+    for kw in call.keywords:
+        if kw.arg != "detail":
+            continue
+        if not isinstance(kw.value, ast.Dict):
+            continue
+        for val in kw.value.values:
+            if (
+                isinstance(val, ast.Call)
+                and isinstance(val.func, ast.Name)
+                and val.func.id == "str"
+                and len(val.args) == 1
+                and isinstance(val.args[0], ast.Name)
+                and val.args[0].id in _EXC_NAMES
+            ):
+                return True
+    return False
+
+
+def _scan_file_dict_detail_str_exception(path: Path) -> list[tuple[str, int, str]]:
+    """Return [(handler_name, lineno, excerpt)] for dict-detail str(e) on 5xx."""
+    src = path.read_text()
+    tree = ast.parse(src)
+    findings = []
+    for node in ast.walk(tree):
+        if not _is_http_exception_raise(node):
+            continue
+        if not _detail_dict_contains_str_exception(node.exc):
+            continue
+        if not _status_code_is_5xx(node.exc):
+            continue
+        handler = _enclosing_function(node, tree) or "<module>"
+        excerpt = ast.unparse(node).splitlines()[0][:120]
+        findings.append((handler, node.lineno, excerpt))
+    return findings
+
+
+def test_no_5xx_endpoint_leaks_dict_detail_str_exception():
+    """No `raise HTTPException(status_code=5xx, detail={"key": str(e)})` pattern
+    is allowed in backend/app/api/v1/endpoints/. Dict-wrapped str(e) values on
+    5xx responses leak internal exception text (SQL fragments, column values,
+    internal paths) to the client without appearing in the top-level keyword scan.
+
+    Fixed in applications.py (PR #721); this test prevents future regressions."""
+    violations = []
+    for path in _iter_endpoint_files():
+        rel = path.relative_to(ENDPOINTS_DIR)
+        for handler, lineno, excerpt in _scan_file_dict_detail_str_exception(path):
+            violations.append(f"{rel}:{lineno}  {handler}()  {excerpt!r}")
+
+    if violations:
+        msg = (
+            'Found HTTPException(status_code=5xx, detail={"key": str(e)}) regressions.\n'
+            "Dict-wrapped str(e) values on 5xx responses leak internal exception context.\n"
+            "Use static strings only: "
+            'detail={"message": "<static>", "error_code": "..."} + raise ... from e\n'
             "The traceback is captured by logger.exception() / exc_info=True "
             "and must NOT be echoed verbatim to the HTTP client.\n\n"
             "Violations:\n  " + "\n  ".join(violations)


### PR DESCRIPTION
## Summary

- **`applications.py:127`**: 422 handler for form data validation failure was echoing `"error": str(e)` and `"received_form_data": str(application_data.form_data)`. Both are PII risks — the form data can contain bank account numbers and other sensitive fields; the exception message may expose internal model structure. Replaced with static error code only.

- **`applications.py:286`**: 409 Conflict handler for duplicate-key `IntegrityError` was echoing `"detail": str(e)`. SQLAlchemy `IntegrityError` strings contain constraint names, table names, and key values. Removed; static message retained.

- **`applications.py:294`**: 500 handler for non-duplicate `IntegrityError` was echoing `"detail": str(e)`. This is a critical leak — 500 responses must never echo internal exception text. Removed; static message retained.

All three paths retain `logger.exception()` called before the raise, so the full traceback is preserved in Loki without reaching the client.

Note: The existing AST invariant (`test_no_exception_leak_in_endpoints.py`) targeted `detail=str(e)` at the top-level `HTTPException` argument. These sites used a nested dict (`detail={"key": str(e)}`), which evaded the invariant. A follow-up PR should extend the invariant to catch this pattern.

## Test plan

- [ ] Verify CI backend tests pass (no functional changes — only removes fields from error responses)
- [ ] Verify the application creation endpoint still returns 409 on duplicate submission
- [ ] Verify the application creation endpoint still returns 422 on invalid form data