### PR TITLE
feat: include all student-uploaded documents in college 申請資料 ZIP export

### DIFF
--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -77,6 +77,30 @@ def _ext_for_application_document(original_filename: Optional[str], object_name:
     return ""
 
 
+def _application_document_entry(
+    object_name: Optional[str],
+    original_filename: Optional[str],
+    base_path: str,
+    student_prefix: str,
+) -> Optional[Dict[str, str]]:
+    """Describe where the student-uploaded 申請文件 goes in the ZIP.
+
+    Returns None when the application has no 申請文件. Otherwise returns the
+    kwargs for `_fetch_and_write`: the source object name, the sanitized ZIP
+    path, the error-placeholder path, and a human label for the error text.
+    """
+    if not object_name:
+        return None
+    ext = _ext_for_application_document(original_filename, object_name)
+    filename = _sanitize_filename(f"{student_prefix}_申請文件{ext}")
+    return {
+        "object_name": object_name,
+        "zip_path": f"{base_path}/{filename}",
+        "error_path": f"{base_path}/_錯誤_找不到檔案_申請文件.txt",
+        "error_label": original_filename or object_name,
+    }
+
+
 CJK_FONT_PATH = "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc"
 _font_registered = False
 

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -312,6 +312,17 @@ class ExportPackageService:
                 error_label=af.original_filename or af.object_name,
             )
 
+        # Student-uploaded 申請文件 — stored on the application itself,
+        # not as an ApplicationFile, so the app.files loop above misses it.
+        entry = _application_document_entry(
+            app.application_document_url,
+            app.application_document_original_filename,
+            base_path,
+            student_prefix,
+        )
+        if entry:
+            await _fetch_and_write(zf, self.minio, **entry)
+
     def _generate_summary_pdf(
         self,
         app: Application,

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -101,6 +101,32 @@ def _application_document_entry(
     }
 
 
+async def _fetch_and_write(
+    zf: zipfile.ZipFile,
+    minio: MinIOService,
+    object_name: str,
+    zip_path: str,
+    error_path: str,
+    error_label: str,
+) -> None:
+    """Stream one MinIO object into the ZIP at `zip_path`.
+
+    On any failure, writes a `_錯誤_…txt` placeholder at `error_path`
+    instead so a single bad object never aborts the whole ZIP build.
+    """
+    try:
+        response = await asyncio.to_thread(minio.get_file_stream, object_name)
+        try:
+            file_bytes = await asyncio.to_thread(response.read)
+        finally:
+            response.close()
+            response.release_conn()
+        zf.writestr(zip_path, file_bytes)
+    except Exception as e:
+        logger.exception(f"Failed to fetch file {object_name}")
+        zf.writestr(error_path, f"檔案下載失敗：{error_label}\n錯誤：{str(e)}")
+
+
 CJK_FONT_PATH = "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc"
 _font_registered = False
 
@@ -277,20 +303,14 @@ class ExportPackageService:
             else:
                 filename = f"{student_prefix}_{label}{ext}"
 
-            try:
-                response = await asyncio.to_thread(self.minio.get_file_stream, af.object_name)
-                try:
-                    file_bytes = await asyncio.to_thread(response.read)
-                finally:
-                    response.close()
-                    response.release_conn()
-                zf.writestr(f"{base_path}/{_sanitize_filename(filename)}", file_bytes)
-            except Exception as e:
-                logger.exception(f"Failed to fetch file {af.object_name} for app {app.id}")
-                zf.writestr(
-                    f"{base_path}/_錯誤_找不到檔案_{_sanitize_filename(label)}.txt",
-                    f"檔案下載失敗：{af.original_filename or af.object_name}\n錯誤：{str(e)}",
-                )
+            await _fetch_and_write(
+                zf,
+                self.minio,
+                object_name=af.object_name,
+                zip_path=f"{base_path}/{_sanitize_filename(filename)}",
+                error_path=f"{base_path}/_錯誤_找不到檔案_{_sanitize_filename(label)}.txt",
+                error_label=af.original_filename or af.object_name,
+            )
 
     def _generate_summary_pdf(
         self,

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -62,6 +62,21 @@ def _sanitize_filename(name: str) -> str:
     return re.sub(r'[/\\:*?"<>|]', "_", name).strip()
 
 
+def _ext_for_application_document(original_filename: Optional[str], object_name: str) -> str:
+    """Extension (with leading dot) for the student-uploaded 申請文件.
+
+    Prefers the original filename's extension, falls back to the stored
+    object name's suffix. Only the last path segment is inspected, so a dot
+    in a directory name is never mistaken for an extension.
+    """
+    for source in (original_filename, object_name):
+        if source:
+            last_segment = source.rsplit("/", 1)[-1]
+            if "." in last_segment:
+                return "." + last_segment.rsplit(".", 1)[1]
+    return ""
+
+
 CJK_FONT_PATH = "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc"
 _font_registered = False
 

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -46,6 +46,7 @@ FILE_TYPE_LABELS: Dict[str, str] = {
     "insurance_record": "投保紀錄",
     "agreement": "切結書",
     "bank_account_cover": "存摺封面",
+    "bank_account_proof": "存摺封面",  # value actually stored on the cloned passbook ApplicationFile
     "other": "其他文件",
 }
 

--- a/backend/app/tests/test_export_package_pure_helpers.py
+++ b/backend/app/tests/test_export_package_pure_helpers.py
@@ -23,6 +23,7 @@ import pytest
 from app.services.export_package_service import (
     _sanitize_filename,
     _ext_for_application_document,
+    _application_document_entry,
     FILE_TYPE_LABELS,
     DEGREE_LABELS,
 )
@@ -191,3 +192,38 @@ class TestExtForApplicationDocument:
         # A dot in a directory segment must not be treated as the
         # file extension — only the last path segment counts.
         assert _ext_for_application_document(None, "v1.2/objectname") == ""
+
+
+class TestApplicationDocumentEntry:
+    """Pin: descriptor for placing the student-uploaded 申請文件 into
+    the ZIP. Returns None when the application has no 申請文件."""
+
+    def test_returns_none_when_no_object_name(self):
+        assert _application_document_entry(None, "x.pdf", "117_資工系", "310_王小明") is None
+
+    def test_returns_none_when_object_name_empty(self):
+        assert _application_document_entry("", "x.pdf", "117_資工系", "310_王小明") is None
+
+    def test_builds_entry_with_expected_paths(self):
+        entry = _application_document_entry(
+            "application-documents/12_x.pdf",
+            "申請文件.pdf",
+            "117_資工系",
+            "310_王小明",
+        )
+        assert entry == {
+            "object_name": "application-documents/12_x.pdf",
+            "zip_path": "117_資工系/310_王小明_申請文件.pdf",
+            "error_path": "117_資工系/_錯誤_找不到檔案_申請文件.txt",
+            "error_label": "申請文件.pdf",
+        }
+
+    def test_error_label_falls_back_to_object_name(self):
+        entry = _application_document_entry("application-documents/12_x.pdf", None, "117_資工系", "310_王小明")
+        assert entry["error_label"] == "application-documents/12_x.pdf"
+
+    def test_zip_filename_is_sanitized(self):
+        # A student name containing a path separator must not escape
+        # the student folder (ZIP path-traversal guard).
+        entry = _application_document_entry("application-documents/12_x.pdf", "x.pdf", "117_資工系", "310_a/b")
+        assert "/" not in entry["zip_path"].rsplit("/", 1)[-1]

--- a/backend/app/tests/test_export_package_pure_helpers.py
+++ b/backend/app/tests/test_export_package_pure_helpers.py
@@ -98,11 +98,11 @@ class TestFileTypeLabels:
     """Pin: FILE_TYPE_LABELS — zh-TW labels for 8 file types.
     Used by the export PDF and ZIP folder naming."""
 
-    def test_all_8_known_file_types_present(self):
-        # Pin: exactly 8 file types. Pin so adding a new file_type
-        # without a label silently labels it as the dict's KeyError
-        # behavior in the export pipeline (currently uses .get()
-        # with default but the missing label would surface in PDFs).
+    def test_all_9_known_file_types_present(self):
+        # Pin: exactly 9 file types. bank_account_proof is the
+        # value actually stored on the cloned passbook
+        # ApplicationFile (application_service.py:2118); it must
+        # have a label or it falls through to the 其他文件 default.
         expected_keys = {
             "transcript",
             "research_proposal",
@@ -111,6 +111,7 @@ class TestFileTypeLabels:
             "insurance_record",
             "agreement",
             "bank_account_cover",
+            "bank_account_proof",
             "other",
         }
         assert set(FILE_TYPE_LABELS.keys()) == expected_keys
@@ -124,6 +125,12 @@ class TestFileTypeLabels:
         # doesn't change to 銀行帳戶 which would mismatch the
         # admin UI's existing strings.
         assert FILE_TYPE_LABELS["bank_account_cover"] == "存摺封面"
+
+    def test_bank_account_proof_label(self):
+        # Pin: the cloned passbook's real file_type
+        # (bank_account_proof) maps to 存摺封面 so it stops landing
+        # under 其他文件 in the export ZIP.
+        assert FILE_TYPE_LABELS["bank_account_proof"] == "存摺封面"
 
     def test_all_labels_are_non_empty_chinese(self):
         # Pin: every label is non-empty and contains CJK chars.

--- a/backend/app/tests/test_export_package_pure_helpers.py
+++ b/backend/app/tests/test_export_package_pure_helpers.py
@@ -24,6 +24,7 @@ from app.services.export_package_service import (
     _sanitize_filename,
     _ext_for_application_document,
     _application_document_entry,
+    _fetch_and_write,
     FILE_TYPE_LABELS,
     DEGREE_LABELS,
 )
@@ -227,3 +228,72 @@ class TestApplicationDocumentEntry:
         # the student folder (ZIP path-traversal guard).
         entry = _application_document_entry("application-documents/12_x.pdf", "x.pdf", "117_資工系", "310_a/b")
         assert "/" not in entry["zip_path"].rsplit("/", 1)[-1]
+
+
+class TestFetchAndWrite:
+    """Pin: the shared MinIO fetch-and-write used by both the
+    app.files loop and the 申請文件. On success the bytes land at
+    zip_path; on any MinIO error a placeholder .txt lands at
+    error_path instead (the ZIP build never aborts)."""
+
+    def test_success_writes_bytes_and_releases_connection(self):
+        import asyncio
+        import io
+        import zipfile
+        from unittest.mock import MagicMock
+
+        fake_response = MagicMock()
+        fake_response.read.return_value = b"PDF-BYTES"
+        minio = MagicMock()
+        minio.get_file_stream.return_value = fake_response
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            asyncio.run(
+                _fetch_and_write(
+                    zf,
+                    minio,
+                    object_name="application-documents/12_x.pdf",
+                    zip_path="dept/stu/stu_申請文件.pdf",
+                    error_path="dept/stu/_錯誤_找不到檔案_申請文件.txt",
+                    error_label="申請文件.pdf",
+                )
+            )
+
+        buf.seek(0)
+        with zipfile.ZipFile(buf) as zf:
+            assert zf.read("dept/stu/stu_申請文件.pdf") == b"PDF-BYTES"
+            assert "dept/stu/_錯誤_找不到檔案_申請文件.txt" not in zf.namelist()
+        fake_response.close.assert_called_once()
+        fake_response.release_conn.assert_called_once()
+
+    def test_failure_writes_error_placeholder(self):
+        import asyncio
+        import io
+        import zipfile
+        from unittest.mock import MagicMock
+
+        minio = MagicMock()
+        minio.get_file_stream.side_effect = Exception("object missing")
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            asyncio.run(
+                _fetch_and_write(
+                    zf,
+                    minio,
+                    object_name="application-documents/12_x.pdf",
+                    zip_path="dept/stu/stu_申請文件.pdf",
+                    error_path="dept/stu/_錯誤_找不到檔案_申請文件.txt",
+                    error_label="申請文件.pdf",
+                )
+            )
+
+        buf.seek(0)
+        with zipfile.ZipFile(buf) as zf:
+            names = zf.namelist()
+            assert "dept/stu/stu_申請文件.pdf" not in names
+            assert "dept/stu/_錯誤_找不到檔案_申請文件.txt" in names
+            content = zf.read("dept/stu/_錯誤_找不到檔案_申請文件.txt").decode("utf-8")
+            assert "object missing" in content
+            assert "申請文件.pdf" in content

--- a/backend/app/tests/test_export_package_pure_helpers.py
+++ b/backend/app/tests/test_export_package_pure_helpers.py
@@ -22,6 +22,7 @@ import pytest
 
 from app.services.export_package_service import (
     _sanitize_filename,
+    _ext_for_application_document,
     FILE_TYPE_LABELS,
     DEGREE_LABELS,
 )
@@ -164,3 +165,29 @@ class TestDegreeLabels:
         # is explicit.
         for key in DEGREE_LABELS:
             assert isinstance(key, str), f"DEGREE_LABELS key {key!r} is not str"
+
+
+class TestExtForApplicationDocument:
+    """Pin: extension derivation for the student-uploaded 申請文件.
+    Prefers the original filename's extension, falls back to the
+    stored MinIO object name's suffix."""
+
+    def test_uses_original_filename_extension(self):
+        assert _ext_for_application_document("申請文件.pdf", "application-documents/12_x.pdf") == ".pdf"
+
+    def test_original_filename_extension_wins_over_object_name(self):
+        assert _ext_for_application_document("draft.docx", "application-documents/12_x.pdf") == ".docx"
+
+    def test_falls_back_to_object_name_when_no_original(self):
+        assert _ext_for_application_document(None, "application-documents/12_x.pdf") == ".pdf"
+
+    def test_empty_original_falls_back_to_object_name(self):
+        assert _ext_for_application_document("", "application-documents/12_x.pdf") == ".pdf"
+
+    def test_returns_empty_when_no_extension_anywhere(self):
+        assert _ext_for_application_document("noext", "application-documents/12_x") == ""
+
+    def test_directory_dot_not_mistaken_for_extension(self):
+        # A dot in a directory segment must not be treated as the
+        # file extension — only the last path segment counts.
+        assert _ext_for_application_document(None, "v1.2/objectname") == ""

--- a/docs/superpowers/plans/2026-06-09-college-export-all-student-documents.md
+++ b/docs/superpowers/plans/2026-06-09-college-export-all-student-documents.md
@@ -1,0 +1,686 @@
+# Include All Student-Uploaded Documents in College 申請資料 ZIP — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the college 申請資料 ZIP export bundle every student-uploaded document — add the missing 申請文件 (`application_document_url`) and correctly label the cloned 存摺封面.
+
+**Architecture:** All changes live in one backend service module, `backend/app/services/export_package_service.py`. We add three module-level pure helpers (extension derivation, the 申請文件 ZIP-entry descriptor, and a MinIO fetch-and-write), refactor the existing `app.files` loop to use the fetch helper (behavior preserved), then append the 申請文件 to each student's folder by composing the helpers. The query already loads everything needed — no DB/query/schema/API/frontend changes.
+
+**Tech Stack:** Python 3, FastAPI, SQLAlchemy (async), MinIO, reportlab, pytest. zh-TW UI strings.
+
+---
+
+## Background (read first)
+
+The ZIP builder `ExportPackageService._add_application_to_zip` currently writes, per student folder: a summary PDF, then every `ApplicationFile` in `app.files`. Two student-uploaded sources are wrong:
+
+1. **申請文件 missing.** `POST /applications/{id}/application-document` (`backend/app/api/v1/endpoints/applications.py:937`, `require_student`) stores a student-uploaded PDF on `application.application_document_url` + `application.application_document_original_filename` — **not** as an `ApplicationFile`. The ZIP never reads it.
+2. **存摺封面 mislabeled.** The cloned passbook is an `ApplicationFile` with `file_type = "bank_account_proof"` (`application_service.py:2118`), but `FILE_TYPE_LABELS` only maps `"bank_account_cover"`, so it falls through to the `"其他文件"` default.
+
+`MinIOService.get_file_stream(object_name)` reads from `self.default_bucket` — the same bucket the 申請文件 is written to — and raises `HTTPException(404)` (an `Exception` subclass) on a missing object, so the existing `except Exception` fallback already handles a missing 申請文件 gracefully.
+
+### Current code being refactored
+
+`backend/app/services/export_package_service.py`, inside `_add_application_to_zip`, the per-file block (≈ lines 217–253) currently inlines the MinIO fetch + write + error fallback:
+
+```python
+        # Add uploaded files from ApplicationFile records
+        type_totals = Counter(af.file_type or "other" for af in app.files)
+        file_type_counter: Dict[str, int] = defaultdict(int)
+        for af in app.files:
+            ft = af.file_type or "other"
+            file_type_counter[ft] += 1
+            count = file_type_counter[ft]
+            label = FILE_TYPE_LABELS.get(ft, "其他文件")
+
+            # Determine file extension from original filename or mime_type
+            ext = ""
+            if af.original_filename and "." in af.original_filename:
+                ext = "." + af.original_filename.rsplit(".", 1)[1]
+            elif af.mime_type and "/" in af.mime_type:
+                ext_map = {"application/pdf": ".pdf", "image/jpeg": ".jpg", "image/png": ".png"}
+                ext = ext_map.get(af.mime_type, "")
+
+            # Add sequence number only if multiple files of same type
+            if type_totals[ft] > 1:
+                filename = f"{student_prefix}_{label}_{count}{ext}"
+            else:
+                filename = f"{student_prefix}_{label}{ext}"
+
+            try:
+                response = await asyncio.to_thread(self.minio.get_file_stream, af.object_name)
+                try:
+                    file_bytes = await asyncio.to_thread(response.read)
+                finally:
+                    response.close()
+                    response.release_conn()
+                zf.writestr(f"{base_path}/{_sanitize_filename(filename)}", file_bytes)
+            except Exception as e:
+                logger.exception(f"Failed to fetch file {af.object_name} for app {app.id}")
+                zf.writestr(
+                    f"{base_path}/_錯誤_找不到檔案_{_sanitize_filename(label)}.txt",
+                    f"檔案下載失敗：{af.original_filename or af.object_name}\n錯誤：{str(e)}",
+                )
+```
+
+### Test-suite routing (important)
+
+CI splits tests: the **unit** suite runs `app/tests/test_*.py -m "not integration and not asyncio"`; the **integration** suite runs only `app/tests/test_*_service*.py -m "integration or asyncio"`. `test_export_package_pure_helpers.py` does **not** match `*_service*`, so an `async def test_` there would be collected by **neither** suite and silently never run. **Rule for this plan: every test in that file stays a plain `def` (sync).** The one async helper is exercised by calling `asyncio.run(...)` inside a sync test.
+
+### Running the tests
+
+These are pure-import tests (no live DB). Run in the backend dev container:
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py -p no:cacheprovider -v
+```
+
+If the container mounts a different checkout than this worktree, run locally instead with the env vars from the `backend_local_pytest_env` memory note (`DATABASE_URL`, `DATABASE_URL_SYNC`, `SECRET_KEY`, `MINIO_*`) from `backend/`.
+
+### Lint gates (run before the final commit)
+
+```bash
+uvx --from "black==26.3.1" black --check --line-length=120 backend/app/services/export_package_service.py backend/app/tests/test_export_package_pure_helpers.py
+flake8 app --select=B904,B014 --max-line-length=120
+```
+
+---
+
+## File Structure
+
+- **Modify** `backend/app/services/export_package_service.py`
+  - `FILE_TYPE_LABELS` — add `"bank_account_proof": "存摺封面"`.
+  - New module-level `_ext_for_application_document(original_filename, object_name) -> str`.
+  - New module-level `_application_document_entry(object_name, original_filename, base_path, student_prefix) -> Optional[dict]`.
+  - New module-level `async _fetch_and_write(zf, minio, object_name, zip_path, error_path, error_label) -> None`.
+  - `_add_application_to_zip` — refactor the `app.files` loop to call `_fetch_and_write`; append the 申請文件 block.
+- **Modify** `backend/app/tests/test_export_package_pure_helpers.py`
+  - Update the `FILE_TYPE_LABELS` pin (8 → 9 keys) + add `bank_account_proof` label assertion.
+  - New tests for `_ext_for_application_document`, `_application_document_entry`, `_fetch_and_write`.
+
+---
+
+## Task 1: Fix the 存摺封面 label
+
+**Files:**
+- Modify: `backend/app/tests/test_export_package_pure_helpers.py` (class `TestFileTypeLabels`)
+- Modify: `backend/app/services/export_package_service.py` (`FILE_TYPE_LABELS`)
+
+- [ ] **Step 1: Update the pin test to expect the new key**
+
+In `backend/app/tests/test_export_package_pure_helpers.py`, replace the `test_all_8_known_file_types_present` method (inside `class TestFileTypeLabels`) with:
+
+```python
+    def test_all_9_known_file_types_present(self):
+        # Pin: exactly 9 file types. bank_account_proof is the
+        # value actually stored on the cloned passbook
+        # ApplicationFile (application_service.py:2118); it must
+        # have a label or it falls through to the 其他文件 default.
+        expected_keys = {
+            "transcript",
+            "research_proposal",
+            "recommendation_letter",
+            "certificate",
+            "insurance_record",
+            "agreement",
+            "bank_account_cover",
+            "bank_account_proof",
+            "other",
+        }
+        assert set(FILE_TYPE_LABELS.keys()) == expected_keys
+```
+
+Then, immediately after the existing `test_bank_account_cover_label` method, add:
+
+```python
+    def test_bank_account_proof_label(self):
+        # Pin: the cloned passbook's real file_type
+        # (bank_account_proof) maps to 存摺封面 so it stops landing
+        # under 其他文件 in the export ZIP.
+        assert FILE_TYPE_LABELS["bank_account_proof"] == "存摺封面"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py::TestFileTypeLabels -p no:cacheprovider -v
+```
+Expected: FAIL — `test_all_9_known_file_types_present` (set inequality: actual is missing `bank_account_proof`) and `test_bank_account_proof_label` (KeyError).
+
+- [ ] **Step 3: Add the label**
+
+In `backend/app/services/export_package_service.py`, change the `FILE_TYPE_LABELS` dict so the bank entry reads:
+
+```python
+    "bank_account_cover": "存摺封面",
+    "bank_account_proof": "存摺封面",  # value actually stored on the cloned passbook ApplicationFile
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py::TestFileTypeLabels -p no:cacheprovider -v
+```
+Expected: PASS (all `TestFileTypeLabels` tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/export_package_service.py backend/app/tests/test_export_package_pure_helpers.py
+git commit -m "fix: label cloned passbook as 存摺封面 in college 申請資料 ZIP"
+```
+
+---
+
+## Task 2: Add `_ext_for_application_document` pure helper
+
+**Files:**
+- Modify: `backend/app/tests/test_export_package_pure_helpers.py` (new test class + import)
+- Modify: `backend/app/services/export_package_service.py` (new module-level function)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `backend/app/tests/test_export_package_pure_helpers.py`, extend the import at the top of the file:
+
+```python
+from app.services.export_package_service import (
+    _sanitize_filename,
+    _ext_for_application_document,
+    FILE_TYPE_LABELS,
+    DEGREE_LABELS,
+)
+```
+
+Then add this new test class at the end of the file:
+
+```python
+class TestExtForApplicationDocument:
+    """Pin: extension derivation for the student-uploaded 申請文件.
+    Prefers the original filename's extension, falls back to the
+    stored MinIO object name's suffix."""
+
+    def test_uses_original_filename_extension(self):
+        assert (
+            _ext_for_application_document("申請文件.pdf", "application-documents/12_x.pdf")
+            == ".pdf"
+        )
+
+    def test_original_filename_extension_wins_over_object_name(self):
+        assert (
+            _ext_for_application_document("draft.docx", "application-documents/12_x.pdf")
+            == ".docx"
+        )
+
+    def test_falls_back_to_object_name_when_no_original(self):
+        assert (
+            _ext_for_application_document(None, "application-documents/12_x.pdf") == ".pdf"
+        )
+
+    def test_empty_original_falls_back_to_object_name(self):
+        assert (
+            _ext_for_application_document("", "application-documents/12_x.pdf") == ".pdf"
+        )
+
+    def test_returns_empty_when_no_extension_anywhere(self):
+        assert _ext_for_application_document("noext", "application-documents/12_x") == ""
+
+    def test_directory_dot_not_mistaken_for_extension(self):
+        # A dot in a directory segment must not be treated as the
+        # file extension — only the last path segment counts.
+        assert _ext_for_application_document(None, "v1.2/objectname") == ""
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py::TestExtForApplicationDocument -p no:cacheprovider -v
+```
+Expected: FAIL at import — `ImportError: cannot import name '_ext_for_application_document'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `backend/app/services/export_package_service.py`, add this module-level function directly below the existing `_sanitize_filename` function:
+
+```python
+def _ext_for_application_document(original_filename: Optional[str], object_name: str) -> str:
+    """Extension (with leading dot) for the student-uploaded 申請文件.
+
+    Prefers the original filename's extension, falls back to the stored
+    object name's suffix. Only the last path segment is inspected, so a dot
+    in a directory name is never mistaken for an extension.
+    """
+    for source in (original_filename, object_name):
+        if source:
+            last_segment = source.rsplit("/", 1)[-1]
+            if "." in last_segment:
+                return "." + last_segment.rsplit(".", 1)[1]
+    return ""
+```
+
+(`Optional` is already imported at the top of the module via `from typing import Dict, List, Optional, Tuple`.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py::TestExtForApplicationDocument -p no:cacheprovider -v
+```
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/export_package_service.py backend/app/tests/test_export_package_pure_helpers.py
+git commit -m "feat: add _ext_for_application_document helper for 申請文件 export"
+```
+
+---
+
+## Task 3: Add `_application_document_entry` pure helper
+
+**Files:**
+- Modify: `backend/app/tests/test_export_package_pure_helpers.py` (new test class + import)
+- Modify: `backend/app/services/export_package_service.py` (new module-level function)
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the import in `backend/app/tests/test_export_package_pure_helpers.py`:
+
+```python
+from app.services.export_package_service import (
+    _sanitize_filename,
+    _ext_for_application_document,
+    _application_document_entry,
+    FILE_TYPE_LABELS,
+    DEGREE_LABELS,
+)
+```
+
+Add this test class at the end of the file:
+
+```python
+class TestApplicationDocumentEntry:
+    """Pin: descriptor for placing the student-uploaded 申請文件 into
+    the ZIP. Returns None when the application has no 申請文件."""
+
+    def test_returns_none_when_no_object_name(self):
+        assert (
+            _application_document_entry(None, "x.pdf", "117_資工系", "310_王小明") is None
+        )
+
+    def test_returns_none_when_object_name_empty(self):
+        assert (
+            _application_document_entry("", "x.pdf", "117_資工系", "310_王小明") is None
+        )
+
+    def test_builds_entry_with_expected_paths(self):
+        entry = _application_document_entry(
+            "application-documents/12_x.pdf",
+            "申請文件.pdf",
+            "117_資工系",
+            "310_王小明",
+        )
+        assert entry == {
+            "object_name": "application-documents/12_x.pdf",
+            "zip_path": "117_資工系/310_王小明_申請文件.pdf",
+            "error_path": "117_資工系/_錯誤_找不到檔案_申請文件.txt",
+            "error_label": "申請文件.pdf",
+        }
+
+    def test_error_label_falls_back_to_object_name(self):
+        entry = _application_document_entry(
+            "application-documents/12_x.pdf", None, "117_資工系", "310_王小明"
+        )
+        assert entry["error_label"] == "application-documents/12_x.pdf"
+
+    def test_zip_filename_is_sanitized(self):
+        # A student name containing a path separator must not escape
+        # the student folder (ZIP path-traversal guard).
+        entry = _application_document_entry(
+            "application-documents/12_x.pdf", "x.pdf", "117_資工系", "310_a/b"
+        )
+        assert "/" not in entry["zip_path"].rsplit("/", 1)[-1]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py::TestApplicationDocumentEntry -p no:cacheprovider -v
+```
+Expected: FAIL at import — `ImportError: cannot import name '_application_document_entry'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `backend/app/services/export_package_service.py`, add this module-level function directly below `_ext_for_application_document`:
+
+```python
+def _application_document_entry(
+    object_name: Optional[str],
+    original_filename: Optional[str],
+    base_path: str,
+    student_prefix: str,
+) -> Optional[Dict[str, str]]:
+    """Describe where the student-uploaded 申請文件 goes in the ZIP.
+
+    Returns None when the application has no 申請文件. Otherwise returns the
+    kwargs for `_fetch_and_write`: the source object name, the sanitized ZIP
+    path, the error-placeholder path, and a human label for the error text.
+    """
+    if not object_name:
+        return None
+    ext = _ext_for_application_document(original_filename, object_name)
+    filename = _sanitize_filename(f"{student_prefix}_申請文件{ext}")
+    return {
+        "object_name": object_name,
+        "zip_path": f"{base_path}/{filename}",
+        "error_path": f"{base_path}/_錯誤_找不到檔案_申請文件.txt",
+        "error_label": original_filename or object_name,
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py::TestApplicationDocumentEntry -p no:cacheprovider -v
+```
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/export_package_service.py backend/app/tests/test_export_package_pure_helpers.py
+git commit -m "feat: add _application_document_entry descriptor for 申請文件 export"
+```
+
+---
+
+## Task 4: Add `_fetch_and_write` helper and refactor the `app.files` loop
+
+**Files:**
+- Modify: `backend/app/tests/test_export_package_pure_helpers.py` (new test class + import)
+- Modify: `backend/app/services/export_package_service.py` (new module-level async function + loop refactor)
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the import in `backend/app/tests/test_export_package_pure_helpers.py`:
+
+```python
+from app.services.export_package_service import (
+    _sanitize_filename,
+    _ext_for_application_document,
+    _application_document_entry,
+    _fetch_and_write,
+    FILE_TYPE_LABELS,
+    DEGREE_LABELS,
+)
+```
+
+Add this test class at the end of the file. Note it is a **sync** `def` test that drives the async helper via `asyncio.run` — see the "Test-suite routing" note above for why no `async def` is allowed in this file:
+
+```python
+class TestFetchAndWrite:
+    """Pin: the shared MinIO fetch-and-write used by both the
+    app.files loop and the 申請文件. On success the bytes land at
+    zip_path; on any MinIO error a placeholder .txt lands at
+    error_path instead (the ZIP build never aborts)."""
+
+    def test_success_writes_bytes_and_releases_connection(self):
+        import asyncio
+        import io
+        import zipfile
+        from unittest.mock import MagicMock
+
+        fake_response = MagicMock()
+        fake_response.read.return_value = b"PDF-BYTES"
+        minio = MagicMock()
+        minio.get_file_stream.return_value = fake_response
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            asyncio.run(
+                _fetch_and_write(
+                    zf,
+                    minio,
+                    object_name="application-documents/12_x.pdf",
+                    zip_path="dept/stu/stu_申請文件.pdf",
+                    error_path="dept/stu/_錯誤_找不到檔案_申請文件.txt",
+                    error_label="申請文件.pdf",
+                )
+            )
+
+        buf.seek(0)
+        with zipfile.ZipFile(buf) as zf:
+            assert zf.read("dept/stu/stu_申請文件.pdf") == b"PDF-BYTES"
+            assert "dept/stu/_錯誤_找不到檔案_申請文件.txt" not in zf.namelist()
+        fake_response.close.assert_called_once()
+        fake_response.release_conn.assert_called_once()
+
+    def test_failure_writes_error_placeholder(self):
+        import asyncio
+        import io
+        import zipfile
+        from unittest.mock import MagicMock
+
+        minio = MagicMock()
+        minio.get_file_stream.side_effect = Exception("object missing")
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            asyncio.run(
+                _fetch_and_write(
+                    zf,
+                    minio,
+                    object_name="application-documents/12_x.pdf",
+                    zip_path="dept/stu/stu_申請文件.pdf",
+                    error_path="dept/stu/_錯誤_找不到檔案_申請文件.txt",
+                    error_label="申請文件.pdf",
+                )
+            )
+
+        buf.seek(0)
+        with zipfile.ZipFile(buf) as zf:
+            names = zf.namelist()
+            assert "dept/stu/stu_申請文件.pdf" not in names
+            assert "dept/stu/_錯誤_找不到檔案_申請文件.txt" in names
+            content = zf.read("dept/stu/_錯誤_找不到檔案_申請文件.txt").decode("utf-8")
+            assert "object missing" in content
+            assert "申請文件.pdf" in content
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py::TestFetchAndWrite -p no:cacheprovider -v
+```
+Expected: FAIL at import — `ImportError: cannot import name '_fetch_and_write'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `backend/app/services/export_package_service.py`, add this module-level async function directly below `_application_document_entry`:
+
+```python
+async def _fetch_and_write(
+    zf: zipfile.ZipFile,
+    minio: MinIOService,
+    object_name: str,
+    zip_path: str,
+    error_path: str,
+    error_label: str,
+) -> None:
+    """Stream one MinIO object into the ZIP at `zip_path`.
+
+    On any failure, writes a `_錯誤_…txt` placeholder at `error_path`
+    instead so a single bad object never aborts the whole ZIP build.
+    """
+    try:
+        response = await asyncio.to_thread(minio.get_file_stream, object_name)
+        try:
+            file_bytes = await asyncio.to_thread(response.read)
+        finally:
+            response.close()
+            response.release_conn()
+        zf.writestr(zip_path, file_bytes)
+    except Exception as e:
+        logger.exception(f"Failed to fetch file {object_name}")
+        zf.writestr(error_path, f"檔案下載失敗：{error_label}\n錯誤：{str(e)}")
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py::TestFetchAndWrite -p no:cacheprovider -v
+```
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Refactor the `app.files` loop to use the helper**
+
+In `backend/app/services/export_package_service.py`, inside `_add_application_to_zip`, replace the `try/except` block at the end of the `for af in app.files:` loop (the block shown in "Current code being refactored" above) with a single call:
+
+```python
+            await _fetch_and_write(
+                zf,
+                self.minio,
+                object_name=af.object_name,
+                zip_path=f"{base_path}/{_sanitize_filename(filename)}",
+                error_path=f"{base_path}/_錯誤_找不到檔案_{_sanitize_filename(label)}.txt",
+                error_label=af.original_filename or af.object_name,
+            )
+```
+
+Leave everything above it in the loop (the `type_totals`, `file_type_counter`, `label`, `ext`, and `filename` computation) unchanged. The ZIP paths and error-filename format are identical to before — this is a pure extract-method refactor.
+
+- [ ] **Step 6: Run the full file to confirm the refactor preserved behavior**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py -p no:cacheprovider -v
+```
+Expected: PASS (all classes, including the original sanitize/label/degree tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/export_package_service.py backend/app/tests/test_export_package_pure_helpers.py
+git commit -m "refactor: extract _fetch_and_write for ZIP export file streaming"
+```
+
+---
+
+## Task 5: Append the 申請文件 to each student's folder
+
+**Files:**
+- Modify: `backend/app/services/export_package_service.py` (`_add_application_to_zip`)
+
+This task wires together the helpers from Tasks 2–4. Its behavior is fully covered by those helpers' unit tests; the new code here is a four-line composition. Verification is the full test run plus a dev-container smoke (Step 3).
+
+- [ ] **Step 1: Add the 申請文件 block**
+
+In `backend/app/services/export_package_service.py`, in `_add_application_to_zip`, immediately **after** the `for af in app.files:` loop (i.e. at the end of the method), add:
+
+```python
+        # Student-uploaded 申請文件 — stored on the application itself,
+        # not as an ApplicationFile, so the app.files loop above misses it.
+        entry = _application_document_entry(
+            app.application_document_url,
+            app.application_document_original_filename,
+            base_path,
+            student_prefix,
+        )
+        if entry:
+            await _fetch_and_write(zf, self.minio, **entry)
+```
+
+`base_path` and `student_prefix` are already defined near the top of `_add_application_to_zip` (`base_path = f"{dept_folder}/{student_folder}"`, `student_prefix = f"{std_code}_{std_name}"`).
+
+- [ ] **Step 2: Run the full test file**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py -p no:cacheprovider -v
+```
+Expected: PASS (all tests).
+
+- [ ] **Step 3: Dev-container smoke test (manual, end-to-end)**
+
+Confirm a real export now contains the 申請文件 and the correctly-labeled passbook. With the dev stack running:
+
+1. As a student (e.g. `stuphd001`), submit an application and upload a 申請文件 via the application-document upload, plus a verified bank passbook.
+2. As a college user (e.g. `cs_college`), call the export:
+   ```bash
+   curl -s -o /tmp/export.zip -H "Authorization: Bearer <college_token>" \
+     "http://localhost:8000/api/v1/college-review/export-package?scholarship_type_id=<id>&academic_year=<yr>&semester=<sem>"
+   unzip -l /tmp/export.zip
+   ```
+3. Verify the student's folder contains a `…_申請文件.<ext>` entry and a `…_存摺封面.<ext>` entry (not `…_其他文件…`).
+
+Expected: both entries present; no `_錯誤_…txt` placeholders for files that exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/export_package_service.py
+git commit -m "feat: include student-uploaded 申請文件 in college 申請資料 ZIP"
+```
+
+---
+
+## Task 6: Lint, full-suite check, and finish
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: black**
+
+Run:
+```bash
+uvx --from "black==26.3.1" black --check --line-length=120 \
+  backend/app/services/export_package_service.py \
+  backend/app/tests/test_export_package_pure_helpers.py
+```
+Expected: `All done!` / no files would be reformatted. If it reports changes, drop `--check` to apply, then re-run.
+
+- [ ] **Step 2: flake8 hard-gated rules**
+
+Run (from `backend/`):
+```bash
+cd backend && flake8 app --select=B904,B014 --max-line-length=120
+```
+Expected: no output (exit 0). `_fetch_and_write` does not re-raise inside its `except`, so B904 does not apply.
+
+- [ ] **Step 3: Full pure-helpers file once more**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend \
+  python -m pytest app/tests/test_export_package_pure_helpers.py -p no:cacheprovider -v
+```
+Expected: PASS (all classes).
+
+- [ ] **Step 4: Finish the branch**
+
+Use the superpowers:finishing-a-development-branch skill to choose how to integrate (PR / merge / cleanup). The branch contains the four feature commits from Tasks 1–5 plus the spec/plan docs.
+
+---
+
+## Self-Review Notes (for the planner; remove or keep)
+
+- **Spec coverage:** label fix (Task 1), 申請文件 inclusion (Tasks 2,3,5), shared fetch/error-fallback (Task 4), out-of-scope summary-PDF untouched (no task), error-placeholder behavior (Task 4 Step 1 second test + Task 5 smoke). All spec sections map to a task.
+- **Type/name consistency:** `_fetch_and_write` kwargs (`object_name`, `zip_path`, `error_path`, `error_label`) match exactly the keys returned by `_application_document_entry`, so `**entry` unpacks cleanly. `_ext_for_application_document(original_filename, object_name)` signature is used consistently in Task 3.
+- **No placeholders:** every code step shows full code; every run step shows the command and expected outcome.

--- a/docs/superpowers/specs/2026-06-09-college-export-all-student-documents-design.md
+++ b/docs/superpowers/specs/2026-06-09-college-export-all-student-documents-design.md
@@ -1,0 +1,207 @@
+# College 申請資料 ZIP — Include All Student-Uploaded Documents
+
+**Date:** 2026-06-09
+**Status:** Approved design, ready for implementation plan
+**Scope owner:** college review / export-package
+
+## Problem
+
+The college-facing **申請資料 ZIP** export (`/api/v1/college-review/export-package`,
+backed by `ExportPackageService.generate_export_zip`) is supposed to bundle every
+document a student uploaded for their application, grouped by department and
+student. It does not.
+
+The ZIP builder iterates only `Application.files` (the `ApplicationFile` rows).
+That misses one entire student-upload path and mislabels another:
+
+| Source | Student-uploaded? | In ZIP today |
+|---|---|---|
+| `app.files` — dynamic-form uploads (成績單, 研究計畫, …) | ✅ | ✅ included |
+| `app.files` — cloned 存摺封面 (`file_type = "bank_account_proof"`) | ✅ | ⚠️ included but mislabeled as 「其他文件」 |
+| `application.application_document_url` — 申請文件 single PDF | ✅ | ❌ **missing entirely** |
+
+### Why these two
+
+- **申請文件 (`application_document_url`).** The endpoint
+  `POST /applications/{id}/application-document` (`applications.py:937`) is
+  `require_student` and stores the upload on `application.application_document_url`
+  (plus `application_document_original_filename`) — **not** as an `ApplicationFile`
+  row. Because the ZIP loops `app.files` only, this student-uploaded PDF never
+  appears in the export.
+- **存摺封面 label.** At submission the passbook is cloned into an `ApplicationFile`
+  with `file_type = "bank_account_proof"` (`application_service.py:2118, 2180`),
+  but `FILE_TYPE_LABELS` in `export_package_service.py` only maps the string
+  `"bank_account_cover"`. So `bank_account_proof` falls through to the `"其他文件"`
+  default. The file is present in the ZIP; only its name is wrong.
+
+`submitted_form_data.documents` is **not** a separate source — it is derived from
+`app.files` (`application_service.py:686–723`), so nothing extra hides there.
+
+## Goal
+
+After this change the 申請資料 ZIP contains, per student folder:
+
+1. The auto-generated summary PDF (unchanged).
+2. Every `app.files` upload, with the cloned passbook correctly labeled 「存摺封面」.
+3. The student-uploaded 申請文件 (`application_document_url`), when present.
+
+## Out of scope
+
+- The summary PDF's 「四、上傳文件清單」 section is **left as-is**. It is derived
+  from `app.files` / `submitted_form_data.documents` and will not list the 申請文件.
+  Deliberately excluded to keep the change focused.
+- No change to the 申請總表 Excel export (`department-summary-export*`), the
+  200-application cap, permission checks, or audit logging.
+- Batch-import handling is unaffected. Note `application_document_url` is also the
+  column batch-import populates; including it in the ZIP is correct regardless of
+  who set it (it is "the application's document"), but no batch-import-specific
+  behavior is added.
+
+## Design
+
+All changes are confined to `backend/app/services/export_package_service.py`.
+The query in `_query_applications` already eager-loads `app.files` via
+`selectinload`, and `application_document_url` / `application_document_original_filename`
+are plain (non-deferred) columns on `Application`, so **no query change is needed**.
+
+### 1. Fix the 存摺封面 label
+
+Add the real stored `file_type` to the label map:
+
+```python
+FILE_TYPE_LABELS = {
+    ...
+    "bank_account_proof": "存摺封面",   # the value actually stored on ApplicationFile
+    "bank_account_cover": "存摺封面",   # retained; harmless, may be referenced elsewhere
+    ...
+}
+```
+
+Result: cloned passbooks render as `{學號}_{姓名}_存摺封面{ext}` instead of
+`…_其他文件…`. Existing per-file-type sequence numbering (the
+`if type_totals[ft] > 1` branch) is unchanged.
+
+### 2. Extract a MinIO fetch-and-write helper (Approach B)
+
+The current `for af in app.files` loop inlines a block that: fetches the object
+from MinIO on a worker thread, writes the bytes into the ZIP, and on failure
+writes a `_錯誤_…txt` placeholder into the same folder. Adding the 申請文件 would
+duplicate that block, so extract it first:
+
+```python
+async def _fetch_and_write(
+    self,
+    zf: zipfile.ZipFile,
+    object_name: str,
+    zip_path: str,
+    error_path: str,
+    error_label: str,
+) -> None:
+    """Stream one MinIO object into the ZIP; on failure write an error .txt
+    placeholder into the same folder. Behavior identical to the prior inline
+    block in the app.files loop."""
+    try:
+        response = await asyncio.to_thread(self.minio.get_file_stream, object_name)
+        try:
+            file_bytes = await asyncio.to_thread(response.read)
+        finally:
+            response.close()
+            response.release_conn()
+        zf.writestr(zip_path, file_bytes)
+    except Exception as e:
+        logger.exception(f"Failed to fetch file {object_name}")
+        zf.writestr(error_path, f"檔案下載失敗：{error_label}\n錯誤：{str(e)}")
+```
+
+The `app.files` loop is refactored to call `_fetch_and_write` instead of inlining
+the fetch — same ZIP paths, same error filenames, no behavioral change.
+
+> Note: `MinIOService.get_file_stream` reads from `self.default_bucket`, which is
+> the same bucket the 申請文件 upload writes to (`minio_service.default_bucket`,
+> object name `application-documents/{id}_{timestamp}{ext}`). It raises
+> `HTTPException(404)` on a missing object; that is an `Exception` subclass, so the
+> `except Exception` fallback catches it and writes the placeholder — no 500 leaks
+> out of the ZIP build.
+
+### 3. Add the 申請文件 to the student folder
+
+After the `app.files` loop in `_add_application_to_zip`, append:
+
+```python
+# Student-uploaded 申請文件 (stored on the application, not as an ApplicationFile)
+if app.application_document_url:
+    ext = _ext_for_application_document(
+        app.application_document_original_filename,
+        app.application_document_url,
+    )
+    doc_path = f"{base_path}/{_sanitize_filename(f'{student_prefix}_申請文件{ext}')}"
+    await self._fetch_and_write(
+        zf,
+        object_name=app.application_document_url,
+        zip_path=doc_path,
+        error_path=f"{base_path}/_錯誤_找不到檔案_申請文件.txt",
+        error_label=app.application_document_original_filename or app.application_document_url,
+    )
+```
+
+Extension derivation (small pure helper, unit-testable):
+
+```python
+def _ext_for_application_document(original_filename: str | None, object_name: str) -> str:
+    """Prefer the original filename's extension; fall back to the object-name
+    suffix (the stored object name always ends in the uploaded extension)."""
+    for source in (original_filename, object_name):
+        if source and "." in source.rsplit("/", 1)[-1]:
+            return "." + source.rsplit(".", 1)[1]
+    return ""
+```
+
+Properties:
+- **Additive.** Applications using the dynamic-form flow have
+  `application_document_url IS NULL` and get nothing extra.
+- **No collision.** The 申請文件 label is distinct from every `app.files` label, so
+  it never clashes with the per-file-type sequence naming.
+- **Both can coexist.** An application with dynamic uploads *and* an
+  `application_document_url` gets both in the folder.
+
+## Error handling
+
+- Missing/unreadable 申請文件 object → `_錯誤_找不到檔案_申請文件.txt` in that
+  student's folder (same pattern as existing per-file errors). The ZIP build for
+  other students/files continues.
+- Per project policy, no fallback/mock data: a genuinely absent object surfaces as
+  an explicit error placeholder inside the ZIP, not a silent omission.
+
+## Testing
+
+Test file: `backend/app/tests/test_export_package_pure_helpers.py` (pure-helper
+style — no live MinIO/DB/reportlab at import).
+
+1. **`FILE_TYPE_LABELS` pin update.** The existing test asserts the 8 known file
+   types; update it so `bank_account_proof` maps to `"存摺封面"` (and the count/key
+   set reflects the added entry). This is a deliberate label addition, not drift.
+2. **`_ext_for_application_document` pure helper:**
+   - `("申請文件.pdf", "application-documents/12_x.pdf")` → `".pdf"`
+   - `(None, "application-documents/12_x.pdf")` → `".pdf"`
+   - `("noext", "application-documents/12_x")` → `""`
+   - original filename's extension wins over the object name's.
+3. **申請文件 ZIP path naming** (pure, no MinIO): given a student prefix + ext,
+   assert the path is `{base}/{學號}_{姓名}_申請文件{ext}` and is `_sanitize_filename`-safe.
+4. **Fetch path with mocked MinIO** (kept minimal): `_fetch_and_write` writes bytes
+   on success and an `_錯誤_…txt` placeholder when `get_file_stream` raises — mock
+   `self.minio` so no live MinIO is needed. Optional if the pure-path coverage above
+   is judged sufficient; the success/fallback branch is the one new behavioral
+   surface worth pinning.
+
+Run in the dev container:
+`python -m pytest app/tests/test_export_package_pure_helpers.py -p no:cacheprovider`.
+
+## Files touched
+
+- `backend/app/services/export_package_service.py` — label map, `_fetch_and_write`
+  helper, `_ext_for_application_document` helper, 申請文件 block in
+  `_add_application_to_zip`.
+- `backend/app/tests/test_export_package_pure_helpers.py` — updated label pin + new
+  helper/path tests.
+
+No migrations, no API/schema changes, no frontend changes, no OpenAPI regeneration.


### PR DESCRIPTION
## Summary

The college 申請資料 ZIP export (`/api/v1/college-review/export-package`) is meant to bundle **every** document a student uploaded, grouped by department/student. Two student-uploaded sources were wrong:

- **申請文件 was missing entirely.** Students upload a single PDF via `POST /applications/{id}/application-document` (`require_student`), which is stored on `Application.application_document_url` — **not** as an `ApplicationFile`. The ZIP only looped `app.files`, so this never appeared. It is now added to each student's folder as `{學號}_{姓名}_申請文件{ext}`.
- **存摺封面 was mislabeled.** The cloned passbook is an `ApplicationFile` with `file_type = "bank_account_proof"`, but `FILE_TYPE_LABELS` only mapped `"bank_account_cover"`, so it fell through to 「其他文件」. Now mapped to 「存摺封面」.

### Implementation

All changes confined to `backend/app/services/export_package_service.py` + its pure-helper test file. No migrations, no API/schema/frontend changes.

- Add `bank_account_proof → 存摺封面` to `FILE_TYPE_LABELS`.
- New module-level helpers: `_ext_for_application_document` (extension derivation), `_application_document_entry` (ZIP-entry descriptor), `_fetch_and_write` (MinIO stream → ZIP, with `_錯誤_…txt` fallback on failure).
- Refactor the existing `app.files` loop onto `_fetch_and_write` (behavior-preserving), then append the 申請文件 by composing the two new helpers.

A missing/unreadable 申請文件 object writes a `_錯誤_找不到檔案_申請文件.txt` placeholder in that student's folder rather than aborting the ZIP. Out of scope (untouched): the summary PDF's document list, the 申請總表 Excel export, the 200-application cap, permission checks, audit logging.

Design + plan: `docs/superpowers/specs/2026-06-09-college-export-all-student-documents-design.md`, `docs/superpowers/plans/2026-06-09-college-export-all-student-documents.md`.

## Test Plan

- [x] Unit: `app/tests/test_export_package_pure_helpers.py` — 37 passed (label pin 8→9, `_ext_for_application_document`, `_application_document_entry`, `_fetch_and_write` success + error-fallback). Async helper driven via `asyncio.run` in a sync test to stay in the unit suite.
- [x] Lint: black (26.3.1, --line-length=120) clean; flake8 B904/B014 clean.
- [ ] Manual smoke: as a student upload a 申請文件 + verify a passbook; as college, GET `/college-review/export-package`; confirm the student folder contains `…_申請文件.<ext>` and `…_存摺封面.<ext>` (not `…_其他文件…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)