### PR TITLE
fix(staging): set BASE_URL to staging origin (file/email URLs were localhost) — fixes #889

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -227,6 +227,7 @@ jobs:
           MINIO_SECRET_KEY: ${{ secrets.STAGING_MINIO_SECRET_KEY }}
           MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
           FRONTEND_URL: ${{ secrets.STAGING_API_URL }}
+          BASE_URL: ${{ secrets.STAGING_API_URL }}
           NEXT_PUBLIC_API_URL: ${{ secrets.STAGING_API_URL }}
           NEXT_PUBLIC_NYCU_PORTAL_URL: ${{ secrets.NEXT_PUBLIC_NYCU_PORTAL_URL }}
           NODE_ENV: ${{ secrets.NODE_ENV }}
@@ -357,6 +358,7 @@ jobs:
           MINIO_SECRET_KEY: ${{ secrets.STAGING_MINIO_SECRET_KEY }}
           MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
           FRONTEND_URL: ${{ secrets.STAGING_API_URL }}
+          BASE_URL: ${{ secrets.STAGING_API_URL }}
           NEXT_PUBLIC_API_URL: ${{ secrets.STAGING_API_URL }}
           NEXT_PUBLIC_NYCU_PORTAL_URL: ${{ secrets.NEXT_PUBLIC_NYCU_PORTAL_URL }}
           NODE_ENV: ${{ secrets.NODE_ENV }}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -57,6 +57,10 @@ services:
       PORTAL_JWT_SERVER_URL: "https://portal.test.nycu.edu.tw/jwt/portal"
       PORTAL_TEST_MODE: "false"
       PORTAL_SSO_TIMEOUT: "10.0"
+      # Public origin used to build ABSOLUTE file URLs (file_path/download_url) and
+      # email links. MUST be the staging origin, not localhost — otherwise browsers
+      # and email recipients get http://localhost:8000 links (issue #889).
+      BASE_URL: ${BASE_URL:-https://ss.test.nycu.edu.tw}
       # Frontend URLs
       FRONTEND_URL: ${FRONTEND_URL:-https://ss.test.nycu.edu.tw}  # External URL (for user redirects)
       FRONTEND_INTERNAL_URL: http://frontend:3000  # Internal Docker network URL (for API calls)


### PR DESCRIPTION
## Problem (#889)

Backend default `settings.base_url` is `http://localhost:8000` (`backend/app/core/config.py:27`). `docker-compose.staging.yml` never set `BASE_URL` for the backend container, so on staging **every absolute URL built from `base_url` pointed at localhost**:
- application file `file_path` / `download_url` (`GET /applications/{id}` returned `http://localhost:8000/api/v1/files/...`)
- notification email links

These are unusable from a real browser or email client. (Verified on staging app 91 during the #885/#887 verification: `file_path` came back as `http://localhost:8000/...`.) It's localhost-invisible because on localhost `base_url == frontend origin`.

## Fix

- **`docker-compose.staging.yml`**: add `BASE_URL: ${BASE_URL:-https://ss.test.nycu.edu.tw}` to the backend `environment`, mirroring the existing `FRONTEND_URL` default. The default means staging is correct even if no secret is wired.
- **`.github/workflows/deploy-pipeline.yml`**: pass `BASE_URL: ${{ secrets.STAGING_API_URL }}` in both env blocks that run `docker compose up` (the `Start new containers` step and the rollback step).

## Regression risk

Minimal — adds one env var. It cannot break existing code paths; it only changes absolute URLs from `localhost:8000` to the staging origin (the intended value). PR #885's frontend already builds **relative** `/api/v1/preview` URLs so document preview worked despite the bug; this additionally fixes any consumer that trusts `file_path`/`download_url` verbatim and fixes email links.

## Verification after merge

After deploy, `GET /api/v1/applications/{id}` should return `file_path` on `https://ss.test.nycu.edu.tw`, and a scheduled email link should be staging-absolute.

Fixes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)