### PR TITLE
test: fix + wire two orphaned deep test suites into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,12 @@ jobs:
             test-mark: "not integration and not asyncio"
             continue-on-error: false
           - test-suite: integration
-            test-path: app/tests/test_*_service*.py
+            # test_*_service*.py + two deep async suites rescued from the
+            # orphaned set: their filenames lack "service" so the glob missed
+            # them, and being asyncio they're also excluded from the unit lane —
+            # so they ran nowhere. (More test_*_deep.py files remain orphaned;
+            # tracked separately, pending fixes to their stale assertions.)
+            test-path: "app/tests/test_*_service*.py app/tests/test_submit_application_deep.py app/tests/test_update_application_deep.py"
             test-mark: "integration or asyncio"
             continue-on-error: false
           - test-suite: critical-workflows

--- a/backend/app/tests/test_submit_application_deep.py
+++ b/backend/app/tests/test_submit_application_deep.py
@@ -176,7 +176,13 @@ async def test_submit_happy_path_flips_status_and_sets_submitted_at(db: AsyncSes
     await db.refresh(app)
     assert app.status == ApplicationStatus.submitted.value or app.status == ApplicationStatus.submitted
     assert app.submitted_at is not None
-    assert before_submit <= app.submitted_at <= after_submit
+    # submitted_at is tz-naive on the sqlite test DB but tz-aware on postgres;
+    # normalise to aware-UTC before comparing against the aware bounds so the
+    # assertion holds on both backends.
+    submitted_at = app.submitted_at
+    if submitted_at.tzinfo is None:
+        submitted_at = submitted_at.replace(tzinfo=timezone.utc)
+    assert before_submit <= submitted_at <= after_submit
     # Response carries the same app_id.
     if hasattr(result, "app_id"):
         assert result.app_id == app.app_id

--- a/backend/app/tests/test_update_application_deep.py
+++ b/backend/app/tests/test_update_application_deep.py
@@ -167,7 +167,19 @@ async def test_update_persists_form_data_status_is_renewal_subtype_list(db: Asyn
     service = ApplicationService(db)
 
     update_data = ApplicationUpdate(
-        form_data=ApplicationFormData(fields={"bank_account": "123456789"}, documents=[]),
+        # fields is Dict[str, DynamicFormField] — pass a full field object, not a
+        # bare string (the schema rejects a plain string value).
+        form_data=ApplicationFormData(
+            fields={
+                "bank_account": {
+                    "field_id": "bank_account",
+                    "field_type": "text",
+                    "value": "123456789",
+                    "required": False,
+                }
+            },
+            documents=[],
+        ),
         is_renewal=True,
         scholarship_subtype_list=["nstc", "moe_1w"],
     )
@@ -175,9 +187,12 @@ async def test_update_persists_form_data_status_is_renewal_subtype_list(db: Asyn
     result = await service.update_application(application_id=app.id, update_data=update_data, current_user=student)
 
     await db.refresh(app)
-    # form_data persisted.
+    # form_data persisted — the field round-trips as a serialised DynamicFormField,
+    # so the value lives under ["bank_account"]["value"].
     assert app.submitted_form_data is not None
-    assert app.submitted_form_data.get("fields", {}).get("bank_account") == "123456789"
+    persisted = app.submitted_form_data.get("fields", {}).get("bank_account")
+    persisted_value = persisted.get("value") if isinstance(persisted, dict) else persisted
+    assert persisted_value == "123456789"
     # is_renewal flipped.
     assert app.is_renewal is True
     # subtype list updated.


### PR DESCRIPTION
## Problem

`test_submit_application_deep.py` and `test_update_application_deep.py` ran in **no CI lane**:
- the **integration** glob is `app/tests/test_*_service*.py` — their filenames lack "service", so it missed them;
- the **unit** lane is `-m "not integration and not asyncio"` — they're `@pytest.mark.asyncio`, so excluded.

Both also had **stale assertions** that failed when run:
- **submit**: compared tz-aware `datetime.now(timezone.utc)` bounds against `app.submitted_at`, which is tz-**naive** on the sqlite test DB → `can't compare offset-naive and offset-aware datetimes`. Fixed by normalising `submitted_at` to aware-UTC before the comparison (holds on both sqlite and postgres).
- **update**: built `ApplicationFormData(fields={"bank_account": "123456789"})` — a bare string where `fields` is now `Dict[str, DynamicFormField]` (pydantic rejects it); and asserted the value at `fields.bank_account` instead of the round-tripped `fields.bank_account.value`. Fixed both.

## Fix

- Correct the two stale assertions.
- Add both files to the integration `test-path` so they actually run (they're asyncio → collected under `-m "integration or asyncio"`; still excluded from unit, so no double-run).

## Verification

`14 passed` for the two files (container, sqlite — same conftest DB CI uses).

## Note (separate follow-up)

The broader `test_*_deep.py` set is still orphaned by the same glob. Running all 19 non-"service" deep files shows **97 passed, 10 failed across 8 files** (e.g. `test_can_professor_review_deep`, `test_update_application_status_deep`, `test_delete_application_deep`, …). Those need per-file triage (stale-assertion vs real bug) before they can be wired in — intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)