### PR TITLE
fix(notifications): use scholarship_name in emails + add contract tests

### DIFF
--- a/backend/app/services/scholarship_notification_service.py
+++ b/backend/app/services/scholarship_notification_service.py
@@ -196,7 +196,7 @@ class ScholarshipNotificationService:
                     <h3 style="margin-top: 0; color: #2d3748;">Application Information:</h3>
                     <ul style="margin: 10px 0;">
                         <li><strong>Application ID:</strong> {application.app_id}</li>
-                        <li><strong>Scholarship Type:</strong> {application.scholarship_type}</li>
+                        <li><strong>Scholarship Type:</strong> {application.scholarship_name or 'N/A'}</li>
                         <li><strong>Previous Status:</strong> {old_status.replace('_', ' ').title()}</li>
                         <li><strong>Current Status:</strong> {new_status.replace('_', ' ').title()}</li>
                         <li><strong>Status Changed:</strong> {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}</li>
@@ -299,7 +299,7 @@ class ScholarshipNotificationService:
                             <h3 style="margin-top: 0; color: #2d3748;">Deadline Information:</h3>
                             <ul style="margin: 10px 0;">
                                 <li><strong>Application ID:</strong> {application.app_id}</li>
-                                <li><strong>Scholarship Type:</strong> {application.scholarship_type}</li>
+                                <li><strong>Scholarship Type:</strong> {application.scholarship_name or 'N/A'}</li>
                                 <li><strong>Review Deadline:</strong> {application.review_deadline.strftime('%Y-%m-%d')}</li>
                                 <li><strong>Days Remaining:</strong> {days_remaining} days</li>
                                 <li><strong>Current Status:</strong> {application.status.replace('_', ' ').title()}</li>
@@ -374,7 +374,7 @@ class ScholarshipNotificationService:
                         <li><strong>Student:</strong> {student_name}</li>
                         <li><strong>Student ID:</strong> {student_no}</li>
                         <li><strong>Application ID:</strong> {application.app_id}</li>
-                        <li><strong>Scholarship Type:</strong> {application.scholarship_type}</li>
+                        <li><strong>Scholarship Type:</strong> {application.scholarship_name or 'N/A'}</li>
                         <li><strong>Application Status:</strong> {application.status.replace('_', ' ').title()}</li>
                         <li><strong>Submitted:</strong> {application.submitted_at.strftime('%Y-%m-%d') if application.submitted_at else 'N/A'}</li>
                     </ul>

--- a/backend/app/tests/test_scholarship_notification_service.py
+++ b/backend/app/tests/test_scholarship_notification_service.py
@@ -1,0 +1,186 @@
+"""
+Contract tests for ScholarshipNotificationService (previously zero coverage).
+
+This service was exercised in the suite only via a StubNotificationService in
+bulk_approval tests, so the real implementation never ran. These tests pin the
+observable contract of its email-sending methods with stubbed collaborators
+(no DB session, no SMTP):
+
+- recipient resolution (student `user.email` vs `professor_user.email`)
+- the guards that return False (missing user / missing student_data)
+- the happy-path return value and that send_email is actually invoked
+- exceptions from the email layer are swallowed into a False return
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.models.application import ApplicationStatus
+from app.services.scholarship_notification_service import ScholarshipNotificationService
+
+
+class FakeResult:
+    """Mimics the subset of a SQLAlchemy Result the service uses."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalar_one_or_none(self):
+        rows = list(self._rows)
+        return rows[0] if rows else None
+
+
+class StubAsyncSession:
+    """Records execute/commit; returns a preset row list for the User lookup."""
+
+    def __init__(self, results=None):
+        self.results = results or []
+        self.executed = []
+        self.committed = 0
+
+    async def execute(self, query, params=None):
+        self.executed.append((query, params))
+        return FakeResult(self.results)
+
+    async def commit(self):
+        self.committed += 1
+
+
+class StubEmailService:
+    """Records send_email calls; optionally raises to test the error path."""
+
+    def __init__(self, raises: Exception = None):
+        self.calls = []
+        self.raises = raises
+
+    async def send_email(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.raises:
+            raise self.raises
+        return True
+
+
+def _service(results=None, email_raises=None):
+    """Build the service with stubbed db + email collaborators."""
+    svc = ScholarshipNotificationService(db=StubAsyncSession(results=results))
+    svc.email_service = StubEmailService(raises=email_raises)
+    return svc
+
+
+def _application(**overrides):
+    """Duck-typed Application — the service only reads attributes."""
+    defaults = {
+        "id": 1,
+        "user_id": 42,
+        "app_id": "APP-114-1-00001",
+        "status": ApplicationStatus.submitted.value,
+        "student_data": {"std_cname": "王小明", "std_stdcode": "310460031"},
+        "scholarship_name": "國科會博士生獎學金",
+        "sub_scholarship_type": "nstc",
+        "semester": "first",
+        "academic_year": 114,
+        "submitted_at": datetime(2026, 5, 30, 12, 0, 0, tzinfo=timezone.utc),
+        "review_deadline": None,
+        "is_renewal": False,
+        "reviews": [],
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _user(email="student@nycu.edu.tw"):
+    return SimpleNamespace(id=42, email=email, name="王小明", nycu_id="310460031")
+
+
+# ─── send_application_submitted_notification ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_submitted_happy_path_sends_to_student_email():
+    svc = _service(results=[_user("stu@nycu.edu.tw")])
+    ok = await svc.send_application_submitted_notification(_application())
+    assert ok is True
+    assert len(svc.email_service.calls) == 1
+    assert svc.email_service.calls[0]["to"] == "stu@nycu.edu.tw"
+
+
+@pytest.mark.asyncio
+async def test_submitted_returns_false_when_user_missing():
+    svc = _service(results=[])  # User lookup yields nothing
+    ok = await svc.send_application_submitted_notification(_application())
+    assert ok is False
+    assert svc.email_service.calls == []  # no email attempted
+
+
+@pytest.mark.asyncio
+async def test_submitted_returns_false_when_student_data_missing():
+    svc = _service(results=[_user()])
+    ok = await svc.send_application_submitted_notification(_application(student_data=None))
+    assert ok is False
+    assert svc.email_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_submitted_returns_false_when_email_layer_raises():
+    svc = _service(results=[_user()], email_raises=RuntimeError("SMTP down"))
+    ok = await svc.send_application_submitted_notification(_application())
+    assert ok is False  # exception swallowed, not propagated
+
+
+@pytest.mark.asyncio
+async def test_submitted_renewal_still_sends():
+    svc = _service(results=[_user()])
+    ok = await svc.send_application_submitted_notification(_application(is_renewal=True))
+    assert ok is True
+    assert len(svc.email_service.calls) == 1
+
+
+# ─── send_status_change_notification ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_status_change_happy_path_sends_to_student():
+    svc = _service(results=[_user("stu@nycu.edu.tw")])
+    ok = await svc.send_status_change_notification(
+        _application(),
+        old_status=ApplicationStatus.submitted.value,
+        new_status=ApplicationStatus.approved.value,
+    )
+    assert ok is True
+    assert svc.email_service.calls[0]["to"] == "stu@nycu.edu.tw"
+
+
+@pytest.mark.asyncio
+async def test_status_change_returns_false_when_student_data_missing():
+    svc = _service(results=[_user()])
+    ok = await svc.send_status_change_notification(
+        _application(student_data=None),
+        old_status="submitted",
+        new_status="approved",
+    )
+    assert ok is False
+    assert svc.email_service.calls == []
+
+
+# ─── send_professor_review_request ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_professor_review_request_sends_to_professor_email():
+    # No User lookup on this path — professor_user is passed in directly.
+    svc = _service(results=[])
+    professor = SimpleNamespace(id=7, email="prof@nycu.edu.tw", name="李教授")
+    ok = await svc.send_professor_review_request(_application(), professor)
+    assert ok is True
+    assert svc.email_service.calls[0]["to"] == "prof@nycu.edu.tw"
+
+
+@pytest.mark.asyncio
+async def test_professor_review_request_returns_false_without_student_data():
+    svc = _service(results=[])
+    professor = SimpleNamespace(id=7, email="prof@nycu.edu.tw", name="李教授")
+    ok = await svc.send_professor_review_request(_application(student_data=None), professor)
+    assert ok is False
+    assert svc.email_service.calls == []


### PR DESCRIPTION
## Summary

`ScholarshipNotificationService` had **zero real test coverage** (its only caller stubs it out in bulk_approval tests). Writing contract tests surfaced a **latent bug**: three email templates reference `application.scholarship_type` — an attribute that **does not exist** on the Application model (the relationship was renamed to `scholarship_type_ref`).

Because every method wraps its body in `except Exception: return False`, the resulting `AttributeError` was **swallowed** — so these emails *silently never sent* for real applications:
- `send_status_change_notification` (L199)
- `send_deadline_reminder_notifications` (L302)
- `send_professor_review_request` (L377)

(`send_application_submitted_notification` was unaffected — it already uses `scholarship_name`.)

## Fix

Use `application.scholarship_name` (matching the working submitted-notification template) in all three slots.

## Tests (9, all green)

Stubbed db + email collaborators (no SMTP), pinning:
- recipient resolution — student `user.email` vs `professor_user.email`
- the False-returning guards (missing user / missing student_data)
- happy-path returns True **and** `send_email` is actually invoked
- email-layer exceptions are swallowed into a `False` return

These tests are what found the bug and now guard the fix. Verified in the dev container: **9 passed**.

## Follow-up

Sibling latent bug (separate PR — currently only reached by tests that stub the attribute): `scholarship_service._validate_application_documents` reads `application.scholarship_type.required_documents`. Filed as an issue.

This is Wave 5 of the optimization audit (zero-coverage email-service tests) — and a live example of the "test waves find real bugs" pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)