### PR TITLE
fix(tests): repair _sa_instance_state model-construction in pure-helper tests

### DIFF
--- a/backend/app/tests/test_eligibility_verification_pure_helpers.py
+++ b/backend/app/tests/test_eligibility_verification_pure_helpers.py
@@ -33,16 +33,17 @@ def _service() -> EligibilityVerificationService:
 
 
 def _scholarship_type(**overrides) -> ScholarshipType:
-    """Construct a ScholarshipType bypassing SQLAlchemy ORM init."""
-    s = object.__new__(ScholarshipType)
+    """Construct an in-memory ScholarshipType (no DB session)."""
     defaults = {
         "id": 1,
         "code": "TEST",
         "eligible_student_types": None,
     }
     defaults.update(overrides)
-    for k, v in defaults.items():
-        object.__setattr__(s, k, v)
+    # Construct via __init__ to get _sa_instance_state, then stuff __dict__
+    # directly so vestigial/non-column keys are tolerated (bypasses descriptors).
+    s = ScholarshipType()
+    s.__dict__.update(defaults)
     return s
 
 

--- a/backend/app/tests/test_scholarship_configuration_helpers.py
+++ b/backend/app/tests/test_scholarship_configuration_helpers.py
@@ -33,8 +33,7 @@ from app.models.scholarship import ScholarshipConfiguration
 
 
 def _cfg(**overrides) -> ScholarshipConfiguration:
-    """Construct a ScholarshipConfiguration without invoking SQLAlchemy ORM init."""
-    c = object.__new__(ScholarshipConfiguration)
+    """Construct an in-memory ScholarshipConfiguration (no DB session)."""
     defaults = {
         "id": 1,
         "scholarship_type_id": 1,
@@ -72,9 +71,7 @@ def _cfg(**overrides) -> ScholarshipConfiguration:
         "college_review_end": None,
     }
     defaults.update(overrides)
-    for k, v in defaults.items():
-        object.__setattr__(c, k, v)
-    return c
+    return ScholarshipConfiguration(**defaults)
 
 
 # ─── cycle + academic_year_label ──────────────────────────────────────

--- a/backend/app/tests/test_scholarship_rule_model.py
+++ b/backend/app/tests/test_scholarship_rule_model.py
@@ -21,8 +21,11 @@ from app.models.scholarship import ScholarshipRule, ScholarshipSubTypeConfig
 
 
 def _rule(**overrides) -> ScholarshipRule:
-    """Build a ScholarshipRule without invoking SQLAlchemy ORM init."""
-    r = object.__new__(ScholarshipRule)
+    """Build an in-memory ScholarshipRule (no DB session)."""
+    # scholarship_type is a relationship; tests stub it with a duck-typed
+    # SimpleNamespace for validate_sub_type. Pop it out and inject via __dict__
+    # afterwards, since the ORM constructor rejects a non-mapped instance.
+    scholarship_type = overrides.pop("scholarship_type", None)
     defaults = {
         "id": 1,
         "scholarship_type_id": 1,
@@ -32,17 +35,14 @@ def _rule(**overrides) -> ScholarshipRule:
         "academic_year": None,
         "semester": None,
         "is_template": False,
-        # scholarship_type set via SimpleNamespace when validate_sub_type needs it
-        "scholarship_type": None,
     }
     defaults.update(overrides)
-    for k, v in defaults.items():
-        object.__setattr__(r, k, v)
+    r = ScholarshipRule(**defaults)
+    r.__dict__["scholarship_type"] = scholarship_type
     return r
 
 
 def _config(**overrides) -> ScholarshipSubTypeConfig:
-    c = object.__new__(ScholarshipSubTypeConfig)
     defaults = {
         "id": 1,
         "name": "國科會",
@@ -50,9 +50,7 @@ def _config(**overrides) -> ScholarshipSubTypeConfig:
         "amount": None,
     }
     defaults.update(overrides)
-    for k, v in defaults.items():
-        object.__setattr__(c, k, v)
-    return c
+    return ScholarshipSubTypeConfig(**defaults)
 
 
 # ─── ScholarshipRule.validate_sub_type ───────────────────────────────

--- a/backend/app/tests/test_scholarship_type_pure_helpers.py
+++ b/backend/app/tests/test_scholarship_type_pure_helpers.py
@@ -26,8 +26,7 @@ from app.models.scholarship import ScholarshipType
 
 
 def _scholarship(**overrides):
-    """Construct a ScholarshipType without invoking SQLAlchemy ORM init."""
-    s = object.__new__(ScholarshipType)
+    """Construct an in-memory ScholarshipType (no DB session)."""
     defaults = {
         "id": 1,
         "code": "PHD_NSTC_2024",
@@ -37,8 +36,10 @@ def _scholarship(**overrides):
         "whitelist_student_ids": None,
     }
     defaults.update(overrides)
-    for k, v in defaults.items():
-        object.__setattr__(s, k, v)
+    # Construct via __init__ to get _sa_instance_state, then stuff __dict__
+    # directly so vestigial/non-column keys are tolerated (bypasses descriptors).
+    s = ScholarshipType()
+    s.__dict__.update(defaults)
     return s
 
 

--- a/backend/app/tests/test_user_model_role_checks.py
+++ b/backend/app/tests/test_user_model_role_checks.py
@@ -27,13 +27,8 @@ from app.models.user import User, UserRole
 
 
 def _user(role: UserRole) -> User:
-    """Construct a User without invoking SQLAlchemy ORM init."""
-    u = object.__new__(User)
-    object.__setattr__(u, "role", role)
-    object.__setattr__(u, "id", 1)
-    object.__setattr__(u, "name", "Test")
-    object.__setattr__(u, "nycu_id", "test1")
-    return u
+    """Construct an in-memory User (no DB session)."""
+    return User(role=role, id=1, name="Test", nycu_id="test1")
 
 
 # ─── Role predicates ─────────────────────────────────────────────────

--- a/backend/app/tests/test_user_profile_and_task_models.py
+++ b/backend/app/tests/test_user_profile_and_task_models.py
@@ -23,7 +23,6 @@ from app.models.user_profile import UserProfile
 
 
 def _profile(**overrides) -> UserProfile:
-    p = object.__new__(UserProfile)
     defaults = {
         "id": 1,
         "user_id": 42,
@@ -33,13 +32,10 @@ def _profile(**overrides) -> UserProfile:
         "advisor_nycu_id": None,
     }
     defaults.update(overrides)
-    for k, v in defaults.items():
-        object.__setattr__(p, k, v)
-    return p
+    return UserProfile(**defaults)
 
 
 def _task(**overrides) -> BankVerificationTask:
-    t = object.__new__(BankVerificationTask)
     defaults = {
         "id": 1,
         "task_id": "task-001",
@@ -48,9 +44,7 @@ def _task(**overrides) -> BankVerificationTask:
         "processed_count": 0,
     }
     defaults.update(overrides)
-    for k, v in defaults.items():
-        object.__setattr__(t, k, v)
-    return t
+    return BankVerificationTask(**defaults)
 
 
 # ─── UserProfile.has_complete_bank_info ──────────────────────────────


### PR DESCRIPTION
## Summary

Six pure-helper test files constructed SQLAlchemy model instances with `object.__new__(Model)` + `object.__setattr__(inst, k, v)`. That bypasses the ORM `__init__`, so the instance never gets `_sa_instance_state`, and the **first** `object.__setattr__` onto an instrumented column attribute raises:

```
AttributeError: 'X' object has no attribute '_sa_instance_state'
```

— failing **~92 tests** before any assertion runs. This is part of the pre-existing red-CI backlog (`#854` owns the roster/notification slice; these six files are the **non-overlapping** remainder).

## Fix (per helper shape)

| Helper shape | Fix |
|---|---|
| Column-only defaults | `Model(**defaults)` via the ORM constructor |
| Stuffs vestigial / non-column attrs (`whitelist_student_ids`, `eligible_student_types` — not mapped on `ScholarshipType`) | `Model()` then `inst.__dict__.update(defaults)` so non-column keys are tolerated |
| `_rule` stubs the `scholarship_type` **relationship** with a `SimpleNamespace` | pop it out, build columns via constructor, inject via `inst.__dict__[...]` (the constructor rejects a non-mapped instance — verified empirically) |

Service helpers that use `object.__new__(SomeService)` are **left as-is** — services carry no SQLAlchemy instrumentation, so plain attribute setting works there.

## Files & impact

| File | failures fixed |
|---|---|
| test_scholarship_configuration_helpers.py | 29 |
| test_user_model_role_checks.py | 17 |
| test_scholarship_rule_model.py | 16 |
| test_scholarship_type_pure_helpers.py | 13 |
| test_user_profile_and_task_models.py | 13 |
| test_eligibility_verification_pure_helpers.py | 4 |

## Verification

```
99 passed across the six files (was ~92 failed)
black --check (26.3.1): unchanged
```
Verified by overlaying each artifact into the dev backend container and running the suites. No overlap with #854's file list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)