### PR TITLE
test(e2e): duplicate-application prevention + post-withdrawal reapply (issue #76)

### DIFF
--- a/frontend/e2e/specs/student-duplicate-reapply.spec.ts
+++ b/frontend/e2e/specs/student-duplicate-reapply.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * E2E spec: duplicate-application prevention and post-withdrawal reapplication.
+ *
+ * Two non-obvious invariants under test:
+ *
+ * 1. DUPLICATE REJECTION returns HTTP 200 (not 409):
+ *    When a student submits while an active application exists, the endpoint
+ *    returns HTTP 200 with `success: false` and `data.error_code = "DUPLICATE_APPLICATION"`.
+ *    This is intentional — the frontend uses error_code to show a specific message
+ *    rather than treating it as an HTTP error.
+ *    Source: applications.py:210-220
+ *
+ * 2. WITHDRAWAL enables reapplication:
+ *    Status `withdrawn` is in the excluded_statuses list for the duplicate check
+ *    (applications.py:155-160: withdrawn, rejected, cancelled, deleted are excluded).
+ *    So after a student withdraws, they MAY submit a new application.
+ *
+ * Spec flow:
+ *   1. stuphd001 submits a phd application → status = submitted.
+ *   2. stuphd001 tries to POST /applications again (same scholarship/year/semester)
+ *      → HTTP 200, success=false, error_code=DUPLICATE_APPLICATION.
+ *   3. stuphd001 calls POST /applications/{id}/withdraw → status = withdrawn.
+ *   4. stuphd001 submits a new phd application → HTTP 200, success=true (allowed).
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../helpers/auth";
+import { apiAs } from "../helpers/api";
+import {
+  deleteApplicationCascade,
+  getActiveConfig,
+  getApplication,
+  pool,
+} from "../helpers/db";
+import {
+  attachRunState,
+  newRunState,
+  pushTrace,
+  type RunState,
+} from "../helpers/runState";
+import { captureDiagnostics } from "../helpers/diagnose";
+
+const STUDENT_ID = "stuphd001";
+const SCHOLARSHIP_CODE = "phd";
+const SUB_TYPE = "nstc";
+
+async function purgeStudentApps(
+  studentNycuId: string,
+  scholarshipCode: string,
+): Promise<void> {
+  const { rows } = await pool.query<{ app_id: string }>(
+    `SELECT a.app_id
+       FROM applications a
+       JOIN users u ON u.id = a.user_id
+       JOIN scholarship_types st ON st.id = a.scholarship_type_id
+      WHERE u.nycu_id = $1 AND st.code = $2`,
+    [studentNycuId, scholarshipCode],
+  );
+  for (const row of rows) {
+    await deleteApplicationCascade(row.app_id).catch(() => undefined);
+  }
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Duplicate-application prevention + post-withdrawal reapplication", () => {
+  let runState: RunState;
+  // Track both apps so afterAll can clean both.
+  let createdAppIds: string[] = [];
+
+  test.beforeEach(() => {
+    runState = newRunState();
+    createdAppIds = [];
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    if (createdAppIds[0]) runState.appId = createdAppIds[0];
+    await captureDiagnostics(testInfo, runState);
+    await attachRunState(testInfo, runState);
+  });
+
+  test.afterAll(async () => {
+    for (const appId of createdAppIds) {
+      await deleteApplicationCascade(appId).catch(() => undefined);
+    }
+  });
+
+  test("@nightly stuphd001 submit → duplicate 200+false → withdraw → reapply success", async ({
+    browser,
+  }) => {
+    // 0. Pre-clean so no stale applications block this run.
+    await purgeStudentApps(STUDENT_ID, SCHOLARSHIP_CODE);
+
+    const studentLogin = await loginAs(browser, STUDENT_ID);
+    pushTrace(runState, studentLogin.traceId);
+
+    const config = await getActiveConfig(SCHOLARSHIP_CODE);
+
+    const appPayload = {
+      scholarship_type: SCHOLARSHIP_CODE,
+      configuration_id: config.id,
+      scholarship_subtype_list: [SUB_TYPE],
+      sub_type_preferences: [SUB_TYPE],
+      form_data: { fields: {}, documents: [] },
+      agree_terms: true,
+    };
+
+    // 1. Submit the first application.
+    const firstRes = await apiAs<{
+      success: boolean;
+      message: string;
+      data: { id: number; app_id: string; status?: string };
+    }>(studentLogin.token, "POST", "/applications?is_draft=false", appPayload);
+    pushTrace(runState, firstRes.traceId);
+    expect(
+      firstRes.ok,
+      `first submit failed: HTTP ${firstRes.status} body=${JSON.stringify(firstRes.body)}`,
+    ).toBe(true);
+    expect(firstRes.body.success).toBe(true);
+
+    const firstAppId = firstRes.body.data.app_id;
+    createdAppIds.push(firstAppId);
+    runState.appId = firstAppId;
+
+    const firstRow = await getApplication(firstAppId);
+    expect(firstRow!.status).toBe("submitted");
+    const firstNumericId = firstRow!.id as number;
+
+    // 2. Attempt a second application while the first is still active.
+    //    Non-obvious: the endpoint returns HTTP 200 with success=false instead of 409.
+    const dupeRes = await apiAs<{
+      success: boolean;
+      message: string;
+      data: {
+        error_code?: string;
+        existing_app_id?: string;
+        existing_status?: string;
+      };
+    }>(studentLogin.token, "POST", "/applications?is_draft=false", appPayload);
+    pushTrace(runState, dupeRes.traceId);
+
+    // HTTP status must be 200 — not 409, not 422.
+    expect(
+      dupeRes.status,
+      `duplicate rejection must be HTTP 200 (not 409), got ${dupeRes.status}`,
+    ).toBe(200);
+    // success must be false.
+    expect(
+      dupeRes.body.success,
+      "duplicate response body.success must be false",
+    ).toBe(false);
+    // error_code must identify the specific condition.
+    expect(
+      dupeRes.body.data?.error_code,
+      `expected DUPLICATE_APPLICATION error_code, got: ${dupeRes.body.data?.error_code}`,
+    ).toBe("DUPLICATE_APPLICATION");
+
+    // The existing application must still be there, unmodified.
+    const afterDupeCheck = await getApplication(firstAppId);
+    expect(afterDupeCheck!.status).toBe("submitted");
+
+    // 3. Student withdraws the first application.
+    //    After withdrawal, status='withdrawn', which is in the excluded_statuses
+    //    list for the duplicate check — so a new application is then allowed.
+    const withdrawRes = await apiAs<{ success: boolean; message: string }>(
+      studentLogin.token,
+      "POST",
+      `/applications/${firstNumericId}/withdraw`,
+    );
+    pushTrace(runState, withdrawRes.traceId);
+    expect(
+      withdrawRes.ok,
+      `withdraw failed: HTTP ${withdrawRes.status} body=${JSON.stringify(withdrawRes.body)}`,
+    ).toBe(true);
+    expect(withdrawRes.body.success).toBe(true);
+
+    const afterWithdraw = await getApplication(firstAppId);
+    expect(
+      afterWithdraw!.status,
+      "status must be withdrawn after withdrawal",
+    ).toBe("withdrawn");
+
+    // 4. Student submits a new application — must succeed because 'withdrawn'
+    //    is excluded from the duplicate check.
+    const secondRes = await apiAs<{
+      success: boolean;
+      message: string;
+      data: { id: number; app_id: string; status?: string };
+    }>(studentLogin.token, "POST", "/applications?is_draft=false", appPayload);
+    pushTrace(runState, secondRes.traceId);
+
+    expect(
+      secondRes.ok,
+      `reapplication after withdrawal failed: HTTP ${secondRes.status} body=${JSON.stringify(secondRes.body)}`,
+    ).toBe(true);
+    expect(
+      secondRes.body.success,
+      "reapplication after withdrawal must succeed (success=true)",
+    ).toBe(true);
+
+    const secondAppId = secondRes.body.data.app_id;
+    createdAppIds.push(secondAppId);
+
+    const secondRow = await getApplication(secondAppId);
+    expect(secondRow!.status).toBe("submitted");
+    // The two applications must be distinct records.
+    expect(secondAppId).not.toBe(firstAppId);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `student-duplicate-reapply.spec.ts` — pins two non-obvious invariants about the scholarship application lifecycle

## What's tested

| Step | Action | Expected |
|------|--------|----------|
| 1 | stuphd001 submits phd application | HTTP 200, success=true, status=submitted |
| 2 | stuphd001 tries to submit a second phd application | **HTTP 200, success=false, error_code=DUPLICATE_APPLICATION** (not 409!) |
| 3 | stuphd001 withdraws first application | HTTP 200, DB status=withdrawn |
| 4 | stuphd001 submits new phd application | HTTP 200, success=true (reapplication allowed) |

## Why these invariants matter

**Invariant 1 — HTTP 200 for duplicate rejection:**
The endpoint intentionally returns `{success: false, data: {error_code: "DUPLICATE_APPLICATION"}}` with HTTP 200 (not 409), so the frontend can differentiate "this scholarship already has an application" from generic errors and show a targeted message. A future refactor might naively change this to 409, breaking the frontend's error detection.

**Invariant 2 — Withdrawal enables reapplication:**
`withdrawn` is in `excluded_statuses` for the duplicate check (along with `rejected`, `cancelled`, `deleted`). This means students who withdraw can submit a fresh application. This is a deliberate design choice — not all status → re-apply paths are allowed (e.g., `submitted` blocks, `approved` blocks). The spec documents which statuses open the door to reapplication.

## Test plan

- [ ] E2E Smoke passes
- [ ] Backend Tests (all) pass
- [ ] Quick Checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)