### PR TITLE
ci(deploy): add staging auto-rollback on failure + downtime health monitor (#315)

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -195,6 +195,21 @@ jobs:
           cd ~/scholarship-staging
           echo "Deployment files prepared"
 
+      - name: Save last-good deployment tag
+        run: |
+          if [ -f ~/scholarship-staging/last-good-tag ]; then
+            echo "Previous good tag: $(cat ~/scholarship-staging/last-good-tag)"
+          fi
+          # Capture the CURRENTLY RUNNING tag before we stop it
+          CURRENT_RUNNING=""
+          if docker inspect scholarship_backend_staging >/dev/null 2>&1; then
+            CURRENT_RUNNING=$(docker inspect --format='{{index .Config.Labels "org.opencontainers.image.version"}}' scholarship_backend_staging 2>/dev/null || echo "")
+          fi
+          if [ -n "$CURRENT_RUNNING" ]; then
+            echo "$CURRENT_RUNNING" > ~/scholarship-staging/last-good-tag
+            echo "Saved running tag: $CURRENT_RUNNING"
+          fi
+
       - name: Stop old containers
         run: |
           cd ~/scholarship-staging
@@ -329,6 +344,50 @@ jobs:
           echo "- Backend: ✅ Running" >> $GITHUB_STEP_SUMMARY
           echo "- Frontend: ✅ Running" >> $GITHUB_STEP_SUMMARY
           echo "- Database: ✅ Migrated" >> $GITHUB_STEP_SUMMARY
+
+      - name: Rollback to last-good deployment
+        if: failure()
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          DATABASE_URL_SYNC: ${{ secrets.STAGING_DATABASE_URL_SYNC }}
+          SECRET_KEY: ${{ secrets.STAGING_SECRET_KEY }}
+          CORS_ORIGINS: ${{ secrets.STAGING_CORS_ORIGINS }}
+          MINIO_ENDPOINT: ${{ secrets.STAGING_MINIO_ENDPOINT }}
+          MINIO_ACCESS_KEY: ${{ secrets.STAGING_MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.STAGING_MINIO_SECRET_KEY }}
+          MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
+          FRONTEND_URL: ${{ secrets.STAGING_API_URL }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.STAGING_API_URL }}
+          NEXT_PUBLIC_NYCU_PORTAL_URL: ${{ secrets.NEXT_PUBLIC_NYCU_PORTAL_URL }}
+          NODE_ENV: ${{ secrets.NODE_ENV }}
+          STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
+          STUDENT_API_ACCOUNT: ${{ secrets.STUDENT_API_ACCOUNT }}
+          STUDENT_API_HMAC_KEY: ${{ secrets.STUDENT_API_HMAC_KEY }}
+          SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
+        run: |
+          cd ~/scholarship-staging
+          if [ -f ~/scholarship-staging/last-good-tag ]; then
+            PREV_TAG=$(cat ~/scholarship-staging/last-good-tag)
+            echo "::warning::Deploy failed — rolling back from ${{ needs.pre-deployment.outputs.version }} to $PREV_TAG"
+            TAG=$PREV_TAG docker compose up -d
+            echo "Rollback started. Waiting for health check..."
+            sleep 15
+            if curl -sf http://localhost:8000/health; then
+              echo "::notice::Rollback to $PREV_TAG succeeded. Staging is back online."
+            else
+              echo "::error::Rollback health check also failed. Manual intervention required."
+            fi
+          else
+            echo "::warning::No last-good-tag found — cannot auto-rollback. Containers remain down."
+          fi
+
+      - name: Record successful deployment tag
+        if: success()
+        run: |
+          echo "${{ needs.pre-deployment.outputs.version }}" > ~/scholarship-staging/last-good-tag
+          echo "Saved last-good tag: ${{ needs.pre-deployment.outputs.version }}"
 
   # Staging validation tests
   staging-tests:

--- a/.github/workflows/staging-health-monitor.yml
+++ b/.github/workflows/staging-health-monitor.yml
@@ -1,0 +1,73 @@
+name: Staging Health Monitor
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'  # Every 10 minutes
+  workflow_dispatch:
+
+jobs:
+  health-check:
+    name: Check Staging Health
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Check staging health endpoint
+        id: health
+        run: |
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 https://ss.test.nycu.edu.tw/health || echo "000")
+          echo "status=$HTTP_STATUS" >> $GITHUB_OUTPUT
+          echo "Staging health check: HTTP $HTTP_STATUS"
+
+      - name: Open issue on downtime
+        if: steps.health.outputs.status != '200'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const status = '${{ steps.health.outputs.status }}';
+            // Check if there's already an open staging-down issue
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'staging-down',
+              state: 'open',
+            });
+            if (issues.data.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Staging down: health check returned HTTP ${status}`,
+                body: `## Staging is down\n\nThe health check at https://ss.test.nycu.edu.tw/health returned HTTP ${status}.\n\n**Detected at**: ${new Date().toISOString()}\n\nThis issue was auto-filed by the staging health monitor. Close when staging is back online.`,
+                labels: ['staging-down'],
+              });
+            }
+
+      - name: Close resolved downtime issue
+        if: steps.health.outputs.status == '200'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'staging-down',
+              state: 'open',
+            });
+            for (const issue of issues.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `✅ Staging health check is now passing (HTTP 200). Auto-closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/staging-health-monitor.yml
+++ b/.github/workflows/staging-health-monitor.yml
@@ -8,18 +8,32 @@ on:
 jobs:
   health-check:
     name: Check Staging Health
-    runs-on: ubuntu-latest
+    # Must run on the self-hosted staging runner — ss.test.nycu.edu.tw is
+    # only reachable via WireGuard VPN, which github-hosted runners don't
+    # have. The self-hosted runner is on the staging server itself, so
+    # localhost checks are the most direct signal of service availability.
+    runs-on: [self-hosted, scholarship, test]
     permissions:
       issues: write
       contents: read
 
     steps:
-      - name: Check staging health endpoint
+      - name: Check staging health endpoints
         id: health
         run: |
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 https://ss.test.nycu.edu.tw/health || echo "000")
-          echo "status=$HTTP_STATUS" >> $GITHUB_OUTPUT
-          echo "Staging health check: HTTP $HTTP_STATUS"
+          # Check backend directly (avoids nginx routing issues)
+          BACKEND_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 http://localhost:8000/health || echo "000")
+          # Check frontend
+          FRONTEND_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 http://localhost:3000 || echo "000")
+          echo "backend=$BACKEND_STATUS" >> $GITHUB_OUTPUT
+          echo "frontend=$FRONTEND_STATUS" >> $GITHUB_OUTPUT
+          # Overall: healthy only if both return 200
+          if [ "$BACKEND_STATUS" = "200" ] && [ "$FRONTEND_STATUS" = "200" ]; then
+            echo "status=200" >> $GITHUB_OUTPUT
+          else
+            echo "status=down" >> $GITHUB_OUTPUT
+          fi
+          echo "Backend: $BACKEND_STATUS, Frontend: $FRONTEND_STATUS"
 
       - name: Open issue on downtime
         if: steps.health.outputs.status != '200'
@@ -27,7 +41,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const status = '${{ steps.health.outputs.status }}';
+            const backend = '${{ steps.health.outputs.backend }}';
+            const frontend = '${{ steps.health.outputs.frontend }}';
             // Check if there's already an open staging-down issue
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -39,8 +54,8 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `Staging down: health check returned HTTP ${status}`,
-                body: `## Staging is down\n\nThe health check at https://ss.test.nycu.edu.tw/health returned HTTP ${status}.\n\n**Detected at**: ${new Date().toISOString()}\n\nThis issue was auto-filed by the staging health monitor. Close when staging is back online.`,
+                title: `Staging down: backend=${backend} frontend=${frontend}`,
+                body: `## Staging is down\n\nHealth check failed:\n- Backend (localhost:8000/health): HTTP ${backend}\n- Frontend (localhost:3000): HTTP ${frontend}\n\n**Detected at**: ${new Date().toISOString()}\n\nThis issue was auto-filed by the staging health monitor. Close when staging is back online.`,
                 labels: ['staging-down'],
               });
             }


### PR DESCRIPTION
Closes #315.

## Summary

Two CI/CD changes to reduce staging downtime:

### Feature A — Auto-rollback in `deploy-staging`
Today the staging deploy stops the old containers, then runs `docker compose up -d` + `alembic upgrade head` + health checks. If anything after `down` fails, staging is offline until a human notices.

- **Save last-good tag** (new step, before `Stop old containers`): reads the version label off the currently-running `scholarship_backend_staging` container and writes it to `~/scholarship-staging/last-good-tag`. The recovery target is whatever was actually serving traffic, not whatever last passed.
- **Rollback** (new step at end of job, `if: failure()`): on any step failure, `TAG=$PREV_TAG docker compose up -d` brings the old release back up, then re-probes `/health`. Emits `::notice` on recovery, `::error` if rollback also fails.
- **Record successful tag** (new step at end of job, `if: success()`): only stamps the new tag as last-good when the whole job passes — a half-finished deploy can never overwrite the known-good marker.

### Feature B — `staging-health-monitor.yml`
New cron workflow (`*/10 * * * *`) that probes `https://ss.test.nycu.edu.tw/health`:
- Non-200 → opens a `staging-down`-labelled issue, with dedupe (only one open at a time).
- 200 with an existing `staging-down` issue → comments and closes it.

Uses `actions/github-script@v7` with `permissions: { issues: write, contents: read }` and the default `GITHUB_TOKEN` — no PAT needed.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(...))"` passes on both workflow files.
- `deploy-staging` job step order verified programmatically:
  1. … (5 setup steps)
  6. Save last-good deployment tag
  7. Stop old containers
  8. Start new containers
  9. Run database migrations
  10. Seed database
  11. Health check
  12. Run smoke tests
  13. Cleanup old images
  14. Deployment summary
  15. Rollback to last-good deployment   `[if: failure()]`
  16. Record successful deployment tag   `[if: success()]`

## Notes / follow-ups

- First deploy after this lands won't have a `last-good-tag` file yet; the rollback step logs a `::warning` and exits cleanly, so the first failure still requires manual recovery. Subsequent deploys are protected.
- The rollback relies on the backend image carrying an `org.opencontainers.image.version` label, which `docker/metadata-action@v5` already emits.
- Health monitor cron is GitHub-Actions–best-effort; expect drift up to several minutes during peak load. MTTR is still much better than waiting for a human report.

## Test plan
- [ ] Merge to main, watch the next `deploy-pipeline` run succeed and write `~/scholarship-staging/last-good-tag` on the self-hosted runner
- [ ] Trigger `Staging Health Monitor` via `workflow_dispatch` and confirm the run reports `HTTP 200`
- [ ] (Optional) Force-fail a deploy on a feature branch (e.g. by introducing a broken migration) to verify the rollback step actually flips the running tag back

🤖 Generated with [Claude Code](https://claude.com/claude-code)