### PR TITLE
fix(nginx): serve /pdf.worker.min.mjs via no-slash proxy

### DIFF
--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -322,6 +322,31 @@ http {
             add_header Cache-Control "public, immutable";
         }
 
+        # pdf.js worker for the regulations preview (react-pdf).
+        # Exact match so this only affects /pdf.worker.min.mjs and nothing else.
+        # MUST NOT fall through to `location /`: that block proxies with a
+        # trailing slash + variable upstream (`proxy_pass http://$var/;`), which
+        # mangles the request URI so the frontend treats the worker path as an
+        # app route and returns SPA HTML — pdf.js then fails with a module-MIME
+        # error ("responded with text/html"). The no-trailing-slash proxy here
+        # forwards the full request URI, serving the public file as JS.
+        location = /pdf.worker.min.mjs {
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Request-ID $request_id;
+
+            # SECURITY: Remove potentially sensitive headers
+            proxy_hide_header X-Powered-By;
+            proxy_hide_header Server;
+
+            add_header X-Content-Type-Options "nosniff";
+        }
+
         # Frontend routes (all other requests)
         location / {
             limit_req zone=frontend burst=100 nodelay;

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -373,6 +373,30 @@ http {
             add_header X-Content-Type-Options "nosniff";
         }
 
+        # pdf.js worker for the regulations preview (react-pdf).
+        # Exact match so this only affects /pdf.worker.min.mjs and nothing else.
+        # MUST NOT fall through to `location /`: that block proxies with a
+        # trailing slash + variable upstream (`proxy_pass http://$var/;`), which
+        # mangles the request URI so the frontend treats the worker path as an
+        # app route and returns SPA HTML — pdf.js then fails with a module-MIME
+        # error ("responded with text/html"). The no-trailing-slash proxy here
+        # forwards the full request URI, serving the public file as JS.
+        location = /pdf.worker.min.mjs {
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Request-ID $request_id;
+
+            # SECURITY: Remove potentially sensitive headers
+            proxy_hide_header X-Powered-By;
+            proxy_hide_header Server;
+
+            add_header X-Content-Type-Options "nosniff";
+        }
+
         # Frontend routes (所有其他請求)
         location / {
             limit_req zone=frontend burst=50 nodelay;


### PR DESCRIPTION
## Problem
Student regulations preview (學生預覽獎學金文件) on **staging** fails:
```
Setting up fake worker.
pdf.worker.min.mjs: Failed to load module script: ... MIME type "text/html"
無法載入文件
```

## Root cause (isolated, not guessed)
- `curl` via nginx → `200 text/html` (~5.6 kB SPA shell).
- `curl` the frontend container directly (bypass nginx) → `200 application/javascript`, 1369774 bytes (the real worker). File is present in the image.
- So the frontend is fine; **nginx** is the culprit.

The catch-all `location /` uses `proxy_pass http://$frontend_upstream/;` — a **trailing slash + variable** upstream. With a variable upstream, nginx cannot rewrite the matched location prefix, so `/pdf.worker.min.mjs` is forwarded mangled and the frontend resolves it as an app route, returning the SPA HTML. The top-level static-asset location works precisely because it uses a **no-trailing-slash** proxy. `.mjs` isn't in that list, so the worker fell through to the broken catch-all.

## Fix
Add an exact-match `location = /pdf.worker.min.mjs` that proxies with **no trailing slash** (forwards the full request URI) in both `nginx.staging.conf` and `nginx.prod.conf`.
- Exact match → blast radius is the worker path only; `/_next/static` and all other routes untouched.
- Security headers preserved (`X-Content-Type-Options: nosniff`, hide `X-Powered-By`/`Server`).
- `nginx -t` passes for both configs (verified with mounted certs).

Pairs with the already-merged `?v=<pdfjs version>` worker-URL pin (#814) which prevents a stale 404 from being cached.

## Test plan
- [ ] Deploy/reload nginx on staging, then: `curl -sI 'https://ss.test.nycu.edu.tw/pdf.worker.min.mjs?v=4.8.69'` → `200` + `Content-Type: application/javascript`.
- [ ] Open a scholarship application as a student → 閱讀獎學金要點 → regulations PDF renders, no fake-worker / MIME error.