### PR TITLE
fix(tests): force-disable SIS API in StudentService service fixture (last CI unit failure)

### DIFF
--- a/backend/app/tests/test_student_service.py
+++ b/backend/app/tests/test_student_service.py
@@ -22,8 +22,17 @@ from app.services.student_service import StudentService
 
 
 @pytest.fixture
-def service():
-    """StudentService with API disabled (no env vars in test env)."""
+def service(monkeypatch):
+    """StudentService with the SIS API force-disabled.
+
+    `settings.student_api_enabled` defaults to True and the base_url/account/
+    hmac_key settings all have non-None defaults, so a bare StudentService() is
+    "configured" in every environment (CI included). Force the disabled state so
+    the disabled-path assertions are deterministic instead of env-dependent.
+    """
+    import app.services.student_service as student_service_module
+
+    monkeypatch.setattr(student_service_module.settings, "student_api_enabled", False)
     return StudentService()
 
 


### PR DESCRIPTION
## Summary

`test_is_api_available_false_when_not_configured` (and the other disabled-path tests) relied on a bare `StudentService()` being unconfigured. But `settings.student_api_enabled` **defaults to `True`** and `student_api_base_url` / `_account` / `_hmac_key` all have **non-None defaults**, so the service is "configured" in *every* environment — including CI — and `is_api_available()` returns `True`.

This was the **sole remaining failure in the CI `Backend Tests (unit)` suite** (confirmed from the CI unit-job log on main `a8bc33b6`).

## Fix
Monkeypatch `settings.student_api_enabled = False` in the `service` fixture so the disabled-path assertions are deterministic instead of env-dependent. Every test using this fixture exercises disabled-API behaviour, so forcing the disabled state is correct.

## Verification
Dev container against current main: **15 passed** (was 1 failed). With this, the unit suite is **2709 passed / 0 real failures** (the only other dev-container failure — `test_nycu_employee` position filter — is Redis-cache pollution that doesn't occur in CI, where Redis is absent).

Completes the unit-suite portion of the main-CI-green effort (#854, #867, #868, #870, #871).

🤖 Generated with [Claude Code](https://claude.com/claude-code)