### PR TITLE
test(frontend): un-skip 7 admin/dashboard jest suites (mock useAuth)

### DIFF
--- a/frontend/components/__tests__/admin-configuration-management.test.tsx
+++ b/frontend/components/__tests__/admin-configuration-management.test.tsx
@@ -52,6 +52,19 @@ const mockGetAcademies = jest.fn().mockResolvedValue({
   data: [],
 });
 
+const mockGetScholarshipConfiguration = jest.fn().mockResolvedValue({
+  success: true,
+  data: { id: 1, config_code: "test_config" },
+});
+
+const mockToggleConfigSupplementaryImport = jest
+  .fn()
+  .mockResolvedValue({ success: true, data: {} });
+
+const mockToggleScholarshipWhitelist = jest
+  .fn()
+  .mockResolvedValue({ success: true, data: {} });
+
 // Mock the API client
 jest.mock("@/lib/api", () => ({
   __esModule: true,
@@ -61,6 +74,8 @@ jest.mock("@/lib/api", () => ({
         mockGetScholarshipConfigTypes(...args),
       getScholarshipConfigurations: (...args: any[]) =>
         mockGetScholarshipConfigurations(...args),
+      getScholarshipConfiguration: (...args: any[]) =>
+        mockGetScholarshipConfiguration(...args),
       createScholarshipConfiguration: (...args: any[]) =>
         mockCreateScholarshipConfiguration(...args),
       updateScholarshipConfiguration: (...args: any[]) =>
@@ -73,18 +88,53 @@ jest.mock("@/lib/api", () => ({
     referenceData: {
       getAcademies: (...args: any[]) => mockGetAcademies(...args),
     },
+    college: {
+      toggleConfigSupplementaryImport: (...args: any[]) =>
+        mockToggleConfigSupplementaryImport(...args),
+    },
+    whitelist: {
+      toggleScholarshipWhitelist: (...args: any[]) =>
+        mockToggleScholarshipWhitelist(...args),
+    },
   },
   ScholarshipType: {},
   ScholarshipConfiguration: {},
   ScholarshipConfigurationFormData: {},
 }));
 
+// Mock sonner toast (component reports errors/success via toast, not inline UI)
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// Mock useAuth so child components don't throw outside AuthProvider
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 1, role: "admin", name: "Test Admin" },
+    login: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { toast } from "sonner";
 import mockApiDefault from "@/lib/api";
-const mockApi = mockApiDefault;
+const mockApi = mockApiDefault as any;
+const mockToast = toast as unknown as {
+  success: jest.Mock;
+  error: jest.Mock;
+};
 
 // Override with mutable mocks
 mockApi.admin.getScholarshipConfigTypes = mockGetScholarshipConfigTypes;
 mockApi.admin.getScholarshipConfigurations = mockGetScholarshipConfigurations;
+mockApi.admin.getScholarshipConfiguration = mockGetScholarshipConfiguration;
 mockApi.admin.createScholarshipConfiguration =
   mockCreateScholarshipConfiguration;
 mockApi.admin.updateScholarshipConfiguration =
@@ -93,7 +143,10 @@ mockApi.admin.deleteScholarshipConfiguration =
   mockDeleteScholarshipConfiguration;
 mockApi.admin.duplicateScholarshipConfiguration =
   mockDuplicateScholarshipConfiguration;
-// Note: referenceData is already mocked in jest.mock() above (line 73-75)
+mockApi.college.toggleConfigSupplementaryImport =
+  mockToggleConfigSupplementaryImport;
+mockApi.whitelist.toggleScholarshipWhitelist = mockToggleScholarshipWhitelist;
+// Note: referenceData is already mocked in jest.mock() above
 
 // Mock UI components to avoid complex rendering issues
 jest.mock("@/components/ui/card", () => ({
@@ -132,30 +185,40 @@ jest.mock("@/components/ui/button", () => ({
   ),
 }));
 
-jest.mock("@/components/ui/tabs", () => ({
-  Tabs: ({ children, value, onValueChange }: any) => (
-    <div
-      data-testid="tabs"
-      data-value={value}
-      onClick={() => onValueChange && onValueChange("test-value")}
-    >
-      {children}
-    </div>
-  ),
-  TabsList: ({ children }: any) => (
-    <div data-testid="tabs-list">{children}</div>
-  ),
-  TabsTrigger: ({ children, value }: any) => (
-    <button data-testid="tabs-trigger" data-value={value}>
-      {children}
-    </button>
-  ),
-  TabsContent: ({ children, value }: any) => (
-    <div data-testid="tabs-content" data-value={value}>
-      {children}
-    </div>
-  ),
-}));
+jest.mock("@/components/ui/tabs", () => {
+  // Only mount the active TabsContent, mirroring real Radix behaviour.
+  // (Defined inside the factory because jest hoists the mock; React is global.)
+  const TabsCtx = React.createContext("");
+  return {
+    Tabs: ({ children, value, onValueChange }: any) => (
+      <TabsCtx.Provider value={value}>
+        <div
+          data-testid="tabs"
+          data-value={value}
+          onClick={() => onValueChange && onValueChange("test-value")}
+        >
+          {children}
+        </div>
+      </TabsCtx.Provider>
+    ),
+    TabsList: ({ children }: any) => (
+      <div data-testid="tabs-list">{children}</div>
+    ),
+    TabsTrigger: ({ children, value }: any) => (
+      <button data-testid="tabs-trigger" data-value={value}>
+        {children}
+      </button>
+    ),
+    TabsContent: ({ children, value }: any) => {
+      const active = React.useContext(TabsCtx);
+      return active === value ? (
+        <div data-testid="tabs-content" data-value={value}>
+          {children}
+        </div>
+      ) : null;
+    },
+  };
+});
 
 jest.mock("@/components/ui/select", () => ({
   Select: ({ children, value, onValueChange }: any) => (
@@ -303,7 +366,7 @@ afterAll(() => {
 // TODO: Fix remaining tests - many test non-existent functionality or complex dialog/tab interactions
 // 6/20 tests passing - basic rendering and simple actions work
 // Remaining failures: tests expect component to load data that's passed as props, or complex UI interactions
-describe.skip("AdminConfigurationManagement Component", () => {
+describe("AdminConfigurationManagement Component", () => {
   const mockScholarshipTypes = [
     {
       id: 1,
@@ -372,6 +435,12 @@ describe.skip("AdminConfigurationManagement Component", () => {
     },
   ];
 
+  // mockConfigurations[0] is active, [1] is inactive. The component issues two
+  // requests (is_active:true then is_active:false) and concatenates the results,
+  // so split the data by the requested flag to avoid duplicate rows/keys.
+  const activeConfigs = mockConfigurations.filter(c => c.is_active);
+  const inactiveConfigs = mockConfigurations.filter(c => !c.is_active);
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -381,10 +450,12 @@ describe.skip("AdminConfigurationManagement Component", () => {
       data: mockScholarshipTypes,
     });
 
-    mockApi.admin.getScholarshipConfigurations.mockResolvedValue({
-      success: true,
-      data: mockConfigurations,
-    });
+    mockApi.admin.getScholarshipConfigurations.mockImplementation((p: any) =>
+      Promise.resolve({
+        success: true,
+        data: p?.is_active ? activeConfigs : inactiveConfigs,
+      })
+    );
   });
 
   it("should render component with loading state initially", () => {
@@ -413,13 +484,12 @@ describe.skip("AdminConfigurationManagement Component", () => {
       <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
     );
 
-    // Wait for error to appear (component auto-selects first scholarship type)
+    // Errors are surfaced via toast (no inline error UI).
     await waitFor(
       () => {
-        const errorElements = screen.queryAllByText(
-          /載入配置失敗|Failed to load/i
+        expect(mockToast.error).toHaveBeenCalledWith(
+          expect.stringContaining("載入配置失敗")
         );
-        expect(errorElements.length).toBeGreaterThan(0);
       },
       { timeout: 2000 }
     );
@@ -430,18 +500,17 @@ describe.skip("AdminConfigurationManagement Component", () => {
       <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
     );
 
-    // Wait for initial load
-    await waitFor(() => {
-      expect(mockApi.admin.getScholarshipConfigTypes).toHaveBeenCalled();
-    });
-
-    // Check that configurations are loaded
+    // Check that configurations are loaded for the auto-selected first type.
+    // Load is per-type only (active + inactive), no academic_year/semester filter.
     await waitFor(() => {
       expect(mockApi.admin.getScholarshipConfigurations).toHaveBeenCalledWith({
         scholarship_type_id: 1,
-        academic_year: expect.any(Number),
         is_active: true,
       });
+    });
+    expect(mockApi.admin.getScholarshipConfigurations).toHaveBeenCalledWith({
+      scholarship_type_id: 1,
+      is_active: false,
     });
   });
 
@@ -454,9 +523,11 @@ describe.skip("AdminConfigurationManagement Component", () => {
       expect(
         screen.getByText("PhD獎學金114學年度第一學期")
       ).toBeInTheDocument();
-      expect(screen.getByText("50,000 TWD")).toBeInTheDocument();
-      expect(screen.getByText("114學年度 第一學期")).toBeInTheDocument();
     });
+    // Year/semester rendered together: "114 第一學期"
+    expect(screen.getByText(/114\s*第一學期/)).toBeInTheDocument();
+    // Config code badge is rendered
+    expect(screen.getByText("PHD-114-1")).toBeInTheDocument();
   });
 
   it("should show empty state when no configurations exist", async () => {
@@ -471,9 +542,6 @@ describe.skip("AdminConfigurationManagement Component", () => {
 
     await waitFor(() => {
       expect(screen.getByText("尚無配置資料")).toBeInTheDocument();
-      expect(
-        screen.getByText("點擊「新增配置」開始建立獎學金配置")
-      ).toBeInTheDocument();
     });
   });
 
@@ -554,8 +622,11 @@ describe.skip("AdminConfigurationManagement Component", () => {
     const submitButton = screen.getByText("建立配置");
     await user.click(submitButton);
 
+    // Error surfaced via toast: "建立配置失敗: Creation failed"
     await waitFor(() => {
-      expect(screen.getByText("Creation failed")).toBeInTheDocument();
+      expect(mockToast.error).toHaveBeenCalledWith(
+        expect.stringContaining("Creation failed")
+      );
     });
   });
 
@@ -565,15 +636,19 @@ describe.skip("AdminConfigurationManagement Component", () => {
       <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
     );
 
+    // Wait for the row (and its action buttons) to render.
     await waitFor(() => {
-      const editButtons = screen.getAllByTestId("button");
-      // Find the edit button (with Edit icon, should be one of the action buttons)
-      const editButton = editButtons.find(
-        button =>
-          button.getAttribute("onClick")?.includes("openEditDialog") ||
-          button.textContent?.includes("Edit")
-      );
-      expect(editButton).toBeTruthy();
+      expect(
+        screen.getByText("PhD獎學金114學年度第一學期")
+      ).toBeInTheDocument();
+    });
+
+    // The edit action button carries title="編輯配置" (spread onto the mock button).
+    const editButton = screen.getAllByTitle("編輯配置")[0];
+    await user.click(editButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("編輯獎學金配置")).toBeInTheDocument();
     });
   });
 
@@ -624,7 +699,7 @@ describe.skip("AdminConfigurationManagement Component", () => {
     });
   });
 
-  it("should filter configurations by academic year", async () => {
+  it("should load configurations for the selected type (per-type, no year filter)", async () => {
     render(
       <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
     );
@@ -632,45 +707,18 @@ describe.skip("AdminConfigurationManagement Component", () => {
     await waitFor(() => {
       expect(mockApi.admin.getScholarshipConfigurations).toHaveBeenCalledWith({
         scholarship_type_id: 1,
-        academic_year: expect.any(Number),
         is_active: true,
       });
     });
   });
 
-  it("should filter configurations by semester", async () => {
-    render(
-      <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
-    );
+  // Year/semester filtering at the API level was removed; load is per scholarship
+  // type only (active + inactive). Filtering now happens client-side via search.
+  it.skip("should filter configurations by semester", () => {});
 
-    // Initial load
-    await waitFor(() => {
-      expect(mockApi.admin.getScholarshipConfigurations).toHaveBeenCalledTimes(
-        1
-      );
-    });
-  });
-
-  it("should refresh configurations when refresh button is clicked", async () => {
-    const user = userEvent.setup();
-    render(
-      <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("重新載入")).toBeInTheDocument();
-    });
-
-    const refreshButton = screen.getByText("重新載入");
-    await user.click(refreshButton);
-
-    // Should call API again
-    await waitFor(() => {
-      expect(mockApi.admin.getScholarshipConfigurations).toHaveBeenCalledTimes(
-        2
-      );
-    });
-  });
+  // The standalone "重新載入" refresh button was removed from the redesigned UI;
+  // reloads happen automatically after create/update/delete and on type change.
+  it.skip("should refresh configurations when refresh button is clicked", () => {});
 
   it("should display active/inactive status correctly", async () => {
     render(
@@ -678,10 +726,11 @@ describe.skip("AdminConfigurationManagement Component", () => {
     );
 
     await waitFor(() => {
-      // Active configuration should show "啟用"
-      expect(screen.getByText("啟用")).toBeInTheDocument();
-      // Note: Inactive configs might not be shown due to filtering, but status should be correct when shown
+      // Active config row shows the "已啟用" status badge.
+      expect(screen.getByText("已啟用")).toBeInTheDocument();
     });
+    // Inactive config row shows "已停用".
+    expect(screen.getByText("已停用")).toBeInTheDocument();
   });
 
   it("should handle API errors gracefully", async () => {
@@ -695,34 +744,18 @@ describe.skip("AdminConfigurationManagement Component", () => {
       <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
     );
 
+    // Load failures are surfaced via toast (the error has no `.message`, so the
+    // component falls back to its default "載入配置失敗: ..." prefix).
     await waitFor(() => {
-      expect(screen.getByText("Server error")).toBeInTheDocument();
+      expect(mockToast.error).toHaveBeenCalledWith(
+        expect.stringContaining("載入配置失敗")
+      );
     });
   });
 
-  it("should close error message when X button is clicked", async () => {
-    const user = userEvent.setup();
-    mockApi.admin.getScholarshipConfigurations.mockRejectedValue({
-      response: {
-        data: { message: "Test error message" },
-      },
-    });
-
-    render(
-      <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("Test error message")).toBeInTheDocument();
-    });
-
-    const closeButton = screen.getByText("×");
-    await user.click(closeButton);
-
-    await waitFor(() => {
-      expect(screen.queryByText("Test error message")).not.toBeInTheDocument();
-    });
-  });
+  // The redesigned component reports errors via toast notifications rather than a
+  // dismissible inline error banner, so there is no "×" close button to test.
+  it.skip("should close error message when X button is clicked", () => {});
 
   it("should validate form data before submission", async () => {
     const user = userEvent.setup();

--- a/frontend/components/__tests__/admin-dashboard.test.tsx
+++ b/frontend/components/__tests__/admin-dashboard.test.tsx
@@ -27,7 +27,24 @@ jest.mock("@/hooks/use-scholarship-permissions", () => ({
 
 // Helpers from lib/utils — not under test here.
 jest.mock("@/lib/utils/application-helpers", () => ({
-  getDisplayStatusInfo: () => ({ statusLabel: "已提交", statusVariant: "default" }),
+  getDisplayStatusInfo: () => ({
+    statusLabel: "已提交",
+    statusVariant: "default",
+  }),
+}));
+
+// Child components downstream of the dashboard call useAuth; stub it so
+// they don't throw "useAuth must be used within AuthProvider" in tests.
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 1, role: "admin", name: "Test Admin" },
+    login: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 // API client only referenced inside the error "test login" button path.
@@ -60,7 +77,7 @@ const baseProps = {
   onTabChange: jest.fn(),
 };
 
-describe.skip("AdminDashboard", () => {
+describe("AdminDashboard", () => {
   it("renders the welcome banner unconditionally", () => {
     render(<AdminDashboard {...baseProps} />);
     expect(screen.getByText("獎學金管理系統儀表板")).toBeInTheDocument();
@@ -76,25 +93,28 @@ describe.skip("AdminDashboard", () => {
           approved: 18,
           rejected: 3,
         }}
-      />,
+      />
     );
     // Card labels + values appear together. Use getByText which is keyed on
     // the rendered number string — Loader2 would replace these if loading.
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("7")).toBeInTheDocument();
     expect(screen.getByText("18")).toBeInTheDocument();
-    // "3" might be ambiguous; assert via label proximity.
-    expect(screen.getByText("總申請案件")).toBeInTheDocument();
+    // "總申請案件" appears twice (CardTitle + the small label under the
+    // number), so assert presence via getAllByText.
+    expect(screen.getAllByText("總申請案件").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("待審核")).toBeInTheDocument();
   });
 
   it("falls back to 0 for missing stat fields, never crashes on partial data", () => {
     render(<AdminDashboard {...baseProps} stats={{ total_applications: 5 }} />);
     expect(screen.getByText("5")).toBeInTheDocument();
-    // pending_review, approved, rejected default to 0 — there should be
-    // multiple "0" cells.
+    // pending_review and approved default to 0 (the 4th card,
+    // avg_processing_time, falls back to "N/A" rather than 0), so there
+    // should be at least two "0" cells — the key contract is no crash on
+    // partial data.
     const zeros = screen.getAllByText("0");
-    expect(zeros.length).toBeGreaterThanOrEqual(3);
+    expect(zeros.length).toBeGreaterThanOrEqual(2);
   });
 
   it("shows the error banner with diagnostic context when `error` is set", () => {
@@ -103,7 +123,7 @@ describe.skip("AdminDashboard", () => {
         {...baseProps}
         error="Network timeout"
         user={{ id: 99, role: "admin" }}
-      />,
+      />
     );
     expect(screen.getByText("載入資料時發生錯誤")).toBeInTheDocument();
     expect(screen.getByText("Network timeout")).toBeInTheDocument();
@@ -121,7 +141,7 @@ describe.skip("AdminDashboard", () => {
         {...baseProps}
         error="Auth failed"
         isAuthenticated={false}
-      />,
+      />
     );
     expect(screen.getByText(/認證狀態: 未認證/)).toBeInTheDocument();
   });
@@ -146,7 +166,7 @@ describe.skip("AdminDashboard", () => {
             created_at: "2026-03-10T00:00:00Z",
           },
         ]}
-      />,
+      />
     );
     expect(screen.getByText("博士獎學金")).toBeInTheDocument();
     expect(screen.getByText("APP-114-1-00007")).toBeInTheDocument();
@@ -167,7 +187,7 @@ describe.skip("AdminDashboard", () => {
             created_at: "2026-03-10T00:00:00Z",
           },
         ]}
-      />,
+      />
     );
     expect(screen.getByText("APP-42")).toBeInTheDocument();
   });
@@ -189,7 +209,7 @@ describe.skip("AdminDashboard", () => {
             notification_type: "warning",
           },
         ]}
-      />,
+      />
     );
     expect(screen.getByText("系統維護通知")).toBeInTheDocument();
     expect(screen.getByText("今晚 11 點到 1 點維護")).toBeInTheDocument();
@@ -197,7 +217,7 @@ describe.skip("AdminDashboard", () => {
 
   it("shows loading state for stats when isStatsLoading=true", () => {
     const { container } = render(
-      <AdminDashboard {...baseProps} isStatsLoading={true} stats={null} />,
+      <AdminDashboard {...baseProps} isStatsLoading={true} stats={null} />
     );
     // 4 stat cards each get a spinner instead of a number.
     // lucide-react renders <svg> with class containing 'lucide-loader' or

--- a/frontend/components/__tests__/admin-rule-management.test.tsx
+++ b/frontend/components/__tests__/admin-rule-management.test.tsx
@@ -30,7 +30,8 @@ jest.mock("@/lib/api", () => ({
   api: {
     admin: {
       getAvailableYears: (...args: unknown[]) => mockGetAvailableYears(...args),
-      getScholarshipRules: (...args: unknown[]) => mockGetScholarshipRules(...args),
+      getScholarshipRules: (...args: unknown[]) =>
+        mockGetScholarshipRules(...args),
       deleteScholarshipRule: jest.fn(),
       createScholarshipRule: jest.fn(),
       updateScholarshipRule: jest.fn(),
@@ -50,6 +51,17 @@ jest.mock("../copy-rules-modal", () => ({
 jest.mock("sonner", () => ({
   toast: { success: jest.fn(), error: jest.fn() },
 }));
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 1, role: "admin", name: "Test Admin" },
+    login: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
 
 beforeEach(() => {
   mockGetAvailableYears.mockResolvedValue({
@@ -62,13 +74,15 @@ beforeEach(() => {
   });
 });
 
-describe.skip("AdminRuleManagement", () => {
-  it("renders empty-state copy and short-circuits API calls when scholarshipTypes is []", () => {
+describe("AdminRuleManagement", () => {
+  it("renders empty-state copy and short-circuits the rules fetch when scholarshipTypes is []", () => {
     render(<AdminRuleManagement scholarshipTypes={[]} />);
     expect(screen.getByText("尚無獎學金類型")).toBeInTheDocument();
 
-    // Short-circuit: no API calls fire when there's nothing to manage.
-    expect(mockGetAvailableYears).not.toHaveBeenCalled();
+    // Rules short-circuit: with no scholarship types there is never a
+    // selected type, so the rules-loading effect never calls the API.
+    // (The available-years effect, by contrast, fetches unconditionally on
+    // mount — it is intentionally NOT asserted here.)
     expect(mockGetScholarshipRules).not.toHaveBeenCalled();
   });
 
@@ -76,22 +90,43 @@ describe.skip("AdminRuleManagement", () => {
     render(
       <AdminRuleManagement
         scholarshipTypes={[
-          { id: 1, code: "phd", name: "博士獎學金", application_cycle: "semester" } as never,
-          { id: 2, code: "undergrad", name: "學士新生", application_cycle: "yearly" } as never,
+          {
+            id: 1,
+            code: "phd",
+            name: "博士獎學金",
+            application_cycle: "semester",
+          } as never,
+          {
+            id: 2,
+            code: "undergrad",
+            name: "學士新生",
+            application_cycle: "yearly",
+          } as never,
         ]}
-      />,
+      />
     );
     expect(screen.getByRole("tab", { name: "博士獎學金" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "學士新生" })).toBeInTheDocument();
   });
 
-  it("fetches available years from the API on mount", async () => {
+  // broken mock harness: `@/lib/api` pulls in `openapi-fetch` (ESM-only) via
+  // lib/api/typed-client.ts. Under NODE_OPTIONS="--experimental-require-module"
+  // the whole api subtree loads through native ESM, so jest's CJS mock registry
+  // never substitutes it — the component imports the real `api` and the spies
+  // below see 0 calls (verified: `imported !== jest.requireMock("@/lib/api").api`).
+  // These cannot pass without a jest.config/harness change, which is out of scope.
+  it.skip("fetches available years from the API on mount", async () => {
     render(
       <AdminRuleManagement
         scholarshipTypes={[
-          { id: 1, code: "phd", name: "博士獎學金", application_cycle: "semester" } as never,
+          {
+            id: 1,
+            code: "phd",
+            name: "博士獎學金",
+            application_cycle: "semester",
+          } as never,
         ]}
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -99,7 +134,9 @@ describe.skip("AdminRuleManagement", () => {
     });
   });
 
-  it("fetches rules for the active scholarship type when one is selected", async () => {
+  // broken mock harness — see note above (`@/lib/api` loads via native ESM,
+  // jest mock not applied, spy sees 0 calls).
+  it.skip("fetches rules for the active scholarship type when one is selected", async () => {
     mockGetScholarshipRules.mockResolvedValue({
       success: true,
       data: [
@@ -110,9 +147,14 @@ describe.skip("AdminRuleManagement", () => {
     render(
       <AdminRuleManagement
         scholarshipTypes={[
-          { id: 1, code: "phd", name: "博士獎學金", application_cycle: "semester" } as never,
+          {
+            id: 1,
+            code: "phd",
+            name: "博士獎學金",
+            application_cycle: "semester",
+          } as never,
         ]}
-      />,
+      />
     );
 
     // Wait for the auto-selection + fetch to settle.
@@ -121,7 +163,9 @@ describe.skip("AdminRuleManagement", () => {
     });
   });
 
-  it("does not crash if the years endpoint rejects", async () => {
+  // broken mock harness — see note above. (Asserts `mockGetAvailableYears`
+  // was called, which the dead mock never registers.)
+  it.skip("does not crash if the years endpoint rejects", async () => {
     // The "years" API failure used to silently break the year selector;
     // pin that the component still renders the tab list and doesn't
     // unmount on the error.
@@ -130,9 +174,14 @@ describe.skip("AdminRuleManagement", () => {
     render(
       <AdminRuleManagement
         scholarshipTypes={[
-          { id: 1, code: "phd", name: "博士獎學金", application_cycle: "semester" } as never,
+          {
+            id: 1,
+            code: "phd",
+            name: "博士獎學金",
+            application_cycle: "semester",
+          } as never,
         ]}
-      />,
+      />
     );
 
     // Tabs render regardless of the years-fetch outcome.
@@ -144,7 +193,9 @@ describe.skip("AdminRuleManagement", () => {
     });
   });
 
-  it("does not crash if the rules endpoint returns an unsuccessful response", async () => {
+  // broken mock harness — see note above. (Asserts `mockGetScholarshipRules`
+  // was called, which the dead mock never registers.)
+  it.skip("does not crash if the rules endpoint returns an unsuccessful response", async () => {
     // Pin the soft-failure branch: production code maps a non-success
     // response to setRules([]), not an exception bubbling out.
     mockGetScholarshipRules.mockResolvedValue({
@@ -155,9 +206,14 @@ describe.skip("AdminRuleManagement", () => {
     render(
       <AdminRuleManagement
         scholarshipTypes={[
-          { id: 1, code: "phd", name: "博士獎學金", application_cycle: "semester" } as never,
+          {
+            id: 1,
+            code: "phd",
+            name: "博士獎學金",
+            application_cycle: "semester",
+          } as never,
         ]}
-      />,
+      />
     );
 
     await waitFor(() => {

--- a/frontend/components/__tests__/admin-scholarship-dashboard.test.tsx
+++ b/frontend/components/__tests__/admin-scholarship-dashboard.test.tsx
@@ -24,7 +24,8 @@ const mockRefetch = jest.fn();
 const mockUseScholarshipSpecificApplications = jest.fn();
 
 jest.mock("@/hooks/use-admin", () => ({
-  useScholarshipSpecificApplications: () => mockUseScholarshipSpecificApplications(),
+  useScholarshipSpecificApplications: () =>
+    mockUseScholarshipSpecificApplications(),
 }));
 
 jest.mock("@/hooks/use-scholarship-permissions", () => ({
@@ -56,10 +57,21 @@ jest.mock("@/lib/api", () => ({
 jest.mock("sonner", () => ({
   toast: { success: jest.fn(), error: jest.fn() },
 }));
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 1, role: "admin", name: "Test Admin" },
+    login: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
 
 const baseUser = { id: 1, role: "admin", name: "Test", nycu_id: "admin1" };
 
-describe.skip("AdminScholarshipDashboard", () => {
+describe("AdminScholarshipDashboard", () => {
   beforeEach(() => {
     mockRefetch.mockClear();
   });

--- a/frontend/components/__tests__/admin-scholarship-management-interface.test.tsx
+++ b/frontend/components/__tests__/admin-scholarship-management-interface.test.tsx
@@ -23,7 +23,7 @@ const mockGetFormConfig = jest.fn();
 const mockGetAll = jest.fn();
 const mockGetConfigurationWhitelist = jest.fn();
 
-jest.mock("@/lib/api", () => ({
+jest.mock("../../lib/api", () => ({
   __esModule: true,
   api: {
     applicationFields: {
@@ -42,7 +42,8 @@ jest.mock("@/lib/api", () => ({
       getAll: (...args: unknown[]) => mockGetAll(...args),
     },
     whitelist: {
-      getConfigurationWhitelist: (...args: unknown[]) => mockGetConfigurationWhitelist(...args),
+      getConfigurationWhitelist: (...args: unknown[]) =>
+        mockGetConfigurationWhitelist(...args),
       batchAddWhitelist: jest.fn(),
       batchRemoveWhitelist: jest.fn(),
       importWhitelistExcel: jest.fn(),
@@ -56,22 +57,39 @@ jest.mock("sonner", () => ({
   toast: { success: jest.fn(), error: jest.fn() },
 }));
 
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 1, role: "admin", name: "Test Admin" },
+    login: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 beforeEach(() => {
   // Hang the initial fetch so the component sits in loading state on first render.
   // Individual tests can re-mock to resolve.
   mockGetFormConfig.mockReturnValue(new Promise(() => {}));
   mockGetAll.mockResolvedValue({ success: true, data: [] });
-  mockGetConfigurationWhitelist.mockResolvedValue({ success: true, data: { students: [] } });
+  mockGetConfigurationWhitelist.mockResolvedValue({
+    success: true,
+    data: { students: [] },
+  });
 });
 
-describe.skip("AdminScholarshipManagementInterface", () => {
+describe("AdminScholarshipManagementInterface", () => {
   it("renders the loading copy while the form-config fetch is in flight", () => {
     render(<AdminScholarshipManagementInterface type="phd" />);
     expect(screen.getByText("載入設定中...")).toBeInTheDocument();
   });
 
   it("forwards the `type` prop to api.applicationFields.getFormConfig", async () => {
-    render(<AdminScholarshipManagementInterface type="undergraduate_freshman" />);
+    render(
+      <AdminScholarshipManagementInterface type="undergraduate_freshman" />
+    );
     await waitFor(() => {
       expect(mockGetFormConfig).toHaveBeenCalled();
     });

--- a/frontend/components/__tests__/batch-import-panel.test.tsx
+++ b/frontend/components/__tests__/batch-import-panel.test.tsx
@@ -25,6 +25,18 @@ const mockGetMyScholarships = jest.fn();
 const mockGetScholarshipPeriods = jest.fn();
 const mockGetHistory = jest.fn();
 
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 1, role: "admin", name: "Test Admin" },
+    login: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 jest.mock("@/lib/api", () => ({
   __esModule: true,
   apiClient: {
@@ -32,7 +44,8 @@ jest.mock("@/lib/api", () => ({
       getMyScholarships: (...args: unknown[]) => mockGetMyScholarships(...args),
     },
     referenceData: {
-      getScholarshipPeriods: (...args: unknown[]) => mockGetScholarshipPeriods(...args),
+      getScholarshipPeriods: (...args: unknown[]) =>
+        mockGetScholarshipPeriods(...args),
     },
     batchImport: {
       getHistory: (...args: unknown[]) => mockGetHistory(...args),
@@ -52,7 +65,7 @@ beforeEach(() => {
   mockGetHistory.mockResolvedValue({ success: true, data: [] });
 });
 
-describe.skip("BatchImportPanel", () => {
+describe("BatchImportPanel", () => {
   it("renders the Chinese upload section heading in default (zh) locale", async () => {
     render(<BatchImportPanel />);
     expect(await screen.findByText("批次匯入申請資料")).toBeInTheDocument();
@@ -60,10 +73,20 @@ describe.skip("BatchImportPanel", () => {
 
   it("renders the English upload section heading when locale='en'", async () => {
     render(<BatchImportPanel locale="en" />);
-    expect(await screen.findByText("Batch Import Applications")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Batch Import Applications")
+    ).toBeInTheDocument();
   });
 
-  it("triggers getMyScholarships and getHistory on mount", async () => {
+  // broken mock harness — `@/lib/api` loads via native ESM (the
+  // `--experimental-require-module` node flag this repo runs jest under),
+  // so jest.mock("@/lib/api") does not intercept the component's import and
+  // the spy sees 0 calls even though the mount effect runs. The component
+  // instead resolves through the real apiClient + the global fetch mock,
+  // which is why the render-based tests above still pass. Fixing this needs
+  // a jest.config/setup change (out of scope here). Same limitation is
+  // documented in admin-rule-management.test.tsx and other admin tests.
+  it.skip("triggers getMyScholarships and getHistory on mount", async () => {
     render(<BatchImportPanel />);
     await waitFor(() => {
       expect(mockGetMyScholarships).toHaveBeenCalled();

--- a/frontend/components/__tests__/enhanced-admin-dashboard.test.tsx
+++ b/frontend/components/__tests__/enhanced-admin-dashboard.test.tsx
@@ -20,10 +20,32 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { EnhancedAdminDashboard } from "../enhanced-admin-dashboard";
 
+jest.mock("@/hooks/use-auth", () => ({
+  __esModule: true,
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 1, role: "admin", name: "Test Admin" },
+    login: jest.fn(),
+    logout: jest.fn(),
+    isLoading: false,
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 jest.mock("@/lib/api", () => ({
   __esModule: true,
   api: {
     request: jest.fn(),
+  },
+  apiClient: {
+    admin: {
+      getDashboardStats: jest
+        .fn()
+        .mockResolvedValue({ success: true, data: null }),
+      getRecentApplications: jest
+        .fn()
+        .mockResolvedValue({ success: true, data: [] }),
+    },
   },
 }));
 
@@ -33,11 +55,19 @@ jest.mock("../semester-selector", () => ({
 }));
 
 jest.mock("@/lib/utils/application-helpers", () => ({
-  getDisplayStatusInfo: () => ({ statusLabel: "已提交", statusVariant: "default" }),
+  getDisplayStatusInfo: () => ({
+    statusLabel: "已提交",
+    statusVariant: "default",
+  }),
 }));
 
 const baseProps = {
-  stats: { total_applications: 10, pending_review: 4, approved: 5, rejected: 1 },
+  stats: {
+    total_applications: 10,
+    pending_review: 4,
+    approved: 5,
+    rejected: 1,
+  },
   recentApplications: [] as any[],
   systemAnnouncements: [] as any[],
   isStatsLoading: false,
@@ -53,9 +83,11 @@ const baseProps = {
   onTabChange: jest.fn(),
 };
 
-describe.skip("EnhancedAdminDashboard", () => {
+describe("EnhancedAdminDashboard", () => {
   it("short-circuits to the error card when error is set", () => {
-    render(<EnhancedAdminDashboard {...baseProps} error="Service unavailable" />);
+    render(
+      <EnhancedAdminDashboard {...baseProps} error="Service unavailable" />
+    );
     expect(screen.getByText("載入錯誤")).toBeInTheDocument();
     expect(screen.getByText("Service unavailable")).toBeInTheDocument();
     // The semester selector is NOT rendered on the error path.
@@ -69,7 +101,7 @@ describe.skip("EnhancedAdminDashboard", () => {
         {...baseProps}
         error="Service unavailable"
         fetchDashboardStats={fetchDashboardStats}
-      />,
+      />
     );
     fireEvent.click(screen.getByRole("button", { name: "重新載入" }));
     expect(fetchDashboardStats).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## What

Un-skips 7 `describe.skip`'d admin/dashboard jest suites, recovering **45 previously-dark tests**.

The skip comments blamed a broken `jest.mock("@/lib/api")`, but the real blocker was child components calling the `useAuth` hook, which throws `useAuth must be used within AuthProvider` with no provider in the test. The fix is a per-suite `jest.mock("@/hooks/use-auth", ...)` plus repairs to stale assertions / incomplete api mocks.

| Suite | Result |
|---|---|
| admin-dashboard | 13 passed |
| enhanced-admin-dashboard | 4 passed |
| admin-rule-management | 2 passed, 4 skipped |
| admin-scholarship-dashboard | 4 passed |
| admin-scholarship-management-interface | 3 passed |
| admin-configuration-management | 17 passed, 3 skipped |
| batch-import-panel | 2 passed, 1 skipped |

**45 passed, 8 skipped** across the 7 suites (run together).

## The 8 remaining skips

These are api-call-assertion tests where `jest.mock("@/lib/api")` isn't intercepted under the local node 22.1 `--experimental-require-module` flag (native-ESM load bypasses jest's CJS module-registry). It's a **harness limitation, not a product bug** — documented inline. A follow-up can switch the mock to `jest.unstable_mockModule`/vm-modules or transform `@/lib/api` to CJS. No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)