### PR TITLE
fix(college): replace non-null assertions with optional chaining in ApplicationReviewPanel

### DIFF
--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -1203,8 +1203,8 @@ export function ApplicationReviewPanel({
           setShowDeleteDialog(open);
           if (!open) setApplicationToDelete(null);
         }}
-        applicationId={applicationToDelete!.id}
-        applicationName={applicationToDelete!.student_name ?? ""}
+        applicationId={applicationToDelete?.id ?? 0}
+        applicationName={applicationToDelete?.student_name ?? ""}
         onSuccess={() => {
           // Close the ApplicationReviewDialog
           setSelectedApplication(null);
@@ -1227,8 +1227,8 @@ export function ApplicationReviewPanel({
           setShowDocumentRequestDialog(open);
           if (!open) setApplicationToRequestDocs(null);
         }}
-        applicationId={applicationToRequestDocs!.id}
-        applicationName={applicationToRequestDocs!.student_name ?? ""}
+        applicationId={applicationToRequestDocs?.id ?? 0}
+        applicationName={applicationToRequestDocs?.student_name ?? ""}
       />
 
       <FilePreviewDialog


### PR DESCRIPTION
## Summary

- `applicationToDelete` and `applicationToRequestDocs` are initialized as `null`
- The JSX passed `applicationToDelete!.id` and `applicationToRequestDocs!.id` directly as props — TypeScript's `!` strips to bare `.id` at runtime
- React evaluates all prop expressions on every render, even when `open={false}`, so both crash immediately on mount
- Fixed with optional chaining + `?? 0` fallback: `applicationToDelete?.id ?? 0`

This was causing **all authenticated pages to crash** on staging when logged in as a college-role user (`A00001`), with `Cannot read properties of null (reading 'id')` in the bundle.

## Test plan

- [ ] Log in as college reviewer on staging → page loads without "Application error"
- [ ] Open delete dialog on an application → `applicationId` passes the real ID correctly
- [ ] Open document request dialog → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)