### PR TITLE
fix(manual-distribution): add missing joinedload import

### DIFF
--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -14,7 +14,7 @@ from typing import Any, Literal, Optional
 
 from sqlalchemy import and_, case as sa_case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 
 from app.models.application import Application
 from app.models.audit_log import AuditLog


### PR DESCRIPTION
## Summary

- `joinedload` was used in `get_state_for_panel` (lines 1607 and 1677 of `manual_distribution_service.py`) to eager-load `Application.student` relationships, but it was never imported — only `selectinload` was imported from `sqlalchemy.orm`.
- Every call to `GET /api/v1/manual-distribution/state` raised `NameError: name 'joinedload' is not defined` → HTTP 500.
- This broke the `ManualDistributionPanel` (the panel data never loaded, so the revoke button never appeared), causing the nightly `admin-revoke-suspend.spec.ts` test 1 to fail.

## Test plan

- [x] `GET /api/v1/manual-distribution/state?scholarship_type_id=3&academic_year=114&semester=yearly` returns HTTP 200 locally
- [x] Nightly E2E tests all pass locally with `npx playwright test --workers=1`
- [ ] Nightly CI run green (closes #771 and #774)

🤖 Generated with [Claude Code](https://claude.com/claude-code)