### PR TITLE
fix(notifications): log queue processing failures with full traceback

### DIFF
--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -307,6 +307,18 @@ class NotificationService:
                 processed += 1
 
             except Exception as e:
+                # Surface the failure in logs (with full traceback) before mutating
+                # the row — operators should not have to query notification_queue
+                # to discover that background processing is failing.
+                logger.exception(
+                    "Notification queue item failed",
+                    extra={
+                        "queue_item_id": item.id,
+                        "attempts": item.attempts,
+                        "max_attempts": item.max_attempts,
+                        "notification_type": item.notification_type,
+                    },
+                )
                 item.status = "failed"
                 item.error_message = str(e)
                 failed += 1


### PR DESCRIPTION
## Summary

- `_process_notification_queue` previously caught every `Exception` during background batch processing and only wrote `str(e)` to the queue row's `error_message`. Stack traces were lost, no log line was emitted, and operators had to query `notification_queue` directly to discover that processing was failing.
- This PR adds a structured `logger.exception(...)` call with `queue_item_id`, `attempts`, `max_attempts`, and `notification_type` before the row mutation so that Grafana / loki / stdout pick up the failure path the same way every other backend endpoint does.

Closes #821

## Test plan

- [x] `docker compose -f docker-compose.dev.yml exec backend python -m pytest tests/ --no-cov -q` — 89 passed
- [x] `uvx --from black==26.3.1 black backend/app/services/notification_service.py --line-length=120` — 1 file left unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)