### PR TITLE
fix: review-stage on submit + college review-window handoff gap

### DIFF
--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -236,7 +236,10 @@ async def seed_scholarship_configurations(session: AsyncSession) -> None:
             "professor_review_start": now,
             "professor_review_end": now + timedelta(days=30),
             "requires_college_review": True,
-            "college_review_start": now + timedelta(days=35),
+            # College review overlaps the professor window so a professor-reviewed
+            # application is immediately visible to college reviewers — the previous
+            # `now + 35d` start left a gap where prof review was open but college was not.
+            "college_review_start": now - timedelta(days=5),
             "college_review_end": now + timedelta(days=60),
             "review_deadline": now + timedelta(days=65),
             "is_active": True,

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -502,6 +502,8 @@ class ApplicationService:
 
         if not is_draft:
             application.submitted_at = datetime.now(timezone.utc)
+            # Keep review_stage consistent with the submitted status (mirrors submit_application).
+            application.review_stage = ReviewStage.student_submitted.value
 
         return application
 
@@ -1278,6 +1280,9 @@ class ApplicationService:
 
         application.status = ApplicationStatus.submitted
         application.status_name = ScholarshipI18n.get_application_status_text(ApplicationStatus.submitted.value)
+        # Advance the workflow stage off student_draft so reviewers no longer
+        # see "學生編輯中" on a submitted application (it now awaits professor review).
+        application.review_stage = ReviewStage.student_submitted.value
         application.submitted_at = datetime.now(timezone.utc)
         application.updated_at = datetime.now(timezone.utc)
 


### PR DESCRIPTION
## Summary

Fixes two review-flow visibility bugs reported together:

1. **Professor saw "學生編輯中" on submitted applications.** Submitting an application set `status=submitted` but never advanced `review_stage` off its `student_draft` default. The professor/college listings render `review_stage`, so an already-submitted app still showed the "學生編輯中" (Student Drafting) stage badge.
   - `submit_application` and the `create`-with-`is_draft=False` shortcut now set `review_stage = student_submitted` → renders "學生已送出".

2. **Professor-reviewed apps invisible to college reviewers.** The college queue is time-gated by `apply_renewal_phase_filter(role="college")` (intentional — phased-calendar design). The `phd_114` seed opened `college_review_start` at `now+35d` while the professor window opened at `now`, leaving a multi-week gap where a professor-reviewed app surfaced nowhere. Professor review is advisory (issue #182): it advances `review_stage` to `professor_reviewed` but leaves `status=submitted`, so the app is gated by the college window like any pending app.
   - Seed `college_review_start` → `now-5d` so the college window overlaps the professor window. **Filter logic unchanged** — only the seeded window dates are corrected.

## Verification (localhost dev env)

- Submit app → DB and professor listing report `review_stage=student_submitted` (was `student_draft`).
- With the college window open: professor submits review → `review_stage=professor_reviewed`, `status=submitted` → app appears in the college review listing (`professor_review_completed=true`).
- No backend errors during the flow.

## Test plan

- [ ] Reset DB (`./scripts/reset_database.sh`); confirm `phd_114` config has `college_review_start <= now` (no gap vs professor window).
- [ ] Student submits an application → professor listing shows "學生已送出", not "學生編輯中".
- [ ] Professor submits review → college reviewer (matching `college_code`) sees the app in their review queue.
- [ ] Regression: renewal-vs-general phase split still filters not-yet-reviewed apps correctly.