### PR TITLE
fix+test: clear remaining orphaned deep-test failures (2 real bugs) + wire all into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,12 +251,11 @@ jobs:
             test-mark: "not integration and not asyncio"
             continue-on-error: false
           - test-suite: integration
-            # test_*_service*.py + two deep async suites rescued from the
-            # orphaned set: their filenames lack "service" so the glob missed
-            # them, and being asyncio they're also excluded from the unit lane —
-            # so they ran nowhere. (More test_*_deep.py files remain orphaned;
-            # tracked separately, pending fixes to their stale assertions.)
-            test-path: "app/tests/test_*_service*.py app/tests/test_submit_application_deep.py app/tests/test_update_application_deep.py"
+            # test_*_service*.py + ALL test_*_deep.py. The deep async suites were
+            # orphaned: their filenames lack "service" so this glob missed them,
+            # and being asyncio they're also excluded from the unit lane — so they
+            # ran nowhere. Their stale assertions are now fixed and all 19 pass.
+            test-path: "app/tests/test_*_service*.py app/tests/test_*_deep.py"
             test-mark: "integration or asyncio"
             continue-on-error: false
           - test-suite: critical-workflows

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2388,13 +2388,17 @@ class ApplicationService:
             if application.professor_id != professor_id:
                 return False
 
-            # Check application status - should be submitted or under review (or historical)
+            # Check application status - should be submitted or under review (or historical).
+            # application is loaded fresh from the DB, so status is the Enum MEMBER, not its
+            # .value string — compare against members (matching the dominant convention in
+            # this file). Comparing a member against .value strings always failed → the
+            # method wrongly returned False for every status.
             if application.status not in [
-                ApplicationStatus.submitted.value,
-                ApplicationStatus.under_review.value,
-                ApplicationStatus.approved.value,
-                ApplicationStatus.partial_approved.value,
-                ApplicationStatus.rejected.value,
+                ApplicationStatus.submitted,
+                ApplicationStatus.under_review,
+                ApplicationStatus.approved,
+                ApplicationStatus.partial_approved,
+                ApplicationStatus.rejected,
             ]:
                 return False
 

--- a/backend/app/services/scholarship_notification_service.py
+++ b/backend/app/services/scholarship_notification_service.py
@@ -172,14 +172,16 @@ class ScholarshipNotificationService:
                 },
             )
 
-            # Note: rejection_reason moved to ApplicationReview model
-            # Get rejection reason from latest ApplicationReview if applicable
+            # Note: rejection_reason moved to ApplicationReview model.
+            # ApplicationReview stores the reject reason in `comments` (it has no
+            # `decision_reason` column — reading that AttributeError'd at runtime
+            # when sending a rejected-application email).
             rejection_reason = None
             if new_status == ApplicationStatus.rejected.value and application.reviews:
-                # Get the latest review with a decision_reason
+                # Get the latest review carrying a comment (the reject reason).
                 for review in reversed(application.reviews):
-                    if review.decision_reason:
-                        rejection_reason = review.decision_reason
+                    if review.comments:
+                        rejection_reason = review.comments
                         break
 
             subject = f"{status_info['title']} - {application.app_id}"

--- a/backend/app/tests/test_delete_application_deep.py
+++ b/backend/app/tests/test_delete_application_deep.py
@@ -209,7 +209,10 @@ async def test_submitted_deletion_is_soft_delete(db: AsyncSession, silence_colla
     assert persisted is not None, "submitted delete must NOT hard-delete the row"
     assert _val(persisted.status) == ApplicationStatus.deleted.value
     assert persisted.deleted_at is not None
-    assert before <= persisted.deleted_at <= after
+    deleted_at = (
+        persisted.deleted_at if persisted.deleted_at.tzinfo else persisted.deleted_at.replace(tzinfo=timezone.utc)
+    )
+    assert before <= deleted_at <= after
     assert persisted.deleted_by_id == admin.id
     assert persisted.deletion_reason == "compliance request"
 

--- a/backend/app/tests/test_get_professor_applications_paginated_deep.py
+++ b/backend/app/tests/test_get_professor_applications_paginated_deep.py
@@ -53,6 +53,11 @@ async def _seed_config(db: AsyncSession, *, requires_prof: bool, suffix: str) ->
         academic_year=114,
         application_start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         application_end_date=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        # The "pending" professor queue overlays a review-phase filter that
+        # requires an open professor-review window; without these the renewal
+        # phase filter excludes every row (total=0).
+        professor_review_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        professor_review_end=datetime(2030, 1, 1, tzinfo=timezone.utc),
         requires_professor_recommendation=requires_prof,
         requires_college_review=False,
         amount=0,

--- a/backend/app/tests/test_notify_deadline_reminder_deep.py
+++ b/backend/app/tests/test_notify_deadline_reminder_deep.py
@@ -47,7 +47,10 @@ def _val(x):
 async def test_deadline_reminder_far_future_uses_high_priority_and_N_days_copy(db: AsyncSession):
     user = await _seed_user(db, nycu_id="ddl_far")
     service = NotificationService(db)
-    deadline = datetime.now(timezone.utc) + timedelta(days=5)
+    # +5d2h so timedelta.days (which floors, the shipped behaviour — see
+    # test_notification_service.test_notify_deadline_reminder_multiple_days)
+    # lands on 5 rather than 4 after the few ms elapse since "now".
+    deadline = datetime.now(timezone.utc) + timedelta(days=5, hours=2)
 
     notif = await service.notifyDeadlineReminder(
         user_id=user.id,
@@ -67,7 +70,12 @@ async def test_deadline_reminder_far_future_uses_high_priority_and_N_days_copy(d
     assert fetched.action_url == "/student/applications"
     # expires_at is deadline + 7 days.
     assert fetched.expires_at is not None
-    delta = fetched.expires_at - deadline
+    # sqlite returns a tz-naive datetime; normalise before subtracting the
+    # aware `deadline`.
+    expires_at = fetched.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    delta = expires_at - deadline
     assert abs(delta.total_seconds() - timedelta(days=7).total_seconds()) < 5
     # Metadata captures reminder_type + days_left.
     assert fetched.meta_data is not None

--- a/backend/app/tests/test_notify_document_required_deep.py
+++ b/backend/app/tests/test_notify_document_required_deep.py
@@ -120,8 +120,12 @@ async def test_with_deadline_includes_upload_by_suffix(db: AsyncSession):
     assert "Please upload by 2026/12/15" in (fetched.message_en or "")
     # expires_at is set to the deadline.
     assert fetched.expires_at is not None
-    # Compare as UTC; the model column may strip subseconds.
-    assert fetched.expires_at.replace(microsecond=0) == deadline.replace(microsecond=0)
+    # Compare as UTC; the model column may strip subseconds and the sqlite test
+    # DB returns a tz-naive value, so normalise to aware-UTC before comparing.
+    expires_at = fetched.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    assert expires_at.replace(microsecond=0) == deadline.replace(microsecond=0)
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_update_application_status_deep.py
+++ b/backend/app/tests/test_update_application_status_deep.py
@@ -158,7 +158,8 @@ async def test_approve_sets_approved_at_and_creates_review_row(db: AsyncSession,
     assert _val(app.status) == ApplicationStatus.approved.value
     assert app.reviewer_id == admin.id
     assert app.approved_at is not None
-    assert before <= app.approved_at <= after
+    approved_at = app.approved_at if app.approved_at.tzinfo else app.approved_at.replace(tzinfo=timezone.utc)
+    assert before <= approved_at <= after
 
     # An ApplicationReview row was created with the comments.
     reviews = (
@@ -194,8 +195,9 @@ async def test_reject_creates_review_row_with_decision_reason(db: AsyncSession, 
         (await db.execute(select(ApplicationReview).where(ApplicationReview.application_id == app.id))).scalars().all()
     )
     assert len(reviews) == 1
-    # rejection_reason from the status update lands on decision_reason on the review row.
-    assert reviews[0].decision_reason == "GPA below threshold."
+    # The reject reason lands on the review row's `comments` (ApplicationReview
+    # has no decision_reason column; that field lives on the Application model).
+    assert reviews[0].comments == "GPA below threshold."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Clears the remaining orphaned `test_*_deep.py` failures (the 8 across 6 files left after #896) and wires the whole `test_*_deep.py` set into CI. Triaged each — **2 real production bugs the tests caught**, the rest stale/brittle tests.

### Real production bugs (fixed)
| Bug | File | Fix |
|---|---|---|
| `can_professor_review_application` compared the DB-loaded status **enum member** against `.value` strings → always `False` | `application_service.py` | compare against enum members (no live caller today, but genuinely wrong) |
| the rejected-application email read `review.decision_reason`, which `ApplicationReview` has no column for → **AttributeError at runtime** | `scholarship_notification_service.py` | read `review.comments` (where the reject reason is stored; `decision_reason` is on the `Application` model) |

### Test fixes
- **deadline-reminder** deep test set `deadline = now + 5d` exactly and expected "5 days", but `timedelta.days` **floors** (the shipped behaviour — `test_notification_service.test_notify_deadline_reminder_multiple_days` sets `+6d` to land on 5), so the few ms elapsed gave 4. Buffered to `+5d2h`. **Not a production bug** — an initial `round()` attempt regressed that established test (CI caught it), so it was reverted.
- paginated **pending** queue test: seed `professor_review_start/end` so the (intentional) review-phase filter doesn't exclude every row.
- `update_application_status` reject test: assert `review.comments`, not the non-existent `decision_reason`.
- tz-naive(sqlite)/aware compares in delete / update_status / document_required / deadline tests: normalise to aware-UTC.

## CI wiring

Broadens the integration `test-path` glob to `app/tests/test_*_deep.py`. All 19 non-service deep files pass — **107 passed**.

## Regression check

Established notification/professor/application/review tests stay green (39 passed locally); the initial `round()` regression was caught by CI and reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
