### PR TITLE
perf(manual_distribution): batch-load renewal apps to avoid N+1 (issue #830)

### DIFF
--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -1527,11 +1527,22 @@ class ManualDistributionService:
                     approved_challenges.append(app)
 
         # 3. Release handling — approved challenges cancel their renewal targets.
+        # Batch-load all referenced renewal applications to avoid N+1 queries.
+        challenge_renewal_ids = [
+            app.challenges_application_id for app in approved_challenges if app.challenges_application_id is not None
+        ]
+        renewal_apps_by_id: dict[int, Application] = {}
+        if challenge_renewal_ids:
+            renewal_apps_by_id = {
+                app.id: app
+                for app in (
+                    await self.db.scalars(select(Application).where(Application.id.in_(challenge_renewal_ids)))
+                ).all()
+            }
+
         released: dict[tuple[str, int], int] = {}
         for challenge_app in approved_challenges:
-            renewal_app = await self.db.scalar(
-                select(Application).where(Application.id == challenge_app.challenges_application_id)
-            )
+            renewal_app = renewal_apps_by_id.get(challenge_app.challenges_application_id)
             if renewal_app is None:
                 logger.warning(
                     "Challenge app %s references missing renewal id=%s — skipping release",


### PR DESCRIPTION
## Summary
- Replaces a per-iteration `SELECT` in `execute_general_distribution`'s release-handling loop with a single batched `IN (...)` query that builds an id-to-application map before the loop.
- For N approved challenge applications, DB round-trips drop from N to 1; behavior (missing-renewal warning + skip, status mutation, freed-year accounting) is preserved unchanged.

## Test plan
- [ ] `uvx --from black==26.3.1 black backend/app/services/manual_distribution_service.py --line-length=120` reports no changes
- [ ] `uvx --from flake8==7.3.0 flake8 backend/app/services/manual_distribution_service.py --max-line-length=120` reports no new findings (two pre-existing F841 warnings on lines 677/790 are unrelated)
- [ ] Trigger general distribution with approved challenge applications referencing existing renewal apps and confirm released slot counts + cancelled-by-challenge statuses match prior behavior
- [ ] Trigger general distribution with at least one challenge referencing a deleted renewal id and confirm the "missing renewal id" warning still fires and the row is skipped

Closes #830

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)