### PR TITLE
perf(roster): eager-load student & scholarship_type in _get_eligible_applications

### DIFF
--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, case as sa_case, func, or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.core.exceptions import RosterAlreadyExistsError, RosterGenerationError, RosterLockedError, RosterNotFoundError
 from app.core.metrics import payment_rosters_total
@@ -608,18 +608,28 @@ class RosterService:
 
         # 2. 基本查詢：已核准的申請
         # 容錯處理：如果 scholarship_configuration_id 為 NULL，則比對 scholarship_type_id
-        query = self.db.query(Application).filter(
-            and_(
-                or_(
-                    Application.scholarship_configuration_id == scholarship_configuration_id,
-                    and_(
-                        Application.scholarship_configuration_id.is_(None),
-                        Application.scholarship_type_id == config.scholarship_type_id,
+        # Eager-load the to-one relationships that _create_roster_item / verification
+        # loops read per row (student, scholarship_configuration → scholarship_type),
+        # otherwise each roster row triggers extra lazy round-trips (N+1).
+        query = (
+            self.db.query(Application)
+            .options(
+                joinedload(Application.student),
+                joinedload(Application.scholarship_configuration).joinedload(ScholarshipConfiguration.scholarship_type),
+            )
+            .filter(
+                and_(
+                    or_(
+                        Application.scholarship_configuration_id == scholarship_configuration_id,
+                        and_(
+                            Application.scholarship_configuration_id.is_(None),
+                            Application.scholarship_type_id == config.scholarship_type_id,
+                        ),
                     ),
-                ),
-                Application.status == "approved",  # 已核准
-                Application.academic_year == academic_year,
-                Application.deleted_at.is_(None),  # 排除已退件
+                    Application.status == "approved",  # 已核准
+                    Application.academic_year == academic_year,
+                    Application.deleted_at.is_(None),  # 排除已退件
+                )
             )
         )
 


### PR DESCRIPTION
## Summary

`RosterService._get_eligible_applications` returned `db.query(Application).all()` with **no eager-loading**. Each returned row then triggers lazy round-trips in the per-application paths:

- `_create_roster_item` reads `application.scholarship_configuration.scholarship_type.name` (2-level lazy chain) + `application.scholarship_configuration.amount`.
- the verification / issue-check loops read `application.student.{name, student_number, bank_account}`.

For a roster of N applications that's up to ~2N extra **serial** queries (sync `Session` = blocking round-trips).

## Fix

Add `.options(joinedload(...))` for the two to-one relationships so they load with the base query:

```python
query = (
    self.db.query(Application)
    .options(
        joinedload(Application.student),
        joinedload(Application.scholarship_configuration).joinedload(ScholarshipConfiguration.scholarship_type),
    )
    .filter(...)
)
```

`joinedload` is safe here — both relationships are many-to-one, so no row multiplication.

## Verification

- **No behavior change.** Full roster test suite identical before/after: **357 passed / 34 pre-existing failures** both ways (verified by overlaying the artifact in the dev container). The 34 pre-existing failures (`_sa_instance_state`, Redis/MinIO infra) are unrelated to this query and are owned by #854.
- `black --check` (26.3.1): unchanged.
- No file overlap with #854 (it touches `roster_service.py` only at `generate_roster` ~L154; this PR is at `_get_eligible_applications` ~L611).

🤖 Generated with [Claude Code](https://claude.com/claude-code)