### PR TITLE
fix(dev): dev profile email domain dev.local → dev.example.com (login was broken)

### DIFF
--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -126,7 +126,9 @@ class DeveloperProfileRequest(BaseModel):
     chinese_name: Optional[str] = None
     english_name: Optional[str] = None
     role: UserRole
-    email_domain: Optional[str] = "dev.local"
+    # dev.example.com, not dev.local — EmailStr rejects the ".local" special-use
+    # TLD, which made @dev.local dev users fail UserResponse serialization on login.
+    email_domain: Optional[str] = "dev.example.com"
     custom_attributes: Optional[dict] = None
 
 

--- a/backend/app/services/developer_profile_service.py
+++ b/backend/app/services/developer_profile_service.py
@@ -21,7 +21,11 @@ class DeveloperProfile(BaseModel):
     chinese_name: Optional[str] = None
     english_name: Optional[str] = None
     role: UserRole
-    email_domain: str = "dev.local"
+    # dev.example.com (RFC-2606 reserved, non-routable — keeps dev users from
+    # impersonating real ones) NOT dev.local: EmailStr rejects the special-use
+    # ".local" TLD, so an @dev.local dev user could never be serialized by
+    # UserResponse → mock-sso login returned HTTP 400 (dev quick-setup unusable).
+    email_domain: str = "dev.example.com"
     custom_attributes: Dict = {}
 
 

--- a/backend/app/tests/test_user_schemas.py
+++ b/backend/app/tests/test_user_schemas.py
@@ -182,12 +182,14 @@ def test_token_response_token_type_defaults_bearer():
 # ─── DeveloperProfileRequest defaults ───────────────────────────────
 
 
-def test_developer_profile_email_domain_defaults_dev_local():
-    # Pin: "dev.local" — isolated dev environment. Flipping to
-    # real domain ("nycu.edu.tw") would let dev users pretend to be
-    # real ones in the development DB.
+def test_developer_profile_email_domain_defaults_dev_example():
+    # Pin: "dev.example.com" — RFC-2606 reserved, non-routable, so dev users
+    # still can't impersonate real ones in the development DB. NOT "dev.local":
+    # EmailStr rejects the special-use ".local" TLD, which made @dev.local dev
+    # users fail UserResponse serialization and break mock-sso login. NOT a real
+    # domain ("nycu.edu.tw") either, for the same impersonation reason.
     d = DeveloperProfileRequest(role=UserRole.student)
-    assert d.email_domain == "dev.local"
+    assert d.email_domain == "dev.example.com"
 
 
 def test_developer_profile_requires_role():

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -8669,7 +8669,7 @@ export interface components {
             role: components["schemas"]["UserRole"];
             /**
              * Email Domain
-             * @default dev.local
+             * @default dev.example.com
              */
             email_domain: string | null;
             /** Custom Attributes */


### PR DESCRIPTION
## Bug

`quick_setup_developer` / `DeveloperProfileRequest` defaulted `email_domain="dev.local"`. `UserResponse.email` is `EmailStr`, which rejects the RFC-2606 special-use `.local` TLD as invalid. So serializing any quick-setup dev user (`dev_authtest_student@dev.local`) failed — **mock-sso login of a dev profile returned HTTP 400 and no quick-setup dev user could ever log in.**

Found by the orphaned-async-test wave (`test_developer_profiles`).

## Fix

Default to `dev.example.com` — also RFC-2606 reserved and non-routable (dev users still can't impersonate real ones), but a valid email shape `EmailStr` accepts. Updated the pin test `test_developer_profile_email_domain_defaults_*` + its rationale comment.

Verified: `EmailStr` rejects `x@dev.local`, accepts `x@dev.example.com`; `test_developer_profiles` + `test_user_schemas` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)