### PR TITLE
fix(observability): add logger.exception before 5xx HTTPException in broad-except handlers (28 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/email_management.py
+++ b/backend/app/api/v1/endpoints/email_management.py
@@ -156,6 +156,7 @@ async def approve_scheduled_email(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as exc:
+        logger.exception("Failed to approve email")
         raise HTTPException(status_code=500, detail="Failed to approve email") from exc
 
 
@@ -175,6 +176,7 @@ async def cancel_scheduled_email(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as exc:
+        logger.exception("Failed to cancel email")
         raise HTTPException(status_code=500, detail="Failed to cancel email") from exc
 
 
@@ -201,6 +203,7 @@ async def update_scheduled_email(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as exc:
+        logger.exception("Failed to update scheduled email")
         raise HTTPException(status_code=500, detail="Failed to update scheduled email") from exc
 
 
@@ -222,6 +225,7 @@ async def process_due_emails(
         stats = await email_service.process_due_emails(db=db, batch_size=batch_size)
         return {"success": True, "message": "Emails processed successfully", "data": EmailProcessingStats(**stats)}
     except Exception as e:
+        logger.exception("Failed to process emails")
         raise HTTPException(status_code=500, detail="Failed to process emails") from e
 
 
@@ -288,6 +292,7 @@ async def get_test_mode_status(*, db: AsyncSession = Depends(get_db), current_us
         return ApiResponse(success=True, message="Test mode status retrieved successfully", data=test_config)
 
     except Exception as e:
+        logger.exception("Failed to get test mode status")
         raise HTTPException(status_code=500, detail="Failed to get test mode status") from e
 
 
@@ -356,6 +361,7 @@ async def enable_test_mode(
 
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to enable test mode")
         raise HTTPException(status_code=500, detail="Failed to enable test mode") from e
 
 
@@ -407,6 +413,7 @@ async def disable_test_mode(
 
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to disable test mode")
         raise HTTPException(status_code=500, detail="Failed to disable test mode") from e
 
 
@@ -457,6 +464,7 @@ async def get_test_mode_audit_logs(
         )
 
     except Exception as e:
+        logger.exception("Failed to get audit logs")
         raise HTTPException(status_code=500, detail="Failed to get audit logs") from e
 
 
@@ -507,6 +515,7 @@ async def cleanup_old_audit_logs(
 
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to cleanup audit logs")
         raise HTTPException(status_code=500, detail="Failed to cleanup audit logs") from e
 
 
@@ -742,6 +751,7 @@ async def get_email_templates(*, db: AsyncSession = Depends(get_db), current_use
         return ApiResponse(success=True, message=f"成功獲取 {len(template_list)} 個郵件模板", data=template_list)
 
     except Exception as e:
+        logger.exception("獲取郵件模板失敗")
         raise HTTPException(status_code=500, detail="獲取郵件模板失敗") from e
 
 

--- a/backend/app/api/v1/endpoints/nycu_employee.py
+++ b/backend/app/api/v1/endpoints/nycu_employee.py
@@ -2,6 +2,7 @@
 NYCU Employee API endpoints.
 """
 
+import logging
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -19,6 +20,8 @@ from app.integrations.nycu_emp import (
     NYCUEmpValidationError,
     create_nycu_emp_client_from_env,
 )
+
+logger = logging.getLogger(__name__)
 
 # SECURITY: All NYCU employee directory endpoints expose internal staff PII
 # (names, departments, positions, employee numbers). Gate the entire router
@@ -121,6 +124,7 @@ async def get_employees(
     except NYCUEmpError as e:
         raise HTTPException(status_code=500, detail="API error") from e
     except Exception as e:
+        logger.exception("Unexpected error")
         raise HTTPException(status_code=500, detail="Unexpected error") from e
 
 
@@ -168,6 +172,7 @@ async def get_all_employees(status: str = Query("01", description="Employee stat
     except NYCUEmpError as e:
         raise HTTPException(status_code=500, detail="API error") from e
     except Exception as e:
+        logger.exception("Unexpected error")
         raise HTTPException(status_code=500, detail="Unexpected error") from e
 
 
@@ -241,6 +246,7 @@ async def search_employees(
     except NYCUEmpError as e:
         raise HTTPException(status_code=500, detail="API error") from e
     except Exception as e:
+        logger.exception("Unexpected error")
         raise HTTPException(status_code=500, detail="Unexpected error") from e
 
 
@@ -286,4 +292,5 @@ async def get_employee_by_no(
     except NYCUEmpError as e:
         raise HTTPException(status_code=500, detail="API error") from e
     except Exception as e:
+        logger.exception("Unexpected error")
         raise HTTPException(status_code=500, detail="Unexpected error") from e

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -3,6 +3,7 @@ Scholarship Configuration Management API endpoints
 Clean, database-driven approach for dynamic scholarship configuration management
 """
 
+import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
@@ -32,6 +33,8 @@ from app.schemas.scholarship_configuration import (
     WhitelistStudentInfo,
 )
 from app.services.whitelist_excel_service import whitelist_excel_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -514,6 +517,7 @@ async def get_colleges(current_user: User = Depends(require_admin), db: AsyncSes
         return ApiResponse(success=True, message=f"Retrieved {len(colleges)} colleges", data=colleges)
 
     except Exception as e:
+        logger.exception("Failed to retrieve colleges")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve colleges"
         ) from e
@@ -578,6 +582,7 @@ async def get_scholarship_types(current_user: User = Depends(require_staff), db:
         return ApiResponse(success=True, message=f"Retrieved {len(type_configs)} scholarship types", data=type_configs)
 
     except Exception as e:
+        logger.exception("Failed to retrieve scholarship types")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve scholarship types"
         ) from e
@@ -714,6 +719,7 @@ async def get_quota_overview(
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid period format: {period}") from exc
     except Exception as e:
+        logger.exception("Failed to retrieve quota overview")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve quota overview"
         ) from e
@@ -806,6 +812,7 @@ async def create_scholarship_configuration(
         raise
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to create configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create configuration"
         ) from e
@@ -904,6 +911,7 @@ async def get_scholarship_configuration(
     except HTTPException:
         raise
     except Exception as e:
+        logger.exception("Failed to retrieve configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve configuration"
         ) from e
@@ -1107,6 +1115,7 @@ async def deactivate_scholarship_configuration(
         raise
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to deactivate configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to deactivate configuration"
         ) from e
@@ -1194,6 +1203,7 @@ async def duplicate_scholarship_configuration(
         raise
     except Exception as e:
         await db.rollback()
+        logger.exception("Failed to duplicate configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to duplicate configuration"
         ) from e
@@ -1324,6 +1334,7 @@ async def list_scholarship_configurations(
         return ApiResponse(success=True, message=f"Retrieved {len(config_list)} configurations", data=config_list)
 
     except Exception as e:
+        logger.exception("Failed to list configurations")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list configurations"
         ) from e

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -78,6 +78,7 @@ async def get_all_configurations(
             "trace_id": None,
         }
     except Exception as e:
+        logger.exception("Failed to retrieve configurations")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve configurations"
         ) from e
@@ -247,6 +248,7 @@ async def get_system_doc_file(
         )
         file_content = response.read()
     except Exception as e:
+        logger.exception("無法取得文件")
         raise HTTPException(status_code=500, detail="無法取得文件") from e
 
     content_type = "application/pdf"
@@ -327,6 +329,7 @@ async def get_configuration(
     except HTTPException:
         raise
     except Exception as e:
+        logger.exception("Failed to retrieve configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve configuration"
         ) from e
@@ -587,6 +590,7 @@ async def validate_configuration(
             "data": response_data.model_dump() if hasattr(response_data, "model_dump") else response_data.dict(),
         }
     except Exception as e:
+        logger.exception("Failed to validate configuration")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to validate configuration"
         ) from e
@@ -677,6 +681,7 @@ async def get_configuration_audit_logs(
             "trace_id": None,
         }
     except Exception as e:
+        logger.exception("Failed to retrieve audit logs")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve audit logs"
         ) from e

--- a/backend/app/api/v1/endpoints/user_profiles.py
+++ b/backend/app/api/v1/endpoints/user_profiles.py
@@ -472,6 +472,7 @@ async def get_bank_document(
     except HTTPException:
         raise
     except Exception as exc:
+        logger.exception("檔案服務發生錯誤")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="檔案服務發生錯誤") from exc
 
 


### PR DESCRIPTION
## Summary

Production observability gap: in 5 backend endpoint files, broad `except Exception` handlers raised `HTTPException(status_code=5xx, ...)` **without first calling** `logger.exception()`. When a service method failed, the full traceback silently disappeared — no log line, no stack trace, only the generic 500 response on the wire.

This PR inserts `logger.exception(<same message as detail=>)` as the **first statement** in each handler body, before the `raise`. The traceback is automatically attached by `logger.exception` and will now land in structured logs.

## What changed

| File | Sites fixed |
|------|-------------|
| `backend/app/api/v1/endpoints/email_management.py` | 10 |
| `backend/app/api/v1/endpoints/nycu_employee.py` | 4 |
| `backend/app/api/v1/endpoints/scholarship_configurations.py` | 8 |
| `backend/app/api/v1/endpoints/system_settings.py` | 5 |
| `backend/app/api/v1/endpoints/user_profiles.py` | 1 |
| **Total** | **28** |

Also added `import logging` + `logger = logging.getLogger(__name__)` to two files that didn't already have a module-level logger (`nycu_employee.py`, `scholarship_configurations.py`). The other three files already had a logger declared.

## Notes

- Zero behaviour change for callers: `HTTPException` `status_code` and `detail` strings are unchanged byte-for-byte. Only `logger.exception(...)` was inserted as a new line before the existing raise.
- `logger.exception` already includes `exc_info=True` by default; no need to pass it explicitly.
- The `from exc` chaining on each `raise` is preserved.
- Diff is purely additive — `git diff` shows 34 insertions and 0 deletions (34 = 28 logger calls + 3 lines for each of the two new logger declarations).
- black formatter run clean; flake8 with E9/F63/F7/F82/F401/B904 selects passes.

## Test plan

- [x] `python3 -m py_compile` on all 5 files — syntax OK
- [x] `black` — files unchanged after formatting
- [x] `flake8 --select=E9,F63,F7,F82,F401,B904` — no new warnings
- [ ] Trigger a 5xx in any of the touched endpoints in staging and confirm the traceback now appears in backend logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)