### PR TITLE
fix(nginx): route system-settings upload/file proxy to frontend

### DIFF
--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -191,6 +191,53 @@ http {
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         }
 
+        # Next.js system-docs proxy routes (upload + inline file preview)
+        # Must reach the frontend so the Next.js route handlers run; otherwise
+        # these hit the backend directly (no matching route -> 405/404).
+        location /api/v1/system-settings/upload-proxy {
+            limit_req zone=frontend burst=30 nodelay;
+
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Request-ID $request_id;
+
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+
+            # Allow up to 10MB document uploads (backend enforces the 10MB cap)
+            client_max_body_size 11M;
+        }
+
+        location /api/v1/system-settings/file-proxy {
+            limit_req zone=frontend burst=30 nodelay;
+
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Request-ID $request_id;
+
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+
+            # Inline PDF preview renders in a same-origin iframe; re-declare
+            # SAMEORIGIN so the server-level X-Frame-Options DENY isn't inherited.
+            add_header X-Frame-Options SAMEORIGIN always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        }
+
         # Backend API routes (all other /api/ requests)
         location /api/ {
             limit_req zone=api burst=40 nodelay;

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -180,6 +180,51 @@ http {
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         }
 
+        # Next.js system-docs proxy routes (upload + inline file preview)
+        # Must reach the frontend so the Next.js route handlers run; otherwise
+        # these hit the backend directly (no matching route -> 405/404).
+        location /api/v1/system-settings/upload-proxy {
+            limit_req zone=frontend burst=20 nodelay;
+
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Request-ID $request_id;
+
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+
+            # Allow up to 10MB document uploads (backend enforces the 10MB cap)
+            client_max_body_size 11M;
+        }
+
+        location /api/v1/system-settings/file-proxy {
+            limit_req zone=frontend burst=20 nodelay;
+
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Request-ID $request_id;
+
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+
+            # Inline PDF preview renders in a same-origin iframe; re-declare
+            # SAMEORIGIN so the server-level X-Frame-Options DENY isn't inherited.
+            add_header X-Frame-Options SAMEORIGIN always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        }
+
         # Backend API routes (其他所有 /api/ 請求)
         location /api/ {
             # Handle OPTIONS requests directly (CORS preflight)


### PR DESCRIPTION
## Summary
Fixes `405 Method Not Allowed` on `POST /api/v1/system-settings/upload-proxy?key=regulations_url` (and a latent `404` on `file-proxy`) in staging/prod.

The Next.js route handlers `frontend/app/api/v1/system-settings/upload-proxy/route.ts` (POST) and `file-proxy/route.ts` (GET) proxy to the backend's `/upload/{key}` and `/file/{key}`. These work on localhost (Next dev serves the handlers), but nginx only whitelisted `/api/v1/download`, `/api/v1/preview`, and `/api/email/` to the frontend — **every other `/api/*` request goes straight to FastAPI**.

So on staging the upload hit FastAPI, which has no POST route for that path (it only matches the parameterized `/{id}` route for GET/PUT/DELETE) → **405**. `file-proxy` GET was likewise broken (resolves to `/{id}` → 404).

## Changes
Added two `location` blocks → frontend, in `nginx/nginx.staging.conf` and `nginx/nginx.prod.conf`, mirroring the existing download/preview/email pattern:
- `/api/v1/system-settings/upload-proxy` — `client_max_body_size 11M` (backend enforces a 10MB document cap)
- `/api/v1/system-settings/file-proxy` — re-declares `X-Frame-Options SAMEORIGIN` so the server-level `DENY` isn't inherited (inline PDF preview renders in a same-origin iframe)

Longest-prefix match beats `/api/`; `upload-proxy` ≠ the backend's `upload/{key}` path, so the backend route is unaffected.

## Deploy note
Config is baked into the nginx container — needs an nginx reload/redeploy on staging (and prod) to take effect:
```
docker compose -f docker-compose.staging.yml exec nginx nginx -s reload
```
(after the new config lands in the container; rebuild/restart the nginx service if it's COPY'd into the image).

## Test plan
- [ ] Deploy to staging, reload nginx
- [ ] As admin, upload a PDF for 獎學金要點 (`regulations_url`) → expect 200, not 405
- [ ] Upload 申請文件範例檔 (`sample_document_url`) → expect 200
- [ ] Verify inline PDF preview renders (file-proxy GET, iframe) for both docs
- [ ] Confirm a >10MB upload is rejected cleanly (backend 400), not nginx 413