### PR TITLE
fix(frontend): guard file preview against createObjectURL on non-Blob restored files

### DIFF
--- a/frontend/components/file-upload.tsx
+++ b/frontend/components/file-upload.tsx
@@ -217,6 +217,11 @@ export function FileUpload({
       if (fp && (fp.startsWith("/") || fp.startsWith(window.location.origin))) {
         return fp;
       }
+      // Restored uploaded-file entries are plain objects (not real Blobs), so
+      // URL.createObjectURL would throw a TypeError. With no usable same-origin
+      // URL there is nothing to preview — return undefined (the dialog is
+      // skipped) instead of crashing the click handler.
+      if (!(file instanceof Blob)) return undefined;
       return URL.createObjectURL(file);
     }
     // 如果是本地文件，創建臨時URL
@@ -241,6 +246,11 @@ export function FileUpload({
   // 處理文件預覽
   const handleFilePreview = (file: File) => {
     const previewUrl = getFilePreviewUrl(file);
+    if (!previewUrl) {
+      // No previewable URL (e.g. a restored file lacking a same-origin path);
+      // nothing to show, and opening the dialog with an empty src renders blank.
+      return;
+    }
     const fileType = getFileType(file);
 
     setPreviewFile({


### PR DESCRIPTION
## Problem

`getFilePreviewUrl` (`frontend/components/file-upload.tsx`) fell through to `URL.createObjectURL(file)` for an uploaded file that had no usable same-origin URL. Restored draft documents are plain objects cast `as unknown as File` (not real `Blob`s — see `ScholarshipApplicationStep.tsx` restore block), so `createObjectURL` on them throws a `TypeError` in the click handler.

It is not reachable through the current wizard (the restore block always sets `url` when a `file_id` exists, which after PR #885 it always does), but the code path exists and is a latent crash — surfaced by the careful regression audit of #885.

## Fix

- `getFilePreviewUrl`: if there's no `url` and no same-origin `file_path`, and the object isn't a real `Blob`, return `undefined` instead of calling `createObjectURL`.
- `handleFilePreview`: skip opening the dialog when there's no preview URL (renders nothing rather than crashing).

No behavior change for real `File`/`Blob` objects or for files carrying a `url` / same-origin `file_path`. Verified with `tsc --noEmit` (clean).

> Note: a frontend jest unit test for this could not be run locally (the local environment hits `ERR_REQUIRE_ESM` loading the jest/next harness — unrelated to this change; CI Frontend Tests are green). Adding a `getFilePreviewUrl` unit test is left as a follow-up to run under CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)