### PR TITLE
fix: auto-fix CI failure for PR #856 — black formatting in seed script

### DIFF
--- a/backend/scripts/seed_summary_export_demo.py
+++ b/backend/scripts/seed_summary_export_demo.py
@@ -88,9 +88,7 @@ async def main():
             sys.exit(1)
 
         phd_config = (
-            await db.execute(
-                select(ScholarshipConfiguration).where(ScholarshipConfiguration.config_code == "phd_114")
-            )
+            await db.execute(select(ScholarshipConfiguration).where(ScholarshipConfiguration.config_code == "phd_114"))
         ).scalar_one_or_none()
         if not phd_config:
             print("ERROR: phd_114 config not found.")


### PR DESCRIPTION
## Summary

Auto-fix for the `Quick Checks (backend-lint)` CI failure on PR #856.

**Root cause**: The `await db.execute(select(ScholarshipConfiguration).where(...))` call in `seed_summary_export_demo.py` was wrapped across 3 lines unnecessarily. Black collapses it to 2 lines (118 chars on the inner line, within the 120-char limit).

**Change**: Collapsed the `select(...).where(...)` expression onto one line.

> Auto-fix by scheduled agent — 2026-05-31.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVWPEF3K8bLsXEQE7b2a6y)_