### PR TITLE
fix(roster): resilient export dir + nycu test cache isolation (nightly #869)

### DIFF
--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -143,8 +143,21 @@ class ExcelExportService:
         }
 
     def ensure_export_directory(self):
-        """確保匯出目錄存在"""
-        Path(self.export_base_path).mkdir(parents=True, exist_ok=True)
+        """確保匯出目錄存在；若無權限則退回系統暫存目錄（容器中 cwd 可能不可寫）"""
+        try:
+            Path(self.export_base_path).mkdir(parents=True, exist_ok=True)
+        except (PermissionError, OSError) as exc:
+            import tempfile
+
+            fallback = os.path.join(tempfile.gettempdir(), "scholarship-exports")
+            logger.warning(
+                "Cannot create export dir %s (%s); falling back to %s",
+                self.export_base_path,
+                exc,
+                fallback,
+            )
+            Path(fallback).mkdir(parents=True, exist_ok=True)
+            self.export_base_path = fallback
 
     def export_roster_to_excel(
         self,

--- a/backend/app/tests/test_nycu_employee_endpoints.py
+++ b/backend/app/tests/test_nycu_employee_endpoints.py
@@ -5,6 +5,7 @@ Tests for NYCU Employee API endpoints.
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import pytest_asyncio
 from fastapi.testclient import TestClient
 
 from app.integrations.nycu_emp import NYCUEmpItem, NYCUEmpPage
@@ -17,6 +18,18 @@ from app.integrations.nycu_emp.exceptions import (
 )
 from app.main import app
 from app.models.user import User, UserRole
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_nycu_cache():
+    """Clear the Redis-backed employee-directory cache around each test so the
+    cached payload from one test does not leak into another (the dev container
+    has Redis; CI does not, where this is a no-op)."""
+    from app.core.cache import invalidate
+
+    await invalidate("nycu:employees")
+    yield
+    await invalidate("nycu:employees")
 
 
 @pytest.fixture


### PR DESCRIPTION
Addresses test-stability issues — one nightly e2e-full failure (#869) and one dev-container test-isolation failure.

## 1. Roster download 500 — `PermissionError: 'exports'`
`ExcelExportService.ensure_export_directory` created the configured `roster_export_dir` (default `"./exports"`, a **relative** path) with no error handling. In the nightly e2e container the cwd isn't writable, so roster download 500'd (`PermissionError: [Errno 13] Permission denied: 'exports'`) — failing `roster-admin.spec.ts:200`. Now falls back to a writable system temp dir on `PermissionError`/`OSError`.

## 2. nycu cache pollution (dev-container test isolation)
`test_nycu_employee_endpoints` shared the Redis-backed `nycu:employees:<status>` cache across tests: `test_get_all_employees_success` seeds 2 pages, then `test_search_employees_position_filter` read that stale payload and counted **2 instead of 1**. Added an autouse fixture invalidating the cache prefix around each test (no-op in CI, which has no Redis).

## Verification
Full **unit** suite in the dev container: **2711 passed / 0 failed** (previously 1 dev-only failure from the cache pollution).

Addresses the roster-download half of #869. The other nightly e2e failure (`professor-reject-upsert` review-flow semantics) is a deeper state-machine question tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)