### PR TITLE
fix(SECURITY): sanitize exception leaks in pre_authorization + applications (6 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -94,7 +94,6 @@ async def create_application(
                 detail={
                     "message": "Scholarship type is required",
                     "error_code": "MISSING_SCHOLARSHIP_TYPE",
-                    "received_data": application_data.model_dump(exclude_none=True),
                 },
             )
 
@@ -107,7 +106,6 @@ async def create_application(
                 detail={
                     "message": "Form data is required",
                     "error_code": "MISSING_FORM_DATA",
-                    "received_data": application_data.model_dump(exclude_none=True),
                 },
             )
 
@@ -265,7 +263,6 @@ async def create_application(
                 "message": "Validation error",
                 "error_code": "VALIDATION_ERROR",
                 "errors": e.errors() if hasattr(e, "errors") else str(e),
-                "received_data": application_data.dict(exclude_none=True),
             },
         ) from e
     except HTTPException:

--- a/backend/app/api/v1/endpoints/pre_authorization.py
+++ b/backend/app/api/v1/endpoints/pre_authorization.py
@@ -79,7 +79,7 @@ async def pre_authorize_user(
                 "actor_user_id": current_user.id,
             },
         )
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to pre-authorize user") from e
 
 
 @router.post("/assign-scholarship")
@@ -137,7 +137,7 @@ async def assign_scholarship_to_admin(
                 "actor_user_id": current_user.id,
             },
         )
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to assign scholarship") from e
 
 
 @router.get("/pre-authorized-users")
@@ -249,7 +249,9 @@ async def remove_admin_from_scholarship(
                 "actor_user_id": current_user.id,
             },
         )
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to remove admin from scholarship"
+        ) from e
 
 
 @router.get("/user/{nycu_id}")


### PR DESCRIPTION
## Summary

- **pre_authorization.py (3 sites)**: Three broad `except Exception as e:` handlers were forwarding `str(e)` as the 400 response `detail`. This could expose DB errors, SQLAlchemy internals, or service-layer exception messages to the client. Replaced with static messages; `logger.exception()` already preserves full tracebacks so nothing is lost operationally.
- **applications.py (3 sites)**: Three 422 error responses were echoing the full submitted form data as `"received_data": application_data.model_dump(...)`. This could include bank account numbers, contact info, and other PII from the application form. The validation context is captured by logger and the `errors` field is preserved; the raw data echo is not needed.

## Test plan

- [ ] Verify `pre_authorization.py` still returns 400 on service failures (not a traceback)
- [ ] Verify `applications.py` 422 responses still include `errors` field but not `received_data`
- [ ] Backend lint passes (black + flake8)
- [ ] CI Quick Checks green