### PR TITLE
fix(security): sanitize 3 HTTPException detail leaks in minio_service.py

### DIFF
--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -88,7 +88,7 @@ class MinIOService:
             logger.exception("Failed to ensure buckets exist")
             from fastapi import HTTPException
 
-            raise HTTPException(status_code=500, detail=f"MinIO bucket initialization failed: {str(e)}") from e
+            raise HTTPException(status_code=500, detail="MinIO bucket initialization failed") from e
 
     def _set_bucket_policy(self, bucket_name: str, private: bool = True):
         """設定bucket政策"""
@@ -255,7 +255,7 @@ class MinIOService:
 
             from fastapi import HTTPException
 
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            raise HTTPException(status_code=500, detail="File upload failed") from e
 
     def get_file_stream(self, object_name: str):
         """
@@ -335,7 +335,7 @@ class MinIOService:
             logger.exception(f"Failed to clone file {source_object_name}")
             from fastapi import HTTPException
 
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            raise HTTPException(status_code=500, detail="File clone failed") from e
 
     def extract_object_name_from_url(self, url: str) -> Optional[str]:
         """

--- a/backend/app/tests/test_no_exception_leak_in_endpoints.py
+++ b/backend/app/tests/test_no_exception_leak_in_endpoints.py
@@ -307,3 +307,88 @@ def test_no_5xx_endpoint_leaks_dict_detail_str_exception():
             "Violations:\n  " + "\n  ".join(violations)
         )
         pytest.fail(msg)
+
+
+# ---------------------------------------------------------------------------
+# Fifth check: extend exception-detail-leak coverage to services/ and utils/
+# ---------------------------------------------------------------------------
+# The prior four checks only scan backend/app/api/v1/endpoints/. However,
+# services can also raise HTTPException directly (e.g. MinioService).
+# Three such sites in minio_service.py were sanitized in PR #724; this
+# check prevents future regressions in the service layer.
+#
+# Scope: backend/app/services/ + backend/app/utils/ (excluding
+# endpoint_decorators.py which has intentional narrow-exception patterns
+# where str(e) is appropriate because the exception type carries a
+# user-facing message by design).
+#
+# Pattern caught: detail=str(e)  OR  detail=f"...{str(e)/e}..."
+
+SERVICES_DIR = Path(__file__).resolve().parent.parent / "services"
+UTILS_DIR = Path(__file__).resolve().parent.parent / "utils"
+
+# endpoint_decorators.py uses narrow-catch exceptions (CollegeReviewAccessError,
+# RankingNotFoundError, etc.) whose messages are user-facing by contract.
+# Those are intentional and excluded from this check.
+_SERVICES_ALLOWLIST: set[str] = {
+    str(UTILS_DIR / "endpoint_decorators.py"),
+}
+
+
+def _iter_service_util_files() -> list[Path]:
+    """Yield every .py file under services/ and utils/, excluding allowlisted files."""
+    paths = []
+    for base in (SERVICES_DIR, UTILS_DIR):
+        if base.exists():
+            paths.extend(
+                p
+                for p in base.rglob("*.py")
+                if p.name != "__init__.py" and "__pycache__" not in p.parts and str(p) not in _SERVICES_ALLOWLIST
+            )
+    return sorted(paths)
+
+
+def _scan_service_file(path: Path) -> list[tuple[str, int, str]]:
+    """Return [(handler_name, lineno, excerpt)] for any HTTPException detail leak."""
+    src = path.read_text()
+    tree = ast.parse(src)
+    findings = []
+    for node in ast.walk(tree):
+        if not _is_http_exception_raise(node):
+            continue
+        is_bad = _detail_is_bare_str_exception(node.exc) or _detail_is_unsanitized_fstring(node.exc)
+        if not is_bad:
+            continue
+        handler = _enclosing_function(node, tree) or "<module>"
+        excerpt = ast.unparse(node).splitlines()[0][:120]
+        findings.append((handler, node.lineno, excerpt))
+    return findings
+
+
+def test_no_service_raises_http_exception_leaking_exception_detail():
+    """No `raise HTTPException(detail=str(e))` or `detail=f"...{str(e)}..."` pattern
+    is allowed in backend/app/services/ or backend/app/utils/ (excluding
+    endpoint_decorators.py which uses intentional narrow-catch patterns).
+
+    Services that raise HTTPException directly (e.g. MinioService) can leak
+    internal SDK error text (bucket names, paths, error codes) to the HTTP
+    client through the detail field. PR #724 sanitized 3 such sites in
+    minio_service.py; this test pins that clean state.
+
+    The traceback must reach structured logs via logger.exception() or
+    exc_info=True — it must NOT be echoed verbatim to the HTTP client."""
+    violations = []
+    for path in _iter_service_util_files():
+        for handler, lineno, excerpt in _scan_service_file(path):
+            rel = path.relative_to(Path(__file__).resolve().parent.parent.parent)
+            violations.append(f"{rel}:{lineno}  {handler}()  {excerpt!r}")
+
+    if violations:
+        msg = (
+            "Found HTTPException(detail=str(e) / f-string) regressions in services/ or utils/.\n"
+            "Services that raise HTTPException directly must use static detail strings.\n"
+            "Use: raise HTTPException(status_code=5xx, detail='<static>') from e\n"
+            "The full error is captured by logger.exception() and must NOT reach the client.\n\n"
+            "Violations:\n  " + "\n  ".join(violations)
+        )
+        pytest.fail(msg)


### PR DESCRIPTION
## Summary

- Sanitizes 3 SECURITY HTTPException detail leaks in `backend/app/services/minio_service.py`
- Three `except Exception` handlers were echoing internal MinIO SDK error text via the `detail=str(e)` / `detail=f"...{str(e)}"` pattern into HTTP 500 responses
- MinIO errors can contain: bucket names, internal paths, SDK error codes, endpoint configuration — none of which should reach the HTTP client
- **Adds 5th AST invariant** to `test_no_exception_leak_in_endpoints.py` extending detection to `services/` and `utils/` to prevent future regressions

## Violation sites (commit 1: fix)

| Function | Line | Pattern |
|---|---|---|
| `ensure_bucket_exists()` | 91 | `detail=f"MinIO bucket initialization failed: {str(e)}"` |
| `upload_file()` | 258 | `detail=str(e)` |
| `clone_file()` | 338 | `detail=str(e)` |

All three have `logger.exception(...)` immediately before, so the full traceback lands in structured logs — the fix only removes the client-visible echo.

## Why these evaded existing guards (commit 2: invariant)

The four prior AST invariants in `test_no_exception_leak_in_endpoints.py` only scan `backend/app/api/v1/endpoints/`. `minio_service.py` raises `HTTPException` directly from the service layer, which was outside that scope.

The 5th invariant extends coverage to `backend/app/services/` and `backend/app/utils/`, with `endpoint_decorators.py` allowlisted (uses narrow-catch exceptions whose messages are user-facing by design: `CollegeReviewAccessError`, `RankingNotFoundError`, `RankingModificationError`).

## Test plan

- [x] `black 26.3.1` — no changes on minio_service.py; test file reformatted cleanly
- [x] `flake8 7.1.1` — no issues on either file
- [x] AST scanner confirms 0 violations in `services/` and `utils/` post-fix
- [x] Traceback still captured by existing `logger.exception()` calls at all 3 sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)