### PR TITLE
fix(observability): replace root-logger calls with module logger (7 sites)

### DIFF
--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -232,11 +232,9 @@ async def upload_batch_import_data(
             content_type=content_type,
         )
         batch_import.file_path = object_name
-    except Exception as e:
+    except Exception:
         # Log error but don't fail the upload if MinIO is unavailable
-        import logging
-
-        logging.error(f"Failed to upload batch import file to MinIO: {e}")
+        logger.warning("Failed to upload batch import file to MinIO", exc_info=True)
 
     # Store parsed data for confirm step
     batch_import.parsed_data = {

--- a/backend/app/api/v1/endpoints/email_management.py
+++ b/backend/app/api/v1/endpoints/email_management.py
@@ -609,9 +609,7 @@ async def send_test_email(
     except HTTPException:
         raise
     except Exception as e:
-        import logging
-
-        logging.error(f"Failed to send test email: {str(e)}", exc_info=True)
+        logger.error("Failed to send test email", exc_info=True)
 
         response_data = SendTestEmailResponse(success=False, message="測試郵件發送失敗", error=str(e))
 
@@ -681,9 +679,7 @@ async def send_simple_test_email(
     except HTTPException:
         raise
     except Exception as e:
-        import logging
-
-        logging.error(f"Failed to send simple test email: {str(e)}", exc_info=True)
+        logger.error("Failed to send simple test email", exc_info=True)
 
         response_data = SimpleTestEmailResponse(success=False, message="Failed to send test email", error=str(e))
 

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -181,10 +181,7 @@ async def get_available_semesters(
         )
 
     except Exception as e:
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.error(f"Error in get_available_semesters: {type(e).__name__}: {str(e)}", exc_info=True)
+        logger.error("Error in get_available_semesters: %s: %s", type(e).__name__, e, exc_info=True)
 
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -369,10 +366,7 @@ async def get_matrix_quota_status(
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid period format: {period}") from exc
     except Exception as e:
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.error(f"Error in get_matrix_quota_status: {type(e).__name__}: {str(e)}", exc_info=True)
+        logger.error("Error in get_matrix_quota_status: %s: %s", type(e).__name__, e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to retrieve matrix quota status",
@@ -495,10 +489,7 @@ async def update_matrix_quota(
 
     except Exception as e:
         await db.rollback()
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.error(f"Error in update_matrix_quota: {type(e).__name__}: {str(e)}", exc_info=True)
+        logger.error("Error in update_matrix_quota: %s: %s", type(e).__name__, e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update matrix quota"
         ) from e
@@ -1061,10 +1052,7 @@ async def update_scholarship_configuration(
         raise
     except Exception as e:
         await db.rollback()
-        import logging
-
-        logger = logging.getLogger(__name__)
-        logger.error(f"Error in update_scholarship_configuration: {type(e).__name__}: {str(e)}", exc_info=True)
+        logger.error("Error in update_scholarship_configuration: %s: %s", type(e).__name__, e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update configuration"
         ) from e


### PR DESCRIPTION
## Summary

Three endpoint files imported and called the **root `logging` module directly** inside `except` handlers instead of using the module-level `logger` object. This caused log entries to appear under the `root` logger name rather than the module name (e.g., `app.api.v1.endpoints.batch_import`), making structured log filtering and alerting unreliable.

### Changes

- **`batch_import.py`**: `import logging; logging.error(f"...")` → `logger.warning("...", exc_info=True)`
  - Also adds missing `exc_info=True` for MinIO upload failure path
- **`email_management.py`**: two `import logging; logging.error(f"...", exc_info=True)` → `logger.error("...", exc_info=True)`
- **`scholarship_configurations.py`**: 4 inline `import logging; logger = logging.getLogger(__name__)` blocks removed
  - The module-level `logger` was already defined at line 37; these were redundant shadow declarations
  - f-string format strings converted to %-style

## Test plan

- [ ] `uvx --from black==26.3.1 black` → no changes (already run)
- [ ] `uvx --from flake8==7.1.1 flake8` → clean (already run)
- [ ] CI backend-lint and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)