### PR TITLE
fix: apply 學號_姓名_ prefix to individual files inside export ZIP (#62)

### DIFF
--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -203,9 +203,10 @@ class ExportPackageService:
         base_path = f"{dept_folder}/{student_folder}"
 
         # Generate summary PDF
+        student_prefix = f"{std_code}_{std_name}"
         try:
             pdf_bytes = self._generate_summary_pdf(app, scholarship_name, academic_year, semester)
-            zf.writestr(f"{base_path}/學生資料彙整.pdf", pdf_bytes)
+            zf.writestr(f"{base_path}/{student_prefix}_學生資料彙整.pdf", pdf_bytes)
         except Exception as e:
             logger.exception(f"Failed to generate summary PDF for app {app.id}")
             zf.writestr(
@@ -232,9 +233,9 @@ class ExportPackageService:
 
             # Add sequence number only if multiple files of same type
             if type_totals[ft] > 1:
-                filename = f"{label}_{count}{ext}"
+                filename = f"{student_prefix}_{label}_{count}{ext}"
             else:
-                filename = f"{label}{ext}"
+                filename = f"{student_prefix}_{label}{ext}"
 
             try:
                 response = await asyncio.to_thread(self.minio.get_file_stream, af.object_name)


### PR DESCRIPTION
Closes #62

## Summary

The college export ZIP already used `{std_code}_{std_name}` as the **folder** name for each student, but the individual files **inside** that folder were named without the prefix (e.g. `成績單.pdf`, `學生資料彙整.pdf`).

This means if someone extracts files from their folder context — or shares an individual file — student identity is lost.

**Before:**
```
A_資工系/
  310460031_王小明/
    學生資料彙整.pdf       ← no student prefix
    成績單.pdf             ← no student prefix
    推薦信.pdf
```

**After:**
```
A_資工系/
  310460031_王小明/
    310460031_王小明_學生資料彙整.pdf   ← prefixed
    310460031_王小明_成績單.pdf         ← prefixed
    310460031_王小明_推薦信.pdf
```

**Changed file:** `backend/app/services/export_package_service.py` — 4 lines in `_add_application_to_zip`.

This completes the **檔名前綴** sub-task of #62. The remaining sub-tasks (欄位修正, 每個系的申請總表) require offline business specs and are out of scope for this PR.

> Auto-fix by scheduled agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_019D5w17f9ku7GF2q2Rvt1Nn)_