### PR TITLE
fix(roster): eagerly load items in download endpoint; allow empty-roster export

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -1590,7 +1590,7 @@ async def download_roster_excel(
     Download roster Excel file (supports MinIO and local files)
     """
     try:
-        stmt = select(PaymentRoster).where(PaymentRoster.id == roster_id)
+        stmt = select(PaymentRoster).options(selectinload(PaymentRoster.items)).where(PaymentRoster.id == roster_id)
 
         result = await db.execute(stmt)
 

--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -489,8 +489,7 @@ class ExcelExportService:
         }
 
         if not excel_data:
-            validation_result["errors"].append("No data to export")
-            validation_result["is_valid"] = False
+            validation_result["warnings"].append("No data rows to export — generating header-only file")
             return validation_result
 
         # 統計資料


### PR DESCRIPTION
## Summary
- **Primary fix**: `GET /payment-rosters/{roster_id}/download?use_minio=false` was returning HTTP 500 because the endpoint loaded the roster without `selectinload(PaymentRoster.items)`. When `ExcelExportService._get_roster_items(roster)` then accessed `roster.items` synchronously, SQLAlchemy 2.0 async raised `MissingGreenlet`. Now eagerly loads items.
- **Secondary fix**: `_validate_export_data` flagged empty `excel_data` as a hard error (`is_valid=False`), making a freshly generated roster with zero approved applications un-downloadable. Empty data is now a warning, and the export proceeds to produce a header-only Excel — the correct behavior for an empty roster.

Closes #847

## Test plan
- [ ] Nightly E2E roster download flow no longer fails with HTTP 500 "下載造冊失敗"
- [ ] Download a roster with approved applications → Excel contains data rows
- [ ] Download a roster with zero approved applications → header-only Excel is produced, no 500
- [ ] Existing roster download tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)