### PR TITLE
fix(applications): consolidate document enrichment to shared helper (4 paths dropped uploaded files)

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -790,42 +790,8 @@ class ApplicationService:
         # Convert to response models with integrated file data
         recent_applications_response = []
         for application in recent_applications:
-            # 整合文件資訊到 submitted_form_data.documents
-            integrated_form_data = application.submitted_form_data.copy() if application.submitted_form_data else {}
-
-            if application.files:
-                # 生成文件訪問 token
-                from app.core.config import settings
-                from app.core.security import create_access_token
-
-                token_data = {"sub": str(user.id)}
-                access_token = create_access_token(token_data)
-
-                # 更新 submitted_form_data 中的 documents
-                if "documents" in integrated_form_data:
-                    existing_docs = integrated_form_data["documents"]
-                    for existing_doc in existing_docs:
-                        # 查找對應的文件記錄
-                        matching_file = next(
-                            (f for f in application.files if f.file_type == existing_doc.get("document_id")),
-                            None,
-                        )
-                        if matching_file:
-                            # 更新現有文件資訊
-                            base_url = f"{settings.base_url}{settings.api_v1_str}"
-                            existing_doc.update(
-                                {
-                                    "file_id": matching_file.id,
-                                    "filename": matching_file.filename,
-                                    "original_filename": matching_file.original_filename,
-                                    "file_size": matching_file.file_size,
-                                    "mime_type": matching_file.mime_type or matching_file.content_type,
-                                    "file_path": f"{base_url}/files/applications/{application.id}/files/{matching_file.id}?token={access_token}",
-                                    "download_url": f"{base_url}/files/applications/{application.id}/files/{matching_file.id}/download?token={access_token}",
-                                    "is_verified": matching_file.is_verified,
-                                    "object_name": matching_file.object_name,
-                                }
-                            )
+            # 整合 application.files 進 submitted_form_data.documents（create-or-update，共用 helper）。
+            integrated_form_data = self._integrate_application_file_data(application, user)
 
             # 創建響應數據
             app_data = ApplicationListResponse(
@@ -1328,73 +1294,9 @@ class ApplicationService:
         except Exception as e:
             logger.error(f"❌ Failed to trigger automated submission emails: {e}", exc_info=True)
 
-        # 整合文件資訊到 submitted_form_data.documents
-        integrated_form_data = application.submitted_form_data.copy() if application.submitted_form_data else {}
-
-        # 生成文件訪問 token
-        from app.core.config import settings
-        from app.core.security import create_access_token
-
-        token_data = {"sub": str(user.id)}
-        access_token = create_access_token(token_data)
-
-        # 將 files 的完整資訊合併到 documents 中
-        if application.files:
-            integrated_documents = []
-            for file in application.files:
-                # 生成文件 URL
-                base_url = f"{settings.base_url}{settings.api_v1_str}"
-                file_path = f"{base_url}/files/applications/{application_id}/files/{file.id}?token={access_token}"
-                download_url = (
-                    f"{base_url}/files/applications/{application_id}/files/{file.id}/download?token={access_token}"
-                )
-
-                # 整合文件資訊
-                integrated_document = {
-                    "document_id": file.file_type,
-                    "document_type": file.file_type,
-                    "file_id": file.id,
-                    "filename": file.filename,
-                    "original_filename": file.original_filename,
-                    "file_size": file.file_size,
-                    "mime_type": file.mime_type or file.content_type,
-                    "file_path": file_path,
-                    "download_url": download_url,
-                    "upload_time": file.uploaded_at.isoformat() if file.uploaded_at else None,
-                    "is_verified": file.is_verified,
-                    "object_name": file.object_name,
-                }
-                integrated_documents.append(integrated_document)
-
-            # 更新 submitted_form_data 中的 documents
-            if "documents" in integrated_form_data:
-                # 如果已有 documents，合併文件資訊
-                existing_docs = integrated_form_data["documents"]
-                for existing_doc in existing_docs:
-                    # 查找對應的文件記錄
-                    matching_file = next(
-                        (f for f in application.files if f.file_type == existing_doc.get("document_id")),
-                        None,
-                    )
-                    if matching_file:
-                        # 更新現有文件資訊
-                        base_url = f"{settings.base_url}{settings.api_v1_str}"
-                        existing_doc.update(
-                            {
-                                "file_id": matching_file.id,
-                                "filename": matching_file.filename,
-                                "original_filename": matching_file.original_filename,
-                                "file_size": matching_file.file_size,
-                                "mime_type": matching_file.mime_type or matching_file.content_type,
-                                "file_path": f"{base_url}/files/applications/{application_id}/files/{matching_file.id}?token={access_token}",
-                                "download_url": f"{base_url}/files/applications/{application_id}/files/{matching_file.id}/download?token={access_token}",
-                                "is_verified": matching_file.is_verified,
-                                "object_name": matching_file.object_name,
-                            }
-                        )
-            else:
-                # 如果沒有 documents，創建新的
-                integrated_form_data["documents"] = integrated_documents
+        # 整合 application.files 進 submitted_form_data.documents（create-or-update，共用 helper）。
+        # 僅用於 response（不寫回 DB），與 get_application_by_id 一致；避免以 documents:[] 存的草稿送出後掉檔。
+        integrated_form_data = self._integrate_application_file_data(application, user)
 
         # Convert application to response model
         response_data = {
@@ -1503,42 +1405,9 @@ class ApplicationService:
         # Convert to response models
         response_applications = []
         for application in applications:
-            # 整合文件資訊到 submitted_form_data.documents
-            integrated_form_data = application.submitted_form_data.copy() if application.submitted_form_data else {}
-
-            if application.files:
-                # 生成文件訪問 token
-                from app.core.config import settings
-                from app.core.security import create_access_token
-
-                token_data = {"sub": str(current_user.id)}
-                access_token = create_access_token(token_data)
-
-                # 更新 submitted_form_data 中的 documents
-                if "documents" in integrated_form_data:
-                    existing_docs = integrated_form_data["documents"]
-                    for existing_doc in existing_docs:
-                        # 查找對應的文件記錄
-                        matching_file = next(
-                            (f for f in application.files if f.file_type == existing_doc.get("document_id")),
-                            None,
-                        )
-                        if matching_file:
-                            # 更新現有文件資訊
-                            base_url = f"{settings.base_url}{settings.api_v1_str}"
-                            existing_doc.update(
-                                {
-                                    "file_id": matching_file.id,
-                                    "filename": matching_file.filename,
-                                    "original_filename": matching_file.original_filename,
-                                    "file_size": matching_file.file_size,
-                                    "mime_type": matching_file.mime_type or matching_file.content_type,
-                                    "file_path": f"{base_url}/files/applications/{application.id}/files/{matching_file.id}?token={access_token}",
-                                    "download_url": f"{base_url}/files/applications/{application.id}/files/{matching_file.id}/download?token={access_token}",
-                                    "is_verified": matching_file.is_verified,
-                                    "object_name": matching_file.object_name,
-                                }
-                            )
+            # 整合 application.files 進 submitted_form_data.documents（create-or-update，共用 helper）。
+            # 與 get_application_by_id 一致：把尚未出現在 documents[] 的已上傳檔案補進去（審核列表才不會掉檔）。
+            integrated_form_data = self._integrate_application_file_data(application, current_user)
 
             # Use eagerly loaded student (already loaded with selectinload)
             app_user = application.student
@@ -1925,42 +1794,9 @@ class ApplicationService:
         # Convert to response models
         response_applications = []
         for application in applications:
-            # 整合文件資訊到 submitted_form_data.documents
-            integrated_form_data = application.submitted_form_data.copy() if application.submitted_form_data else {}
-
-            if application.files:
-                # 生成文件訪問 token
-                from app.core.config import settings
-                from app.core.security import create_access_token
-
-                token_data = {"sub": str(current_user.id)}
-                access_token = create_access_token(token_data)
-
-                # 更新 submitted_form_data 中的 documents
-                if "documents" in integrated_form_data:
-                    existing_docs = integrated_form_data["documents"]
-                    for existing_doc in existing_docs:
-                        # 查找對應的文件記錄
-                        matching_file = next(
-                            (f for f in application.files if f.file_type == existing_doc.get("document_id")),
-                            None,
-                        )
-                        if matching_file:
-                            # 更新現有文件資訊
-                            base_url = f"{settings.base_url}{settings.api_v1_str}"
-                            existing_doc.update(
-                                {
-                                    "file_id": matching_file.id,
-                                    "filename": matching_file.filename,
-                                    "original_filename": matching_file.original_filename,
-                                    "file_size": matching_file.file_size,
-                                    "mime_type": matching_file.mime_type or matching_file.content_type,
-                                    "file_path": f"{base_url}/files/applications/{application.id}/files/{matching_file.id}?token={access_token}",
-                                    "download_url": f"{base_url}/files/applications/{application.id}/files/{matching_file.id}/download?token={access_token}",
-                                    "is_verified": matching_file.is_verified,
-                                    "object_name": matching_file.object_name,
-                                }
-                            )
+            # 整合 application.files 進 submitted_form_data.documents（create-or-update，共用 helper）。
+            # 與 get_application_by_id 一致：把尚未出現在 documents[] 的已上傳檔案補進去。
+            integrated_form_data = self._integrate_application_file_data(application, current_user)
 
             # Use eagerly loaded student (already loaded with selectinload)
             app_user = application.student

--- a/backend/app/tests/test_application_service_integration.py
+++ b/backend/app/tests/test_application_service_integration.py
@@ -171,6 +171,72 @@ class TestApplicationServiceIntegration:
         result = service._integrate_application_file_data(application, user)
         assert "documents" in result
 
+    @staticmethod
+    def _fake_file(**over):
+        """Build a duck-typed ApplicationFile with all attrs the helper reads."""
+        from types import SimpleNamespace
+
+        defaults = dict(
+            id=42,
+            file_type="transcript",
+            filename="t.pdf",
+            original_filename="transcript.pdf",
+            file_size=1234,
+            mime_type="application/pdf",
+            content_type="application/pdf",
+            is_verified=True,
+            object_name="applications/1/documents/abc.pdf",
+            uploaded_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        defaults.update(over)
+        return SimpleNamespace(**defaults)
+
+    def test_integrate_adds_file_missing_from_documents(self, service):
+        """#885 regression guard: a file present in application.files but ABSENT
+        from documents[] (e.g. a draft saved with documents:[]) MUST be added on
+        read. This is the create branch shared by get_application_by_id,
+        get_user_applications, get_applications, get_applications_for_review,
+        submit_application, and get_student_dashboard_stats."""
+        application = Mock(spec=Application)
+        application.submitted_form_data = {"fields": {}, "documents": []}
+        application.app_id = "APP001"
+        application.id = 1
+        application.files = [self._fake_file(file_type="transcript", id=42)]
+        user = Mock(spec=User)
+        user.id = 7
+
+        result = service._integrate_application_file_data(application, user)
+
+        docs = result["documents"]
+        assert len(docs) == 1, "uploaded file must be added, not dropped"
+        d = docs[0]
+        assert d["file_id"] == 42
+        assert d["document_type"] == "transcript"
+        assert d["object_name"] == "applications/1/documents/abc.pdf"
+        assert d["mime_type"] == "application/pdf"
+        # same-origin proxy path that files.py serves inline
+        assert "/files/applications/1/files/42" in d["file_path"]
+
+    def test_integrate_updates_existing_doc_without_duplicating(self, service):
+        """A partial doc already in documents[] (matching file_type) must be
+        enriched in place — not duplicated — when its ApplicationFile exists."""
+        application = Mock(spec=Application)
+        application.submitted_form_data = {
+            "fields": {},
+            "documents": [{"document_type": "transcript", "document_id": "transcript"}],
+        }
+        application.app_id = "APP001"
+        application.id = 1
+        application.files = [self._fake_file(file_type="transcript", id=99)]
+        user = Mock(spec=User)
+        user.id = 7
+
+        result = service._integrate_application_file_data(application, user)
+
+        docs = result["documents"]
+        assert len(docs) == 1, "matching doc must be updated in place, not duplicated"
+        assert docs[0]["file_id"] == 99
+
 
 @pytest.mark.asyncio
 class TestApplicationServiceDashboard:


### PR DESCRIPTION
## Problem

PR #885 fixed `get_application_by_id` to rebuild `submitted_form_data.documents[]` from `application_files` via the shared `_integrate_application_file_data` helper (create-or-update). But **four other paths still used the old inline loop that only UPDATES docs already in `documents[]` and never ADDS uploaded files**:

| Function | was |
|---|---|
| `get_student_dashboard_stats` | L794-828 |
| `submit_application` | L1331-1397 |
| `get_applications_for_review` | L1507-1541 |
| `get_applications` | L1929-1963 |

**Impact:** a student who uploads files to a draft saved with `documents:[]` had those files invisible in the student list, the dashboard, the submitted-application response, **and the reviewer's queue** — reviewers could not see the uploaded documents at all.

## Fix

All four now call `self._integrate_application_file_data(application, <user>)`, identical to `get_application_by_id` / `get_user_applications`. Removes ~175 lines of duplicated logic.

## Careful regression verification

- **Async safety:** confirmed every one of the four call sites already eager-loads `Application.files` via `selectinload` (L780, L1216, L1461, L1885), so the helper's `.files` access cannot raise `MissingGreenlet`.
- **No persistence change:** `submit_application`'s block built a `.copy()` used only in the response (never written back to `application.submitted_form_data`), so the DB behavior is unchanged — only the returned `documents[]` is now complete. The other three are read-only list paths.
- **No new test failures:** 103 passed across `test_application_service*`, `test_get_applications_for_review_deep`, `test_application_bulk_approve_dashboard`, `test_application_list_response_props`, `test_critical_workflows`, `test_college_review_service`. (Two failures in `test_submit_application_deep` / `test_update_application_deep` are **pre-existing on main** — tz-naive/aware datetime compare and a string-vs-DynamicFormField fixture — and are not collected by the CI integration glob `test_*_service*.py`.)

## New regression tests

`test_application_service_integration.py` gains two tests pinning the behavior all five functions now share:
- `test_integrate_adds_file_missing_from_documents` — the exact #885 scenario (file in `application.files`, absent from `documents[]` → **added**).
- `test_integrate_updates_existing_doc_without_duplicating` — matching doc enriched in place, not duplicated.

All prior helper tests used `files=[]`, which is why the original bug shipped uncaught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)