### PR TITLE
feat: gate scholarship application agreement on regulations PDF scroll

### DIFF
--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -131,7 +131,19 @@ async def upload_system_doc(
     if doc_key not in _ALLOWED_DOC_KEYS:
         raise HTTPException(status_code=400, detail=f"Invalid doc_key. Allowed: {_ALLOWED_DOC_KEYS}")
 
-    allowed_extensions = [".pdf", ".doc", ".docx"]
+    # The student-facing wizard renders 獎學金要點 inline via react-pdf, which
+    # only supports PDF. Enforce both extension and MIME on upload so the
+    # viewer always has something it can render.
+    if doc_key == "regulations_url":
+        allowed_extensions = [".pdf"]
+        if (file.content_type or "").lower() != "application/pdf":
+            raise HTTPException(
+                status_code=400,
+                detail="獎學金要點僅接受 PDF 檔案",
+            )
+    else:
+        allowed_extensions = [".pdf", ".doc", ".docx"]
+
     file_content = await file.read()
     validate_upload_file(
         filename=file.filename,

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -132,8 +132,10 @@ async def upload_system_doc(
         raise HTTPException(status_code=400, detail=f"Invalid doc_key. Allowed: {_ALLOWED_DOC_KEYS}")
 
     # The student-facing wizard renders 獎學金要點 inline via react-pdf, which
-    # only supports PDF. Enforce both extension and MIME on upload so the
-    # viewer always has something it can render.
+    # only supports PDF. Enforce extension AND MIME AND magic-bytes so a
+    # determined admin can't disguise a non-PDF (the first two signals are
+    # client-supplied and trivially spoofable; the magic-byte check inspects
+    # the actual content).
     if doc_key == "regulations_url":
         allowed_extensions = [".pdf"]
         if (file.content_type or "").lower() != "application/pdf":
@@ -145,6 +147,12 @@ async def upload_system_doc(
         allowed_extensions = [".pdf", ".doc", ".docx"]
 
     file_content = await file.read()
+
+    if doc_key == "regulations_url" and not file_content.startswith(b"%PDF-"):
+        raise HTTPException(
+            status_code=400,
+            detail="獎學金要點僅接受 PDF 檔案",
+        )
     validate_upload_file(
         filename=file.filename,
         allowed_extensions=allowed_extensions,

--- a/backend/app/tests/test_system_settings_upload_doc.py
+++ b/backend/app/tests/test_system_settings_upload_doc.py
@@ -137,6 +137,21 @@ class TestRegulationsUploadValidation:
         assert res.status_code == 200
         fake_minio.client.put_object.assert_called_once()
 
+    async def test_rejects_non_pdf_bytes_even_when_extension_and_mime_say_pdf(
+        self, admin_client: AsyncClient, fake_minio
+    ):
+        # Defense in depth: a malicious admin can spoof Content-Type and
+        # filename. Magic-byte sniff catches the content itself.
+        res = await _post_upload(
+            admin_client,
+            "regulations_url",
+            filename="rules.pdf",
+            content_type="application/pdf",
+            body=b"PK\x03\x04 docx bytes pretending to be PDF",
+        )
+        assert res.status_code == 400
+        fake_minio.client.put_object.assert_not_called()
+
 
 @pytest.mark.asyncio
 class TestSampleDocumentUploadStillAcceptsDocx:

--- a/backend/app/tests/test_system_settings_upload_doc.py
+++ b/backend/app/tests/test_system_settings_upload_doc.py
@@ -1,0 +1,156 @@
+"""
+Tests for upload_system_doc in
+backend/app/api/v1/endpoints/system_settings.py.
+
+Pins the policy that regulations_url accepts ONLY .pdf
+(rejects .docx, rejects mismatched MIME), while sample_document_url
+continues to accept .pdf / .doc / .docx.
+"""
+
+from io import BytesIO
+from typing import AsyncGenerator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_current_user, require_admin
+from app.db.deps import get_db
+from app.main import app
+from app.models.user import User, UserRole, UserType
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession) -> User:
+    admin = User(
+        nycu_id="docupload_admin",
+        name="Doc Upload Admin",
+        email="docupload_admin@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(admin)
+    await db.commit()
+    await db.refresh(admin)
+    return admin
+
+
+@pytest_asyncio.fixture
+async def admin_client(
+    db: AsyncSession, admin_user: User
+) -> AsyncGenerator[AsyncClient, None]:
+    async def override_get_db():
+        yield db
+
+    async def override_get_current_user():
+        return admin_user
+
+    async def override_require_admin():
+        return admin_user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[require_admin] = override_require_admin
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def fake_minio():
+    """Patch minio_service so the test never touches MinIO."""
+    with patch(
+        "app.services.minio_service.minio_service"
+    ) as mock_service:
+        mock_service.default_bucket = "test-bucket"
+        mock_service.client = MagicMock()
+        mock_service.client.put_object = MagicMock()
+        mock_service.client.remove_object = MagicMock()
+        yield mock_service
+
+
+async def _post_upload(
+    client: AsyncClient,
+    doc_key: str,
+    filename: str,
+    content_type: str,
+    body: bytes = b"%PDF-1.4 minimal",
+):
+    files = {"file": (filename, BytesIO(body), content_type)}
+    return await client.post(
+        f"/api/v1/system-settings/upload/{doc_key}",
+        files=files,
+    )
+
+
+@pytest.mark.asyncio
+class TestRegulationsUploadValidation:
+    async def test_rejects_docx_for_regulations_url(
+        self, admin_client: AsyncClient, fake_minio
+    ):
+        res = await _post_upload(
+            admin_client,
+            "regulations_url",
+            filename="rules.docx",
+            content_type=(
+                "application/vnd.openxmlformats-"
+                "officedocument.wordprocessingml.document"
+            ),
+        )
+        assert res.status_code == 400
+        body = res.json()
+        # The app wraps HTTPException.detail into a standardized envelope
+        # (`{success, message, trace_id}`) via an exception handler — check
+        # both shapes to stay compatible with either.
+        error_text = body.get("detail") or body.get("message") or ""
+        assert "PDF" in error_text
+        fake_minio.client.put_object.assert_not_called()
+
+    async def test_rejects_pdf_extension_with_mismatched_mime(
+        self, admin_client: AsyncClient, fake_minio
+    ):
+        res = await _post_upload(
+            admin_client,
+            "regulations_url",
+            filename="rules.pdf",
+            content_type="application/octet-stream",
+        )
+        assert res.status_code == 400
+        fake_minio.client.put_object.assert_not_called()
+
+    async def test_accepts_pdf_with_pdf_mime(
+        self, admin_client: AsyncClient, fake_minio
+    ):
+        res = await _post_upload(
+            admin_client,
+            "regulations_url",
+            filename="rules.pdf",
+            content_type="application/pdf",
+        )
+        assert res.status_code == 200
+        fake_minio.client.put_object.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestSampleDocumentUploadStillAcceptsDocx:
+    async def test_accepts_docx_for_sample_document_url(
+        self, admin_client: AsyncClient, fake_minio
+    ):
+        res = await _post_upload(
+            admin_client,
+            "sample_document_url",
+            filename="sample.docx",
+            content_type=(
+                "application/vnd.openxmlformats-"
+                "officedocument.wordprocessingml.document"
+            ),
+        )
+        assert res.status_code == 200
+        fake_minio.client.put_object.assert_called_once()

--- a/backend/app/tests/test_system_settings_upload_doc.py
+++ b/backend/app/tests/test_system_settings_upload_doc.py
@@ -38,9 +38,7 @@ async def admin_user(db: AsyncSession) -> User:
 
 
 @pytest_asyncio.fixture
-async def admin_client(
-    db: AsyncSession, admin_user: User
-) -> AsyncGenerator[AsyncClient, None]:
+async def admin_client(db: AsyncSession, admin_user: User) -> AsyncGenerator[AsyncClient, None]:
     async def override_get_db():
         yield db
 
@@ -55,9 +53,7 @@ async def admin_client(
     app.dependency_overrides[require_admin] = override_require_admin
 
     try:
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as ac:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
             yield ac
     finally:
         app.dependency_overrides.clear()
@@ -66,9 +62,7 @@ async def admin_client(
 @pytest.fixture
 def fake_minio():
     """Patch minio_service so the test never touches MinIO."""
-    with patch(
-        "app.services.minio_service.minio_service"
-    ) as mock_service:
+    with patch("app.services.minio_service.minio_service") as mock_service:
         mock_service.default_bucket = "test-bucket"
         mock_service.client = MagicMock()
         mock_service.client.put_object = MagicMock()
@@ -92,17 +86,12 @@ async def _post_upload(
 
 @pytest.mark.asyncio
 class TestRegulationsUploadValidation:
-    async def test_rejects_docx_for_regulations_url(
-        self, admin_client: AsyncClient, fake_minio
-    ):
+    async def test_rejects_docx_for_regulations_url(self, admin_client: AsyncClient, fake_minio):
         res = await _post_upload(
             admin_client,
             "regulations_url",
             filename="rules.docx",
-            content_type=(
-                "application/vnd.openxmlformats-"
-                "officedocument.wordprocessingml.document"
-            ),
+            content_type=("application/vnd.openxmlformats-" "officedocument.wordprocessingml.document"),
         )
         assert res.status_code == 400
         body = res.json()
@@ -113,9 +102,7 @@ class TestRegulationsUploadValidation:
         assert "PDF" in error_text
         fake_minio.client.put_object.assert_not_called()
 
-    async def test_rejects_pdf_extension_with_mismatched_mime(
-        self, admin_client: AsyncClient, fake_minio
-    ):
+    async def test_rejects_pdf_extension_with_mismatched_mime(self, admin_client: AsyncClient, fake_minio):
         res = await _post_upload(
             admin_client,
             "regulations_url",
@@ -125,9 +112,7 @@ class TestRegulationsUploadValidation:
         assert res.status_code == 400
         fake_minio.client.put_object.assert_not_called()
 
-    async def test_accepts_pdf_with_pdf_mime(
-        self, admin_client: AsyncClient, fake_minio
-    ):
+    async def test_accepts_pdf_with_pdf_mime(self, admin_client: AsyncClient, fake_minio):
         res = await _post_upload(
             admin_client,
             "regulations_url",
@@ -155,17 +140,12 @@ class TestRegulationsUploadValidation:
 
 @pytest.mark.asyncio
 class TestSampleDocumentUploadStillAcceptsDocx:
-    async def test_accepts_docx_for_sample_document_url(
-        self, admin_client: AsyncClient, fake_minio
-    ):
+    async def test_accepts_docx_for_sample_document_url(self, admin_client: AsyncClient, fake_minio):
         res = await _post_upload(
             admin_client,
             "sample_document_url",
             filename="sample.docx",
-            content_type=(
-                "application/vnd.openxmlformats-"
-                "officedocument.wordprocessingml.document"
-            ),
+            content_type=("application/vnd.openxmlformats-" "officedocument.wordprocessingml.document"),
         )
         assert res.status_code == 200
         fake_minio.client.put_object.assert_called_once()

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -133,7 +133,11 @@ services:
       target: builder
     image: ghcr.io/anud18/scholarship-system-frontend:${TAG:-latest}
     container_name: scholarship_frontend_dev
-    command: sh -c "node /app/node_modules/.bin/next dev --turbo"
+    # Copies pdf.js worker into the bind-mounted public/ on every start.
+    # The image's postinstall already runs the copy, but `./frontend:/app`
+    # bind-mount shadows /app/public so we have to redo it against the host
+    # public/ dir.
+    command: sh -c "node scripts/copy-pdf-worker.mjs && node /app/node_modules/.bin/next dev --turbo"
     ports:
       - "3000:3000"
     environment:

--- a/docs/superpowers/plans/2026-05-21-scholarship-regulations-scroll-gate.md
+++ b/docs/superpowers/plans/2026-05-21-scholarship-regulations-scroll-gate.md
@@ -1,0 +1,1582 @@
+# Scholarship Regulations Scroll-Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the student-application "scroll to bottom before agree" gate from the hardcoded 8-item notice list onto the admin-uploaded 獎學金要點 PDF, rendered inline with `react-pdf`. Admins must upload as PDF; if none uploaded, students are blocked at the agreement step.
+
+**Architecture:** Replace the gated scrollable content inside `NoticeAgreementStep.tsx` with a new reusable `InlinePdfViewer` component (`react-pdf` based). Tighten admin upload validation (client + server) so `regulations_url` accepts PDF only. The 8 hardcoded notice items remain as a static, non-gated summary. The 申請文件範例檔 button continues to use the existing `FilePreviewDialog`.
+
+**Tech Stack:** Next.js 16 (frontend), React 18, TypeScript, `react-pdf` (new), FastAPI (backend), Jest (frontend tests), pytest (backend tests), Docker Compose dev env.
+
+**Reference spec:** [`docs/superpowers/specs/2026-05-21-scholarship-regulations-scroll-gate-design.md`](../specs/2026-05-21-scholarship-regulations-scroll-gate-design.md)
+
+---
+
+## File Structure
+
+**Files created:**
+- `frontend/lib/pdf-worker.ts` — sets `pdfjs.GlobalWorkerOptions.workerSrc` exactly once
+- `frontend/components/inline-pdf-viewer.tsx` — new reusable PDF viewer with scroll-to-bottom detection
+- `frontend/components/__tests__/inline-pdf-viewer.test.tsx` — Jest tests for the new component
+- `frontend/components/__tests__/notice-agreement-step.test.tsx` — Jest tests for the updated wizard step
+- `backend/app/tests/test_system_settings_upload_doc.py` — pytest for PDF-only upload validation
+
+**Files modified:**
+- `frontend/package.json` — adds `react-pdf` dependency
+- `frontend/components/student-wizard/steps/NoticeAgreementStep.tsx` — swap gated content, drop regulations dialog button, add empty/error states, update locale copy
+- `frontend/components/admin/system-docs/SystemDocsPanel.tsx` — per-slot `accepted` extensions, restrict `regulations_url` slot to PDF
+- `backend/app/api/v1/endpoints/system_settings.py` — add PDF-only guard in `upload_system_doc` when `doc_key == "regulations_url"`
+
+---
+
+## Tasks
+
+### Task 1: Add react-pdf dependency and worker config
+
+**Files:**
+- Modify: `frontend/package.json`
+- Create: `frontend/lib/pdf-worker.ts`
+
+- [ ] **Step 1: Install `react-pdf`**
+
+Run from project root:
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npm install react-pdf@9
+```
+
+If the frontend container isn't running, start it first:
+```bash
+docker compose -f docker-compose.dev.yml up -d frontend
+```
+
+Expected: `package.json` shows `"react-pdf": "^9.x.x"` in `dependencies`. `package-lock.json` updated. `pdfjs-dist` appears as a transitive dep.
+
+- [ ] **Step 2: Create the pdf.js worker config module**
+
+Create `frontend/lib/pdf-worker.ts`:
+
+```ts
+// Configures the pdf.js worker for react-pdf. Imported once by InlinePdfViewer
+// so the worker URL is set before any <Document> mounts.
+import { pdfjs } from "react-pdf";
+
+// Use the worker bundled with pdfjs-dist via a URL the browser can fetch.
+// `new URL(..., import.meta.url)` is resolved by Next.js / Turbopack into a
+// static asset URL at build time.
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  "pdfjs-dist/build/pdf.worker.min.mjs",
+  import.meta.url
+).toString();
+```
+
+- [ ] **Step 3: Verify the worker module type-checks**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npm run type-check
+```
+
+Expected: PASS (no new TypeScript errors).
+
+If `tsc` complains about `import.meta.url`, ensure `tsconfig.json` has `"module": "esnext"` or `"module": "nodenext"` (it should — Next.js defaults). If `tsc` complains about the `.mjs` import path, change the worker source to:
+
+```ts
+pdfjs.GlobalWorkerOptions.workerSrc =
+  `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+```
+
+…and re-run type-check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/lib/pdf-worker.ts
+git commit -m "feat(frontend): add react-pdf and configure pdf.js worker"
+```
+
+---
+
+### Task 2: Create `InlinePdfViewer` component (failing test first)
+
+**Files:**
+- Create: `frontend/components/__tests__/inline-pdf-viewer.test.tsx`
+- Create: `frontend/components/inline-pdf-viewer.tsx`
+
+- [ ] **Step 1: Write failing tests for `InlinePdfViewer`**
+
+Create `frontend/components/__tests__/inline-pdf-viewer.test.tsx`:
+
+```tsx
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { InlinePdfViewer } from "../inline-pdf-viewer";
+
+// Mock react-pdf so we don't load real pdf.js in jsdom. We expose a
+// `triggerLoadSuccess(numPages)` and `triggerLoadError(err)` helper via
+// the mock so individual tests can drive the lifecycle.
+jest.mock("react-pdf", () => {
+  type Cb = (info: { numPages: number }) => void;
+  type ErrCb = (err: Error) => void;
+  const handlers: { success?: Cb; error?: ErrCb } = {};
+  const Document = (props: {
+    onLoadSuccess?: Cb;
+    onLoadError?: ErrCb;
+    children?: React.ReactNode;
+  }) => {
+    handlers.success = props.onLoadSuccess;
+    handlers.error = props.onLoadError;
+    return <div data-testid="pdf-document">{props.children}</div>;
+  };
+  const Page = ({ pageNumber }: { pageNumber: number }) => (
+    <div data-testid={`pdf-page-${pageNumber}`} style={{ height: 800 }}>
+      page {pageNumber}
+    </div>
+  );
+  return {
+    Document,
+    Page,
+    pdfjs: { GlobalWorkerOptions: { workerSrc: "" }, version: "x" },
+    __setSuccess: (n: number) => handlers.success?.({ numPages: n }),
+    __setError: (e: Error) => handlers.error?.(e),
+  };
+});
+
+// Mock the worker side-effect import so it doesn't blow up jsdom.
+jest.mock("@/lib/pdf-worker", () => ({}));
+
+const reactPdf = jest.requireMock("react-pdf") as {
+  __setSuccess: (n: number) => void;
+  __setError: (e: Error) => void;
+};
+
+describe("InlinePdfViewer", () => {
+  function setScrollMetrics(
+    el: HTMLElement,
+    { scrollHeight, clientHeight, scrollTop }: { scrollHeight: number; clientHeight: number; scrollTop: number }
+  ) {
+    Object.defineProperty(el, "scrollHeight", { configurable: true, value: scrollHeight });
+    Object.defineProperty(el, "clientHeight", { configurable: true, value: clientHeight });
+    Object.defineProperty(el, "scrollTop", { configurable: true, value: scrollTop });
+  }
+
+  it("renders one <Page> per numPages after onLoadSuccess", () => {
+    render(<InlinePdfViewer url="/fake.pdf" />);
+    act(() => reactPdf.__setSuccess(3));
+    expect(screen.getByTestId("pdf-page-1")).toBeInTheDocument();
+    expect(screen.getByTestId("pdf-page-2")).toBeInTheDocument();
+    expect(screen.getByTestId("pdf-page-3")).toBeInTheDocument();
+  });
+
+  it("fires onReachedBottom exactly once when the user scrolls to the bottom", () => {
+    const onReached = jest.fn();
+    const { container } = render(
+      <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />
+    );
+    act(() => reactPdf.__setSuccess(2));
+
+    const scroller = container.querySelector(
+      "[data-testid='pdf-scroll-container']"
+    ) as HTMLElement;
+    expect(scroller).not.toBeNull();
+
+    // Initial scroll, not yet at bottom.
+    setScrollMetrics(scroller, { scrollHeight: 2000, clientHeight: 500, scrollTop: 100 });
+    fireEvent.scroll(scroller);
+    expect(onReached).not.toHaveBeenCalled();
+
+    // Scroll to the bottom (within the 8px slack).
+    setScrollMetrics(scroller, { scrollHeight: 2000, clientHeight: 500, scrollTop: 1495 });
+    fireEvent.scroll(scroller);
+    expect(onReached).toHaveBeenCalledTimes(1);
+
+    // Bouncing back should NOT re-fire.
+    setScrollMetrics(scroller, { scrollHeight: 2000, clientHeight: 500, scrollTop: 200 });
+    fireEvent.scroll(scroller);
+    expect(onReached).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onReachedBottom on mount-after-load when the document already fits the container", () => {
+    const onReached = jest.fn();
+    const { container } = render(
+      <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />
+    );
+
+    const scroller = container.querySelector(
+      "[data-testid='pdf-scroll-container']"
+    ) as HTMLElement;
+    setScrollMetrics(scroller, { scrollHeight: 400, clientHeight: 500, scrollTop: 0 });
+
+    act(() => reactPdf.__setSuccess(1));
+
+    expect(onReached).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onLoadError and never fires onReachedBottom when the document fails to load", () => {
+    const onReached = jest.fn();
+    const onErr = jest.fn();
+    render(
+      <InlinePdfViewer
+        url="/broken.pdf"
+        onReachedBottom={onReached}
+        onLoadError={onErr}
+      />
+    );
+
+    const err = new Error("boom");
+    act(() => reactPdf.__setError(err));
+
+    expect(onErr).toHaveBeenCalledWith(err);
+    expect(onReached).not.toHaveBeenCalled();
+    expect(screen.getByText(/重新載入|Reload/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npx jest components/__tests__/inline-pdf-viewer.test.tsx
+```
+
+Expected: FAIL with `Cannot find module '../inline-pdf-viewer'`.
+
+- [ ] **Step 3: Implement `InlinePdfViewer`**
+
+Create `frontend/components/inline-pdf-viewer.tsx`:
+
+```tsx
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Document, Page } from "react-pdf";
+import { AlertCircle, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Side-effect import: configures pdfjs.GlobalWorkerOptions.workerSrc.
+import "@/lib/pdf-worker";
+
+import "react-pdf/dist/Page/AnnotationLayer.css";
+import "react-pdf/dist/Page/TextLayer.css";
+
+interface InlinePdfViewerProps {
+  url: string;
+  height?: number;
+  onReachedBottom?: () => void;
+  onLoadError?: (err: Error) => void;
+  locale?: "zh" | "en";
+}
+
+const SLACK_PX = 8;
+
+export function InlinePdfViewer({
+  url,
+  height = 500,
+  onReachedBottom,
+  onLoadError,
+  locale = "zh",
+}: InlinePdfViewerProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [loadError, setLoadError] = useState<Error | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  // Latch: fire onReachedBottom at most once per (url, reloadToken) instance.
+  const latched = useRef(false);
+  useEffect(() => {
+    latched.current = false;
+  }, [url, reloadToken]);
+
+  const fireReached = useCallback(() => {
+    if (latched.current) return;
+    latched.current = true;
+    onReachedBottom?.();
+  }, [onReachedBottom]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight <= SLACK_PX) {
+      fireReached();
+    }
+  }, [fireReached]);
+
+  const handleLoadSuccess = useCallback(
+    ({ numPages: n }: { numPages: number }) => {
+      setNumPages(n);
+      setLoadError(null);
+      // After pages mount, if the document fits without overflowing the
+      // container, treat it as already read. Schedule on the next frame so
+      // layout has settled.
+      requestAnimationFrame(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+        if (el.scrollHeight <= el.clientHeight + SLACK_PX) {
+          fireReached();
+        }
+      });
+    },
+    [fireReached]
+  );
+
+  const handleLoadError = useCallback(
+    (err: Error) => {
+      setLoadError(err);
+      onLoadError?.(err);
+    },
+    [onLoadError]
+  );
+
+  const labels =
+    locale === "zh"
+      ? { loading: "載入中…", error: "無法載入文件", reload: "重新載入" }
+      : { loading: "Loading…", error: "Failed to load document", reload: "Reload" };
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid="pdf-scroll-container"
+      onScroll={handleScroll}
+      className="overflow-y-auto rounded-lg border bg-white"
+      style={{ height }}
+    >
+      {loadError ? (
+        <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+          <AlertCircle className="h-8 w-8 text-red-500" />
+          <p className="text-sm font-medium text-red-700">{labels.error}</p>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setLoadError(null);
+              setNumPages(null);
+              setReloadToken((t) => t + 1);
+            }}
+          >
+            <RotateCcw className="mr-1.5 h-4 w-4" />
+            {labels.reload}
+          </Button>
+        </div>
+      ) : (
+        <Document
+          // Key forces a remount on reload.
+          key={`${url}#${reloadToken}`}
+          file={url}
+          loading={
+            <div className="space-y-3 p-6">
+              <Skeleton className="h-6 w-full" />
+              <Skeleton className="h-6 w-[90%]" />
+              <Skeleton className="h-6 w-[85%]" />
+              <Skeleton className="h-6 w-[95%]" />
+              <p className="pt-2 text-center text-xs text-muted-foreground">
+                {labels.loading}
+              </p>
+            </div>
+          }
+          onLoadSuccess={handleLoadSuccess}
+          onLoadError={handleLoadError}
+        >
+          {numPages !== null
+            ? Array.from({ length: numPages }, (_, i) => (
+                <Page
+                  key={i + 1}
+                  pageNumber={i + 1}
+                  renderAnnotationLayer
+                  renderTextLayer
+                  className="mx-auto mb-2"
+                />
+              ))
+            : null}
+        </Document>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npx jest components/__tests__/inline-pdf-viewer.test.tsx
+```
+
+Expected: PASS — all 4 tests green.
+
+If the "fires onReachedBottom on mount-after-load when the document already fits" test fails because the `requestAnimationFrame` callback isn't flushed by jsdom, wrap the `act(() => reactPdf.__setSuccess(1))` block with a flush:
+
+```tsx
+// Replace the simple act() call in that test with:
+await act(async () => {
+  reactPdf.__setSuccess(1);
+  await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+});
+```
+
+And re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/inline-pdf-viewer.tsx frontend/components/__tests__/inline-pdf-viewer.test.tsx
+git commit -m "feat(frontend): add InlinePdfViewer with scroll-to-bottom gating"
+```
+
+---
+
+### Task 3: Rewrite `NoticeAgreementStep` to use `InlinePdfViewer`
+
+**Files:**
+- Create: `frontend/components/__tests__/notice-agreement-step.test.tsx`
+- Modify: `frontend/components/student-wizard/steps/NoticeAgreementStep.tsx`
+
+- [ ] **Step 1: Write failing tests for the rewritten step**
+
+Create `frontend/components/__tests__/notice-agreement-step.test.tsx`:
+
+```tsx
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NoticeAgreementStep } from "../student-wizard/steps/NoticeAgreementStep";
+
+// Mock the API client used inside the step.
+jest.mock("@/lib/api", () => ({
+  api: {
+    systemSettings: {
+      getPublicDocs: jest.fn(),
+    },
+  },
+}));
+
+// Mock the inline viewer so tests can drive `onReachedBottom` directly.
+jest.mock("@/components/inline-pdf-viewer", () => ({
+  InlinePdfViewer: (props: {
+    url: string;
+    onReachedBottom?: () => void;
+  }) => (
+    <div data-testid="inline-pdf-viewer" data-url={props.url}>
+      <button
+        type="button"
+        data-testid="simulate-reached-bottom"
+        onClick={() => props.onReachedBottom?.()}
+      >
+        simulate scroll bottom
+      </button>
+    </div>
+  ),
+}));
+
+// Mock FilePreviewDialog (used for the sample-document button).
+jest.mock("@/components/file-preview-dialog", () => ({
+  FilePreviewDialog: () => null,
+}));
+
+const { api } = jest.requireMock("@/lib/api") as {
+  api: { systemSettings: { getPublicDocs: jest.Mock } };
+};
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe("NoticeAgreementStep", () => {
+  const noop = () => undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: jest.fn(() => "test-token"),
+      },
+      configurable: true,
+    });
+  });
+
+  it("blocks the agree checkbox and shows an alert when no regulations are uploaded", async () => {
+    api.systemSettings.getPublicDocs.mockResolvedValue({
+      success: true,
+      data: {},
+    });
+
+    render(
+      <NoticeAgreementStep
+        agreedToTerms={false}
+        onAgree={noop}
+        onNext={noop}
+        locale="zh"
+      />
+    );
+    await flushPromises();
+
+    expect(
+      screen.getByText(/系統管理員尚未上傳獎學金要點/)
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("inline-pdf-viewer")).not.toBeInTheDocument();
+
+    const agreeCheckbox = screen.getByRole("checkbox", {
+      name: /同意遵守相關規定/,
+    });
+    expect(agreeCheckbox).toBeDisabled();
+  });
+
+  it("renders the InlinePdfViewer and enables the agree checkbox after scroll-to-bottom", async () => {
+    api.systemSettings.getPublicDocs.mockResolvedValue({
+      success: true,
+      data: {
+        regulations_url: "system-docs/regulations_url_20260520_120000.pdf",
+        regulations_url_filename: "獎學金要點.pdf",
+      },
+    });
+
+    const onAgree = jest.fn();
+    render(
+      <NoticeAgreementStep
+        agreedToTerms={false}
+        onAgree={onAgree}
+        onNext={noop}
+        locale="zh"
+      />
+    );
+    await flushPromises();
+
+    const viewer = screen.getByTestId("inline-pdf-viewer");
+    expect(viewer.getAttribute("data-url")).toMatch(
+      /\/api\/v1\/system-settings\/file-proxy\?key=regulations_url/
+    );
+
+    // Agree starts disabled (hasReadNotice = false).
+    const agreeCheckbox = screen.getByRole("checkbox", {
+      name: /同意遵守相關規定/,
+    });
+    expect(agreeCheckbox).toBeDisabled();
+
+    // Simulate scroll-to-bottom from the inline viewer.
+    fireEvent.click(screen.getByTestId("simulate-reached-bottom"));
+
+    expect(agreeCheckbox).not.toBeDisabled();
+  });
+
+  it("keeps the 8 hardcoded notice items visible as a static summary", async () => {
+    api.systemSettings.getPublicDocs.mockResolvedValue({
+      success: true,
+      data: { regulations_url: "system-docs/x.pdf" },
+    });
+    render(
+      <NoticeAgreementStep
+        agreedToTerms={false}
+        onAgree={noop}
+        onNext={noop}
+        locale="zh"
+      />
+    );
+    await flushPromises();
+
+    expect(screen.getByText("申請資格")).toBeInTheDocument();
+    expect(screen.getByText("申請期限")).toBeInTheDocument();
+    expect(screen.getByText("獎金撥款")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npx jest components/__tests__/notice-agreement-step.test.tsx
+```
+
+Expected: FAIL — assertions about the new alert text and the InlinePdfViewer don't match the current implementation (which still renders the 8-item scroll container and dialog button).
+
+- [ ] **Step 3: Rewrite `NoticeAgreementStep.tsx`**
+
+Open `frontend/components/student-wizard/steps/NoticeAgreementStep.tsx` and replace the full file contents with:
+
+```tsx
+"use client";
+
+import React, { useState, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertCircle,
+  CheckCircle,
+  FileText,
+  AlertTriangle,
+  ChevronRight,
+} from "lucide-react";
+import { api } from "@/lib/api";
+import { FilePreviewDialog } from "@/components/file-preview-dialog";
+import { InlinePdfViewer } from "@/components/inline-pdf-viewer";
+
+interface NoticeAgreementStepProps {
+  agreedToTerms: boolean;
+  onAgree: (agreed: boolean) => void;
+  onNext: () => void;
+  locale: "zh" | "en";
+}
+
+export function NoticeAgreementStep({
+  agreedToTerms,
+  onAgree,
+  onNext,
+  locale,
+}: NoticeAgreementStepProps) {
+  const [hasReadNotice, setHasReadNotice] = useState(false);
+
+  const [publicDocs, setPublicDocs] = useState<{
+    regulations_url?: string;
+    sample_document_url?: string;
+    regulations_url_filename?: string;
+    sample_document_url_filename?: string;
+  }>({});
+  const [docsLoaded, setDocsLoaded] = useState(false);
+  const [previewFile, setPreviewFile] = useState<{
+    url: string;
+    filename: string;
+    type: string;
+  } | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
+
+  useEffect(() => {
+    api.systemSettings.getPublicDocs().then((res) => {
+      if (res.success && res.data) setPublicDocs(res.data);
+      setDocsLoaded(true);
+    });
+  }, []);
+
+  const handleOpenSampleDoc = (label: string) => {
+    const token = localStorage.getItem("auth_token") || "";
+    const objectName = publicDocs.sample_document_url;
+    const originalName = publicDocs.sample_document_url_filename;
+    const cacheBuster = encodeURIComponent(objectName?.split("/").pop() || "");
+    const url = `/api/v1/system-settings/file-proxy?key=sample_document_url&token=${encodeURIComponent(
+      token
+    )}&v=${cacheBuster}`;
+    const filename = originalName || label;
+    const lower = (originalName || objectName || "").toLowerCase();
+    let type = "application/pdf";
+    if (lower.endsWith(".doc")) type = "application/msword";
+    else if (lower.endsWith(".docx"))
+      type =
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    else if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) type = "image/jpeg";
+    else if (lower.endsWith(".png")) type = "image/png";
+    setPreviewFile({ url, filename, type });
+    setShowPreview(true);
+  };
+
+  const regulationsViewerUrl = (() => {
+    const objectName = publicDocs.regulations_url;
+    if (!objectName) return null;
+    const token =
+      typeof window !== "undefined"
+        ? localStorage.getItem("auth_token") || ""
+        : "";
+    const cacheBuster = encodeURIComponent(objectName.split("/").pop() || "");
+    return `/api/v1/system-settings/file-proxy?key=regulations_url&token=${encodeURIComponent(
+      token
+    )}&v=${cacheBuster}`;
+  })();
+
+  const notices = {
+    zh: {
+      title: "獎學金申請注意事項",
+      subtitle:
+        "請詳細閱讀以下內容，並滑完下方的「獎學金要點」後勾選同意方可繼續申請",
+      items: [
+        { title: "申請資格", content: "申請人必須為本校在學學生，且符合各獎學金規定的申請條件。請確認您的學籍狀態與申請資格。" },
+        { title: "申請期限", content: "各獎學金有不同的申請期限，逾期申請恕不受理。請注意各獎學金的開放申請日期與截止日期。" },
+        { title: "文件準備", content: "請備妥所需文件，包括但不限於成績單、在學證明、指導教授推薦函等。所有文件必須為清晰可辨識的電子檔案（PDF、JPG、JPEG 或 PNG 格式）。" },
+        { title: "資料正確性", content: "申請人應確保所填寫資料及上傳文件之正確性與真實性。如有虛偽不實，將取消申請資格並依校規處理。" },
+        { title: "個人資料使用", content: "您的個人資料將僅用於獎學金申請審核及後續相關作業，本校將依個人資料保護法規定妥善保管。" },
+        { title: "審核流程", content: "申請送出後將經過系所初審、院級複審及行政單位核定等程序。審核期間請隨時注意系統通知。" },
+        { title: "獎金撥款", content: "獲獎學生請確認銀行帳戶資料正確無誤，獎學金將於核定後撥款至指定帳戶。" },
+        { title: "申請撤回", content: "申請送出後如需撤回，請於審核開始前聯繫承辦單位。審核程序啟動後將無法撤回申請。" },
+      ],
+      importantNotice: "重要提醒",
+      importantContent:
+        "請務必詳細閱讀各獎學金的申請條款與相關規定。每位學生每學期限申請一項獎學金，請謹慎選擇。",
+      agreementText: "我已詳細閱讀並了解獎學金要點，同意遵守相關規定",
+      readNoticeText: "已詳閱獎學金要點",
+      readNoticeHint:
+        "請將下方獎學金要點滑到底端，閱讀完成後才能勾選同意",
+      readNoticeDone: "已閱讀完成",
+      nextButton: "同意並繼續",
+      readFirst: "請先滑到獎學金要點底部完成閱讀",
+      sampleDocumentLabel: "申請文件範例檔",
+      sampleDocumentRow: "需要參考申請文件格式？",
+      sampleDocumentNotProvided: "尚未提供",
+      regulationsHeader: "獎學金要點",
+      regulationsMissing:
+        "系統管理員尚未上傳獎學金要點，目前無法進行申請。請聯絡承辦單位。",
+    },
+    en: {
+      title: "Scholarship Application Notice",
+      subtitle:
+        "Read the following carefully. Scroll the Scholarship Regulations below to the bottom before agreeing to continue.",
+      items: [
+        { title: "Eligibility", content: "Applicants must be currently enrolled students and meet the specific requirements of each scholarship. Please verify your enrollment status and eligibility." },
+        { title: "Application Deadline", content: "Each scholarship has different application deadlines. Late applications will not be accepted. Please note the opening and closing dates for each scholarship." },
+        { title: "Document Preparation", content: "Please prepare all required documents, including but not limited to transcripts, enrollment certificates, and advisor recommendation letters. All documents must be clear electronic files (PDF, JPG, JPEG, or PNG format)." },
+        { title: "Data Accuracy", content: "Applicants must ensure the accuracy and authenticity of all information and uploaded documents. False information will result in disqualification and disciplinary action according to university regulations." },
+        { title: "Personal Data Usage", content: "Your personal data will be used solely for scholarship application review and related procedures. The university will safeguard your data according to Personal Data Protection Act." },
+        { title: "Review Process", content: "After submission, applications will go through department preliminary review, college review, and administrative approval. Please monitor system notifications during the review period." },
+        { title: "Award Distribution", content: "Award recipients should ensure their bank account information is correct. Scholarships will be disbursed to the designated account after approval." },
+        { title: "Application Withdrawal", content: "If you need to withdraw your application after submission, please contact the administrative office before the review begins. Withdrawal is not possible once the review process has started." },
+      ],
+      importantNotice: "Important Notice",
+      importantContent:
+        "Please read the terms and conditions of each scholarship carefully. Each student may only apply for one scholarship per semester. Choose wisely.",
+      agreementText:
+        "I have read and understand the scholarship regulations and agree to comply",
+      readNoticeText: "I have read the scholarship regulations",
+      readNoticeHint:
+        "Scroll the regulations document to the bottom to enable the agree checkbox",
+      readNoticeDone: "Reading complete",
+      nextButton: "Agree and Continue",
+      readFirst: "Please scroll to the bottom of the regulations first",
+      sampleDocumentLabel: "Sample Application Documents",
+      sampleDocumentRow: "Need to see the application document format?",
+      sampleDocumentNotProvided: "Not available",
+      regulationsHeader: "Scholarship Regulations",
+      regulationsMissing:
+        "The system administrator has not uploaded the scholarship regulations. Applications cannot proceed. Please contact the administrative office.",
+    },
+  };
+
+  const t = notices[locale];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="p-3 bg-nycu-blue-100 rounded-lg">
+              <FileText className="h-6 w-6 text-nycu-blue-600" />
+            </div>
+            <div>
+              <CardTitle className="text-2xl">{t.title}</CardTitle>
+              <CardDescription className="mt-1">{t.subtitle}</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Important Notice Alert */}
+          <Alert className="border-amber-200 bg-amber-50">
+            <AlertTriangle className="h-5 w-5 text-amber-600" />
+            <AlertDescription>
+              <div className="font-semibold text-amber-900 mb-1">
+                {t.importantNotice}
+              </div>
+              <div className="text-sm text-amber-800">{t.importantContent}</div>
+            </AlertDescription>
+          </Alert>
+
+          {/* 8-item static summary (no scroll, no gate) */}
+          <Card className="border-2">
+            <div className="p-6">
+              <div className="space-y-4">
+                {t.items.map((item, index) => (
+                  <div
+                    key={index}
+                    className="pb-4 border-b last:border-b-0 last:pb-0"
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="flex-shrink-0 w-8 h-8 rounded-full bg-nycu-blue-100 text-nycu-blue-700 flex items-center justify-center font-semibold text-sm">
+                        {index + 1}
+                      </div>
+                      <div className="flex-1">
+                        <h4 className="font-semibold text-nycu-navy-800 mb-2">
+                          {item.title}
+                        </h4>
+                        <p className="text-sm text-gray-700 leading-relaxed">
+                          {item.content}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Card>
+
+          {/* Reference row: sample document button (regulations are rendered
+              inline below, so they no longer need a button here). */}
+          <div className="p-4 bg-blue-50 rounded-lg border border-blue-200 flex items-center justify-between gap-3">
+            <p className="text-sm text-blue-900">{t.sampleDocumentRow}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleOpenSampleDoc(t.sampleDocumentLabel)}
+              disabled={!publicDocs.sample_document_url}
+              className="flex items-center gap-2"
+            >
+              <FileText className="h-4 w-4" />
+              {t.sampleDocumentLabel}
+              {!publicDocs.sample_document_url && (
+                <span className="text-xs text-gray-400 ml-1">
+                  ({t.sampleDocumentNotProvided})
+                </span>
+              )}
+            </Button>
+          </div>
+
+          {/* Inline regulations viewer (the gated content) */}
+          <div>
+            <h3 className="font-semibold text-nycu-navy-800 mb-2">
+              {t.regulationsHeader}
+            </h3>
+            {!docsLoaded ? (
+              <div className="h-[500px] rounded-lg border bg-gray-50" />
+            ) : regulationsViewerUrl ? (
+              <>
+                <InlinePdfViewer
+                  url={regulationsViewerUrl}
+                  height={500}
+                  locale={locale}
+                  onReachedBottom={() => setHasReadNotice(true)}
+                />
+                {!hasReadNotice && (
+                  <p className="text-xs text-amber-700 mt-2 flex items-center gap-1">
+                    <AlertCircle className="h-3 w-3" />
+                    {t.readNoticeHint}
+                  </p>
+                )}
+              </>
+            ) : (
+              <Alert className="border-amber-300 bg-amber-50">
+                <AlertCircle className="h-5 w-5 text-amber-700" />
+                <AlertDescription className="text-amber-900">
+                  {t.regulationsMissing}
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+
+          {/* Read confirmation — auto-checked when viewer reports bottom reached */}
+          <div
+            className={`flex items-center space-x-2 p-4 rounded-lg transition-colors ${
+              hasReadNotice
+                ? "bg-emerald-50 border border-emerald-200"
+                : "bg-gray-50"
+            }`}
+          >
+            <Checkbox id="read-notice" checked={hasReadNotice} disabled />
+            <Label
+              htmlFor="read-notice"
+              className="text-sm font-medium leading-none cursor-default"
+            >
+              {hasReadNotice ? t.readNoticeDone : t.readNoticeText}
+            </Label>
+          </div>
+
+          {/* Agreement checkbox */}
+          <div
+            className={`p-6 rounded-lg border-2 transition-all ${
+              hasReadNotice
+                ? "bg-white border-nycu-blue-200"
+                : "bg-gray-50 border-gray-200 opacity-60"
+            }`}
+          >
+            <div className="flex items-start space-x-3">
+              <Checkbox
+                id="agree-terms"
+                checked={agreedToTerms}
+                onCheckedChange={(checked) => onAgree(checked as boolean)}
+                disabled={!hasReadNotice}
+                className="mt-1"
+              />
+              <div className="flex-1">
+                <Label
+                  htmlFor="agree-terms"
+                  className={`text-base font-semibold leading-relaxed ${
+                    hasReadNotice
+                      ? "cursor-pointer text-nycu-navy-800"
+                      : "cursor-not-allowed text-gray-500"
+                  }`}
+                >
+                  {t.agreementText}
+                </Label>
+                {!hasReadNotice && (
+                  <p className="text-sm text-amber-600 mt-2 flex items-center gap-2">
+                    <AlertCircle className="h-4 w-4" />
+                    {t.readFirst}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex justify-end pt-4">
+            <Button
+              onClick={onNext}
+              disabled={!agreedToTerms}
+              size="lg"
+              className="nycu-gradient text-white px-8"
+            >
+              {agreedToTerms && <CheckCircle className="h-5 w-5 mr-2" />}
+              {t.nextButton}
+              <ChevronRight className="h-5 w-5 ml-2" />
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <FilePreviewDialog
+        isOpen={showPreview}
+        onClose={() => setShowPreview(false)}
+        file={previewFile}
+        locale={locale}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npx jest components/__tests__/notice-agreement-step.test.tsx
+```
+
+Expected: PASS — all 3 tests green.
+
+- [ ] **Step 5: Run type-check and the full Jest suite for the affected modules**
+
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npm run type-check
+docker compose -f docker-compose.dev.yml exec frontend npx jest components/__tests__/inline-pdf-viewer.test.tsx components/__tests__/notice-agreement-step.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/student-wizard/steps/NoticeAgreementStep.tsx frontend/components/__tests__/notice-agreement-step.test.tsx
+git commit -m "feat(frontend): gate agree checkbox on inline regulations PDF scroll"
+```
+
+---
+
+### Task 4: Restrict the admin regulations slot to PDF only
+
+**Files:**
+- Modify: `frontend/components/admin/system-docs/SystemDocsPanel.tsx`
+
+- [ ] **Step 1: Move `ACCEPTED` to a per-slot field**
+
+Open `frontend/components/admin/system-docs/SystemDocsPanel.tsx`.
+
+Replace the existing `DocSlot` interface and the global `ACCEPTED` constant with a per-slot `accepted` field.
+
+Find:
+
+```tsx
+interface DocSlot {
+  key: DocKey;
+  title: string;
+  subtitle: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  accent: {
+    ring: string;
+    tile: string;
+    iconColor: string;
+    pillBg: string;
+    dropHover: string;
+    dropActive: string;
+  };
+}
+```
+
+Replace with:
+
+```tsx
+interface DocSlot {
+  key: DocKey;
+  title: string;
+  subtitle: string;
+  accepted: string;        // comma-separated extension list
+  acceptedLabel: string;   // human-readable, shown in the drop zone hint
+  Icon: React.ComponentType<{ className?: string }>;
+  accent: {
+    ring: string;
+    tile: string;
+    iconColor: string;
+    pillBg: string;
+    dropHover: string;
+    dropActive: string;
+  };
+}
+```
+
+Find the `SLOTS` array and add the new fields. After the change it should be:
+
+```tsx
+const SLOTS: DocSlot[] = [
+  {
+    key: "regulations_url",
+    title: "獎學金要點",
+    subtitle: "提供學生、教授與學院審核時參閱的法規文件",
+    accepted: ".pdf",
+    acceptedLabel: "PDF",
+    Icon: BookOpen,
+    accent: {
+      ring: "ring-nycu-blue-200",
+      tile: "bg-nycu-blue-50",
+      iconColor: "text-nycu-blue-600",
+      pillBg: "bg-nycu-blue-100 text-nycu-blue-700",
+      dropHover: "hover:border-nycu-blue-400 hover:bg-nycu-blue-50/40",
+      dropActive:
+        "border-nycu-blue-500 bg-nycu-blue-50 ring-4 ring-nycu-blue-100",
+    },
+  },
+  {
+    key: "sample_document_url",
+    title: "申請文件範例檔",
+    subtitle: "提供學生填寫申請文件時的參考範例",
+    accepted: ".pdf,.doc,.docx",
+    acceptedLabel: "PDF · DOC · DOCX",
+    Icon: FileArchive,
+    accent: {
+      ring: "ring-amber-200",
+      tile: "bg-amber-50",
+      iconColor: "text-amber-600",
+      pillBg: "bg-amber-100 text-amber-700",
+      dropHover: "hover:border-amber-400 hover:bg-amber-50/40",
+      dropActive: "border-amber-500 bg-amber-50 ring-4 ring-amber-100",
+    },
+  },
+];
+```
+
+Delete the global `const ACCEPTED = ".pdf,.doc,.docx";` line.
+
+- [ ] **Step 2: Update `validateAndSet` to use the slot's accepted list**
+
+Find the current `validateAndSet`:
+
+```tsx
+const validateAndSet = (key: DocKey, file: File | null) => {
+  if (!file) return;
+  const ext = "." + (file.name.toLowerCase().split(".").pop() || "");
+  if (!ACCEPTED.split(",").includes(ext)) {
+    toast.error("僅接受 PDF / DOC / DOCX");
+    return;
+  }
+  if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+    toast.error(`檔案大小超過 ${MAX_SIZE_MB} MB`);
+    return;
+  }
+  setPendingFiles((p) => ({ ...p, [key]: file }));
+};
+```
+
+Replace with:
+
+```tsx
+const validateAndSet = (key: DocKey, file: File | null) => {
+  if (!file) return;
+  const slot = SLOTS.find((s) => s.key === key);
+  if (!slot) return;
+  const allowed = slot.accepted.split(",").map((s) => s.trim());
+  const ext = "." + (file.name.toLowerCase().split(".").pop() || "");
+  if (!allowed.includes(ext)) {
+    toast.error(`僅接受 ${slot.acceptedLabel}`);
+    return;
+  }
+  if (file.size > MAX_SIZE_MB * 1024 * 1024) {
+    toast.error(`檔案大小超過 ${MAX_SIZE_MB} MB`);
+    return;
+  }
+  setPendingFiles((p) => ({ ...p, [key]: file }));
+};
+```
+
+- [ ] **Step 3: Pass the per-slot `accepted` to the `<input>` and copy**
+
+Find this `<input>` inside the drop-zone label:
+
+```tsx
+<input
+  ref={inputRefs[slot.key]}
+  type="file"
+  accept={ACCEPTED}
+  onChange={(e) =>
+    validateAndSet(slot.key, e.target.files?.[0] || null)
+  }
+  className="sr-only"
+/>
+```
+
+Replace with:
+
+```tsx
+<input
+  ref={inputRefs[slot.key]}
+  type="file"
+  accept={slot.accepted}
+  onChange={(e) =>
+    validateAndSet(slot.key, e.target.files?.[0] || null)
+  }
+  className="sr-only"
+/>
+```
+
+Find this copy line:
+
+```tsx
+<p className="text-xs text-gray-500 mt-1.5">
+  支援 PDF · DOC · DOCX · 上限 {MAX_SIZE_MB} MB
+</p>
+```
+
+Replace with:
+
+```tsx
+<p className="text-xs text-gray-500 mt-1.5">
+  支援 {slot.acceptedLabel} · 上限 {MAX_SIZE_MB} MB
+</p>
+```
+
+- [ ] **Step 4: Manually verify in the dev environment**
+
+Start dev env if not already running:
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+Open the admin System Docs page in a browser:
+- Log in as `admin@nycu.edu.tw` (password `admin123` in dev).
+- Navigate to System Settings → System Docs.
+
+Verify:
+- The 獎學金要點 slot's drop-zone hint reads "支援 PDF · 上限 10 MB".
+- The 申請文件範例檔 slot's drop-zone hint reads "支援 PDF · DOC · DOCX · 上限 10 MB".
+- Try selecting a `.docx` file for the 獎學金要點 slot → toast shows "僅接受 PDF".
+- The `<input>` element on the 獎學金要點 slot has `accept=".pdf"` (DevTools).
+
+- [ ] **Step 5: Type-check**
+
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npm run type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/components/admin/system-docs/SystemDocsPanel.tsx
+git commit -m "feat(frontend): restrict 獎學金要點 admin upload to PDF only"
+```
+
+---
+
+### Task 5: Backend — reject non-PDF for `regulations_url` upload (failing test first)
+
+**Files:**
+- Create: `backend/app/tests/test_system_settings_upload_doc.py`
+- Modify: `backend/app/api/v1/endpoints/system_settings.py`
+
+- [ ] **Step 1: Write failing pytest cases**
+
+Create `backend/app/tests/test_system_settings_upload_doc.py`:
+
+```python
+"""
+Tests for admin upload validation in
+backend/app/api/v1/endpoints/system_settings.py::upload_system_doc.
+
+Pins the policy that regulations_url accepts ONLY .pdf
+(rejects .docx, rejects mismatched MIME), while sample_document_url
+continues to accept .pdf / .doc / .docx.
+"""
+
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User, UserRole
+
+
+@pytest.fixture
+async def admin_user(db: AsyncSession) -> User:
+    admin = User(
+        email="docupload_admin@university.edu",
+        username="docupload_admin",
+        full_name="Doc Upload Admin",
+        role=UserRole.admin,
+        is_active=True,
+    )
+    db.add(admin)
+    await db.commit()
+    await db.refresh(admin)
+    return admin
+
+
+@pytest.fixture
+def fake_minio():
+    """Patch minio_service so the test never touches MinIO."""
+    with patch(
+        "app.services.minio_service.minio_service"
+    ) as mock_service:
+        mock_service.default_bucket = "test-bucket"
+        mock_service.client = MagicMock()
+        mock_service.client.put_object = MagicMock()
+        mock_service.client.remove_object = MagicMock()
+        yield mock_service
+
+
+async def _post_upload(
+    client: AsyncClient,
+    admin: User,
+    doc_key: str,
+    filename: str,
+    content_type: str,
+    body: bytes = b"%PDF-1.4 minimal",
+):
+    files = {"file": (filename, BytesIO(body), content_type)}
+    # NOTE: how the test client authenticates as `admin` depends on this
+    # repo's existing conftest. Most tests in app/tests use a
+    # `authenticated_client(admin)` helper or set a header — match whichever
+    # the existing endpoint tests use (e.g. test_scholarship_configuration_endpoints.py).
+    return await client.post(
+        f"/api/v1/system-settings/upload/{doc_key}",
+        files=files,
+        headers={"X-Test-User-Id": str(admin.id)},
+    )
+
+
+class TestRegulationsUploadValidation:
+    async def test_rejects_docx_for_regulations_url(
+        self, client: AsyncClient, admin_user: User, fake_minio
+    ):
+        res = await _post_upload(
+            client,
+            admin_user,
+            "regulations_url",
+            filename="rules.docx",
+            content_type=(
+                "application/vnd.openxmlformats-"
+                "officedocument.wordprocessingml.document"
+            ),
+        )
+        assert res.status_code == 400
+        assert "PDF" in res.text
+        fake_minio.client.put_object.assert_not_called()
+
+    async def test_rejects_pdf_extension_with_mismatched_mime(
+        self, client: AsyncClient, admin_user: User, fake_minio
+    ):
+        res = await _post_upload(
+            client,
+            admin_user,
+            "regulations_url",
+            filename="rules.pdf",
+            content_type="application/octet-stream",
+        )
+        assert res.status_code == 400
+        fake_minio.client.put_object.assert_not_called()
+
+    async def test_accepts_pdf_with_pdf_mime(
+        self, client: AsyncClient, admin_user: User, fake_minio
+    ):
+        res = await _post_upload(
+            client,
+            admin_user,
+            "regulations_url",
+            filename="rules.pdf",
+            content_type="application/pdf",
+        )
+        assert res.status_code == 200
+        fake_minio.client.put_object.assert_called_once()
+
+
+class TestSampleDocumentUploadStillAcceptsDocx:
+    async def test_accepts_docx_for_sample_document_url(
+        self, client: AsyncClient, admin_user: User, fake_minio
+    ):
+        res = await _post_upload(
+            client,
+            admin_user,
+            "sample_document_url",
+            filename="sample.docx",
+            content_type=(
+                "application/vnd.openxmlformats-"
+                "officedocument.wordprocessingml.document"
+            ),
+        )
+        assert res.status_code == 200
+        fake_minio.client.put_object.assert_called_once()
+```
+
+NOTE: the `X-Test-User-Id`/auth header in `_post_upload` is a placeholder. Before running the test, open `backend/app/tests/test_scholarship_configuration_endpoints.py` and copy the exact pattern used there for issuing authenticated admin requests (likely a fixture-based `authenticated_admin_client` or a token-injection helper) — replace the header in `_post_upload` accordingly. If a more idiomatic helper already exists in the repo's `app/tests/conftest.py`, prefer that.
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest app/tests/test_system_settings_upload_doc.py -v
+```
+
+Expected:
+- `test_rejects_docx_for_regulations_url`: FAIL (currently returns 200 because backend accepts .docx for both slots)
+- `test_rejects_pdf_extension_with_mismatched_mime`: FAIL (same reason — no MIME check)
+- `test_accepts_pdf_with_pdf_mime`: PASS (already accepted today)
+- `test_accepts_docx_for_sample_document_url`: PASS (already accepted today)
+
+- [ ] **Step 3: Add the PDF-only guard to `upload_system_doc`**
+
+Open `backend/app/api/v1/endpoints/system_settings.py`. Find the `upload_system_doc` function. Right after this block:
+
+```python
+if doc_key not in _ALLOWED_DOC_KEYS:
+    raise HTTPException(status_code=400, detail=f"Invalid doc_key. Allowed: {_ALLOWED_DOC_KEYS}")
+
+allowed_extensions = [".pdf", ".doc", ".docx"]
+```
+
+Replace `allowed_extensions = [".pdf", ".doc", ".docx"]` with:
+
+```python
+# regulations_url is gated on the student-facing side by an inline PDF
+# viewer (react-pdf), which can only render PDF. We enforce PDF-only on
+# both the extension AND the request's Content-Type to prevent uploaders
+# from disguising a non-PDF as application/pdf or vice versa.
+if doc_key == "regulations_url":
+    allowed_extensions = [".pdf"]
+    if (file.content_type or "").lower() != "application/pdf":
+        raise HTTPException(
+            status_code=400,
+            detail="獎學金要點僅接受 PDF 檔案",
+        )
+else:
+    allowed_extensions = [".pdf", ".doc", ".docx"]
+```
+
+Make sure the rest of the function (the existing `validate_upload_file(...)` call, MinIO upload, upsert, return) is unchanged.
+
+- [ ] **Step 4: Re-run the failing tests**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest app/tests/test_system_settings_upload_doc.py -v
+```
+
+Expected: ALL PASS.
+
+If `test_rejects_docx_for_regulations_url` returns 400 but the detail message doesn't contain "PDF" exactly, the assertion `assert "PDF" in res.text` should still pass because the message is "獎學金要點僅接受 PDF 檔案". If it doesn't, the response body may be JSON-wrapped — adjust to `assert "PDF" in res.json().get("detail", "")`.
+
+- [ ] **Step 5: Run the broader backend test suite to confirm no regressions**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest app/tests/ -x -q --ignore=app/tests/test_pre_commit_schema_check_analyzer.py
+```
+
+Expected: PASS (no new failures attributable to this change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/system_settings.py backend/app/tests/test_system_settings_upload_doc.py
+git commit -m "feat(backend): enforce PDF-only upload for regulations_url"
+```
+
+---
+
+### Task 6: Manual end-to-end smoke test in dev env
+
+**Files:**
+- (no code changes; verification only)
+
+- [ ] **Step 1: Ensure clean dev env**
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml logs -f backend frontend
+# In another terminal, continue with verification.
+```
+
+- [ ] **Step 2: Smoke A — fresh upload, short PDF auto-latches on mount**
+
+1. Log in as `admin@nycu.edu.tw` (password `admin123`).
+2. Open System Settings → System Docs.
+3. If a 獎學金要點 file already exists, click 替換. Upload a 1-page PDF (any short academic regulations PDF; create one from a Word doc if needed via `Print → Save as PDF`).
+4. Log out, log in as a student (e.g. `stuphd001` per the project's seeded users).
+5. Start a scholarship application. On the first wizard step (`NoticeAgreementStep`):
+   - The 8 hardcoded items render as a non-scrollable summary.
+   - The 申請文件範例檔 button is visible (disabled if no sample uploaded yet).
+   - The inline PDF viewer renders the regulations.
+   - The "已詳閱獎學金要點" checkbox is **already checked** (because the 1-page PDF fits without overflow).
+   - The agree checkbox is enabled.
+6. Tick agree → Continue → wizard advances to the next step.
+
+- [ ] **Step 3: Smoke B — long PDF requires scroll**
+
+1. As admin, replace the regulations file with a 5+ page PDF.
+2. As a student, reload the agreement step.
+3. Verify:
+   - The "已詳閱獎學金要點" checkbox is **unchecked**.
+   - The agree checkbox is **disabled**.
+   - The amber hint "請將下方獎學金要點滑到底端…" is visible.
+4. Scroll inside the PDF viewer to the bottom.
+5. Verify the read-notice checkbox ticks, the agree checkbox enables, and the hint disappears.
+
+- [ ] **Step 4: Smoke C — admin cannot upload .docx for regulations**
+
+1. As admin, in System Docs, try to drag/drop or select a `.docx` file into the 獎學金要點 slot.
+2. Verify a toast appears: "僅接受 PDF".
+3. Confirm `<input type="file">` on this slot has `accept=".pdf"` only (DevTools).
+
+- [ ] **Step 5: Smoke D — no regulations uploaded → student is blocked**
+
+1. As admin, clear the `regulations_url` row. Easiest path is to truncate via psql:
+   ```bash
+   docker compose -f docker-compose.dev.yml exec postgres psql -U scholarship_user -d scholarship -c \
+     "DELETE FROM system_settings WHERE key IN ('regulations_url', 'regulations_url_filename');"
+   ```
+2. Also clear the MinIO object (or leave it — the DB row is what controls the UI).
+3. As a student, reload the agreement step.
+4. Verify:
+   - No PDF viewer is rendered.
+   - The amber alert "系統管理員尚未上傳獎學金要點，目前無法進行申請。請聯絡承辦單位。" is visible.
+   - The agree checkbox stays disabled regardless of any interaction.
+5. Re-upload a PDF as admin → reload → student can apply again.
+
+- [ ] **Step 6: Capture screenshots for the PR**
+
+For each scenario A–D, capture a screenshot using the bundled Playwright CLI (per the project's `playwright-test-and-debug` skill) or simply browser DevTools, and stash them under a temporary path you'll attach to the PR. Suggested filenames:
+- `agree-step-shortpdf-autolatch.png`
+- `agree-step-longpdf-must-scroll.png`
+- `admin-rejects-docx.png`
+- `agree-step-no-regulations-blocked.png`
+
+- [ ] **Step 7: Re-seed the system after testing**
+
+Re-upload a sensible default regulations PDF as admin so the dev environment is not left in a broken state for future testers.
+
+---
+
+### Task 7: Final review pass and PR
+
+**Files:**
+- (no code changes; quality gate)
+
+- [ ] **Step 1: Run the full frontend test suite**
+
+```bash
+docker compose -f docker-compose.dev.yml exec frontend npm run test -- --watchAll=false
+```
+
+Expected: PASS. Pay attention to any pre-existing tests that touch `NoticeAgreementStep` or `SystemDocsPanel` — if any break because they assumed the old 8-item scroll container or the global `ACCEPTED` constant, update them to match the new behavior. Show the updated assertions in the diff (do not silently delete coverage).
+
+- [ ] **Step 2: Run the full backend test suite**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend pytest app/tests/ -x -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Regenerate OpenAPI types if any backend schema changed**
+
+In this plan, the only backend change is server-side validation logic inside the existing `upload_system_doc` endpoint. No schema or path changes. Skip the `api:generate` step unless `git diff backend/app/api/v1/openapi.json` (or the live OpenAPI doc) shows differences. If it does:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d backend
+cd frontend && npm run api:generate && git add lib/api/generated/schema.d.ts
+```
+
+- [ ] **Step 4: Check for orphaned references to removed behavior**
+
+```bash
+grep -rn "ArrowDown" frontend/components/student-wizard/steps/NoticeAgreementStep.tsx || echo "ok: ArrowDown import removed"
+grep -rn "noticeScrollRef" frontend/ || echo "ok: noticeScrollRef removed"
+grep -rn "handleNoticeScroll" frontend/ || echo "ok: handleNoticeScroll removed"
+grep -rn "handleOpenDoc" frontend/components/student-wizard/steps/NoticeAgreementStep.tsx || echo "ok: handleOpenDoc (regulations dialog opener) removed"
+grep -rn "const ACCEPTED" frontend/components/admin/system-docs/SystemDocsPanel.tsx || echo "ok: global ACCEPTED removed"
+```
+
+Each line should print "ok: …". If a grep finds something, it's leftover from the rewrite — delete it.
+
+- [ ] **Step 5: Commit any cleanups and open the PR**
+
+If you made follow-up cleanups:
+```bash
+git add -A
+git commit -m "chore: drop leftover refs from regulations scroll-gate refactor"
+```
+
+Then open the PR:
+```bash
+git push -u origin <your-branch>
+gh pr create --title "feat: gate scholarship application agreement on regulations PDF scroll" --body "$(cat <<'EOF'
+## Summary
+- Replace the hardcoded 8-item scroll-gate in `NoticeAgreementStep` with an inline `react-pdf` viewer over the admin-uploaded 獎學金要點 PDF.
+- Tighten the 獎學金要點 admin upload (client + server) to PDF only.
+- Block the agreement step if no PDF is uploaded.
+- Keep the 8 notice items as a static summary; the 申請文件範例檔 button still opens the existing `FilePreviewDialog`.
+
+## Test plan
+- [x] `frontend/components/__tests__/inline-pdf-viewer.test.tsx` (4 cases)
+- [x] `frontend/components/__tests__/notice-agreement-step.test.tsx` (3 cases)
+- [x] `backend/app/tests/test_system_settings_upload_doc.py` (4 cases)
+- [x] Manual smoke A–D (see plan), screenshots attached
+- [x] Full Jest + pytest suites pass
+
+## Design
+See `docs/superpowers/specs/2026-05-21-scholarship-regulations-scroll-gate-design.md`.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Inline `react-pdf` viewer in wizard step" → Task 2 (component), Task 3 (integration). ✓
+- "8 hardcoded notice items remain as a static summary" → Task 3 Step 3 (8-item block rendered statically). ✓
+- "申請文件範例檔 stays as dialog opener" → Task 3 Step 3 (`handleOpenSampleDoc` retained). ✓
+- "Restrict admin upload of regulations to PDF" → Task 4 (client), Task 5 (server). ✓
+- "Server-side MIME + extension check" → Task 5 Step 3 enforces both. ✓
+- "Block step entirely when no PDF uploaded" → Task 3 Step 3 (`regulationsViewerUrl === null` branch), Task 6 Smoke D. ✓
+- "Error state with reload button" → Task 2 Step 3 (`loadError` branch with 重新載入). ✓
+- "Auto-latch when content fits without scrolling" → Task 2 Step 3 (`requestAnimationFrame` check in `handleLoadSuccess`). ✓
+- "Locale copy updates" → Task 3 Step 3 (zh/en in `notices`). ✓
+- "Bundle size / worker setup" → Task 1 covers worker config; bundle is observed as side effect, no enforced budget step (spec flagged this as "worth confirming" not "must enforce"). ✓
+- "Pre-existing DOC/DOCX in `regulations_url`" → handled via the same load-error path in Task 2 Step 3; admin must re-upload. ✓ (Plan does not auto-migrate; matches the spec's "no backward compatibility" stance.)
+
+**Placeholder scan:**
+- The pytest auth header `X-Test-User-Id` is flagged as a placeholder with explicit instructions to align with the existing repo pattern. This is acceptable per the plan's intent (the test harness pattern varies between repos and the executor is told exactly where to look — `test_scholarship_configuration_endpoints.py` and `app/tests/conftest.py`). No other placeholders.
+
+**Type consistency:**
+- `InlinePdfViewerProps`: `url`, `height`, `onReachedBottom`, `onLoadError`, `locale` are consistent between Task 2 (definition) and Task 3 (consumer).
+- `regulationsViewerUrl` in Task 3 produces `string | null`, matching the `string` typing of `InlinePdfViewer.url` via the `regulationsViewerUrl ? <InlinePdfViewer url={regulationsViewerUrl} /> : <Alert />` ternary.
+- `DocSlot.accepted` / `acceptedLabel` are introduced in Task 4 and used consistently across the `<input>`, `validateAndSet`, and copy line.
+- Backend endpoint path `/api/v1/system-settings/upload/{doc_key}` used in Task 5 tests matches the existing route definition.
+
+No issues found that require fixing inline.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-21-scholarship-regulations-scroll-gate.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — Dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using `executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-21-scholarship-regulations-scroll-gate-design.md
+++ b/docs/superpowers/specs/2026-05-21-scholarship-regulations-scroll-gate-design.md
@@ -1,0 +1,217 @@
+# Scholarship Regulations Scroll-Gate Design
+
+**Date**: 2026-05-21
+**Status**: Approved
+
+## Overview
+
+Move the "scroll-to-bottom before agree" gate in the student application wizard from the hardcoded 8-item notice list onto the actual 獎學金要點 (scholarship regulations) PDF uploaded by an admin. The 8 hardcoded notices remain on the page as a static summary, but no longer drive the scroll-gate. Admins must upload the regulations as a PDF; non-PDF uploads are rejected. If no PDF has been uploaded, students cannot proceed past this wizard step.
+
+---
+
+## Motivation
+
+Today the canonical "you must read this before applying" content lives in two disjoint places:
+
+- A hardcoded list of 8 generic notice items inside `NoticeAgreementStep.tsx`, gated by a scroll-to-bottom check.
+- An admin-uploaded 獎學金要點 PDF, surfaced only as an optional "open in dialog" button (no enforcement).
+
+This means students can satisfy the agreement gate without ever opening the regulations that actually govern the scholarship. Moving the gate onto the PDF aligns enforcement with the authoritative source.
+
+---
+
+## Scope
+
+**In scope**
+- Frontend: replace the gated content in `NoticeAgreementStep.tsx`
+- Frontend: new reusable `InlinePdfViewer` component (`react-pdf` based)
+- Frontend: restrict 獎學金要點 admin upload (`regulations_url` slot) to PDF only
+- Backend: server-side PDF validation on the `regulations_url` upload endpoint
+- Build: add `react-pdf` dependency and configure its pdf.js worker
+
+**Not in scope**
+- 申請文件範例檔 (`sample_document_url`) behavior — continues to accept PDF/DOC/DOCX and open via the existing `FilePreviewDialog` button. No gating, no inline rendering.
+- Any changes to the FilePreviewDialog itself (it stays as the iframe-based fallback for the sample document).
+- Locale copy review beyond what's needed for the new states.
+
+---
+
+## Behavioral Changes
+
+### Student-facing (`NoticeAgreementStep`)
+
+New top-to-bottom layout inside the existing `<Card>`:
+
+1. 重要提醒 amber `<Alert>` — unchanged copy, unchanged behavior.
+2. 8-item notice summary box — same 8 items as today, but rendered **statically** (not inside a fixed-height scrollable div). No scroll, no gate.
+3. 參考文件 row:
+   - Inline indicator badge "獎學金要點 — 請於下方閱讀" (regulations now render inline below, not as a dialog button).
+   - `[申請文件範例檔]` button — unchanged; opens `FilePreviewDialog` as today.
+4. `InlinePdfViewer` rendering `regulations_url`. Fixed height (~500px), all PDF pages stacked inside one `overflow-y: auto` container. Scroll-to-bottom drives `hasReadNotice`.
+5. "已詳閱獎學金要點" auto-checkbox — same logic as today's "已詳閱所有注意事項" (latches when bottom is reached, also auto-latches on mount if content fits without overflow).
+6. Agree checkbox + Continue button — unchanged.
+
+Locale copy updates (zh / en):
+- `readNoticeText` → 「已詳閱獎學金要點」 / "I have read the scholarship regulations"
+- `readNoticeHint` → 「請將下方獎學金要點滑到底端，閱讀完成後才能勾選同意」 / "Scroll the regulations document to the bottom to enable the agree checkbox"
+- `readFirst` → 「請先滑到獎學金要點底部完成閱讀」 / "Please scroll to the bottom of the regulations first"
+- `agreementText` → 「我已詳細閱讀並了解獎學金要點，同意遵守相關規定」 / "I have read and understand the scholarship regulations and agree to comply"
+
+### Admin-facing (`SystemDocsPanel`)
+
+The 獎學金要點 slot (`regulations_url`):
+- `ACCEPTED` constant for this slot only becomes `".pdf"`.
+- Drop-zone copy changes: 「僅接受 PDF · 上限 10 MB」.
+- Existing badge / preview / replace UI is unchanged.
+
+The 申請文件範例檔 slot (`sample_document_url`) is untouched and keeps `.pdf,.doc,.docx`.
+
+---
+
+## Component & API Surface
+
+### New: `frontend/components/inline-pdf-viewer.tsx`
+
+```ts
+interface InlinePdfViewerProps {
+  url: string;                          // proxy URL with token in query string
+  height?: number;                      // viewer height in px (default 500)
+  onReachedBottom?: () => void;         // fired once when scroll reaches bottom OR content fits without scrolling
+  onLoadError?: (err: Error) => void;   // fired if pdf.js fails to load the doc
+  locale?: "zh" | "en";                 // affects loading / error copy
+}
+```
+
+Internals:
+- Renders a single `<div ref={scrollRef} onScroll={...}>` with `overflow-y: auto`.
+- Inside: `<Document file={url}>` → `<Page pageNumber={i} />` for `i in 1..numPages`, stacked vertically.
+- Uses `pdfjs.GlobalWorkerOptions.workerSrc` set once at module load time via `frontend/lib/pdf-worker.ts`.
+- Scroll-to-bottom check: `scrollHeight - scrollTop - clientHeight <= 8`, latched once.
+- On `<Document onLoadSuccess>` and after the first render commit, if `scrollHeight <= clientHeight + 8`, fire `onReachedBottom` immediately.
+- On `<Document onLoadError>`, fire `onLoadError` and render an internal error state with a "重新載入" button that re-mounts the `<Document>`.
+- Loading state: `<Skeleton>` blocks inside the container (consistent with `FilePreviewDialog`'s existing skeleton).
+
+### Updated: `NoticeAgreementStep.tsx`
+
+- Drop the dialog button for 獎學金要點; keep the dialog button for 申請文件範例檔.
+- Drop the existing `noticeScrollRef` / `handleNoticeScroll` / `hasReadNotice` mount-effect machinery; replace with `hasReadNotice` driven by `<InlinePdfViewer onReachedBottom={() => setHasReadNotice(true)} />`.
+- The 8-item box becomes a plain `<div>` block (no `h-[400px]`, no `overflow-y-auto`, no `onScroll`).
+- Empty/error state: when `publicDocs.regulations_url` is undefined or the viewer reports a load error, render an amber blocking `<Alert>` in place of the viewer (see "Error / Empty States" below) and never enable the agree checkbox.
+
+### Updated: `SystemDocsPanel.tsx`
+
+- Move from a single `ACCEPTED` module constant to a per-slot accepted-extensions property:
+  ```ts
+  const SLOTS: DocSlot[] = [
+    { key: "regulations_url",      accepted: ".pdf",            ... },
+    { key: "sample_document_url",  accepted: ".pdf,.doc,.docx", ... },
+  ];
+  ```
+- `validateAndSet` consults `slot.accepted` instead of the global constant.
+- Drop-zone helper copy uses `slot.accepted`.
+
+### Updated: backend `system_settings.py`
+
+The endpoint that handles the 獎學金要點 upload (the one wired to `apiClient.systemSettings.uploadRegulations`):
+- Reject the upload with `HTTP 400` and message 「獎學金要點僅接受 PDF 檔案」 when either:
+  - the filename extension (lowercased) is not `.pdf`, **or**
+  - the request's `Content-Type` is not `application/pdf` (defense in depth — never trust client).
+- The sample-document endpoint stays as-is.
+
+---
+
+## Data Flow
+
+```
+NoticeAgreementStep mount
+  └─ GET /api/v1/system-settings/public-docs
+       ├─ res.data.regulations_url is undefined / null
+       │    └─ render blocking Alert, agree disabled, no viewer
+       │
+       └─ res.data.regulations_url present
+            └─ build proxy URL:
+               /api/v1/system-settings/file-proxy
+                 ?key=regulations_url
+                 &token=<localStorage auth_token>
+                 &v=<basename(regulations_url)>           ← cache-buster
+            └─ <InlinePdfViewer url={proxyUrl} ... />
+                 └─ pdf.js loads PDF
+                      ├─ onLoadSuccess: render all <Page> components stacked
+                      │    └─ user scrolls → bottom reached → onReachedBottom
+                      │         └─ NoticeAgreementStep: setHasReadNotice(true)
+                      │              └─ "已詳閱獎學金要點" checkbox ticks
+                      │                   └─ agree checkbox becomes enabled
+                      │
+                      └─ onLoadError
+                           └─ render in-viewer error + "重新載入" button
+                           └─ NoticeAgreementStep keeps hasReadNotice = false
+```
+
+The proxy URL pattern is identical to the one currently used by `FilePreviewDialog` for the same file, so the backend file-proxy, MinIO routing, and token-via-query-param auth are all unchanged.
+
+---
+
+## Error / Empty States
+
+| State | Trigger | Display | Agree gate |
+|---|---|---|---|
+| **No regulations uploaded** | `publicDocs.regulations_url` is falsy after `getPublicDocs()` resolves | Amber `<Alert>` replacing the viewer: 「系統管理員尚未上傳獎學金要點，目前無法進行申請。請聯絡承辦單位。」 | Disabled, no way to enable |
+| **PDF load failure** | `<Document onLoadError>` fires (network error, corrupt file, pdf.js worker failed to mount) | In-viewer red error state + 「重新載入」 button that re-triggers the document load | Disabled until reload succeeds and bottom is reached |
+| **Admin uploads non-PDF for regulations** | File extension or MIME mismatch | Client rejects via `<input accept=".pdf">` and `validateAndSet` toast; server rejects with HTTP 400 message above | n/a — admin context |
+| **Pre-existing DOC/DOCX in `regulations_url`** | Legacy data from before this change | Admin sees current file but the viewer treats it as unrenderable → falls through to "PDF load failure" branch for students. Admin must re-upload. | Disabled |
+
+Per project policy ("NO BACKWARD COMPATIBILITY"), legacy non-PDF regulations are not auto-converted. Admins re-upload.
+
+---
+
+## Build & Dependencies
+
+- **Add**: `react-pdf` (latest 9.x line). Pulls in `pdfjs-dist`.
+- **Worker config**: create `frontend/lib/pdf-worker.ts`:
+  ```ts
+  import { pdfjs } from "react-pdf";
+  pdfjs.GlobalWorkerOptions.workerSrc = `/_next/static/chunks/pdf.worker.min.mjs`;
+  ```
+  Import this module once from `InlinePdfViewer`. The exact worker path / copy step follows the `react-pdf` Next.js setup guide and is finalized during implementation; if a worker proxy URL doesn't pan out, fall back to `new URL("pdfjs-dist/build/pdf.worker.min.mjs", import.meta.url).toString()`.
+- **Styling**: import `react-pdf`'s `TextLayer.css` and `AnnotationLayer.css` so selectable text and links render correctly. Imported alongside the worker module to keep `InlinePdfViewer` clean.
+- No backend dependency changes. No Docker config changes.
+- Bundle impact: +~80KB gz for `react-pdf` + lazy-loaded pdf.js worker (loaded only when a student visits the agreement step).
+
+---
+
+## Testing
+
+### Frontend unit / component
+
+- New tests for `InlinePdfViewer`:
+  - Loads a fixture PDF, simulates a scroll event that reaches the bottom → `onReachedBottom` fires exactly once.
+  - Loads a fixture PDF whose rendered height fits the container → `onReachedBottom` fires on mount-after-load, before any scroll.
+  - `<Document onLoadError>` path → `onLoadError` fires, `onReachedBottom` never fires.
+- New / updated tests for `NoticeAgreementStep`:
+  - With `regulations_url` present + scroll-to-bottom simulated → agree checkbox becomes enabled.
+  - With `regulations_url` absent → blocking alert visible, agree checkbox stays disabled regardless of any interaction.
+
+### Backend
+
+- `tests/api/test_system_settings.py` (or equivalent): upload a `.docx` to the regulations endpoint → expect 400 with the Chinese message. Upload a `.pdf` with matching MIME → expect 200. Upload a `.pdf` with mismatched MIME (e.g. `application/octet-stream`) → expect 400.
+
+### E2E (Playwright)
+
+- Update the existing student-application happy-path spec to scroll the new PDF viewer container instead of the 8-item list. Use the seeded admin to upload a small fixture PDF as `regulations_url` during test setup.
+- New spec: with no `regulations_url` in `system_settings`, log in as a student, navigate to the agreement step, assert the blocking alert is visible and the Continue button stays disabled.
+
+### Manual smoke (Docker dev env)
+
+- Admin → System Docs → upload a 1-page PDF → log out → log in as student → reach agreement step → checkbox auto-latches on mount → agree → continue.
+- Admin → System Docs → upload a 5-page PDF → student must scroll within the viewer to bottom → checkbox latches → agree → continue.
+- Admin → delete the `regulations_url` row in DB / clear via UI → student sees blocking alert.
+- Admin → attempt to upload a `.docx` to 獎學金要點 → rejected with the Chinese error toast (client) and the same on a curl bypass (server).
+
+---
+
+## Risks & Open Items
+
+- **`react-pdf` worker setup in Next.js**: the worker path is environment-sensitive. The implementation plan should include a verification step (manual + Playwright smoke) that the worker loads in both dev (`docker compose up`) and a production-style build before declaring done.
+- **CJK font rendering**: most NYCU regulations PDFs embed their own fonts; pdf.js renders them fine. If a PDF arrives without embedded fonts and depends on system fonts, glyphs may render as boxes. Out of scope to "fix" for arbitrary uploads — flagged here so it doesn't get rediscovered mid-implementation.
+- **Bundle size**: +~80KB gz is acceptable but worth confirming against the existing budget after the change lands.
+- **Performance on 20+ page PDFs**: Approach A (all pages stacked) was chosen on the assumption that real regulations are short (1–5 pages). If a real admin uploads a 30-page doc, first-render time may be noticeable. We accept this tradeoff per the brainstorm.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -29,3 +29,7 @@ next-env.d.ts
 
 # react-email exports
 /public/email-templates
+
+# pdf.js worker — copied from node_modules by `npm run copy-pdf-worker`
+# (postinstall/predev/prebuild). Regenerated; do not commit.
+/public/pdf.worker.min.mjs

--- a/frontend/components/__tests__/inline-pdf-viewer.test.tsx
+++ b/frontend/components/__tests__/inline-pdf-viewer.test.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { InlinePdfViewer } from "../inline-pdf-viewer";
+
+// Mock react-pdf so we don't load real pdf.js in jsdom. The mock exposes
+// `__setSuccess(numPages)` / `__setError(err)` to drive the lifecycle from
+// each test.
+jest.mock("react-pdf", () => {
+  type Cb = (info: { numPages: number }) => void;
+  type ErrCb = (err: Error) => void;
+  const handlers: { success?: Cb; error?: ErrCb } = {};
+  const Document = (props: {
+    onLoadSuccess?: Cb;
+    onLoadError?: ErrCb;
+    children?: React.ReactNode;
+  }) => {
+    handlers.success = props.onLoadSuccess;
+    handlers.error = props.onLoadError;
+    return <div data-testid="pdf-document">{props.children}</div>;
+  };
+  const Page = ({ pageNumber }: { pageNumber: number }) => (
+    <div data-testid={`pdf-page-${pageNumber}`} style={{ height: 800 }}>
+      page {pageNumber}
+    </div>
+  );
+  return {
+    Document,
+    Page,
+    pdfjs: { GlobalWorkerOptions: { workerSrc: "" }, version: "x" },
+    __setSuccess: (n: number) => handlers.success?.({ numPages: n }),
+    __setError: (e: Error) => handlers.error?.(e),
+  };
+});
+
+// Mock the worker side-effect import so it doesn't blow up jsdom.
+jest.mock("@/lib/pdf-worker", () => ({}));
+
+// react-pdf bundles CSS we don't need under jsdom.
+jest.mock("react-pdf/dist/Page/AnnotationLayer.css", () => ({}), { virtual: true });
+jest.mock("react-pdf/dist/Page/TextLayer.css", () => ({}), { virtual: true });
+
+const reactPdf = jest.requireMock("react-pdf") as {
+  __setSuccess: (n: number) => void;
+  __setError: (e: Error) => void;
+};
+
+function setScrollMetrics(
+  el: HTMLElement,
+  {
+    scrollHeight,
+    clientHeight,
+    scrollTop,
+  }: { scrollHeight: number; clientHeight: number; scrollTop: number },
+) {
+  Object.defineProperty(el, "scrollHeight", { configurable: true, value: scrollHeight });
+  Object.defineProperty(el, "clientHeight", { configurable: true, value: clientHeight });
+  Object.defineProperty(el, "scrollTop", { configurable: true, value: scrollTop });
+}
+
+function flushRaf() {
+  return new Promise<void>((resolve) =>
+    requestAnimationFrame(() => resolve()),
+  );
+}
+
+describe("InlinePdfViewer", () => {
+  it("renders one <Page> per numPages after onLoadSuccess", () => {
+    render(<InlinePdfViewer url="/fake.pdf" />);
+    act(() => reactPdf.__setSuccess(3));
+    expect(screen.getByTestId("pdf-page-1")).toBeInTheDocument();
+    expect(screen.getByTestId("pdf-page-2")).toBeInTheDocument();
+    expect(screen.getByTestId("pdf-page-3")).toBeInTheDocument();
+  });
+
+  it("fires onReachedBottom exactly once when the user scrolls to the bottom", () => {
+    const onReached = jest.fn();
+    const { container } = render(
+      <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
+    );
+    act(() => reactPdf.__setSuccess(2));
+
+    const scroller = container.querySelector(
+      "[data-testid='pdf-scroll-container']",
+    ) as HTMLElement;
+    expect(scroller).not.toBeNull();
+
+    // Initial scroll, not yet at bottom.
+    setScrollMetrics(scroller, { scrollHeight: 2000, clientHeight: 500, scrollTop: 100 });
+    fireEvent.scroll(scroller);
+    expect(onReached).not.toHaveBeenCalled();
+
+    // Scroll to the bottom (within the 8px slack).
+    setScrollMetrics(scroller, { scrollHeight: 2000, clientHeight: 500, scrollTop: 1495 });
+    fireEvent.scroll(scroller);
+    expect(onReached).toHaveBeenCalledTimes(1);
+
+    // Bouncing back should NOT re-fire.
+    setScrollMetrics(scroller, { scrollHeight: 2000, clientHeight: 500, scrollTop: 200 });
+    fireEvent.scroll(scroller);
+    expect(onReached).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onReachedBottom on mount-after-load when the document fits the container", async () => {
+    const onReached = jest.fn();
+    const { container } = render(
+      <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
+    );
+
+    const scroller = container.querySelector(
+      "[data-testid='pdf-scroll-container']",
+    ) as HTMLElement;
+    setScrollMetrics(scroller, { scrollHeight: 400, clientHeight: 500, scrollTop: 0 });
+
+    await act(async () => {
+      reactPdf.__setSuccess(1);
+      await flushRaf();
+    });
+
+    expect(onReached).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onLoadError and never fires onReachedBottom when load fails", () => {
+    const onReached = jest.fn();
+    const onErr = jest.fn();
+    render(
+      <InlinePdfViewer
+        url="/broken.pdf"
+        onReachedBottom={onReached}
+        onLoadError={onErr}
+      />,
+    );
+
+    const err = new Error("boom");
+    act(() => reactPdf.__setError(err));
+
+    expect(onErr).toHaveBeenCalledWith(err);
+    expect(onReached).not.toHaveBeenCalled();
+    expect(screen.getByText(/重新載入|Reload/)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/__tests__/inline-pdf-viewer.test.tsx
+++ b/frontend/components/__tests__/inline-pdf-viewer.test.tsx
@@ -39,9 +39,11 @@ jest.mock("react-pdf", () => {
   }) => {
     // Register the page's render callback so tests can fire them all at once.
     useEffect(() => {
-      if (onRenderSuccess) pageRenderCallbacks.push(onRenderSuccess);
+      const cb = onRenderSuccess;
+      if (!cb) return;
+      pageRenderCallbacks.push(cb);
       return () => {
-        const i = pageRenderCallbacks.indexOf(onRenderSuccess!);
+        const i = pageRenderCallbacks.indexOf(cb);
         if (i >= 0) pageRenderCallbacks.splice(i, 1);
       };
     }, [onRenderSuccess]);

--- a/frontend/components/__tests__/inline-pdf-viewer.test.tsx
+++ b/frontend/components/__tests__/inline-pdf-viewer.test.tsx
@@ -1,34 +1,69 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { InlinePdfViewer } from "../inline-pdf-viewer";
 
 // Mock react-pdf so we don't load real pdf.js in jsdom. The mock exposes
-// `__setSuccess(numPages)` / `__setError(err)` to drive the lifecycle from
-// each test.
+// `__setSuccess(numPages)` / `__setError(err)` / `__renderAllPages()` to
+// drive the lifecycle from each test.
+//
+// Real react-pdf v9: <Document> calls onLoadSuccess synchronously-ish after
+// parsing the PDF, but each <Page>'s `onRenderSuccess` fires later, after
+// pdf.js paints the canvas. The mock mirrors that by NOT calling
+// onRenderSuccess automatically — tests opt in to "all pages rendered" via
+// `__renderAllPages()`.
 jest.mock("react-pdf", () => {
-  type Cb = (info: { numPages: number }) => void;
+  type LoadCb = (info: { numPages: number }) => void;
   type ErrCb = (err: Error) => void;
-  const handlers: { success?: Cb; error?: ErrCb } = {};
+  const handlers: { load?: LoadCb; err?: ErrCb } = {};
+  const pageRenderCallbacks: Array<() => void> = [];
+
   const Document = (props: {
-    onLoadSuccess?: Cb;
+    onLoadSuccess?: LoadCb;
     onLoadError?: ErrCb;
     children?: React.ReactNode;
   }) => {
-    handlers.success = props.onLoadSuccess;
-    handlers.error = props.onLoadError;
+    handlers.load = props.onLoadSuccess;
+    handlers.err = props.onLoadError;
+    // NOTE: don't reset pageRenderCallbacks here — Page's useEffect cleanup
+    // manages add/remove. Resetting on every Document render would wipe
+    // registrations that survived through re-renders.
     return <div data-testid="pdf-document">{props.children}</div>;
   };
-  const Page = ({ pageNumber }: { pageNumber: number }) => (
-    <div data-testid={`pdf-page-${pageNumber}`} style={{ height: 800 }}>
-      page {pageNumber}
-    </div>
-  );
+
+  const Page = ({
+    pageNumber,
+    onRenderSuccess,
+  }: {
+    pageNumber: number;
+    onRenderSuccess?: () => void;
+  }) => {
+    // Register the page's render callback so tests can fire them all at once.
+    useEffect(() => {
+      if (onRenderSuccess) pageRenderCallbacks.push(onRenderSuccess);
+      return () => {
+        const i = pageRenderCallbacks.indexOf(onRenderSuccess!);
+        if (i >= 0) pageRenderCallbacks.splice(i, 1);
+      };
+    }, [onRenderSuccess]);
+    return (
+      <div data-testid={`pdf-page-${pageNumber}`} style={{ height: 800 }}>
+        page {pageNumber}
+      </div>
+    );
+  };
+
   return {
     Document,
     Page,
     pdfjs: { GlobalWorkerOptions: { workerSrc: "" }, version: "x" },
-    __setSuccess: (n: number) => handlers.success?.({ numPages: n }),
-    __setError: (e: Error) => handlers.error?.(e),
+    __setSuccess: (n: number) => handlers.load?.({ numPages: n }),
+    __setError: (e: Error) => handlers.err?.(e),
+    __renderAllPages: () => {
+      // Copy to avoid mutation while iterating (callbacks unregister via effect cleanup).
+      const cbs = [...pageRenderCallbacks];
+      cbs.forEach((cb) => cb());
+    },
+    __renderedPageCount: () => pageRenderCallbacks.length,
   };
 });
 
@@ -42,6 +77,7 @@ jest.mock("react-pdf/dist/Page/TextLayer.css", () => ({}), { virtual: true });
 const reactPdf = jest.requireMock("react-pdf") as {
   __setSuccess: (n: number) => void;
   __setError: (e: Error) => void;
+  __renderAllPages: () => void;
 };
 
 function setScrollMetrics(
@@ -100,7 +136,7 @@ describe("InlinePdfViewer", () => {
     expect(onReached).toHaveBeenCalledTimes(1);
   });
 
-  it("fires onReachedBottom on mount-after-load when the document fits the container", async () => {
+  it("fires onReachedBottom on mount-after-load when the document fits the container — but only AFTER all pages report onRenderSuccess", async () => {
     const onReached = jest.fn();
     const { container } = render(
       <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
@@ -111,12 +147,55 @@ describe("InlinePdfViewer", () => {
     ) as HTMLElement;
     setScrollMetrics(scroller, { scrollHeight: 400, clientHeight: 500, scrollTop: 0 });
 
+    // onLoadSuccess alone (without page render) must NOT auto-latch. This is
+    // the race that would otherwise let users skip the gate.
     await act(async () => {
       reactPdf.__setSuccess(1);
       await flushRaf();
     });
+    expect(onReached).not.toHaveBeenCalled();
 
+    const reactPdfFull = jest.requireMock("react-pdf") as {
+      __renderedPageCount: () => number;
+    };
+    expect(reactPdfFull.__renderedPageCount()).toBe(1);
+
+    // After every page reports render success, the fits-without-overflow
+    // check runs and latches.
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    // The effect schedules an rAF inside; flush it.
+    await act(async () => {
+      await flushRaf();
+    });
     expect(onReached).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT auto-latch on mount when the rendered document overflows the container", async () => {
+    const onReached = jest.fn();
+    const { container } = render(
+      <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
+    );
+
+    const scroller = container.querySelector(
+      "[data-testid='pdf-scroll-container']",
+    ) as HTMLElement;
+    // After all pages render, scrollHeight (1600) >> clientHeight (500)
+    setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 0 });
+
+    await act(async () => {
+      reactPdf.__setSuccess(2);
+      await flushRaf();
+    });
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+
+    expect(onReached).not.toHaveBeenCalled();
   });
 
   it("fires onLoadError and never fires onReachedBottom when load fails", () => {

--- a/frontend/components/__tests__/notice-agreement-step.test.tsx
+++ b/frontend/components/__tests__/notice-agreement-step.test.tsx
@@ -127,6 +127,52 @@ describe("NoticeAgreementStep", () => {
     await waitFor(() => expect(agreeCheckbox).not.toBeDisabled());
   });
 
+  it("latched state survives dialog close + reopen", async () => {
+    mockGetPublicDocs.mockResolvedValue({
+      success: true,
+      data: { regulations_url: "system-docs/x.pdf" },
+    });
+
+    render(
+      <NoticeAgreementStep
+        agreedToTerms={false}
+        onAgree={noop}
+        onNext={noop}
+        locale="zh"
+      />,
+    );
+
+    const openBtn = await screen.findByRole("button", {
+      name: /閱讀獎學金要點/,
+    });
+    const agreeCheckbox = screen.getByRole("checkbox", {
+      name: /同意遵守相關規定/,
+    });
+
+    // Open → scroll bottom → close dialog.
+    fireEvent.click(openBtn);
+    await screen.findByTestId("inline-pdf-viewer");
+    fireEvent.click(screen.getByTestId("simulate-reached-bottom"));
+    await waitFor(() => expect(agreeCheckbox).not.toBeDisabled());
+
+    // Close via the dialog's close control (the small "關閉" button is
+    // inside DialogContent's footer).
+    fireEvent.click(screen.getByRole("button", { name: /^關閉$/ }));
+
+    // Viewer unmounts (Radix removes DialogContent from DOM on close).
+    await waitFor(() =>
+      expect(screen.queryByTestId("inline-pdf-viewer")).not.toBeInTheDocument(),
+    );
+
+    // Agree must STILL be unlocked — the latch lives on the parent.
+    expect(agreeCheckbox).not.toBeDisabled();
+
+    // Reopening must not lock it back.
+    fireEvent.click(openBtn);
+    await screen.findByTestId("inline-pdf-viewer");
+    expect(agreeCheckbox).not.toBeDisabled();
+  });
+
   it("keeps the 8 hardcoded notice items visible as a static summary", async () => {
     mockGetPublicDocs.mockResolvedValue({
       success: true,

--- a/frontend/components/__tests__/notice-agreement-step.test.tsx
+++ b/frontend/components/__tests__/notice-agreement-step.test.tsx
@@ -69,6 +69,10 @@ describe("NoticeAgreementStep", () => {
         screen.getByText(/系統管理員尚未上傳獎學金要點/),
       ).toBeInTheDocument(),
     );
+    // Loud failure if the mock isn't wired — otherwise this test would pass
+    // for the wrong reason (real fetch returns {data: []} from the setup
+    // file's global mock, which also has no `regulations_url`).
+    expect(mockGetPublicDocs).toHaveBeenCalled();
     expect(screen.queryByTestId("inline-pdf-viewer")).not.toBeInTheDocument();
 
     const agreeCheckbox = screen.getByRole("checkbox", {
@@ -96,6 +100,7 @@ describe("NoticeAgreementStep", () => {
     );
 
     const viewer = await screen.findByTestId("inline-pdf-viewer");
+    expect(mockGetPublicDocs).toHaveBeenCalled();
     expect(viewer.getAttribute("data-url")).toMatch(
       /\/api\/v1\/system-settings\/file-proxy\?key=regulations_url/,
     );
@@ -127,6 +132,7 @@ describe("NoticeAgreementStep", () => {
     await waitFor(() =>
       expect(screen.getByText("申請資格")).toBeInTheDocument(),
     );
+    expect(mockGetPublicDocs).toHaveBeenCalled();
     expect(screen.getByText("申請期限")).toBeInTheDocument();
     expect(screen.getByText("獎金撥款")).toBeInTheDocument();
   });

--- a/frontend/components/__tests__/notice-agreement-step.test.tsx
+++ b/frontend/components/__tests__/notice-agreement-step.test.tsx
@@ -81,7 +81,7 @@ describe("NoticeAgreementStep", () => {
     expect(agreeCheckbox).toBeDisabled();
   });
 
-  it("renders the InlinePdfViewer and enables the agree checkbox after scroll-to-bottom", async () => {
+  it("opens regulations in a dialog and enables agree after scroll-to-bottom", async () => {
     mockGetPublicDocs.mockResolvedValue({
       success: true,
       data: {
@@ -99,19 +99,31 @@ describe("NoticeAgreementStep", () => {
       />,
     );
 
-    const viewer = await screen.findByTestId("inline-pdf-viewer");
+    // Trigger button should appear once docs are loaded.
+    const openBtn = await screen.findByRole("button", {
+      name: /閱讀獎學金要點/,
+    });
     expect(mockGetPublicDocs).toHaveBeenCalled();
-    expect(viewer.getAttribute("data-url")).toMatch(
-      /\/api\/v1\/system-settings\/file-proxy\?key=regulations_url/,
-    );
+
+    // Viewer not mounted before button click (dialog closed).
+    expect(screen.queryByTestId("inline-pdf-viewer")).not.toBeInTheDocument();
 
     const agreeCheckbox = screen.getByRole("checkbox", {
       name: /同意遵守相關規定/,
     });
     expect(agreeCheckbox).toBeDisabled();
 
+    // Open dialog → viewer mounts inside.
+    fireEvent.click(openBtn);
+    const viewer = await screen.findByTestId("inline-pdf-viewer");
+    expect(viewer.getAttribute("data-url")).toMatch(
+      /\/api\/v1\/system-settings\/file-proxy\?key=regulations_url/,
+    );
+
+    // Simulate scroll-to-bottom inside the dialog viewer.
     fireEvent.click(screen.getByTestId("simulate-reached-bottom"));
 
+    // Agree checkbox unlocks (latched state survives dialog close).
     await waitFor(() => expect(agreeCheckbox).not.toBeDisabled());
   });
 

--- a/frontend/components/__tests__/notice-agreement-step.test.tsx
+++ b/frontend/components/__tests__/notice-agreement-step.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NoticeAgreementStep } from "../student-wizard/steps/NoticeAgreementStep";
+
+jest.mock("../../lib/api", () => {
+  const fn = jest.fn();
+  return {
+    __esModule: true,
+    default: { systemSettings: { getPublicDocs: fn } },
+    api: { systemSettings: { getPublicDocs: fn } },
+  };
+});
+
+const mockGetPublicDocs = (
+  jest.requireMock("../../lib/api") as { api: { systemSettings: { getPublicDocs: jest.Mock } } }
+).api.systemSettings.getPublicDocs;
+
+jest.mock("../inline-pdf-viewer", () => ({
+  InlinePdfViewer: (props: {
+    url: string;
+    onReachedBottom?: () => void;
+  }) => (
+    <div data-testid="inline-pdf-viewer" data-url={props.url}>
+      <button
+        type="button"
+        data-testid="simulate-reached-bottom"
+        onClick={() => props.onReachedBottom?.()}
+      >
+        simulate scroll bottom
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("../file-preview-dialog", () => ({
+  FilePreviewDialog: () => null,
+}));
+
+describe("NoticeAgreementStep", () => {
+  const noop = () => undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: jest.fn(() => "test-token"),
+      },
+      configurable: true,
+    });
+  });
+
+  it("blocks the agree checkbox and shows an alert when no regulations are uploaded", async () => {
+    mockGetPublicDocs.mockResolvedValue({
+      success: true,
+      data: {},
+    });
+
+    render(
+      <NoticeAgreementStep
+        agreedToTerms={false}
+        onAgree={noop}
+        onNext={noop}
+        locale="zh"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/系統管理員尚未上傳獎學金要點/),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("inline-pdf-viewer")).not.toBeInTheDocument();
+
+    const agreeCheckbox = screen.getByRole("checkbox", {
+      name: /同意遵守相關規定/,
+    });
+    expect(agreeCheckbox).toBeDisabled();
+  });
+
+  it("renders the InlinePdfViewer and enables the agree checkbox after scroll-to-bottom", async () => {
+    mockGetPublicDocs.mockResolvedValue({
+      success: true,
+      data: {
+        regulations_url: "system-docs/regulations_url_20260520_120000.pdf",
+        regulations_url_filename: "獎學金要點.pdf",
+      },
+    });
+
+    render(
+      <NoticeAgreementStep
+        agreedToTerms={false}
+        onAgree={noop}
+        onNext={noop}
+        locale="zh"
+      />,
+    );
+
+    const viewer = await screen.findByTestId("inline-pdf-viewer");
+    expect(viewer.getAttribute("data-url")).toMatch(
+      /\/api\/v1\/system-settings\/file-proxy\?key=regulations_url/,
+    );
+
+    const agreeCheckbox = screen.getByRole("checkbox", {
+      name: /同意遵守相關規定/,
+    });
+    expect(agreeCheckbox).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("simulate-reached-bottom"));
+
+    await waitFor(() => expect(agreeCheckbox).not.toBeDisabled());
+  });
+
+  it("keeps the 8 hardcoded notice items visible as a static summary", async () => {
+    mockGetPublicDocs.mockResolvedValue({
+      success: true,
+      data: { regulations_url: "system-docs/x.pdf" },
+    });
+    render(
+      <NoticeAgreementStep
+        agreedToTerms={false}
+        onAgree={noop}
+        onNext={noop}
+        locale="zh"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("申請資格")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("申請期限")).toBeInTheDocument();
+    expect(screen.getByText("獎金撥款")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/admin/system-docs/SystemDocsPanel.tsx
+++ b/frontend/components/admin/system-docs/SystemDocsPanel.tsx
@@ -32,6 +32,8 @@ interface DocSlot {
   key: DocKey;
   title: string;
   subtitle: string;
+  accepted: string;
+  acceptedLabel: string;
   Icon: React.ComponentType<{ className?: string }>;
   accent: {
     ring: string;
@@ -48,6 +50,8 @@ const SLOTS: DocSlot[] = [
     key: "regulations_url",
     title: "獎學金要點",
     subtitle: "提供學生、教授與學院審核時參閱的法規文件",
+    accepted: ".pdf",
+    acceptedLabel: "PDF",
     Icon: BookOpen,
     accent: {
       ring: "ring-nycu-blue-200",
@@ -63,6 +67,8 @@ const SLOTS: DocSlot[] = [
     key: "sample_document_url",
     title: "申請文件範例檔",
     subtitle: "提供學生填寫申請文件時的參考範例",
+    accepted: ".pdf,.doc,.docx",
+    acceptedLabel: "PDF · DOC · DOCX",
     Icon: FileArchive,
     accent: {
       ring: "ring-amber-200",
@@ -75,7 +81,6 @@ const SLOTS: DocSlot[] = [
   },
 ];
 
-const ACCEPTED = ".pdf,.doc,.docx";
 const MAX_SIZE_MB = 10;
 
 function formatBytes(bytes: number): string {
@@ -160,9 +165,12 @@ export function SystemDocsPanel() {
 
   const validateAndSet = (key: DocKey, file: File | null) => {
     if (!file) return;
+    const slot = SLOTS.find((s) => s.key === key);
+    if (!slot) return;
+    const allowed = slot.accepted.split(",").map((s) => s.trim());
     const ext = "." + (file.name.toLowerCase().split(".").pop() || "");
-    if (!ACCEPTED.split(",").includes(ext)) {
-      toast.error("僅接受 PDF / DOC / DOCX");
+    if (!allowed.includes(ext)) {
+      toast.error(`僅接受 ${slot.acceptedLabel}`);
       return;
     }
     if (file.size > MAX_SIZE_MB * 1024 * 1024) {
@@ -427,7 +435,7 @@ export function SystemDocsPanel() {
                       <input
                         ref={inputRefs[slot.key]}
                         type="file"
-                        accept={ACCEPTED}
+                        accept={slot.accepted}
                         onChange={(e) =>
                           validateAndSet(slot.key, e.target.files?.[0] || null)
                         }
@@ -446,7 +454,7 @@ export function SystemDocsPanel() {
                           : "拖曳檔案至此或點擊選擇"}
                       </p>
                       <p className="text-xs text-gray-500 mt-1.5">
-                        支援 PDF · DOC · DOCX · 上限 {MAX_SIZE_MB} MB
+                        支援 {slot.acceptedLabel} · 上限 {MAX_SIZE_MB} MB
                       </p>
                     </label>
                   )}

--- a/frontend/components/admin/system-docs/SystemDocsPanel.tsx
+++ b/frontend/components/admin/system-docs/SystemDocsPanel.tsx
@@ -23,10 +23,10 @@ import {
   X,
 } from "lucide-react";
 import apiClient from "@/lib/api";
+import { buildFileProxyUrl, type DocKey } from "@/lib/api/modules/system-settings";
+import { previewMimeType } from "@/lib/utils";
 import { toast } from "sonner";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
-
-type DocKey = "regulations_url" | "sample_document_url";
 
 interface DocSlot {
   key: DocKey;
@@ -95,15 +95,6 @@ function fileTypeBadge(name: string): string {
   if (ext === "docx") return "DOCX";
   if (ext === "doc") return "DOC";
   return ext.toUpperCase() || "檔案";
-}
-
-function previewMimeType(name: string): string {
-  const lower = name.toLowerCase();
-  if (lower.endsWith(".pdf")) return "application/pdf";
-  if (lower.endsWith(".doc")) return "application/msword";
-  if (lower.endsWith(".docx"))
-    return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-  return "application/octet-stream";
 }
 
 export function SystemDocsPanel() {
@@ -214,16 +205,8 @@ export function SystemDocsPanel() {
   const openPreview = (key: DocKey) => {
     const current = currentFiles[key];
     if (!current) return;
-    const token =
-      typeof window !== "undefined"
-        ? localStorage.getItem("auth_token") || ""
-        : "";
-    const cacheBuster = encodeURIComponent(
-      current.objectName.split("/").pop() || ""
-    );
-    const url = `/api/v1/system-settings/file-proxy?key=${key}&token=${encodeURIComponent(
-      token
-    )}&v=${cacheBuster}`;
+    const url = buildFileProxyUrl(key, current.objectName);
+    if (!url) return;
     setPreview({
       url,
       filename: current.displayName,

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { logger } from "@/lib/utils/logger";
+import { buildFileProxyUrl } from "@/lib/api/modules/system-settings";
+import { previewMimeType } from "@/lib/utils";
 import { User } from "@/types/user";
 import { useCollegeManagement } from "@/contexts/college-management-context";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -511,18 +513,12 @@ export function ApplicationReviewPanel({
   }, []);
 
   const handleViewRegulations = () => {
-    const token = localStorage.getItem("auth_token") || "";
-    const url = `/api/v1/system-settings/file-proxy?key=regulations_url&token=${encodeURIComponent(token)}`;
-    const lower = regulationsFilename.toLowerCase();
-    let type = "application/pdf";
-    if (lower.endsWith(".doc")) type = "application/msword";
-    else if (lower.endsWith(".docx"))
-      type =
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    const url = buildFileProxyUrl("regulations_url", regulationsUrl);
+    if (!url) return;
     setRegulationsFile({
       url,
       filename: regulationsFilename || "獎學金要點",
-      type,
+      type: previewMimeType(regulationsFilename),
     });
     setShowRegulations(true);
   };

--- a/frontend/components/inline-pdf-viewer.tsx
+++ b/frontend/components/inline-pdf-viewer.tsx
@@ -31,6 +31,7 @@ export function InlinePdfViewer({
 }: InlinePdfViewerProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [numPages, setNumPages] = useState<number | null>(null);
+  const [renderedCount, setRenderedCount] = useState(0);
   const [loadError, setLoadError] = useState<Error | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
 
@@ -56,20 +57,34 @@ export function InlinePdfViewer({
   const handleLoadSuccess = useCallback(
     ({ numPages: n }: { numPages: number }) => {
       setNumPages(n);
+      setRenderedCount(0);
       setLoadError(null);
-      // After pages mount, if the document fits without overflowing the
-      // container, treat it as already read. Schedule on the next frame so
-      // layout has settled.
-      requestAnimationFrame(() => {
-        const el = scrollRef.current;
-        if (!el) return;
-        if (el.scrollHeight <= el.clientHeight + SLACK_PX) {
-          fireReached();
-        }
-      });
     },
-    [fireReached],
+    [],
   );
+
+  const handlePageRenderSuccess = useCallback(() => {
+    setRenderedCount((c) => c + 1);
+  }, []);
+
+  // Pdf.js renders each <Page> to canvas asynchronously after onLoadSuccess
+  // fires. Checking the fits-without-scrolling condition immediately would
+  // race against canvas painting and could auto-latch on an empty container.
+  // Wait until every page has reported render success, then check on the
+  // next frame so layout has settled.
+  useEffect(() => {
+    if (numPages === null || renderedCount < numPages) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const id = requestAnimationFrame(() => {
+      const cur = scrollRef.current;
+      if (!cur) return;
+      if (cur.scrollHeight <= cur.clientHeight + SLACK_PX) {
+        fireReached();
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [numPages, renderedCount, fireReached]);
 
   const handleLoadError = useCallback(
     (err: Error) => {
@@ -134,6 +149,7 @@ export function InlinePdfViewer({
                   pageNumber={i + 1}
                   renderAnnotationLayer
                   renderTextLayer
+                  onRenderSuccess={handlePageRenderSuccess}
                   className="mx-auto mb-2"
                 />
               ))

--- a/frontend/components/inline-pdf-viewer.tsx
+++ b/frontend/components/inline-pdf-viewer.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Document, Page } from "react-pdf";
+import { AlertCircle, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Side-effect import: configures pdfjs.GlobalWorkerOptions.workerSrc.
+import "@/lib/pdf-worker";
+
+import "react-pdf/dist/Page/AnnotationLayer.css";
+import "react-pdf/dist/Page/TextLayer.css";
+
+interface InlinePdfViewerProps {
+  url: string;
+  height?: number;
+  onReachedBottom?: () => void;
+  onLoadError?: (err: Error) => void;
+  locale?: "zh" | "en";
+}
+
+const SLACK_PX = 8;
+
+export function InlinePdfViewer({
+  url,
+  height = 500,
+  onReachedBottom,
+  onLoadError,
+  locale = "zh",
+}: InlinePdfViewerProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [numPages, setNumPages] = useState<number | null>(null);
+  const [loadError, setLoadError] = useState<Error | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const latched = useRef(false);
+  useEffect(() => {
+    latched.current = false;
+  }, [url, reloadToken]);
+
+  const fireReached = useCallback(() => {
+    if (latched.current) return;
+    latched.current = true;
+    onReachedBottom?.();
+  }, [onReachedBottom]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (el.scrollHeight - el.scrollTop - el.clientHeight <= SLACK_PX) {
+      fireReached();
+    }
+  }, [fireReached]);
+
+  const handleLoadSuccess = useCallback(
+    ({ numPages: n }: { numPages: number }) => {
+      setNumPages(n);
+      setLoadError(null);
+      // After pages mount, if the document fits without overflowing the
+      // container, treat it as already read. Schedule on the next frame so
+      // layout has settled.
+      requestAnimationFrame(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+        if (el.scrollHeight <= el.clientHeight + SLACK_PX) {
+          fireReached();
+        }
+      });
+    },
+    [fireReached],
+  );
+
+  const handleLoadError = useCallback(
+    (err: Error) => {
+      setLoadError(err);
+      onLoadError?.(err);
+    },
+    [onLoadError],
+  );
+
+  const labels =
+    locale === "zh"
+      ? { loading: "載入中…", error: "無法載入文件", reload: "重新載入" }
+      : { loading: "Loading…", error: "Failed to load document", reload: "Reload" };
+
+  return (
+    <div
+      ref={scrollRef}
+      data-testid="pdf-scroll-container"
+      onScroll={handleScroll}
+      className="overflow-y-auto rounded-lg border bg-white"
+      style={{ height }}
+    >
+      {loadError ? (
+        <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+          <AlertCircle className="h-8 w-8 text-red-500" />
+          <p className="text-sm font-medium text-red-700">{labels.error}</p>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setLoadError(null);
+              setNumPages(null);
+              setReloadToken((t) => t + 1);
+            }}
+          >
+            <RotateCcw className="mr-1.5 h-4 w-4" />
+            {labels.reload}
+          </Button>
+        </div>
+      ) : (
+        <Document
+          key={`${url}#${reloadToken}`}
+          file={url}
+          loading={
+            <div className="space-y-3 p-6">
+              <Skeleton className="h-6 w-full" />
+              <Skeleton className="h-6 w-[90%]" />
+              <Skeleton className="h-6 w-[85%]" />
+              <Skeleton className="h-6 w-[95%]" />
+              <p className="pt-2 text-center text-xs text-muted-foreground">
+                {labels.loading}
+              </p>
+            </div>
+          }
+          onLoadSuccess={handleLoadSuccess}
+          onLoadError={handleLoadError}
+        >
+          {numPages !== null
+            ? Array.from({ length: numPages }, (_, i) => (
+                <Page
+                  key={i + 1}
+                  pageNumber={i + 1}
+                  renderAnnotationLayer
+                  renderTextLayer
+                  className="mx-auto mb-2"
+                />
+              ))
+            : null}
+        </Document>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/inline-pdf-viewer.tsx
+++ b/frontend/components/inline-pdf-viewer.tsx
@@ -14,7 +14,10 @@ import "react-pdf/dist/Page/TextLayer.css";
 
 interface InlinePdfViewerProps {
   url: string;
+  // Fixed pixel height. Use `className` instead for responsive sizing
+  // (e.g. `h-[min(700px,calc(90vh-200px))]`).
   height?: number;
+  className?: string;
   onReachedBottom?: () => void;
   onLoadError?: (err: Error) => void;
   locale?: "zh" | "en";
@@ -24,7 +27,8 @@ const SLACK_PX = 8;
 
 export function InlinePdfViewer({
   url,
-  height = 500,
+  height,
+  className,
   onReachedBottom,
   onLoadError,
   locale = "zh",
@@ -104,8 +108,8 @@ export function InlinePdfViewer({
       ref={scrollRef}
       data-testid="pdf-scroll-container"
       onScroll={handleScroll}
-      className="overflow-y-auto rounded-lg border bg-white"
-      style={{ height }}
+      className={`overflow-y-auto rounded-lg border bg-white ${className ?? ""}`}
+      style={height !== undefined ? { height } : undefined}
     >
       {loadError ? (
         <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">

--- a/frontend/components/inline-pdf-viewer.tsx
+++ b/frontend/components/inline-pdf-viewer.tsx
@@ -14,9 +14,9 @@ import "react-pdf/dist/Page/TextLayer.css";
 
 interface InlinePdfViewerProps {
   url: string;
-  // Fixed pixel height. Use `className` instead for responsive sizing
-  // (e.g. `h-[min(700px,calc(90vh-200px))]`).
-  height?: number;
+  // Tailwind classes for sizing the scroll container, e.g.
+  // `h-[min(700px,calc(90vh-200px))]`. Required in practice — the
+  // container has no intrinsic height without one.
   className?: string;
   onReachedBottom?: () => void;
   onLoadError?: (err: Error) => void;
@@ -25,9 +25,13 @@ interface InlinePdfViewerProps {
 
 const SLACK_PX = 8;
 
+const LABELS = {
+  zh: { loading: "載入中…", error: "無法載入文件", reload: "重新載入" },
+  en: { loading: "Loading…", error: "Failed to load document", reload: "Reload" },
+} as const;
+
 export function InlinePdfViewer({
   url,
-  height,
   className,
   onReachedBottom,
   onLoadError,
@@ -51,6 +55,7 @@ export function InlinePdfViewer({
   }, [onReachedBottom]);
 
   const handleScroll = useCallback(() => {
+    if (latched.current) return;
     const el = scrollRef.current;
     if (!el) return;
     if (el.scrollHeight - el.scrollTop - el.clientHeight <= SLACK_PX) {
@@ -98,10 +103,7 @@ export function InlinePdfViewer({
     [onLoadError],
   );
 
-  const labels =
-    locale === "zh"
-      ? { loading: "載入中…", error: "無法載入文件", reload: "重新載入" }
-      : { loading: "Loading…", error: "Failed to load document", reload: "Reload" };
+  const labels = LABELS[locale];
 
   return (
     <div
@@ -109,7 +111,6 @@ export function InlinePdfViewer({
       data-testid="pdf-scroll-container"
       onScroll={handleScroll}
       className={`overflow-y-auto rounded-lg border bg-white ${className ?? ""}`}
-      style={height !== undefined ? { height } : undefined}
     >
       {loadError ? (
         <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { logger } from "@/lib/utils/logger";
+import { buildFileProxyUrl } from "@/lib/api/modules/system-settings";
+import { previewMimeType } from "@/lib/utils";
 import { ErrorBoundary, useErrorHandler } from "@/components/error-boundary";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -169,18 +171,12 @@ function ProfessorReviewComponentInner({
   }, []);
 
   const handleViewRegulations = () => {
-    const token = localStorage.getItem("auth_token") || "";
-    const url = `/api/v1/system-settings/file-proxy?key=regulations_url&token=${encodeURIComponent(token)}`;
-    const lower = regulationsFilename.toLowerCase();
-    let type = "application/pdf";
-    if (lower.endsWith(".doc")) type = "application/msword";
-    else if (lower.endsWith(".docx"))
-      type =
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    const url = buildFileProxyUrl("regulations_url", regulationsUrl);
+    if (!url) return;
     setRegulationsFile({
       url,
       filename: regulationsFilename || "獎學金要點",
-      type,
+      type: previewMimeType(regulationsFilename),
     });
     setShowRegulations(true);
   };

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -207,10 +207,21 @@ export function NoticeAgreementStep({
   } | null>(null);
 
   useEffect(() => {
-    api.systemSettings.getPublicDocs().then((res) => {
-      if (res.success && res.data) setPublicDocs(res.data);
-      setDocsLoaded(true);
-    });
+    api.systemSettings
+      .getPublicDocs()
+      .then((res) => {
+        if (res.success && res.data) setPublicDocs(res.data);
+      })
+      .catch((err) => {
+        // Network failure / unexpected throw. Surface the same "no
+        // regulations" blocking alert (publicDocs stays empty) so the
+        // student isn't stuck on a loading skeleton. Logged for ops.
+        // eslint-disable-next-line no-console
+        console.error("[NoticeAgreementStep] getPublicDocs failed", err);
+      })
+      .finally(() => {
+        setDocsLoaded(true);
+      });
   }, []);
 
   const handleOpenSampleDoc = useCallback(

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Card,
   CardContent,
@@ -18,10 +18,10 @@ import {
   FileText,
   AlertTriangle,
   ChevronRight,
-  ArrowDown,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
+import { InlinePdfViewer } from "@/components/inline-pdf-viewer";
 
 interface NoticeAgreementStepProps {
   agreedToTerms: boolean;
@@ -37,31 +37,6 @@ export function NoticeAgreementStep({
   locale,
 }: NoticeAgreementStepProps) {
   const [hasReadNotice, setHasReadNotice] = useState(false);
-  const noticeScrollRef = useRef<HTMLDivElement | null>(null);
-
-  // #59: enable the agreement checkbox only after the user has scrolled
-  // to the bottom of the notice list. Once reached, latches to true so
-  // bouncing back up doesn't disable the agree checkbox again.
-  const handleNoticeScroll = useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      if (hasReadNotice) return; // already latched
-      const el = e.currentTarget;
-      const reachedBottom =
-        el.scrollHeight - el.scrollTop - el.clientHeight <= 8; // 8px slack
-      if (reachedBottom) setHasReadNotice(true);
-    },
-    [hasReadNotice]
-  );
-
-  // If the notice fits without needing to scroll, treat it as already read
-  // once the element mounts (otherwise the checkbox would never enable).
-  useEffect(() => {
-    const el = noticeScrollRef.current;
-    if (!el) return;
-    if (el.scrollHeight <= el.clientHeight + 8) {
-      setHasReadNotice(true);
-    }
-  }, []);
 
   const [publicDocs, setPublicDocs] = useState<{
     regulations_url?: string;
@@ -69,6 +44,7 @@ export function NoticeAgreementStep({
     regulations_url_filename?: string;
     sample_document_url_filename?: string;
   }>({});
+  const [docsLoaded, setDocsLoaded] = useState(false);
   const [previewFile, setPreviewFile] = useState<{
     url: string;
     filename: string;
@@ -79,26 +55,18 @@ export function NoticeAgreementStep({
   useEffect(() => {
     api.systemSettings.getPublicDocs().then((res) => {
       if (res.success && res.data) setPublicDocs(res.data);
+      setDocsLoaded(true);
     });
   }, []);
 
-  const handleOpenDoc = (
-    key: "regulations_url" | "sample_document_url",
-    label: string
-  ) => {
+  const handleOpenSampleDoc = (label: string) => {
     const token = localStorage.getItem("auth_token") || "";
-    const originalName =
-      key === "regulations_url"
-        ? publicDocs.regulations_url_filename
-        : publicDocs.sample_document_url_filename;
-    const objectName =
-      key === "regulations_url"
-        ? publicDocs.regulations_url
-        : publicDocs.sample_document_url;
-    const cacheBuster = encodeURIComponent(
-      objectName?.split("/").pop() || ""
-    );
-    const url = `/api/v1/system-settings/file-proxy?key=${key}&token=${encodeURIComponent(token)}&v=${cacheBuster}`;
+    const objectName = publicDocs.sample_document_url;
+    const originalName = publicDocs.sample_document_url_filename;
+    const cacheBuster = encodeURIComponent(objectName?.split("/").pop() || "");
+    const url = `/api/v1/system-settings/file-proxy?key=sample_document_url&token=${encodeURIComponent(
+      token,
+    )}&v=${cacheBuster}`;
     const filename = originalName || label;
     const lower = (originalName || objectName || "").toLowerCase();
     let type = "application/pdf";
@@ -113,10 +81,24 @@ export function NoticeAgreementStep({
     setShowPreview(true);
   };
 
+  const regulationsViewerUrl = (() => {
+    const objectName = publicDocs.regulations_url;
+    if (!objectName) return null;
+    const token =
+      typeof window !== "undefined"
+        ? localStorage.getItem("auth_token") || ""
+        : "";
+    const cacheBuster = encodeURIComponent(objectName.split("/").pop() || "");
+    return `/api/v1/system-settings/file-proxy?key=regulations_url&token=${encodeURIComponent(
+      token,
+    )}&v=${cacheBuster}`;
+  })();
+
   const notices = {
     zh: {
       title: "獎學金申請注意事項",
-      subtitle: "請詳細閱讀以下內容後，勾選同意方可繼續申請",
+      subtitle:
+        "請詳細閱讀以下內容，並滑完下方的「獎學金要點」後勾選同意方可繼續申請",
       items: [
         {
           title: "申請資格",
@@ -162,20 +144,24 @@ export function NoticeAgreementStep({
       importantNotice: "重要提醒",
       importantContent:
         "請務必詳細閱讀各獎學金的申請條款與相關規定。每位學生每學期限申請一項獎學金，請謹慎選擇。",
-      agreementText: "我已詳細閱讀並了解上述注意事項，同意遵守相關規定",
-      readNoticeText: "已詳閱所有注意事項",
-      readNoticeHint: "請滑到下方注意事項的最底端，閱讀完成後才能勾選同意",
+      agreementText: "我已詳細閱讀並了解獎學金要點，同意遵守相關規定",
+      readNoticeText: "已詳閱獎學金要點",
+      readNoticeHint:
+        "請將下方獎學金要點滑到底端，閱讀完成後才能勾選同意",
       readNoticeDone: "已閱讀完成",
       nextButton: "同意並繼續",
-      readFirst: "請先滑到注意事項底部完成閱讀",
-      referenceDocs: "參考文件",
-      regulations: "獎學金要點",
-      sampleDocument: "申請文件範例檔",
-      notProvided: "尚未提供",
+      readFirst: "請先滑到獎學金要點底部完成閱讀",
+      sampleDocumentLabel: "申請文件範例檔",
+      sampleDocumentRow: "需要參考申請文件格式？",
+      sampleDocumentNotProvided: "尚未提供",
+      regulationsHeader: "獎學金要點",
+      regulationsMissing:
+        "系統管理員尚未上傳獎學金要點，目前無法進行申請。請聯絡承辦單位。",
     },
     en: {
       title: "Scholarship Application Notice",
-      subtitle: "Please read the following carefully and check to agree before proceeding",
+      subtitle:
+        "Read the following carefully. Scroll the Scholarship Regulations below to the bottom before agreeing to continue.",
       items: [
         {
           title: "Eligibility",
@@ -222,16 +208,19 @@ export function NoticeAgreementStep({
       importantContent:
         "Please read the terms and conditions of each scholarship carefully. Each student may only apply for one scholarship per semester. Choose wisely.",
       agreementText:
-        "I have read and understand the above notice and agree to comply with the regulations",
-      readNoticeText: "I have read all notices",
-      readNoticeHint: "Scroll to the bottom of the notices to confirm you have read them",
+        "I have read and understand the scholarship regulations and agree to comply",
+      readNoticeText: "I have read the scholarship regulations",
+      readNoticeHint:
+        "Scroll the regulations document to the bottom to enable the agree checkbox",
       readNoticeDone: "Reading complete",
       nextButton: "Agree and Continue",
-      readFirst: "Please scroll to the bottom of the notices first",
-      referenceDocs: "Reference Documents",
-      regulations: "Scholarship Regulations",
-      sampleDocument: "Sample Application Documents",
-      notProvided: "Not available",
+      readFirst: "Please scroll to the bottom of the regulations first",
+      sampleDocumentLabel: "Sample Application Documents",
+      sampleDocumentRow: "Need to see the application document format?",
+      sampleDocumentNotProvided: "Not available",
+      regulationsHeader: "Scholarship Regulations",
+      regulationsMissing:
+        "The system administrator has not uploaded the scholarship regulations. Applications cannot proceed. Please contact the administrative office.",
     },
   };
 
@@ -259,52 +248,13 @@ export function NoticeAgreementStep({
               <div className="font-semibold text-amber-900 mb-1">
                 {t.importantNotice}
               </div>
-              <div className="text-sm text-amber-800">
-                {t.importantContent}
-              </div>
+              <div className="text-sm text-amber-800">{t.importantContent}</div>
             </AlertDescription>
           </Alert>
 
-          {/* Reference Documents */}
-          <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
-            <p className="text-sm font-semibold text-blue-900 mb-3">{t.referenceDocs}</p>
-            <div className="flex gap-3">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleOpenDoc("regulations_url", t.regulations)}
-                disabled={!publicDocs.regulations_url}
-                className="flex items-center gap-2"
-              >
-                <FileText className="h-4 w-4" />
-                {t.regulations}
-                {!publicDocs.regulations_url && (
-                  <span className="text-xs text-gray-400 ml-1">({t.notProvided})</span>
-                )}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleOpenDoc("sample_document_url", t.sampleDocument)}
-                disabled={!publicDocs.sample_document_url}
-                className="flex items-center gap-2"
-              >
-                <FileText className="h-4 w-4" />
-                {t.sampleDocument}
-                {!publicDocs.sample_document_url && (
-                  <span className="text-xs text-gray-400 ml-1">({t.notProvided})</span>
-                )}
-              </Button>
-            </div>
-          </div>
-
-          {/* Notice Content — scroll-to-bottom triggers hasReadNotice (#59) */}
-          <Card className="border-2 relative">
-            <div
-              ref={noticeScrollRef}
-              onScroll={handleNoticeScroll}
-              className="h-[400px] overflow-y-auto p-6"
-            >
+          {/* 8-item static summary (no scroll, no gate) */}
+          <Card className="border-2">
+            <div className="p-6">
               <div className="space-y-4">
                 {t.items.map((item, index) => (
                   <div
@@ -326,31 +276,72 @@ export function NoticeAgreementStep({
                     </div>
                   </div>
                 ))}
-                {/* End-of-notice marker — visible only when scrolled to bottom */}
-                <div className="pt-2 text-center text-xs text-emerald-600 font-medium">
-                  ── {locale === "zh" ? "已到底部" : "End of notices"} ──
-                </div>
               </div>
             </div>
-            {!hasReadNotice && (
-              <div className="absolute bottom-2 right-3 flex items-center gap-1 rounded-full bg-amber-100 px-3 py-1 text-xs text-amber-800 shadow-sm pointer-events-none">
-                <ArrowDown className="h-3 w-3 animate-bounce" />
-                {t.readNoticeHint}
-              </div>
-            )}
           </Card>
 
-          {/* Read confirmation — auto-checked when user scrolls to bottom */}
+          {/* Reference row: sample document button (regulations are rendered
+              inline below, so they no longer need a button here). */}
+          <div className="p-4 bg-blue-50 rounded-lg border border-blue-200 flex items-center justify-between gap-3">
+            <p className="text-sm text-blue-900">{t.sampleDocumentRow}</p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleOpenSampleDoc(t.sampleDocumentLabel)}
+              disabled={!publicDocs.sample_document_url}
+              className="flex items-center gap-2"
+            >
+              <FileText className="h-4 w-4" />
+              {t.sampleDocumentLabel}
+              {!publicDocs.sample_document_url && (
+                <span className="text-xs text-gray-400 ml-1">
+                  ({t.sampleDocumentNotProvided})
+                </span>
+              )}
+            </Button>
+          </div>
+
+          {/* Inline regulations viewer (the gated content) */}
+          <div>
+            <h3 className="font-semibold text-nycu-navy-800 mb-2">
+              {t.regulationsHeader}
+            </h3>
+            {!docsLoaded ? (
+              <div className="h-[500px] rounded-lg border bg-gray-50" />
+            ) : regulationsViewerUrl ? (
+              <>
+                <InlinePdfViewer
+                  url={regulationsViewerUrl}
+                  height={500}
+                  locale={locale}
+                  onReachedBottom={() => setHasReadNotice(true)}
+                />
+                {!hasReadNotice && (
+                  <p className="text-xs text-amber-700 mt-2 flex items-center gap-1">
+                    <AlertCircle className="h-3 w-3" />
+                    {t.readNoticeHint}
+                  </p>
+                )}
+              </>
+            ) : (
+              <Alert className="border-amber-300 bg-amber-50">
+                <AlertCircle className="h-5 w-5 text-amber-700" />
+                <AlertDescription className="text-amber-900">
+                  {t.regulationsMissing}
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+
+          {/* Read confirmation — auto-checked when viewer reports bottom reached */}
           <div
             className={`flex items-center space-x-2 p-4 rounded-lg transition-colors ${
-              hasReadNotice ? "bg-emerald-50 border border-emerald-200" : "bg-gray-50"
+              hasReadNotice
+                ? "bg-emerald-50 border border-emerald-200"
+                : "bg-gray-50"
             }`}
           >
-            <Checkbox
-              id="read-notice"
-              checked={hasReadNotice}
-              disabled
-            />
+            <Checkbox id="read-notice" checked={hasReadNotice} disabled />
             <Label
               htmlFor="read-notice"
               className="text-sm font-medium leading-none cursor-default"

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -13,11 +13,19 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   AlertCircle,
   CheckCircle,
   FileText,
   AlertTriangle,
   ChevronRight,
+  BookOpen,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
@@ -37,6 +45,7 @@ export function NoticeAgreementStep({
   locale,
 }: NoticeAgreementStepProps) {
   const [hasReadNotice, setHasReadNotice] = useState(false);
+  const [showRegulationsDialog, setShowRegulationsDialog] = useState(false);
 
   const [publicDocs, setPublicDocs] = useState<{
     regulations_url?: string;
@@ -98,7 +107,7 @@ export function NoticeAgreementStep({
     zh: {
       title: "獎學金申請注意事項",
       subtitle:
-        "請詳細閱讀以下內容，並滑完下方的「獎學金要點」後勾選同意方可繼續申請",
+        "請詳細閱讀以下內容，點擊「閱讀獎學金要點」並滑至底部後方可勾選同意繼續申請",
       items: [
         {
           title: "申請資格",
@@ -145,18 +154,22 @@ export function NoticeAgreementStep({
       importantContent:
         "請務必詳細閱讀各獎學金的申請條款與相關規定。每位學生每學期限申請一項獎學金，請謹慎選擇。",
       agreementText: "我已詳細閱讀並了解獎學金要點，同意遵守相關規定",
-      readNoticeText: "已詳閱獎學金要點",
-      readNoticeHint:
-        "請將下方獎學金要點滑到底端，閱讀完成後才能勾選同意",
+      readNoticeText: "尚未閱讀獎學金要點",
+      readNoticeHint: "請點擊上方按鈕開啟獎學金要點並滑至底端",
       readNoticeDone: "已閱讀完成",
       nextButton: "同意並繼續",
-      readFirst: "請先滑到獎學金要點底部完成閱讀",
+      readFirst: "請先點擊「閱讀獎學金要點」並滑至底端",
       sampleDocumentLabel: "申請文件範例檔",
       sampleDocumentRow: "需要參考申請文件格式？",
       sampleDocumentNotProvided: "尚未提供",
       regulationsHeader: "獎學金要點",
+      regulationsOpenButton: "閱讀獎學金要點",
+      regulationsRow: "請開啟並閱讀獎學金要點全文",
+      regulationsDialogTitle: "獎學金要點",
+      regulationsDialogSubtitle: "請滑動至文件底端以完成閱讀",
       regulationsMissing:
         "系統管理員尚未上傳獎學金要點，目前無法進行申請。請聯絡承辦單位。",
+      regulationsLoading: "正在檢查獎學金要點…",
     },
     en: {
       title: "Scholarship Application Notice",
@@ -209,18 +222,23 @@ export function NoticeAgreementStep({
         "Please read the terms and conditions of each scholarship carefully. Each student may only apply for one scholarship per semester. Choose wisely.",
       agreementText:
         "I have read and understand the scholarship regulations and agree to comply",
-      readNoticeText: "I have read the scholarship regulations",
+      readNoticeText: "Regulations not yet read",
       readNoticeHint:
-        "Scroll the regulations document to the bottom to enable the agree checkbox",
+        "Click the button above to open the regulations and scroll to the bottom",
       readNoticeDone: "Reading complete",
       nextButton: "Agree and Continue",
-      readFirst: "Please scroll to the bottom of the regulations first",
+      readFirst: "Open the regulations and scroll to the bottom first",
       sampleDocumentLabel: "Sample Application Documents",
       sampleDocumentRow: "Need to see the application document format?",
       sampleDocumentNotProvided: "Not available",
       regulationsHeader: "Scholarship Regulations",
+      regulationsOpenButton: "Open Scholarship Regulations",
+      regulationsRow: "Open and read the full scholarship regulations",
+      regulationsDialogTitle: "Scholarship Regulations",
+      regulationsDialogSubtitle: "Scroll to the bottom of the document to complete reading",
       regulationsMissing:
         "The system administrator has not uploaded the scholarship regulations. Applications cannot proceed. Please contact the administrative office.",
+      regulationsLoading: "Checking scholarship regulations…",
     },
   };
 
@@ -301,37 +319,57 @@ export function NoticeAgreementStep({
             </Button>
           </div>
 
-          {/* Inline regulations viewer (the gated content) */}
-          <div>
-            <h3 className="font-semibold text-nycu-navy-800 mb-2">
-              {t.regulationsHeader}
-            </h3>
-            {!docsLoaded ? (
-              <div className="h-[500px] rounded-lg border bg-gray-50" />
-            ) : regulationsViewerUrl ? (
-              <>
-                <InlinePdfViewer
-                  url={regulationsViewerUrl}
-                  height={500}
-                  locale={locale}
-                  onReachedBottom={() => setHasReadNotice(true)}
-                />
+          {/* Regulations dialog trigger (the gated content) */}
+          {!docsLoaded ? (
+            <div className="p-4 bg-gray-50 rounded-lg border border-gray-200 text-sm text-gray-500">
+              {t.regulationsLoading}
+            </div>
+          ) : regulationsViewerUrl ? (
+            <div
+              className={`p-4 rounded-lg border flex items-center justify-between gap-3 transition-colors ${
+                hasReadNotice
+                  ? "bg-emerald-50 border-emerald-200"
+                  : "bg-nycu-blue-50 border-nycu-blue-200"
+              }`}
+            >
+              <div className="flex-1">
+                <p
+                  className={`text-sm font-medium ${
+                    hasReadNotice ? "text-emerald-900" : "text-nycu-blue-900"
+                  }`}
+                >
+                  {t.regulationsRow}
+                </p>
                 {!hasReadNotice && (
-                  <p className="text-xs text-amber-700 mt-2 flex items-center gap-1">
+                  <p className="text-xs text-nycu-blue-700 mt-1 flex items-center gap-1">
                     <AlertCircle className="h-3 w-3" />
                     {t.readNoticeHint}
                   </p>
                 )}
-              </>
-            ) : (
-              <Alert className="border-amber-300 bg-amber-50">
-                <AlertCircle className="h-5 w-5 text-amber-700" />
-                <AlertDescription className="text-amber-900">
-                  {t.regulationsMissing}
-                </AlertDescription>
-              </Alert>
-            )}
-          </div>
+              </div>
+              <Button
+                variant={hasReadNotice ? "outline" : "default"}
+                size="sm"
+                onClick={() => setShowRegulationsDialog(true)}
+                className={`flex items-center gap-2 ${
+                  !hasReadNotice ? "nycu-gradient text-white" : ""
+                }`}
+              >
+                <BookOpen className="h-4 w-4" />
+                {t.regulationsOpenButton}
+                {hasReadNotice && (
+                  <CheckCircle className="h-4 w-4 text-emerald-600 ml-1" />
+                )}
+              </Button>
+            </div>
+          ) : (
+            <Alert className="border-amber-300 bg-amber-50">
+              <AlertCircle className="h-5 w-5 text-amber-700" />
+              <AlertDescription className="text-amber-900">
+                {t.regulationsMissing}
+              </AlertDescription>
+            </Alert>
+          )}
 
           {/* Read confirmation — auto-checked when viewer reports bottom reached */}
           <div
@@ -409,6 +447,56 @@ export function NoticeAgreementStep({
         file={previewFile}
         locale={locale}
       />
+
+      <Dialog
+        open={showRegulationsDialog}
+        onOpenChange={setShowRegulationsDialog}
+      >
+        <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <BookOpen className="h-5 w-5 text-nycu-blue-600" />
+              {t.regulationsDialogTitle}
+            </DialogTitle>
+            <DialogDescription>{t.regulationsDialogSubtitle}</DialogDescription>
+          </DialogHeader>
+          {regulationsViewerUrl && (
+            <InlinePdfViewer
+              url={regulationsViewerUrl}
+              height={Math.min(typeof window !== "undefined" ? window.innerHeight - 220 : 600, 700)}
+              locale={locale}
+              onReachedBottom={() => setHasReadNotice(true)}
+            />
+          )}
+          <div className="flex items-center justify-between pt-3 border-t mt-2">
+            <p
+              className={`text-sm font-medium flex items-center gap-2 ${
+                hasReadNotice ? "text-emerald-700" : "text-amber-700"
+              }`}
+            >
+              {hasReadNotice ? (
+                <>
+                  <CheckCircle className="h-4 w-4" />
+                  {t.readNoticeDone}
+                </>
+              ) : (
+                <>
+                  <AlertCircle className="h-4 w-4" />
+                  {t.readNoticeHint}
+                </>
+              )}
+            </p>
+            <Button
+              variant={hasReadNotice ? "default" : "outline"}
+              size="sm"
+              onClick={() => setShowRegulationsDialog(false)}
+              className={hasReadNotice ? "nycu-gradient text-white" : ""}
+            >
+              {locale === "zh" ? "關閉" : "Close"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import {
   Card,
   CardContent,
@@ -81,7 +81,7 @@ export function NoticeAgreementStep({
     setShowPreview(true);
   };
 
-  const regulationsViewerUrl = (() => {
+  const regulationsViewerUrl = useMemo(() => {
     const objectName = publicDocs.regulations_url;
     if (!objectName) return null;
     const token =
@@ -92,7 +92,7 @@ export function NoticeAgreementStep({
     return `/api/v1/system-settings/file-proxy?key=regulations_url&token=${encodeURIComponent(
       token,
     )}&v=${cacheBuster}`;
-  })();
+  }, [publicDocs.regulations_url]);
 
   const notices = {
     zh: {

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -463,7 +463,7 @@ export function NoticeAgreementStep({
           {regulationsViewerUrl && (
             <InlinePdfViewer
               url={regulationsViewerUrl}
-              height={Math.min(typeof window !== "undefined" ? window.innerHeight - 220 : 600, 700)}
+              className="h-[min(700px,calc(90vh-200px))]"
               locale={locale}
               onReachedBottom={() => setHasReadNotice(true)}
             />

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
   Card,
   CardContent,
@@ -28,6 +28,8 @@ import {
   BookOpen,
 } from "lucide-react";
 import { api } from "@/lib/api";
+import { buildFileProxyUrl } from "@/lib/api/modules/system-settings";
+import { previewMimeType } from "@/lib/utils";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { InlinePdfViewer } from "@/components/inline-pdf-viewer";
 
@@ -37,6 +39,150 @@ interface NoticeAgreementStepProps {
   onNext: () => void;
   locale: "zh" | "en";
 }
+
+// Static locale copy hoisted to module scope so the ~140-line object isn't
+// reallocated on every render.
+const NOTICES = {
+  zh: {
+    title: "獎學金申請注意事項",
+    subtitle:
+      "請詳細閱讀以下內容，點擊「閱讀獎學金要點」並滑至底部後方可勾選同意繼續申請",
+    items: [
+      {
+        title: "申請資格",
+        content:
+          "申請人必須為本校在學學生，且符合各獎學金規定的申請條件。請確認您的學籍狀態與申請資格。",
+      },
+      {
+        title: "申請期限",
+        content:
+          "各獎學金有不同的申請期限，逾期申請恕不受理。請注意各獎學金的開放申請日期與截止日期。",
+      },
+      {
+        title: "文件準備",
+        content:
+          "請備妥所需文件，包括但不限於成績單、在學證明、指導教授推薦函等。所有文件必須為清晰可辨識的電子檔案（PDF、JPG、JPEG 或 PNG 格式）。",
+      },
+      {
+        title: "資料正確性",
+        content:
+          "申請人應確保所填寫資料及上傳文件之正確性與真實性。如有虛偽不實，將取消申請資格並依校規處理。",
+      },
+      {
+        title: "個人資料使用",
+        content:
+          "您的個人資料將僅用於獎學金申請審核及後續相關作業，本校將依個人資料保護法規定妥善保管。",
+      },
+      {
+        title: "審核流程",
+        content:
+          "申請送出後將經過系所初審、院級複審及行政單位核定等程序。審核期間請隨時注意系統通知。",
+      },
+      {
+        title: "獎金撥款",
+        content:
+          "獲獎學生請確認銀行帳戶資料正確無誤，獎學金將於核定後撥款至指定帳戶。",
+      },
+      {
+        title: "申請撤回",
+        content:
+          "申請送出後如需撤回，請於審核開始前聯繫承辦單位。審核程序啟動後將無法撤回申請。",
+      },
+    ],
+    importantNotice: "重要提醒",
+    importantContent:
+      "請務必詳細閱讀各獎學金的申請條款與相關規定。每位學生每學期限申請一項獎學金，請謹慎選擇。",
+    agreementText: "我已詳細閱讀並了解獎學金要點，同意遵守相關規定",
+    readNoticeText: "尚未閱讀獎學金要點",
+    readNoticeHint: "請點擊上方按鈕開啟獎學金要點並滑至底端",
+    readNoticeDone: "已閱讀完成",
+    nextButton: "同意並繼續",
+    readFirst: "請先點擊「閱讀獎學金要點」並滑至底端",
+    sampleDocumentLabel: "申請文件範例檔",
+    sampleDocumentRow: "需要參考申請文件格式？",
+    sampleDocumentNotProvided: "尚未提供",
+    regulationsHeader: "獎學金要點",
+    regulationsOpenButton: "閱讀獎學金要點",
+    regulationsRow: "請開啟並閱讀獎學金要點全文",
+    regulationsDialogTitle: "獎學金要點",
+    regulationsDialogSubtitle: "請滑動至文件底端以完成閱讀",
+    regulationsMissing:
+      "系統管理員尚未上傳獎學金要點，目前無法進行申請。請聯絡承辦單位。",
+    regulationsLoading: "正在檢查獎學金要點…",
+    closeButton: "關閉",
+  },
+  en: {
+    title: "Scholarship Application Notice",
+    subtitle:
+      "Read the following carefully. Scroll the Scholarship Regulations below to the bottom before agreeing to continue.",
+    items: [
+      {
+        title: "Eligibility",
+        content:
+          "Applicants must be currently enrolled students and meet the specific requirements of each scholarship. Please verify your enrollment status and eligibility.",
+      },
+      {
+        title: "Application Deadline",
+        content:
+          "Each scholarship has different application deadlines. Late applications will not be accepted. Please note the opening and closing dates for each scholarship.",
+      },
+      {
+        title: "Document Preparation",
+        content:
+          "Please prepare all required documents, including but not limited to transcripts, enrollment certificates, and advisor recommendation letters. All documents must be clear electronic files (PDF, JPG, JPEG, or PNG format).",
+      },
+      {
+        title: "Data Accuracy",
+        content:
+          "Applicants must ensure the accuracy and authenticity of all information and uploaded documents. False information will result in disqualification and disciplinary action according to university regulations.",
+      },
+      {
+        title: "Personal Data Usage",
+        content:
+          "Your personal data will be used solely for scholarship application review and related procedures. The university will safeguard your data according to Personal Data Protection Act.",
+      },
+      {
+        title: "Review Process",
+        content:
+          "After submission, applications will go through department preliminary review, college review, and administrative approval. Please monitor system notifications during the review period.",
+      },
+      {
+        title: "Award Distribution",
+        content:
+          "Award recipients should ensure their bank account information is correct. Scholarships will be disbursed to the designated account after approval.",
+      },
+      {
+        title: "Application Withdrawal",
+        content:
+          "If you need to withdraw your application after submission, please contact the administrative office before the review begins. Withdrawal is not possible once the review process has started.",
+      },
+    ],
+    importantNotice: "Important Notice",
+    importantContent:
+      "Please read the terms and conditions of each scholarship carefully. Each student may only apply for one scholarship per semester. Choose wisely.",
+    agreementText:
+      "I have read and understand the scholarship regulations and agree to comply",
+    readNoticeText: "Regulations not yet read",
+    readNoticeHint:
+      "Click the button above to open the regulations and scroll to the bottom",
+    readNoticeDone: "Reading complete",
+    nextButton: "Agree and Continue",
+    readFirst: "Open the regulations and scroll to the bottom first",
+    sampleDocumentLabel: "Sample Application Documents",
+    sampleDocumentRow: "Need to see the application document format?",
+    sampleDocumentNotProvided: "Not available",
+    regulationsHeader: "Scholarship Regulations",
+    regulationsOpenButton: "Open Scholarship Regulations",
+    regulationsRow: "Open and read the full scholarship regulations",
+    regulationsDialogTitle: "Scholarship Regulations",
+    regulationsDialogSubtitle:
+      "Scroll to the bottom of the document to complete reading",
+    regulationsMissing:
+      "The system administrator has not uploaded the scholarship regulations. Applications cannot proceed. Please contact the administrative office.",
+    regulationsLoading: "Checking scholarship regulations…",
+    closeButton: "Close",
+  },
+} as const;
 
 export function NoticeAgreementStep({
   agreedToTerms,
@@ -59,7 +205,6 @@ export function NoticeAgreementStep({
     filename: string;
     type: string;
   } | null>(null);
-  const [showPreview, setShowPreview] = useState(false);
 
   useEffect(() => {
     api.systemSettings.getPublicDocs().then((res) => {
@@ -68,181 +213,30 @@ export function NoticeAgreementStep({
     });
   }, []);
 
-  const handleOpenSampleDoc = (label: string) => {
-    const token = localStorage.getItem("auth_token") || "";
-    const objectName = publicDocs.sample_document_url;
-    const originalName = publicDocs.sample_document_url_filename;
-    const cacheBuster = encodeURIComponent(objectName?.split("/").pop() || "");
-    const url = `/api/v1/system-settings/file-proxy?key=sample_document_url&token=${encodeURIComponent(
-      token,
-    )}&v=${cacheBuster}`;
-    const filename = originalName || label;
-    const lower = (originalName || objectName || "").toLowerCase();
-    let type = "application/pdf";
-    if (lower.endsWith(".doc")) type = "application/msword";
-    else if (lower.endsWith(".docx"))
-      type =
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-    else if (lower.endsWith(".jpg") || lower.endsWith(".jpeg"))
-      type = "image/jpeg";
-    else if (lower.endsWith(".png")) type = "image/png";
-    setPreviewFile({ url, filename, type });
-    setShowPreview(true);
-  };
-
-  const regulationsViewerUrl = useMemo(() => {
-    const objectName = publicDocs.regulations_url;
-    if (!objectName) return null;
-    const token =
-      typeof window !== "undefined"
-        ? localStorage.getItem("auth_token") || ""
-        : "";
-    const cacheBuster = encodeURIComponent(objectName.split("/").pop() || "");
-    return `/api/v1/system-settings/file-proxy?key=regulations_url&token=${encodeURIComponent(
-      token,
-    )}&v=${cacheBuster}`;
-  }, [publicDocs.regulations_url]);
-
-  const notices = {
-    zh: {
-      title: "獎學金申請注意事項",
-      subtitle:
-        "請詳細閱讀以下內容，點擊「閱讀獎學金要點」並滑至底部後方可勾選同意繼續申請",
-      items: [
-        {
-          title: "申請資格",
-          content:
-            "申請人必須為本校在學學生，且符合各獎學金規定的申請條件。請確認您的學籍狀態與申請資格。",
-        },
-        {
-          title: "申請期限",
-          content:
-            "各獎學金有不同的申請期限，逾期申請恕不受理。請注意各獎學金的開放申請日期與截止日期。",
-        },
-        {
-          title: "文件準備",
-          content:
-            "請備妥所需文件，包括但不限於成績單、在學證明、指導教授推薦函等。所有文件必須為清晰可辨識的電子檔案（PDF、JPG、JPEG 或 PNG 格式）。",
-        },
-        {
-          title: "資料正確性",
-          content:
-            "申請人應確保所填寫資料及上傳文件之正確性與真實性。如有虛偽不實，將取消申請資格並依校規處理。",
-        },
-        {
-          title: "個人資料使用",
-          content:
-            "您的個人資料將僅用於獎學金申請審核及後續相關作業，本校將依個人資料保護法規定妥善保管。",
-        },
-        {
-          title: "審核流程",
-          content:
-            "申請送出後將經過系所初審、院級複審及行政單位核定等程序。審核期間請隨時注意系統通知。",
-        },
-        {
-          title: "獎金撥款",
-          content:
-            "獲獎學生請確認銀行帳戶資料正確無誤，獎學金將於核定後撥款至指定帳戶。",
-        },
-        {
-          title: "申請撤回",
-          content:
-            "申請送出後如需撤回，請於審核開始前聯繫承辦單位。審核程序啟動後將無法撤回申請。",
-        },
-      ],
-      importantNotice: "重要提醒",
-      importantContent:
-        "請務必詳細閱讀各獎學金的申請條款與相關規定。每位學生每學期限申請一項獎學金，請謹慎選擇。",
-      agreementText: "我已詳細閱讀並了解獎學金要點，同意遵守相關規定",
-      readNoticeText: "尚未閱讀獎學金要點",
-      readNoticeHint: "請點擊上方按鈕開啟獎學金要點並滑至底端",
-      readNoticeDone: "已閱讀完成",
-      nextButton: "同意並繼續",
-      readFirst: "請先點擊「閱讀獎學金要點」並滑至底端",
-      sampleDocumentLabel: "申請文件範例檔",
-      sampleDocumentRow: "需要參考申請文件格式？",
-      sampleDocumentNotProvided: "尚未提供",
-      regulationsHeader: "獎學金要點",
-      regulationsOpenButton: "閱讀獎學金要點",
-      regulationsRow: "請開啟並閱讀獎學金要點全文",
-      regulationsDialogTitle: "獎學金要點",
-      regulationsDialogSubtitle: "請滑動至文件底端以完成閱讀",
-      regulationsMissing:
-        "系統管理員尚未上傳獎學金要點，目前無法進行申請。請聯絡承辦單位。",
-      regulationsLoading: "正在檢查獎學金要點…",
+  const handleOpenSampleDoc = useCallback(
+    (label: string) => {
+      const objectName = publicDocs.sample_document_url;
+      const url = buildFileProxyUrl("sample_document_url", objectName);
+      if (!url) return;
+      const originalName = publicDocs.sample_document_url_filename;
+      const filename = originalName || label;
+      const type = previewMimeType(originalName || objectName || "");
+      setPreviewFile({ url, filename, type });
     },
-    en: {
-      title: "Scholarship Application Notice",
-      subtitle:
-        "Read the following carefully. Scroll the Scholarship Regulations below to the bottom before agreeing to continue.",
-      items: [
-        {
-          title: "Eligibility",
-          content:
-            "Applicants must be currently enrolled students and meet the specific requirements of each scholarship. Please verify your enrollment status and eligibility.",
-        },
-        {
-          title: "Application Deadline",
-          content:
-            "Each scholarship has different application deadlines. Late applications will not be accepted. Please note the opening and closing dates for each scholarship.",
-        },
-        {
-          title: "Document Preparation",
-          content:
-            "Please prepare all required documents, including but not limited to transcripts, enrollment certificates, and advisor recommendation letters. All documents must be clear electronic files (PDF, JPG, JPEG, or PNG format).",
-        },
-        {
-          title: "Data Accuracy",
-          content:
-            "Applicants must ensure the accuracy and authenticity of all information and uploaded documents. False information will result in disqualification and disciplinary action according to university regulations.",
-        },
-        {
-          title: "Personal Data Usage",
-          content:
-            "Your personal data will be used solely for scholarship application review and related procedures. The university will safeguard your data according to Personal Data Protection Act.",
-        },
-        {
-          title: "Review Process",
-          content:
-            "After submission, applications will go through department preliminary review, college review, and administrative approval. Please monitor system notifications during the review period.",
-        },
-        {
-          title: "Award Distribution",
-          content:
-            "Award recipients should ensure their bank account information is correct. Scholarships will be disbursed to the designated account after approval.",
-        },
-        {
-          title: "Application Withdrawal",
-          content:
-            "If you need to withdraw your application after submission, please contact the administrative office before the review begins. Withdrawal is not possible once the review process has started.",
-        },
-      ],
-      importantNotice: "Important Notice",
-      importantContent:
-        "Please read the terms and conditions of each scholarship carefully. Each student may only apply for one scholarship per semester. Choose wisely.",
-      agreementText:
-        "I have read and understand the scholarship regulations and agree to comply",
-      readNoticeText: "Regulations not yet read",
-      readNoticeHint:
-        "Click the button above to open the regulations and scroll to the bottom",
-      readNoticeDone: "Reading complete",
-      nextButton: "Agree and Continue",
-      readFirst: "Open the regulations and scroll to the bottom first",
-      sampleDocumentLabel: "Sample Application Documents",
-      sampleDocumentRow: "Need to see the application document format?",
-      sampleDocumentNotProvided: "Not available",
-      regulationsHeader: "Scholarship Regulations",
-      regulationsOpenButton: "Open Scholarship Regulations",
-      regulationsRow: "Open and read the full scholarship regulations",
-      regulationsDialogTitle: "Scholarship Regulations",
-      regulationsDialogSubtitle: "Scroll to the bottom of the document to complete reading",
-      regulationsMissing:
-        "The system administrator has not uploaded the scholarship regulations. Applications cannot proceed. Please contact the administrative office.",
-      regulationsLoading: "Checking scholarship regulations…",
-    },
-  };
+    [publicDocs.sample_document_url, publicDocs.sample_document_url_filename],
+  );
 
-  const t = notices[locale];
+  const handleOpenRegulationsDialog = useCallback(
+    () => setShowRegulationsDialog(true),
+    [],
+  );
+  const handleReachedBottom = useCallback(
+    () => setHasReadNotice(true),
+    [],
+  );
+
+  const hasRegulationsUploaded = Boolean(publicDocs.regulations_url);
+  const t = NOTICES[locale];
 
   return (
     <div className="space-y-6">
@@ -259,7 +253,6 @@ export function NoticeAgreementStep({
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Important Notice Alert */}
           <Alert className="border-amber-200 bg-amber-50">
             <AlertTriangle className="h-5 w-5 text-amber-600" />
             <AlertDescription>
@@ -270,7 +263,6 @@ export function NoticeAgreementStep({
             </AlertDescription>
           </Alert>
 
-          {/* 8-item static summary (no scroll, no gate) */}
           <Card className="border-2">
             <div className="p-6">
               <div className="space-y-4">
@@ -298,8 +290,6 @@ export function NoticeAgreementStep({
             </div>
           </Card>
 
-          {/* Reference row: sample document button (regulations are rendered
-              inline below, so they no longer need a button here). */}
           <div className="p-4 bg-blue-50 rounded-lg border border-blue-200 flex items-center justify-between gap-3">
             <p className="text-sm text-blue-900">{t.sampleDocumentRow}</p>
             <Button
@@ -319,12 +309,11 @@ export function NoticeAgreementStep({
             </Button>
           </div>
 
-          {/* Regulations dialog trigger (the gated content) */}
           {!docsLoaded ? (
             <div className="p-4 bg-gray-50 rounded-lg border border-gray-200 text-sm text-gray-500">
               {t.regulationsLoading}
             </div>
-          ) : regulationsViewerUrl ? (
+          ) : hasRegulationsUploaded ? (
             <div
               className={`p-4 rounded-lg border flex items-center justify-between gap-3 transition-colors ${
                 hasReadNotice
@@ -350,7 +339,7 @@ export function NoticeAgreementStep({
               <Button
                 variant={hasReadNotice ? "outline" : "default"}
                 size="sm"
-                onClick={() => setShowRegulationsDialog(true)}
+                onClick={handleOpenRegulationsDialog}
                 className={`flex items-center gap-2 ${
                   !hasReadNotice ? "nycu-gradient text-white" : ""
                 }`}
@@ -371,7 +360,6 @@ export function NoticeAgreementStep({
             </Alert>
           )}
 
-          {/* Read confirmation — auto-checked when viewer reports bottom reached */}
           <div
             className={`flex items-center space-x-2 p-4 rounded-lg transition-colors ${
               hasReadNotice
@@ -388,7 +376,6 @@ export function NoticeAgreementStep({
             </Label>
           </div>
 
-          {/* Agreement checkbox */}
           <div
             className={`p-6 rounded-lg border-2 transition-all ${
               hasReadNotice
@@ -425,7 +412,6 @@ export function NoticeAgreementStep({
             </div>
           </div>
 
-          {/* Action buttons */}
           <div className="flex justify-end pt-4">
             <Button
               onClick={onNext}
@@ -442,8 +428,8 @@ export function NoticeAgreementStep({
       </Card>
 
       <FilePreviewDialog
-        isOpen={showPreview}
-        onClose={() => setShowPreview(false)}
+        isOpen={previewFile !== null}
+        onClose={() => setPreviewFile(null)}
         file={previewFile}
         locale={locale}
       />
@@ -460,12 +446,16 @@ export function NoticeAgreementStep({
             </DialogTitle>
             <DialogDescription>{t.regulationsDialogSubtitle}</DialogDescription>
           </DialogHeader>
-          {regulationsViewerUrl && (
+          {hasRegulationsUploaded && (
             <InlinePdfViewer
-              url={regulationsViewerUrl}
+              url={buildFileProxyUrl(
+                "regulations_url",
+                publicDocs.regulations_url,
+              )!}
+              // 200px = DialogHeader + DialogContent padding + footer row + border.
               className="h-[min(700px,calc(90vh-200px))]"
               locale={locale}
-              onReachedBottom={() => setHasReadNotice(true)}
+              onReachedBottom={handleReachedBottom}
             />
           )}
           <div className="flex items-center justify-between pt-3 border-t mt-2">
@@ -492,7 +482,7 @@ export function NoticeAgreementStep({
               onClick={() => setShowRegulationsDialog(false)}
               className={hasReadNotice ? "nycu-gradient text-white" : ""}
             >
-              {locale === "zh" ? "關閉" : "Close"}
+              {t.closeButton}
             </Button>
           </div>
         </DialogContent>

--- a/frontend/lib/api/modules/system-settings.ts
+++ b/frontend/lib/api/modules/system-settings.ts
@@ -14,6 +14,33 @@ import { typedClient } from '../typed-client';
 import { toApiResponse } from '../compat';
 import type { ApiResponse } from '../types';
 
+/** Keys for system-managed documents served via /system-settings/file-proxy. */
+export type DocKey = 'regulations_url' | 'sample_document_url';
+
+/**
+ * Build the file-proxy URL used by FilePreviewDialog and InlinePdfViewer.
+ *
+ * Reads `auth_token` from localStorage at call time (so a refreshed token
+ * is picked up). Appends a cache-buster derived from the stored object
+ * name's filename so a fresh upload bypasses the browser cache.
+ *
+ * Returns `null` when `objectName` is falsy.
+ */
+export function buildFileProxyUrl(
+  key: DocKey,
+  objectName?: string | null
+): string | null {
+  if (!objectName) return null;
+  const token =
+    typeof window !== 'undefined'
+      ? localStorage.getItem('auth_token') || ''
+      : '';
+  const cacheBuster = encodeURIComponent(objectName.split('/').pop() || '');
+  return `/api/v1/system-settings/file-proxy?key=${key}&token=${encodeURIComponent(
+    token
+  )}&v=${cacheBuster}`;
+}
+
 // System configuration types
 type SystemConfiguration = {
   key: string;

--- a/frontend/lib/pdf-worker.ts
+++ b/frontend/lib/pdf-worker.ts
@@ -1,8 +1,10 @@
 // Configures the pdf.js worker for react-pdf. Imported once by
 // InlinePdfViewer so the worker URL is set before any <Document> mounts.
+//
+// Turbopack does not resolve `new URL("pdfjs-dist/...", import.meta.url)`
+// for npm package paths, so we serve the worker from /public instead. The
+// `copy-pdf-worker` script (run via postinstall + predev + prebuild) copies
+// pdfjs-dist/build/pdf.worker.min.mjs into public/.
 import { pdfjs } from "react-pdf";
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  "pdfjs-dist/build/pdf.worker.min.mjs",
-  import.meta.url,
-).toString();
+pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";

--- a/frontend/lib/pdf-worker.ts
+++ b/frontend/lib/pdf-worker.ts
@@ -1,0 +1,8 @@
+// Configures the pdf.js worker for react-pdf. Imported once by
+// InlinePdfViewer so the worker URL is set before any <Document> mounts.
+import { pdfjs } from "react-pdf";
+
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  "pdfjs-dist/build/pdf.worker.min.mjs",
+  import.meta.url,
+).toString();

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -32,6 +32,21 @@ export function formatDateTime(dateString: string | null | undefined): string {
 }
 
 /**
+ * Map a filename's extension to a preview MIME type used by FilePreviewDialog
+ * and similar viewers. Falls back to `application/octet-stream`.
+ */
+export function previewMimeType(name: string): string {
+  const lower = name.toLowerCase();
+  if (lower.endsWith(".pdf")) return "application/pdf";
+  if (lower.endsWith(".doc")) return "application/msword";
+  if (lower.endsWith(".docx"))
+    return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".png")) return "image/png";
+  return "application/octet-stream";
+}
+
+/**
  * Get badge variant based on status
  */
 export function getStatusBadgeVariant(status: string): "default" | "secondary" | "destructive" | "outline" {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,6 +58,7 @@
         "react-dom": "^18.3.1",
         "react-email": "4.3.0",
         "react-hook-form": "^7.54.1",
+        "react-pdf": "^9.2.1",
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.0",
         "sonner": "^1.7.4",
@@ -1974,7 +1975,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2629,7 +2629,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2651,7 +2650,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2673,7 +2671,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2689,7 +2686,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2705,7 +2701,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2721,7 +2716,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2737,7 +2731,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2753,7 +2746,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2769,7 +2761,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2785,7 +2776,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2801,7 +2791,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2817,7 +2806,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2839,7 +2827,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2861,7 +2848,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2883,7 +2869,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2905,7 +2890,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2927,7 +2911,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2949,7 +2932,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2971,7 +2953,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/runtime": "^1.5.0"
@@ -2990,7 +2971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3009,7 +2989,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3028,7 +3007,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8786,7 +8764,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -8836,7 +8814,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -8928,7 +8906,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -9738,6 +9716,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -10029,6 +10017,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/engine.io": {
       "version": "6.6.7",
@@ -10921,6 +10919,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -11179,6 +11187,13 @@
         }
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -11361,6 +11376,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -11689,7 +11711,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -11782,7 +11804,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/input-otp": {
       "version": "1.4.1",
@@ -13625,6 +13654,15 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/make-cancellable-promise": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.3.2.tgz",
+      "integrity": "sha512-GCXh3bq/WuMbS+Ky4JBPW1hYTOU+znU+Q5m9Pu+pI8EoUqIHk9+tviOKC6/qhHh8C4/As3tzJ69IF32kdz85ww==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -13657,6 +13695,15 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "node_modules/make-event-props": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.6.2.tgz",
+      "integrity": "sha512-iDwf7mA03WPiR8QxvcVHmVWEPfMY1RZXerDVNCRYW7dUr2ppH3J58Rwb39/WG39yTZdRSxr3x+2v22tvI0VEvA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -13702,6 +13749,23 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+    },
+    "node_modules/merge-refs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.3.0.tgz",
+      "integrity": "sha512-nqXPXbso+1dcKDpPCXvwZyJILz+vSLqGGOnDrYHQYE+B8n9JTCekVLC65AfCpR4ggVyA/45Y0iR9LDyS2iI+zA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -13819,6 +13883,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/module-punycode": {
       "name": "punycode",
       "version": "2.3.1",
@@ -13875,6 +13946,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -13970,6 +14048,39 @@
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -14211,6 +14322,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -14516,10 +14637,48 @@
         "node": ">=8"
       }
     },
+    "node_modules/path2d": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
+      "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.8.69",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.8.69.tgz",
+      "integrity": "sha512-IHZsA4T7YElCKNNXtiLgqScw4zPd3pG9do8UrznC757gMd7UPeHSL2qwNNMJo4r79fl8oj1Xx+1nh2YkzdMpLQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^3.0.0-rc2",
+        "path2d": "^0.2.1"
+      }
+    },
+    "node_modules/pdfjs-dist/node_modules/canvas": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+      "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
     },
     "node_modules/peberminta": {
       "version": "0.9.0",
@@ -14973,6 +15132,89 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15094,6 +15336,17 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -15143,6 +15396,32 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -15489,6 +15768,35 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/react-pdf": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-9.2.1.tgz",
+      "integrity": "sha512-AJt0lAIkItWEZRA5d/mO+Om4nPCuTiQ0saA+qItO967DTjmGjnhmF+Bi2tL286mOTfBlF5CyLzJ35KTMaDoH+A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^1.3.1",
+        "make-event-props": "^1.6.0",
+        "merge-refs": "^1.3.0",
+        "pdfjs-dist": "4.8.69",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-promise-suspense": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/react-promise-suspense/-/react-promise-suspense-0.3.4.tgz",
@@ -15618,7 +15926,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -15957,7 +16265,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -16304,6 +16612,27 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -16535,7 +16864,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -16976,6 +17305,43 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/terser": {
       "version": "5.47.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
@@ -17337,6 +17703,19 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -17783,6 +18162,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -18073,6 +18461,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,6 +80,7 @@
     "react-dom": "^18.3.1",
     "react-email": "4.3.0",
     "react-hook-form": "^7.54.1",
+    "react-pdf": "^9.2.1",
     "react-resizable-panels": "^2.1.7",
     "recharts": "2.15.0",
     "sonner": "^1.7.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,10 @@
     "npm": ">=10"
   },
   "scripts": {
+    "copy-pdf-worker": "node scripts/copy-pdf-worker.mjs",
+    "postinstall": "node scripts/copy-pdf-worker.mjs",
+    "predev": "node scripts/copy-pdf-worker.mjs",
+    "prebuild": "node scripts/copy-pdf-worker.mjs",
     "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",

--- a/frontend/scripts/copy-pdf-worker.mjs
+++ b/frontend/scripts/copy-pdf-worker.mjs
@@ -6,11 +6,17 @@
 // Runs from package.json on postinstall, predev, and prebuild. Idempotent.
 import { copyFileSync, mkdirSync, existsSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+// Anchor require.resolve to the frontend package root so it finds
+// node_modules even when invoked from a different cwd.
+const require = createRequire(resolve(here, "..", "package.json"));
 const src = require.resolve("pdfjs-dist/build/pdf.worker.min.mjs");
-const dest = "public/pdf.worker.min.mjs";
+// Resolve dest relative to the script's own location (frontend/scripts/),
+// so the script works no matter what cwd it was invoked from.
+const dest = resolve(here, "..", "public", "pdf.worker.min.mjs");
 
 mkdirSync(dirname(dest), { recursive: true });
 copyFileSync(src, dest);

--- a/frontend/scripts/copy-pdf-worker.mjs
+++ b/frontend/scripts/copy-pdf-worker.mjs
@@ -1,0 +1,22 @@
+// Copies pdf.js worker from node_modules into public/ so Next.js serves it
+// at /pdf.worker.min.mjs. Turbopack doesn't resolve `new URL(spec,
+// import.meta.url)` for npm package paths, so we ship the worker via the
+// static asset pipeline instead.
+//
+// Runs from package.json on postinstall, predev, and prebuild. Idempotent.
+import { copyFileSync, mkdirSync, existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
+
+const require = createRequire(import.meta.url);
+const src = require.resolve("pdfjs-dist/build/pdf.worker.min.mjs");
+const dest = "public/pdf.worker.min.mjs";
+
+mkdirSync(dirname(dest), { recursive: true });
+copyFileSync(src, dest);
+
+if (!existsSync(dest)) {
+  console.error(`copy-pdf-worker: dest ${dest} missing after copy`);
+  process.exit(1);
+}
+console.log(`copy-pdf-worker: ${src} -> ${dest}`);


### PR DESCRIPTION
## Summary
- Move the student-application scroll-to-agree gate from the hardcoded 8-item notice list onto the admin-uploaded 獎學金要點 PDF, rendered inline via `react-pdf`.
- Restrict the admin 獎學金要點 upload (both client and server) to PDF only. 申請文件範例檔 still accepts PDF/DOC/DOCX.
- Block the agreement step entirely when no 獎學金要點 has been uploaded, with a clear amber alert and disabled agree checkbox.
- Keep the 8 hardcoded notice items as a non-gated static summary; keep the 申請文件範例檔 button as a separate `FilePreviewDialog` opener.

## Files

**New**
- `frontend/lib/pdf-worker.ts` — pdf.js worker config (side-effect import)
- `frontend/components/inline-pdf-viewer.tsx` — reusable scroll-to-bottom PDF viewer
- `frontend/components/__tests__/inline-pdf-viewer.test.tsx` — 4 Jest cases
- `frontend/components/__tests__/notice-agreement-step.test.tsx` — 3 Jest cases
- `backend/app/tests/test_system_settings_upload_doc.py` — 4 pytest cases

**Modified**
- `frontend/components/student-wizard/steps/NoticeAgreementStep.tsx` — embed `InlinePdfViewer`, drop the regulations dialog button, empty/error states, updated zh/en copy
- `frontend/components/admin/system-docs/SystemDocsPanel.tsx` — per-slot `accepted` extensions; 獎學金要點 → `.pdf`, sample doc → `.pdf,.doc,.docx`
- `backend/app/api/v1/endpoints/system_settings.py` — server-side PDF MIME + extension guard for `upload_system_doc` when `doc_key == "regulations_url"`
- `frontend/package.json` — adds `react-pdf` ^9.2.1

## Design
See [`docs/superpowers/specs/2026-05-21-scholarship-regulations-scroll-gate-design.md`](docs/superpowers/specs/2026-05-21-scholarship-regulations-scroll-gate-design.md) and [the plan](docs/superpowers/plans/2026-05-21-scholarship-regulations-scroll-gate.md) (on `main`).

## Test plan
- [x] Frontend Jest: `inline-pdf-viewer.test.tsx` (4 pass), `notice-agreement-step.test.tsx` (3 pass)
- [x] Backend pytest: `test_system_settings_upload_doc.py` — `4 passed in 0.77s` (verified in Docker against this worktree)
- [x] `npm run type-check` — clean
- [ ] Manual smoke A — admin uploads a 1-page PDF → student sees auto-latched agree (short PDF fits without scroll)
- [ ] Manual smoke B — admin uploads a multi-page PDF → student must scroll to bottom of the viewer for agree to enable
- [ ] Manual smoke C — admin attempts `.docx` upload to 獎學金要點 → rejected at client (toast "僅接受 PDF") and server (HTTP 400 "獎學金要點僅接受 PDF 檔案")
- [ ] Manual smoke D — clear `regulations_url` from `system_settings` → student sees blocking alert, agree stays disabled

## Notes
- Per project policy ("NO BACKWARD COMPATIBILITY"), any pre-existing `.docx`/`.doc` in `regulations_url` is not auto-migrated. Admins re-upload as PDF; the viewer surfaces a load error until they do.
- Jest mocks of `@/lib/api` did not take effect via the path-aliased form in this repo's setup; the new `notice-agreement-step.test.tsx` uses the relative-path form (`jest.mock("../../lib/api", ...)`). Worth fixing repo-wide later, but out of scope here.