### PR TITLE
fix(ci): unblock checks — copy-pdf-worker EPERM + black-format seed.py

### DIFF
--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -485,12 +485,8 @@ async def seed_admin_scholarships(session: AsyncSession):
     # College reviewer cs_college needs explicit permission for the doctoral
     # (phd / 博士生獎學金) scholarship so it can review doctoral applications out
     # of the box — _check_scholarship_permission gates college users on this row.
-    cs_college_id = (
-        await session.execute(text("SELECT id FROM users WHERE nycu_id = 'cs_college'"))
-    ).scalar()
-    phd_scholarship_id = (
-        await session.execute(text("SELECT id FROM scholarship_types WHERE code = 'phd'"))
-    ).scalar()
+    cs_college_id = (await session.execute(text("SELECT id FROM users WHERE nycu_id = 'cs_college'"))).scalar()
+    phd_scholarship_id = (await session.execute(text("SELECT id FROM scholarship_types WHERE code = 'phd'"))).scalar()
     if cs_college_id and phd_scholarship_id:
         await session.execute(
             text("""

--- a/frontend/scripts/copy-pdf-worker.mjs
+++ b/frontend/scripts/copy-pdf-worker.mjs
@@ -4,7 +4,7 @@
 // static asset pipeline instead.
 //
 // Runs from package.json on postinstall, predev, and prebuild. Idempotent.
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,11 +18,38 @@ const src = require.resolve("pdfjs-dist/build/pdf.worker.min.mjs");
 // so the script works no matter what cwd it was invoked from.
 const dest = resolve(here, "..", "public", "pdf.worker.min.mjs");
 
+const srcBytes = readFileSync(src);
+
+// Skip the write when an identical copy already exists. A prior `docker compose
+// up --build` (running as root) can leave a root-owned worker file in the
+// bind-mounted public/ dir; a later host-side `npm install` postinstall runs as
+// a non-root user and cannot overwrite it -> EACCES. The file it would write is
+// byte-identical (same pdfjs-dist), so treat "already correct" as success.
+if (existsSync(dest) && readFileSync(dest).equals(srcBytes)) {
+  console.log(`copy-pdf-worker: ${dest} already up to date, skipping`);
+  process.exit(0);
+}
+
 mkdirSync(dirname(dest), { recursive: true });
 // Read-then-write instead of copyFileSync: the latter uses copy_file_range/
 // fcopyfile, which returns EPERM when src and dest straddle a reflink/overlay
 // boundary (e.g. cache-restored node_modules in CI). A userspace copy avoids it.
-writeFileSync(dest, readFileSync(src));
+try {
+  writeFileSync(dest, srcBytes);
+} catch (err) {
+  // A foreign-owned dest (e.g. root-owned from a docker build) blocks an
+  // in-place overwrite. Unlink and recreate before giving up.
+  if (err.code === "EACCES" || err.code === "EPERM") {
+    try {
+      unlinkSync(dest);
+    } catch {
+      // ignore; rethrow original if recreate still fails
+    }
+    writeFileSync(dest, srcBytes);
+  } else {
+    throw err;
+  }
+}
 
 if (!existsSync(dest)) {
   console.error(`copy-pdf-worker: dest ${dest} missing after copy`);

--- a/frontend/scripts/copy-pdf-worker.mjs
+++ b/frontend/scripts/copy-pdf-worker.mjs
@@ -4,7 +4,7 @@
 // static asset pipeline instead.
 //
 // Runs from package.json on postinstall, predev, and prebuild. Idempotent.
-import { copyFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,7 +19,10 @@ const src = require.resolve("pdfjs-dist/build/pdf.worker.min.mjs");
 const dest = resolve(here, "..", "public", "pdf.worker.min.mjs");
 
 mkdirSync(dirname(dest), { recursive: true });
-copyFileSync(src, dest);
+// Read-then-write instead of copyFileSync: the latter uses copy_file_range/
+// fcopyfile, which returns EPERM when src and dest straddle a reflink/overlay
+// boundary (e.g. cache-restored node_modules in CI). A userspace copy avoids it.
+writeFileSync(dest, readFileSync(src));
 
 if (!existsSync(dest)) {
   console.error(`copy-pdf-worker: dest ${dest} missing after copy`);


### PR DESCRIPTION
## Summary
- `npm postinstall` runs `scripts/copy-pdf-worker.mjs`, which used `copyFileSync` to copy the pdf.js worker from `node_modules` into `public/`.
- `copyFileSync` uses the kernel `copy_file_range`/`fcopyfile` path. When CI restores `node_modules` from cache, src and dest can straddle a reflink/overlay boundary, and the syscall returns `EPERM` — failing the build.
- Switch to a userspace read-then-write (`writeFileSync(dest, readFileSync(src))`), which avoids the kernel copy syscall while staying idempotent.

Fixes the CI failure seen on PR #816:
```
Error: EPERM: operation not permitted, copyfile '.../pdf.worker.min.mjs' -> '.../public/pdf.worker.min.mjs'
```

## Test plan
- [x] Run `node scripts/copy-pdf-worker.mjs` locally — copies worker, idempotent on re-run
- [ ] CI `postinstall` passes on GitHub Actions runner