### PR TITLE
fix: auto-fix CI failure for PR #857 — black formatting in export endpoint

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -1125,9 +1125,7 @@ async def import_ranking_from_excel(
 async def export_ranking_excel(
     ranking_id: int,
     request: Request,
-    template: bool = Query(
-        False, description="Render the rank column blank, as a fill-in import template"
-    ),
+    template: bool = Query(False, description="Render the rank column blank, as a fill-in import template"),
     current_user: User = Depends(require_scholarship_manager),
     db: AsyncSession = Depends(get_db),
 ):


### PR DESCRIPTION
## Summary

Auto-fix for the `Quick Checks (backend-lint)` CI failure on PR #857.

**Root cause**: The `template: bool = Query(...)` parameter in `export_ranking_excel` was written across 3 lines, but Black collapses it to a single line (107 chars, within the 120-char limit).

**Change**: Collapsed `Query(False, description="…")` onto one line in `ranking_management.py`.

> Auto-fix by scheduled agent — 2026-05-31.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVWPEF3K8bLsXEQE7b2a6y)_