### PR TITLE
fix(tests+model): move can_student_apply* to ScholarshipConfiguration; repair renewal tests

### DIFF
--- a/backend/app/models/scholarship.py
+++ b/backend/app/models/scholarship.py
@@ -248,56 +248,6 @@ class ScholarshipType(Base):
 
         return translations
 
-    def can_student_apply(
-        self,
-        student_id: int,
-        existing_applications: List["Application"],
-        is_renewal: bool = None,
-    ) -> bool:
-        """
-        Check if student can apply for this scholarship based on semester limits and application type
-
-        Args:
-            student_id: Student ID to check
-            existing_applications: List of existing applications for this student
-            is_renewal: True for renewal, False for general, None to auto-detect based on current period
-
-        Returns:
-            bool: True if student can apply, False otherwise
-        """
-        # Check whitelist first
-        if not self.is_student_in_whitelist(student_id):
-            return False
-
-        # Auto-detect application type if not provided
-        if is_renewal is None:
-            is_renewal = self.current_application_type == "renewal"
-
-        # Check if we're in the correct application period
-        if is_renewal and not self.is_renewal_application_period:
-            return False
-        elif not is_renewal and not self.is_general_application_period:
-            return False
-
-        # Check if student already has an application for this semester
-        for application in existing_applications:
-            if (
-                application.scholarship_type_id == self.id
-                and application.student_id == student_id
-                and application.is_renewal == is_renewal
-            ):
-                return False
-
-        return True
-
-    def can_student_apply_renewal(self, student_id: int, existing_applications: List["Application"]) -> bool:
-        """Check if student can apply for renewal"""
-        return self.can_student_apply(student_id, existing_applications, True)
-
-    def can_student_apply_general(self, student_id: int, existing_applications: List["Application"]) -> bool:
-        """Check if student can apply for general application"""
-        return self.can_student_apply(student_id, existing_applications, False)
-
     def get_application_timeline(self) -> Dict[str, Dict[str, datetime]]:
         """Get complete application timeline"""
         timeline = {
@@ -921,6 +871,57 @@ class ScholarshipConfiguration(Base):
         elif self.is_general_application_period:
             return "general"
         return None
+
+    def can_student_apply(
+        self,
+        student_id: int,
+        existing_applications: List["Application"],
+        is_renewal: bool = None,
+    ) -> bool:
+        """
+        Check if student can apply for this configuration based on the current
+        application period and existing applications.
+
+        Args:
+            student_id: Student (user) ID to check
+            existing_applications: List of existing applications for this student
+            is_renewal: True for renewal, False for general, None to auto-detect based on current period
+
+        Returns:
+            bool: True if student can apply, False otherwise
+        """
+        # Check whitelist first
+        if not self.is_student_in_whitelist(student_id):
+            return False
+
+        # Auto-detect application type if not provided
+        if is_renewal is None:
+            is_renewal = self.current_application_type == "renewal"
+
+        # Check if we're in the correct application period
+        if is_renewal and not self.is_renewal_application_period:
+            return False
+        elif not is_renewal and not self.is_general_application_period:
+            return False
+
+        # Check if student already has an application for this configuration
+        for application in existing_applications:
+            if (
+                application.scholarship_configuration_id == self.id
+                and application.user_id == student_id
+                and application.is_renewal == is_renewal
+            ):
+                return False
+
+        return True
+
+    def can_student_apply_renewal(self, student_id: int, existing_applications: List["Application"]) -> bool:
+        """Check if student can apply for renewal"""
+        return self.can_student_apply(student_id, existing_applications, True)
+
+    def can_student_apply_general(self, student_id: int, existing_applications: List["Application"]) -> bool:
+        """Check if student can apply for general application"""
+        return self.can_student_apply(student_id, existing_applications, False)
 
     def is_renewal_professor_review_period(self) -> bool:
         """Check if within renewal professor review period"""

--- a/backend/app/tests/test_renewal_flow_sequence.py
+++ b/backend/app/tests/test_renewal_flow_sequence.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from app.models.enums import Semester
-from app.models.scholarship import ScholarshipStatus, ScholarshipType
+from app.models.scholarship import ScholarshipConfiguration
 
 
 class TestRenewalFlowSequence:
@@ -18,13 +18,13 @@ class TestRenewalFlowSequence:
         """Create a scholarship with sequential renewal and general flows"""
         now = datetime.now(timezone.utc)
 
-        return ScholarshipType(
-            code="SEQUENTIAL_SCHOLARSHIP",
-            name="順序流程獎學金",
+        return ScholarshipConfiguration(
+            config_code="SEQUENTIAL_SCHOLARSHIP",
+            config_name="順序流程獎學金",
             academic_year=113,
             semester=Semester.first,
             amount=50000,
-            status=ScholarshipStatus.active.value,
+            is_active=True,
             # 續領申請期間（優先處理）
             renewal_application_start_date=now - timedelta(days=60),
             renewal_application_end_date=now - timedelta(days=40),

--- a/backend/app/tests/test_scholarship_renewal.py
+++ b/backend/app/tests/test_scholarship_renewal.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from app.models.enums import Semester
-from app.models.scholarship import ScholarshipStatus, ScholarshipType
+from app.models.scholarship import ScholarshipConfiguration
 
 
 class TestScholarshipRenewalPeriod:
@@ -18,13 +18,13 @@ class TestScholarshipRenewalPeriod:
         """Create a scholarship with renewal periods"""
         now = datetime.now(timezone.utc)
 
-        return ScholarshipType(
-            code="TEST_SCHOLARSHIP",
-            name="測試獎學金",
+        return ScholarshipConfiguration(
+            config_code="TEST_SCHOLARSHIP",
+            config_name="測試獎學金",
             academic_year=113,
             semester=Semester.first,
             amount=50000,
-            status=ScholarshipStatus.active.value,
+            is_active=True,
             # 續領申請期間（優先處理）
             renewal_application_start_date=now - timedelta(days=10),
             renewal_application_end_date=now + timedelta(days=5),
@@ -144,12 +144,11 @@ class TestApplicationRenewal:
         renewal_app = Application(
             app_id="APP-2025-000001",
             user_id=1,
-            student_id=1,
             scholarship_type_id=1,
             is_renewal=True,
             academic_year=113,
             semester=Semester.first,
-            status=ApplicationStatus.submitted.value,
+            status=ApplicationStatus.submitted,
         )
 
         assert renewal_app.is_renewal_application is True
@@ -161,12 +160,11 @@ class TestApplicationRenewal:
         general_app = Application(
             app_id="APP-2025-000002",
             user_id=2,
-            student_id=2,
             scholarship_type_id=1,
             is_renewal=False,
             academic_year=113,
             semester=Semester.first,
-            status=ApplicationStatus.submitted.value,
+            status=ApplicationStatus.submitted,
         )
 
         assert general_app.is_renewal_application is False


### PR DESCRIPTION
## Summary

`test_scholarship_renewal.py` (7) and `test_renewal_flow_sequence.py` (4) were red on main. Fixing them surfaced a latent **model bug**.

### Test fixes
1. Fixtures built `ScholarshipType(academic_year=, amount=, renewal_*_date=, ...)`, but those fields + the period-detection properties (`is_renewal_application_period`, `current_application_type`, …) live on **`ScholarshipConfiguration`** after the Type/Config split. Switched the fixtures to build `ScholarshipConfiguration` (`code`→`config_code`, `name`→`config_name`, `status`→`is_active`).
2. `Application(student_id=...)` — `student_id` was removed (student data now comes from the external API). Dropped it. `get_review_stage()` compares `status` to the `ApplicationStatus` **enum member**, so the in-memory fixture passes the enum, not `.value`.

### Model fix (latent bug — solved, not skipped)
`can_student_apply` / `_renewal` / `_general` lived on **`ScholarshipType`** but reference Config-only members (`current_application_type`, `is_renewal_application_period`, `is_general_application_period`) — so they could **never run on a real ScholarshipType** (`AttributeError`). They have **no production callers** (only a commented-out reference in `scholarship_service.py:409`). Moved them to `ScholarshipConfiguration` where their dependencies live, and fixed the existing-application loop to current columns (`scholarship_configuration_id`, `user_id` — `student_id`/`scholarship_type_id` matching was also stale).

## Verification
Dev container against current main: **11 passed** across both files. Grep confirmed no production code (or other test) references these methods on `ScholarshipType`.

Part of the main-CI-green effort (follows #854, #867, #868).

🤖 Generated with [Claude Code](https://claude.com/claude-code)