### PR TITLE
fix(observability): replace pass-only broad-except with debug/warning logs

### DIFF
--- a/backend/app/api/v1/endpoints/user_profiles.py
+++ b/backend/app/api/v1/endpoints/user_profiles.py
@@ -417,8 +417,11 @@ async def get_bank_document(
                 )
 
             except Exception:
-                # If MinIO fails, try fallback to local storage
-                pass
+                logger.warning(
+                    "MinIO bank document fetch failed for object %s; falling back to local storage",
+                    object_name,
+                    exc_info=True,
+                )
 
         # Fallback to local storage (backward compatibility for legacy files
         # uploaded before MinIO migration). The MinIO path above performed

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -83,9 +83,14 @@ async def get_student_info(current_user: User = Depends(get_current_user), db: A
                     term_data = await student_service.get_student_term_info(student_code, str(year), term)
                     if term_data:
                         semesters.append({"academic_year": str(year), "term": term, **term_data})
-                except Exception:
-                    # Log but continue - some semesters may not exist
-                    pass
+                except Exception as term_exc:
+                    logger.debug(
+                        "SIS term fetch skipped: student=%s year=%s term=%s: %s",
+                        student_code,
+                        year,
+                        term,
+                        term_exc,
+                    )
 
     # Return student information with new structure
     return {


### PR DESCRIPTION
## Summary

- **users.py:86**: comment said "Log but continue" but the handler used `pass` instead of logging. Add `logger.debug(...)` with the exception text, matching the pattern already present in `admin/students.py` (debug-level because many semester slots legitimately don't exist before enrollment).
- **user_profiles.py:419**: MinIO bank-document fetch failure was silently swallowed, making MinIO regressions invisible in structured logs. Add `logger.warning(..., exc_info=True)` so the fallback-to-local-storage path is traceable. The file still falls through to local storage as before.

## Test plan

- [ ] Backend lint passes
- [ ] Backend unit/smoke/integration tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)