### PR TITLE
feat: support OpenDocument (ODF) for admin reference & sample docs

### DIFF
--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -91,6 +91,19 @@ async def get_all_configurations(
 
 _ALLOWED_DOC_KEYS = {"regulations_url", "sample_document_url"}
 
+# Document formats accepted for admin-managed reference material
+# (申請文件範例檔 + 補充參考文件): PDF, Microsoft Office, and OpenDocument (ODF).
+# Note: 獎學金要點 (regulations_url) is intentionally excluded — it is rendered
+# inline via react-pdf and stays PDF-only (enforced separately below).
+_REFERENCE_DOC_EXTENSIONS = [".pdf", ".doc", ".docx", ".odt", ".ods", ".odp"]
+
+# MIME types for OpenDocument (ODF) formats, keyed by extension.
+_ODF_CONTENT_TYPES = {
+    ".odt": "application/vnd.oasis.opendocument.text",
+    ".ods": "application/vnd.oasis.opendocument.spreadsheet",
+    ".odp": "application/vnd.oasis.opendocument.presentation",
+}
+
 
 @router.get("/public-docs")
 async def get_public_docs(
@@ -149,7 +162,7 @@ async def upload_system_doc(
                 detail="獎學金要點僅接受 PDF 檔案",
             )
     else:
-        allowed_extensions = [".pdf", ".doc", ".docx"]
+        allowed_extensions = _REFERENCE_DOC_EXTENSIONS
 
     file_content = await file.read()
 
@@ -281,6 +294,11 @@ async def get_system_doc_file(
         content_type = "application/msword"
     elif object_name.endswith(".docx"):
         content_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    else:
+        for odf_ext, odf_mime in _ODF_CONTENT_TYPES.items():
+            if object_name.endswith(odf_ext):
+                content_type = odf_mime
+                break
 
     from urllib.parse import quote
 
@@ -352,7 +370,7 @@ async def create_supplementary_doc(
     if len(stripped_title) > 200:
         raise HTTPException(status_code=400, detail="title must be <= 200 chars")
 
-    allowed_extensions = [".pdf", ".doc", ".docx"]
+    allowed_extensions = _REFERENCE_DOC_EXTENSIONS
     file_content = await file.read()
     validate_upload_file(
         filename=file.filename,

--- a/backend/app/tests/test_supplementary_docs.py
+++ b/backend/app/tests/test_supplementary_docs.py
@@ -174,6 +174,38 @@ class TestUploadSupplementaryDoc:
         assert rows[0].title == "FAQ"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "filename, content_type",
+        [
+            ("ref.odt", "application/vnd.oasis.opendocument.text"),
+            ("ref.ods", "application/vnd.oasis.opendocument.spreadsheet"),
+            ("ref.odp", "application/vnd.oasis.opendocument.presentation"),
+        ],
+    )
+    async def test_admin_uploads_odf(
+        self,
+        admin_client: AsyncClient,
+        fake_minio,
+        db: AsyncSession,
+        filename: str,
+        content_type: str,
+    ):
+        file_bytes = b"PK\x03\x04 odf zip bytes"
+        response = await admin_client.post(
+            "/api/v1/system-settings/supplementary-docs",
+            data={"title": "ODF Ref"},
+            files={"file": (filename, BytesIO(file_bytes), content_type)},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["original_filename"] == filename
+        assert body["data"]["content_type"] == content_type
+        assert body["data"]["object_name"].startswith("system-docs/supp_")
+        assert body["data"]["object_name"].endswith(filename[filename.rfind(".") :])
+        fake_minio.client.put_object.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_non_admin_forbidden(self, student_client: AsyncClient, fake_minio):
         response = await student_client.post(
             "/api/v1/system-settings/supplementary-docs",

--- a/backend/app/tests/test_system_settings_upload_doc.py
+++ b/backend/app/tests/test_system_settings_upload_doc.py
@@ -149,3 +149,41 @@ class TestSampleDocumentUploadStillAcceptsDocx:
         )
         assert res.status_code == 200
         fake_minio.client.put_object.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestSampleDocumentUploadAcceptsODF:
+    """申請文件範例檔 also accepts OpenDocument (ODF) formats."""
+
+    @pytest.mark.parametrize(
+        "filename, content_type",
+        [
+            ("sample.odt", "application/vnd.oasis.opendocument.text"),
+            ("sample.ods", "application/vnd.oasis.opendocument.spreadsheet"),
+            ("sample.odp", "application/vnd.oasis.opendocument.presentation"),
+        ],
+    )
+    async def test_accepts_odf_for_sample_document_url(
+        self, admin_client: AsyncClient, fake_minio, filename: str, content_type: str
+    ):
+        res = await _post_upload(
+            admin_client,
+            "sample_document_url",
+            filename=filename,
+            content_type=content_type,
+            body=b"PK\x03\x04 odf zip bytes",
+        )
+        assert res.status_code == 200, res.text
+        fake_minio.client.put_object.assert_called_once()
+
+    async def test_regulations_url_still_rejects_odt(self, admin_client: AsyncClient, fake_minio):
+        # 獎學金要點 must remain PDF-only — ODF must not leak into it.
+        res = await _post_upload(
+            admin_client,
+            "regulations_url",
+            filename="rules.odt",
+            content_type="application/vnd.oasis.opendocument.text",
+            body=b"PK\x03\x04 odf zip bytes",
+        )
+        assert res.status_code == 400
+        fake_minio.client.put_object.assert_not_called()

--- a/frontend/components/admin/system-docs/AddSupplementaryDocDialog.tsx
+++ b/frontend/components/admin/system-docs/AddSupplementaryDocDialog.tsx
@@ -17,8 +17,8 @@ import { Label } from "@/components/ui/label";
 import apiClient from "@/lib/api";
 import type { SupplementaryDoc } from "@/lib/api/modules/system-settings";
 
-const ACCEPTED = ".pdf,.doc,.docx";
-const ACCEPTED_LABEL = "PDF · DOC · DOCX";
+const ACCEPTED = ".pdf,.doc,.docx,.odt,.ods,.odp";
+const ACCEPTED_LABEL = "PDF · DOC · DOCX · ODF";
 const MAX_SIZE_MB = 10;
 
 interface Props {

--- a/frontend/components/admin/system-docs/SystemDocsPanel.tsx
+++ b/frontend/components/admin/system-docs/SystemDocsPanel.tsx
@@ -68,8 +68,8 @@ const SLOTS: DocSlot[] = [
     key: "sample_document_url",
     title: "申請文件範例檔",
     subtitle: "提供學生填寫申請文件時的參考範例",
-    accepted: ".pdf,.doc,.docx",
-    acceptedLabel: "PDF · DOC · DOCX",
+    accepted: ".pdf,.doc,.docx,.odt,.ods,.odp",
+    acceptedLabel: "PDF · DOC · DOCX · ODF",
     Icon: FileArchive,
     accent: {
       ring: "ring-amber-200",

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -41,6 +41,12 @@ export function previewMimeType(name: string): string {
   if (lower.endsWith(".doc")) return "application/msword";
   if (lower.endsWith(".docx"))
     return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+  if (lower.endsWith(".odt"))
+    return "application/vnd.oasis.opendocument.text";
+  if (lower.endsWith(".ods"))
+    return "application/vnd.oasis.opendocument.spreadsheet";
+  if (lower.endsWith(".odp"))
+    return "application/vnd.oasis.opendocument.presentation";
   if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
   if (lower.endsWith(".png")) return "image/png";
   return "application/octet-stream";


### PR DESCRIPTION
## Summary

Adds OpenDocument Format (ODF) support to the two admin **系統管理** document-upload features so admins can upload `.odt` / `.ods` / `.odp` in addition to PDF / DOC / DOCX:

- **申請文件範例檔** (`sample_document_url`)
- **補充參考文件** (supplementary docs)

**獎學金要點** (`regulations_url`) intentionally **stays PDF-only** — it is rendered inline via `react-pdf`, which only supports PDF. A test pins this.

> **Scope note:** "support ODF" is interpreted as the full OpenDocument family (`.odt` text, `.ods` spreadsheet, `.odp` presentation), mirroring how both `.doc` and `.docx` are accepted today.

## Changes

**Backend** (`app/api/v1/endpoints/system_settings.py`)
- New shared `_REFERENCE_DOC_EXTENSIONS = [.pdf, .doc, .docx, .odt, .ods, .odp]` (DRY across both upload endpoints).
- New `_ODF_CONTENT_TYPES` map; `get_system_doc_file` now returns the correct ODF MIME type when streaming sample docs.

**Frontend**
- `SystemDocsPanel.tsx` & `AddSupplementaryDocDialog.tsx`: extended `accept` lists and labels to `PDF · DOC · DOCX · ODF`.
- `lib/utils.ts`: `previewMimeType` now maps `.odt` / `.ods` / `.odp` to their OASIS MIME types.

No OpenAPI/proxy changes: endpoint signatures are unchanged (extension validation is runtime), upload proxies only validate the `key`, and file proxies forward the backend content-type.

## Test plan

- [x] `black --check` (line-length 120) — clean
- [x] `flake8 --select=B904,B014` — clean
- [x] Backend tests: 32 passed, incl. new parametrized ODF acceptance tests on both upload paths + regulations-url-still-rejects-ODF
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — clean