### PR TITLE
perf(frontend): lazy-load xlsx (sheetjs) instead of top-level import

### DIFF
--- a/frontend/components/college-ranking-table.tsx
+++ b/frontend/components/college-ranking-table.tsx
@@ -73,7 +73,6 @@ import {
 import { getTranslation } from "@/lib/i18n";
 import { toast } from "sonner";
 import { exportRankingExcel } from "@/lib/api/modules/college";
-import * as XLSX from "xlsx";
 import { ApplicationReviewDialog } from "@/components/common/ApplicationReviewDialog";
 import { Application as ApplicationType, User } from "@/lib/api";
 import { ApplicationStatus, getApplicationStatusLabel } from "@/lib/enums";
@@ -588,6 +587,8 @@ export function CollegeRankingTable({
     setIsImporting(true);
 
     try {
+      // Lazy-load the heavy sheetjs lib only when an import actually happens
+      const XLSX = await import("xlsx");
       // Read Excel file
       const data = await file.arrayBuffer();
       const uint8Array = new Uint8Array(data);
@@ -725,8 +726,10 @@ export function CollegeRankingTable({
     }
   };
 
-  const handleTemplateDownload = () => {
+  const handleTemplateDownload = async () => {
     try {
+      // Lazy-load the heavy sheetjs lib only when a template is downloaded
+      const XLSX = await import("xlsx");
       // Sort by department code, then student ID
       const sorted = [...localApplications].sort((a, b) => {
         const deptA = a.department_code || a.department_name || "";

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -62,7 +62,6 @@ import {
   getDepartmentName,
 } from "@/hooks/use-reference-data";
 import { useScholarshipData } from "@/hooks/use-scholarship-data";
-import * as XLSX from "xlsx";
 import { apiClient } from "@/lib/api";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import {
@@ -359,8 +358,10 @@ export function ApplicationReviewPanel({
     }
   };
 
-  const handleExportApplications = () => {
+  const handleExportApplications = async () => {
     try {
+      // Lazy-load the heavy sheetjs lib only when an export actually happens
+      const XLSX = await import("xlsx");
       if (applications.length === 0) {
         toast.error(locale === "zh" ? "無資料可匯出" : "No data to export", {
           description:


### PR DESCRIPTION
## Summary

`college-ranking-table.tsx` and `college/review/ApplicationReviewPanel.tsx` imported the heavy **sheetjs** lib at module top (`import * as XLSX from "xlsx"`), pulling it into the **initial chunk** of both components — even though XLSX is only used inside import/export/template click handlers.

Move to dynamic `const XLSX = await import("xlsx")` inside each handler so the lib loads on demand:

| File | Handlers |
|---|---|
| `college-ranking-table.tsx` | `handleFileUpload` (already async) + `handleTemplateDownload` (made async) |
| `ApplicationReviewPanel.tsx` | `handleExportApplications` (made async) |

The two newly-async handlers are wired via `onClick={...}`, which tolerates a Promise-returning handler. Removes sheetjs from the initial bundle of these college-review screens; it now loads only when a user actually imports/exports an Excel file.

## Verification

- `npm run type-check`: **zero new errors** (only the 2 pre-existing `react-pdf` module errors remain, unrelated to this change).
- `eslint` on both files: **clean (exit 0)** — no `no-misused-promises`.

From the optimization audit (frontend perf, finding #2 — highest bundle win for least risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)