### PR TITLE
fix: 造冊生成後學生領取月份數沒有增加（match received-months by 學號）

### DIFF
--- a/backend/alembic/versions/add_roster_student_number_001.py
+++ b/backend/alembic/versions/add_roster_student_number_001.py
@@ -1,0 +1,105 @@
+"""add payment_roster_items.student_number (學號) and backfill from std_stdcode
+
+PaymentRosterItem.student_id_number was repurposed to hold the national ID
+(身分證字號 / std_pid) for the Excel payment column (see backfill_roster_nat_id_001),
+which overwrote the 學號 it used to carry. But cross-roster student matching —
+the received-months cumulative count (已領月份數), the PhD 36-month cap, and the
+scholarship-history lookup — keys off the 學號 (std_stdcode), the system's
+canonical student identifier.
+
+This migration adds a dedicated student_number (學號) snapshot column and
+backfills it from applications.student_data->>'std_stdcode'. It iterates rows
+via the ORM so the StudentDataJSON TypeDecorator decrypts student_data, mirroring
+backfill_roster_nat_id_001.
+
+Revision ID: add_roster_student_number_001
+Revises: merge_20260608_sq_audit
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.orm import Session, joinedload
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+revision: str = "add_roster_student_number_001"
+down_revision: Union[str, None] = "merge_20260608_sq_audit"
+branch_labels = None
+depends_on = None
+
+_TABLE = "payment_roster_items"
+_COLUMN = "student_number"
+_INDEX = "ix_payment_roster_items_student_number"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    existing_columns = {c["name"] for c in inspector.get_columns(_TABLE)}
+    if _COLUMN not in existing_columns:
+        op.add_column(_TABLE, sa.Column(_COLUMN, sa.String(length=20), nullable=True))
+
+    existing_indexes = {ix["name"] for ix in inspector.get_indexes(_TABLE)}
+    if _INDEX not in existing_indexes:
+        op.create_index(_INDEX, _TABLE, [_COLUMN])
+
+    _backfill(bind)
+
+
+def _backfill(bind) -> None:
+    """Populate student_number from each item's application std_stdcode."""
+    session = Session(bind=bind)
+    try:
+        # Import models — TypeDecorators fire during ORM load (decrypt student_data).
+        from app.models.application import Application  # noqa: F401
+        from app.models.payment_roster import PaymentRosterItem
+
+        items = session.query(PaymentRosterItem).options(joinedload(PaymentRosterItem.application)).all()
+        updated = 0
+        skipped_no_app = 0
+        skipped_no_stdcode = 0
+
+        for item in items:
+            app = item.application
+            if not app or not app.student_data:
+                skipped_no_app += 1
+                continue
+
+            std_stdcode = app.student_data.get("std_stdcode", "")
+            if not std_stdcode:
+                skipped_no_stdcode += 1
+                continue
+
+            if item.student_number != std_stdcode:
+                item.student_number = std_stdcode
+                updated += 1
+
+        session.flush()
+        logger.info(
+            f"Backfill student_number complete: updated={updated}, "
+            f"skipped_no_app={skipped_no_app}, skipped_no_stdcode={skipped_no_stdcode}"
+        )
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    existing_indexes = {ix["name"] for ix in inspector.get_indexes(_TABLE)}
+    if _INDEX in existing_indexes:
+        op.drop_index(_INDEX, table_name=_TABLE)
+
+    existing_columns = {c["name"] for c in inspector.get_columns(_TABLE)}
+    if _COLUMN in existing_columns:
+        op.drop_column(_TABLE, _COLUMN)

--- a/backend/app/models/payment_roster.py
+++ b/backend/app/models/payment_roster.py
@@ -188,6 +188,12 @@ class PaymentRosterItem(Base):
 
     # 學生基本資料（造冊當時快照）
     student_id_number = Column(String(20), nullable=False)  # 身分證字號 (national ID / std_pid)
+    # 學號 (student number / std_stdcode) snapshot — the system's canonical
+    # student identifier, used for cross-roster student matching (received-months
+    # cumulative count, 36-month cap, scholarship history). student_id_number was
+    # repurposed to hold the national ID for the 身分證字號 Excel column, so a
+    # separate 學號 snapshot is required for identity matching.
+    student_number = Column(String(20), nullable=True, index=True)
     student_name = Column(String(100), nullable=False)  # 姓名
     student_email = Column(String(255))  # Email
 

--- a/backend/app/services/received_months_service.py
+++ b/backend/app/services/received_months_service.py
@@ -16,6 +16,11 @@ on its roster_cycle:
 
 Only rosters with PaymentRosterItem.is_included=True are counted.
 
+Students are matched on PaymentRosterItem.student_number (學號 / std_stdcode),
+the canonical student identifier. NOT student_id_number — that column holds the
+national ID (身分證字號 / std_pid) for the Excel payment column and is unsuitable
+for identity matching (e.g. foreign students may lack a national ID).
+
 See docs/received-months-calculation.md for full specification.
 """
 
@@ -45,7 +50,7 @@ def _single_stmt(student_nycu_id: str, scholarship_config_id: int) -> Select:
         .where(
             and_(
                 PaymentRoster.scholarship_configuration_id == scholarship_config_id,
-                PaymentRosterItem.student_id_number == student_nycu_id,
+                PaymentRosterItem.student_number == student_nycu_id,
                 PaymentRosterItem.is_included.is_(True),
             )
         )
@@ -56,7 +61,7 @@ def _single_stmt(student_nycu_id: str, scholarship_config_id: int) -> Select:
 def _bulk_stmt(student_nycu_ids: list[str], scholarship_config_id: int) -> Select:
     return (
         select(
-            PaymentRosterItem.student_id_number,
+            PaymentRosterItem.student_number,
             PaymentRoster.roster_cycle,
             func.count(PaymentRosterItem.id),
         )
@@ -64,11 +69,11 @@ def _bulk_stmt(student_nycu_ids: list[str], scholarship_config_id: int) -> Selec
         .where(
             and_(
                 PaymentRoster.scholarship_configuration_id == scholarship_config_id,
-                PaymentRosterItem.student_id_number.in_(student_nycu_ids),
+                PaymentRosterItem.student_number.in_(student_nycu_ids),
                 PaymentRosterItem.is_included.is_(True),
             )
         )
-        .group_by(PaymentRosterItem.student_id_number, PaymentRoster.roster_cycle)
+        .group_by(PaymentRosterItem.student_number, PaymentRoster.roster_cycle)
     )
 
 

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -882,7 +882,8 @@ class RosterService:
         roster_item = PaymentRosterItem(
             roster_id=roster.id,
             application_id=application.id,
-            student_id_number=student_data.get("std_pid", ""),
+            student_id_number=student_data.get("std_pid", ""),  # 身分證字號 (national ID)
+            student_number=student_data.get("std_stdcode", ""),  # 學號 — identity-matching key
             student_name=student_data.get("std_cname", ""),
             student_email=student_data.get("com_email", ""),
             bank_account=bank_account,  # From submitted_form_data, not student_data

--- a/backend/app/services/student_scholarship_history_service.py
+++ b/backend/app/services/student_scholarship_history_service.py
@@ -65,12 +65,16 @@ class StudentScholarshipHistoryService:
     ) -> Tuple[List[PaymentRecord], Optional[str]]:
         """Return roster items for the student from rosters in a paid state
         (COMPLETED or LOCKED). Also returns the student_name snapshot from the
-        most-recent matching item, for SIS-fallback display."""
+        most-recent matching item, for SIS-fallback display.
+
+        ``student_number`` is the 學號 (std_stdcode) the admin looks up by, so it
+        must match PaymentRosterItem.student_number — NOT student_id_number, which
+        holds the national ID (身分證字號) for the Excel payment column."""
         stmt = (
             select(PaymentRosterItem, PaymentRoster)
             .join(PaymentRoster, PaymentRosterItem.roster_id == PaymentRoster.id)
             .where(
-                PaymentRosterItem.student_id_number == student_number,
+                PaymentRosterItem.student_number == student_number,
                 PaymentRosterItem.is_included.is_(True),
                 PaymentRoster.status.in_([RosterStatus.COMPLETED, RosterStatus.LOCKED]),
             )

--- a/backend/app/tests/test_pii_crypto.py
+++ b/backend/app/tests/test_pii_crypto.py
@@ -63,10 +63,15 @@ def test_idempotent_encrypt_passthrough_empty(two_keys):
 
 def test_tamper_detection(two_keys):
     envelope = pii_crypto.encrypt_pii(_PLAINTEXT)
-    # Flip a character in the base64 payload.
+    # Flip a character in the MIDDLE of the base64 payload. The FINAL base64
+    # char can encode only padding bits, so flipping it may decode to the same
+    # bytes and leave the GCM tag valid → flaky "DID NOT RAISE". A middle char
+    # always maps to a full nonce/ciphertext/tag byte, so corruption — and thus
+    # the GCM auth failure — is deterministic.
     head, payload = envelope.rsplit(":", 1)
-    flipped_char = "A" if payload[-1] != "A" else "B"
-    tampered = f"{head}:{payload[:-1]}{flipped_char}"
+    mid = len(payload) // 2
+    flipped_char = "A" if payload[mid] != "A" else "B"
+    tampered = f"{head}:{payload[:mid]}{flipped_char}{payload[mid + 1:]}"
     with pytest.raises(pii_crypto.PIICryptoError):
         pii_crypto.decrypt_pii(tampered)
 

--- a/backend/app/tests/test_received_months_service.py
+++ b/backend/app/tests/test_received_months_service.py
@@ -110,7 +110,10 @@ def _make_item(
     item = PaymentRosterItem(
         roster_id=roster_id,
         application_id=application_id,
-        student_id_number=student_nycu_id,
+        # National ID (身分證字號) — deliberately distinct from the 學號 so this
+        # suite guards that matching keys off student_number, not the national ID.
+        student_id_number=f"A{student_nycu_id}",
+        student_number=student_nycu_id,
         student_name="Test Student",
         scholarship_name="Test Scholarship",
         scholarship_amount=10000,

--- a/backend/app/tests/test_received_months_with_roster.py
+++ b/backend/app/tests/test_received_months_with_roster.py
@@ -142,7 +142,12 @@ def _make_item(
     item = PaymentRosterItem(
         roster_id=roster.id,
         application_id=application_id,
-        student_id_number=student_nycu_id,
+        # student_id_number snapshots the national ID (身分證字號), which is
+        # DISTINCT from the 學號. Derive a national-ID-shaped value so these
+        # fixtures mirror production and guard against matching on the wrong
+        # column — received_months must match by student_number (學號).
+        student_id_number=f"A{student_nycu_id}",
+        student_number=student_nycu_id,
         student_name=f"Student {student_nycu_id}",
         scholarship_name="Received Months Test Scholarship",
         scholarship_amount=amount,
@@ -353,6 +358,38 @@ class TestCalculateReceivedMonthsSingle:
         # Invisible under B.
         assert calculate_received_months(db_sync, "112550001", config_b.id) == 0
 
+    def test_matches_by_student_number_not_national_id(self, db_sync):
+        """Regression for "造冊生成後學生領取月份數沒有增加".
+
+        PaymentRosterItem.student_id_number was repurposed to hold the national
+        ID (身分證字號 / std_pid) for the Excel payment column, so cross-roster
+        matching must key off student_number (學號 / std_stdcode), which is what
+        every caller (distribution panel, 36-month cap, history) passes in.
+
+        Here student_id_number and student_number are deliberately distinct:
+        querying by the 學號 must find the item; querying by the national ID
+        must not.
+        """
+        admin = _make_admin(db_sync)
+        scholarship = _make_scholarship(db_sync)
+        config = _make_config(db_sync, scholarship)
+        roster = _make_roster(
+            db_sync,
+            config=config,
+            creator=admin,
+            roster_code="ROSTER-113-2025-01-NSTC",
+            period_label="2025-01",
+            roster_cycle=RosterCycle.MONTHLY,
+        )
+        # _make_item stores student_number="112550001" and
+        # student_id_number="A112550001" (national ID).
+        _make_item(db_sync, roster=roster, student_nycu_id="112550001")
+
+        # Matches by 學號.
+        assert calculate_received_months(db_sync, "112550001", config.id) == 1
+        # Does NOT match by national ID.
+        assert calculate_received_months(db_sync, "A112550001", config.id) == 0
+
 
 # ---------------------------------------------------------------------------
 # Bulk calculation (sync)
@@ -488,7 +525,9 @@ class TestCalculateReceivedMonthsBulkAsync:
         item = PaymentRosterItem(
             roster_id=roster.id,
             application_id=1,
-            student_id_number="112550001",
+            # National ID (身分證字號) — distinct from the 學號 used to match.
+            student_id_number="A112550001",
+            student_number="112550001",
             student_name="Async Student",
             scholarship_name="Async Test Scholarship",
             scholarship_amount=Decimal("10000"),

--- a/backend/app/tests/test_roster_service_generation.py
+++ b/backend/app/tests/test_roster_service_generation.py
@@ -110,6 +110,7 @@ def _make_approved_application(
     student_id: str = "112550001",
     national_id: str = "A123456789",
     student_name: str = "羅斯特同學",
+    submitted_form_data: dict | None = None,
 ) -> Application:
     a = Application(
         user_id=user.id,
@@ -122,7 +123,7 @@ def _make_approved_application(
         academic_year=113,
         semester="first",
         student_data={"std_stdcode": student_id, "std_pid": national_id, "std_cname": student_name},
-        submitted_form_data={},
+        submitted_form_data={} if submitted_form_data is None else submitted_form_data,
         agree_terms=True,
         amount=Decimal("50000"),
     )
@@ -202,6 +203,59 @@ class TestRosterServiceGenerate:
 
         audit = patch_dependencies["audit"]
         assert audit.log_roster_creation.call_count == 1
+
+    def test_received_months_increases_after_generation(self, db_sync, patch_dependencies):
+        """
+        Regression for "造冊生成後學生領取月份數沒有增加".
+
+        After generating a roster, the student's received-months count must
+        increase. This broke because the roster item snapshots the national ID
+        in student_id_number (for the Excel 身分證字號 column) while every
+        received-months caller matches by 學號 (std_stdcode). The item must also
+        snapshot the 學號 in student_number so the cumulative count works.
+
+        The application carries a bank account so the item is is_included=True
+        (excluded items don't count toward received months).
+        """
+        from app.services.received_months_service import calculate_received_months
+
+        admin = _make_admin(db_sync)
+        scholarship = _make_scholarship(db_sync)
+        config = _make_config(db_sync, scholarship)
+        _make_approved_application(
+            db_sync,
+            admin,
+            scholarship,
+            config,
+            student_id="112550001",  # 學號
+            national_id="A123456789",  # 身分證字號
+            submitted_form_data={"fields": {"bank_account": {"value": "0001234567"}}},
+        )
+
+        # Before generation: nothing received.
+        assert calculate_received_months(db_sync, "112550001", config.id) == 0
+
+        svc = RosterService(db_sync)
+        roster = svc.generate_roster(
+            scholarship_configuration_id=config.id,
+            period_label="2024-01",
+            roster_cycle=RosterCycle.MONTHLY,
+            academic_year=113,
+            created_by_user_id=admin.id,
+            trigger_type=RosterTriggerType.MANUAL,
+            student_verification_enabled=False,
+        )
+
+        item = db_sync.query(PaymentRosterItem).filter_by(roster_id=roster.id).one()
+        assert item.is_included is True  # guard: excluded items wouldn't count
+        # Snapshots: 學號 in student_number, national ID in student_id_number.
+        assert item.student_number == "112550001"
+        assert item.student_id_number == "A123456789"
+
+        # After generation: one MONTHLY roster ⇒ one month, matched by 學號.
+        assert calculate_received_months(db_sync, "112550001", config.id) == 1
+        # The national ID must NOT match.
+        assert calculate_received_months(db_sync, "A123456789", config.id) == 0
 
     @pytest.mark.smoke
     def test_generate_roster_raises_on_duplicate_without_force(self, db_sync, patch_dependencies):

--- a/backend/app/tests/test_student_scholarship_history_service.py
+++ b/backend/app/tests/test_student_scholarship_history_service.py
@@ -158,7 +158,9 @@ async def seeded_rosters(db):
         item = PaymentRosterItem(
             roster_id=roster.id,
             application_id=1,  # placeholder — SQLite test DB doesn't enforce FK
-            student_id_number=stdcode,
+            # National ID (身分證字號) — distinct from the 學號 lookup key.
+            student_id_number=f"A{stdcode}",
+            student_number=stdcode,  # 學號 — what _fetch_paid_payments matches on
             student_name="王小明",
             scholarship_name=name,
             scholarship_amount=amount,
@@ -178,7 +180,7 @@ async def seeded_rosters(db):
 
 @pytest.mark.asyncio
 async def test_fetch_paid_payments_filters_drafts_and_excluded(db, seeded_rosters):
-    """Service must filter status IN (COMPLETED, LOCKED) AND is_included=TRUE AND matching student_id_number."""
+    """Service must filter status IN (COMPLETED, LOCKED) AND is_included=TRUE AND matching student_number (學號)."""
     svc = StudentScholarshipHistoryService()
     records, snapshot_name = await svc._fetch_paid_payments(db, "S001")
 
@@ -245,7 +247,8 @@ async def test_fetch_paid_payments_includes_completed_rosters(db):
     item = PaymentRosterItem(
         roster_id=completed_roster.id,
         application_id=1,
-        student_id_number="S999",
+        student_id_number="A999",  # national ID — distinct from the 學號 lookup key
+        student_number="S999",
         student_name="陳完成",
         scholarship_name="教育部",
         scholarship_amount="7500",

--- a/docs/received-months-calculation.md
+++ b/docs/received-months-calculation.md
@@ -15,9 +15,13 @@
 
 篩選條件（**皆需符合**）：
 
-- `payment_roster_items.student_id_number = :student_nycu_id`
+- `payment_roster_items.student_number = :student_nycu_id`
 - `payment_roster_items.is_included = TRUE`
 - `payment_rosters.scholarship_configuration_id = :config_id`
+
+> ⚠️ 比對鍵是 **`student_number`（學號 / `std_stdcode`）**，不是 `student_id_number`。
+> `student_id_number` 已改存身分證字號（`std_pid`，供造冊 Excel 的「身分證字號」欄位），
+> 不能用於跨造冊的學生身分比對（外籍生可能無身分證字號）。各呼叫端（分發頁、36 個月上限、歷史查詢）一律以學號比對。
 
 **跨 sub_type 合併**：不篩選 `sub_type`，所以同一配置下的 `nstc`、`moe_1w`、`moe_2w` 一併計入。
 
@@ -44,7 +48,7 @@ SELECT
 FROM payment_roster_items pri
 JOIN payment_rosters pr ON pr.id = pri.roster_id
 WHERE pr.scholarship_configuration_id = :config_id
-  AND pri.student_id_number = :student_nycu_id
+  AND pri.student_number = :student_nycu_id
   AND pri.is_included = TRUE;
 ```
 


### PR DESCRIPTION
## 問題

造冊生成後，手動分發頁的「已領月份數」欄位沒有增加，永遠顯示 0。

## 根因

`PaymentRosterItem.student_id_number` 曾經存學號（`std_stdcode`），後來被改存**身分證字號**（`std_pid`），以供造冊 Excel 的「身分證字號」欄位使用（見 migration `backfill_roster_nat_id_001`，該 migration 直接覆寫了原本的學號值）。

但有三個「以學號辨識學生」的消費端從未跟著更新，仍以學號去比對這個現在存身分證的欄位 → 比對不到任何 roster item → 月份數歸零：

- `received_months_service`（分發頁「已領月份數」）— **本次回報的 bug**
- `phd_eligibility_plugin`（博士生 36 個月上限）— 同源潛在 bug
- `student_scholarship_history_service`（學生獎助歷史查詢）— 同源潛在 bug

這是典型的「欄位語意被改用、卻沒有 grep 全部使用點」的回歸。

## 修法

為 `PaymentRosterItem` 新增專用的 `student_number`（學號 / `std_stdcode`）快照欄位，三個消費端改以它比對。學號是系統的標準學生識別鍵，且在外籍生無身分證字號時仍可靠。

- `models/payment_roster.py` — 新增 `student_number` 欄位（建索引）
- `services/roster_service.py` — `_create_roster_item` 同時快照學號與身分證（唯一的 producer，涵蓋所有造冊路徑）
- `services/received_months_service.py`、`services/student_scholarship_history_service.py` — 改以 `student_number` 比對
- `phd_eligibility_plugin` 與分發頁呼叫端本來就傳學號，無需改動 — 自動修復
- `alembic/versions/add_roster_student_number_001.py` — 新增欄位 + 索引（皆有 existence check），並從 `applications.student_data->>std_stdcode` 經 ORM 回填，沿用 `backfill_roster_nat_id_001` 既有模式（single head off `merge_20260608_sq_audit`）
- `docs/received-months-calculation.md` — 更新比對鍵說明

**`student_id_number`（身分證字號）的 Excel 匯出維持不變。**

## Test plan

- [x] TDD RED→GREEN：將測試 fixture 改為貼近現實（身分證 ≠ 學號），先觀察到 19 個失敗（皆為 `0 == 預期值`，重現 bug），修完後全綠
- [x] 端到端回歸測試 `test_received_months_increases_after_generation`：實際跑 `generate_roster` → 已領月份數由 0 → 1，且以學號比對、身分證不比對
- [x] 受影響套件 186 項測試通過（received-months / history / phd / roster-generation / manual-distribution / payment-roster）
- [x] Lint：`black --check --line-length=120` 乾淨、`flake8 --select=B904,B014` 乾淨、無 F401
- [ ] ⚠️ Migration 尚未在實際 Postgres 跑過（本 session dev 容器未啟動）；它幾乎是 `backfill_roster_nat_id_001` 的複本，schema/查詢變更已由 SQLite 測試驗證。建議 merge 前在 dev 跑一次 `alembic upgrade head` 確認回填。
