### PR TITLE
fix(lint): drop redundant PermissionError in except (B014) from #874

### DIFF
--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -146,7 +146,7 @@ class ExcelExportService:
         """確保匯出目錄存在；若無權限則退回系統暫存目錄（容器中 cwd 可能不可寫）"""
         try:
             Path(self.export_base_path).mkdir(parents=True, exist_ok=True)
-        except (PermissionError, OSError) as exc:
+        except OSError as exc:
             import tempfile
 
             fallback = os.path.join(tempfile.gettempdir(), "scholarship-exports")


### PR DESCRIPTION
#874's `except (PermissionError, OSError)` tripped the hard **flake8-bugbear B014** gate (`Quick Checks (backend-lint)` went red on main). `PermissionError` is a subclass of `OSError`, so `except OSError` catches exactly the same exceptions — behaviour unchanged. Restores backend-lint to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)