### PR TITLE
test(frontend): unit-test CSP frame-src + extract & test getFilePreviewUrl

### DIFF
--- a/frontend/__tests__/middleware-csp.test.ts
+++ b/frontend/__tests__/middleware-csp.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the CSP middleware (frontend/middleware.ts).
+ *
+ * Regression guard for PR #885: document preview iframes (a same-origin
+ * /api/v1/preview proxy, and a blob: URL for a just-selected local PDF) are
+ * only allowed to render if the CSP carries `frame-src 'self' blob:`. With no
+ * frame-src directive the browser falls back to `default-src 'self'`, which
+ * blocks blob: frames and silently renders a blank preview. These tests pin
+ * the directive in BOTH the dev and prod CSP branches and confirm the
+ * clickjacking protections were not loosened in the process.
+ */
+import { middleware } from "@/middleware";
+
+// The middleware only reads request.headers and request.nextUrl.hostname, so a
+// minimal stand-in is enough (NextResponse is the real one from next/server).
+function mockRequest(url: string) {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL(url),
+  } as unknown as Parameters<typeof middleware>[0];
+}
+
+describe("middleware Content-Security-Policy", () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    Object.defineProperty(process.env, "NODE_ENV", { value: originalEnv, configurable: true });
+  });
+
+  function setNodeEnv(value: string) {
+    Object.defineProperty(process.env, "NODE_ENV", { value, configurable: true });
+  }
+
+  it("dev CSP allows frame-src 'self' blob: for blob/same-origin PDF preview", () => {
+    setNodeEnv("development");
+    const res = middleware(mockRequest("http://localhost:3000/student/apply"));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("frame-src 'self' blob:");
+    // blob: images must still be allowed (the preview dialog renders images via <img>)
+    expect(csp).toContain("img-src 'self' data: blob: https:");
+  });
+
+  it("prod CSP allows frame-src 'self' blob: and keeps clickjacking protections", () => {
+    setNodeEnv("production");
+    const res = middleware(mockRequest("https://ss.test.nycu.edu.tw/student/apply"));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    // the #885 fix
+    expect(csp).toContain("frame-src 'self' blob:");
+    // and it must NOT have loosened the directive to anything wider than blob:
+    expect(csp).not.toContain("frame-src 'self' blob: https:");
+    expect(csp).not.toContain("frame-src *");
+    // clickjacking / object protections intact
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+
+  it("emits a per-request nonce and exposes it for nginx", () => {
+    setNodeEnv("production");
+    const res = middleware(mockRequest("https://ss.test.nycu.edu.tw/"));
+    const nonce = res.headers.get("X-CSP-Nonce");
+    expect(nonce).toBeTruthy();
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain(`'nonce-${nonce}'`);
+  });
+});

--- a/frontend/components/file-upload.tsx
+++ b/frontend/components/file-upload.tsx
@@ -11,6 +11,7 @@ import { Upload, File, X, CheckCircle, AlertCircle, Eye } from "lucide-react";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { Locale } from "@/lib/validators";
 import { getTranslation } from "@/lib/i18n";
+import { resolveFilePreviewUrl } from "@/lib/file-preview";
 
 // Files passed as `initialFiles` may have been previously uploaded — the
 // caller attaches server-side metadata (id, url, file_path, originalSize)
@@ -204,29 +205,9 @@ export function FileUpload({
     return formatFileSize(file.size);
   };
 
-  // 獲取文件的預覽URL
-  const getFilePreviewUrl = (file: File) => {
-    if (isUploadedFile(file)) {
-      const uploaded = file as UploadedFileLike;
-      // Prefer a same-origin proxy URL set by the caller. Only fall back to
-      // file_path if it's a same-origin/relative URL — never iframe an absolute
-      // cross-origin URL (e.g. a misconfigured http://localhost:8000 file_path
-      // on staging) or a bare local filename, which both render blank.
-      if (uploaded.url) return uploaded.url;
-      const fp = uploaded.file_path;
-      if (fp && (fp.startsWith("/") || fp.startsWith(window.location.origin))) {
-        return fp;
-      }
-      // Restored uploaded-file entries are plain objects (not real Blobs), so
-      // URL.createObjectURL would throw a TypeError. With no usable same-origin
-      // URL there is nothing to preview — return undefined (the dialog is
-      // skipped) instead of crashing the click handler.
-      if (!(file instanceof Blob)) return undefined;
-      return URL.createObjectURL(file);
-    }
-    // 如果是本地文件，創建臨時URL
-    return URL.createObjectURL(file);
-  };
+  // 獲取文件的預覽URL — pure logic lives in lib/file-preview so it can be
+  // unit-tested without rendering this component (see lib/__tests__/file-preview).
+  const getFilePreviewUrl = (file: File) => resolveFilePreviewUrl(file, window.location.origin);
 
   // 獲取文件類型
   const getFileType = (file: File) => {

--- a/frontend/lib/__tests__/file-preview.test.ts
+++ b/frontend/lib/__tests__/file-preview.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for resolveFilePreviewUrl — the preview-URL preference logic
+ * extracted from FileUpload (PR #885 / #892).
+ *
+ * Pins:
+ * - url > same-origin file_path > object URL > undefined.
+ * - a cross-origin absolute file_path (e.g. http://localhost:8000 on staging)
+ *   or a bare filename is NOT used as an iframe src.
+ * - a restored non-Blob entry with no usable URL returns undefined and does NOT
+ *   call URL.createObjectURL (the #892 crash guard).
+ */
+import { resolveFilePreviewUrl, isUploadedFileLike } from "@/lib/file-preview";
+
+const ORIGIN = "https://ss.test.nycu.edu.tw";
+
+describe("resolveFilePreviewUrl", () => {
+  beforeEach(() => {
+    (global.URL.createObjectURL as unknown) = jest.fn(() => "blob:mock");
+  });
+
+  it("prefers a caller-set url over file_path", () => {
+    const f = {
+      id: 1,
+      url: "/api/v1/preview?fileId=1",
+      file_path: "http://localhost:8000/api/v1/files/1",
+    } as unknown as File;
+    expect(resolveFilePreviewUrl(f, ORIGIN)).toBe("/api/v1/preview?fileId=1");
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("uses a relative file_path", () => {
+    const f = { id: 1, file_path: "/api/v1/files/applications/1/files/2" } as unknown as File;
+    expect(resolveFilePreviewUrl(f, ORIGIN)).toBe("/api/v1/files/applications/1/files/2");
+  });
+
+  it("uses a same-origin absolute file_path", () => {
+    const f = { id: 1, file_path: `${ORIGIN}/api/v1/files/x` } as unknown as File;
+    expect(resolveFilePreviewUrl(f, ORIGIN)).toBe(`${ORIGIN}/api/v1/files/x`);
+  });
+
+  it("returns undefined for a cross-origin file_path on a non-Blob restored entry (no crash)", () => {
+    const f = { id: 1, file_path: "http://localhost:8000/api/v1/files/x" } as unknown as File;
+    expect(resolveFilePreviewUrl(f, ORIGIN)).toBeUndefined();
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for a bare-filename file_path on a non-Blob restored entry", () => {
+    const f = { id: 1, file_path: "Screenshot.png" } as unknown as File;
+    expect(resolveFilePreviewUrl(f, ORIGIN)).toBeUndefined();
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("creates an object URL for a real local File", () => {
+    const f = new File(["x"], "a.pdf", { type: "application/pdf" });
+    expect(resolveFilePreviewUrl(f, ORIGIN)).toBe("blob:mock");
+    expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isUploadedFileLike", () => {
+  it("detects id / url / file_path", () => {
+    expect(isUploadedFileLike({ id: 1 })).toBe(true);
+    expect(isUploadedFileLike({ url: "/x" })).toBe(true);
+    expect(isUploadedFileLike({ file_path: "/x" })).toBe(true);
+  });
+
+  it("is false for a plain local File and nullish input", () => {
+    expect(isUploadedFileLike(new File(["x"], "a.pdf"))).toBe(false);
+    expect(isUploadedFileLike(null)).toBe(false);
+    expect(isUploadedFileLike(undefined)).toBe(false);
+  });
+});

--- a/frontend/lib/file-preview.ts
+++ b/frontend/lib/file-preview.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure resolver for a file's preview URL, extracted from `FileUpload` so the
+ * preference logic can be unit-tested without rendering the component (whose
+ * jest suite is skipped due to a useEffect/timer issue).
+ *
+ * Encodes the PR #885 / #892 contract:
+ * - prefer a caller-set same-origin `url` (e.g. a /api/v1/preview proxy URL);
+ * - else a same-origin/relative `file_path` (never an absolute cross-origin URL
+ *   such as a misconfigured http://localhost:8000 file_path on staging, nor a
+ *   bare local filename — both render blank in an iframe);
+ * - else an object URL for a real local Blob;
+ * - else `undefined` — a restored uploaded entry is a plain object (not a Blob),
+ *   so calling URL.createObjectURL on it would throw a TypeError.
+ */
+export interface UploadedFileLike {
+  id?: string | number;
+  url?: string;
+  file_path?: string;
+}
+
+/** True when the object carries server-side upload metadata (id / url / file_path). */
+export function isUploadedFileLike(file: unknown): boolean {
+  const f = file as UploadedFileLike | null | undefined;
+  return Boolean(f && (f.id || f.file_path || f.url));
+}
+
+export function resolveFilePreviewUrl(file: File, origin: string): string | undefined {
+  if (isUploadedFileLike(file)) {
+    const uploaded = file as unknown as UploadedFileLike;
+    if (uploaded.url) return uploaded.url;
+    const fp = uploaded.file_path;
+    if (fp && (fp.startsWith("/") || fp.startsWith(origin))) {
+      return fp;
+    }
+    // Restored uploaded entries are plain objects (not real Blobs), so
+    // URL.createObjectURL would throw — return undefined and let the caller
+    // skip opening the preview.
+    if (!(file instanceof Blob)) return undefined;
+    return URL.createObjectURL(file);
+  }
+  // A freshly-selected local file.
+  return URL.createObjectURL(file);
+}


### PR DESCRIPTION
## Why

The bug-CI-test inventory flagged two missing frontend jest tests guarding PR #885/#892. The existing `file-upload.test.tsx` is `describe.skip`'d (a useEffect/timer bug times it out), so the preview logic had **zero** coverage.

## What

**`__tests__/middleware-csp.test.ts`** — asserts `middleware()` emits a CSP with `frame-src 'self' blob:` in **both** the dev and prod branches (the #885 fix that lets the same-origin `/api/v1/preview` proxy and `blob:` PDFs render in an iframe), and that it did **not** loosen `frame-src` beyond `blob:` nor weaken `frame-ancestors 'none'` / `object-src 'none'` / `X-Frame-Options: DENY`. Also pins the per-request nonce.

**`lib/file-preview.ts` + `lib/__tests__/file-preview.test.ts`** — the preview-URL preference logic was a closure inside `FileUpload` (untestable while its suite is skipped). Extracted to a pure `resolveFilePreviewUrl(file, origin)` and unit-tested every branch:
- `url` > same-origin/relative `file_path` > object URL > `undefined`
- a cross-origin absolute `file_path` (e.g. `http://localhost:8000` on staging) or a bare filename is **not** used as an iframe src
- a restored **non-Blob** entry with no usable URL returns `undefined` and never calls `URL.createObjectURL` (the **#892 crash guard**)

`FileUpload` now delegates to the helper — no behavior change (verified `tsc` clean + `next lint` clean).

## Verification

`11 passed` (3 CSP + 8 preview). Note: local jest needs `node --experimental-require-module` on node 22.1; CI's node 22.12+ has `require(esm)` on by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)