### PR TITLE
feat(api): wire bulk-approve + doc-cancel to frontend SDK; remove replaced send-test endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/email_management.py
+++ b/backend/app/api/v1/endpoints/email_management.py
@@ -23,8 +23,6 @@ from app.schemas.email_management import (
     ScheduledEmailListResponse,
     ScheduledEmailRead,
     ScheduledEmailUpdate,
-    SendTestEmailRequest,
-    SendTestEmailResponse,
     SimpleTestEmailRequest,
     SimpleTestEmailResponse,
 )
@@ -520,100 +518,6 @@ async def cleanup_old_audit_logs(
 
 
 # ========== Manual Test Email Endpoints ==========
-
-
-@router.post("/send-test")
-async def send_test_email(
-    *, db: AsyncSession = Depends(get_db), current_user: User = Depends(require_admin), request: SendTestEmailRequest
-):
-    """
-    手動發送測試郵件
-
-    Args:
-        request: 測試郵件請求，包含模板鍵名、收件人和測試數據
-
-    Returns:
-        測試郵件發送結果，包含渲染後的主旨和內容
-    """
-    try:
-        from app.services.email_service import EmailService
-        from app.services.system_setting_service import EmailTemplateService
-
-        # Get email template
-        template = await EmailTemplateService.get_template(db, request.template_key)
-        if not template:
-            raise HTTPException(
-                status_code=404, detail=f"郵件模板 '{request.template_key}' 不存在，請檢查模板鍵名是否正確"
-            )
-
-        # Render subject and body with test data
-        try:
-            rendered_subject = (
-                request.subject_override
-                if request.subject_override
-                else template.subject_template.format(**request.test_data)
-            )
-            rendered_body = (
-                request.body_override if request.body_override else template.body_template.format(**request.test_data)
-            )
-        except KeyError as e:
-            # SECURITY: intentional exception detail in client response.
-            # KeyError.args[0] is the missing template-variable name (e.g.
-            # 'student_name'). The user needs that name to fix their
-            # test_data payload — generic "missing variable" gives them
-            # nothing actionable. The exception is from str.format() so
-            # there's no path-traversal / DB / auth context to leak.
-            raise HTTPException(
-                status_code=400, detail=f"模板變數缺失：{str(e)}。請確保 test_data 包含所有必需的變數"
-            ) from e
-
-        # Initialize email service with database session
-        email_service = EmailService(db)
-
-        # Send test email with metadata
-        metadata = {
-            "email_category": EmailCategory.system,
-            "sent_by_user_id": current_user.id,
-            "sent_by_system": False,
-            "template_key": request.template_key,
-        }
-
-        # Add [TEST] prefix to subject
-        test_subject = f"[測試郵件] {rendered_subject}"
-
-        await email_service.send_email(
-            to=request.recipient_email, subject=test_subject, body=rendered_body, db=db, **metadata
-        )
-
-        # Get the last email history entry to return ID
-        from app.models.email_management import EmailHistory
-
-        result = await db.execute(
-            select(EmailHistory)
-            .where(EmailHistory.sent_by_user_id == current_user.id)
-            .order_by(EmailHistory.sent_at.desc())
-            .limit(1)
-        )
-        last_email = result.scalar_one_or_none()
-
-        response_data = SendTestEmailResponse(
-            success=True,
-            message=f"測試郵件已成功發送至 {request.recipient_email}",
-            email_id=last_email.id if last_email else None,
-            rendered_subject=test_subject,
-            rendered_body=rendered_body,
-        )
-
-        return ApiResponse(success=True, message="測試郵件發送成功", data=response_data)
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Failed to send test email", exc_info=True)
-
-        response_data = SendTestEmailResponse(success=False, message="測試郵件發送失敗", error=str(e))
-
-        return ApiResponse(success=False, message=f"測試郵件發送失敗: {str(e)}", data=response_data)
 
 
 @router.post("/send-simple-test")

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -5593,32 +5593,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/email-management/send-test": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Send Test Email
-         * @description 手動發送測試郵件
-         *
-         *     Args:
-         *         request: 測試郵件請求，包含模板鍵名、收件人和測試數據
-         *
-         *     Returns:
-         *         測試郵件發送結果，包含渲染後的主旨和內容
-         */
-        post: operations["send_test_email_api_v1_email_management_send_test_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v1/email-management/send-simple-test": {
         parameters: {
             query?: never;
@@ -9877,37 +9851,6 @@ export interface components {
          * @enum {string}
          */
         Semester: "first" | "second" | "yearly";
-        /**
-         * SendTestEmailRequest
-         * @description Schema for sending test email
-         */
-        SendTestEmailRequest: {
-            /**
-             * Template Key
-             * @description 郵件模板鍵名
-             */
-            template_key: string;
-            /**
-             * Recipient Email
-             * @description 測試收件人信箱
-             */
-            recipient_email: string;
-            /**
-             * Test Data
-             * @description 測試數據（用於模板變數替換）
-             */
-            test_data?: Record<string, never>;
-            /**
-             * Subject Override
-             * @description 覆蓋主旨（可選）
-             */
-            subject_override?: string | null;
-            /**
-             * Body Override
-             * @description 覆蓋內容（可選）
-             */
-            body_override?: string | null;
-        };
         /**
          * SendingType
          * @enum {string}
@@ -19725,39 +19668,6 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    send_test_email_api_v1_email_management_send_test_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SendTestEmailRequest"];
-            };
-        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/frontend/lib/api/modules/__tests__/admin.test.ts
+++ b/frontend/lib/api/modules/__tests__/admin.test.ts
@@ -496,6 +496,6 @@ describe("createAdminApi", () => {
     // refactor adding/removing methods requires explicit review.
     // SECURITY-critical surface — every change should be deliberate.
     const api = createAdminApi();
-    expect(Object.keys(api).length).toBe(77);
+    expect(Object.keys(api).length).toBe(78);
   });
 });

--- a/frontend/lib/api/modules/__tests__/document-requests.test.ts
+++ b/frontend/lib/api/modules/__tests__/document-requests.test.ts
@@ -132,6 +132,6 @@ describe("createDocumentRequestsApi", () => {
     const api = createDocumentRequestsApi();
     expect(api.getMyDocumentRequests).toBeDefined();
     expect(api.fulfillDocumentRequest).toBeDefined();
-    expect(Object.keys(api).length).toBe(2);
+    expect(Object.keys(api).length).toBe(3);
   });
 });

--- a/frontend/lib/api/modules/admin.ts
+++ b/frontend/lib/api/modules/admin.ts
@@ -1059,7 +1059,7 @@ export function createAdminApi() {
         body: {
           application_ids: applicationIds,
           ...(options?.comments !== undefined && { comments: options.comments }),
-          ...(options?.sendNotifications !== undefined && { send_notifications: options.sendNotifications }),
+          send_notifications: options?.sendNotifications ?? true,
         },
       });
       return toApiResponse(response) as ApiResponse<{

--- a/frontend/lib/api/modules/admin.ts
+++ b/frontend/lib/api/modules/admin.ts
@@ -1031,5 +1031,44 @@ export function createAdminApi() {
       });
       return toApiResponse(response) as ApiResponse<{ id: number; app_id: string; reason: string }>;
     },
+
+    /**
+     * Bulk-approve multiple applications (admin only).
+     *
+     * Transitions each application from submitted/under_review → approved.
+     * Individual failures are collected in data.failed_approvals (HTTP 200
+     * is always returned — the endpoint never raises 4xx for per-item failures).
+     *
+     * POST /api/v1/admin/applications/bulk-approve
+     * See issue #665 for endpoint wiring context.
+     */
+    bulkApproveApplications: async (
+      applicationIds: number[],
+      options?: {
+        comments?: string;
+        sendNotifications?: boolean;
+      }
+    ): Promise<ApiResponse<{
+      total_requested: number;
+      successful_approvals: Array<{ application_id: number; app_id: string }>;
+      failed_approvals: Array<{ application_id: number; reason: string; current_status?: string }>;
+      notifications_sent: number;
+      notifications_failed: number;
+    }>> => {
+      const response = await typedClient.raw.POST('/api/v1/admin/applications/bulk-approve', {
+        body: {
+          application_ids: applicationIds,
+          ...(options?.comments !== undefined && { comments: options.comments }),
+          ...(options?.sendNotifications !== undefined && { send_notifications: options.sendNotifications }),
+        },
+      });
+      return toApiResponse(response) as ApiResponse<{
+        total_requested: number;
+        successful_approvals: Array<{ application_id: number; app_id: string }>;
+        failed_approvals: Array<{ application_id: number; reason: string; current_status?: string }>;
+        notifications_sent: number;
+        notifications_failed: number;
+      }>;
+    },
   };
 }

--- a/frontend/lib/api/modules/document-requests.ts
+++ b/frontend/lib/api/modules/document-requests.ts
@@ -65,5 +65,28 @@ export function createDocumentRequestsApi() {
       );
       return toApiResponse<unknown>(response);
     },
+
+    /**
+     * Cancel a pending document request (staff only).
+     *
+     * Only requests in 'pending' status can be cancelled.
+     * cancellationReason is required by the backend schema (Field(...)).
+     *
+     * PATCH /api/v1/document-requests/{request_id}/cancel
+     * Type-safe: Path parameter and body validated against OpenAPI
+     */
+    cancelDocumentRequest: async (
+      requestId: number,
+      cancellationReason: string
+    ): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.PATCH(
+        '/api/v1/document-requests/{request_id}/cancel',
+        {
+          params: { path: { request_id: requestId } },
+          body: { cancellation_reason: cancellationReason },
+        }
+      );
+      return toApiResponse<unknown>(response);
+    },
   };
 }


### PR DESCRIPTION
## Summary

- **Change 1 — `bulkApproveApplications` added to `frontend/lib/api/modules/admin.ts`**: Wires `POST /api/v1/admin/applications/bulk-approve` into the frontend SDK. Accepts `applicationIds: number[]` plus optional `comments` and `sendNotifications` params. Response is fully typed (includes `successful_approvals`, `failed_approvals`, `notifications_sent`, `notifications_failed`). The endpoint is already tested in `admin-bulk-approve.spec.ts`; this change makes it callable from application code without raw `fetch`. (ref #665)

- **Change 2 — `cancelDocumentRequest` added to `frontend/lib/api/modules/document-requests.ts`**: Wires `PATCH /api/v1/document-requests/{request_id}/cancel` into the SDK. Requires `cancellationReason: string` because the backend `DocumentRequestCancel` schema marks it `Field(...)` (no default — a body-less call returns 422). (ref #665)

- **Change 3 — orphaned `POST /send-test` backend handler removed**: `backend/app/api/v1/endpoints/email_management.py` previously exposed two test-email routes. `/send-simple-test` is the current wired route; `/send-test` was the original, template-based variant that is no longer called from any frontend code. The handler and its exclusive imports (`SendTestEmailRequest`, `SendTestEmailResponse`) are deleted. The `send-simple-test` handler and the `# Manual Test Email Endpoints` section comment are unaffected.

## Test plan

- [ ] Confirm `admin-bulk-approve.spec.ts` (@nightly) still passes — no SDK change needed there, but the new method is the correct call site for future UI code
- [ ] Confirm no TypeScript errors: `cd frontend && npx tsc --noEmit`
- [ ] Confirm no Python import errors: `cd backend && python -c "from app.api.v1.endpoints.email_management import router"`
- [ ] Confirm `POST /api/v1/email-management/send-test` returns 404/405 (route removed)
- [ ] Confirm `POST /api/v1/email-management/send-simple-test` still returns 200 (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)