### PR TITLE
fix(api): standardize delete_configuration to return ApiResponse format

### DIFF
--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -550,7 +550,7 @@ async def delete_configuration(
             },
         )
 
-        return {"message": "Configuration deleted successfully"}
+        return {"success": True, "message": "Configuration deleted successfully", "data": None}
     except HTTPException:
         raise
     except Exception as e:


### PR DESCRIPTION
## Summary

- Fixes the last remaining CLAUDE.md §5 violation found by AST scan of all backend endpoint handlers
- `DELETE /admin/configurations/{key}` returned `{"message": "Configuration deleted successfully"}` — missing the required `success` and `data` fields
- Frontend compat layer buffered this via fallback (`toApiResponse` wraps non-ApiResponse dicts as `{success: true, data: rawData}`), so no user-facing breakage occurred, but the response was inconsistent

## Fix

One-line change: `{"message": ...}` → `{"success": True, "message": ..., "data": None}`

Matches the pattern used by all other admin configuration endpoints.

## Test plan

- [ ] `DELETE /api/v1/admin/configurations/{key}` returns `{success: true, message: "...", data: null}`
- [ ] Backend lint and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)