### PR TITLE
fix: sort renewal applications before new applications in Excel export and roster (#71)

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -58,9 +58,10 @@ def _sanitise_filename_part(value: str) -> str:
 
 
 def _sort_key(a: "Application"):
-    """Sort key that places applications with a missing std_stdcode last."""
+    """Sort key: renewal applications first, then by student code (blanks last)."""
     code = ((a.student_data or {}).get("std_stdcode") or "").strip()
-    return (not code, code, a.id)  # False(=0) for real codes → first; True(=1) for blanks → last
+    renewal_group = 0 if getattr(a, "is_renewal", False) else 1  # 0=renewal first, 1=new
+    return (renewal_group, not code, code, a.id)
 
 
 @router.get("/applications/department-summary-export")

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -729,7 +729,7 @@ class RosterService:
                 f"not applying semester filter for period {period_label}"
             )
 
-        return query.all()
+        return query.order_by(Application.is_renewal.desc(), Application.submitted_at).all()
 
     def _extract_semester_from_period(self, period_label: str) -> Optional[str]:
         """從期間標記提取學期資訊"""

--- a/backend/app/tests/test_application_summary_export_helpers.py
+++ b/backend/app/tests/test_application_summary_export_helpers.py
@@ -15,12 +15,12 @@ constants are critical:
     entry filename. A regression allowing `\\/:*?"<>|` would
     break ZIP creation on Windows extraction.
 
-  - **_sort_key(a)**: sorts applications by std_stdcode, with
-    missing/blank student codes pushed to the END. Critical for
-    the report's pedagogical order — admins read the list as
-    "real students first, anomalies later".
+  - **_sort_key(a)**: sorts applications with renewal applications
+    first, then by std_stdcode, with missing/blank student codes
+    pushed to the END within each group. Renewal-first order
+    matches the college ranking screen and roster list (issue #71).
 
-12 cases.
+13 cases.
 """
 
 from types import SimpleNamespace
@@ -94,11 +94,12 @@ def test_sanitise_whitespace_only_returns_untitled():
 # ─── _sort_key ──────────────────────────────────────────────────────
 
 
-def _app(std_stdcode, app_id):
+def _app(std_stdcode, app_id, is_renewal=False):
     """Build a duck-typed Application stand-in."""
     return SimpleNamespace(
         student_data={"std_stdcode": std_stdcode} if std_stdcode is not None else None,
         id=app_id,
+        is_renewal=is_renewal,
     )
 
 
@@ -144,3 +145,21 @@ def test_sort_handles_none_student_data_as_blank():
     sorted_apps = sorted(apps, key=_sort_key)
     assert sorted_apps[0].id == 2
     assert sorted_apps[1].id == 1
+
+
+def test_sort_renewal_apps_come_before_new_apps():
+    # Pin: renewal applications (is_renewal=True) sort FIRST,
+    # regardless of student code. Required by issue #71 — the
+    # 申請總表 Excel must match the college ranking screen order
+    # where renewal applications appear above new applications.
+    apps = [
+        _app("310460001", 1, is_renewal=False),  # new app, real code
+        _app("310460002", 2, is_renewal=True),  # renewal, real code
+        _app("", 3, is_renewal=False),  # new app, blank code
+    ]
+    sorted_apps = sorted(apps, key=_sort_key)
+    # Renewal (id=2) must come first
+    assert sorted_apps[0].id == 2
+    # New apps follow, real code before blank
+    assert sorted_apps[1].id == 1
+    assert sorted_apps[2].id == 3


### PR DESCRIPTION
Closes #71 (partial — addresses backend ordering for Excel export and roster list)

## Summary

- **`application_summary_export.py`**: Updated `_sort_key` so the 申請總表 Excel export places renewal applications (`is_renewal=True`) before new applications within each department sheet, matching the college ranking screen order.
- **`roster_service.py`**: Added `ORDER BY is_renewal DESC, submitted_at` to `_get_eligible_applications` so the payment roster list (造冊列表) maintains renewal-first order.
- **`test_application_summary_export_helpers.py`**: Added `is_renewal` field to the `_app` test helper and a new test case asserting renewal apps sort before new apps.

## What this does NOT change
The college ranking screen (學院排名畫面) already returns items sorted by `rank_position`, and `rank_position` is assigned renewal-first during ranking creation (see `CollegeReviewService._create_ranking_items`). A frontend UI change to visually separate renewal vs. new blocks would be a follow-up.

## Test plan
- [x] All 13 unit tests in `test_application_summary_export_helpers.py` pass (including the new renewal-first test)
- [x] Existing tests for blank-code-last and alphabetical ordering unaffected

> Auto-fix by scheduled agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNsEdUY51qGXmwhmWXC7Jn)_