### PR TITLE
fix(frontend): update semester-selector to read from ApiResponse wrapper

### DIFF
--- a/frontend/components/semester-selector.tsx
+++ b/frontend/components/semester-selector.tsx
@@ -124,17 +124,12 @@ export const SemesterSelector: React.FC<SemesterSelectorProps> = ({
 
       if (activePeriodsOnly) {
         // 獲取有實際申請資料的學期
-        const url = `/api/v1/reference-data/active-academic-periods`;
-        const response = await fetch(url);
-        if (!response.ok)
-          throw new Error("Failed to fetch active academic periods");
-
-        const data = await response.json();
-        setCombinations(data.active_periods || []);
+        const response = await apiClient.request("/reference-data/active-academic-periods");
+        setCombinations(response.data?.active_periods || []);
         setDetectedCycle("semester");
         setActualMode("combined");
         setCurrentInfo({
-          current_period: data.current_period,
+          current_period: response.data?.current_period,
           cycle: "semester",
         });
       } else {
@@ -232,17 +227,12 @@ export const SemesterSelector: React.FC<SemesterSelectorProps> = ({
   const loadBasicData = async () => {
     try {
       setLoading(true);
-      const response = await fetch(
-        `/api/v1/reference-data/semesters`
-      );
-      if (!response.ok) throw new Error("Failed to fetch semester data");
-
-      const data = await response.json();
-      setAcademicYears(data.academic_years || []);
-      setSemesters(data.semesters || []);
+      const response = await apiClient.request("/reference-data/semesters");
+      setAcademicYears(response.data?.academic_years || []);
+      setSemesters(response.data?.semesters || []);
       setCurrentInfo({
-        current_academic_year: data.current_academic_year,
-        current_semester: data.current_semester,
+        current_academic_year: response.data?.current_academic_year,
+        current_semester: response.data?.current_semester,
       });
       setActualMode("separate");
     } catch (error) {


### PR DESCRIPTION
## Summary

- Fixes a Wave 1 regression introduced by c78f3e41 (chore(api): standardize ApiResponse + add missing endpoint logging)
- Two raw `fetch()` calls in `semester-selector.tsx` accessed flat dict fields that were moved one level deeper when reference_data.py endpoints were wrapped in ApiResponse
- Admin semester dropdowns (`enhanced-admin-dashboard`, `admin-scholarship-dashboard`, `scholarship-timeline`) silently rendered empty after the backend change

## Root Cause

Before c78f3e41: `GET /reference-data/semesters` returned `{academic_years: [...], semesters: [...], ...}` — frontend accessed `data.academic_years` correctly.

After c78f3e41: same endpoint now returns `{success: true, message: "...", data: {academic_years: [...], ...}}` — but frontend still read `data.academic_years` (undefined).

Same pattern for `GET /reference-data/active-academic-periods` → `data.active_periods`.

## Fix

Replace both raw `fetch()` calls with `apiClient.request()` (already imported), which returns `ApiResponse<T>` directly. Access the payload via `response.data?.field` to match the current backend shape.

## Test plan

- [ ] Admin semester selector dropdowns on `/admin/scholarships` and `/admin/dashboard` now populate
- [ ] Both `activePeriodsOnly=true` and `activePeriodsOnly=false` paths work
- [ ] No regression in the `else` branch (scholarship-based `apiClient.admin.getAvailableSemesters`) — not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)