### PR TITLE
fix: resolve latent renamed-attribute bugs (#859, #865)

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -699,7 +699,7 @@ class ApplicationService:
             cancelled_due_to_application_id=application.cancelled_due_to_application_id,
             academic_year=application.academic_year,
             semester=self._convert_semester_to_string(application.semester),
-            student_data=application.student_data,
+            student_data=application.student_data or {},
             submitted_form_data=integrated_form_data,
             agree_terms=application.agree_terms,
             professor_id=application.professor_id,
@@ -847,7 +847,7 @@ class ApplicationService:
                 cancelled_due_to_application_id=application.cancelled_due_to_application_id,
                 academic_year=application.academic_year,
                 semester=self._convert_semester_to_string(application.semester),
-                student_data=application.student_data,
+                student_data=application.student_data or {},
                 submitted_form_data=integrated_form_data,  # 使用整合後的表單資料
                 agree_terms=application.agree_terms,
                 professor_id=application.professor_id,

--- a/backend/app/services/scholarship_service.py
+++ b/backend/app/services/scholarship_service.py
@@ -594,7 +594,7 @@ class ScholarshipApplicationService:
     def _validate_application_documents(self, application: "Application") -> Tuple[bool, str]:
         """Validate that all required documents are uploaded"""
 
-        required_docs = application.scholarship_type.required_documents or []
+        required_docs = application.scholarship_type_ref.required_documents or []
         uploaded_docs = [f.document_type for f in application.files if f.document_type]
 
         missing_docs = []

--- a/backend/app/tests/test_scholarship_application_service_helpers.py
+++ b/backend/app/tests/test_scholarship_application_service_helpers.py
@@ -67,7 +67,7 @@ def test_initial_priority_independent_of_student_id(service):
 def _app_with_docs(required_docs, uploaded_doc_types):
     """Build a minimal Application-like object for the validator."""
     app = SimpleNamespace()
-    app.scholarship_type = SimpleNamespace(required_documents=required_docs)
+    app.scholarship_type_ref = SimpleNamespace(required_documents=required_docs)
     app.files = [SimpleNamespace(document_type=t) for t in uploaded_doc_types]
     return app
 
@@ -105,7 +105,7 @@ def test_validate_documents_required_none_treated_as_empty(service):
     # via the `or []` fallback. Defensive against legacy records
     # without the column populated.
     app = SimpleNamespace()
-    app.scholarship_type = SimpleNamespace(required_documents=None)
+    app.scholarship_type_ref = SimpleNamespace(required_documents=None)
     app.files = [SimpleNamespace(document_type="anything")]
     ok, msg = service._validate_application_documents(app)
     assert ok is True
@@ -125,7 +125,7 @@ def test_validate_documents_none_document_type_filtered_out(service):
     # included them in the "uploaded" set would falsely pass a
     # missing document.
     app = SimpleNamespace()
-    app.scholarship_type = SimpleNamespace(required_documents=["transcript"])
+    app.scholarship_type_ref = SimpleNamespace(required_documents=["transcript"])
     app.files = [
         SimpleNamespace(document_type=None),  # filtered out
         SimpleNamespace(document_type="transcript"),
@@ -137,7 +137,7 @@ def test_validate_documents_none_document_type_filtered_out(service):
 def test_validate_documents_only_none_doc_types_yields_missing(service):
     # Pin: all-None files leave the required set unsatisfied.
     app = SimpleNamespace()
-    app.scholarship_type = SimpleNamespace(required_documents=["transcript"])
+    app.scholarship_type_ref = SimpleNamespace(required_documents=["transcript"])
     app.files = [
         SimpleNamespace(document_type=None),
         SimpleNamespace(document_type=None),

--- a/backend/app/tests/test_scholarship_service_pure_helpers.py
+++ b/backend/app/tests/test_scholarship_service_pure_helpers.py
@@ -110,7 +110,7 @@ def test_initial_priority_new_application_is_zero(app_service):
 def _app(*, required_docs, uploaded_docs):
     """Duck-typed Application with just the attributes the helper reads."""
     return SimpleNamespace(
-        scholarship_type=SimpleNamespace(required_documents=required_docs),
+        scholarship_type_ref=SimpleNamespace(required_documents=required_docs),
         files=[SimpleNamespace(document_type=d) for d in uploaded_docs],
     )
 
@@ -143,7 +143,7 @@ def test_validate_docs_none_required_is_ok(app_service):
     """No required docs configured ⇒ trivially valid (handles the edge
     case where scholarship_type.required_documents is None)."""
     app = SimpleNamespace(
-        scholarship_type=SimpleNamespace(required_documents=None),
+        scholarship_type_ref=SimpleNamespace(required_documents=None),
         files=[],
     )
     ok, _ = app_service._validate_application_documents(app)


### PR DESCRIPTION
Resolves two latent renamed-attribute bugs filed earlier this session — same class as #858 (`.user`→`.student`) and #864 (notification `scholarship_type`→`scholarship_name`).

## #859 — null `student_data` crashes list/dashboard builders
`_create_application_list_response` (L702) and `get_student_dashboard_stats` (L850) passed nullable `application.student_data` straight into `ApplicationListResponse.student_data` (a required `Dict`). Any application with null `student_data` (e.g. a draft surfaced on the dashboard) raised a pydantic `dict_type` ValidationError. Coalesced to `or {}`, matching the other builders in the file (241, 1603, 2025).

## #865 — `_validate_application_documents` reads a non-existent attribute
`ScholarshipApplicationService._validate_application_documents` read `application.scholarship_type.required_documents`, but `Application` has no `scholarship_type` attribute — the relationship is `scholarship_type_ref`. The tests masked it by stubbing the non-existent `scholarship_type` on a duck-typed object. Pointed the code at `scholarship_type_ref` and renamed the test stubs to match.

## Verification
Dev container: **38 passed** across the affected builder + validator test files.

Closes #859, Closes #865.

🤖 Generated with [Claude Code](https://claude.com/claude-code)