### PR TITLE
fix(roster): preserve traceback in export-dir warning (WARNING-traceback invariant)

### DIFF
--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -151,10 +151,10 @@ class ExcelExportService:
 
             fallback = os.path.join(tempfile.gettempdir(), "scholarship-exports")
             logger.warning(
-                "Cannot create export dir %s (%s); falling back to %s",
+                "Cannot create export dir %s; falling back to %s",
                 self.export_base_path,
-                exc,
                 fallback,
+                exc_info=True,
             )
             Path(fallback).mkdir(parents=True, exist_ok=True)
             self.export_base_path = fallback


### PR DESCRIPTION
#874's fallback warning interpolated the exception (`%s` on `exc`) without `exc_info=True`, tripping the AST invariant `test_no_logger_warning_traceback_loss` — the only **Backend Tests (unit)** failure on latest main. Dropped the `exc` interpolation and pass `exc_info=True` so the OSError traceback is preserved. Restores unit to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)