### PR TITLE
fix(applications): draft keeps uploaded files + inline document preview works

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -925,48 +925,11 @@ class ApplicationService:
         if not application:
             return None
 
-        # 先標準化表單資料格式
-        integrated_form_data = self._normalize_submitted_form_data(
-            application.submitted_form_data.copy() if application.submitted_form_data else {}
-        )
-
-        # 然後整合文件資訊到 submitted_form_data.documents
-        if application.files:
-            # 生成文件訪問 token
-            from app.core.config import settings
-            from app.core.security import create_access_token
-
-            token_data = {"sub": str(current_user.id)}
-            access_token = create_access_token(token_data)
-
-            # 更新 submitted_form_data 中的 documents
-            if "documents" in integrated_form_data:
-                existing_docs = integrated_form_data["documents"]
-                for existing_doc in existing_docs:
-                    # 查找對應的文件記錄
-                    matching_file = next(
-                        (f for f in application.files if f.file_type == existing_doc.get("document_id")),
-                        None,
-                    )
-                    if matching_file:
-                        # 更新現有文件資訊
-                        base_url = f"{settings.base_url}{settings.api_v1_str}"
-                        existing_doc.update(
-                            {
-                                "file_id": matching_file.id,
-                                "filename": matching_file.filename,
-                                "original_filename": matching_file.original_filename,
-                                "file_size": matching_file.file_size,
-                                "mime_type": matching_file.mime_type or matching_file.content_type,
-                                "file_path": f"{base_url}/files/applications/{application_id}/files/{matching_file.id}?token={access_token}",
-                                "download_url": f"{base_url}/files/applications/{application_id}/files/{matching_file.id}/download?token={access_token}",
-                                "is_verified": matching_file.is_verified,
-                                "object_name": matching_file.object_name,
-                            }
-                        )
-
-            # 更新 application 的 submitted_form_data
-            application.submitted_form_data = integrated_form_data
+        # 整合 application.files 的檔案參照進 submitted_form_data.documents。
+        # 使用共用 helper（其他讀取路徑也用它）：它會「create-or-update」——把尚未
+        # 出現在 documents[] 的已上傳檔案「補進去」。先前這裡的 inline 迴圈只更新
+        # 已存在的 doc，所以以 documents:[] 存的草稿在重開時會掉光所有上傳檔案。
+        integrated_form_data = self._integrate_application_file_data(application, current_user)
 
         # Construct ApplicationResponse with additional display fields
         from app.schemas.application import ApplicationResponse

--- a/frontend/components/file-upload.tsx
+++ b/frontend/components/file-upload.tsx
@@ -208,10 +208,16 @@ export function FileUpload({
   const getFilePreviewUrl = (file: File) => {
     if (isUploadedFile(file)) {
       const uploaded = file as UploadedFileLike;
-      // 如果是已上傳的文件，使用其URL
-      return (
-        uploaded.url || uploaded.file_path || URL.createObjectURL(file)
-      );
+      // Prefer a same-origin proxy URL set by the caller. Only fall back to
+      // file_path if it's a same-origin/relative URL — never iframe an absolute
+      // cross-origin URL (e.g. a misconfigured http://localhost:8000 file_path
+      // on staging) or a bare local filename, which both render blank.
+      if (uploaded.url) return uploaded.url;
+      const fp = uploaded.file_path;
+      if (fp && (fp.startsWith("/") || fp.startsWith(window.location.origin))) {
+        return fp;
+      }
+      return URL.createObjectURL(file);
     }
     // 如果是本地文件，創建臨時URL
     return URL.createObjectURL(file);

--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -640,8 +640,34 @@ export function ScholarshipApplicationStep({
       // Load file data
       if (formData.documents) {
         const existingFileData: Record<string, File[]> = {};
+        const previewAppId =
+          editingApplication?.id ?? savedApplicationIdRef.current;
+        const previewToken = localStorage.getItem("auth_token") || "";
         formData.documents.forEach((doc: SubmittedDocumentPayload) => {
           if (doc.document_id && doc.original_filename) {
+            // Build a SAME-ORIGIN preview URL through the Next /api/v1/preview
+            // proxy from file_id, so the iframe never depends on the backend's
+            // file_path — that can be an absolute http://localhost:8000 URL when
+            // the deployment's BASE_URL is misconfigured (observed on staging),
+            // which the browser cannot load (blank preview).
+            const lowerName = doc.original_filename.toLowerCase();
+            const proxyType = lowerName.endsWith(".pdf")
+              ? "pdf"
+              : [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"].some(ext =>
+                    lowerName.endsWith(ext)
+                  )
+                ? "image"
+                : "";
+            const previewUrl =
+              doc.file_id && previewAppId
+                ? `/api/v1/preview?fileId=${encodeURIComponent(
+                    String(doc.file_id)
+                  )}&filename=${encodeURIComponent(
+                    doc.original_filename
+                  )}&type=${proxyType}&applicationId=${previewAppId}&token=${encodeURIComponent(
+                    previewToken
+                  )}`
+                : undefined;
             const fileData = {
               id: doc.file_id || doc.id,
               filename: doc.filename || doc.original_filename,
@@ -651,6 +677,8 @@ export function ScholarshipApplicationStep({
               file_type: doc.document_type,
               file_path: doc.file_path,
               download_url: doc.download_url,
+              // same-origin proxy URL preferred by FileUpload.getFilePreviewUrl
+              url: previewUrl,
               is_verified: doc.is_verified,
               uploaded_at: doc.upload_time,
               name: doc.original_filename,

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -33,6 +33,7 @@ export function middleware(request: NextRequest) {
       "script-src 'self' 'unsafe-eval' 'unsafe-inline'", // HMR requires unsafe-eval
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
+      "frame-src 'self' blob:", // inline file preview: same-origin /api proxy + just-selected blob: PDFs
       "font-src 'self'",
       "connect-src 'self' ws: wss:", // WebSocket for HMR
       "frame-ancestors 'none'",
@@ -53,6 +54,7 @@ export function middleware(request: NextRequest) {
       `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`, // strict-dynamic for bundled scripts
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https:",
+      "frame-src 'self' blob:", // inline file preview: same-origin /api proxy + just-selected blob: PDFs
       "font-src 'self'",
       "connect-src 'self' https://*.nycu.edu.tw",
       "base-uri 'self'",


### PR DESCRIPTION
Fixes two student-reported bugs on `ss.test` (file upload during a scholarship application): **clicking preview shows nothing**, and **saving as draft loses the uploaded file**.

## Root cause + fix

### Bug A / B1 — file vanishes on draft reopen; preview blank (backend, the keystone)
`application_service.get_application_by_id` enriched `submitted_form_data.documents[]` from `application.files` with an inline loop that **only updated docs already present** and never **added** files missing from `documents[]`. A draft saved with `documents: []` lost every uploaded file on reopen (so the form looked empty), and there was no valid file reference to preview. Replaced that block with the existing shared helper **`_integrate_application_file_data`** (already used by other read paths) which create-or-updates a doc for **every** `application.files` row — setting `file_id`/`object_name`/`mime_type` and a same-origin `/api/v1/files/...?token=` path that `files.py` serves **`inline`** with the correct content-type (so an iframe renders it).

**Verified end-to-end on the dev stack (mock-SSO):** create draft → upload a PDF → `GET /applications/{id}`:
- **before:** `submitted_form_data.documents == []` (file lost)
- **after:** `documents == [{file_id, mime_type: "application/pdf", file_path: ".../api/v1/files/applications/.../files/...?token=..."}]`

No new backend test failures (the same 8 pre-existing failures appear with **and** without the change).

### Bug B2 — just-selected (pre-upload) PDF preview blank (CSP)
The CSP in `frontend/middleware.ts` had **no `frame-src`**, so iframes fell back to `default-src 'self'` and a `blob:` PDF iframe was blocked (confirmed on staging via `curl -I`: `img-src` allows `blob:` so blob *images* worked; `object-src 'none'` rules out `<embed>`). Added `frame-src 'self' blob:` to both the dev and prod CSP — allows the same-origin `/api` preview iframe **and** just-selected `blob:` PDFs.

## Note on verification
Backend fix is API-verified (above) + lint/black clean. The live **UI** rendering couldn't be exercised locally because the dev frontend image is stale (missing the `react-pdf`/`pdfjs-dist` tree → crash-loops); the data-layer fix is conclusive and the wizard reads exactly this `documents[]`. **Recommend confirming the preview render on staging** once deployed (E00001 can delete a test student's existing application to reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)