### PR TITLE
fix(api): wrap reference_data endpoints in ApiResponse envelope (CLAUDE.md §5)

### DIFF
--- a/backend/app/api/v1/endpoints/reference_data.py
+++ b/backend/app/api/v1/endpoints/reference_data.py
@@ -153,7 +153,7 @@ async def get_enroll_types(
 async def get_all_reference_data(
     response: Response,
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> ApiResponse[dict]:
     """
     Get all reference data in a single request.
 
@@ -168,7 +168,8 @@ async def get_all_reference_data(
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "0"
 
-    return await _get_all_reference_data_cached(session)
+    data = await _get_all_reference_data_cached(session)
+    return ApiResponse(success=True, message="Reference data retrieved successfully", data=data)
 
 
 @cached(key_fn=lambda *_, **__: "refdata:all", ttl=86400)  # 24 h
@@ -516,9 +517,10 @@ async def get_scholarship_periods(
 @router.get("/scholarship-types-with-cycles")
 async def get_scholarship_types_with_cycles(
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> ApiResponse[dict]:
     """Get all scholarship types with their application cycles"""
-    return await _get_scholarship_types_with_cycles_cached(session)
+    data = await _get_scholarship_types_with_cycles_cached(session)
+    return ApiResponse(success=True, message="Scholarship types retrieved successfully", data=data)
 
 
 @cached(key_fn=lambda *_, **__: "refdata:scholarships:active", ttl=43200)  # 12 h

--- a/backend/app/tests/test_reference_data_response_shape.py
+++ b/backend/app/tests/test_reference_data_response_shape.py
@@ -93,3 +93,40 @@ def test_semesters_returns_api_response():
     assert "academic_years" in data
     assert "semesters" in data
     assert "current_academic_year" in data
+
+
+def test_all_reference_data_returns_api_response():
+    """GET /api/v1/reference-data/all returns wrapped ApiResponse[dict].
+
+    Wave-1 closeout: this aggregate endpoint historically returned a bare dict
+    (degrees, identities, academies, departments, ...). It is now wrapped in
+    ApiResponse so frontend auto-detection in ``frontend/lib/api.ts`` continues
+    to work uniformly.
+    """
+    client = TestClient(app)
+    response = client.get("/api/v1/reference-data/all")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    _assert_api_response_shape(payload, expected_data_type=dict)
+    # Original dict keys are now under .data
+    data = payload["data"]
+    for key in ("degrees", "identities", "academies", "departments", "genders"):
+        assert key in data, f"missing '{key}' in /reference-data/all .data payload"
+
+
+def test_scholarship_types_with_cycles_returns_api_response():
+    """GET /api/v1/reference-data/scholarship-types-with-cycles returns wrapped ApiResponse[dict].
+
+    Wave-1 closeout: this endpoint historically returned a bare dict
+    (scholarships, cycle_counts, total_scholarships). It is now wrapped in
+    ApiResponse for parity with the rest of the reference-data module.
+    """
+    client = TestClient(app)
+    response = client.get("/api/v1/reference-data/scholarship-types-with-cycles")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    _assert_api_response_shape(payload, expected_data_type=dict)
+    data = payload["data"]
+    assert "scholarships" in data
+    assert "cycle_counts" in data
+    assert "total_scholarships" in data

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -16833,7 +16833,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ApiResponse_dict_"];
                 };
             };
         };
@@ -16961,7 +16961,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["ApiResponse_dict_"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- Wrap `GET /api/v1/reference-data/all` and `GET /api/v1/reference-data/scholarship-types-with-cycles` in the standard `{success, message, data}` envelope per CLAUDE.md §5. They were the last two endpoints in `reference_data.py` returning a bare `dict`, bypassing the frontend's auto-detection in `frontend/lib/api.ts` (`if ("success" in data && "message" in data)`).
- Wrap at the route layer, **not** inside the `@cached(...)` helper, so existing Redis cache entries (24 h TTL on `/all`, 12 h on `/scholarship-types-with-cycles`) stay valid — `_get_all_reference_data_cached` and `_get_scholarship_types_with_cycles_cached` keep returning raw `dict`; the endpoint wraps on read.
- Update the two endpoints' return-type annotations from `-> dict` to `-> ApiResponse[dict]`.
- Refresh `frontend/lib/api/generated/schema.d.ts` for just the two affected operations (response type goes from `Record<string, never>` → `components["schemas"]["ApiResponse_dict_"]`); the rest of the file is untouched because the worktree base diverges from the currently-deployed dev backend, so a full `npm run api:generate` would have introduced unrelated schema drift.
- Add two regression tests (`test_all_reference_data_returns_api_response`, `test_scholarship_types_with_cycles_returns_api_response`) in `backend/app/tests/test_reference_data_response_shape.py` following the wave-1 pattern. They hit the DB (same as the four pre-existing wave-1 tests in the same file) and are not smoke-marked.

## Test plan

- [x] Baseline: `docker compose -f docker-compose.dev.yml exec backend python -m pytest tests/ --no-cov -q` → 89 passed
- [x] Post-change: same command → 89 passed
- [x] `uvx --from black==26.3.1 black --line-length=120` on both touched backend files → no changes
- [x] `python -m flake8 ... --select=F` on both touched backend files → no findings
- [x] Live curl `GET /api/v1/reference-data/all` → returns `{success, message, data: {degrees, identities, academies, departments, genders, ...}}`
- [x] Live curl `GET /api/v1/reference-data/scholarship-types-with-cycles` → returns `{success, message, data: {scholarships, cycle_counts, total_scholarships}}`
- [x] `npx tsc --noEmit` on frontend → no type errors after schema patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)