### PR TITLE
chore(dev): isolated docker-compose override for parallel test stacks

### DIFF
--- a/docker-compose.postal-test.yml
+++ b/docker-compose.postal-test.yml
@@ -1,0 +1,43 @@
+# Isolated stack for testing the fix/postal-account-visible-to-admin branch.
+# Use with a dedicated project name so volumes/networks never touch the
+# running scholarship_*_dev stack:
+#   docker compose -p schol_postal -f docker-compose.dev.yml -f docker-compose.postal-test.yml up -d
+# Container names are renamed and host ports remapped to avoid collisions.
+# `!override` replaces the base `ports` list instead of appending to it
+# (default compose merge concatenates sequences, which re-binds the base port).
+services:
+  postgres:
+    container_name: scholarship_postgres_postal
+    ports: !override
+      - "5532:5432"
+
+  redis:
+    container_name: scholarship_redis_postal
+    ports: !override
+      - "6479:6379"
+
+  minio:
+    container_name: scholarship_minio_postal
+    ports: !override
+      - "9100:9000"
+      - "9101:9001"
+
+  backend:
+    container_name: scholarship_backend_postal
+    ports: !override
+      - "8100:8000"
+    environment:
+      CORS_ORIGINS: "http://localhost:3100,http://localhost:8100"
+      FRONTEND_URL: http://localhost:3100
+
+  frontend:
+    container_name: scholarship_frontend_postal
+    ports: !override
+      - "3100:3000"
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8100
+
+  mock-student-api:
+    container_name: scholarship_mock_student_api_postal
+    ports: !override
+      - "8180:8080"


### PR DESCRIPTION
## What

Adds `docker-compose.postal-test.yml` — a compose override that lets a **second full stack** run alongside the default `scholarship_*_dev` stack with zero conflicts.

- Renames every container with a `*_postal` suffix
- Remaps host ports:

| service | default | isolated |
|---|---|---|
| frontend | 3000 | 3100 |
| backend | 8000 | 8100 |
| postgres | 5432 | 5532 |
| redis | 6379 | 6479 |
| minio | 9000/9001 | 9100/9101 |
| mock-student-api | 8080 | 8180 |

- A dedicated project name gives project-scoped volumes/networks (fresh DB).

## Why `!override`

Compose merges sequences (like `ports`) by **concatenation**, so a plain override would keep the base `3000:3000` *and* add `3100:3000` → port re-bind / collision. The `!override` YAML tag on each `ports` list replaces instead of appends.

## Usage

```bash
docker compose -p schol_postal \
  -f docker-compose.dev.yml -f docker-compose.postal-test.yml up -d
docker exec scholarship_backend_postal alembic upgrade head
docker exec scholarship_backend_postal python -m app.seed
```

Used to run the ranking → distribution → roster (造冊) flow end-to-end on a feature branch while the main dev stack stays up. Dev-tooling only; no app code touched.