### PR TITLE
fix(ts): narrow remaining 22 any sites in college.ts + consumer casts

### DIFF
--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -167,7 +167,19 @@ export function RankingManagementPanel({
               student_info?: { display_name?: string; student_id?: string };
             };
           }
-          const transformedApplications = (response.data.items || []).map(
+          const rankingPayload = response.data as {
+            items?: RankingItemPayload[];
+            total_quota?: number;
+            college_quota?: number;
+            college_quota_breakdown?: Record<string, unknown>;
+            sub_type_metadata?: Array<{ code?: string; [key: string]: unknown }>;
+            sub_type_code?: string;
+            academic_year?: number;
+            semester?: string | null;
+            is_finalized?: boolean;
+            college_review_end?: string | null;
+          };
+          const transformedApplications = (rankingPayload.items || []).map(
             (item: RankingItemPayload) => ({
               id: item.application?.id || item.id,
               ranking_item_id: item.id,
@@ -200,18 +212,15 @@ export function RankingManagementPanel({
           );
 
           // #91: college_review_end is now returned directly by the ranking detail endpoint
-          setActiveConfigDeadline(
-            (response.data as { college_review_end?: string | null })
-              .college_review_end ?? null
-          );
+          setActiveConfigDeadline(rankingPayload.college_review_end ?? null);
 
           setRankingData({
             applications: transformedApplications,
-            totalQuota: response.data.total_quota || 0,
-            collegeQuota: response.data.college_quota,
-            collegeQuotaBreakdown: response.data.college_quota_breakdown,
-            subTypeMetadata: Array.isArray(response.data.sub_type_metadata)
-              ? response.data.sub_type_metadata.reduce(
+            totalQuota: rankingPayload.total_quota || 0,
+            collegeQuota: rankingPayload.college_quota,
+            collegeQuotaBreakdown: rankingPayload.college_quota_breakdown,
+            subTypeMetadata: Array.isArray(rankingPayload.sub_type_metadata)
+              ? rankingPayload.sub_type_metadata.reduce(
                   (
                     acc: Record<string, { code: string; [key: string]: unknown }>,
                     meta: { code?: string; [key: string]: unknown }
@@ -226,11 +235,11 @@ export function RankingManagementPanel({
                   },
                   {}
                 )
-              : response.data.sub_type_metadata || {},
-            subTypeCode: response.data.sub_type_code || "default",
-            academicYear: response.data.academic_year || 0,
-            semester: response.data.semester,
-            isFinalized: response.data.is_finalized || false,
+              : rankingPayload.sub_type_metadata || {},
+            subTypeCode: rankingPayload.sub_type_code || "default",
+            academicYear: rankingPayload.academic_year || 0,
+            semester: rankingPayload.semester,
+            isFinalized: rankingPayload.is_finalized || false,
           });
         }
       } catch (error) {
@@ -314,17 +323,18 @@ export function RankingManagementPanel({
           // Refresh rankings list
           await fetchRankings();
           // Select the newly created ranking
-          setSelectedRanking(response.data.id);
+          const newRanking = response.data as { id: number; ranking_name?: string };
+          setSelectedRanking(newRanking.id);
           // Load ranking details
-          await fetchRankingDetails(response.data.id);
+          await fetchRankingDetails(newRanking.id);
           // Increment data version
           incrementDataVersion();
 
           // Show success notification
           toast.success(
             locale === "zh"
-              ? `排名「${response.data.ranking_name || "新排名"}」已成功建立`
-              : `Ranking "${response.data.ranking_name || "New Ranking"}" has been created successfully`
+              ? `排名「${newRanking.ranking_name || "新排名"}」已成功建立`
+              : `Ranking "${newRanking.ranking_name || "New Ranking"}" has been created successfully`
           );
         } catch (fetchError) {
           logger.error("Failed to load ranking after creation", { fetchError: fetchError });
@@ -442,7 +452,15 @@ export function RankingManagementPanel({
 
         // 檢查是否自動重新執行了分發
         if (response.success && response.data) {
-          const redistribution = response.data.redistribution_info;
+          const reviewResult = response.data as {
+            redistribution_info?: {
+              auto_redistributed?: boolean;
+              reason?: string;
+              total_allocated?: number;
+              roster_info?: { roster_code?: string };
+            };
+          };
+          const redistribution = reviewResult.redistribution_info;
 
           if (redistribution?.auto_redistributed) {
             toast.success(

--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -218,24 +218,27 @@ export function RankingManagementPanel({
             applications: transformedApplications,
             totalQuota: rankingPayload.total_quota || 0,
             collegeQuota: rankingPayload.college_quota,
-            collegeQuotaBreakdown: rankingPayload.college_quota_breakdown,
+            collegeQuotaBreakdown: rankingPayload.college_quota_breakdown as
+              | Record<string, { quota?: number; label?: string; label_en?: string }>
+              | undefined,
             subTypeMetadata: Array.isArray(rankingPayload.sub_type_metadata)
-              ? rankingPayload.sub_type_metadata.reduce(
+              ? (rankingPayload.sub_type_metadata.reduce(
                   (
-                    acc: Record<string, { code: string; [key: string]: unknown }>,
+                    acc: Record<string, { code: string; label: string; label_en: string }>,
                     meta: { code?: string; [key: string]: unknown }
                   ) => {
                     if (meta.code) {
                       acc[meta.code] = meta as {
                         code: string;
-                        [key: string]: unknown;
+                        label: string;
+                        label_en: string;
                       };
                     }
                     return acc;
                   },
                   {}
-                )
-              : rankingPayload.sub_type_metadata || {},
+                ) as Record<string, { code: string; label: string; label_en: string }>)
+              : (rankingPayload.sub_type_metadata as Record<string, { code: string; label: string; label_en: string }> | undefined) || {},
             subTypeCode: rankingPayload.sub_type_code || "default",
             academicYear: rankingPayload.academic_year || 0,
             semester: rankingPayload.semester,

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -177,7 +177,7 @@ export function ApplicationReviewPanel({
         };
         setCollegeQuotaInfo({
           collegeQuota: quotaData.college_quota ?? null,
-          breakdown: quotaData.college_quota_breakdown ?? {},
+          breakdown: (quotaData.college_quota_breakdown as Record<string, number>) ?? {},
         });
         logger.debug("College quota fetched:", quotaData.college_quota);
       } else {

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -171,11 +171,15 @@ export function ApplicationReviewPanel({
       );
 
       if (response.success && response.data) {
+        const quotaData = response.data as {
+          college_quota?: number | null;
+          college_quota_breakdown?: Record<string, unknown>;
+        };
         setCollegeQuotaInfo({
-          collegeQuota: response.data.college_quota ?? null,
-          breakdown: response.data.college_quota_breakdown ?? {},
+          collegeQuota: quotaData.college_quota ?? null,
+          breakdown: quotaData.college_quota_breakdown ?? {},
         });
-        logger.debug("College quota fetched:", response.data.college_quota);
+        logger.debug("College quota fetched:", quotaData.college_quota);
       } else {
         setCollegeQuotaInfo(null);
       }

--- a/frontend/components/common/ApplicationReviewDialog.tsx
+++ b/frontend/components/common/ApplicationReviewDialog.tsx
@@ -929,11 +929,12 @@ export function ApplicationReviewDialog({
           const reviewResponse = (role === "admin" || role === "super_admin")
             ? await api.admin.getApplicationReview(applicationId)
             : await api.college.getReview(applicationId);
-          if (reviewResponse.success && reviewResponse.data && reviewResponse.data.id > 0) {
-            setExistingReview(reviewResponse.data);
+          const reviewData = reviewResponse.data as ExistingReview | undefined;
+          if (reviewResponse.success && reviewData && reviewData.id > 0) {
+            setExistingReview(reviewData);
 
             // Merge existing review items with all available sub-types
-            const existingItems = reviewResponse.data.items || [];
+            const existingItems = reviewData.items || [];
             const mergedItems = availableSubTypes.map((subType: SubTypeOption) => {
               const existingItem = existingItems.find(
                 (item: SubTypeReviewItem) => item.sub_type_code === subType.value

--- a/frontend/components/common/ApplicationReviewDialog.tsx
+++ b/frontend/components/common/ApplicationReviewDialog.tsx
@@ -958,8 +958,8 @@ export function ApplicationReviewDialog({
 
             // Debug logging
             logger.debug('📋 Loaded existing review:', {
-              reviewId: reviewResponse.data.id,
-              reviewedAt: reviewResponse.data.reviewed_at,
+              reviewId: reviewData?.id,
+              reviewedAt: reviewData?.reviewed_at,
               existingItemsCount: existingItems.length,
               mergedItemsCount: mergedItems.length,
               mergedItems: mergedItems

--- a/frontend/contexts/college-management-context.tsx
+++ b/frontend/contexts/college-management-context.tsx
@@ -481,8 +481,9 @@ export function CollegeManagementProvider({
         logger.debug("Rankings fetched", { count: response.data.length });
 
         // Normalize semester values (consistent with RankingManagementPanel logic)
-        const normalizedRankings = response.data.map(
-          (ranking: { semester?: string | null; [key: string]: unknown }) => {
+        const rawRankings = response.data as Array<{ semester?: string | null; [key: string]: unknown }>;
+        const normalizedRankings = rawRankings.map(
+          (ranking) => {
             const rawSemester =
               typeof ranking.semester === "string" && ranking.semester.length > 0
                 ? ranking.semester.toLowerCase()

--- a/frontend/hooks/use-admin.ts
+++ b/frontend/hooks/use-admin.ts
@@ -375,10 +375,10 @@ export function useCollegeApplications() {
         if (response.success && response.data) {
           // Update the application in the list
           setApplications(prev =>
-            prev.map(app => (app.id === applicationId ? response.data! : app))
+            prev.map(app => (app.id === applicationId ? response.data! as Application : app))
           );
 
-          return response.data;
+          return response.data as Application;
         } else {
           throw new Error(
             response.message || "Failed to update application status"

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -30,7 +30,7 @@ export function createCollegeApi() {
      */
     getApplicationsForReview: async (
       queryString?: string
-    ): Promise<ApiResponse<any[]>> => {
+    ): Promise<ApiResponse<unknown[]>> => {
       // Parse query string into params object
       const queryParams: {
         academic_year?: number;
@@ -67,7 +67,7 @@ export function createCollegeApi() {
           params: { query: queryParams },
         }
       );
-      return toApiResponse<any[]>(response);
+      return toApiResponse<unknown[]>(response);
     },
 
     /**
@@ -77,7 +77,7 @@ export function createCollegeApi() {
     getRankings: async (
       academicYear?: number,
       semester?: string
-    ): Promise<ApiResponse<any[]>> => {
+    ): Promise<ApiResponse<unknown[]>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/college-review/rankings",
         {
@@ -89,21 +89,21 @@ export function createCollegeApi() {
           },
         }
       );
-      return toApiResponse<any[]>(response);
+      return toApiResponse<unknown[]>(response);
     },
 
     /**
      * Get ranking details by ID
      * Type-safe: Path parameter validated against OpenAPI
      */
-    getRanking: async (rankingId: number): Promise<ApiResponse<any>> => {
+    getRanking: async (rankingId: number): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/college-review/rankings/{ranking_id}",
         {
           params: { path: { ranking_id: rankingId } },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -112,7 +112,7 @@ export function createCollegeApi() {
      */
     createRanking: async (
       data: CreateRankingInput
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const payload: CreateRankingRequest = {
         ...data,
         force_new: data.force_new ?? false,
@@ -123,7 +123,7 @@ export function createCollegeApi() {
           body: payload,
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -222,14 +222,14 @@ export function createCollegeApi() {
      */
     getDistributionDetails: async (
       rankingId: number
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/college-review/rankings/{ranking_id}/distribution-details",
         {
           params: { path: { ranking_id: rankingId } },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -239,14 +239,14 @@ export function createCollegeApi() {
      */
     getRankingRosterStatus: async (
       rankingId: number
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/college-review/rankings/{ranking_id}/roster-status",
         {
           params: { path: { ranking_id: rankingId } },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -257,7 +257,7 @@ export function createCollegeApi() {
       scholarshipTypeId: number,
       academicYear: number,
       semester?: string
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/college-review/quota-status",
         {
@@ -270,7 +270,7 @@ export function createCollegeApi() {
           },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -344,7 +344,7 @@ export function createCollegeApi() {
         is_priority?: boolean;
         needs_special_attention?: boolean;
       }
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       // Path is not in the generated OpenAPI schema (orphan/legacy route);
       // the `as never` cast bypasses typed-route inference while keeping the
       // call working at runtime. See issue #665.
@@ -355,7 +355,7 @@ export function createCollegeApi() {
           body: reviewData,
         } as never
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -409,7 +409,7 @@ export function createCollegeApi() {
     getStudentPreview: async (
       studentId: string,
       academicYear?: number
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/college-review/students/{student_id}/preview",
         {
@@ -419,7 +419,7 @@ export function createCollegeApi() {
           },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -442,14 +442,14 @@ export function createCollegeApi() {
      * Uses multi-role review API endpoint
      * Type-safe: Path parameter validated against OpenAPI
      */
-    getReview: async (applicationId: number): Promise<ApiResponse<any>> => {
+    getReview: async (applicationId: number): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/reviews/applications/{application_id}/review",
         {
           params: { path: { application_id: applicationId } },
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**
@@ -466,7 +466,7 @@ export function createCollegeApi() {
           comments?: string;
         }>;
       }
-    ): Promise<ApiResponse<any>> => {
+    ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.POST(
         "/api/v1/reviews/applications/{application_id}/review",
         {
@@ -474,7 +474,7 @@ export function createCollegeApi() {
           body: reviewData,
         }
       );
-      return toApiResponse<any>(response);
+      return toApiResponse<unknown>(response);
     },
 
     /**


### PR DESCRIPTION
## Summary

- All `ApiResponse<any>`/`any[]` return types in `frontend/lib/api/modules/college.ts` narrowed to `ApiResponse<unknown>`/`unknown[]` (22 sites across 11 functions)
- Consumer cascade fixes with explicit `as`-casts wherever `.data` properties are accessed:
  - `RankingManagementPanel.tsx`: `getRanking` → `rankingPayload` typed object; `createRanking` → `newRanking.{id,ranking_name}`; `reviewApplication` → `reviewResult.redistribution_info`
  - `ApplicationReviewDialog.tsx`: `getReview` → `reviewData as ExistingReview`
  - `ApplicationReviewPanel.tsx`: `getQuotaStatus` → `quotaData.{college_quota,college_quota_breakdown}`
  - `college-management-context.tsx`: `getRankings` → cast before `.map()` callback
  - `use-admin.ts`: `submitReview` → `response.data as Application` in setState + return

## Test plan

- [ ] Bundle Size Analysis passes (next build)
- [ ] Verify OpenAPI Types passes (tsc --noEmit)
- [ ] No `any` remaining in `college.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)