### PR TITLE
fix(e2e): align professor-reject-upsert spec with reject-is-rejected policy (#869)

### DIFF
--- a/backend/app/tests/test_review_service_status_gating.py
+++ b/backend/app/tests/test_review_service_status_gating.py
@@ -200,7 +200,11 @@ async def test_professor_approve_promotes_to_approved_when_no_college_review(db:
 
 @pytest.mark.asyncio
 async def test_full_reject_is_terminal_regardless_of_pipeline(db: AsyncSession):
-    """All-rejected should still be terminal — no later role can rescue."""
+    """A professor full-reject sets status=rejected.
+
+    (Policy: a professor reject means the application is rejected. College/admin
+    still retain the right to edit / send it back — 回發 — afterwards, but that is
+    a separate explicit action, not this update_application_status path.)"""
     student = _user(UserRole.student, "s4")
     professor = _user(UserRole.professor, "p4")
     db.add_all([student, professor])

--- a/frontend/e2e/specs/professor-reject-upsert.spec.ts
+++ b/frontend/e2e/specs/professor-reject-upsert.spec.ts
@@ -100,7 +100,7 @@ test.describe("Professor reject recommendation + upsert", () => {
     }
   });
 
-  test("@nightly stuphd001 → professor reject → upsert to approve; status stays submitted", async ({
+  test("@nightly stuphd001 → professor reject → rejected; upsert to approve → under_review", async ({
     browser,
   }) => {
     // 0. Drain any leftover (stuphd001, phd) apps from concurrent specs
@@ -194,14 +194,16 @@ test.describe("Professor reject recommendation + upsert", () => {
     expect(reviewsAfterReject[0].reviewer_id).toBe(professorUserId);
     expect(reviewsAfterReject[0].recommendation).toBe("reject");
 
-    //    b) application.status is unchanged — professor recommendation is
-    //       advisory only and must not flip status away from 'submitted'.
+    //    b) application.status becomes 'rejected' — a professor full-reject
+    //       marks the application rejected (政策: 教授拒絕代表此申請沒料了).
+    //       College/admin retain the right to edit / send back (回發) later, but
+    //       that is a separate action, not this professor-review path.
     const appAfterReject = await getApplication(appId);
     expect(appAfterReject, `application ${appId} disappeared after reject`).not.toBeNull();
     expect(
       appAfterReject!.status,
-      `professor reject should NOT change application.status, got ${appAfterReject!.status}`,
-    ).toBe("submitted");
+      `professor full-reject should set application.status=rejected, got ${appAfterReject!.status}`,
+    ).toBe("rejected");
 
     //    c) review_stage advanced to 'professor_reviewed' (per
     //       create_professor_review at services/application_service.py:1729).
@@ -256,8 +258,10 @@ test.describe("Professor reject recommendation + upsert", () => {
     //    c) Recommendation reflects the newer value.
     expect(reviewsAfterUpsert[0].recommendation).toBe("approve");
 
-    //    d) Status still 'submitted' — second call also advisory.
+    //    d) Status -> 'under_review' — the upsert to approve re-opens the app
+    //       and it awaits college review (issue #182: professor approve keeps it
+    //       at under_review while requires_college_review is set).
     const appAfterUpsert = await getApplication(appId);
-    expect(appAfterUpsert!.status).toBe("submitted");
+    expect(appAfterUpsert!.status).toBe("under_review");
   });
 });


### PR DESCRIPTION
Resolves the remaining nightly e2e-full failure in #869 (`professor-reject-upsert.spec.ts`).

## Policy (confirmed with maintainer)
A professor **full-reject** marks the application `rejected` ("教授拒絕代表此申請沒料了"). The **college/admin** sides retain the right to **edit / send back (回發)** afterwards — but that's a separate explicit action, not the professor-review path.

The backend already implements this (`review_service.update_application_status` L489-498) and the unit test `test_full_reject_is_terminal_regardless_of_pipeline` confirms it. The nightly e2e spec encoded the **older** "advisory — stays submitted" assumption (2026-05-18, issue #76) and was the conflicting surface.

## Changes
- e2e spec: after professor reject → `status === "rejected"` (was `"submitted"`); after upsert-to-approve → `status === "under_review"` (was `"submitted"` — the re-approve re-opens and awaits college review, per issue #182 + `requires_college_review`).
- Unit test docstring softened (assertion unchanged): the old "no later role can rescue" wording contradicted the 回發 capability.

## Verification
- Unit suite (`test_review_service_status_gating.py`): **4 passed** (assertion unchanged, still green).
- The post-upsert `under_review` follows the #182 code path; the **next nightly run** confirms the full e2e end-to-end (the e2e stack isn't runnable in this dev container — mock-SSO is disabled here).

Closes #869 (pending the next nightly going green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)