### PR TITLE
docs(claude): capture testing/lint/CI + model/perf lessons from the 2026-05-30 cleanup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -680,6 +680,53 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 INTERNAL_API_URL=http://backend:8000  # Docker internal network
 ```
 
+## Testing, Lint & CI Standards
+
+Hard-won from the 2026-05-30 backend-test-backlog cleanup (cleared ~150 failures). Follow these to avoid re-introducing the same classes of failure.
+
+### CI suite layout (`.github/workflows/ci.yml`)
+- **unit**: `app/tests/test_*.py -m "not integration and not asyncio"` — sync tests only.
+- **integration**: `app/tests/test_*_service*.py -m "integration or asyncio"` — async tests. `asyncio_mode = auto`, so any `async def test_` is auto-collected here (it is EXCLUDED from unit).
+- **smoke / critical-workflows**: explicit file lists.
+- A test that is `@pytest.mark.asyncio` / `async def` runs in **integration**, not unit. Converting a sync test to async moves it between suites.
+
+### Lint is HARD-gated — black passing is NOT enough
+Before committing backend changes, run **all three**:
+```bash
+uvx --from "black==26.3.1" black --check --line-length=120 backend/app
+flake8 app --select=B904,B014 --max-line-length=120     # CI fails hard on these
+python -m pytest app/tests/<touched_file> -p no:cacheprovider   # in the dev container
+```
+- **B904**: `raise` inside `except` must use `raise ... from exc` (or `from None`).
+- **B014**: no redundant exception tuples — `PermissionError` ⊂ `OSError`, so write `except OSError`, never `except (PermissionError, OSError)`.
+- **WARNING/ERROR-traceback AST invariant** (`test_no_logger_warning_traceback_loss.py`, `test_no_logger_error_traceback_loss.py`): any `logger.warning(...)` / `logger.error(...)` that interpolates the exception variable inside an `except` block MUST also pass `exc_info=True` (or drop the interpolation). The trace gets discarded otherwise.
+
+### Test-fixture pitfalls (the recurring failures)
+- **Never build a model with `Model.__new__(Model)` / `object.__new__(Model)` then set attributes** — it bypasses `__init__`, so `_sa_instance_state` is missing and the first instrumented-attribute write raises `'NoneType' object has no attribute 'set'`. Use `Model(**defaults)`; for vestigial/non-column keys or duck-typed relationship stubs use `m = Model(); m.__dict__.update(defaults)` (or `m.__dict__["rel"] = SimpleNamespace(...)`).
+- **Keep fixtures in sync with the model.** Passing a removed/renamed column raises `'<field>' is an invalid keyword argument for <Model>`. Known removals: `ScholarshipType.category` (gone; status lives in `status`), `Application.student_id` (student data is external-API now; FK is `user_id`), `User` uses `nycu_id`/`name`/`status` (NOT `username`/`full_name`/`is_active`).
+- **Enum vs string in in-memory objects.** A DB-loaded model returns the **enum member** (`Enum` column), but an in-memory fixture holds exactly what you passed. Methods compare against the enum member (`status == ApplicationStatus.submitted`), so pass the member, not `.value`, when constructing test objects — otherwise predicates like `is_editable` / `get_review_stage` silently mismatch.
+- **No sync-calling-async.** Service methods on async-session services are `async`; tests must be `async def` + `await` + use the async `db` fixture (not `db_sync`). A sync call returns an un-awaited coroutine → `'coroutine' object has no attribute 'id'`.
+- **No env- or cache-dependent assertions.** Settings have non-None defaults (e.g. `student_api_enabled=True`, SIS URLs), so a bare service is "configured" everywhere — `monkeypatch` settings to force the state you assert. The dev container has Redis; CI does not — clear `@cached` state in an autouse fixture (`await invalidate("<prefix>")`) so one test's payload doesn't leak into another.
+- **No flaky randomness.** Don't corrupt the *last* base64 char of a random-nonce envelope to test tamper-detection (it can hit only padding bits → no corruption → `DID NOT RAISE`); corrupt a **middle** char (a full byte). Verify determinism by running the test ~30×.
+
+## Model & Schema Gotchas
+
+- **ScholarshipType vs ScholarshipConfiguration split.** Application-period dates, `academic_year`, `amount`, the period-detection properties (`is_renewal_application_period`, `current_application_type`, …) and `can_student_apply*` live on **ScholarshipConfiguration**, NOT `ScholarshipType`. Building these on a `ScholarshipType` is a bug.
+- **Renamed-relationship bug class.** Several latent `AttributeError`s came from an incomplete rename: `Application.user`→`.student`, `Application.scholarship_type`→`.scholarship_type_ref`, notification `application.scholarship_type`→`application.scholarship_name`. When you rename a relationship, **grep the whole repo** for the old name (services, endpoints, AND tests that stub it).
+- **Coalesce nullable JSON into required-dict response fields.** `ApplicationListResponse.student_data` / `submitted_form_data` are required `Dict`; a draft can have `student_data IS NULL`. Always write `student_data=application.student_data or {}` (see the canonical builders) — passing `None` raises a pydantic `dict_type` error.
+- **Pydantic v2 cross-field validators run in field-definition order.** A `@field_validator` on a field reading a flag defined *later* sees that flag as unset. Use `@model_validator(mode="after")` for any rule that spans fields (e.g. renewal-review-dates-require-the-`requires_*`-flag).
+- **Enum "pin" tripwire tests** (`test_shared_enums_value_contract.py`) intentionally fail when an enum gains a value — the correct response is to update the count AFTER confirming dependent frontend switches / admin filters handle the new value, not to delete the test.
+
+## Performance Patterns
+
+- **Eager-load to-one relationships read inside loops.** A `db.query(Application).all()` whose rows later read `application.student` / `application.scholarship_configuration.scholarship_type` in a loop is N+1. Add `.options(joinedload(Application.student), joinedload(Application.scholarship_configuration).joinedload(...))` (many-to-one → `joinedload` is safe, no row multiplication).
+- **Index foreign keys and audit-trail lookups.** PostgreSQL does NOT auto-index FKs. Index columns filtered/ordered on hot paths (e.g. `applications.scholarship_configuration_id`; composite `audit_logs(resource_type, resource_id, created_at)`), and declare them in the model `__table_args__` so autogenerate stays in sync.
+- **Lazy-load heavy frontend libs.** Import `xlsx` / `react-pdf` via `await import(...)` inside the handler (make the handler `async`), not at module top, to keep them out of the initial chunk.
+
+## Review-Flow Policy
+
+- A **professor full-reject is terminal for the professor**: it sets `application.status = rejected`, and the professor **cannot re-review** that application (the review endpoint returns HTTP 403). Only **college/admin** may revert it (回發) — that is a separate, explicit edit path, not a professor re-submit.
+
 ---
 
 **Remember**: Create a flexible, maintainable system where new scholarship types can be added through database configuration without code changes.


### PR DESCRIPTION
Codifies the patterns that cost the most time during the backend-test-backlog cleanup (~150 failures cleared, CI now green) into `.claude/CLAUDE.md`, so they don't recur:

- **Testing, Lint & CI Standards** — unit/integration suite markers; hard-gated flake8-bugbear **B904/B014** + WARNING/ERROR-traceback AST invariants (black alone isn't enough); recurring fixture pitfalls (`Model.__new__`+`_sa_instance_state`, removed/renamed columns, enum-vs-string, sync-calling-async, env/cache-dependent assertions, flaky randomness).
- **Model & Schema Gotchas** — ScholarshipType-vs-Configuration split, renamed-relationship bug class, nullable-JSON→required-dict coalesce, pydantic v2 field-validator ordering, enum-pin tripwire tests.
- **Performance Patterns** — eager-load to-one relationships in loops, index FKs + audit lookups, lazy-load heavy frontend libs.
- **Review-Flow Policy** — professor full-reject is terminal for the professor (status=rejected, 403 on re-review); college/admin revert via 回發.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)