### PR TITLE
fix(roster): store national ID (std_pid) in payment_roster_items, not student number

### DIFF
--- a/backend/alembic/versions/20260529_backfill_roster_national_id.py
+++ b/backend/alembic/versions/20260529_backfill_roster_national_id.py
@@ -1,0 +1,81 @@
+"""backfill payment_roster_items.student_id_number with decrypted std_pid
+
+Historically student_id_number stored std_stdcode (student number) instead
+of std_pid (national ID).  The Excel payment template column is 身分證字號 so
+this field must hold the real national ID.
+
+This migration iterates existing rows, loads the decrypted std_pid from
+applications.student_data (StudentDataJSON ORM TypeDecorator handles
+decryption), and writes it into student_id_number.
+
+Revision ID: 20260529_backfill_roster_national_id
+Revises: merge_renewal_main_001
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Union
+
+from alembic import op
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+revision: str = "20260529_backfill_roster_national_id"
+down_revision: Union[str, None] = "merge_renewal_main_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    try:
+        # Import models — TypeDecorators fire during ORM load/flush
+        from app.models.payment_roster import PaymentRosterItem
+        from app.models.application import Application
+
+        inspector = session.execute(__import__("sqlalchemy").text("SELECT COUNT(*) FROM payment_roster_items")).scalar()
+        logger.info(f"Backfilling national ID for {inspector} payment_roster_items")
+
+        items = session.query(PaymentRosterItem).all()
+        updated = 0
+        skipped_no_app = 0
+        skipped_no_pid = 0
+
+        for item in items:
+            if not item.application_id:
+                skipped_no_app += 1
+                continue
+
+            app = session.get(Application, item.application_id)
+            if not app or not app.student_data:
+                skipped_no_app += 1
+                continue
+
+            std_pid = app.student_data.get("std_pid", "")
+            if not std_pid:
+                skipped_no_pid += 1
+                continue
+
+            if item.student_id_number != std_pid:
+                item.student_id_number = std_pid
+                updated += 1
+
+        session.flush()
+        logger.info(
+            f"Backfill complete: updated={updated}, "
+            f"skipped_no_app={skipped_no_app}, skipped_no_pid={skipped_no_pid}"
+        )
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def downgrade() -> None:
+    # No safe reverse: we don't know which rows held std_stdcode vs std_pid.
+    pass

--- a/backend/alembic/versions/20260529_backfill_roster_national_id.py
+++ b/backend/alembic/versions/20260529_backfill_roster_national_id.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Session
 
 logger = logging.getLogger("alembic.runtime.migration")
 
-revision: str = "20260529_backfill_roster_national_id"
+revision: str = "backfill_roster_nat_id_001"
 down_revision: Union[str, None] = "merge_renewal_main_001"
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/20260529_backfill_roster_national_id.py
+++ b/backend/alembic/versions/20260529_backfill_roster_national_id.py
@@ -8,7 +8,7 @@ This migration iterates existing rows, loads the decrypted std_pid from
 applications.student_data (StudentDataJSON ORM TypeDecorator handles
 decryption), and writes it into student_id_number.
 
-Revision ID: 20260529_backfill_roster_national_id
+Revision ID: backfill_roster_nat_id_001
 Revises: merge_renewal_main_001
 """
 
@@ -18,7 +18,8 @@ import logging
 from typing import Union
 
 from alembic import op
-from sqlalchemy.orm import Session
+from sqlalchemy import text
+from sqlalchemy.orm import Session, joinedload
 
 logger = logging.getLogger("alembic.runtime.migration")
 
@@ -37,20 +38,16 @@ def upgrade() -> None:
         from app.models.payment_roster import PaymentRosterItem
         from app.models.application import Application
 
-        inspector = session.execute(__import__("sqlalchemy").text("SELECT COUNT(*) FROM payment_roster_items")).scalar()
-        logger.info(f"Backfilling national ID for {inspector} payment_roster_items")
+        row_count = session.execute(text("SELECT COUNT(*) FROM payment_roster_items")).scalar()
+        logger.info(f"Backfilling national ID for {row_count} payment_roster_items")
 
-        items = session.query(PaymentRosterItem).all()
+        items = session.query(PaymentRosterItem).options(joinedload(PaymentRosterItem.application)).all()
         updated = 0
         skipped_no_app = 0
         skipped_no_pid = 0
 
         for item in items:
-            if not item.application_id:
-                skipped_no_app += 1
-                continue
-
-            app = session.get(Application, item.application_id)
+            app = item.application
             if not app or not app.student_data:
                 skipped_no_app += 1
                 continue

--- a/backend/alembic/versions/20260529_merge_roster_supp_docs.py
+++ b/backend/alembic/versions/20260529_merge_roster_supp_docs.py
@@ -1,0 +1,25 @@
+"""merge backfill_roster_national_id + add_supp_docs_001 heads
+
+Revision ID: 20260529_merge_roster_supp_docs
+Revises: 20260529_backfill_roster_national_id, add_supp_docs_001
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+revision: str = "20260529_merge_roster_supp_docs"
+down_revision: Union[str, Sequence[str], None] = (
+    "20260529_backfill_roster_national_id",
+    "add_supp_docs_001",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/20260529_merge_roster_supp_docs.py
+++ b/backend/alembic/versions/20260529_merge_roster_supp_docs.py
@@ -1,7 +1,7 @@
-"""merge backfill_roster_national_id + add_supp_docs_001 heads
+"""merge backfill_roster_nat_id_001 + add_supp_docs_001 heads
 
 Revision ID: 20260529_merge_roster_supp_docs
-Revises: 20260529_backfill_roster_national_id, add_supp_docs_001
+Revises: backfill_roster_nat_id_001, add_supp_docs_001
 """
 
 from __future__ import annotations
@@ -10,7 +10,7 @@ from typing import Sequence, Union
 
 revision: str = "20260529_merge_roster_supp_docs"
 down_revision: Union[str, Sequence[str], None] = (
-    "20260529_backfill_roster_national_id",
+    "backfill_roster_nat_id_001",
     "add_supp_docs_001",
 )
 branch_labels = None

--- a/backend/app/models/payment_roster.py
+++ b/backend/app/models/payment_roster.py
@@ -184,10 +184,7 @@ class PaymentRosterItem(Base):
     application_id = Column(Integer, ForeignKey("applications.id"), nullable=False, index=True)
 
     # 學生基本資料（造冊當時快照）
-    # NOTE: Despite the column name, this stores the student number (std_stdcode /
-    # nycu_id) — NOT the national ID (std_pid). The latter is encrypted at rest
-    # inside applications.student_data via StudentDataJSON (see issue #73).
-    student_id_number = Column(String(20), nullable=False)  # 學號 (student number)
+    student_id_number = Column(String(20), nullable=False)  # 身分證字號 (national ID / std_pid)
     student_name = Column(String(100), nullable=False)  # 姓名
     student_email = Column(String(255))  # Email
 

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -485,12 +485,8 @@ async def seed_admin_scholarships(session: AsyncSession):
     # College reviewer cs_college needs explicit permission for the doctoral
     # (phd / 博士生獎學金) scholarship so it can review doctoral applications out
     # of the box — _check_scholarship_permission gates college users on this row.
-    cs_college_id = (
-        await session.execute(text("SELECT id FROM users WHERE nycu_id = 'cs_college'"))
-    ).scalar()
-    phd_scholarship_id = (
-        await session.execute(text("SELECT id FROM scholarship_types WHERE code = 'phd'"))
-    ).scalar()
+    cs_college_id = (await session.execute(text("SELECT id FROM users WHERE nycu_id = 'cs_college'"))).scalar()
+    phd_scholarship_id = (await session.execute(text("SELECT id FROM scholarship_types WHERE code = 'phd'"))).scalar()
     if cs_college_id and phd_scholarship_id:
         await session.execute(
             text("""

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -857,7 +857,7 @@ class RosterService:
         roster_item = PaymentRosterItem(
             roster_id=roster.id,
             application_id=application.id,
-            student_id_number=student_data.get("std_stdcode", ""),
+            student_id_number=student_data.get("std_pid", ""),
             student_name=student_data.get("std_cname", ""),
             student_email=student_data.get("com_email", ""),
             bank_account=bank_account,  # From submitted_form_data, not student_data

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -18,6 +18,8 @@ from sqlalchemy.pool import StaticPool
 # Override settings BEFORE importing models (models use settings to determine JSON type)
 os.environ["TESTING"] = "true"
 os.environ["PYTEST_CURRENT_TEST"] = "true"
+# Enable dev-key fallback in pii_crypto so tests that write std_pid don't need PII_ENCRYPTION_KEYS
+os.environ.setdefault("ENVIRONMENT", "test")
 
 # MinIO mocking is now handled automatically in the service based on testing environment
 

--- a/backend/app/tests/test_roster_service_generation.py
+++ b/backend/app/tests/test_roster_service_generation.py
@@ -108,6 +108,7 @@ def _make_approved_application(
     *,
     app_id: str = "APP-113-1-00001",
     student_id: str = "112550001",
+    national_id: str = "A123456789",
     student_name: str = "羅斯特同學",
 ) -> Application:
     a = Application(
@@ -120,7 +121,7 @@ def _make_approved_application(
         app_id=app_id,
         academic_year=113,
         semester="first",
-        student_data={"std_stdcode": student_id, "std_cname": student_name},
+        student_data={"std_stdcode": student_id, "std_pid": national_id, "std_cname": student_name},
         submitted_form_data={},
         agree_terms=True,
         amount=Decimal("50000"),


### PR DESCRIPTION
## Problem

`payment_roster_items.student_id_number` was being populated with `std_stdcode` (學號/student number) instead of `std_pid` (身分證字號/national ID). The Excel payment template's first column is **身分證字號**, required by the government accounting system for salary/scholarship tax reporting — putting the student number there produces an incorrect/unusable roster.

Root cause: when the PII encryption feature (#73) was implemented, `applications.student_data.std_pid` was encrypted, but `roster_service.py` was not updated to pull the national ID into the roster item — it fell back to the student number as a safer identifier.

## Fix

**`roster_service.py:860`** — `_create_roster_item()` now reads `std_pid` from the already-decrypted `application.student_data` (the `StudentDataJSON` ORM TypeDecorator handles decryption transparently):

```python
# Before
student_id_number=student_data.get("std_stdcode", ""),
# After
student_id_number=student_data.get("std_pid", ""),
```

**`payment_roster.py`** — removed misleading NOTE comment; updated inline comment to reflect the field actually stores the national ID as intended.

**`20260529_backfill_roster_national_id.py`** — Alembic data migration that iterates existing `payment_roster_items`, loads each associated `Application` through the ORM (so `StudentDataJSON` decrypts `std_pid`), and writes the national ID into `student_id_number`. Skips rows with no application or no `std_pid`.

The student number (`std_stdcode`) remains as a local variable used for the student verification API call — it is not stored anywhere in the roster item.

## Test plan

- [x] 89 existing backend tests pass
- [ ] Generate a new roster on staging → download Excel → column 1 shows a valid national ID (A123456789 format), not a student number (9-digit numeric)
- [ ] Re-run `alembic upgrade head` on staging to apply backfill migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)