### PR TITLE
chore(api): wrap raw-list returns in ApiResponse format

### DIFF
--- a/backend/app/api/v1/endpoints/admin/email_templates.py
+++ b/backend/app/api/v1/endpoints/admin/email_templates.py
@@ -136,7 +136,11 @@ async def get_email_templates(
     result = await db.execute(stmt)
     templates = result.scalars().all()
 
-    return [EmailTemplateSchema.model_validate(template) for template in templates]
+    return {
+        "success": True,
+        "message": "Email templates retrieved successfully",
+        "data": [EmailTemplateSchema.model_validate(template).model_dump() for template in templates],
+    }
 
 
 # Per-scholarship email templates (closes issue #647)

--- a/backend/app/api/v1/endpoints/nycu_employee.py
+++ b/backend/app/api/v1/endpoints/nycu_employee.py
@@ -159,7 +159,11 @@ async def get_all_employees(status: str = Query("01", description="Employee stat
                 )
             )
 
-        return response_pages
+        return {
+            "success": True,
+            "message": "All employee pages retrieved successfully",
+            "data": response_pages,
+        }
 
     except NYCUEmpAuthenticationError as e:
         raise HTTPException(status_code=401, detail="Authentication failed") from e


### PR DESCRIPTION
## Summary

- `admin/email_templates.py` `get_email_templates`: returned a bare list of `EmailTemplateSchema` objects — now wrapped in `{success, message, data}`
- `nycu_employee.py` `get_all_employees`: returned a bare list of `EmployeeListResponse` objects — now wrapped in `{success, message, data}`

These were the last two CLAUDE.md §5 violations identified by AST scan of route handlers. All other endpoints were already standardized in prior waves.

## Test plan

- [ ] CI passes (backend tests, lint)
- [ ] `GET /api/v1/admin/email-templates` returns `{success: true, message: ..., data: [...]}` — verify via curl or frontend admin email template page
- [ ] `GET /api/v1/admin/nycu-employees` returns `{success: true, message: ..., data: [...]}` — verify response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)