### PR TITLE
fix: two real bugs (whitelist parser, renewal-review validator) + unit contract updates

### DIFF
--- a/backend/app/schemas/scholarship_configuration.py
+++ b/backend/app/schemas/scholarship_configuration.py
@@ -5,7 +5,7 @@ Scholarship Configuration schemas for API requests and responses
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.models.enums import ApplicationCycle, QuotaManagementMode, Semester
 
@@ -96,23 +96,20 @@ class ScholarshipConfigurationBase(BaseModel):
                     raise ValueError(f"配額總和 ({college_total}) 超過總配額 ({total_quota})")
         return v
 
-    @field_validator("renewal_professor_review_end")
-    @classmethod
-    def validate_renewal_professor_review(cls, v, values):
-        """Validate renewal professor review dates"""
-        if not values.data.get("requires_professor_recommendation"):
-            if v or values.data.get("renewal_professor_review_start"):
-                raise ValueError("續領教授審查時間不應設定當不需要教授推薦時")
-        return v
-
-    @field_validator("renewal_college_review_end")
-    @classmethod
-    def validate_renewal_college_review(cls, v, values):
-        """Validate renewal college review dates"""
-        if not values.data.get("requires_college_review"):
-            if v or values.data.get("renewal_college_review_start"):
-                raise ValueError("續領學院審查時間不應設定當不需要學院審查時")
-        return v
+    @model_validator(mode="after")
+    def validate_renewal_review_dates(self):
+        """Renewal review dates must not be set unless the matching review step
+        is required. Implemented as a model-level validator so it can read the
+        requires_* flags reliably regardless of field-definition order (a
+        field_validator on the *_end field runs before the flags are populated).
+        """
+        if not self.requires_professor_recommendation and (
+            self.renewal_professor_review_end or self.renewal_professor_review_start
+        ):
+            raise ValueError("續領教授審查時間不應設定當不需要教授推薦時")
+        if not self.requires_college_review and (self.renewal_college_review_end or self.renewal_college_review_start):
+            raise ValueError("續領學院審查時間不應設定當不需要學院審查時")
+        return self
 
     @field_validator("effective_end_date")
     @classmethod

--- a/backend/app/services/whitelist_excel_service.py
+++ b/backend/app/services/whitelist_excel_service.py
@@ -143,8 +143,16 @@ class WhitelistExcelService:
                 continue
 
             # 提取資料
-            nycu_id = str(row_data[col_indices["nycu_id"]]).strip() if "nycu_id" in col_indices else ""
-            sub_type = str(row_data[col_indices["sub_type"]]).strip() if "sub_type" in col_indices else ""
+            nycu_id = (
+                str(row_data[col_indices["nycu_id"]]).strip()
+                if "nycu_id" in col_indices and row_data[col_indices["nycu_id"]] is not None
+                else ""
+            )
+            sub_type = (
+                str(row_data[col_indices["sub_type"]]).strip()
+                if "sub_type" in col_indices and row_data[col_indices["sub_type"]] is not None
+                else ""
+            )
             name = (
                 str(row_data[col_indices["name"]]).strip()
                 if "name" in col_indices and row_data[col_indices["name"]]

--- a/backend/app/tests/test_shared_enums_value_contract.py
+++ b/backend/app/tests/test_shared_enums_value_contract.py
@@ -61,10 +61,10 @@ def test_application_status_lifecycle_values():
 
 
 def test_application_status_count_pinned_for_change_review():
-    """Pin: 12 statuses defined. Adding a new status without updating
+    """Pin: 13 statuses defined. Adding a new status without updating
     the frontend switch-statement + admin filters would silently treat
     the new status as 'unknown'. This count forces code review."""
-    assert len(list(ApplicationStatus)) == 12
+    assert len(list(ApplicationStatus)) == 13
 
 
 # ─── ReviewStage (16 workflow positions) ─────────────────────────────

--- a/backend/app/tests/test_type_fixes.py
+++ b/backend/app/tests/test_type_fixes.py
@@ -39,7 +39,7 @@ def test_application_model_properties():
         app_id="APP-2025-123456",
         user_id=1,
         scholarship_name="Academic Excellence",
-        status=ApplicationStatus.draft.value,
+        status=ApplicationStatus.draft,
         academic_year=113,
         semester=Semester.first,
         scholarship_subtype_list=[],
@@ -57,7 +57,7 @@ def test_application_model_properties():
     assert app.can_be_reviewed is False
 
     # Test property values for submitted status
-    app.status = ApplicationStatus.submitted.value
+    app.status = ApplicationStatus.submitted
     assert app.is_editable is False
     assert app.is_submitted is True
     assert app.can_be_reviewed is True


### PR DESCRIPTION
Clears the remaining **unit-suite** failures on main. Two were genuine production bugs surfaced by the tests; two are legitimate test-contract updates (not skips).

## Production bugs found
1. **whitelist parser imports blank rows as `nycu_id="None"`** — `str(None).strip()` yields the string `"None"`, which passes the `if not nycu_id` guard. A blank `nycu_id`/`sub_type` cell was imported as a real whitelist entry. Guarded with `is not None` (mirrors the existing name/note handling). *(`whitelist_excel_service.py`)*
2. **renewal-review validators always reject** — `validate_renewal_professor_review` / `validate_renewal_college_review` were `@field_validator`s on the `*_end` fields. Pydantic v2 runs field validators in **definition order**, and the `requires_professor_recommendation` / `requires_college_review` flags are defined *after* the date fields — so `values.data.get(flag)` was always `None`, and the validators raised whenever renewal review dates were set **even with the flag enabled**. Replaced both with one `@model_validator(mode="after")` that reads the flags reliably. *(`scholarship_configuration.py`)*

## Test-contract updates
3. `test_shared_enums_value_contract`: `ApplicationStatus` grew to **13** values; updated the pinned count `12 → 13` (the tripwire keeps guarding the next change).
4. `test_type_fixes`: `is_editable`/`is_submitted` compare `status` to the **enum member**; the in-memory fixture now passes the enum, not `.value` (matches DB-loaded objects).

> `test_student_service::is_api_available_false_when_not_configured` fails **only** in the dev container (which sets `STUDENT_API_*` env vars); CI doesn't, so it's green there — intentionally left unchanged.

## Verification
Dev container against current main: **48 passed** across the four touched test files (incl. the schema validator's accept-and-reject cases).

Part of the main-CI-green effort (follows #854, #867, #868, #870).

🤖 Generated with [Claude Code](https://claude.com/claude-code)