### PR TITLE
fix(applications): correct broken get_applications_for_review response builder

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1577,8 +1577,8 @@ class ApplicationService:
                                 }
                             )
 
-            # Use eagerly loaded user (already loaded with selectinload)
-            app_user = application.user
+            # Use eagerly loaded student (already loaded with selectinload)
+            app_user = application.student
 
             # 創建響應數據
             app_data = ApplicationListResponse(
@@ -1600,7 +1600,7 @@ class ApplicationService:
                 cancelled_due_to_application_id=application.cancelled_due_to_application_id,
                 academic_year=application.academic_year,
                 semester=self._convert_semester_to_string(application.semester),
-                student_data=application.student_data,
+                student_data=application.student_data or {},
                 submitted_form_data=integrated_form_data,  # 使用整合後的表單資料
                 agree_terms=application.agree_terms,
                 professor_id=application.professor_id,
@@ -1999,8 +1999,8 @@ class ApplicationService:
                                 }
                             )
 
-            # Use eagerly loaded user (already loaded with selectinload)
-            app_user = application.user
+            # Use eagerly loaded student (already loaded with selectinload)
+            app_user = application.student
 
             # 創建響應數據
             app_data = ApplicationListResponse(
@@ -2022,7 +2022,7 @@ class ApplicationService:
                 cancelled_due_to_application_id=application.cancelled_due_to_application_id,
                 academic_year=application.academic_year,
                 semester=self._convert_semester_to_string(application.semester),
-                student_data=application.student_data,
+                student_data=application.student_data or {},
                 submitted_form_data=integrated_form_data,  # 使用整合後的表單資料
                 agree_terms=application.agree_terms,
                 professor_id=application.professor_id,


### PR DESCRIPTION
## Summary

`ApplicationService.get_applications_for_review` (and its dead twin `get_applications`) crashed whenever it returned a **non-empty** result — surfaced by the already-on-`main` deep test `test_get_applications_for_review_deep.py`, which is currently **red**.

Two distinct crashes in the same response builder:

| # | Error | Cause | Fix |
|---|-------|-------|-----|
| 1 | `AttributeError: 'Application' object has no attribute 'user'` | Accessed `application.user`; the relationship is named **`student`** (model line 185). It's already eager-loaded via `selectinload(Application.student)` (line 1500/1924). | `application.user` → `application.student` |
| 2 | `pydantic ValidationError: student_data Input should be a valid dictionary` | Passed nullable `application.student_data` into required `ApplicationListResponse.student_data: Dict[str, Any]`. | `student_data=application.student_data or {}` — matches the existing convention at lines 241 & 2520 |

## Why it went unnoticed (blast radius)

Both live endpoints that route here — `GET /applications/review/list` and `GET /applications/college/review` — have **dead frontend wrappers** (`getByScholarshipType`, `getCollegeReview` have no callers). The real review UI uses `CollegeReviewService.get_applications_for_review` (a different method). So no production 500s, but the public API endpoints were broken and the deep test is red on main.

## Verification

```
test_get_applications_for_review_deep.py   5 passed   (was: AttributeError on 4/5)
test_application_service.py               21 passed   (no regressions)
black --check (26.3.1)                     unchanged
```
Verified by running the exact PR artifact inside the dev backend container.

## Scope

Intentionally minimal — only the `get_applications_for_review` / `get_applications` builder pair. The **identical** `student_data or {}` omission also exists in `_create_application_list_response` (line 702) and `get_student_dashboard_stats` (line 850); those are on other code paths and will be fixed with their own test coverage in a follow-up (the dashboard one is a real latent crash on drafts with null student_data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)