### PR TITLE
fix(schemas): add missing RevokeRequest and SuspendRequest

### DIFF
--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -699,6 +699,18 @@ class BulkApproveRequest(BaseModel):
     send_notifications: bool = Field(True, description="Whether to notify applicants")
 
 
+class RevokeRequest(BaseModel):
+    """Request body for revoking a scholarship allocation."""
+
+    reason: str = Field(..., min_length=1, max_length=500, description="Reason for revocation")
+
+
+class SuspendRequest(BaseModel):
+    """Request body for suspending a scholarship allocation."""
+
+    reason: str = Field(..., min_length=1, max_length=500, description="Reason for suspension")
+
+
 class HistoricalApplicationResponse(BaseModel):
     """Historical application response schema for admin view"""
 


### PR DESCRIPTION
## Summary

- `test_revoke_suspend_schemas.py` imports `RevokeRequest` and `SuspendRequest` from `app.schemas.application`, but these classes were never defined
- This caused the nightly **Backend Slow + Performance** job to fail with a collection error (exit code 2)
- Added both schemas with `reason: str` field, `min_length=1, max_length=500` — matching the test expectations

## Test plan

- [ ] Nightly backend-slow job passes (the collection error is resolved)
- [ ] `test_revoke_suspend_schemas.py` all 6 assertions pass: empty reason rejected, 501-char reason rejected, valid reason accepted, same for SuspendRequest

Fixes nightly failure tracked in #760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)