### PR TITLE
fix(nightly): fix 3 E2E failures + Deployment Pipeline Docker build error

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -1590,7 +1590,7 @@ async def download_roster_excel(
     Download roster Excel file (supports MinIO and local files)
     """
     try:
-        stmt = select(PaymentRoster).where(PaymentRoster.id == roster_id)
+        stmt = select(PaymentRoster).options(selectinload(PaymentRoster.items)).where(PaymentRoster.id == roster_id)
 
         result = await db.execute(stmt)
 
@@ -1682,11 +1682,30 @@ async def download_roster_excel(
 
                 logger.info(f"Roster {roster.roster_code} re-generated and downloaded by user {current_user.id}")
 
-                return FileResponse(
-                    path=export_result["file_path"],
-                    filename=f"{roster.roster_code}.xlsx",
-                    media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                )
+                regen_file_path = export_result["file_path"]
+                if os.path.exists(regen_file_path):
+                    return FileResponse(
+                        path=regen_file_path,
+                        filename=f"{roster.roster_code}.xlsx",
+                        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    )
+
+                # Local file was cleaned up after MinIO upload — serve from MinIO.
+                minio_obj = export_result.get("minio_object_name")
+                if minio_obj:
+                    from fastapi.responses import Response
+
+                    file_content, _ = minio_service.download_roster_file(minio_obj)
+                    return Response(
+                        content=file_content,
+                        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                        headers={
+                            "Content-Disposition": f'attachment; filename="{roster.roster_code}.xlsx"',
+                            "Content-Length": str(len(file_content)),
+                        },
+                    )
+
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="下載造冊失敗")
 
     except HTTPException:
         raise

--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -207,6 +207,7 @@ class ExcelExportService:
                 "estimated_completion": estimated_completion,
             }
 
+        file_name: Optional[str] = None
         try:
             # 取得造冊明細
             roster_items = self._get_roster_items(roster, include_excluded)
@@ -489,8 +490,7 @@ class ExcelExportService:
         }
 
         if not excel_data:
-            validation_result["errors"].append("No data to export")
-            validation_result["is_valid"] = False
+            validation_result["warnings"].append("No roster items to export — generating header-only file")
             return validation_result
 
         # 統計資料

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,10 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/main" > /etc/apk/repositor
 WORKDIR /app
 
 # Install dependencies using bun
+# scripts/ must be present before install because the postinstall hook runs
+# scripts/copy-pdf-worker.mjs (copies pdfjs-dist worker into public/).
 COPY package.json bun.lockb* ./
+COPY scripts ./scripts
 RUN bun install --frozen-lockfile
 
 # Rebuild the source code only when needed

--- a/frontend/e2e/specs/admin-student-history.spec.ts
+++ b/frontend/e2e/specs/admin-student-history.spec.ts
@@ -17,6 +17,8 @@ test.describe("Admin student scholarship history", () => {
     const { context } = await loginAs(browser, "admin");
     const page = await context.newPage();
     await page.goto("/");
+    // AdminManagementShell renders inside the top-level "系統管理" (value="admin") tab.
+    await page.getByRole("tab", { name: "系統管理" }).click();
     await page.getByRole("tab", { name: "學生領取歷史" }).click();
     await page.getByLabel("學號").fill("@@");
     await page.getByRole("button", { name: "查詢" }).click();
@@ -28,6 +30,7 @@ test.describe("Admin student scholarship history", () => {
     const { context } = await loginAs(browser, "admin");
     const page = await context.newPage();
     await page.goto("/");
+    await page.getByRole("tab", { name: "系統管理" }).click();
     await page.getByRole("tab", { name: "學生領取歷史" }).click();
     await page.getByLabel("學號").fill("GHOST00000");
     await page.getByRole("button", { name: "查詢" }).click();
@@ -48,6 +51,7 @@ test.describe("Admin student scholarship history", () => {
     const { context } = await loginAs(browser, "admin");
     const page = await context.newPage();
     await page.goto("/");
+    await page.getByRole("tab", { name: "系統管理" }).click();
     await page.getByRole("tab", { name: "學生領取歷史" }).click();
     await page.getByLabel("學號").fill("stuphd001");
     await page.getByRole("button", { name: "查詢" }).click();


### PR DESCRIPTION
## Summary

- **E2E `admin-student-history`**: Added `"系統管理"` outer-tab click before `"學生領取歷史"` in all 3 tests — `AdminManagementShell` only renders after the outer tab is active, so every test was timing out waiting for a tab that didn't exist yet
- **Roster download HTTP 500 (MissingGreenlet)**: Added `selectinload(PaymentRoster.items)` to the download endpoint query — async SQLAlchemy can't lazy-load relationships
- **Roster download HTTP 500 (UnboundLocalError + empty roster + deleted local file)**: Three cascading bugs in `ExcelExportService.export_roster_to_excel`:
  - `file_name` referenced before assignment in `except` block → initialize to `None` before `try`
  - Empty roster treated as hard validation error → downgraded to warning (header-only Excel is valid)
  - After MinIO upload the local file is deleted; `FileResponse` on a deleted path raises `RuntimeError` → fall back to streaming from MinIO
- **Deployment Pipeline Docker build failure**: `frontend/Dockerfile` `deps` stage was missing `scripts/` when `bun install` ran, so the `postinstall` hook (`scripts/copy-pdf-worker.mjs`) couldn't execute → added `COPY scripts ./scripts` before `RUN bun install --frozen-lockfile`

## Test plan

- [ ] CI Quick Checks pass (lint + unit tests)
- [ ] Deployment Pipeline passes (Docker build now has `scripts/` in deps stage)
- [ ] Nightly E2E: `admin-student-history.spec.ts` all 3 tests pass (tab navigation fixed)
- [ ] Nightly E2E: roster download returns HTTP 200 (MissingGreenlet + export chain fixed)
- [ ] No regressions on other nightly specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)