### PR TITLE
feat(api): wire orphaned roster endpoints into typed payment-rosters module

### DIFF
--- a/frontend/components/roster/RosterDetailDialog.tsx
+++ b/frontend/components/roster/RosterDetailDialog.tsx
@@ -214,16 +214,11 @@ export function RosterDetailDialog({
     }
     setExcludeSubmitting(true);
     try {
-      const response = await apiClient.request(
-        `/payment-rosters/${period.roster_id}/items/${excludeTarget.id}/exclude`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            reason_category: excludeCategory,
-            reason_note: excludeNote.trim() || undefined,
-          }),
-        }
+      const response = await apiClient.paymentRosters.excludeRosterItem(
+        period.roster_id,
+        excludeTarget.id,
+        excludeCategory,
+        excludeNote.trim() || undefined
       );
       if (response.success) {
         toast.success(`已排除 ${excludeTarget.student_name} 的造冊明細`);
@@ -251,13 +246,13 @@ export function RosterDetailDialog({
 
     setLoading(true);
     try {
-      const response = await apiClient.request(
-        `/payment-rosters/${period.roster_id}/items`,
-        { method: "GET" }
-      );
+      const response = await apiClient.paymentRosters.getRosterItems(period.roster_id);
 
       if (response.success && response.data) {
-        const items = response.data.items || response.data;
+        // バックエンドは { items: [...] } または [...] を返す可能性がある
+        // Backend may return { items: [...] } or a bare array
+        const raw = response.data as { items?: RosterItem[] } | RosterItem[];
+        const items: RosterItem[] = Array.isArray(raw) ? raw : (raw.items ?? []);
         setRosterItems(items);
 
         // Check if has matrix (multiple colleges)

--- a/frontend/lib/api/modules/payment-rosters.ts
+++ b/frontend/lib/api/modules/payment-rosters.ts
@@ -7,6 +7,13 @@
 import { typedClient } from '../typed-client';
 import { toApiResponse } from '../compat';
 import type { ApiResponse } from '../types';
+import type { components } from '../generated/schema';
+
+/** Schema 型別別名：造冊建立請求 */
+type RosterCreateRequest = components['schemas']['RosterCreateRequest'];
+
+/** Schema 型別別名：造冊匯出請求 */
+type RosterExportRequest = components['schemas']['RosterExportRequest'];
 
 export interface RevokedSuspendedEntry {
   application_id: number;
@@ -168,6 +175,178 @@ export function createPaymentRostersApi() {
         { params: { path: { roster_id } } }
       );
       return toApiResponse(response) as ApiResponse<{ roster_code: string }>;
+    },
+
+    /**
+     * 取得造冊明細項目
+     * GET /api/v1/payment-rosters/{roster_id}/items
+     */
+    getRosterItems: async (
+      roster_id: number,
+      params?: {
+        skip?: number;
+        limit?: number;
+        is_qualified?: boolean | null;
+      }
+    ): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.GET(
+        '/api/v1/payment-rosters/{roster_id}/items',
+        {
+          params: {
+            path: { roster_id },
+            query: params,
+          },
+        }
+      );
+      return toApiResponse(response);
+    },
+
+    /**
+     * 排除造冊明細項目 (軟刪除: 學生繳回 / 放棄)
+     * POST /api/v1/payment-rosters/{roster_id}/items/{item_id}/exclude
+     */
+    excludeRosterItem: async (
+      roster_id: number,
+      item_id: number,
+      reason_category: string,
+      reason_note?: string
+    ): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.POST(
+        '/api/v1/payment-rosters/{roster_id}/items/{item_id}/exclude',
+        {
+          params: { path: { roster_id, item_id } },
+          body: {
+            reason_category,
+            reason_note: reason_note ?? null,
+          },
+        }
+      );
+      return toApiResponse(response);
+    },
+
+    /**
+     * 取得造冊稽核日誌
+     * GET /api/v1/payment-rosters/{roster_id}/audit-logs
+     */
+    getAuditLogs: async (
+      roster_id: number,
+      params?: { skip?: number; limit?: number }
+    ): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.GET(
+        '/api/v1/payment-rosters/{roster_id}/audit-logs',
+        {
+          params: {
+            path: { roster_id },
+            query: params,
+          },
+        }
+      );
+      return toApiResponse(response);
+    },
+
+    /**
+     * 取得造冊統計資訊
+     * GET /api/v1/payment-rosters/{roster_id}/statistics
+     */
+    getStatistics: async (roster_id: number): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.GET(
+        '/api/v1/payment-rosters/{roster_id}/statistics',
+        { params: { path: { roster_id } } }
+      );
+      return toApiResponse(response);
+    },
+
+    /**
+     * 匯出造冊至 Excel (STD_UP_MIXLISTA 格式)
+     * POST /api/v1/payment-rosters/{roster_id}/export
+     */
+    exportRoster: async (
+      roster_id: number,
+      request?: Partial<RosterExportRequest>
+    ): Promise<ApiResponse<unknown>> => {
+      const body: RosterExportRequest = {
+        template_name: request?.template_name ?? 'STD_UP_MIXLISTA',
+        include_header: request?.include_header ?? true,
+        include_statistics: request?.include_statistics ?? true,
+        max_preview_rows: request?.max_preview_rows ?? null,
+        ...request,
+      };
+      const response = await typedClient.raw.POST(
+        '/api/v1/payment-rosters/{roster_id}/export',
+        {
+          params: { path: { roster_id } },
+          body,
+        }
+      );
+      return toApiResponse(response);
+    },
+
+    /**
+     * 下載造冊 Excel 檔案
+     * GET /api/v1/payment-rosters/{roster_id}/download
+     */
+    downloadRoster: async (
+      roster_id: number,
+      use_minio?: boolean
+    ): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.GET(
+        '/api/v1/payment-rosters/{roster_id}/download',
+        {
+          params: {
+            path: { roster_id },
+            query: use_minio !== undefined ? { use_minio } : undefined,
+          },
+        }
+      );
+      return toApiResponse(response);
+    },
+
+    /**
+     * 預覽造冊學生名單（包含完整驗證）
+     * GET /api/v1/payment-rosters/preview-students
+     */
+    previewStudents: async (params: {
+      config_id: number;
+      ranking_id?: number | null;
+      period_label?: string | null;
+      academic_year?: number | null;
+      student_verification_enabled?: boolean;
+    }): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.GET(
+        '/api/v1/payment-rosters/preview-students',
+        { params: { query: params } }
+      );
+      return toApiResponse(response);
+    },
+
+    /**
+     * 取得造冊週期狀態
+     * GET /api/v1/payment-rosters/cycle-status
+     */
+    getCycleStatus: async (config_id: number): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.GET(
+        '/api/v1/payment-rosters/cycle-status',
+        { params: { query: { config_id } } }
+      );
+      return toApiResponse(response);
+    },
+
+    /**
+     * 造冊產生預演 (不實際建立造冊)
+     * POST /api/v1/payment-rosters/{roster_id}/dry-run
+     */
+    dryRunRoster: async (
+      roster_id: number,
+      request: RosterCreateRequest
+    ): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.POST(
+        '/api/v1/payment-rosters/{roster_id}/dry-run',
+        {
+          params: { path: { roster_id } },
+          body: request,
+        }
+      );
+      return toApiResponse(response);
     },
   };
 }

--- a/frontend/lib/api/modules/payment-rosters.ts
+++ b/frontend/lib/api/modules/payment-rosters.ts
@@ -269,7 +269,8 @@ export function createPaymentRostersApi() {
         include_header: request?.include_header ?? true,
         include_statistics: request?.include_statistics ?? true,
         max_preview_rows: request?.max_preview_rows ?? null,
-        ...request,
+        async_mode: request?.async_mode ?? false,
+        include_excluded: request?.include_excluded ?? false,
       };
       const response = await typedClient.raw.POST(
         '/api/v1/payment-rosters/{roster_id}/export',


### PR DESCRIPTION
## Summary

- Adds 9 typed methods to `frontend/lib/api/modules/payment-rosters.ts` for OpenAPI endpoints that existed in `schema.d.ts` but had no module wrapper
- Migrates `frontend/components/roster/RosterDetailDialog.tsx` away from two raw `apiClient.request()` call sites to the new typed methods
- Imports `RosterCreateRequest` and `RosterExportRequest` directly from `schema.d.ts` so body shapes stay in sync with the generated schema

## New methods added

| Method | HTTP | Path |
|--------|------|------|
| `getRosterItems(rosterId, params?)` | GET | `/api/v1/payment-rosters/{roster_id}/items` |
| `excludeRosterItem(rosterId, itemId, reasonCategory, reasonNote?)` | POST | `/api/v1/payment-rosters/{roster_id}/items/{item_id}/exclude` |
| `getAuditLogs(rosterId, params?)` | GET | `/api/v1/payment-rosters/{roster_id}/audit-logs` |
| `getStatistics(rosterId)` | GET | `/api/v1/payment-rosters/{roster_id}/statistics` |
| `exportRoster(rosterId, request?)` | POST | `/api/v1/payment-rosters/{roster_id}/export` |
| `downloadRoster(rosterId, use_minio?)` | GET | `/api/v1/payment-rosters/{roster_id}/download` |
| `previewStudents(params)` | GET | `/api/v1/payment-rosters/preview-students` |
| `getCycleStatus(configId)` | GET | `/api/v1/payment-rosters/cycle-status` |
| `dryRunRoster(rosterId, request)` | POST | `/api/v1/payment-rosters/{roster_id}/dry-run` |

## Component migrations

- `submitExclude` in `RosterDetailDialog.tsx`: replaced raw `apiClient.request(POST /payment-rosters/.../exclude)` with `apiClient.paymentRosters.excludeRosterItem(...)`
- `loadRosterItems` in `RosterDetailDialog.tsx`: replaced raw `apiClient.request(GET /payment-rosters/.../items)` with `apiClient.paymentRosters.getRosterItems(...)`. The `response.data` is now cast as `{ items?: RosterItem[] } | RosterItem[]` to preserve the backend ambiguity fallback

## Test plan

- [ ] Verify no new tsc errors introduced in the two changed files (pre-existing worktree node_modules resolution errors are unrelated)
- [ ] Verify `npm run lint` passes for `payment-rosters.ts` and `RosterDetailDialog.tsx`
- [ ] Smoke-test the RosterDetailDialog "排除明細" flow (exclude item) and roster items loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)