### PR TITLE
fix(e2e): HTTP 200 for duplicate-application rejection + raise mock-SSO rate limit

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -207,6 +207,8 @@ async def create_application(
                 f"existing_app_id={existing_application.app_id}, "
                 f"status={existing_status}"
             )
+            if response:
+                response.status_code = 200
             return {
                 "success": False,
                 "message": f"您已有此獎學金的申請記錄（{existing_application.app_id}），無法重複申請",

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -226,7 +226,7 @@ async def get_mock_users(db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/mock-sso/login")
-@rate_limit(requests=30, window_seconds=300)  # dev path; still rate-limited so prod misconfigs don't open it wide
+@rate_limit(requests=200, window_seconds=300)  # dev path; 200/5min — high enough for nightly E2E suites (~40 logins)
 async def mock_sso_login(request: Request, request_data: PortalSSORequest, db: AsyncSession = Depends(get_db)):
     """Login as mock user for development"""
     if not settings.enable_mock_sso:


### PR DESCRIPTION
## Summary

- **`applications.py`**: Duplicate-application rejection path (non-draft) was missing `response.status_code = 200` override. FastAPI fell back to the router default of `201 Created`, causing the nightly E2E test `@nightly student-duplicate-reapply` to fail at `expect(dupeRes.status).toBe(200)`. The draft path already had the correct override; added the same `if response: response.status_code = 200` guard for the non-draft path.

- **`auth.py`**: Mock-SSO `/mock-sso/login` rate limit was `30/5min`. The full nightly suite (~12 spec files × avg ~4 `loginAs()` calls ≈ 40+ logins) exhausted the budget, causing HTTP 429 on `admin-config-deadline` and `admin-returns-application` tests. Raised to `200/5min` — still throttled against prod misconfig but won't block E2E.

## Test plan

- [ ] CI backend tests pass
- [ ] Run `npx playwright test --grep @nightly` locally to confirm 0 failures:
  - `student-duplicate-reapply`: first submit → 201 ✅, duplicate → **200** + `DUPLICATE_APPLICATION` ✅
  - `admin-config-deadline`: no longer hits 429 on mock-SSO login ✅
  - `admin-returns-application`: no longer hits 429 on mock-SSO login ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)