### PR TITLE
fix(nightly-e2e): resolve student-history strict mode + roster download 500

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -1671,6 +1671,7 @@ async def download_roster_excel(
                 )
             else:
                 # 沒有可用的檔案，重新產生
+                # 當 use_minio=False 時跳過 MinIO 上傳/清理，確保本地檔案存在供 FileResponse 直接回傳
                 export_service = ExcelExportService()
                 export_result = export_service.export_roster_to_excel(
                     roster=roster,
@@ -1678,6 +1679,7 @@ async def download_roster_excel(
                     include_header=True,
                     include_statistics=True,
                     include_excluded=False,
+                    skip_minio_upload=not use_minio,
                 )
 
                 logger.info(f"Roster {roster.roster_code} re-generated and downloaded by user {current_user.id}")

--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -155,6 +155,7 @@ class ExcelExportService:
         include_header: bool = True,
         include_statistics: bool = True,
         async_mode: bool = False,
+        skip_minio_upload: bool = False,
     ) -> Dict[str, Any]:
         """
         匯出造冊至Excel檔案
@@ -166,6 +167,7 @@ class ExcelExportService:
             include_header: 是否在檔案中包含表頭
             include_statistics: 是否加入統計資訊工作表
             async_mode: 是否以非同步模式回傳背景任務資訊
+            skip_minio_upload: 是否跳過 MinIO 上傳並保留本地檔案 (用於 use_minio=False 的下載路徑)
 
         Returns:
             Dict[str, Any]: 匯出結果
@@ -250,8 +252,13 @@ class ExcelExportService:
             roster.excel_file_size = file_size
             roster.excel_file_hash = file_hash
 
-            # Upload to MinIO automatically (if roster has valid ID)
-            if roster.id is None:
+            # Upload to MinIO automatically (if roster has valid ID and not explicitly skipped)
+            if skip_minio_upload:
+                logger.info(
+                    f"Skipping MinIO upload for roster {roster.id} (skip_minio_upload=True); "
+                    f"local file retained at: {file_path}"
+                )
+            elif roster.id is None:
                 logger.warning(
                     "Roster ID is None, cannot upload to MinIO. " "Roster must be persisted to database before export."
                 )

--- a/frontend/e2e/specs/admin-student-history.spec.ts
+++ b/frontend/e2e/specs/admin-student-history.spec.ts
@@ -56,7 +56,7 @@ test.describe("Admin student scholarship history", () => {
     await page.getByLabel("學號").fill("stuphd001");
     await page.getByRole("button", { name: "查詢" }).click();
     await expect(
-      page.getByText(/領取明細|查無此學生資料|尚無領取記錄/),
+      page.getByText(/領取明細|查無此學生資料|尚無領取記錄/).first(),
     ).toBeVisible({ timeout: 10000 });
     await context.close();
   });


### PR DESCRIPTION
## Summary

Fixes two nightly E2E test failures reported in the recent run.

### Failure 1 — `admin-student-history.spec.ts` strict mode violation

The query for seeded student `stuphd001` renders BOTH the section title `領取明細` and the empty-state text `尚無領取記錄` simultaneously, which violates Playwright's strict locator mode:

```
strict mode violation: getByText(/領取明細|查無此學生資料|尚無領取記錄/) resolved to 2 elements:
    1) <div>領取明細</div>
    2) <p>尚無領取記錄</p>
```

The assertion only needs to confirm the page rendered without error (the test comment already explicitly states "both outcomes are valid"), so chain `.first()` onto the locator.

### Failure 2 — `roster-admin.spec.ts @nightly` download returns HTTP 500

The nightly check `GET /api/v1/payment-rosters/{rosterId}/download?use_minio=false` returned `{"success":false,"message":"下載造冊失敗"}`.

Root cause:
- Rosters generated with `auto_export_excel=false` have neither a local Excel file nor a `minio_object_name`.
- The download endpoint falls through to `ExcelExportService.export_roster_to_excel()` to regenerate.
- The export service writes the file locally, uploads it to MinIO, **and deletes the local file**.
- `os.path.exists(regen_file_path)` then returns `False`, and the MinIO fallback (`minio_service.download_roster_file(minio_obj)`) is also flaky against fresh uploads.

Fix:
- Add a `skip_minio_upload: bool = False` parameter to `ExcelExportService.export_roster_to_excel()`. When true, the MinIO upload + local-file cleanup block is short-circuited.
- The download endpoint passes `skip_minio_upload=not use_minio`, so the `use_minio=False` path keeps the regenerated file on disk and returns it directly via `FileResponse`.

## Test plan

- [ ] `npx playwright test frontend/e2e/specs/admin-student-history.spec.ts` against dev stack — both `領取明細` and `尚無領取記錄` visible should no longer fail strict mode.
- [ ] `npx playwright test --grep "@nightly" frontend/e2e/specs/roster-admin.spec.ts` against dev stack — `download endpoint returns 200 for existing roster` should return HTTP 200 for the freshly-generated roster.
- [ ] Manually `curl /api/v1/payment-rosters/{id}/download?use_minio=false` on a roster with no MinIO object and no local file — returns 200 + xlsx body.
- [ ] Sanity check: `use_minio=true` path still uploads and cleans up the local file (no regression for the default path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)