### PR TITLE
perf(db): add indexes for audit-log lookups and applications config FK

### DIFF
--- a/backend/alembic/versions/20260531_add_performance_indexes.py
+++ b/backend/alembic/versions/20260531_add_performance_indexes.py
@@ -1,0 +1,79 @@
+"""add performance indexes: audit_logs resource lookup + applications config FK
+
+Revision ID: 20260531_perf_indexes
+Revises: 20260530_sched_email_nullable
+Create Date: 2026-05-31
+
+Two missing indexes that cause full-table scans on hot paths:
+
+1. audit_logs has no index on (resource_type, resource_id, created_at). The
+   per-entity audit-trail view filters resource_type + resource_id and orders by
+   created_at desc on an ever-growing table -> sequential scan.
+
+2. applications.scholarship_configuration_id is a foreign key with no index.
+   PostgreSQL does not auto-index FKs, and roster_service filters heavily on it.
+
+Both indexes are created idempotently (skipped if already present) so the
+migration is safe to re-run on databases that already have them.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260531_perf_indexes"
+down_revision: Union[str, Sequence[str], None] = "20260530_sched_email_nullable"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+AUDIT_INDEX = "ix_audit_logs_resource_lookup"
+APP_CONFIG_INDEX = "ix_applications_scholarship_configuration_id"
+
+
+def upgrade() -> None:
+    """Create the two performance indexes if they do not already exist."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if "audit_logs" in existing_tables:
+        audit_indexes = {i["name"] for i in inspector.get_indexes("audit_logs")}
+        if AUDIT_INDEX not in audit_indexes:
+            op.create_index(
+                AUDIT_INDEX,
+                "audit_logs",
+                ["resource_type", "resource_id", "created_at"],
+                unique=False,
+            )
+
+    if "applications" in existing_tables:
+        app_indexes = {i["name"] for i in inspector.get_indexes("applications")}
+        if APP_CONFIG_INDEX not in app_indexes:
+            op.create_index(
+                APP_CONFIG_INDEX,
+                "applications",
+                ["scholarship_configuration_id"],
+                unique=False,
+            )
+
+
+def downgrade() -> None:
+    """Drop the two performance indexes if present."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if "applications" in existing_tables:
+        app_indexes = {i["name"] for i in inspector.get_indexes("applications")}
+        if APP_CONFIG_INDEX in app_indexes:
+            op.drop_index(APP_CONFIG_INDEX, table_name="applications")
+
+    if "audit_logs" in existing_tables:
+        audit_indexes = {i["name"] for i in inspector.get_indexes("audit_logs")}
+        if AUDIT_INDEX in audit_indexes:
+            op.drop_index(AUDIT_INDEX, table_name="audit_logs")

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -248,6 +248,12 @@ class Application(Base):
             unique=True,
             postgresql_where=sa.text("is_renewal = false AND challenges_application_id IS NULL AND deleted_at IS NULL"),
         ),
+        # Plain index on the FK — heavily filtered by roster_service; PostgreSQL
+        # does not auto-create an index for foreign keys.
+        Index(
+            "ix_applications_scholarship_configuration_id",
+            "scholarship_configuration_id",
+        ),
     )
 
     def __repr__(self):

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -4,7 +4,7 @@ Audit log model for tracking system activities
 
 import enum
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -92,6 +92,17 @@ class AuditLog(Base):
 
     # 關聯
     user = relationship("User", back_populates="audit_logs")
+
+    __table_args__ = (
+        # Per-entity audit-trail lookups filter resource_type + resource_id and
+        # order by created_at desc; without this they full-scan an ever-growing table.
+        Index(
+            "ix_audit_logs_resource_lookup",
+            "resource_type",
+            "resource_id",
+            "created_at",
+        ),
+    )
 
     def __repr__(self):
         return f"<AuditLog(id={self.id}, user_id={self.user_id}, action={self.action})>"


### PR DESCRIPTION
## Summary

Two missing indexes that cause **full-table scans** on hot paths (from the optimization audit, backend-perf findings #3 and #9):

| Index | Table / columns | Why |
|---|---|---|
| `ix_audit_logs_resource_lookup` | `audit_logs(resource_type, resource_id, created_at)` | Per-entity audit-trail view filters `resource_type` + `resource_id` and orders by `created_at desc` on an ever-growing table → sequential scan that degrades over time |
| `ix_applications_scholarship_configuration_id` | `applications(scholarship_configuration_id)` | FK with no index (PostgreSQL doesn't auto-index FKs); `roster_service` filters heavily on it |

## Changes

- Migration `20260531_perf_indexes` — creates both indexes **idempotently** (existence-checked) with a fully reversible `downgrade()`.
- Both index declarations added to the models' `__table_args__` (`audit_log.py`, `application.py`) to keep ORM metadata in sync with the schema (no autogenerate drift).

## Verification

- **Applied against live dev Postgres**: `upgrade` created both indexes with correct definitions (`btree`), `downgrade` dropped both cleanly, head returned to the prior revision.
- **migration-reviewer agent**: verdict **SAFE** — idempotent, reversible, no model/migration drift, correct naming.
- Single linear head (`down_revision` = `20260530_sched_email_nullable`, the current head).
- `black --check` (26.3.1): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)