### PR TITLE
fix(minio): clone bank document with correct CopySource API; stop writing placeholder

### DIFF
--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from typing import Dict, Optional, Tuple
 
 from minio import Minio
+from minio.commonconfig import CopySource
 from minio.error import S3Error
 
 from app.core.config import settings
@@ -309,27 +310,17 @@ class MinIOService:
             file_extension = source_object_name.split(".")[-1] if "." in source_object_name else ""
             new_object_name = f"applications/{application_id}/documents/{uuid.uuid4().hex}.{file_extension}"
 
-            # 嘗試複製檔案
-            try:
-                self.client.copy_object(
-                    bucket_name=self.default_bucket,
-                    object_name=new_object_name,
-                    copy_source=f"{self.default_bucket}/{source_object_name}",
-                )
-                logger.info(f"Cloned file {source_object_name} to {new_object_name}")
-                return new_object_name
-            except Exception:
-                # 如果複製失敗，創建一個placeholder
-                placeholder_content = b"Placeholder content"
-                self.client.put_object(
-                    bucket_name=self.default_bucket,
-                    object_name=new_object_name,
-                    data=io.BytesIO(placeholder_content),
-                    length=len(placeholder_content),
-                    content_type="application/pdf",
-                )
-                logger.info(f"Created placeholder file {new_object_name}")
-                return new_object_name
+            # 複製檔案到申請路徑。
+            # 注意：minio 7.x 的 copy_object 參數為 source（必須是 CopySource 物件），
+            # 不是字串 copy_source。若複製失敗必須直接 raise，
+            # 嚴禁寫入 placeholder 假檔（違反 CLAUDE.md 原則 #1，會產生污染資料）。
+            self.client.copy_object(
+                bucket_name=self.default_bucket,
+                object_name=new_object_name,
+                source=CopySource(self.default_bucket, source_object_name),
+            )
+            logger.info(f"Cloned file {source_object_name} to {new_object_name}")
+            return new_object_name
 
         except Exception as e:
             logger.exception(f"Failed to clone file {source_object_name}")

--- a/backend/app/tests/test_minio_service_unit.py
+++ b/backend/app/tests/test_minio_service_unit.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException
+from minio.commonconfig import CopySource
 from minio.error import S3Error
 
 from app.services.minio_service import MinIOService
@@ -147,21 +148,33 @@ def test_clone_file_to_application_success(minio_service, monkeypatch):
 
     new_name = minio_service.clone_file_to_application("user-profiles/1/file.pdf", application_id="APP-1")
 
+    # Must use the minio 7.x API: copy_object(..., source=CopySource(bucket, object)).
+    # A Mock client swallows wrong kwargs, so assert the real signature here — this is
+    # exactly the regression that produced 19-byte placeholder bank documents in prod.
     minio_service.client.copy_object.assert_called_once()
+    _, kwargs = minio_service.client.copy_object.call_args
+    source = kwargs["source"]
+    assert isinstance(source, CopySource)
+    assert source.bucket_name == minio_service.default_bucket
+    assert source.object_name == "user-profiles/1/file.pdf"
+    # No placeholder must ever be written on the success path.
+    minio_service.client.put_object.assert_not_called()
     assert new_name.startswith("applications/APP-1/documents/")
     assert new_name.endswith(".pdf")
 
 
-def test_clone_file_to_application_creates_placeholder(minio_service, monkeypatch):
+def test_clone_file_to_application_raises_on_copy_failure(minio_service, monkeypatch):
+    """A failed copy must raise (HTTP 500), never fabricate a placeholder file."""
     monkeypatch.setattr("app.services.minio_service.uuid", SimpleNamespace(uuid4=lambda: SimpleNamespace(hex="xyz987")))
 
     minio_service.client.copy_object.side_effect = Exception("not found")
 
-    new_name = minio_service.clone_file_to_application("user-profiles/1/missing.jpg", application_id="APP-2")
+    with pytest.raises(HTTPException) as exc:
+        minio_service.clone_file_to_application("user-profiles/1/missing.jpg", application_id="APP-2")
 
-    minio_service.client.put_object.assert_called_once()
-    assert new_name.startswith("applications/APP-2/documents/")
-    assert new_name.endswith(".jpg")
+    assert exc.value.status_code == 500
+    # CLAUDE.md #1: never write fallback/mock data when the real copy fails.
+    minio_service.client.put_object.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -173,18 +186,6 @@ async def test_upload_file_unexpected_error(minio_service, monkeypatch):
 
     with pytest.raises(HTTPException) as exc:
         await MinIOService.upload_file(minio_service, upload, application_id=3, file_type="doc")
-
-    assert exc.value.status_code == 500
-
-
-def test_clone_file_to_application_placeholder_failure(minio_service, monkeypatch):
-    monkeypatch.setattr("app.services.minio_service.uuid", SimpleNamespace(uuid4=lambda: SimpleNamespace(hex="abcd")))
-
-    minio_service.client.copy_object.side_effect = Exception("missing")
-    minio_service.client.put_object.side_effect = S3Error("code", "msg", "resource", "request", "host", "response")
-
-    with pytest.raises(HTTPException) as exc:
-        minio_service.clone_file_to_application("user-profiles/1/placeholder.pdf", application_id="APP-3")
 
     assert exc.value.status_code == 500
 


### PR DESCRIPTION
## Problem

When a student creates an application, `_clone_user_profile_documents` clones the user-profile bank document (存摺封面) into the application. The cloned `ApplicationFile` was a **19-byte file containing the literal string `Placeholder content`** — not the real PDF. Reviewers/students saw a corrupt bank document.

Confirmed on `ss.test` (student 008, app 90, file_id 18): source profile doc = real 240 KB `%PDF-1.7`; cloned file = 19 bytes `Placeholder content`.

## Root cause

`MinIOService.clone_file_to_application()` called minio 7.x `copy_object` with a **non-existent `copy_source=` string kwarg**. The real signature is `copy_object(bucket_name, object_name, source: CopySource, ...)`. So **every call raised `TypeError`**, the inner `except Exception` always fired, and it silently wrote a placeholder file while returning as if it had succeeded — violating CLAUDE.md Core Principle #1 (never return fallback/mock data on failure; raise).

Because the call was always broken, **every cloned bank document in every environment** was a corrupt 19-byte placeholder, fully hidden by the fallback.

## Fix

- Use the correct API: `source=CopySource(self.default_bucket, source_object_name)`.
- Remove the placeholder fallback so a genuine copy failure raises (`HTTPException 500` via the existing outer handler).

## Verification (dev container, minio 7.2.18)

```
OLD CALL TypeError -> Minio.copy_object() got an unexpected keyword argument 'copy_source'
FIXED copy bytes = 223 | matches source = True | is placeholder = False
```

Old kwarg raises `TypeError`; the corrected `CopySource` call copies byte-identical content (not a placeholder).

## Scope

Separate from #885 (preview-blank + draft-loses-file). This is the **application-create clone path** — a third independent document bug found while inspecting draft content. After deploy, re-create a test application to confirm the bank doc clones as a real PDF, then clean up the existing corrupt file_id 18.

Fixes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)