### PR TITLE
fix(e2e): fix admin-returns 500 + professor-reject advisory-status regression

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -17,7 +17,7 @@ from app.core.cache import invalidate as cache_invalidate
 from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFoundError, ValidationError
 from app.core.metrics import scholarship_applications_total, scholarship_reviews_total
 from app.core.schema_validation import serialize_value
-from app.models.application import Application, ApplicationStatus, ReviewStatus
+from app.models.application import Application, ApplicationStatus
 from app.models.enums import Semester
 from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
@@ -1607,25 +1607,32 @@ class ApplicationService:
         elif status_update.status == ApplicationStatus.rejected.value:
             application.status_name = ScholarshipI18n.get_application_status_text(ApplicationStatus.rejected.value)
 
-        # Create/update ApplicationReview record for comments and rejection reason
-        # instead of storing directly on Application
-        if hasattr(status_update, "comments") or hasattr(status_update, "rejection_reason"):
-            #             from app.models.application import ApplicationReview, ReviewStatus
-
-            review = ApplicationReview(
-                application_id=application.id,
-                reviewer_id=user.id,
-                review_stage="status_update",
-                review_status=(
-                    ReviewStatus.APPROVED.value
-                    if status_update.status == ApplicationStatus.approved.value
-                    else ReviewStatus.REJECTED.value
-                ),
-                comments=getattr(status_update, "comments", None),
-                decision_reason=getattr(status_update, "rejection_reason", None),
-                reviewed_at=datetime.now(timezone.utc),
+        # Persist admin comments / rejection reason as an ApplicationReview row
+        if getattr(status_update, "comments", None) or getattr(status_update, "rejection_reason", None):
+            combined_comments = getattr(status_update, "comments", None) or getattr(
+                status_update, "rejection_reason", None
             )
-            self.db.add(review)
+            recommendation = "approve" if status_update.status == ApplicationStatus.approved.value else "reject"
+            # Upsert: admin may set status multiple times on the same application
+            existing_stmt = select(ApplicationReview).where(
+                ApplicationReview.application_id == application.id,
+                ApplicationReview.reviewer_id == user.id,
+            )
+            existing_result = await self.db.execute(existing_stmt)
+            existing_admin_review = existing_result.scalar_one_or_none()
+            if existing_admin_review:
+                existing_admin_review.recommendation = recommendation
+                existing_admin_review.comments = combined_comments
+                existing_admin_review.reviewed_at = datetime.now(timezone.utc)
+            else:
+                review = ApplicationReview(
+                    application_id=application.id,
+                    reviewer_id=user.id,
+                    recommendation=recommendation,
+                    comments=combined_comments,
+                    reviewed_at=datetime.now(timezone.utc),
+                )
+                self.db.add(review)
 
         application.reviewed_at = datetime.now(timezone.utc)
 

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -482,6 +482,12 @@ class ReviewService:
                 else str(latest_review.reviewer.role).lower()
             )
 
+        # Professor recommendations are purely advisory: never change application.status.
+        # Only advance review_stage so college/admin can see where the pipeline stands.
+        if latest_reviewer_role == "professor":
+            application.review_stage = ReviewStage.professor_reviewed.value
+            return application.status
+
         awaits_further = await self._awaits_further_required_review(application, latest_reviewer_role)
 
         if all_approved:
@@ -489,25 +495,15 @@ class ReviewService:
                 ApplicationStatus.under_review.value if awaits_further else ApplicationStatus.approved.value
             )
         elif all_rejected:
-            if latest_reviewer_role == "professor":
-                # Professor rejection is advisory only; a later college/admin review
-                # may still approve — keep the application in review rather than
-                # setting a terminal status that students cannot appeal.
-                application.status = ApplicationStatus.under_review.value
-            else:
-                application.status = ApplicationStatus.rejected.value
+            application.status = ApplicationStatus.rejected.value
         else:
-            # 部分同意 — also gated: if college hasn't weighed in yet, we
-            # shouldn't lock a partial outcome in (and the student should
-            # still be able to withdraw).
+            # 部分同意
             application.status = (
                 ApplicationStatus.under_review.value if awaits_further else ApplicationStatus.partial_approved.value
             )
 
         # 根據審查者角色更新階段
-        if latest_reviewer_role == "professor":
-            application.review_stage = ReviewStage.professor_reviewed.value
-        elif latest_reviewer_role == "college":
+        if latest_reviewer_role == "college":
             application.review_stage = ReviewStage.college_reviewed.value
         elif latest_reviewer_role in ("admin", "super_admin"):
             application.review_stage = ReviewStage.admin_reviewed.value


### PR DESCRIPTION
## Summary

- **admin-returns-application** (`PATCH /applications/{id}/status`): Fixed HTTP 500 caused by `ApplicationService.update_application_status` creating an `ApplicationReview` with invalid kwargs (`review_stage`, `review_status`, `decision_reason` — none of these are model fields) and missing the required `recommendation` column. Replaced with a valid upsert pattern using only the columns the model defines.
- **professor-reject-upsert**: Fixed `ReviewService.update_application_status` mutating `application.status` even when the reviewer role is `professor`. Per the E2E spec, professor recommendations are purely advisory — the application's `status` must stay at `submitted`; only `review_stage` advances to `professor_reviewed`. Added an early-return guard for the professor role so no status change occurs.
- Removes the now-unused `ReviewStatus` import from `application_service.py` (F401).

## Affected tests

- `frontend/e2e/specs/admin-returns-application.spec.ts` @nightly
- `frontend/e2e/specs/professor-reject-upsert.spec.ts` @nightly

The third failing test (`admin-config-deadline`) was already addressed by `seed_admin_scholarships()` added in `dc90552a`; no further code change needed for that spec.

## Test plan

- [ ] CI E2E nightly: `admin-returns-application` passes (HTTP 200, DB status → `returned`)
- [ ] CI E2E nightly: `professor-reject-upsert` passes (status stays `submitted` after professor reject; upsert keeps 1 review row)
- [ ] Backend lint (flake8 E9/F63/F7/F82/F401): clean
- [ ] `admin-config-deadline` already handled by seed fix in prior PR — verify it passes too

🤖 Generated with [Claude Code](https://claude.com/claude-code)