### PR TITLE
fix(review): show reviewers only sub-types the student applied for

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2595,8 +2595,12 @@ class ApplicationService:
         Filtering rules (additive — stricter as the role moves through the
         review chain):
 
-        - All callers: only ``is_active=True`` sub-type configs.
-        - ``professor``: returns every active sub-type (full set).
+        - All callers: only ``is_active=True`` sub-type configs that the
+          applicant actually applied for (``Application.scholarship_subtype_list``).
+          Reviewers must never see sub-types the student didn't request — and
+          this keeps the form in sync with the submit-time permission check in
+          ``ReviewService.get_reviewable_subtypes``.
+        - ``professor``: returns every applied active sub-type.
         - ``college``: also excludes sub-types where any professor has
           recommended ``reject`` on the application.
         - ``admin`` / ``super_admin``: also excludes sub-types where any
@@ -2626,7 +2630,17 @@ class ApplicationService:
         if not application.scholarship or not application.scholarship.sub_type_configs:
             return []
 
-        active_configs = [c for c in application.scholarship.sub_type_configs if c.is_active]
+        # Only sub-types the applicant actually applied for. An empty applied
+        # list (single-mode / "general" application) -> empty list, so the
+        # frontend falls back to its single "default" recommendation form.
+        # Normalized to match the lowercase/stripped convention used by
+        # ReviewService.get_reviewable_subtypes (the submit-time gate).
+        applied_codes = {
+            code.lower().strip() for code in (application.scholarship_subtype_list or []) if isinstance(code, str)
+        }
+        active_configs = [
+            c for c in application.scholarship.sub_type_configs if c.is_active and c.sub_type_code in applied_codes
+        ]
 
         async def _rejected_by_role(role: UserRole) -> set[str]:
             """sub_type_codes rejected by any reviewer of the given role on this application."""

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2639,7 +2639,9 @@ class ApplicationService:
             code.lower().strip() for code in (application.scholarship_subtype_list or []) if isinstance(code, str)
         }
         active_configs = [
-            c for c in application.scholarship.sub_type_configs if c.is_active and c.sub_type_code in applied_codes
+            c
+            for c in application.scholarship.sub_type_configs
+            if c.is_active and (c.sub_type_code or "").lower().strip() in applied_codes
         ]
 
         async def _rejected_by_role(role: UserRole) -> set[str]:

--- a/backend/app/tests/test_application_available_sub_types_service.py
+++ b/backend/app/tests/test_application_available_sub_types_service.py
@@ -126,3 +126,52 @@ class TestGetApplicationAvailableSubTypes:
         result = await service.get_application_available_sub_types(app.id, prof)
 
         assert result == []
+
+    async def test_college_excludes_professor_rejected_within_applied(self, db: AsyncSession):
+        """College sees applied sub-types minus the ones a professor rejected.
+
+        Composition of the two filters: student applied for {nstc, moe_1w}
+        (moe_2w configured but not applied), professor rejected nstc → college
+        sees only moe_1w. moe_2w stays hidden because it was never applied for.
+        """
+        from datetime import datetime, timezone
+
+        from app.models.review import ApplicationReview, ApplicationReviewItem
+
+        scholarship = await _scholarship_with_configs(db, ["nstc", "moe_1w", "moe_2w"])
+        prof = await _professor(db)
+        app = await _application(db, scholarship=scholarship, applied=["nstc", "moe_1w"])
+
+        # Professor rejects the applied sub-type "nstc".
+        review = ApplicationReview(
+            application_id=app.id,
+            reviewer_id=prof.id,
+            recommendation="reject",
+            reviewed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        db.add(review)
+        await db.flush()
+        db.add(
+            ApplicationReviewItem(
+                review_id=review.id,
+                sub_type_code="nstc",
+                recommendation="reject",
+                comments="不符合",
+            )
+        )
+        await db.flush()
+
+        college = User(
+            nycu_id="college_subtype",
+            name="學院",
+            email="college@nycu.edu.tw",
+            user_type=UserType.employee,
+            role=UserRole.college,
+        )
+        db.add(college)
+        await db.flush()
+
+        service = ApplicationService(db)
+        result = await service.get_application_available_sub_types(app.id, college)
+
+        assert {row["value"] for row in result} == {"moe_1w"}

--- a/backend/app/tests/test_application_available_sub_types_service.py
+++ b/backend/app/tests/test_application_available_sub_types_service.py
@@ -1,0 +1,128 @@
+"""DB-aware tests for ApplicationService.get_application_available_sub_types.
+
+Guards the fix for "教授看到學生申請的獎學金子類別會看到沒申請的": reviewers
+must only see the sub-types the student actually applied for
+(``Application.scholarship_subtype_list``), never the full set of active
+configs on the scholarship type.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application, ApplicationStatus
+from app.models.scholarship import (
+    ScholarshipSubTypeConfig,
+    ScholarshipType,
+    SubTypeSelectionMode,
+)
+from app.models.user import User, UserRole, UserType
+from app.services.application_service import ApplicationService
+
+
+async def _scholarship_with_configs(db: AsyncSession, codes: list[str]) -> ScholarshipType:
+    """A ScholarshipType with one active sub-type config per code."""
+    scholarship = ScholarshipType(
+        code="subtype_visibility_test",
+        name="Test",
+        sub_type_selection_mode=SubTypeSelectionMode.multiple,
+        status="active",
+    )
+    db.add(scholarship)
+    await db.flush()
+
+    for order, code in enumerate(codes):
+        db.add(
+            ScholarshipSubTypeConfig(
+                scholarship_type_id=scholarship.id,
+                sub_type_code=code,
+                name=f"子類-{code}",
+                name_en=code.upper(),
+                display_order=order,
+                is_active=True,
+            )
+        )
+    await db.flush()
+    await db.refresh(scholarship, attribute_names=["sub_type_configs"])
+    return scholarship
+
+
+async def _professor(db: AsyncSession) -> User:
+    prof = User(
+        nycu_id="prof_subtype",
+        name="教授",
+        email="prof@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.professor,
+    )
+    db.add(prof)
+    await db.flush()
+    return prof
+
+
+async def _application(
+    db: AsyncSession,
+    *,
+    scholarship: ScholarshipType,
+    applied: list[str],
+) -> Application:
+    student = User(
+        nycu_id="310460099",
+        name="王小明",
+        email="student@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(student)
+    await db.flush()
+
+    app = Application(
+        app_id="APP-114-0-09999",
+        user_id=student.id,
+        scholarship_type_id=scholarship.id,
+        academic_year=114,
+        semester=None,
+        status=ApplicationStatus.submitted,
+        sub_type_selection_mode=SubTypeSelectionMode.multiple,
+        scholarship_subtype_list=applied,
+    )
+    db.add(app)
+    await db.flush()
+    return app
+
+
+@pytest.mark.asyncio
+class TestGetApplicationAvailableSubTypes:
+    async def test_professor_sees_only_applied_subtypes(self, db: AsyncSession):
+        """Scholarship has 3 active configs; student applied for 2 → prof sees 2."""
+        scholarship = await _scholarship_with_configs(db, ["nstc", "moe_1w", "moe_2w"])
+        prof = await _professor(db)
+        app = await _application(db, scholarship=scholarship, applied=["nstc", "moe_1w"])
+
+        service = ApplicationService(db)
+        result = await service.get_application_available_sub_types(app.id, prof)
+
+        codes = {row["value"] for row in result}
+        assert codes == {"nstc", "moe_1w"}
+        assert "moe_2w" not in codes  # not applied for — must be hidden
+
+    async def test_applied_codes_normalized_before_matching(self, db: AsyncSession):
+        """Mixed-case / whitespace applied codes still match lowercase configs."""
+        scholarship = await _scholarship_with_configs(db, ["nstc", "moe_1w"])
+        prof = await _professor(db)
+        app = await _application(db, scholarship=scholarship, applied=["  NSTC ", "Moe_1w"])
+
+        service = ApplicationService(db)
+        result = await service.get_application_available_sub_types(app.id, prof)
+
+        assert {row["value"] for row in result} == {"nstc", "moe_1w"}
+
+    async def test_empty_applied_list_returns_empty(self, db: AsyncSession):
+        """No applied sub-types → empty list (frontend falls back to default form)."""
+        scholarship = await _scholarship_with_configs(db, ["nstc", "moe_1w"])
+        prof = await _professor(db)
+        app = await _application(db, scholarship=scholarship, applied=[])
+
+        service = ApplicationService(db)
+        result = await service.get_application_available_sub_types(app.id, prof)
+
+        assert result == []


### PR DESCRIPTION
## Problem

教授（及學院 / 管理員）審查時，會在子類別清單中看到學生**沒有申請**的子類別。

`ApplicationService.get_application_available_sub_types`（`GET /professor/applications/{id}/sub-types` 背後的方法，`professor-review-component.tsx` 與 `common/ApplicationReviewDialog.tsx` 都用它載入表單）遍歷該獎學金類型的**所有** active `sub_type_configs`，完全忽略學生實際申請的清單。

這也與送出時的權限閘 `ReviewService.get_reviewable_subtypes` 不一致 —— 後者依 `Application.scholarship_subtype_list`（學生申請清單）過濾。表單顯示多餘子類別，實際送出未申請的子類別會被 403 擋下。

## Fix

`backend/app/services/application_service.py` — 將 `active_configs` 限縮為 `application.scholarship_subtype_list` 內的代碼，並正規化為小寫/去空白以對齊送出閘。空的申請清單回傳 `[]`，前端 fallback 回單一 "default" 推薦表單。

純後端修改，所有共用此方法的審查角色（professor / college / admin）一併修正。

## Test

新增 `backend/app/tests/test_application_available_sub_types_service.py`：

- 學生申請 2/3 個子類別 → 教授只看到該 2 個
- 大小寫 / 空白的申請代碼仍正確比對
- 空申請清單 → 回傳 `[]`

驗證：
- 新測試 3 passed
- `test_professor_endpoints.py` + `test_application_subtype_submission_guard.py` 30 passed，無回歸
- black clean、flake8 `B904,B014` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
