### PR TITLE
fix(college-review): show all college applications regardless of review phase

### DIFF
--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -41,6 +41,20 @@ class ApplicationStatus(enum.Enum):
     deleted = "deleted"  # 刪除
 
 
+# Statuses an application holds once it has entered the review pipeline — the
+# set surfaced in reviewer-facing listings (professor and college). Excludes
+# pre-submission (draft) and administrative/terminal states (withdrawn,
+# cancelled, deleted, ...). Shared so the professor and college listings stay
+# in sync instead of re-declaring the same five values.
+REVIEWABLE_APPLICATION_STATUSES = [
+    ApplicationStatus.submitted.value,  # 已送出
+    ApplicationStatus.under_review.value,  # 審批中
+    ApplicationStatus.approved.value,  # 核准
+    ApplicationStatus.partial_approved.value,  # 部分同意
+    ApplicationStatus.rejected.value,  # 駁回
+]
+
+
 class ReviewStage(enum.Enum):
     """
     Review stage - Internal workflow position

--- a/backend/app/services/application_enricher_service.py
+++ b/backend/app/services/application_enricher_service.py
@@ -261,6 +261,7 @@ class ApplicationEnricherService:
                     "files_count": len(app.get("files", [])),
                 },
                 # 教授審核資訊
+                "requires_professor_recommendation": app.get("requires_professor_recommendation", False),
                 "professor_review_completed": app.get("professor_review_completed", False),
                 "professor_review_items": app.get("professor_review_items", []),
             }

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -18,7 +18,7 @@ from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFound
 from app.core.metrics import scholarship_applications_total, scholarship_reviews_total
 from app.core.schema_validation import serialize_value
 from app.models.application import Application, ApplicationStatus
-from app.models.enums import ReviewStage, Semester
+from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, ReviewStage, Semester
 from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
 from app.models.user import User, UserRole
@@ -2447,15 +2447,7 @@ class ApplicationService:
                     # Only applications assigned to this specific professor
                     Application.professor_id == professor_id,
                     # Only applications in valid statuses for professor viewing
-                    Application.status.in_(
-                        [
-                            ApplicationStatus.submitted.value,
-                            ApplicationStatus.under_review.value,
-                            ApplicationStatus.approved.value,
-                            ApplicationStatus.partial_approved.value,
-                            ApplicationStatus.rejected.value,
-                        ]
-                    ),
+                    Application.status.in_(REVIEWABLE_APPLICATION_STATUSES),
                 )
             )
 

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFoundError
 from app.core.metrics import scholarship_reviews_total
-from app.models.application import Application, ApplicationStatus
+from app.models.application import Application
 from app.models.college_review import CollegeRanking, CollegeRankingItem
 from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, Semester
 from app.models.review import ApplicationReview  # Unified review system
@@ -502,14 +502,9 @@ class CollegeReviewService:
             f"Building query for sub_type_code={sub_type_code}, semester_filter type={type(semester_filter)}, semester_filter={semester_filter}, creator_college={creator_college}"
         )
 
-        # Valid statuses for ranking: include all reviewed/approved states
-        valid_ranking_statuses = [
-            ApplicationStatus.submitted.value,
-            ApplicationStatus.under_review.value,
-            ApplicationStatus.approved.value,
-            ApplicationStatus.partial_approved.value,
-            ApplicationStatus.rejected.value,
-        ]
+        # Valid statuses for ranking: the same reviewed/approved states the
+        # review listings surface (shared constant keeps the three sites in sync).
+        valid_ranking_statuses = REVIEWABLE_APPLICATION_STATUSES
 
         if sub_type_code == "default":
             # Include all applications for this scholarship type, regardless of sub-type

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -312,6 +312,7 @@ class CollegeReviewService:
             select(Application)
             .options(
                 selectinload(Application.scholarship_type_ref),
+                selectinload(Application.scholarship_configuration),  # for requires_professor_recommendation
                 selectinload(Application.reviews).selectinload(ApplicationReview.reviewer),
                 selectinload(Application.reviews).selectinload(ApplicationReview.items),
                 selectinload(Application.files),
@@ -405,6 +406,12 @@ class CollegeReviewService:
                 "created_at": app.created_at,
                 "student_data": student_payload,
                 "is_renewal": app.is_renewal,
+                # Whether this scholarship requires a professor recommendation step.
+                # Lets the college UI distinguish "professor hasn't recommended yet"
+                # (show 教授審核中) from "no professor step at all" (show —).
+                "requires_professor_recommendation": bool(
+                    app.scholarship_configuration and app.scholarship_configuration.requires_professor_recommendation
+                ),
                 # Professor review details
                 "professor_review_completed": any(
                     self._role_matches(review.reviewer.role, "professor") for review in app.reviews if review.reviewer

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -27,7 +27,6 @@ from app.models.review import ApplicationReview  # Unified review system
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User, UserRole
 from app.services.email_automation_service import email_automation_service
-from app.services.review_phase_filter import apply_renewal_phase_filter
 
 func: Any = sa_func
 
@@ -293,29 +292,29 @@ class CollegeReviewService:
             f"Getting applications for college review with filters: type_id={scholarship_type_id}, type={scholarship_type}, sub_type={sub_type}, year={academic_year}, semester={semester}"
         )
 
-        # Base query for applications in reviewable state with comprehensive eager loading
-        # Phase 4 (renewal routing): for *pending* applications we must restrict to
-        # those matching the current college review phase — renewal apps during
-        # renewal_college_review, general apps during college_review. Historical
-        # statuses (approved / partial_approved / rejected) remain visible
-        # unconditionally so reviewers can audit past decisions.
+        # Base query for applications in reviewable state with comprehensive eager loading.
         #
-        # Pending = submitted OR under_review. Professor review is advisory (issue
-        # #182): it advances review_stage to professor_reviewed but leaves status at
-        # ``submitted``, so a professor-reviewed app awaiting college sign-off is
-        # still ``submitted``. The professor listing already treats submitted as
-        # pending; the college listing must too, or these apps never surface here.
-        pending_statuses = [
+        # College reviewers must see EVERY application belonging to their college,
+        # including ones still awaiting professor sign-off:
+        # 「學院端應該要可以看到隸屬於該學院的所有申請，即使還卡在教授審核的階段」.
+        #
+        # Professor review is advisory (issue #182): it advances review_stage to
+        # professor_reviewed but leaves status at ``submitted``. Previously this
+        # pending listing was time-gated by apply_renewal_phase_filter(role=
+        # "college"), so while a configuration was still inside its *professor*
+        # review window (college window not yet open), a professor-stage
+        # application was invisible to the college. We intentionally drop that
+        # gate here: pending (submitted / under_review) and historical (approved /
+        # partial_approved / rejected) rows are all shown, scoped to the college
+        # by the ``college_code`` filter below. The professor listing keeps its
+        # own renewal-phase filter — only college visibility is broadened.
+        visible_statuses = [
             ApplicationStatus.submitted.value,
             ApplicationStatus.under_review.value,
+            ApplicationStatus.approved.value,  # 包含已核准的申請
+            ApplicationStatus.partial_approved.value,  # 包含部分同意的申請
+            ApplicationStatus.rejected.value,  # 包含已駁回的申請
         ]
-        pending_phase_subquery = (
-            apply_renewal_phase_filter(
-                select(Application.id).where(Application.status.in_(pending_statuses)),
-                role="college",
-                alias_name="college_phase_cfg",
-            )
-        ).subquery()
 
         stmt = (
             select(Application)
@@ -326,21 +325,9 @@ class CollegeReviewService:
                 selectinload(Application.files),
                 selectinload(Application.student),  # Load student information
             )
-            .where(
-                or_(
-                    # Pending rows (submitted / under_review) must match the current
-                    # renewal/general college review phase.
-                    and_(
-                        Application.status.in_(pending_statuses),
-                        Application.id.in_(select(pending_phase_subquery.c.id)),
-                    ),
-                    Application.status == ApplicationStatus.approved.value,  # 包含已核准的申請
-                    Application.status == ApplicationStatus.partial_approved.value,  # 包含部分同意的申請
-                    Application.status == ApplicationStatus.rejected.value,  # 包含已駁回的申請
-                )
-            )
+            .where(Application.status.in_(visible_statuses))
         )
-        logger.info("Base query created, looking for status in [under_review, approved, partial_approved, rejected]")
+        logger.info("Base query created, looking for status in %s", visible_statuses)
 
         # Apply filters
         if scholarship_type_id:

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -22,7 +22,7 @@ from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFound
 from app.core.metrics import scholarship_reviews_total
 from app.models.application import Application, ApplicationStatus
 from app.models.college_review import CollegeRanking, CollegeRankingItem
-from app.models.enums import Semester
+from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, Semester
 from app.models.review import ApplicationReview  # Unified review system
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User, UserRole
@@ -308,14 +308,6 @@ class CollegeReviewService:
         # partial_approved / rejected) rows are all shown, scoped to the college
         # by the ``college_code`` filter below. The professor listing keeps its
         # own renewal-phase filter — only college visibility is broadened.
-        visible_statuses = [
-            ApplicationStatus.submitted.value,
-            ApplicationStatus.under_review.value,
-            ApplicationStatus.approved.value,  # 包含已核准的申請
-            ApplicationStatus.partial_approved.value,  # 包含部分同意的申請
-            ApplicationStatus.rejected.value,  # 包含已駁回的申請
-        ]
-
         stmt = (
             select(Application)
             .options(
@@ -325,9 +317,9 @@ class CollegeReviewService:
                 selectinload(Application.files),
                 selectinload(Application.student),  # Load student information
             )
-            .where(Application.status.in_(visible_statuses))
+            .where(Application.status.in_(REVIEWABLE_APPLICATION_STATUSES))
         )
-        logger.info("Base query created, looking for status in %s", visible_statuses)
+        logger.debug("Base query created, looking for status in %s", REVIEWABLE_APPLICATION_STATUSES)
 
         # Apply filters
         if scholarship_type_id:
@@ -375,10 +367,11 @@ class CollegeReviewService:
         result = await self.db.execute(stmt)
         applications = result.scalars().all()
         logger.info(f"Query executed, found {len(applications)} applications")
-        for app in applications:
-            logger.info(
-                f"  App {app.id}: status={app.status}, type_id={app.scholarship_type_id}, year={app.academic_year}, semester={app.semester}"
-            )
+        if logger.isEnabledFor(logging.DEBUG):
+            for app in applications:
+                logger.debug(
+                    f"  App {app.id}: status={app.status}, type_id={app.scholarship_type_id}, year={app.academic_year}, semester={app.semester}"
+                )
 
         # Note: CollegeReview removed - use Application.final_ranking_position instead
         # college_review_lookup logic removed - data now in Application model

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -23,6 +23,7 @@ from app.models.enums import ApplicationStatus, ReviewStage
 from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.payment_roster import PaymentRoster, PaymentRosterItem, RosterStatus
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipSubTypeConfig
+from app.models.user import User, UserRole
 from app.services.received_months_service import calculate_received_months_bulk_async
 
 logger = logging.getLogger(__name__)
@@ -889,8 +890,83 @@ class ManualDistributionService:
                 raise ValueError(f"Duplicate ranking item: {item_id}")
             seen_items.add(item_id)
 
+        # Professor-approval gate (issue: 分發時一定要教授有同意那個獎學金才能被分發到).
+        # A student may only be distributed to a sub-type the professor approved
+        # for that application. Exemptions handled in _assert_professor_approved:
+        #   - renewal applications (續領豁免 — they don't go through professor review)
+        #   - scholarships that don't require a professor recommendation step
+        #     (no professor reviews exist, so there is nothing to gate on)
+        await self._assert_professor_approved(allocations)
+
         # Quota validation is done real-time via the quota-status endpoint on the frontend.
         # The frontend sends only valid allocations based on displayed remaining counts.
+
+    async def _assert_professor_approved(self, allocations: list[dict[str, Any]]) -> None:
+        """Block any allocation to a sub-type the professor did not approve.
+
+        Only allocations that assign a sub-type are checked (``sub_type_code`` set;
+        ``None`` means unallocate). Renewal applications and scholarships that don't
+        require a professor recommendation are exempt — for those there is no
+        professor approval to enforce against.
+        """
+        allocating = [a for a in allocations if a.get("sub_type_code")]
+        if not allocating:
+            return
+
+        item_ids = [a["ranking_item_id"] for a in allocating]
+        stmt = (
+            select(CollegeRankingItem)
+            .options(selectinload(CollegeRankingItem.application).selectinload(Application.scholarship_configuration))
+            .where(CollegeRankingItem.id.in_(item_ids))
+        )
+        items = {it.id: it for it in (await self.db.execute(stmt)).scalars().all()}
+
+        # Keep only allocations that actually need the gate (skip renewal apps and
+        # scholarships without a professor recommendation step).
+        gated: list[tuple[dict[str, Any], Application]] = []
+        for alloc in allocating:
+            item = items.get(alloc["ranking_item_id"])
+            app = item.application if item else None
+            if app is None or app.is_renewal:
+                continue
+            cfg = app.scholarship_configuration
+            if not (cfg and cfg.requires_professor_recommendation):
+                continue
+            gated.append((alloc, app))
+
+        if not gated:
+            return
+
+        approved = await self._professor_approved_sub_types({app.id for _, app in gated})
+
+        violations = []
+        for alloc, app in gated:
+            sub_type = (alloc["sub_type_code"] or "").lower().strip()
+            if sub_type not in approved.get(app.id, set()):
+                violations.append(f"{app.app_id} → {alloc['sub_type_code']}")
+
+        if violations:
+            raise ValueError("以下分發未取得教授對該子類型的核准，無法分發：" + "、".join(violations))
+
+    async def _professor_approved_sub_types(self, app_ids: set[int]) -> dict[int, set[str]]:
+        """application_id → set of sub_type_codes a professor recommended ``approve``."""
+        if not app_ids:
+            return {}
+        stmt = (
+            select(ApplicationReview.application_id, ApplicationReviewItem.sub_type_code)
+            .join(ApplicationReviewItem, ApplicationReviewItem.review_id == ApplicationReview.id)
+            .join(User, User.id == ApplicationReview.reviewer_id)
+            .where(
+                ApplicationReview.application_id.in_(app_ids),
+                User.role == UserRole.professor,
+                ApplicationReviewItem.recommendation == "approve",
+            )
+        )
+        result = await self.db.execute(stmt)
+        approved: dict[int, set[str]] = {}
+        for app_id, sub_type_code in result.all():
+            approved.setdefault(app_id, set()).add((sub_type_code or "").lower().strip())
+        return approved
 
     def _compute_application_identity(self, app: Application) -> str:
         """

--- a/backend/app/tests/test_manual_distribution_professor_gate.py
+++ b/backend/app/tests/test_manual_distribution_professor_gate.py
@@ -1,0 +1,175 @@
+"""Tests for the professor-approval gate on manual distribution.
+
+Rule (用戶需求): 分發時一定要教授有同意「那個」子類型才能被分發到。
+Enforced in ManualDistributionService._validate_allocations (called first by
+allocate()), so a violation blocks the whole allocate() call before any mutation.
+
+Exemptions:
+  - renewal applications (續領豁免)
+  - scholarships that don't require a professor recommendation step
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import ApplicationStatus, ReviewStage, Semester
+from app.models.review import ApplicationReview, ApplicationReviewItem
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.manual_distribution_service import ManualDistributionService
+
+YEAR = 114
+SEM = Semester.first.value
+
+
+async def _setup(
+    db: AsyncSession,
+    *,
+    suffix: str,
+    is_renewal: bool = False,
+    requires_prof: bool = True,
+    approved_sub_types: list[str] | None = None,
+) -> tuple[ManualDistributionService, int, int]:
+    """Build a student + scholarship config + application + ranking item, and
+    optionally a professor review approving the given sub-types.
+
+    Returns (service, ranking_item_id, scholarship_type_id).
+    """
+    student = User(
+        nycu_id=f"gate_stu_{suffix}",
+        name=f"Gate Stu {suffix}",
+        email=f"gate_stu_{suffix}@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    professor = User(
+        nycu_id=f"gate_prof_{suffix}",
+        name=f"Gate Prof {suffix}",
+        email=f"gate_prof_{suffix}@u.edu",
+        user_type=UserType.employee,
+        role=UserRole.professor,
+    )
+    db.add_all([student, professor])
+    await db.commit()
+    await db.refresh(student)
+    await db.refresh(professor)
+
+    sch = ScholarshipType(code=f"gate_sch_{suffix}", name=f"Gate Sch {suffix}", status="active")
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        config_code=f"gate_cfg_{suffix}",
+        config_name=f"Gate cfg {suffix}",
+        academic_year=YEAR,
+        semester=SEM,
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        requires_professor_recommendation=requires_prof,
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+
+    app = Application(
+        app_id=f"APP-GATE-{suffix}",
+        user_id=student.id,
+        scholarship_type_id=sch.id,
+        scholarship_configuration_id=cfg.id,
+        sub_type_selection_mode="multiple",
+        is_renewal=is_renewal,
+        academic_year=YEAR,
+        semester=Semester.first.value,
+        review_stage=ReviewStage.college_ranked.value,
+        status=ApplicationStatus.submitted.value,
+        scholarship_subtype_list=["nstc", "moe_1w"],
+        agree_terms=True,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+
+    if approved_sub_types:
+        review = ApplicationReview(
+            application_id=app.id,
+            reviewer_id=professor.id,
+            recommendation="approve",
+            reviewed_at=datetime.now(timezone.utc),
+        )
+        db.add(review)
+        await db.commit()
+        await db.refresh(review)
+        for st in approved_sub_types:
+            db.add(ApplicationReviewItem(review_id=review.id, sub_type_code=st, recommendation="approve"))
+        await db.commit()
+
+    ranking = CollegeRanking(
+        scholarship_type_id=sch.id,
+        sub_type_code="default",
+        academic_year=YEAR,
+        semester=SEM,
+        total_applications=1,
+        total_quota=5,
+    )
+    db.add(ranking)
+    await db.commit()
+    await db.refresh(ranking)
+
+    item = CollegeRankingItem(ranking_id=ranking.id, application_id=app.id, rank_position=1)
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+
+    return ManualDistributionService(db), item.id, sch.id
+
+
+@pytest.mark.asyncio
+async def test_allocate_allowed_when_professor_approved_that_subtype(db: AsyncSession):
+    service, item_id, sch_id = await _setup(db, suffix="ok", approved_sub_types=["nstc"])
+    # Allocating to the approved sub-type must pass validation (no raise).
+    await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
+
+
+@pytest.mark.asyncio
+async def test_allocate_blocked_for_subtype_professor_did_not_approve(db: AsyncSession):
+    service, item_id, sch_id = await _setup(db, suffix="wrongsub", approved_sub_types=["nstc"])
+    # Professor approved nstc only; allocating to moe_1w must be blocked.
+    with pytest.raises(ValueError, match="教授"):
+        await service._validate_allocations(
+            sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "moe_1w"}]
+        )
+
+
+@pytest.mark.asyncio
+async def test_allocate_blocked_when_no_professor_review(db: AsyncSession):
+    service, item_id, sch_id = await _setup(db, suffix="noreview", approved_sub_types=None)
+    with pytest.raises(ValueError, match="教授"):
+        await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
+
+
+@pytest.mark.asyncio
+async def test_allocate_exempts_renewal_application(db: AsyncSession):
+    # Renewal app with no professor approval — must still be allocatable.
+    service, item_id, sch_id = await _setup(db, suffix="renewal", is_renewal=True, approved_sub_types=None)
+    await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
+
+
+@pytest.mark.asyncio
+async def test_allocate_exempts_scholarship_without_professor_step(db: AsyncSession):
+    # Scholarship that doesn't require professor recommendation — no gate.
+    service, item_id, sch_id = await _setup(db, suffix="noprof", requires_prof=False, approved_sub_types=None)
+    await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
+
+
+@pytest.mark.asyncio
+async def test_unallocate_is_never_blocked(db: AsyncSession):
+    # sub_type_code=None means unallocate — must never be gated.
+    service, item_id, sch_id = await _setup(db, suffix="unalloc", approved_sub_types=None)
+    await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": None}])

--- a/backend/app/tests/test_review_routing_renewal.py
+++ b/backend/app/tests/test_review_routing_renewal.py
@@ -402,24 +402,33 @@ async def test_application_service_pending_list_filters_by_renewal_phase(
 
 
 @pytest.mark.asyncio
-async def test_college_service_pending_list_filters_by_renewal_phase(
+async def test_college_service_pending_list_shows_all_regardless_of_phase(
     db: AsyncSession,
     test_user: User,
     test_scholarship: ScholarshipType,
 ):
     """End-to-end check that CollegeReviewService.get_applications_for_review
-    applies the renewal-phase filter to under_review rows while leaving
-    approved rows untouched.
+    shows EVERY application in the college regardless of the renewal/general
+    review phase.
+
+    This intentionally reverses the earlier phase-gated college behaviour:
+    「學院端應該要可以看到隸屬於該學院的所有申請，即使還卡在教授審核的階段」.
+    The college listing is no longer time-gated, so both the renewal and the
+    general pending apps surface even while only the renewal_college_review
+    window is open. The professor listing keeps its own phase filter (see the
+    professor test above), which is unchanged.
     """
     from app.services.college_review_service import CollegeReviewService
 
-    # Configuration currently in renewal_college_review window.
+    # Configuration currently in renewal_college_review window with the general
+    # college_review window still in the future. Under the old phase-gated
+    # behaviour this would have hidden the general pending app.
     config = _make_config_in_renewal_phase(test_scholarship.id, role="college", config_code="SVC-COL-RENEW")
     db.add(config)
     await db.commit()
     await db.refresh(config)
 
-    # Pending renewal app — should be visible.
+    # Pending renewal app — visible.
     renewal_pending = await _make_pending_application(
         db,
         user=test_user,
@@ -428,7 +437,7 @@ async def test_college_service_pending_list_filters_by_renewal_phase(
         is_renewal=True,
         app_id_suffix="00061",
     )
-    # Pending general app — should be hidden by the renewal-phase filter.
+    # Pending general app — now ALSO visible (previously hidden by the gate).
     general_pending = await _make_pending_application(
         db,
         user=test_user,
@@ -437,8 +446,7 @@ async def test_college_service_pending_list_filters_by_renewal_phase(
         is_renewal=False,
         app_id_suffix="00062",
     )
-    # Approved general app — should still be visible (historical visibility
-    # is unaffected by the phase filter).
+    # Approved general app — historical visibility unchanged.
     approved_general = Application(
         app_id=f"APP-{CURRENT_ACADEMIC_YEAR}-0-00063",
         user_id=test_user.id,
@@ -464,9 +472,51 @@ async def test_college_service_pending_list_filters_by_renewal_phase(
     )
     visible_ids = {r["id"] for r in rows}
 
-    assert renewal_pending.id in visible_ids, "renewal pending app should be visible during renewal phase"
-    assert general_pending.id not in visible_ids, "general pending app should be filtered out during renewal phase"
+    assert renewal_pending.id in visible_ids, "renewal pending app should be visible"
+    assert general_pending.id in visible_ids, "general pending app should now be visible (no college phase gate)"
     assert approved_general.id in visible_ids, "approved app should always remain visible"
+
+
+@pytest.mark.asyncio
+async def test_college_service_sees_pending_app_still_in_professor_stage(
+    db: AsyncSession,
+    test_user: User,
+    test_scholarship: ScholarshipType,
+):
+    """Regression for 「學院端應該看得到還卡在教授審核階段的申請」.
+
+    The configuration's professor review window is open NOW; the college
+    review window is not set / not open yet. Previously the college listing
+    was time-gated by apply_renewal_phase_filter(role="college"), so a
+    professor-stage application was invisible to the college until the college
+    window opened. It must now be visible.
+    """
+    from app.services.college_review_service import CollegeReviewService
+
+    # Professor general window open now; college windows left unset (None) →
+    # the old gate would have hidden every pending row for the college.
+    config = _make_config_in_general_phase(test_scholarship.id, role="professor", config_code="SVC-PROF-STAGE")
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    professor_stage_app = await _make_pending_application(
+        db,
+        user=test_user,
+        scholarship_type=test_scholarship,
+        configuration_id=config.id,
+        is_renewal=False,
+        app_id_suffix="00071",
+    )
+
+    service = CollegeReviewService(db)
+    rows = await service.get_applications_for_review(
+        scholarship_type_id=test_scholarship.id,
+        academic_year=CURRENT_ACADEMIC_YEAR,
+    )
+    visible_ids = {r["id"] for r in rows}
+
+    assert professor_stage_app.id in visible_ids, "college must see apps still in the professor review stage"
 
 
 @pytest.mark.asyncio

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -1114,6 +1114,16 @@ export function ApplicationReviewPanel({
                               </TooltipProvider>
                             ))}
                           </div>
+                        ) : app.requires_professor_recommendation ? (
+                          // Professor step required but no recommendation yet —
+                          // show "教授審核中" instead of a blank cell so college
+                          // reviewers know the app is still awaiting the professor.
+                          <Badge
+                            variant="outline"
+                            className="text-xs cursor-default border-amber-500 text-amber-700 bg-amber-50"
+                          >
+                            {locale === "zh" ? "教授審核中" : "Under prof. review"}
+                          </Badge>
                         ) : (
                           <span className="text-sm text-muted-foreground">—</span>
                         )}

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -139,6 +139,10 @@ export interface Application {
   created_at: string;
   updated_at: string;
   is_recommended?: boolean;
+  /** Whether this scholarship requires a professor recommendation step
+   *  (top-level flag from the college review listing; distinct from the
+   *  nested scholarship_configuration.requires_professor_recommendation). */
+  requires_professor_recommendation?: boolean;
   professor_review_completed?: boolean;
   college_review_completed?: boolean;
   form_data?: Record<string, any>;


### PR DESCRIPTION
## Problem

學院端應該要可以看到隸屬於該學院的所有申請，即使還卡在教授審核的階段。

College reviewers could **not** see applications belonging to their college while those applications were still in the professor review stage.

`CollegeReviewService.get_applications_for_review` (the `/college-review/applications` endpoint) gated *pending* rows through `apply_renewal_phase_filter(role="college")`, which only matches when the current time falls inside the **college** review window. While a configuration is still inside its **professor** review window (college window not yet open), every professor-stage application was therefore invisible to the college.

PR #816 only worked around this by hand-editing the seeded window dates so the windows overlapped, explicitly leaving the phase-filter logic intact. This PR fixes the behaviour itself for the college role.

## Change

- **`backend/app/services/college_review_service.py`** — drop the `apply_renewal_phase_filter(role="college")` time-gate from the college listing. Pending (`submitted` / `under_review`) **and** historical (`approved` / `partial_approved` / `rejected`) applications are now all returned, scoped to the college by the existing `college_code` (`std_academyno`) filter. Removed the now-unused import.
- The **professor** listing (`get_professor_applications_paginated`) keeps its own renewal-phase filter unchanged — only college visibility is broadened.

## Tests

`backend/app/tests/test_review_routing_renewal.py`:
- Reworked `test_college_service_pending_list_filters_by_renewal_phase` → `…_shows_all_regardless_of_phase`: a general pending app is now visible during a renewal-only window (previously hidden).
- Added `test_college_service_sees_pending_app_still_in_professor_stage`: config in its professor window with no college window set — the professor-stage app must surface for the college.

```
app/tests/test_review_routing_renewal.py ... 8 passed
```

- `black --line-length=120 --check` clean on both files.
- The pre-existing `test_college_review_service.py` / `test_college_review_endpoints.py` failures (stale `CollegeReview` create/ranking-scoring + `require_college` mock-patch) are identical on `origin/main` — not introduced here.

> ℹ️ Note: the local dev backend container bind-mounts a different clone (`/home/howard/scholarship-system`), so these tests were run on the host against this working tree.

## Staging Validation (ss.test.nycu.edu.tw)
- Requires WireGuard peer2 VPN
- Login account: A00001 (college) — do **not** use admin/E00001, which bypasses college scoping
- Flow: log in as a college reviewer → 學院審核 / college review applications list
- Assertion: applications belonging to the college that are still awaiting professor review now appear in the list (with their professor-stage status), instead of only showing once the college review window opens