### PR TITLE
fix(roster): correct simulate_roster_generation AttributeErrors (issue #825)

### DIFF
--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -1296,11 +1296,11 @@ class RosterService:
             for application in eligible_applications:
                 try:
                     # 模擬規則驗證
-                    eligibility_result = self._validate_eligibility_rules(application, scholarship_config)
+                    eligibility_result = self._validate_student_eligibility(application, academic_year, period_label)
                     is_rule_passed = eligibility_result.get("is_eligible", False)
 
                     # 模擬學籍驗證
-                    verification_status = StudentVerificationStatus.NOT_VERIFIED
+                    verification_status = StudentVerificationStatus.VERIFIED
                     verification_passed = True
 
                     if student_verification_enabled:
@@ -1309,7 +1309,7 @@ class RosterService:
                             verification_status = StudentVerificationStatus.VERIFIED
                             verification_summary["verified"] += 1
                         else:
-                            verification_status = StudentVerificationStatus.FAILED
+                            verification_status = StudentVerificationStatus.NOT_FOUND
                             verification_passed = False
                             verification_summary["failed"] += 1
                             potential_issues.append(


### PR DESCRIPTION
## Summary

Three `AttributeError`s in `RosterService.simulate_roster_generation()` caused every application in a dry-run to be flagged as an error, rendering the dry-run / roster preview feature completely broken.

- `self._validate_eligibility_rules(...)` → method does not exist; use `self._validate_student_eligibility(application, academic_year, period_label)`
- `StudentVerificationStatus.NOT_VERIFIED` → enum value does not exist; use `VERIFIED` as simulation default
- `StudentVerificationStatus.FAILED` → enum value does not exist; use `NOT_FOUND`

Fixes #825.

## Test plan

- [ ] Backend lint passes
- [ ] Backend tests pass (unit + integration)
- [ ] Trigger a dry-run via the admin roster preview endpoint — should return estimated qualified/disqualified counts, not a list of "處理申請 X 時發生錯誤" for every item

🤖 Generated with [Claude Code](https://claude.com/claude-code)