### PR TITLE
feat(api): add filter params to scholarships.getAll; migrate scholarship-timeline + admin-dashboard to typed API

### DIFF
--- a/frontend/components/enhanced-admin-dashboard.tsx
+++ b/frontend/components/enhanced-admin-dashboard.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 import {
   api,
+  apiClient,
   Application,
   DashboardStats,
   NotificationResponse,
@@ -102,33 +103,17 @@ export function EnhancedAdminDashboard({
     semester: string | null
   ) => {
     try {
-      const statsResponse = await api.request<DashboardStats>("/admin/dashboard/stats", {
-        method: "GET",
-        params: {
-          academic_year: academicYear,
-          semester: semester ?? undefined,
-        },
-      });
+      const statsResponse = await apiClient.admin.getDashboardStats();
       if (statsResponse.success) {
         setFilteredStats(statsResponse.data ?? null);
       }
 
-      const applicationsResponse = await api.request<Application[]>(
-        "/admin/recent-applications",
-        {
-          method: "GET",
-          params: {
-            academic_year: academicYear,
-            semester: semester ?? undefined,
-            limit: 10,
-          },
-        }
-      );
+      const applicationsResponse = await apiClient.admin.getRecentApplications(10);
       if (
         applicationsResponse.success &&
         Array.isArray(applicationsResponse.data)
       ) {
-        setFilteredApplications(applicationsResponse.data);
+        setFilteredApplications(applicationsResponse.data as Application[]);
       }
     } catch (error) {
       logger.error("Error fetching filtered data", { error: error });

--- a/frontend/components/scholarship-timeline.tsx
+++ b/frontend/components/scholarship-timeline.tsx
@@ -167,39 +167,25 @@ export function ScholarshipTimeline({ user }: ScholarshipTimelineProps) {
         user.id
       );
 
-      // 建構查詢參數
-      const queryParams = new URLSearchParams();
-      if (academicYear)
-        queryParams.append("academic_year", academicYear.toString());
-      if (semester && semester !== "null")
-        queryParams.append("semester", semester);
+      const queryFilter = {
+        academic_year: academicYear ?? undefined,
+        semester: (semester && semester !== "null") ? semester : undefined,
+      };
 
       // 根據用戶角色獲取不同的獎學金列表
       let response;
       if (user.role === "super_admin") {
-        // Super admin 可以看到所有獎學金
         logger.debug(
           "ScholarshipTimeline: Fetching all scholarships for super_admin",
           { academicYear, semester }
         );
-
-        // 構建帶參數的 URL
-        const url = queryParams.toString()
-          ? `/scholarships?${queryParams.toString()}`
-          : "/scholarships";
-        response = await apiClient.request(url);
+        response = await apiClient.scholarships.getAll(queryFilter);
       } else if (user.role === "admin" || user.role === "college") {
-        // Admin 和 College 可以看到他們有權限的獎學金
         logger.debug(
           "ScholarshipTimeline: Fetching scholarships for admin/college user",
           { academicYear, semester }
         );
-
-        // 構建帶參數的 URL
-        const url = queryParams.toString()
-          ? `/scholarships?${queryParams.toString()}`
-          : "/scholarships";
-        response = await apiClient.request(url);
+        response = await apiClient.scholarships.getAll(queryFilter);
       } else {
         // 其他角色不顯示此功能
         logger.debug(

--- a/frontend/lib/api/modules/__tests__/scholarships.test.ts
+++ b/frontend/lib/api/modules/__tests__/scholarships.test.ts
@@ -64,13 +64,22 @@ describe("createScholarshipsApi", () => {
 
   // ─── getAll ────────────────────────────────────────────────────────
 
-  it("getAll GETs base /api/v1/scholarships path", async () => {
+  it("getAll GETs base /api/v1/scholarships path without params", async () => {
     // Pin: admin-facing list — NO /eligible suffix, NO filter
     // params. Backend already gates with require_admin.
     mockedRaw.GET.mockResolvedValueOnce(_ok([]));
     const api = createScholarshipsApi();
     await api.getAll();
     expect(mockedRaw.GET).toHaveBeenCalledWith("/api/v1/scholarships");
+  });
+
+  it("getAll passes academic_year+semester query params when provided", async () => {
+    mockedRaw.GET.mockResolvedValueOnce(_ok([]));
+    const api = createScholarshipsApi();
+    await api.getAll({ academic_year: 113, semester: "first" });
+    expect(mockedRaw.GET).toHaveBeenCalledWith("/api/v1/scholarships", {
+      params: { query: { academic_year: 113, semester: "first" } },
+    });
   });
 
   // ─── getCombined ───────────────────────────────────────────────────

--- a/frontend/lib/api/modules/scholarships.ts
+++ b/frontend/lib/api/modules/scholarships.ts
@@ -44,9 +44,9 @@ export function createScholarshipsApi() {
       academic_year?: number | null;
       semester?: string | null;
     }): Promise<ApiResponse<ScholarshipType[]>> => {
-      const response = await typedClient.raw.GET('/api/v1/scholarships', {
-        params: params ? { query: params } : undefined,
-      });
+      const response = params
+        ? await typedClient.raw.GET('/api/v1/scholarships', { params: { query: params } })
+        : await typedClient.raw.GET('/api/v1/scholarships');
       return toApiResponse<ScholarshipType[]>(response);
     },
 

--- a/frontend/lib/api/modules/scholarships.ts
+++ b/frontend/lib/api/modules/scholarships.ts
@@ -40,8 +40,13 @@ export function createScholarshipsApi() {
      * Get all scholarships
      * Type-safe: Response array inferred from OpenAPI
      */
-    getAll: async (): Promise<ApiResponse<ScholarshipType[]>> => {
-      const response = await typedClient.raw.GET('/api/v1/scholarships');
+    getAll: async (params?: {
+      academic_year?: number | null;
+      semester?: string | null;
+    }): Promise<ApiResponse<ScholarshipType[]>> => {
+      const response = await typedClient.raw.GET('/api/v1/scholarships', {
+        params: params ? { query: params } : undefined,
+      });
       return toApiResponse<ScholarshipType[]>(response);
     },
 


### PR DESCRIPTION
## Summary

- Adds optional `academic_year` and `semester` query params to `apiClient.scholarships.getAll()` — the backend already accepts them but the method had no params
- Migrates `scholarship-timeline.tsx` from dynamic URL string construction (`/scholarships?academic_year=...&semester=...`) to `apiClient.scholarships.getAll({ academic_year, semester })`
- Migrates `enhanced-admin-dashboard.tsx` from legacy `api.request()` to `apiClient.admin.getDashboardStats()` and `apiClient.admin.getRecentApplications(10)`, removing the silently-ignored `academic_year`/`semester` params (backend endpoints don't expose these — `query?: never` in schema)

## Test plan

- [ ] Scholarship timeline renders correctly for super_admin, admin, and college roles with semester filtering
- [ ] Enhanced admin dashboard statistics load and display correctly
- [ ] TypeScript compiles cleanly on all 3 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)