### PR TITLE
fix(tests): deterministic tamper in pii-crypto test (flaky DID NOT RAISE)

### DIFF
--- a/backend/app/tests/test_pii_crypto_helpers.py
+++ b/backend/app/tests/test_pii_crypto_helpers.py
@@ -165,8 +165,15 @@ def test_decrypt_tamper_raises_no_fallback():
     with patch.dict(os.environ, _env_with_v1_key(), clear=False):
         reset_key_cache()
         ct = encrypt_pii("A123456789")
-        # Flip a single character in the payload
-        tampered = ct[:-1] + ("A" if ct[-1] != "A" else "B")
+        # Flip a character in the MIDDLE of the base64 payload. Flipping the LAST
+        # char is flaky: with padding stripped it can change only unused base64
+        # bits, leaving the decoded bytes (and GCM tag) intact → decrypt succeeds
+        # and the test sees DID NOT RAISE. A middle char maps to a full byte of
+        # nonce/ciphertext/tag, so the corruption (and auth failure) is reliable.
+        prefix, sep, payload = ct.rpartition(":")
+        mid = len(payload) // 2
+        flipped = "A" if payload[mid] != "A" else "B"
+        tampered = f"{prefix}{sep}{payload[:mid]}{flipped}{payload[mid + 1:]}"
         with pytest.raises(PIICryptoError) as exc:
             decrypt_pii(tampered)
         # Either authentication failure OR malformed envelope is acceptable


### PR DESCRIPTION
`test_decrypt_tamper_raises_no_fallback` flipped the **last** char of the `pii:<v>:<base64url>` envelope. With padding stripped, the last base64 char can carry only unused bits — flipping it sometimes left the decoded bytes (and GCM tag) unchanged → decrypt succeeded → `DID NOT RAISE`. The random GCM nonce makes the envelope differ each run, so this was an **intermittent CI unit-suite failure** (passed locally by luck — it was the only failing unit test on `be0a6f05`).

Flip a **middle** char instead — maps to a full byte of nonce/ciphertext/tag, so corruption (and GCM auth failure) is reliable. **30/30 runs pass.** Security intent unchanged (tampered → must raise, no silent fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)