### PR TITLE
fix(e2e): professor cannot re-review a rejected app (403), per policy (#869)

### DIFF
--- a/frontend/e2e/specs/professor-reject-upsert.spec.ts
+++ b/frontend/e2e/specs/professor-reject-upsert.spec.ts
@@ -100,7 +100,7 @@ test.describe("Professor reject recommendation + upsert", () => {
     }
   });
 
-  test("@nightly stuphd001 → professor reject → rejected; upsert to approve → under_review", async ({
+  test("@nightly stuphd001 → professor reject → rejected; professor cannot re-review (403)", async ({
     browser,
   }) => {
     // 0. Drain any leftover (stuphd001, phd) apps from concurrent specs
@@ -213,10 +213,11 @@ test.describe("Professor reject recommendation + upsert", () => {
     );
     expect(stageAfterReject.rows[0]?.review_stage).toBe("professor_reviewed");
 
-    // 5. Second professor review for the SAME application with a DIFFERENT
-    //    recommendation. The service upserts on (application_id, reviewer_id)
-    //    so the row count must stay at 1 and the value must update.
-    const approveRes = await apiAs<{ success: boolean; data: { id: number } }>(
+    // 5. A professor full-reject is terminal for the professor: once the app is
+    //    `rejected`, the professor can no longer submit/upsert another review —
+    //    only college/admin may revert it (回發). A re-submit must be refused
+    //    (403), NOT silently re-open the application.
+    const reReviewRes = await apiAs<{ success: boolean; message?: string }>(
       profLogin.token,
       "POST",
       `/professor/applications/${appDbId}/review`,
@@ -225,43 +226,30 @@ test.describe("Professor reject recommendation + upsert", () => {
           {
             sub_type_code: SUB_TYPE,
             recommendation: "approve",
-            comments: "E2E upsert path",
+            comments: "E2E re-review attempt after reject",
           },
         ],
       },
     );
-    pushTrace(runState, approveRes.traceId);
+    pushTrace(runState, reReviewRes.traceId);
     expect(
-      approveRes.ok,
-      `professor approve review (upsert) failed: HTTP ${approveRes.status} body=${JSON.stringify(
-        approveRes.body,
+      reReviewRes.status,
+      `professor re-review of a rejected app should be refused (403), got HTTP ${reReviewRes.status} body=${JSON.stringify(
+        reReviewRes.body,
       )}`,
-    ).toBe(true);
-    expect(approveRes.body.success).toBe(true);
+    ).toBe(403);
 
-    // 6. Upsert invariants:
-    //    a) Still exactly one application_reviews row — no duplicate created.
-    const reviewsAfterUpsert = await getReviews(appDbId);
-    expect(
-      reviewsAfterUpsert.length,
-      `expected exactly 1 review row after upsert (no duplicate), got ${reviewsAfterUpsert.length}: ${JSON.stringify(
-        reviewsAfterUpsert,
-      )}`,
-    ).toBe(1);
+    // 6. Invariants after the refused re-review — nothing changed:
+    //    a) still exactly one review row (the original reject), same id,
+    //       recommendation unchanged.
+    const reviewsAfterReReview = await getReviews(appDbId);
+    expect(reviewsAfterReReview.length).toBe(1);
+    expect(reviewsAfterReReview[0].id).toBe(reviewsAfterReject[0].id);
+    expect(reviewsAfterReReview[0].recommendation).toBe("reject");
 
-    //    b) Same row id as before (truly an update, not a delete+insert).
-    expect(
-      reviewsAfterUpsert[0].id,
-      "upsert should reuse the existing review row, not allocate a new id",
-    ).toBe(reviewsAfterReject[0].id);
-
-    //    c) Recommendation reflects the newer value.
-    expect(reviewsAfterUpsert[0].recommendation).toBe("approve");
-
-    //    d) Status -> 'under_review' — the upsert to approve re-opens the app
-    //       and it awaits college review (issue #182: professor approve keeps it
-    //       at under_review while requires_college_review is set).
-    const appAfterUpsert = await getApplication(appId);
-    expect(appAfterUpsert!.status).toBe("under_review");
+    //    b) application status is still 'rejected' — the refused call did not
+    //       re-open it.
+    const appAfterReReview = await getApplication(appId);
+    expect(appAfterReReview!.status).toBe("rejected");
   });
 });


### PR DESCRIPTION
The manual nightly run (26707873409) gave the exact ground truth for the professor-reject flow:
- after a professor full-reject the application is **`rejected`** (DIAGNOSTIC confirmed)
- a second professor review is **refused with HTTP 403** ("Professor not authorized to submit review at this time")

This matches the maintainer's policy: a professor reject is terminal **for the professor**; only college/admin may revert it (回發). The professor-self-upsert flow the old spec (and my #875 guess of `under_review`) exercised is simply **not allowed**.

## Rewrite (second half of the spec)
- professor reject → status `rejected` (unchanged from #875 — that part was right)
- professor re-review attempt → **HTTP 403**
- nothing changes: still 1 review row (same id, recommendation still `reject`), status still `rejected`

The roster-download half of #869 was already fixed by #874 (that run went 28→34 passed; this professor spec is the last failure). ESLint clean.

Closes #869 (pending the next nightly going green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)