### PR TITLE
feat(api): wire getSemesters + getActiveAcademicPeriods; migrate schedule/semester component calls to typed API

### DIFF
--- a/frontend/components/create-schedule-dialog.tsx
+++ b/frontend/components/create-schedule-dialog.tsx
@@ -57,10 +57,9 @@ export function CreateScheduleDialog({
 
   const fetchScholarshipConfigurations = async () => {
     try {
-      const response = await apiClient.request("/scholarship-configurations/configurations")
-      // apiClient already extracts response.data, so response.data is the actual array
-      const configs = Array.isArray(response.data) ? response.data : (response.data?.data || [])
-      setScholarshipConfigs(configs)
+      const response = await apiClient.admin.getScholarshipConfigurations()
+      const configs = Array.isArray(response.data) ? response.data : []
+      setScholarshipConfigs(configs as ScholarshipConfiguration[])
     } catch (error) {
       logger.error("獲取獎學金設定失敗", { error: error })
       toast.error("無法載入獎學金設定")

--- a/frontend/components/edit-schedule-dialog.tsx
+++ b/frontend/components/edit-schedule-dialog.tsx
@@ -66,8 +66,8 @@ export function EditScheduleDialog({
 
   const fetchScholarshipConfigurations = async () => {
     try {
-      const response = await apiClient.request("/scholarship-configurations/configurations")
-      setScholarshipConfigs(response.data || [])
+      const response = await apiClient.admin.getScholarshipConfigurations()
+      setScholarshipConfigs((response.data || []) as ScholarshipConfiguration[])
     } catch (error) {
       logger.error("獲取獎學金設定失敗", { error: error })
       toast.error("無法載入獎學金設定")

--- a/frontend/components/semester-selector.tsx
+++ b/frontend/components/semester-selector.tsx
@@ -124,12 +124,13 @@ export const SemesterSelector: React.FC<SemesterSelectorProps> = ({
 
       if (activePeriodsOnly) {
         // 獲取有實際申請資料的學期
-        const response = await apiClient.request("/reference-data/active-academic-periods");
-        setCombinations(response.data?.active_periods || []);
+        const response = await apiClient.referenceData.getActiveAcademicPeriods();
+        const activeData = response.data as { active_periods?: CombinationOption[]; current_period?: string } | undefined;
+        setCombinations(activeData?.active_periods || []);
         setDetectedCycle("semester");
         setActualMode("combined");
         setCurrentInfo({
-          current_period: response.data?.current_period,
+          current_period: activeData?.current_period,
           cycle: "semester",
         });
       } else {
@@ -227,12 +228,13 @@ export const SemesterSelector: React.FC<SemesterSelectorProps> = ({
   const loadBasicData = async () => {
     try {
       setLoading(true);
-      const response = await apiClient.request("/reference-data/semesters");
-      setAcademicYears(response.data?.academic_years || []);
-      setSemesters(response.data?.semesters || []);
+      const response = await apiClient.referenceData.getSemesters();
+      const semesterData = response.data as { academic_years?: AcademicYearOption[]; semesters?: SemesterOption[]; current_academic_year?: number; current_semester?: string } | undefined;
+      setAcademicYears(semesterData?.academic_years || []);
+      setSemesters(semesterData?.semesters || []);
       setCurrentInfo({
-        current_academic_year: response.data?.current_academic_year,
-        current_semester: response.data?.current_semester,
+        current_academic_year: semesterData?.current_academic_year,
+        current_semester: semesterData?.current_semester,
       });
       setActualMode("separate");
     } catch (error) {

--- a/frontend/lib/api/modules/reference-data.ts
+++ b/frontend/lib/api/modules/reference-data.ts
@@ -112,5 +112,23 @@ export function createReferenceDataApi() {
       });
       return toApiResponse(response);
     },
+
+    /**
+     * 取得可用學期選項 (學期 + 學年)
+     * GET /api/v1/reference-data/semesters
+     */
+    getSemesters: async (): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.GET('/api/v1/reference-data/semesters', {});
+      return toApiResponse(response);
+    },
+
+    /**
+     * 取得有實際申請資料的學年度期間
+     * GET /api/v1/reference-data/active-academic-periods
+     */
+    getActiveAcademicPeriods: async (): Promise<ApiResponse<unknown>> => {
+      const response = await typedClient.raw.GET('/api/v1/reference-data/active-academic-periods', {});
+      return toApiResponse(response);
+    },
   };
 }


### PR DESCRIPTION
## Summary

- Adds two missing typed methods (`getSemesters`, `getActiveAcademicPeriods`) to `frontend/lib/api/modules/reference-data.ts`, closing the orphaned-endpoint gap from issue #665
- Migrates `semester-selector.tsx` from two raw `apiClient.request()` calls to `apiClient.referenceData.getSemesters()` and `apiClient.referenceData.getActiveAcademicPeriods()`
- Migrates `create-schedule-dialog.tsx` and `edit-schedule-dialog.tsx` from `apiClient.request("/scholarship-configurations/configurations")` to `apiClient.admin.getScholarshipConfigurations()`
- Adds `as` casts on `response.data` in `semester-selector.tsx` so TypeScript resolves the `unknown` data shape without errors

## Test plan

- [ ] Verify TypeScript compiles cleanly on the 4 changed files (no new substantive errors beyond pre-existing module-resolution noise in the worktree)
- [ ] Smoke-test SemesterSelector in `separate` mode renders academic years and semesters
- [ ] Smoke-test SemesterSelector in `activePeriodsOnly` mode fetches and renders active periods
- [ ] Verify Create/Edit Schedule dialogs load scholarship configuration dropdown correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)