### PR TITLE
fix(frontend): use apiClient in EditScheduleDialog to fix auth and URL bugs

### DIFF
--- a/frontend/components/edit-schedule-dialog.tsx
+++ b/frontend/components/edit-schedule-dialog.tsx
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { toast } from "sonner";
 import { logger } from "@/lib/utils/logger";
 import { Calendar } from "lucide-react"
+import { apiClient } from "@/lib/api"
 
 interface RosterSchedule {
   id: number
@@ -65,9 +66,8 @@ export function EditScheduleDialog({
 
   const fetchScholarshipConfigurations = async () => {
     try {
-      const response = await fetch("/api/v1/scholarship-configurations")
-      const data = await response.json()
-      setScholarshipConfigs(data.configurations || [])
+      const response = await apiClient.request("/scholarship-configurations/configurations")
+      setScholarshipConfigs(response.data || [])
     } catch (error) {
       logger.error("獲取獎學金設定失敗", { error: error })
       toast.error("無法載入獎學金設定")
@@ -100,17 +100,13 @@ export function EditScheduleDialog({
         scholarship_configuration_id: parseInt(formData.scholarship_configuration_id),
       }
 
-      const response = await fetch(`/api/v1/roster-schedules/${schedule.id}`, {
+      const response = await apiClient.request(`/roster-schedules/${schedule.id}`, {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
         body: JSON.stringify(submitData),
       })
 
-      if (!response.ok) {
-        const errorData = await response.json()
-        throw new Error(errorData.message || "更新排程失敗")
+      if (!response.success) {
+        throw new Error(response.message || "更新排程失敗")
       }
 
       toast.success("排程已更新")


### PR DESCRIPTION
## Summary

- **Wrong URL**: `fetchScholarshipConfigurations` called `GET /api/v1/scholarship-configurations` (the router root — no handler, 404) and then accessed `data.configurations` (undefined). Fixed to use `apiClient.request("/scholarship-configurations/configurations")` and access `response.data`.
- **Missing auth**: `handleSubmit` used raw `fetch()` with only `Content-Type` header — no `Authorization: Bearer` token. The PUT endpoint (`roster_schedules.py:241`) requires `get_current_user`, so every update would return 401. Fixed to use `apiClient.request()` which automatically attaches the token from localStorage.

## Test plan

- [ ] Open admin roster schedule page → click Edit on a schedule → scholarship configurations dropdown populates
- [ ] Modify schedule name → click Update → request succeeds (no 401)
- [ ] CI passes (frontend lint, tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)