### PR TITLE
fix(manual-distribution): restore revoke/suspend endpoints dropped in renewal merge

### DIFF
--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -17,6 +17,7 @@ from app.db.deps import get_sync_db
 from app.models.application import Application
 from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.schemas.application import RevokeRequest, SuspendRequest
 from app.services.manual_distribution_service import ManualDistributionService
 
 logger = logging.getLogger(__name__)
@@ -683,3 +684,51 @@ async def import_received_months(
             "updated": updated,
         },
     }
+
+
+@router.post("/applications/{application_id}/revoke")
+async def revoke_application_allocation(
+    application_id: int,
+    request: RevokeRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_admin_user),
+):
+    """撤銷已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/revoked。"""
+    service = ManualDistributionService(db)
+    try:
+        result = await service.revoke_allocation(
+            application_id=application_id,
+            admin_user_id=current_user.id,
+            reason=request.reason,
+        )
+        await db.commit()
+        return {"success": True, "message": "已撤銷", "data": result}
+    except ValueError as e:
+        msg = str(e)
+        if "already" in msg:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=msg) from e
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg) from e
+
+
+@router.post("/applications/{application_id}/suspend")
+async def suspend_application_allocation(
+    application_id: int,
+    request: SuspendRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_admin_user),
+):
+    """停發已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/suspended。"""
+    service = ManualDistributionService(db)
+    try:
+        result = await service.suspend_allocation(
+            application_id=application_id,
+            admin_user_id=current_user.id,
+            reason=request.reason,
+        )
+        await db.commit()
+        return {"success": True, "message": "已停發", "data": result}
+    except ValueError as e:
+        msg = str(e)
+        if "already" in msg:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=msg) from e
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=msg) from e

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -202,6 +202,12 @@ export function ManualDistributionPanel({
   const [distributionState, setDistributionState] =
     useState<DistributionState | null>(null);
   const [isLoadingState, setIsLoadingState] = useState(false);
+  const [revokeTarget, setRevokeTarget] = useState<{
+    applicationId: number;
+    studentName: string;
+  } | null>(null);
+  const [revokeReason, setRevokeReason] = useState("");
+  const [isRevoking, setIsRevoking] = useState(false);
 
   /**
    * Flatten quota status into (sub_type × year) columns, ordered by:
@@ -574,6 +580,33 @@ export function ManualDistributionPanel({
     }
   };
 
+  const handleRevoke = async () => {
+    if (!revokeTarget || !revokeReason.trim()) return;
+    setIsRevoking(true);
+    try {
+      const resp = await apiClient.manualDistribution.revokeAllocation(
+        revokeTarget.applicationId,
+        revokeReason.trim()
+      );
+      if (resp.success) {
+        setSaveMessage({
+          type: "success",
+          text: `已撤銷 ${revokeTarget.studentName} 的獎學金分發`,
+        });
+        setRevokeTarget(null);
+        setRevokeReason("");
+        await fetchData();
+      } else {
+        setSaveMessage({ type: "error", text: resp.message || "撤銷失敗" });
+      }
+    } catch (err) {
+      logger.error("Revoke error", { err });
+      setSaveMessage({ type: "error", text: "撤銷時發生錯誤" });
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
   const handleGenerateRosters = async () => {
     if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
       return;
@@ -784,6 +817,7 @@ export function ManualDistributionPanel({
   }
 
   return (
+    <>
     <div className="flex gap-4">
       {/* Main table area */}
       <div className="flex-1 min-w-0 space-y-3">
@@ -1259,6 +1293,12 @@ export function ManualDistributionPanel({
                     >
                       身份
                     </th>
+                    <th
+                      rowSpan={2}
+                      className="px-1.5 py-1.5 border border-slate-200 text-center font-semibold text-[11px] w-12"
+                    >
+                      動作
+                    </th>
                   </tr>
                   {/* Row 2 — (year × sub_type) column names */}
                   {subTypeCols.length > 0 && (
@@ -1282,7 +1322,7 @@ export function ManualDistributionPanel({
                   {filteredStudents.length === 0 ? (
                     <tr>
                       <td
-                        colSpan={10 + subTypeCols.length}
+                        colSpan={11 + subTypeCols.length}
                         className="px-4 py-10 text-center text-slate-500"
                       >
                         {students.length === 0
@@ -1304,7 +1344,7 @@ export function ManualDistributionPanel({
                             className="bg-slate-100"
                           >
                             <td
-                              colSpan={10 + subTypeCols.length}
+                              colSpan={11 + subTypeCols.length}
                               className="px-4 py-1.5 text-xs font-bold text-slate-600 border-y border-slate-300"
                             >
                               {collegeName || collegeCode}
@@ -1525,6 +1565,27 @@ export function ManualDistributionPanel({
                                         </span>
                                       )}
                                     </div>
+                                  )}
+                                </td>
+                                <td className="px-1 py-1.5 border-r border-slate-100 text-center">
+                                  {student.allocated_sub_type ? (
+                                    <button
+                                      title="撤銷此學生獎學金"
+                                      onClick={() => {
+                                        setRevokeTarget({
+                                          applicationId: student.application_id,
+                                          studentName: student.student_name,
+                                        });
+                                        setRevokeReason("");
+                                      }}
+                                      className="px-2 py-0.5 text-[11px] bg-red-50 text-red-600 hover:bg-red-100 rounded border border-red-200 cursor-pointer transition-colors"
+                                    >
+                                      撤
+                                    </button>
+                                  ) : (
+                                    <span className="text-[10px] text-slate-300">
+                                      —
+                                    </span>
                                   )}
                                 </td>
                               </tr>
@@ -1822,6 +1883,42 @@ export function ManualDistributionPanel({
         </div>
       )}
     </div>
+
+    {/* Revoke allocation dialog */}
+    <AlertDialog
+      open={revokeTarget !== null}
+      onOpenChange={open => !open && setRevokeTarget(null)}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>撤銷獎學金分發</AlertDialogTitle>
+          <AlertDialogDescription>
+            確定要撤銷 {revokeTarget?.studentName}{" "}
+            的獎學金分發嗎？此操作將從未鎖定造冊中移除該學生，並標記申請為已撤銷。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <textarea
+          placeholder="請說明撤銷原因"
+          value={revokeReason}
+          onChange={e => setRevokeReason(e.target.value)}
+          className="w-full border border-slate-300 rounded-md p-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+          rows={3}
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => setRevokeTarget(null)}>
+            取消
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleRevoke}
+            disabled={!revokeReason.trim() || isRevoking}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-500"
+          >
+            {isRevoking ? "撤銷中…" : "確認撤銷"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+    </>
   );
 }
 

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7222,6 +7222,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/manual-distribution/applications/{application_id}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Revoke Application Allocation
+         * @description 撤銷已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/revoked。
+         */
+        post: operations["revoke_application_allocation_api_v1_manual_distribution_applications__application_id__revoke_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/manual-distribution/applications/{application_id}/suspend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Suspend Application Allocation
+         * @description 停發已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/suspended。
+         */
+        post: operations["suspend_application_allocation_api_v1_manual_distribution_applications__application_id__suspend_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -9206,6 +9246,17 @@ export interface components {
             items: components["schemas"]["ReviewItemCreate"][];
         };
         /**
+         * RevokeRequest
+         * @description Request body for revoking a scholarship allocation.
+         */
+        RevokeRequest: {
+            /**
+             * Reason
+             * @description Reason for revocation
+             */
+            reason: string;
+        };
+        /**
          * RosterCreateRequest
          * @description 造冊建立請求
          */
@@ -10056,6 +10107,17 @@ export interface components {
         SupplementaryImportToggle: {
             /** Allow */
             allow: boolean;
+        };
+        /**
+         * SuspendRequest
+         * @description Request body for suspending a scholarship allocation.
+         */
+        SuspendRequest: {
+            /**
+             * Reason
+             * @description Reason for suspension
+             */
+            reason: string;
         };
         /**
          * SystemSettingCreate
@@ -22099,6 +22161,76 @@ export interface operations {
         requestBody: {
             content: {
                 "multipart/form-data": components["schemas"]["Body_import_received_months_api_v1_manual_distribution_import_received_months_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_application_allocation_api_v1_manual_distribution_applications__application_id__revoke_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                application_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RevokeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    suspend_application_allocation_api_v1_manual_distribution_applications__application_id__suspend_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                application_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SuspendRequest"];
             };
         };
         responses: {

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -386,8 +386,8 @@ describe("createManualDistributionApi", () => {
 
   // ─── 11-method invariant ──────────────────────────────────────────
 
-  it("module exposes exactly 13 methods", async () => {
-    // Pin: 13 methods. Pin so refactor adding/removing methods
+  it("module exposes exactly 14 methods", async () => {
+    // Pin: 14 methods. Pin so refactor adding/removing methods
     // requires explicit review (each one drives a SECURITY-
     // critical allocation operation).
     const api = createManualDistributionApi();
@@ -405,6 +405,7 @@ describe("createManualDistributionApi", () => {
       "importReceivedMonths",
       "previewDistribution",
       "restoreFromHistory",
+      "revokeAllocation",
     ]);
   });
 });

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -545,5 +545,42 @@ export function createManualDistributionApi() {
         updated: number;
       }>;
     },
+
+    /**
+     * Revoke an allocated student's scholarship distribution.
+     * Removes from unlocked rosters and marks application as cancelled/revoked.
+     */
+    revokeAllocation: async (
+      application_id: number,
+      reason: string
+    ): Promise<ApiResponse<unknown>> => {
+      const token = typedClient.getToken();
+      const response = await fetch(
+        `/api/v1/manual-distribution/applications/${application_id}/revoke`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ reason }),
+        }
+      );
+      let body: unknown = null;
+      try {
+        body = await response.json();
+      } catch {
+        // ignore parse error
+      }
+      if (!response.ok) {
+        const b = body as { detail?: string; message?: string } | null;
+        return {
+          success: false,
+          message: b?.detail || b?.message || "撤銷失敗",
+          data: undefined,
+        };
+      }
+      return body as ApiResponse<unknown>;
+    },
   };
 }


### PR DESCRIPTION
## Summary

- Commit `497b3dce` accidentally removed `revoke_application_allocation` and `suspend_application_allocation` route handlers from `manual_distribution.py` during manual conflict resolution of the renewal feature merge. The service methods and Pydantic schemas were intact — only the FastAPI endpoints were missing.
- Adds "動作" column with revoke button + AlertDialog to `ManualDistributionPanel.tsx` to satisfy the `admin-revoke-suspend.spec.ts` nightly E2E contract.

**Backend changes:**
- Restore `POST /api/v1/manual-distribution/applications/{application_id}/revoke`
- Restore `POST /api/v1/manual-distribution/applications/{application_id}/suspend`
- Re-add `RevokeRequest`/`SuspendRequest` import from `app.schemas.application`

**Frontend changes:**
- Add `revokeAllocation()` method to `frontend/lib/api/modules/manual-distribution.ts`
- Add 3 state variables (`revokeTarget`, `revokeReason`, `isRevoking`) + `handleRevoke` handler
- Add "動作" `<th>` column in table header with `rowSpan={2}`
- Add revoke `<button title="撤銷此學生獎學金">` in each allocated student row
- Wrap main component return in `<>...</>` fragment to allow AlertDialog sibling
- Add revoke confirmation `AlertDialog` (with disabled confirm until reason is filled)

## Test plan

- [x] `curl -X POST .../revoke` with admin token → 400 "Application not found" (endpoint exists, routes correctly)
- [x] `curl -X POST .../revoke` with empty body → 422 validation error requiring `reason`
- [x] `curl -X POST .../suspend` with valid reason → same 400 for missing app (endpoint exists)
- [ ] `admin-revoke-suspend.spec.ts` nightly E2E: waits for `th:has-text("動作")`, finds `button[title*="撤銷此學生獎學金"]`, opens AlertDialog, verifies confirm disabled until reason filled, confirms → `text=已撤銷`

🤖 Generated with [Claude Code](https://claude.com/claude-code)