### PR TITLE
fix(frontend): version-pin pdf.js worker URL to prevent stale cache

### DIFF
--- a/frontend/lib/pdf-worker.ts
+++ b/frontend/lib/pdf-worker.ts
@@ -5,6 +5,13 @@
 // for npm package paths, so we serve the worker from /public instead. The
 // `copy-pdf-worker` script (run via postinstall + predev + prebuild) copies
 // pdfjs-dist/build/pdf.worker.min.mjs into public/.
+//
+// The `?v=<pdfjs version>` query pins the worker URL to the bundled pdf.js
+// version. Without it, a browser that once received a 404 HTML page for the
+// bare /pdf.worker.min.mjs (e.g. a server started before the copy ran) keeps
+// replaying that cached HTML even after the file exists — pdf.js then logs
+// "Setting up fake worker" and fails with a module-MIME error. Bumping the
+// query on every version makes the URL unique, so a stale cache can't stick.
 import { pdfjs } from "react-pdf";
 
-pdfjs.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+pdfjs.GlobalWorkerOptions.workerSrc = `/pdf.worker.min.mjs?v=${pdfjs.version}`;


### PR DESCRIPTION
## Summary
- Student regulations preview (`InlinePdfViewer`) failed with `Setting up fake worker` + `Failed to load module script: ... MIME type "text/html"` → `無法載入文件`.
- Root cause: the worker URL `/pdf.worker.min.mjs` was served as **HTML** in the affected environment — a cached 404/SPA page that keeps replaying even after the worker file exists (server started before the `copy-pdf-worker` step), or a stale deploy predating the `/public` worker fix.
- Not a defect in current build: reproduced the full student flow on localhost **and** a clean production image — worker loads as `200 application/javascript`, PDF renders. CSP `strict-dynamic`, middleware, nginx, and missing-file-in-image were all tested and ruled out.

## Change
`frontend/lib/pdf-worker.ts`:
```ts
pdfjs.GlobalWorkerOptions.workerSrc = `/pdf.worker.min.mjs?v=${pdfjs.version}`;
```
The `?v=<pdfjs version>` query makes the URL unique per pdf.js version, so a stale-cached 404 can't stick and the worker always matches the bundled `pdfjs-dist` version.

## Verification
- Live: regulations dialog now loads `/pdf.worker.min.mjs?v=4.8.69` → `200 application/javascript`, PDF renders, no fake-worker / MIME errors.
- Static serving ignores the query (verified on both dev `:3000` and a prod build `:3100`).
- Existing `inline-pdf-viewer` test unaffected (it mocks `@/lib/pdf-worker`).

## Test plan
- [ ] Open a scholarship application as a student, click 閱讀獎學金要點, confirm the regulations PDF renders (no `無法載入文件`).
- [ ] Hard-reload after a fresh deploy and confirm no `Setting up fake worker` warning.
- [ ] If staging still shows the error: redeploy from current `main` (worker-from-`/public` fix `b3e78bbe` must be present).