### PR TITLE
test(roster): cover _create_roster_item + excel row mapping; pin std_pid fix (#819)

### DIFF
--- a/backend/app/tests/test_excel_export_service_rows.py
+++ b/backend/app/tests/test_excel_export_service_rows.py
@@ -1,0 +1,325 @@
+"""
+Row-mapping tests for `ExcelExportService._prepare_excel_data`.
+
+`_prepare_excel_data` (excel_export_service.py ~381) translates a list
+of persisted `PaymentRosterItem` rows into a list of dicts keyed by the
+30-column STD_UP_MIXLISTA template header names. Those dicts are then
+written verbatim into each payment Excel row by `_create_excel_file`.
+
+The mapping is the contract between the database model and what shows
+up on the bank-payment voucher. A regression here:
+
+- Routes payments to wrong accounts (bank_code 700 hardcoded for postal).
+- Reports wrong amounts to the tax-exempt-payment column (immediate
+  audit issue with the accounting system).
+- Puts the student number into the 身分證字號 column instead of the
+  national ID — PR #819 fixed the upstream `_create_roster_item` to
+  store std_pid; this file pins that downstream the row dict's
+  身分證字號 entry maps to `item.student_id_number` so the fix
+  propagates end-to-end.
+
+Tests use SimpleNamespace stubs (no DB) following the pattern in
+`test_college_ranking_export_service.py`. `_prepare_excel_data` writes
+back to `item.excel_row_data` and `item.excel_remarks` — that's fine
+because the stubs accept arbitrary attribute assignment.
+
+Also covers the header-only-file branch of `_validate_export_data`
+(returns is_valid=True + a warning, NOT an error) so a roster with no
+qualified items still ships a valid Excel header for finance to
+acknowledge.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from app.services.excel_export_service import ExcelExportService
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def service() -> ExcelExportService:
+    """`ExcelExportService.__init__` reads template path settings and
+    tries to load the .xlsx template file; both fall back gracefully if
+    missing. `_prepare_excel_data` itself is pure (just maps dicts) — no
+    DB, no filesystem."""
+    return ExcelExportService()
+
+
+def _make_roster(
+    *,
+    period_label: str = "2025-H1",
+    roster_code: str = "ROSTER-114-2025-H1-PHD001",
+    academic_year: int = 114,
+) -> SimpleNamespace:
+    """Minimal roster stub. `_prepare_excel_data` reads `period_label`
+    via `hasattr` + `roster.period_label` for the remarks column."""
+    return SimpleNamespace(
+        period_label=period_label,
+        roster_code=roster_code,
+        academic_year=academic_year,
+    )
+
+
+def _make_item(
+    *,
+    student_id_number: str = "A123456789",
+    student_name: str = "王小明",
+    student_email: str = "wang@nycu.edu.tw",
+    bank_account: Optional[str] = "00012345678",
+    scholarship_name: str = "博士班獎學金",
+    scholarship_amount: Any = 50000,
+    permanent_address: Optional[str] = None,
+    application_identity: Optional[str] = "114新申請",
+    allocated_sub_type: Optional[str] = None,
+    allocation_year: Optional[int] = None,
+    is_included: bool = True,
+) -> SimpleNamespace:
+    """PaymentRosterItem stub with just the attrs _prepare_excel_data reads.
+
+    Also exposes `excel_row_data` + `excel_remarks` as plain attrs so the
+    method's write-back assignments don't AttributeError."""
+    return SimpleNamespace(
+        student_id_number=student_id_number,
+        student_name=student_name,
+        student_email=student_email,
+        bank_account=bank_account,
+        scholarship_name=scholarship_name,
+        scholarship_amount=scholarship_amount,
+        permanent_address=permanent_address,
+        application_identity=application_identity,
+        allocated_sub_type=allocated_sub_type,
+        allocation_year=allocation_year,
+        is_included=is_included,
+        # Write-back targets — pre-init so SimpleNamespace accepts assignment
+        excel_row_data=None,
+        excel_remarks=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 身分證字號 column ← item.student_id_number (PR #819 propagation)
+# ---------------------------------------------------------------------------
+
+
+def test_row_data_national_id_comes_from_student_id_number(service: ExcelExportService) -> None:
+    """Pin: the "身分證字號" key in row_data maps to `item.student_id_number`.
+
+    Upstream (_create_roster_item, PR #819) stores std_pid into
+    student_id_number. If THIS mapping later drifts to a different attr
+    (e.g. someone introduces item.national_id and forgets to migrate
+    here), payments would route by an inconsistent identifier."""
+    roster = _make_roster()
+    item = _make_item(student_id_number="A987654321", student_name="陳大文")
+
+    data = service._prepare_excel_data(roster, [item])
+
+    assert len(data) == 1
+    assert data[0]["身分證字號"] == "A987654321"
+    assert data[0]["姓名"] == "陳大文"
+
+
+def test_row_data_skips_items_missing_required_fields(service: ExcelExportService) -> None:
+    """Items missing student_id_number OR student_name are silently
+    dropped (logged + continued). They never reach the Excel because
+    the bank rejects rows with blank 身分證字號. Pin so this defense
+    doesn't get removed accidentally."""
+    roster = _make_roster()
+    items = [
+        _make_item(student_id_number="", student_name="王小明"),  # missing ID
+        _make_item(student_id_number="A1", student_name=""),  # missing name
+        _make_item(student_id_number="A2", student_name="正常"),  # ok
+    ]
+
+    data = service._prepare_excel_data(roster, items)
+
+    assert len(data) == 1
+    assert data[0]["身分證字號"] == "A2"
+    assert data[0]["姓名"] == "正常"
+
+
+# ---------------------------------------------------------------------------
+# Amount columns — 單價 + 免稅給付 both pull from scholarship_amount
+# ---------------------------------------------------------------------------
+
+
+def test_row_data_amount_matches_scholarship_amount(service: ExcelExportService) -> None:
+    """Both 單價 (unit price, col 10) AND 免稅給付 (tax-exempt payment,
+    col 24) equal `item.scholarship_amount` as a float. They MUST agree
+    — the accounting system reconciles col 10 × col 9 (quantity, always
+    1) against col 24 for tax-exempt verification. Drift here triggers
+    an audit kickback."""
+    roster = _make_roster()
+    item = _make_item(scholarship_amount=50000)
+
+    data = service._prepare_excel_data(roster, [item])
+
+    assert data[0]["單價"] == 50000.0
+    assert data[0]["免稅給付"] == 50000.0
+    # Both are floats (not Decimal/int) — finance Excel parsing expects float
+    assert isinstance(data[0]["單價"], float)
+    assert isinstance(data[0]["免稅給付"], float)
+
+
+def test_row_data_amount_zero_when_scholarship_amount_falsy(service: ExcelExportService) -> None:
+    """Defensive: a None/0 scholarship_amount renders as 0 (not None,
+    not blank, not crash). The downstream validator catches this as a
+    warning rather than letting a blank propagate to the bank file."""
+    roster = _make_roster()
+    item = _make_item(scholarship_amount=None)
+
+    data = service._prepare_excel_data(roster, [item])
+
+    assert data[0]["單價"] == 0
+    assert data[0]["免稅給付"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Fixed-value columns — bank code, identity, unit, etc.
+# ---------------------------------------------------------------------------
+
+
+def test_row_data_bank_code_always_700(service: ExcelExportService) -> None:
+    """銀行代碼 (col 4) is HARDCODED to "700" — the Chunghwa Post code.
+    This system only pays to postal accounts. If a future feature adds
+    real-bank payments, this hardcode MUST be unwound deliberately
+    (and this test updated). Pin so it can't drift silently."""
+    roster = _make_roster()
+    item = _make_item()
+
+    data = service._prepare_excel_data(roster, [item])
+
+    assert data[0]["銀行代碼"] == "700"
+
+
+def test_row_data_fixed_columns_contract(service: ExcelExportService) -> None:
+    """Pin the small set of fixed-value columns the accounting system
+    expects EXACTLY: 職別="學生", 身份別代碼="1", 單位="次", 數量="1",
+    個人身分別="1" (本國人), 居留天數="是". Any drift triggers
+    an audit kickback from the bank batch import."""
+    roster = _make_roster()
+    item = _make_item()
+
+    data = service._prepare_excel_data(roster, [item])
+
+    row = data[0]
+    assert row["職別(稱)"] == "學生"
+    assert row["身份別代碼"] == "1"
+    assert row["單位(ex:時,月,次...)"] == "次"
+    assert row["數量"] == "1"
+    assert row["個人身分別(1:本國人,2:外國人,3:大陸人)"] == "1"
+    assert row["居留天數是否滿183天(是/否)"] == "是"
+
+
+def test_row_data_bank_account_passed_through_from_item(service: ExcelExportService) -> None:
+    """帳號 column (col 3) comes directly from item.bank_account (which
+    upstream _create_roster_item populated from submitted_form_data, not
+    student_data). Falsy bank_account → empty string, not None."""
+    roster = _make_roster()
+    with_account = _make_item(bank_account="00012345678")
+    no_account = _make_item(student_id_number="A2", bank_account=None)
+
+    data = service._prepare_excel_data(roster, [with_account, no_account])
+
+    assert data[0]["帳號"] == "00012345678"
+    assert data[1]["帳號"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Remarks (說明 col 25) — composed from period + scholarship + identity
+# ---------------------------------------------------------------------------
+
+
+def test_row_data_remarks_includes_period_and_scholarship(service: ExcelExportService) -> None:
+    """說明 column is a space-joined breadcrumb of period / scholarship
+    name / identity / allocation. Pin the core pieces so finance can
+    grep for a known scholarship name in the payment report."""
+    roster = _make_roster(period_label="2025-H1")
+    item = _make_item(
+        scholarship_name="博士班獎學金",
+        application_identity="114新申請",
+        allocated_sub_type="nstc",
+        allocation_year=114,
+    )
+
+    data = service._prepare_excel_data(roster, [item])
+
+    remarks = data[0]["說明"]
+    assert "期間:2025-H1" in remarks
+    assert "獎學金:博士班獎學金" in remarks
+    assert "身分:114新申請" in remarks
+    # nstc → 國科會 sub_type display
+    assert "分發:114年 國科會" in remarks
+
+
+def test_row_data_remarks_flags_excluded_status(service: ExcelExportService) -> None:
+    """An excluded item (is_included=False) gets 狀態:不合格 appended
+    so the operator scanning the Excel can see at a glance which rows
+    were dropped. Also flags missing bank info separately."""
+    roster = _make_roster()
+    item = _make_item(is_included=False, bank_account=None)
+
+    data = service._prepare_excel_data(roster, [item])
+
+    remarks = data[0]["說明"]
+    assert "狀態:不合格" in remarks
+    assert "缺銀行資訊" in remarks
+
+
+# ---------------------------------------------------------------------------
+# Write-back side effect — item.excel_row_data and item.excel_remarks
+# ---------------------------------------------------------------------------
+
+
+def test_row_data_written_back_to_item(service: ExcelExportService) -> None:
+    """`_prepare_excel_data` mutates `item.excel_row_data` and
+    `item.excel_remarks` for downstream audit / preview. Pin so a
+    refactor that "returns the rows but doesn't write back" doesn't
+    break the audit trail silently (the preview API reads these
+    columns to show what was emitted)."""
+    roster = _make_roster()
+    item = _make_item()
+
+    data = service._prepare_excel_data(roster, [item])
+
+    assert item.excel_row_data == data[0]
+    assert item.excel_remarks == data[0]["說明"]
+
+
+# ---------------------------------------------------------------------------
+# Empty roster → _validate_export_data returns is_valid=True with warning
+# ---------------------------------------------------------------------------
+
+
+def test_empty_roster_validates_as_header_only(service: ExcelExportService) -> None:
+    """An empty roster (no qualified items) is NOT a hard error — the
+    Excel still ships with just headers so finance can acknowledge the
+    cycle ran to completion. Pin the contract: is_valid=True, no errors,
+    one specific warning naming the header-only case.
+
+    Without this branch a 0-qualified roster would fail validation and
+    the whole roster generation would fall back to RosterGenerationError
+    even though the upstream logic correctly identified zero qualified
+    applicants — a false-positive failure."""
+    result = service._validate_export_data([])
+
+    assert result["is_valid"] is True
+    assert result["errors"] == []
+    assert any("No roster items to export" in w for w in result["warnings"])
+
+
+def test_empty_roster_prepare_excel_data_returns_empty_list(service: ExcelExportService) -> None:
+    """Companion: `_prepare_excel_data(roster, [])` returns an empty list,
+    NOT None, so `_create_excel_file` writes a header-only sheet without
+    a TypeError on `len(excel_data)`."""
+    roster = _make_roster()
+
+    data = service._prepare_excel_data(roster, [])
+
+    assert data == []

--- a/backend/app/tests/test_roster_service_core.py
+++ b/backend/app/tests/test_roster_service_core.py
@@ -1,0 +1,453 @@
+"""
+Core behavior tests for `RosterService._create_roster_item`.
+
+`_create_roster_item` (roster_service.py ~752) is the per-application
+"build one roster row" leaf that is exercised by both
+`generate_roster` (the canonical entry point) and
+`_generate_one_sub_type_roster` (the matrix-distribution batch path).
+It encodes the contract for what ends up in a `PaymentRosterItem`:
+
+- Which student-data field becomes the `身分證字號` column on the bank
+  payment Excel (PR #819: must be `std_pid`, not `std_stdcode`).
+- The inclusion gate — bank account presence, verification status, and
+  rule-eligibility result all collapse into `is_included` + a human
+  `exclusion_reason` string.
+- The `application_identity` snapshot ("114新申請" vs "114續領") that
+  finance reads on the payment voucher to distinguish first-time vs
+  renewal payments.
+
+The method is a leaf that only touches `self.db.query(...)` for backup
+allocation info (which we don't exercise here — `roster.ranking_id=None`
++ no allocated items in DB short-circuits both query chains to None),
+and ends with `self.db.add(roster_item)`. So MagicMock for the DB is
+sufficient — no SQLAlchemy session required.
+
+Regression target: PR #819 fixed `student_id_number=std_stdcode` →
+`student_id_number=std_pid`. The first test pins the corrected behavior
+so any future refactor that drops std_pid back to std_stdcode breaks CI.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.payment_roster import (
+    PaymentRosterItem,
+    StudentVerificationStatus,
+)
+from app.services.roster_service import RosterService
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_db_mock() -> MagicMock:
+    """A DB mock that returns no CollegeRankingItem rows.
+
+    `_create_roster_item` issues two query chains on `self.db`:
+      1. (only if roster.ranking_id) .query(CollegeRankingItem).filter(...).first()
+      2. (always, if allocated_sub_type still None) .query(CollegeRankingItem)
+         .join(CollegeRanking, ...).filter(...).first()
+
+    Returning None on both keeps the allocation_year + allocated_sub_type
+    code paths at their defaults so the test focuses on the fields the
+    method itself derives from `application.student_data` + form data.
+    """
+    db = MagicMock()
+    # Path 1: .query.filter.first → None
+    db.query.return_value.filter.return_value.first.return_value = None
+    # Path 2: .query.join.filter.first → None
+    db.query.return_value.join.return_value.filter.return_value.first.return_value = None
+    return db
+
+
+def _make_roster(roster_id: int = 1, academic_year: int = 114, ranking_id=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=roster_id,
+        ranking_id=ranking_id,
+        academic_year=academic_year,
+    )
+
+
+def _make_application(
+    *,
+    app_id: int = 1001,
+    std_pid: str | None = "A123456789",
+    std_stdcode: str | None = "110550001",
+    std_cname: str | None = "王小明",
+    com_email: str | None = "wang@nycu.edu.tw",
+    bank_account: str | None = "00012345678",
+    is_renewal: bool = False,
+    previous_application_id: int | None = None,
+    academic_year: int = 114,
+    amount: int = 10000,
+    config_amount: int = 50000,
+    sub_scholarship_type: str = "nstc",
+    scholarship_name: str = "博士班獎學金",
+) -> SimpleNamespace:
+    """Build an Application stub with just the attributes _create_roster_item reads.
+
+    student_data: drives the std_pid/std_cname/com_email lookups.
+    submitted_form_data: drives the bank_account inclusion check via the
+    nested ("fields") schema-compliant structure.
+    """
+    student_data: dict = {}
+    if std_pid is not None:
+        student_data["std_pid"] = std_pid
+    if std_stdcode is not None:
+        student_data["std_stdcode"] = std_stdcode
+    if std_cname is not None:
+        student_data["std_cname"] = std_cname
+    if com_email is not None:
+        student_data["com_email"] = com_email
+
+    submitted_form_data: dict = {"fields": {}}
+    if bank_account is not None:
+        submitted_form_data["fields"]["postal_account"] = {
+            "field_id": "postal_account",
+            "field_type": "text",
+            "value": bank_account,
+            "required": True,
+        }
+
+    scholarship_configuration = SimpleNamespace(
+        amount=config_amount,
+        scholarship_type=SimpleNamespace(name=scholarship_name),
+    )
+
+    return SimpleNamespace(
+        id=app_id,
+        student_data=student_data,
+        submitted_form_data=submitted_form_data,
+        amount=amount,
+        scholarship_configuration=scholarship_configuration,
+        sub_scholarship_type=sub_scholarship_type,
+        is_renewal=is_renewal,
+        previous_application_id=previous_application_id,
+        academic_year=academic_year,
+    )
+
+
+@pytest.fixture
+def service() -> RosterService:
+    """RosterService with a no-op DB mock. The mocked `add` is the only
+    side-effect we care about — verify_student / audit calls go through
+    other methods, not _create_roster_item."""
+    svc = RosterService(db=_make_db_mock())  # type: ignore[arg-type]
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Regression: PR #819 — std_pid, not std_stdcode
+# ---------------------------------------------------------------------------
+
+
+def test_create_roster_item_stores_national_id_not_student_number(service: RosterService) -> None:
+    """SECURITY/CORRECTNESS regression: PR #819 fixed
+    `student_id_number = student_data["std_stdcode"]` (student number)
+    →   `student_id_number = student_data["std_pid"]` (national ID).
+
+    The Excel payment template column 1 is 身分證字號 (national ID),
+    required by the government accounting system for tax reporting.
+    Putting the student number there would route payments incorrectly
+    AND leak a different identifier than the tax authority expects.
+
+    Pinning std_pid here means any future refactor that flips the dict
+    key back to std_stdcode breaks CI before it can ship.
+    """
+    roster = _make_roster()
+    application = _make_application(std_pid="A123456789", std_stdcode="110550001")
+
+    item: PaymentRosterItem = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result={"status": StudentVerificationStatus.VERIFIED, "message": "ok"},
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result={"is_eligible": True, "failed_rules": [], "warning_rules": []},
+    )
+
+    assert item.student_id_number == "A123456789", (
+        "student_id_number must come from std_pid (national ID), not " "std_stdcode (student number). See PR #819."
+    )
+    # And explicitly NOT the student number
+    assert item.student_id_number != "110550001"
+
+
+def test_create_roster_item_empty_string_when_std_pid_missing(service: RosterService) -> None:
+    """If std_pid is absent from student_data, the column gets an empty
+    string (the `.get("std_pid", "")` default), not a KeyError. This
+    preserves the existing behavior that `validate_roster_consistency`
+    catches downstream as a missing-field error rather than crashing
+    the whole roster generation."""
+    roster = _make_roster()
+    application = _make_application(std_pid=None, std_stdcode="110550001")
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result=None,
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+
+    assert item.student_id_number == ""
+
+
+# ---------------------------------------------------------------------------
+# Inclusion gate — bank account / verification / eligibility
+# ---------------------------------------------------------------------------
+
+
+def test_create_roster_item_included_when_bank_account_present(service: RosterService) -> None:
+    """Happy path: verified + bank account in submitted_form_data ⇒ is_included=True."""
+    roster = _make_roster()
+    application = _make_application(bank_account="00012345678")
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result={"status": StudentVerificationStatus.VERIFIED, "message": "ok"},
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result={"is_eligible": True, "failed_rules": [], "warning_rules": []},
+    )
+
+    assert item.is_included is True
+    assert item.exclusion_reason is None
+    assert item.bank_account == "00012345678"
+
+
+def test_create_roster_item_excluded_when_bank_account_missing(service: RosterService) -> None:
+    """No bank account anywhere in submitted_form_data ⇒ is_included=False
+    with the 缺少銀行帳戶資訊 reason. Critical because we cannot pay a
+    student with no account number — and the exclusion_reason is what the
+    operator sees in the UI to know WHY they were dropped."""
+    roster = _make_roster()
+    application = _make_application(bank_account=None)
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result={"status": StudentVerificationStatus.VERIFIED, "message": "ok"},
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result={"is_eligible": True, "failed_rules": [], "warning_rules": []},
+    )
+
+    assert item.is_included is False
+    assert item.exclusion_reason == "缺少銀行帳戶資訊"
+    assert item.bank_account == ""
+
+
+def test_create_roster_item_excluded_when_verification_failed(service: RosterService) -> None:
+    """A non-VERIFIED status (graduated, suspended, withdrawn, api_error,
+    not_found) excludes the student regardless of bank account presence.
+    Pin: the exclusion_reason explicitly includes the failed status's
+    .value so operators can see which kind of failure occurred."""
+    roster = _make_roster()
+    application = _make_application(bank_account="00012345678")
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result={"status": StudentVerificationStatus.GRADUATED, "message": "已畢業"},
+        verification_status=StudentVerificationStatus.GRADUATED,
+        eligibility_result={"is_eligible": True, "failed_rules": [], "warning_rules": []},
+    )
+
+    assert item.is_included is False
+    assert "graduated" in item.exclusion_reason
+    assert item.verification_status == StudentVerificationStatus.GRADUATED
+
+
+def test_create_roster_item_excluded_when_eligibility_failed(service: RosterService) -> None:
+    """Verified but failed eligibility rules ⇒ is_included=False, and
+    the failed rule messages are concatenated into exclusion_reason."""
+    roster = _make_roster()
+    application = _make_application(bank_account="00012345678")
+
+    eligibility = {
+        "is_eligible": False,
+        "failed_rules": ["GPA低於 3.0", "未提交推薦信"],
+        "warning_rules": [],
+    }
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result={"status": StudentVerificationStatus.VERIFIED, "message": "ok"},
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=eligibility,
+    )
+
+    assert item.is_included is False
+    assert "不符合獎學金規則" in item.exclusion_reason
+    assert "GPA低於 3.0" in item.exclusion_reason
+    assert "未提交推薦信" in item.exclusion_reason
+    # rule_validation_result + failed_rules columns preserve the full snapshot
+    assert item.rule_validation_result == eligibility
+    assert item.failed_rules == ["GPA低於 3.0", "未提交推薦信"]
+
+
+# ---------------------------------------------------------------------------
+# application_identity snapshot — 新申請 vs 續領
+# ---------------------------------------------------------------------------
+
+
+def test_create_roster_item_application_identity_new(service: RosterService) -> None:
+    """A non-renewal application (is_renewal=False OR no previous_application_id)
+    gets the "{academic_year}新申請" tag — finance reads this on the payment
+    voucher to mark first-time payments."""
+    roster = _make_roster(academic_year=114)
+    application = _make_application(
+        academic_year=114,
+        is_renewal=False,
+        previous_application_id=None,
+    )
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result=None,
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+
+    assert item.application_identity == "114新申請"
+
+
+def test_create_roster_item_application_identity_renewal(service: RosterService) -> None:
+    """A renewal (is_renewal=True AND previous_application_id set) gets
+    the "{academic_year}續領" tag. Both flags must be true — a stray
+    is_renewal=True with no previous_application_id falls back to 新申請
+    rather than mislabeling."""
+    roster = _make_roster(academic_year=114)
+    application = _make_application(
+        academic_year=114,
+        is_renewal=True,
+        previous_application_id=42,
+    )
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result=None,
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+
+    assert item.application_identity == "114續領"
+
+
+def test_create_roster_item_renewal_flag_without_previous_id_is_new(service: RosterService) -> None:
+    """Defensive: is_renewal=True but previous_application_id=None means
+    the renewal data is incomplete. Fall back to 新申請 rather than emitting
+    a misleading 續領 label. Pins the AND-of-both-conditions branch."""
+    roster = _make_roster(academic_year=114)
+    application = _make_application(
+        academic_year=114,
+        is_renewal=True,
+        previous_application_id=None,
+    )
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result=None,
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+
+    assert item.application_identity == "114新申請"
+
+
+# ---------------------------------------------------------------------------
+# Misc field-mapping sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_create_roster_item_uses_application_amount_when_set(service: RosterService) -> None:
+    """`scholarship_amount = application.amount or config.amount` — per-application
+    amount overrides the config default. Pin: if amount is set, it wins."""
+    roster = _make_roster()
+    application = _make_application(amount=12345, config_amount=99999)
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result=None,
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+
+    assert item.scholarship_amount == 12345
+
+
+def test_create_roster_item_falls_back_to_config_amount_when_app_amount_none(service: RosterService) -> None:
+    """If application.amount is falsy, fall back to the configuration's
+    default amount. Without this, monthly auto-renewals (where amount is
+    pre-filled to None) would silently produce a 0-amount roster row."""
+    roster = _make_roster()
+    application = _make_application(amount=None, config_amount=50000)
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result=None,
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+
+    assert item.scholarship_amount == 50000
+
+
+def test_create_roster_item_db_add_called_once(service: RosterService) -> None:
+    """The contract includes the side-effect of calling `self.db.add(item)`
+    so the caller's commit picks up the new row. Without this side-effect
+    the generated PaymentRosterItem would never persist."""
+    roster = _make_roster()
+    application = _make_application()
+
+    item = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result=None,
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+
+    service.db.add.assert_called_once_with(item)
+
+
+def test_create_roster_item_verification_at_set_when_result_present(service: RosterService) -> None:
+    """When a verification_result is provided, verification_at is stamped
+    with `datetime.now(UTC)`. When verification_result is None (e.g.
+    student_verification_enabled=False), verification_at stays None so
+    audit logs don't lie about a verification that never happened."""
+    roster = _make_roster()
+    application = _make_application()
+
+    with_result = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result={"status": StudentVerificationStatus.VERIFIED, "message": "ok"},
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+    without_result = service._create_roster_item(
+        roster=roster,
+        application=application,
+        verification_result=None,
+        verification_status=StudentVerificationStatus.VERIFIED,
+        eligibility_result=None,
+    )
+
+    assert with_result.verification_at is not None
+    assert with_result.verification_at.tzinfo == timezone.utc
+    # Sanity: very recent
+    delta = datetime.now(timezone.utc) - with_result.verification_at
+    assert delta.total_seconds() < 60
+
+    assert without_result.verification_at is None


### PR DESCRIPTION
## Summary

Adds ~15 focused tests against the two roster services with near-zero coverage on their critical mapping logic.

- **`backend/app/tests/test_roster_service_core.py`** (14 cases) — pins `_create_roster_item` contract: which student-data field becomes 身分證字號 (PR #819: `std_pid` not `std_stdcode`), the inclusion gate (bank account / verification / eligibility), `application_identity` snapshot (新申請 vs 續領), amount fallback to config default, and the `db.add` side-effect.
- **`backend/app/tests/test_excel_export_service_rows.py`** (11 cases) — pins `_prepare_excel_data` row-data mapping: that 身分證字號 pulls from `item.student_id_number` (downstream propagation of PR #819), that 單價 == 免稅給付 == `scholarship_amount` (accounting system reconciliation), the 銀行代碼=700 postal-account hardcode, all fixed-value columns, the missing-required-fields skip, and the empty-roster header-only branch of `_validate_export_data`.

Tests use `MagicMock` for the DB and `SimpleNamespace` stubs for `Application` / `PaymentRoster` / `PaymentRosterItem` — no DB, no MinIO, no openpyxl write. Pattern mirrors `test_college_ranking_export_service.py`.

## Context: PR #819

This branch was forked before PR #819 merged, so it includes a cherry-pick of `fdaa6eaa` (the std_stdcode → std_pid fix + docstring update + backfill migration) so the regression test on the new behavior has something to assert against. If PR #819 lands on main first, the rebase will collapse this cherry-pick to a no-op; the test commit (`92878036`) stands on its own.

## Test plan

- [x] All 25 tests pass locally inside the dev container:
  ```
  docker compose -f docker-compose.dev.yml exec backend \
    python -m pytest app/tests/test_roster_service_core.py \
                     app/tests/test_excel_export_service_rows.py \
                     -v --no-cov
  # ============================== 25 passed in 0.62s ==============================
  ```
- [ ] CI runs the new tests as part of the backend test job (no special markers — picked up by default collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)