### PR TITLE
ci: harden test gates (fix #834)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,15 +249,15 @@ jobs:
           - test-suite: unit
             test-path: app/tests/test_*.py
             test-mark: "not integration and not asyncio"
-            continue-on-error: true
+            continue-on-error: false
           - test-suite: integration
             test-path: app/tests/test_*_service*.py
             test-mark: "integration or asyncio"
-            continue-on-error: true
+            continue-on-error: false
           - test-suite: critical-workflows
             test-path: app/tests/test_critical_workflows.py
             test-mark: "integration"
-            continue-on-error: true
+            continue-on-error: false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Fixes #834 — backend test failures were silently passing CI because three matrix rows had `continue-on-error: true`.

Flip `continue-on-error` from `true` to `false` on the `unit`, `integration`, and `critical-workflows` rows of the `backend-tests` matrix in `.github/workflows/ci.yml`. After this change, a non-zero pytest exit on any of those lanes will fail the job and block the PR check.

Smoke lane is unchanged (already hard-gated at line 248). Other soft-gated jobs (diff-cover PR ratchet, k6 perf, e2e-smoke, docker compose bringup) are out of scope for this issue and intentionally remain `true`.

## Evidence of the bug

From issue #834 — run [`26590718749`](https://github.com/anud18/scholarship-system/actions/runs/26590718749?pr=818) was marked **success** while `Backend Tests (unit)` had 4 real `test_roster_dates_*` failures. With this PR, the same scenario would have failed the check.

## Diff

```diff
           - test-suite: unit
             test-path: app/tests/test_*.py
             test-mark: "not integration and not asyncio"
-            continue-on-error: true
+            continue-on-error: false
           - test-suite: integration
             test-path: app/tests/test_*_service*.py
             test-mark: "integration or asyncio"
-            continue-on-error: true
+            continue-on-error: false
           - test-suite: critical-workflows
             test-path: app/tests/test_critical_workflows.py
             test-mark: "integration"
-            continue-on-error: true
+            continue-on-error: false
```

## Test plan

- [ ] Push a deliberately-failing unit test on a draft branch and confirm `Backend Tests (unit)` concludes `failure` and blocks the PR
- [ ] Confirm a clean PR still goes green (no false negatives from the hardening itself)
- [ ] Confirm smoke / diff-cover / e2e-smoke jobs continue to behave as before (no collateral damage)

## Notes

- Acceptance criterion in #834 about "the 4 `test_roster_dates_*` failures either pass or are fixed before gating" is tracked separately; this PR is the gate flip itself. If those tests are still red on `main` when this merges, that becomes immediately visible (which is the point).
- Does not touch PR #836 (fix/ci-gate-period-dates branch).