### PR TITLE
feat(api): wire college-review/statistics to typed college module

### DIFF
--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -274,10 +274,34 @@ export function createCollegeApi() {
     },
 
     /**
-     * NOTE: Statistics endpoint was removed from backend
-     * TODO: Reimplement using ApplicationReview + ApplicationReviewItem
-     * See backend/app/api/v1/endpoints/college_review/utilities.py
+     * 取得學院審核統計資料
+     * Scoped to scholarship types the calling college user has permission for.
      */
+    getReviewStatistics: async (): Promise<
+      ApiResponse<{
+        per_scholarship: Array<{
+          scholarship_type_id: number;
+          code: string | null;
+          name: string | null;
+          name_en: string | null;
+          applications: number;
+          reviews_by_recommendation: Record<string, number>;
+          items_by_sub_type_and_recommendation: Record<string, Record<string, number>>;
+        }>;
+        totals: {
+          applications: number;
+          reviews: number;
+          reviews_by_recommendation: Record<string, number>;
+          items_by_recommendation: Record<string, number>;
+        };
+      }>
+    > => {
+      const response = await typedClient.raw.GET(
+        "/api/v1/college-review/statistics",
+        {}
+      );
+      return toApiResponse(response);
+    },
 
     /**
      * Get available combinations of scholarship types, years, and semesters


### PR DESCRIPTION
## Summary

- The backend endpoint `GET /api/v1/college-review/statistics` is fully implemented in `backend/app/api/v1/endpoints/college_review/utilities.py` and is present in the OpenAPI schema (`frontend/lib/api/generated/schema.d.ts` line 4681).
- The frontend college API module (`frontend/lib/api/modules/college.ts`) had a stale 4-line comment block claiming the endpoint was removed and leaving a TODO to reimplement it.
- This PR removes that outdated comment and adds a typed `getReviewStatistics` method that calls `GET /api/v1/college-review/statistics` through the existing `typedClient.raw.GET` / `toApiResponse` pattern used throughout the module.

## Test plan

- [ ] TypeScript lint passes (`npm run lint` — no errors related to this file)
- [ ] Confirm `collegeApi.getReviewStatistics()` resolves to the correct typed shape matching the OpenAPI schema response for `/api/v1/college-review/statistics`
- [ ] Smoke-test: log in as a college user on localhost and verify a call to the endpoint returns `{ success: true, data: { per_scholarship: [...], totals: {...} } }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)