### PR TITLE
fix(college-review): surface professor-reviewed apps awaiting college sign-off

### DIFF
--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -294,15 +294,24 @@ class CollegeReviewService:
         )
 
         # Base query for applications in reviewable state with comprehensive eager loading
-        # Phase 4 (renewal routing): for *pending* (under_review) applications we
-        # must restrict to those matching the current college review phase
-        # — renewal apps during renewal_college_review, general apps during
-        # college_review. Historical statuses (approved / partial_approved /
-        # rejected) remain visible unconditionally so reviewers can audit past
-        # decisions.
+        # Phase 4 (renewal routing): for *pending* applications we must restrict to
+        # those matching the current college review phase — renewal apps during
+        # renewal_college_review, general apps during college_review. Historical
+        # statuses (approved / partial_approved / rejected) remain visible
+        # unconditionally so reviewers can audit past decisions.
+        #
+        # Pending = submitted OR under_review. Professor review is advisory (issue
+        # #182): it advances review_stage to professor_reviewed but leaves status at
+        # ``submitted``, so a professor-reviewed app awaiting college sign-off is
+        # still ``submitted``. The professor listing already treats submitted as
+        # pending; the college listing must too, or these apps never surface here.
+        pending_statuses = [
+            ApplicationStatus.submitted.value,
+            ApplicationStatus.under_review.value,
+        ]
         pending_phase_subquery = (
             apply_renewal_phase_filter(
-                select(Application.id).where(Application.status == ApplicationStatus.under_review.value),
+                select(Application.id).where(Application.status.in_(pending_statuses)),
                 role="college",
                 alias_name="college_phase_cfg",
             )
@@ -319,9 +328,10 @@ class CollegeReviewService:
             )
             .where(
                 or_(
-                    # Under-review rows must match the current renewal/general phase
+                    # Pending rows (submitted / under_review) must match the current
+                    # renewal/general college review phase.
                     and_(
-                        Application.status == ApplicationStatus.under_review.value,
+                        Application.status.in_(pending_statuses),
                         Application.id.in_(select(pending_phase_subquery.c.id)),
                     ),
                     Application.status == ApplicationStatus.approved.value,  # 包含已核准的申請


### PR DESCRIPTION
## Problem

Student `csphd0001` submitted `APP-114-0-00001`, the assigned professor approved it (`review_stage=professor_reviewed`), yet the college reviewer's pending list showed nothing.

## Root cause

Professor review is **advisory** (issue #182, commits `00c0cfdd` + `ca7ca18b`): it advances `review_stage` → `professor_reviewed` but deliberately leaves `status=submitted` so a single professor approval can't bypass college review.

But the college listing query (`college_review_service.py`) only matched:

```
status IN (under_review, approved, partial_approved, rejected)
```

`submitted` was excluded. So a professor-reviewed application — which stays `submitted` until college signs off — never surfaced to the college reviewer, even once the college review window opened.

The **professor** listing (`application_service.py:2447`) already treats `submitted` as a pending status; the college listing was simply never aligned.

## Fix

Include `submitted` alongside `under_review` in the college pending set and the renewal/general phase-window subquery. Pending = `submitted OR under_review`, both gated by the college review window. No change to the deliberate issue-#182 advisory logic.

## Verification

Validated end-to-end against the local dev API as `cs_college`:

- College review window open + fix → app **visible** (`professor_review_completed: true`)
- Window restored to its configured future date → count 0 (intended phase-window behavior, unchanged)
- Isolation check: window open **before** the fix → still 0, confirming the `submitted` exclusion was the independent blocker

## Test plan

- [ ] Professor-reviewed (`status=submitted`) app appears in college pending list when the college review window is open
- [ ] App is hidden when the college review window is not open (phase gate intact)
- [ ] Historical `approved`/`partial_approved`/`rejected` apps still visible unconditionally
- [ ] `under_review` apps still behave as before
- [ ] Add real-DB regression test (existing college tests fully mock the service, so they cannot catch this)