### PR TITLE
feat(college-export): college 申請總表 — pick a department (and bundle same-name codes)

### DIFF
--- a/backend/app/api/v1/endpoints/reference_data.py
+++ b/backend/app/api/v1/endpoints/reference_data.py
@@ -226,7 +226,13 @@ async def _get_all_reference_data_cached(session: AsyncSession) -> dict:
         "genders": [{"id": gender.id, "name": gender.name} for gender in genders],
         "academies": [{"id": academy.id, "code": academy.code, "name": academy.name} for academy in academies],
         "departments": [
-            {"id": department.id, "code": department.code, "name": department.name} for department in departments
+            {
+                "id": department.id,
+                "code": department.code,
+                "name": department.name,
+                "academy_code": department.academy_code,
+            }
+            for department in departments
         ],
         "enroll_types": [
             {

--- a/backend/app/api/v1/endpoints/reference_data.py
+++ b/backend/app/api/v1/endpoints/reference_data.py
@@ -172,7 +172,7 @@ async def get_all_reference_data(
     return ApiResponse(success=True, message="Reference data retrieved successfully", data=data)
 
 
-@cached(key_fn=lambda *_, **__: "refdata:all", ttl=86400)  # 24 h
+@cached(key_fn=lambda *_, **__: "refdata:all:v2", ttl=86400)  # 24 h; :v2 busts stale pre-academy_code cache on deploy
 async def _get_all_reference_data_cached(session: AsyncSession) -> dict:
     """Server-side cached body of /reference-data/all. See the wrapper above for
     the no-store HTTP header rationale."""

--- a/backend/app/tests/test_reference_data_response_shape.py
+++ b/backend/app/tests/test_reference_data_response_shape.py
@@ -112,6 +112,14 @@ def test_all_reference_data_returns_api_response():
     data = payload["data"]
     for key in ("degrees", "identities", "academies", "departments", "genders"):
         assert key in data, f"missing '{key}' in /reference-data/all .data payload"
+    # Regression guard: academy_code must be present on department objects so the
+    # college summary export can group by academy without a separate /departments call.
+    departments = data["departments"]
+    if departments:
+        dept = departments[0]
+        assert "academy_code" in dept, (
+            f"department object in /all is missing 'academy_code': {dept!r}"
+        )
 
 
 def test_scholarship_types_with_cycles_returns_api_response():

--- a/backend/app/tests/test_reference_data_response_shape.py
+++ b/backend/app/tests/test_reference_data_response_shape.py
@@ -117,9 +117,7 @@ def test_all_reference_data_returns_api_response():
     departments = data["departments"]
     if departments:
         dept = departments[0]
-        assert "academy_code" in dept, (
-            f"department object in /all is missing 'academy_code': {dept!r}"
-        )
+        assert "academy_code" in dept, f"department object in /all is missing 'academy_code': {dept!r}"
 
 
 def test_scholarship_types_with_cycles_returns_api_response():

--- a/backend/scripts/seed_summary_export_demo.py
+++ b/backend/scripts/seed_summary_export_demo.py
@@ -75,7 +75,7 @@ def _build_student_data(idx: int, entry) -> dict:
         "trm_degree": 1,
         "trm_studystatus": 1,
         "trm_ascore_gpa": 3.8,
-        "_api_source": "seed_summary_export_demo",
+        "_api_fetched_at": "2025-10-22T00:00:00Z",
         "_term_data_status": "success",
     }
 

--- a/backend/scripts/seed_summary_export_demo.py
+++ b/backend/scripts/seed_summary_export_demo.py
@@ -88,9 +88,7 @@ async def main():
             sys.exit(1)
 
         phd_config = (
-            await db.execute(
-                select(ScholarshipConfiguration).where(ScholarshipConfiguration.config_code == "phd_114")
-            )
+            await db.execute(select(ScholarshipConfiguration).where(ScholarshipConfiguration.config_code == "phd_114"))
         ).scalar_one_or_none()
         if not phd_config:
             print("ERROR: phd_114 config not found.")

--- a/backend/scripts/seed_summary_export_demo.py
+++ b/backend/scripts/seed_summary_export_demo.py
@@ -1,0 +1,154 @@
+"""
+Seed demo PhD (博士生獎學金) applications spread across several departments so an
+admin can pick different 系所 in the 申請總表 (department summary) export and get
+real data for each.
+
+Creates one User + one approved phd/114 (yearly → semester NULL) Application per
+roster entry, with a self-contained student_data snapshot whose std_depno is a
+REAL departments.code (so the export's std_depno → departments.code → academy_code
+join works). Idempotent: skips users / applications that already exist.
+
+Mirror entries live in mock-student-api/main.py (SAMPLE_STUDENTS / SAMPLE_TERMS)
+so the same students are loginable and re-submittable.
+
+Usage:
+    docker compose -f docker-compose.dev.yml exec backend python scripts/seed_summary_export_demo.py
+"""
+
+import asyncio
+import sys
+
+from sqlalchemy import select
+
+from app.db.session import AsyncSessionLocal
+from app.models.application import Application, ApplicationStatus
+from app.models.enums import ReviewStage
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+
+# (stdcode, cname, ename, sex, academyno, academyname, depno, depname, enrolltype, termcount)
+# depno values are REAL departments.code rows (verified academy_code in parens):
+#   155 資訊科學與工程研究所(C) · 256 網路工程研究所(C) · 257 多媒體工程研究所(C)
+#   260 數據科學與工程研究所(C) · 183 電機學院博士班(E) · 3511 電機工程學系(E)
+DEMO_ROSTER = [
+    ("csdemo01", "林演算法", "LIN,ALGORITHM", 1, "C", "資訊學院", "155", "資訊科學與工程研究所", 4, 5),
+    ("csdemo02", "黃資安", "HUANG,SECURITY", 2, "C", "資訊學院", "155", "資訊科學與工程研究所", 8, 3),
+    ("csdemo03", "吳網路", "WU,NETWORK", 1, "C", "資訊學院", "256", "網路工程研究所", 4, 7),
+    ("csdemo04", "趙多媒體", "CHAO,MULTIMEDIA", 2, "C", "資訊學院", "257", "多媒體工程研究所", 4, 4),
+    ("csdemo05", "錢數據", "CHIEN,DATA", 1, "C", "資訊學院", "260", "數據科學與工程研究所", 8, 6),
+    ("eedemo01", "周電機", "CHOU,EE", 1, "E", "電機學院", "183", "電機學院博士班", 4, 5),
+    ("eedemo02", "鄭電子", "CHENG,ECE", 2, "E", "電機學院", "3511", "電機工程學系", 4, 8),
+]
+
+SUB_TYPE = "nstc"
+
+
+def _build_student_data(idx: int, entry) -> dict:
+    stdcode, cname, ename, sex, academyno, academyname, depno, depname, enrolltype, termcount = entry
+    return {
+        "std_stdcode": stdcode,
+        "std_cname": cname,
+        "std_ename": ename,
+        "std_sex": sex,
+        "std_nation": "中華民國",
+        "std_degree": 1,
+        "std_academyno": academyno,
+        "std_depno": depno,
+        "std_enrollyear": 112,
+        "std_enrollterm": 1,
+        "std_enrolltype": enrolltype,
+        "std_pid": f"D1234{idx:05d}",
+        "std_bdate": "900101",
+        "std_studingstatus": 2,
+        "mgd_title": "在學",
+        "ToDoctor": 1,
+        "com_email": f"{stdcode}@nycu.edu.tw",
+        "com_commadd": "新竹市東區大學路1001號",
+        "com_cellphone": f"091200{idx:04d}",
+        "trm_year": 114,
+        "trm_term": 1,
+        "trm_termcount": termcount,
+        "trm_academyno": academyno,
+        "trm_academyname": academyname,
+        "trm_depno": depno,
+        "trm_depname": depname,
+        "trm_degree": 1,
+        "trm_studystatus": 1,
+        "trm_ascore_gpa": 3.8,
+        "_api_source": "seed_summary_export_demo",
+        "_term_data_status": "success",
+    }
+
+
+async def main():
+    async with AsyncSessionLocal() as db:
+        phd = (await db.execute(select(ScholarshipType).where(ScholarshipType.code == "phd"))).scalar_one_or_none()
+        if not phd:
+            print("ERROR: PhD scholarship type not found. Run seed first.")
+            sys.exit(1)
+
+        phd_config = (
+            await db.execute(
+                select(ScholarshipConfiguration).where(ScholarshipConfiguration.config_code == "phd_114")
+            )
+        ).scalar_one_or_none()
+        if not phd_config:
+            print("ERROR: phd_114 config not found.")
+            sys.exit(1)
+
+        created_users = created_apps = 0
+
+        for idx, entry in enumerate(DEMO_ROSTER, start=1):
+            stdcode, cname = entry[0], entry[1]
+
+            user = (await db.execute(select(User).where(User.nycu_id == stdcode))).scalar_one_or_none()
+            if not user:
+                user = User(
+                    nycu_id=stdcode,
+                    name=cname,
+                    email=f"{stdcode}@nycu.edu.tw",
+                    user_type=UserType.student,
+                    role=UserRole.student,
+                )
+                db.add(user)
+                await db.flush()
+                created_users += 1
+
+            app_id = f"APP-114-0-{100 + idx:05d}"
+            existing = (await db.execute(select(Application).where(Application.app_id == app_id))).scalar_one_or_none()
+            if existing:
+                continue
+
+            db.add(
+                Application(
+                    app_id=app_id,
+                    user_id=user.id,
+                    scholarship_type_id=phd.id,
+                    scholarship_configuration_id=phd_config.id,
+                    amount=phd_config.amount,
+                    scholarship_subtype_list=[SUB_TYPE],
+                    sub_type_selection_mode=SubTypeSelectionMode.multiple,
+                    sub_scholarship_type=SUB_TYPE,
+                    is_renewal=False,
+                    renewal_year=None,
+                    status=ApplicationStatus.approved.value,
+                    review_stage=ReviewStage.completed.value,
+                    academic_year=114,
+                    semester=None,  # phd is yearly -> NULL
+                    student_data=_build_student_data(idx, entry),
+                    submitted_form_data={"fields": {}, "documents": []},
+                    agree_terms=True,
+                )
+            )
+            created_apps += 1
+
+        await db.commit()
+
+        print(f"OK Demo summary-export data seeded: +{created_users} users, +{created_apps} applications")
+        print(f"   Scholarship: {phd.name} (id={phd.id}), 114 yearly")
+        depts = sorted({e[6] for e in DEMO_ROSTER})
+        print(f"   Departments now populated: {', '.join(depts)} (+ existing 1550, 1511)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend/lib/api/modules/reference-data.ts
+++ b/frontend/lib/api/modules/reference-data.ts
@@ -28,8 +28,8 @@ type Department = {
 };
 
 type ReferenceDataAll = {
-  academies: Array<{ id: number; code: string; name: string }>;
-  departments: Array<{ id: number; code: string; name: string }>;
+  academies: Array<Academy>;
+  departments: Array<Department>;
   degrees: Array<{ id: number; name: string }>;
   identities: Array<{ id: number; name: string }>;
   studying_statuses: Array<{ id: number; name: string }>;

--- a/mock-student-api/main.py
+++ b/mock-student-api/main.py
@@ -133,7 +133,7 @@ SAMPLE_STUDENTS = {
         "std_pid": "B123456789",
         "std_bdate": "880310",
         "std_academyno": "EE",
-        "std_depno": "3551",
+        "std_depno": "1511",
         "std_sex": 1,
         "std_nation": "中華民國",
         "std_degree": 1,
@@ -316,7 +316,7 @@ SAMPLE_STUDENTS = {
         "std_pid": "A123456001",
         "std_bdate": "900101",
         "std_academyno": "C",
-        "std_depno": "CS",
+        "std_depno": "1550",
         "std_sex": 1,
         "std_nation": "中華民國",
         "std_degree": 1,
@@ -342,7 +342,7 @@ SAMPLE_STUDENTS = {
         "std_pid": "A123456002",
         "std_bdate": "890215",
         "std_academyno": "C",
-        "std_depno": "CS",
+        "std_depno": "1550",
         "std_sex": 1,
         "std_nation": "中華民國",
         "std_degree": 1,
@@ -368,7 +368,7 @@ SAMPLE_STUDENTS = {
         "std_pid": "A123456003",
         "std_bdate": "880320",
         "std_academyno": "C",
-        "std_depno": "CS",
+        "std_depno": "1550",
         "std_sex": 2,
         "std_nation": "中華民國",
         "std_degree": 1,
@@ -4353,6 +4353,77 @@ SAMPLE_TERMS = {
 }
 
 # HMAC verification function moved to auth.py
+
+
+# --- Demo students for 申請總表 per-department export -----------------------
+# Mirrors backend/scripts/seed_summary_export_demo.py so these students are
+# loginable / re-submittable. std_depno values are REAL departments.code rows.
+# (stdcode -> cname, ename, sex, academyno, academyname, depno, depname, enrolltype, termcount)
+_SUMMARY_EXPORT_DEMO = {
+    "csdemo01": ("林演算法", "LIN,ALGORITHM", 1, "C", "資訊學院", "155", "資訊科學與工程研究所", 4, 5),
+    "csdemo02": ("黃資安", "HUANG,SECURITY", 2, "C", "資訊學院", "155", "資訊科學與工程研究所", 8, 3),
+    "csdemo03": ("吳網路", "WU,NETWORK", 1, "C", "資訊學院", "256", "網路工程研究所", 4, 7),
+    "csdemo04": ("趙多媒體", "CHAO,MULTIMEDIA", 2, "C", "資訊學院", "257", "多媒體工程研究所", 4, 4),
+    "csdemo05": ("錢數據", "CHIEN,DATA", 1, "C", "資訊學院", "260", "數據科學與工程研究所", 8, 6),
+    "eedemo01": ("周電機", "CHOU,EE", 1, "E", "電機學院", "183", "電機學院博士班", 4, 5),
+    "eedemo02": ("鄭電子", "CHENG,ECE", 2, "E", "電機學院", "3511", "電機工程學系", 4, 8),
+}
+
+
+def _mk_summary_demo_student(code, e):
+    cname, ename, sex, aca, acaname, dep, depname, etype, tcount = e
+    return {
+        "std_stdcode": code,
+        "std_enrollyear": 112,
+        "std_enrollterm": 1,
+        "std_highestschname": "國立陽明交通大學",
+        "std_cname": cname,
+        "std_ename": ename,
+        "std_pid": "D1234" + code[-2:].rjust(2, "0"),
+        "std_bdate": "900101",
+        "std_academyno": aca,
+        "std_depno": dep,
+        "std_sex": sex,
+        "std_nation": "中華民國",
+        "std_degree": 1,
+        "std_enrolltype": etype,
+        "std_identity": 1,
+        "std_schoolid": 1,
+        "std_overseaplace": "",
+        "std_termcount": tcount,
+        "std_studingstatus": 2,
+        "mgd_title": "在學",
+        "ToDoctor": 1,
+        "com_commadd": "新竹市東區大學路1001號",
+        "com_email": code + "@nycu.edu.tw",
+        "com_cellphone": "0912000000",
+    }
+
+
+def _mk_summary_demo_terms(code, e):
+    cname, ename, sex, aca, acaname, dep, depname, etype, tcount = e
+    return [{
+        "std_stdcode": code,
+        "trm_year": 114,
+        "trm_term": 1,
+        "trm_termcount": tcount,
+        "trm_studystatus": 1,
+        "trm_degree": 1,
+        "trm_academyno": aca,
+        "trm_academyname": acaname,
+        "trm_depno": dep,
+        "trm_depname": depname,
+        "trm_placings": 0,
+        "trm_placingsrate": 0.0,
+        "trm_depplacing": 0,
+        "trm_depplacingrate": 0.0,
+        "trm_ascore_gpa": 3.8,
+    }]
+
+
+SAMPLE_STUDENTS.update({c: _mk_summary_demo_student(c, e) for c, e in _SUMMARY_EXPORT_DEMO.items()})
+SAMPLE_TERMS.update({c: _mk_summary_demo_terms(c, e) for c, e in _SUMMARY_EXPORT_DEMO.items()})
+# --- end demo students ------------------------------------------------------
 
 
 @app.get("/")

--- a/mock-student-api/main.py
+++ b/mock-student-api/main.py
@@ -4379,7 +4379,7 @@ def _mk_summary_demo_student(code, e):
         "std_highestschname": "國立陽明交通大學",
         "std_cname": cname,
         "std_ename": ename,
-        "std_pid": "D1234" + code[-2:].rjust(2, "0"),
+        "std_pid": f"D1234{list(_SUMMARY_EXPORT_DEMO.keys()).index(code) + 1:05d}",
         "std_bdate": "900101",
         "std_academyno": aca,
         "std_depno": dep,
@@ -4396,7 +4396,7 @@ def _mk_summary_demo_student(code, e):
         "ToDoctor": 1,
         "com_commadd": "新竹市東區大學路1001號",
         "com_email": code + "@nycu.edu.tw",
-        "com_cellphone": "0912000000",
+        "com_cellphone": f"091200{list(_SUMMARY_EXPORT_DEMO.keys()).index(code) + 1:04d}",
     }
 
 


### PR DESCRIPTION
## Problem

A 學院 (college) reviewer opening the **申請總表 (department summary) export** dropdown saw **only "本學院全部 (ZIP)"** — no individual departments. And even with departments listed, a single program (e.g. 資訊工程學系) appears under several department codes, shown as visually-identical options.

## Fix 1 — college reviewers see departments (`reference_data.py`)

The dropdown filters `departments.filter(d => d.academy_code === user.college_code)`, but `GET /reference-data/all` serialized departments as `{id, code, name}` — **dropping `academy_code`** (the standalone `/departments` handler had it). So college users matched **0** departments. Add `academy_code` to the `/all` payload.

### Caching
- **Server (Redis 24h):** cache key bumped to `refdata:all:v2` → deploy auto-recomputes with `academy_code`, **no manual `redis-cli` step**.
- **Client (SWR 24h):** a user whose tab cached the old payload needs a **hard refresh**. QA: verify in a fresh session.

## Fix 2 — bundle same-name departments (`application_summary_export.py` + `ApplicationReviewPanel.tsx`)

A program exists under several codes — e.g. **資訊工程學系 = 117 / 217 / 317 (legacy 交大 3-char) + 1550 (new SIS 4-char)**. The dropdown listed each as a separate identical "資訊工程學系" option; picking one exported only that code's applicants, and the reviewer couldn't tell them apart.

- **Frontend:** group `visibleDepartments` by `academy_code + name`; each option's `value` is the comma-joined code group → one "資訊工程學系" entry covering all its codes. (48 options → 28 for 資訊學院.)
- **Backend:** `department_code` accepts a comma-separated group; resolves + authorises **every** code (college users still confined to their own academy via `academy_code`), and unions applicants whose `std_depno` is in the group into a single workbook.

> The department codes themselves are **not** merged — they remain the SIS join keys (`student_data.std_depno → departments.code`). Bundling is display + query only; deleting codes would silently drop students whose SIS code maps to a removed one.

## Dev data (dev-env only — not deployed)

`mock-student-api` + `backend/scripts/seed_summary_export_demo.py` (idempotent): demo PhD/114 applications across departments, incl. two under sibling 資工系 codes (217, 1550) so the bundle's cross-code union is demonstrable.

## Verification

- Fresh cs_college session: 系所 dropdown lists **28 deduped options** (27 distinct programs + 本學院全部); "資訊工程學系" appears **once** (Playwright).
- Bundle export `department_code=117,217,317,1550` → **one** xlsx unioning csdemo06 (217) + csdemo07 (1550).
- Negative: cs_college mixing an academy-E code → **403**; nonexistent code → **404** (names the missing code).
- Single-code export still works; admin `全部系所` → one xlsx per department.
- `black` + `flake8` + `eslint` clean; regression test pins `academy_code` in `/all`.

## Test plan

- [ ] College reviewer → dropdown lists departments, one entry per program name.
- [ ] Pick 資訊工程學系 → export contains applicants across all its codes.
- [ ] Admin `全部系所 (ZIP)` → one xlsx per department.
- [ ] QA in a fresh browser session (client SWR cache).