### PR TITLE
fix(revoke): set success message after fetchData to prevent race condition

### DIFF
--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -589,13 +589,16 @@ export function ManualDistributionPanel({
         revokeReason.trim()
       );
       if (resp.success) {
-        setSaveMessage({
-          type: "success",
-          text: `已撤銷 ${revokeTarget.studentName} 的獎學金分發`,
-        });
+        const studentName = revokeTarget.studentName;
         setRevokeTarget(null);
         setRevokeReason("");
         await fetchData();
+        // Set success message after fetchData so it isn't cleared by
+        // fetchData's own setSaveMessage(null) at the top of that function.
+        setSaveMessage({
+          type: "success",
+          text: `已撤銷 ${studentName} 的獎學金分發`,
+        });
       } else {
         setSaveMessage({ type: "error", text: resp.message || "撤銷失敗" });
       }


### PR DESCRIPTION
## Summary
- `handleRevoke` was setting the 已撤銷 success toast, then immediately calling `fetchData()`, which starts with `setSaveMessage(null)` — clearing the message before Playwright (or the user) could see it
- Captured `studentName` before clearing `revokeTarget`, moved `setSaveMessage` to run _after_ `fetchData()` completes so the toast stays visible
- Fixes the nightly E2E failure: `admin-revoke-suspend.spec.ts` → "撤 button opens dialog; confirm stays disabled until reason entered" was failing because `toBeVisible('text=已撤銷')` could never observe the toast

## Root cause

```typescript
// Before — fetchData() wipes the message immediately:
setSaveMessage({ type: "success", text: \`已撤銷 \${revokeTarget.studentName} …\` });
setRevokeTarget(null);
setRevokeReason("");
await fetchData();  // ← first line: setSaveMessage(null) 💥
```

```typescript
// After — message survives:
const studentName = revokeTarget.studentName;
setRevokeTarget(null);
setRevokeReason("");
await fetchData();           // clears null (no visible change)
setSaveMessage({ type: "success", text: \`已撤銷 \${studentName} …\` }); // ← stays
```

## Test plan
- [ ] Nightly E2E `admin-revoke-suspend.spec.ts` passes ("撤 button" test no longer times out on 已撤銷)
- [ ] Manual: click revoke on an allocated student → dialog → fill reason → confirm → "已撤銷 … 的獎學金分發" toast appears in the panel
- [ ] Error path still works: revoke non-allocated student → "撤銷失敗" error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)