### PR TITLE
fix(api): wrap nycu_employee endpoints in ApiResponse envelope (CLAUDE.md §5)

### DIFF
--- a/backend/app/api/v1/endpoints/nycu_employee.py
+++ b/backend/app/api/v1/endpoints/nycu_employee.py
@@ -104,7 +104,7 @@ async def get_employees(
         else:
             result = await client.get_employee_page(page_row=str(page), status=status)
 
-        return EmployeeListResponse(
+        response = EmployeeListResponse(
             status=result.status,
             message=result.message,
             total_page=result.total_page,
@@ -112,6 +112,11 @@ async def get_employees(
             employees=result.empDataList,
             page=page,
         )
+        return {
+            "success": True,
+            "message": "Employees retrieved successfully",
+            "data": response.model_dump(),
+        }
 
     except NYCUEmpAuthenticationError as e:
         raise HTTPException(status_code=401, detail="Authentication failed") from e
@@ -235,9 +240,14 @@ async def search_employees(
             position_lower = position_name.lower()
             filtered_employees = [emp for emp in filtered_employees if position_lower in emp.position_name.lower()]
 
-        return EmployeeSearchResponse(
+        response = EmployeeSearchResponse(
             employees=filtered_employees, total_count=total_count, filtered_count=len(filtered_employees)
         )
+        return {
+            "success": True,
+            "message": "Employee search completed",
+            "data": response.model_dump(),
+        }
 
     except NYCUEmpAuthenticationError as e:
         raise HTTPException(status_code=401, detail="Authentication failed") from e
@@ -278,7 +288,11 @@ async def get_employee_by_no(
         for page in pages:
             for employee in page.empDataList:
                 if employee.employee_no == employee_no:
-                    return employee
+                    return {
+                        "success": True,
+                        "message": "Employee found",
+                        "data": employee.model_dump(),
+                    }
 
         # Employee not found
         raise HTTPException(status_code=404, detail=f"Employee {employee_no} not found")


### PR DESCRIPTION
## Summary
- Wrap three `backend/app/api/v1/endpoints/nycu_employee.py` endpoints in the standard `{success, message, data}` ApiResponse envelope mandated by CLAUDE.md §5.
- `get_employees()`, `search_employees()`, and `get_employee_by_no()` previously returned raw Pydantic models (`EmployeeListResponse`, `EmployeeSearchResponse`, `NYCUEmpItem`), bypassing the frontend's auto-detection contract.
- Each response is now serialized via `.model_dump()` and nested under `data`, matching the rest of the API surface (and the already-compliant `get_all_employees` endpoint in the same file).

## Test plan
- [ ] `GET /api/v1/nycu-employee/employees?page=1` returns `{success, message, data: {status, message, total_page, total_count, employees, page}}`
- [ ] `GET /api/v1/nycu-employee/employees/search?query=...` returns `{success, message, data: {employees, total_count, filtered_count}}`
- [ ] `GET /api/v1/nycu-employee/employees/{employee_no}` returns `{success, message, data: <employee>}` on hit and `404` on miss (unchanged)
- [ ] Frontend consumers continue to receive expected payload shape after `api.ts` auto-unwrap
- [ ] `black` + `flake8` clean (verified locally)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)