### PR TITLE
feat(roster): wire lock/unlock buttons in RosterDetailDialog

### DIFF
--- a/frontend/components/roster/RosterDetailDialog.tsx
+++ b/frontend/components/roster/RosterDetailDialog.tsx
@@ -30,7 +30,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Loader2, X } from "lucide-react";
+import { Loader2, Lock, LockOpen, X } from "lucide-react";
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api";
 import type { RevokedSuspendedList } from "@/lib/api/modules/payment-rosters";
@@ -64,6 +64,7 @@ interface RosterDetailDialogProps {
   onOpenChange: (open: boolean) => void;
   period: Period;
   configId: number;
+  onLockStateChange?: () => void;
 }
 
 interface RosterItem {
@@ -90,6 +91,7 @@ export function RosterDetailDialog({
   onOpenChange,
   period,
   configId,
+  onLockStateChange,
 }: RosterDetailDialogProps) {
   const [loading, setLoading] = useState(true);
   const [rosterItems, setRosterItems] = useState<RosterItem[]>([]);
@@ -102,6 +104,9 @@ export function RosterDetailDialog({
     suspended: [],
   });
   const [removingItemId, setRemovingItemId] = useState<number | null>(null);
+
+  const [isLocking, setIsLocking] = useState(false);
+  const [isUnlocking, setIsUnlocking] = useState(false);
 
   // #66: exclude-item dialog state
   const [excludeTarget, setExcludeTarget] = useState<RosterItem | null>(null);
@@ -160,6 +165,44 @@ export function RosterDetailDialog({
       }
     } finally {
       setRemovingItemId(null);
+    }
+  };
+
+  const handleLockRoster = async () => {
+    if (!period.roster_id) return;
+    if (!confirm("確認鎖定此造冊？鎖定後將無法重新產生，但可解鎖。")) return;
+    setIsLocking(true);
+    try {
+      const resp = await apiClient.paymentRosters.lockRoster(period.roster_id);
+      if (resp.success) {
+        toast.success("造冊已鎖定");
+        onLockStateChange?.();
+      } else {
+        toast.error(resp.message || "鎖定失敗");
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "鎖定失敗");
+    } finally {
+      setIsLocking(false);
+    }
+  };
+
+  const handleUnlockRoster = async () => {
+    if (!period.roster_id) return;
+    if (!confirm("確認解鎖此造冊？解鎖後狀態將回到「已完成」。")) return;
+    setIsUnlocking(true);
+    try {
+      const resp = await apiClient.paymentRosters.unlockRoster(period.roster_id);
+      if (resp.success) {
+        toast.success("造冊已解鎖");
+        onLockStateChange?.();
+      } else {
+        toast.error(resp.message || "解鎖失敗");
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "解鎖失敗");
+    } finally {
+      setIsUnlocking(false);
     }
   };
 
@@ -528,6 +571,40 @@ export function RosterDetailDialog({
               </span>
             </div>
           </div>
+
+          {period.roster_id && (
+            <div className="mt-3 flex gap-2 justify-end">
+              {period.roster_status !== "locked" ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleLockRoster}
+                  disabled={isLocking}
+                >
+                  {isLocking ? (
+                    <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                  ) : (
+                    <Lock className="h-4 w-4 mr-1" />
+                  )}
+                  鎖定造冊
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleUnlockRoster}
+                  disabled={isUnlocking}
+                >
+                  {isUnlocking ? (
+                    <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                  ) : (
+                    <LockOpen className="h-4 w-4 mr-1" />
+                  )}
+                  解鎖造冊
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       </DialogContent>
 

--- a/frontend/lib/api/modules/payment-rosters.ts
+++ b/frontend/lib/api/modules/payment-rosters.ts
@@ -147,5 +147,27 @@ export function createPaymentRostersApi() {
       );
       return toApiResponse(response);
     },
+
+    /**
+     * 鎖定造冊 (admin only)
+     */
+    lockRoster: async (roster_id: number): Promise<ApiResponse<{ roster_code: string }>> => {
+      const response = await typedClient.raw.POST(
+        '/api/v1/payment-rosters/{roster_id}/lock',
+        { params: { path: { roster_id } } }
+      );
+      return toApiResponse(response) as ApiResponse<{ roster_code: string }>;
+    },
+
+    /**
+     * 解鎖造冊 (admin only)
+     */
+    unlockRoster: async (roster_id: number): Promise<ApiResponse<{ roster_code: string }>> => {
+      const response = await typedClient.raw.POST(
+        '/api/v1/payment-rosters/{roster_id}/unlock',
+        { params: { path: { roster_id } } }
+      );
+      return toApiResponse(response) as ApiResponse<{ roster_code: string }>;
+    },
   };
 }


### PR DESCRIPTION
## Summary

- `POST /{roster_id}/lock` and `POST /{roster_id}/unlock` backend endpoints (admin-only) existed but had no frontend consumer — identified as Category B orphans in #665
- Adds `lockRoster()` and `unlockRoster()` methods to the payment-rosters API module
- Adds 鎖定造冊 / 解鎖造冊 buttons in the summary section of `RosterDetailDialog`, toggled by current `roster_status`
- Non-admins receive 403 from backend; access control is server-enforced

## Test plan

- [ ] Log in as admin, open a completed roster → summary shows 鎖定造冊 button
- [ ] Click 鎖定造冊 → confirm dialog → roster status changes to locked, success toast shown
- [ ] Re-open the locked roster → summary shows 解鎖造冊 button
- [ ] Click 解鎖造冊 → confirm dialog → roster status changes back to completed
- [ ] Log in as non-admin and confirm buttons are hidden (backend returns 403 if called directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)