### PR TITLE
fix(preview): ensure PDF Content-Type for inline iframe when type param is a document category

### DIFF
--- a/frontend/app/api/v1/preview/route.ts
+++ b/frontend/app/api/v1/preview/route.ts
@@ -246,6 +246,17 @@ export async function GET(request: NextRequest) {
       finalContentType = contentType.startsWith("image/")
         ? contentType
         : "image/jpeg";
+    } else {
+      // type param may be a document category (e.g. "bank_account_cover") rather than
+      // a mime hint — infer from filename extension as a reliable fallback
+      const lowerFilename = (filename || "").toLowerCase();
+      if (lowerFilename.endsWith(".pdf")) {
+        finalContentType = "application/pdf";
+      } else if (/\.(jpe?g|png|gif|bmp|webp)$/.test(lowerFilename)) {
+        finalContentType = contentType.startsWith("image/")
+          ? contentType
+          : "image/jpeg";
+      }
     }
 
     // 處理中文文件名編碼

--- a/frontend/components/application-detail-dialog.tsx
+++ b/frontend/components/application-detail-dialog.tsx
@@ -453,20 +453,24 @@ export function ApplicationDetailDialog({
       return;
     }
 
-    // 構建前端預覽URL，包含token參數
-    const previewUrl = `/api/v1/preview?fileId=${file.id ?? ""}&filename=${encodeURIComponent(filename)}&type=${encodeURIComponent(file.file_type ?? "")}&applicationId=${application?.id}&token=${token}`;
-
-    // 判斷文件類型
+    // 判斷文件類型（必須先於 previewUrl 建立，以傳遞正確的 type 參數）
     let fileType = "other";
+    let proxyType = "";
     if (filename.toLowerCase().endsWith(".pdf")) {
       fileType = "application/pdf";
+      proxyType = "pdf";
     } else if (
       [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"].some(ext =>
         filename.toLowerCase().endsWith(ext)
       )
     ) {
       fileType = "image";
+      proxyType = "image";
     }
+
+    // 構建前端預覽URL，包含token參數
+    // 使用從檔名偵測到的 proxyType，而非 file.file_type（文件分類名稱）
+    const previewUrl = `/api/v1/preview?fileId=${file.id ?? ""}&filename=${encodeURIComponent(filename)}&type=${encodeURIComponent(proxyType)}&applicationId=${application?.id}&token=${token}`;
 
     logger.debug("Opening file preview:", {
       filename,


### PR DESCRIPTION
## Summary

- **`frontend/app/api/v1/preview/route.ts`**: add filename-extension fallback — when `type` param is not `"pdf"` or `"image"` (e.g. it's a document category like `"bank_account_cover"`), infer `Content-Type` from the file extension so `.pdf` files always get `application/pdf`
- **`frontend/components/application-detail-dialog.tsx`**: detect file type from filename _before_ building `previewUrl`, and pass the detected `proxyType` (`"pdf"`/`"image"`/`""`) instead of `file.file_type` (document category)

## Root Cause

`application-detail-dialog.tsx` passed `file.file_type` (a document category like `"bank_account_cover"`) as the `type` query param, but the proxy only set `application/pdf` when `type === "pdf"` exactly — so it always fell through to the backend's stored Content-Type (often `application/octet-stream` from MinIO). Chrome's embedded iframe PDF viewer rejects `application/octet-stream`; opening in a new tab worked because Chrome auto-detects PDF from magic bytes.

## Test plan

- [ ] Open an application with a PDF attachment as admin/college reviewer
- [ ] Click inline preview → PDF renders inside the dialog (not blank)
- [ ] Click "Open in new tab" → still works (regression check)
- [ ] Preview an image file → still renders correctly inline
- [ ] CI green

Closes #752