### PR TITLE
fix(tests): convert test_scholarship_configuration_service to async

### DIFF
--- a/backend/app/tests/test_scholarship_configuration_service.py
+++ b/backend/app/tests/test_scholarship_configuration_service.py
@@ -5,6 +5,7 @@ Unit tests for ScholarshipConfigurationService CRUD operations
 from datetime import datetime
 
 import pytest
+import pytest_asyncio
 
 from app.models.scholarship import ScholarshipType
 from app.models.user import User, UserRole
@@ -15,38 +16,36 @@ class TestScholarshipConfigurationServiceCRUD:
     """Test cases for ScholarshipConfiguration CRUD operations"""
 
     @pytest.fixture
-    def service(self, db_sync):
+    def service(self, db):
         """Create ScholarshipConfigurationService instance for testing"""
-        return ScholarshipConfigurationService(db_sync)
+        return ScholarshipConfigurationService(db)
 
-    @pytest.fixture
-    def test_scholarship_type(self, db_sync):
+    @pytest_asyncio.fixture
+    async def test_scholarship_type(self, db):
         """Create a test scholarship type"""
         scholarship_type = ScholarshipType(
             code="test_phd",
             name="Test PhD Scholarship",
             description="Test PhD scholarship for configuration testing",
-            category="doctoral",
             status="active",
         )
-        db_sync.add(scholarship_type)
-        db_sync.commit()
-        db_sync.refresh(scholarship_type)
+        db.add(scholarship_type)
+        await db.commit()
+        await db.refresh(scholarship_type)
         return scholarship_type
 
-    @pytest.fixture
-    def test_user(self, db_sync):
+    @pytest_asyncio.fixture
+    async def test_user(self, db):
         """Create a test user"""
         user = User(
             email="admin@university.edu",
-            username="admin",
-            full_name="Test Admin",
+            nycu_id="admin",
+            name="Test Admin",
             role=UserRole.admin,
-            is_active=True,
         )
-        db_sync.add(user)
-        db_sync.commit()
-        db_sync.refresh(user)
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
         return user
 
     @pytest.fixture
@@ -71,9 +70,9 @@ class TestScholarshipConfigurationServiceCRUD:
             "version": "1.0",
         }
 
-    def test_create_configuration_success(self, service, test_scholarship_type, test_user, valid_config_data):
+    async def test_create_configuration_success(self, service, test_scholarship_type, test_user, valid_config_data):
         """Test successful configuration creation"""
-        config = service.create_configuration(
+        config = await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=valid_config_data,
             created_by_user_id=test_user.id,
@@ -85,15 +84,17 @@ class TestScholarshipConfigurationServiceCRUD:
         assert config.config_name == valid_config_data["config_name"]
         assert config.config_code == valid_config_data["config_code"]
         assert config.academic_year == valid_config_data["academic_year"]
-        assert config.semester == valid_config_data["semester"]
+        assert config.semester.value == valid_config_data["semester"]
         assert config.amount == valid_config_data["amount"]
         assert config.is_active is True
         assert config.created_by == test_user.id
 
-    def test_create_configuration_duplicate_fails(self, service, test_scholarship_type, test_user, valid_config_data):
+    async def test_create_configuration_duplicate_fails(
+        self, service, test_scholarship_type, test_user, valid_config_data
+    ):
         """Test that creating duplicate configuration fails"""
         # Create first configuration
-        service.create_configuration(
+        await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=valid_config_data,
             created_by_user_id=test_user.id,
@@ -101,27 +102,27 @@ class TestScholarshipConfigurationServiceCRUD:
 
         # Attempt to create duplicate should fail
         with pytest.raises(ValueError, match="Configuration already exists for this academic period"):
-            service.create_configuration(
+            await service.create_configuration(
                 scholarship_type_id=test_scholarship_type.id,
                 config_data=valid_config_data,
                 created_by_user_id=test_user.id,
             )
 
-    def test_create_configuration_missing_required_fields(self, service, test_scholarship_type, test_user):
+    async def test_create_configuration_missing_required_fields(self, service, test_scholarship_type, test_user):
         """Test that missing required fields causes failure"""
         invalid_data = {"description": "Missing required fields"}
 
-        with pytest.raises(KeyError):
-            service.create_configuration(
+        with pytest.raises(ValueError):
+            await service.create_configuration(
                 scholarship_type_id=test_scholarship_type.id,
                 config_data=invalid_data,
                 created_by_user_id=test_user.id,
             )
 
-    def test_update_configuration_success(self, service, test_scholarship_type, test_user, valid_config_data):
+    async def test_update_configuration_success(self, service, test_scholarship_type, test_user, valid_config_data):
         """Test successful configuration update"""
         # Create initial configuration
-        config = service.create_configuration(
+        config = await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=valid_config_data,
             created_by_user_id=test_user.id,
@@ -134,7 +135,7 @@ class TestScholarshipConfigurationServiceCRUD:
             "description": "Updated description",
         }
 
-        updated_config = service.update_configuration(
+        updated_config = await service.update_configuration(
             config_id=config.id,
             config_data=update_data,
             updated_by_user_id=test_user.id,
@@ -145,19 +146,19 @@ class TestScholarshipConfigurationServiceCRUD:
         assert updated_config.description == "Updated description"
         assert updated_config.updated_by == test_user.id
 
-    def test_update_nonexistent_configuration_fails(self, service, test_user):
+    async def test_update_nonexistent_configuration_fails(self, service, test_user):
         """Test that updating non-existent configuration fails"""
         with pytest.raises(ValueError, match="Configuration not found"):
-            service.update_configuration(
+            await service.update_configuration(
                 config_id=999,
                 config_data={"config_name": "New Name"},
                 updated_by_user_id=test_user.id,
             )
 
-    def test_deactivate_configuration_success(self, service, test_scholarship_type, test_user, valid_config_data):
+    async def test_deactivate_configuration_success(self, service, test_scholarship_type, test_user, valid_config_data):
         """Test successful configuration deactivation"""
         # Create configuration
-        config = service.create_configuration(
+        config = await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=valid_config_data,
             created_by_user_id=test_user.id,
@@ -166,27 +167,29 @@ class TestScholarshipConfigurationServiceCRUD:
         assert config.is_active is True
 
         # Deactivate configuration
-        deactivated_config = service.deactivate_configuration(config_id=config.id, updated_by_user_id=test_user.id)
+        deactivated_config = await service.deactivate_configuration(
+            config_id=config.id, updated_by_user_id=test_user.id
+        )
 
         assert deactivated_config.is_active is False
         assert deactivated_config.updated_by == test_user.id
 
-    def test_deactivate_nonexistent_configuration_fails(self, service, test_user):
+    async def test_deactivate_nonexistent_configuration_fails(self, service, test_user):
         """Test that deactivating non-existent configuration fails"""
         with pytest.raises(ValueError, match="Configuration not found"):
-            service.deactivate_configuration(config_id=999, updated_by_user_id=test_user.id)
+            await service.deactivate_configuration(config_id=999, updated_by_user_id=test_user.id)
 
-    def test_duplicate_configuration_success(self, service, test_scholarship_type, test_user, valid_config_data):
+    async def test_duplicate_configuration_success(self, service, test_scholarship_type, test_user, valid_config_data):
         """Test successful configuration duplication"""
         # Create source configuration
-        source_config = service.create_configuration(
+        source_config = await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=valid_config_data,
             created_by_user_id=test_user.id,
         )
 
         # Duplicate to next academic year
-        duplicate_config = service.duplicate_configuration(
+        duplicate_config = await service.duplicate_configuration(
             source_config_id=source_config.id,
             target_academic_year=114,
             target_semester="first",
@@ -197,17 +200,19 @@ class TestScholarshipConfigurationServiceCRUD:
 
         assert duplicate_config.id != source_config.id
         assert duplicate_config.academic_year == 114
-        assert duplicate_config.semester == "first"
+        assert duplicate_config.semester.value == "first"
         assert duplicate_config.config_code == "PHD-114-1"
         assert duplicate_config.config_name == "114學年度第一學期博士生配置"
         assert duplicate_config.amount == source_config.amount  # Should copy amount
         assert duplicate_config.description == source_config.description  # Should copy description
         assert duplicate_config.created_by == test_user.id
 
-    def test_duplicate_to_existing_period_fails(self, service, test_scholarship_type, test_user, valid_config_data):
+    async def test_duplicate_to_existing_period_fails(
+        self, service, test_scholarship_type, test_user, valid_config_data
+    ):
         """Test that duplicating to existing period fails"""
         # Create source configuration
-        source_config = service.create_configuration(
+        source_config = await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=valid_config_data,
             created_by_user_id=test_user.id,
@@ -218,7 +223,7 @@ class TestScholarshipConfigurationServiceCRUD:
             ValueError,
             match="Target configuration already exists for this academic period",
         ):
-            service.duplicate_configuration(
+            await service.duplicate_configuration(
                 source_config_id=source_config.id,
                 target_academic_year=113,
                 target_semester="first",
@@ -227,10 +232,10 @@ class TestScholarshipConfigurationServiceCRUD:
                 created_by_user_id=test_user.id,
             )
 
-    def test_duplicate_nonexistent_source_fails(self, service, test_user):
+    async def test_duplicate_nonexistent_source_fails(self, service, test_user):
         """Test that duplicating non-existent source fails"""
         with pytest.raises(ValueError, match="Source configuration not found"):
-            service.duplicate_configuration(
+            await service.duplicate_configuration(
                 source_config_id=999,
                 target_academic_year=114,
                 target_semester="first",
@@ -239,10 +244,10 @@ class TestScholarshipConfigurationServiceCRUD:
                 created_by_user_id=test_user.id,
             )
 
-    def test_get_configurations_by_filter(self, service, test_scholarship_type, test_user, valid_config_data):
+    async def test_get_configurations_by_filter(self, service, test_scholarship_type, test_user, valid_config_data):
         """Test filtering configurations"""
         # Create multiple configurations
-        config1 = service.create_configuration(
+        config1 = await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=valid_config_data,
             created_by_user_id=test_user.id,
@@ -250,7 +255,7 @@ class TestScholarshipConfigurationServiceCRUD:
 
         config2_data = valid_config_data.copy()
         config2_data.update({"config_code": "PHD-113-2", "semester": "second"})
-        service.create_configuration(
+        await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=config2_data,
             created_by_user_id=test_user.id,
@@ -258,22 +263,24 @@ class TestScholarshipConfigurationServiceCRUD:
 
         config3_data = valid_config_data.copy()
         config3_data.update({"config_code": "PHD-114-1", "academic_year": 114})
-        service.create_configuration(
+        await service.create_configuration(
             scholarship_type_id=test_scholarship_type.id,
             config_data=config3_data,
             created_by_user_id=test_user.id,
         )
 
         # Test filtering by scholarship type
-        configs = service.get_configurations_by_filter(scholarship_type_id=test_scholarship_type.id)
+        configs = await service.get_configurations_by_filter(scholarship_type_id=test_scholarship_type.id)
         assert len(configs) == 3
 
         # Test filtering by academic year
-        configs = service.get_configurations_by_filter(scholarship_type_id=test_scholarship_type.id, academic_year=113)
+        configs = await service.get_configurations_by_filter(
+            scholarship_type_id=test_scholarship_type.id, academic_year=113
+        )
         assert len(configs) == 2
 
         # Test filtering by semester
-        configs = service.get_configurations_by_filter(
+        configs = await service.get_configurations_by_filter(
             scholarship_type_id=test_scholarship_type.id,
             academic_year=113,
             semester="first",
@@ -281,12 +288,12 @@ class TestScholarshipConfigurationServiceCRUD:
         assert len(configs) == 1
         assert configs[0].id == config1.id
 
-    def test_validate_configuration_data_valid(self, service, valid_config_data):
+    async def test_validate_configuration_data_valid(self, service, valid_config_data):
         """Test validation of valid configuration data"""
         errors = service.validate_configuration_data(valid_config_data)
         assert len(errors) == 0
 
-    def test_validate_configuration_data_missing_required(self, service):
+    async def test_validate_configuration_data_missing_required(self, service):
         """Test validation with missing required fields"""
         invalid_data = {"description": "Missing required fields"}
 
@@ -297,7 +304,7 @@ class TestScholarshipConfigurationServiceCRUD:
         assert any("academic_year is required" in error for error in errors)
         assert any("amount is required" in error for error in errors)
 
-    def test_validate_configuration_data_invalid_academic_year(self, service):
+    async def test_validate_configuration_data_invalid_academic_year(self, service):
         """Test validation with invalid academic year"""
         invalid_data = {
             "config_name": "Test",
@@ -309,7 +316,7 @@ class TestScholarshipConfigurationServiceCRUD:
         errors = service.validate_configuration_data(invalid_data)
         assert any("Academic year should be in Taiwan calendar format" in error for error in errors)
 
-    def test_validate_configuration_data_invalid_amount(self, service):
+    async def test_validate_configuration_data_invalid_amount(self, service):
         """Test validation with invalid amount"""
         invalid_data = {
             "config_name": "Test",
@@ -321,7 +328,7 @@ class TestScholarshipConfigurationServiceCRUD:
         errors = service.validate_configuration_data(invalid_data)
         assert any("Amount must be greater than 0" in error for error in errors)
 
-    def test_validate_configuration_data_invalid_dates(self, service):
+    async def test_validate_configuration_data_invalid_dates(self, service):
         """Test validation with invalid date ranges"""
         invalid_data = {
             "config_name": "Test",
@@ -340,32 +347,31 @@ class TestScholarshipConfigurationServiceIntegration:
     """Integration tests for ScholarshipConfigurationService"""
 
     @pytest.fixture
-    def service(self, db_sync):
-        return ScholarshipConfigurationService(db_sync)
+    def service(self, db):
+        return ScholarshipConfigurationService(db)
 
-    def test_configuration_lifecycle(self, service, db_sync):
+    async def test_configuration_lifecycle(self, service, db):
         """Test complete configuration lifecycle"""
         # Create scholarship type
         scholarship_type = ScholarshipType(
             code="lifecycle_test",
             name="Lifecycle Test Scholarship",
-            category="undergraduate",
-            is_active=True,
+            status="active",
         )
-        db_sync.add(scholarship_type)
-        db_sync.commit()
-        db_sync.refresh(scholarship_type)
+        db.add(scholarship_type)
+        await db.commit()
+        await db.refresh(scholarship_type)
 
         # Create user
         user = User(
             email="lifecycle@test.edu",
-            username="lifecycle",
-            full_name="Lifecycle User",
+            nycu_id="lifecycle",
+            name="Lifecycle User",
             role=UserRole.admin,
         )
-        db_sync.add(user)
-        db_sync.commit()
-        db_sync.refresh(user)
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
 
         # Create configuration
         config_data = {
@@ -377,21 +383,21 @@ class TestScholarshipConfigurationServiceIntegration:
             "currency": "TWD",
         }
 
-        config = service.create_configuration(
+        config = await service.create_configuration(
             scholarship_type_id=scholarship_type.id,
             config_data=config_data,
             created_by_user_id=user.id,
         )
 
         # Update configuration
-        updated_config = service.update_configuration(
+        updated_config = await service.update_configuration(
             config_id=config.id,
             config_data={"amount": 30000, "description": "Updated description"},
             updated_by_user_id=user.id,
         )
 
         # Duplicate configuration
-        duplicate_config = service.duplicate_configuration(
+        duplicate_config = await service.duplicate_configuration(
             source_config_id=config.id,
             target_academic_year=114,
             target_semester="first",
@@ -401,7 +407,7 @@ class TestScholarshipConfigurationServiceIntegration:
         )
 
         # Deactivate original configuration
-        deactivated_config = service.deactivate_configuration(config_id=config.id, updated_by_user_id=user.id)
+        deactivated_config = await service.deactivate_configuration(config_id=config.id, updated_by_user_id=user.id)
 
         # Verify final states
         assert updated_config.amount == 30000
@@ -409,6 +415,8 @@ class TestScholarshipConfigurationServiceIntegration:
         assert deactivated_config.is_active is False
 
         # Verify filtering
-        active_configs = service.get_configurations_by_filter(scholarship_type_id=scholarship_type.id, is_active=True)
+        active_configs = await service.get_configurations_by_filter(
+            scholarship_type_id=scholarship_type.id, is_active=True
+        )
         assert len(active_configs) == 1
         assert active_configs[0].id == duplicate_config.id


### PR DESCRIPTION
## Summary

All `ScholarshipConfigurationService` CRUD methods (`create`/`update`/`deactivate`/`duplicate`/`get_configurations_by_filter`) are **async**, but this test suite called them **synchronously** against a sync `db_sync` session — every call returned an un-awaited coroutine (`'coroutine' object has no attribute 'id'`), so all 13 CRUD/integration tests errored on main.

## Rewrite to async
- Fixtures use the async `db` session; `test_scholarship_type` / `test_user` become `@pytest_asyncio.fixture async def` with `await db.commit()/refresh()`.
- All test methods become `async def` with `await service.<method>(...)` (`validate_configuration_data` stays sync — no await).

## Stale fixtures/assertions repaired (surfaced by the rewrite — solved, not skipped)
- Removed-column kwargs: `ScholarshipType(category=)` (gone), `is_active=`→`status="active"`; `User(username=)`→`nycu_id=`, `full_name=`→`name=`, dropped `is_active=`.
- `config.semester` is a `Semester` enum → assert `.value == "first"`.
- Missing-required-field now raises `ValueError` (explicit validation), not `KeyError` → updated the expected exception (still asserts an error is raised).

## Verification
Dev container against current main: **17 passed** (was 13 failed/errored). These async tests now belong to the **integration** suite (asyncio-marked), not unit.

Part of the main-CI-green effort (follows #854, #867).

🤖 Generated with [Claude Code](https://claude.com/claude-code)