### PR TITLE
fix(application): show student postal account to admins

### DIFF
--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -56,6 +56,7 @@ import api, {
 } from "@/lib/api";
 import { isSelectableScholarship } from "@/lib/scholarship-eligibility";
 import { clsx } from "@/lib/utils";
+import { buildApplicationFormFields } from "@/lib/utils/application-helpers";
 import { useApplications } from "@/hooks/use-applications";
 import { useStudentProfile } from "@/hooks/use-student-profile";
 import {
@@ -868,15 +869,13 @@ export function ScholarshipApplicationStep({
 
     setSubmitting(true);
     try {
-      const formFields: Record<string, any> = {};
-      Object.entries(dynamicFormData).forEach(([fieldName, value]) => {
-        formFields[fieldName] = {
-          field_id: fieldName,
-          field_type: "text",
-          value: String(value),
-          required: true,
-        };
-      });
+      // Include the applicant's postal account (郵局帳號) so the admin review
+      // dialog and the bank-verification service can see what the student
+      // entered — it lives in a dedicated wizard section, not dynamicFormData.
+      const formFields = buildApplicationFormFields(
+        dynamicFormData,
+        accountNumber
+      );
 
       const documents = Object.entries(dynamicFileData).map(
         ([docType, files]) => {
@@ -988,15 +987,13 @@ export function ScholarshipApplicationStep({
 
     setSubmitting(true);
     try {
-      const formFields: Record<string, any> = {};
-      Object.entries(dynamicFormData).forEach(([fieldName, value]) => {
-        formFields[fieldName] = {
-          field_id: fieldName,
-          field_type: "text",
-          value: String(value),
-          required: true,
-        };
-      });
+      // Include the applicant's postal account (郵局帳號) so the admin review
+      // dialog and the bank-verification service can see what the student
+      // entered — it lives in a dedicated wizard section, not dynamicFormData.
+      const formFields = buildApplicationFormFields(
+        dynamicFormData,
+        accountNumber
+      );
 
       const documents = Object.entries(dynamicFileData).map(
         ([docType, files]) => {

--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -621,6 +621,10 @@ export function ScholarshipApplicationStep({
         const existingFormData: Record<string, any> = {};
         Object.entries(formData.fields).forEach(
           ([fieldId, fieldData]: [string, any]) => {
+            // The postal account is sourced only from the dedicated
+            // `accountNumber` state (hydrated from the profile); skip the
+            // folded-in copy so it can't drift into dynamicFormData.
+            if (fieldId === "account_number") return;
             if (
               fieldData &&
               typeof fieldData === "object" &&

--- a/frontend/lib/utils/__tests__/application-helpers.test.ts
+++ b/frontend/lib/utils/__tests__/application-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   formatDisplayValue,
   getDocumentLabel,
   fetchApplicationFiles,
+  buildApplicationFormFields,
   BadgeVariant,
 } from "../application-helpers";
 import {
@@ -473,5 +474,63 @@ describe("Application Helpers", () => {
       expect(typeof result).toBe("string");
       expect(result.length).toBeGreaterThan(0);
     });
+  });
+});
+
+describe("buildApplicationFormFields", () => {
+  it("wraps dynamic form values into submitted_form_data field entries", () => {
+    const fields = buildApplicationFormFields(
+      { contact_phone: "0978789789", master_school_info: "nycucs" },
+      ""
+    );
+
+    expect(fields.contact_phone).toEqual({
+      field_id: "contact_phone",
+      field_type: "text",
+      value: "0978789789",
+      required: true,
+    });
+    expect(fields.master_school_info.value).toBe("nycucs");
+  });
+
+  it("includes the postal account number so admins and bank verification can see it", () => {
+    const fields = buildApplicationFormFields({}, "70000121234567");
+
+    // Backend extract_bank_fields_from_application looks up the "account_number" key.
+    expect(fields.account_number).toEqual({
+      field_id: "account_number",
+      field_type: "text",
+      value: "70000121234567",
+      required: true,
+    });
+  });
+
+  it("trims surrounding whitespace from the account number", () => {
+    const fields = buildApplicationFormFields({}, "  70000121234567  ");
+    expect(fields.account_number.value).toBe("70000121234567");
+  });
+
+  it("omits account_number when no account is provided", () => {
+    expect(buildApplicationFormFields({}, "")).not.toHaveProperty(
+      "account_number"
+    );
+    expect(buildApplicationFormFields({}, undefined)).not.toHaveProperty(
+      "account_number"
+    );
+    expect(buildApplicationFormFields({}, "   ")).not.toHaveProperty(
+      "account_number"
+    );
+  });
+
+  it("stringifies non-string dynamic values", () => {
+    const fields = buildApplicationFormFields({ completed_terms: 4 }, "");
+    expect(fields.completed_terms.value).toBe("4");
+  });
+});
+
+describe("formatFieldName - postal account label", () => {
+  it("labels account_number as the post office account", () => {
+    expect(formatFieldName("account_number", "zh")).toBe("郵局帳號");
+    expect(formatFieldName("account_number", "en")).toBe("Post Office Account");
   });
 });

--- a/frontend/lib/utils/__tests__/application-helpers.test.ts
+++ b/frontend/lib/utils/__tests__/application-helpers.test.ts
@@ -526,6 +526,16 @@ describe("buildApplicationFormFields", () => {
     const fields = buildApplicationFormFields({ completed_terms: 4 }, "");
     expect(fields.completed_terms.value).toBe("4");
   });
+
+  it("lets the dedicated account state win over a stale dynamic account_number key", () => {
+    // Editing a draft can surface a previously folded account_number as a
+    // dynamic key; the dedicated state must take precedence on re-save.
+    const fields = buildApplicationFormFields(
+      { account_number: "OLD" },
+      "70000121234567"
+    );
+    expect(fields.account_number.value).toBe("70000121234567");
+  });
 });
 
 describe("formatFieldName - postal account label", () => {

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -318,6 +318,7 @@ export const formatFieldName = (fieldName: string, locale: Locale) => {
     contact_email: locale === "zh" ? "聯絡信箱" : "Contact Email",
     contact_address: locale === "zh" ? "通訊地址" : "Contact Address",
     bank_account: locale === "zh" ? "銀行帳戶" : "Bank Account",
+    account_number: locale === "zh" ? "郵局帳號" : "Post Office Account",
     research_proposal: locale === "zh" ? "研究計畫" : "Research Proposal",
     budget_plan: locale === "zh" ? "預算規劃" : "Budget Plan",
     milestone_plan: locale === "zh" ? "里程碑規劃" : "Milestone Plan",
@@ -475,4 +476,52 @@ export const fetchApplicationFiles = async (applicationId: number) => {
     logger.error("Failed to fetch application files", { error });
     return [];
   }
+};
+
+// Shape of a single entry inside `submitted_form_data.fields`.
+export interface SubmittedFormFieldValue {
+  field_id: string;
+  field_type: string;
+  value: string;
+  required: boolean;
+}
+
+/**
+ * Build the `submitted_form_data.fields` map sent when a student submits an
+ * application.
+ *
+ * Why: the applicant's post-office account (郵局帳號, 限本人) is collected in a
+ * dedicated wizard section and persisted to the user profile, but the admin
+ * review dialog and the backend bank-verification service both read the
+ * account number from the application's `submitted_form_data.fields`
+ * (see backend `extract_bank_fields_from_application`, which looks up the
+ * `account_number` key). If it is omitted here the account never reaches the
+ * admin side, so we always fold it into the form fields.
+ */
+export const buildApplicationFormFields = (
+  dynamicFormData: Record<string, unknown>,
+  accountNumber?: string | null
+): Record<string, SubmittedFormFieldValue> => {
+  const fields: Record<string, SubmittedFormFieldValue> = {};
+
+  Object.entries(dynamicFormData).forEach(([fieldName, value]) => {
+    fields[fieldName] = {
+      field_id: fieldName,
+      field_type: "text",
+      value: String(value),
+      required: true,
+    };
+  });
+
+  const trimmedAccount = accountNumber?.trim();
+  if (trimmedAccount) {
+    fields.account_number = {
+      field_id: "account_number",
+      field_type: "text",
+      value: trimmedAccount,
+      required: true,
+    };
+  }
+
+  return fields;
 };


### PR DESCRIPTION
## Problem

學生在申請頁面填寫**郵局帳號資訊**（郵局局號加帳號共 14 碼，限本人），但**管理員那邊看不到學生填的郵局帳號**。

## Root cause

The postal account is collected in a dedicated wizard section (`accountNumber` state) and saved to the **user profile** via `updateBankInfo`. But both submit paths in `ScholarshipApplicationStep.tsx` built `submitted_form_data.fields` from `dynamicFormData` **only** — the account number was never written into the application record.

Consequences:
- Admin review dialog **Form tab** (`ApplicationFormDataDisplay`, which renders `submitted_form_data.fields` generically) showed nothing.
- Backend bank verification `extract_bank_fields_from_application` — which looks up the `account_number` key in `submitted_form_data.fields` — had no value to verify.

Verified against dev DB: `submitted_form_data.fields` for existing applications contained only `contact_phone` / `master_school_info`, never `account_number`.

This also matches the project architecture (CLAUDE.md §7): `submitted_form_data` is the student-filled snapshot and is meant to hold bank/account data.

## Fix

- Extract field-building into pure helper `buildApplicationFormFields(dynamicFormData, accountNumber)` that folds the postal account into the form fields under the `account_number` key the backend already expects.
- Use it in **both** `handleSubmit` and `handleSaveDraft` (drafts now carry it too).
- Add an `account_number` → 郵局帳號 / Post Office Account label so the admin Form tab renders a friendly name.

Since the admin Form tab and the backend extractor both read `submitted_form_data.fields`, no admin-side or backend changes are needed — the value now flows through automatically.

## Tests (TDD)

New unit tests in `application-helpers.test.ts` (RED → GREEN):
- wraps dynamic values into field entries
- includes `account_number` so admins/verification can see it
- trims whitespace, omits when empty/undefined/blank, stringifies non-strings
- `formatFieldName("account_number")` → 郵局帳號 / Post Office Account

`npx jest` for affected suites: **53 passed**. `tsc --noEmit` clean.

## Test plan
- [ ] Student submits application with 14-digit postal account → admin Form tab shows 郵局帳號
- [ ] Admin bank verification picks up the form account number
- [ ] Save-as-draft also persists the account number