### PR TITLE
feat(seed): grant cs_college doctoral scholarship permission by default

### DIFF
--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -482,6 +482,28 @@ async def seed_admin_scholarships(session: AsyncSession):
             {"admin_id": admin_id, "scholarship_id": sid},
         )
 
+    # College reviewer cs_college needs explicit permission for the doctoral
+    # (phd / 博士生獎學金) scholarship so it can review doctoral applications out
+    # of the box — _check_scholarship_permission gates college users on this row.
+    cs_college_id = (
+        await session.execute(text("SELECT id FROM users WHERE nycu_id = 'cs_college'"))
+    ).scalar()
+    phd_scholarship_id = (
+        await session.execute(text("SELECT id FROM scholarship_types WHERE code = 'phd'"))
+    ).scalar()
+    if cs_college_id and phd_scholarship_id:
+        await session.execute(
+            text("""
+                INSERT INTO admin_scholarships (admin_id, scholarship_id, assigned_at)
+                VALUES (:admin_id, :scholarship_id, NOW())
+                ON CONFLICT ON CONSTRAINT uq_admin_scholarship DO NOTHING
+            """),
+            {"admin_id": cs_college_id, "scholarship_id": phd_scholarship_id},
+        )
+        print("  ✓ cs_college linked to doctoral (phd) scholarship")
+    else:
+        print("  ⚠ cs_college or phd scholarship not found — skipping cs_college link")
+
     await session.commit()
     print(f"  ✓ admin linked to {len(scholarship_ids)} scholarship types")
 


### PR DESCRIPTION
## Summary

College reviewers are gated per-scholarship by an `admin_scholarships` row (`_check_scholarship_permission` in `college_review/_helpers.py`). The seeded `cs_college` reviewer had no such row, so it could not review **doctoral (phd / 博士生獎學金)** applications out of the box — any doctoral college-review flow required a manual permission grant first.

`seed_admin_scholarships` now links `cs_college` to the `phd` scholarship type, matched by the stable `code='phd'` and inserted with `ON CONFLICT DO NOTHING` (idempotent re-seed).

## Verification (localhost dev env)

- Re-seeded; `admin_scholarships` has a `cs_college → phd` row.
- `cs_college` GET `/college-review/applications?scholarship_type_id=2` → `success`, no 403 (previously blocked by the permission check).

## Test plan

- [ ] Fresh `./scripts/reset_database.sh` (or `python -m app.seed`) → `cs_college` has an `admin_scholarships` row for `code='phd'`.
- [ ] Log in as `cs_college`; the doctoral scholarship is selectable and its applications load in the college review queue.
- [ ] Regression: `admin` is still linked to all scholarship types.