### PR TITLE
feat: enforce Taiwan-mobile-only format for application contact phone

### DIFF
--- a/backend/alembic/versions/contact_phone_tw_mobile_001.py
+++ b/backend/alembic/versions/contact_phone_tw_mobile_001.py
@@ -1,0 +1,58 @@
+"""Tighten contact_phone validation to Taiwan mobile only (09 + 8 digits)
+
+Revision ID: contact_phone_tw_mobile_001
+Revises: add_roster_student_number_001
+Create Date: 2026-06-09 00:00:00.000000
+
+Per request, the student application 聯絡電話 (contact_phone) field must:
+  - show the help text "請輸入本人有效的台灣手機 (09xxxxxx)"
+  - only accept a pure-digit Taiwan mobile number: starts with 09, 10 digits.
+
+This supersedes ``add_contact_phone_field_001`` (which also accepted landline
+numbers). It updates the validation_rules JSON on every existing contact_phone
+row across all scholarship types.
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "contact_phone_tw_mobile_001"
+down_revision: Union[str, None] = "add_roster_student_number_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Taiwan mobile only: 09 followed by exactly 8 digits (10 digits total, pure numbers).
+NEW_VALIDATION = {
+    "pattern": r"^09\d{8}$",
+    "patternMessage": "請輸入本人有效的台灣手機 (09xxxxxx)",
+}
+
+# Previous rule (mobile OR landline) restored on downgrade.
+OLD_VALIDATION = {
+    "pattern": r"^09\d{8}$|^0\d{1,2}-?\d{6,8}$",
+    "patternMessage": "請輸入有效的台灣手機 (09xxxxxxxx) 或市話 (含區碼)",
+}
+
+
+def _set_validation(rules: dict) -> None:
+    op.get_bind().execute(
+        sa.text(
+            "UPDATE application_fields "
+            "SET validation_rules = CAST(:rules AS JSON) "
+            "WHERE field_name = 'contact_phone'"
+        ),
+        {"rules": json.dumps(rules)},
+    )
+
+
+def upgrade() -> None:
+    _set_validation(NEW_VALIDATION)
+
+
+def downgrade() -> None:
+    _set_validation(OLD_VALIDATION)

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -38,6 +38,11 @@ from app.services.email_service import EmailService
 from app.services.minio_service import minio_service
 from app.services.review_phase_filter import apply_renewal_phase_filter
 from app.services.student_service import StudentService
+from app.utils.phone_validation import (
+    TAIWAN_MOBILE_MESSAGE,
+    extract_contact_phone,
+    is_valid_taiwan_mobile,
+)
 
 func: Any = sa_func
 
@@ -587,6 +592,10 @@ class ApplicationService:
         if not is_eligible:
             error_message = "Student is not eligible for this scholarship. " + "; ".join(eligibility_errors)
             raise ValidationError(error_message)
+
+        # 直接提交（非草稿）時驗證聯絡電話格式；草稿允許暫存未完成的號碼。
+        if not is_draft and application_data.form_data:
+            self._enforce_contact_phone_format(application_data.form_data.fields)
 
         # Create application instance using helper method
         application = await self._create_application_instance(
@@ -1232,6 +1241,19 @@ class ApplicationService:
 
         return application
 
+    def _enforce_contact_phone_format(self, form_fields: Optional[Dict[str, Any]]) -> None:
+        """Reject a submission whose contact_phone is present but not a TW mobile.
+
+        The number must be pure digits starting with 09 and 10 digits long.
+        Empty/absent values are deferred to the required-field check so forms
+        without a contact_phone field keep submitting unchanged.
+        """
+        phone = extract_contact_phone(form_fields)
+        if phone is None or phone == "":
+            return
+        if not is_valid_taiwan_mobile(phone):
+            raise ValidationError(TAIWAN_MOBILE_MESSAGE)
+
     async def submit_application(self, application_id: int, user: User) -> ApplicationResponse:
         """提交申請"""
         # Get application with relationships loaded
@@ -1259,6 +1281,9 @@ class ApplicationService:
 
         # 驗證所有必填欄位
         _ = ApplicationFormData(**application.submitted_form_data)
+
+        # 驗證聯絡電話格式（台灣手機，09 開頭共十碼純數字）
+        self._enforce_contact_phone_format((application.submitted_form_data or {}).get("fields"))
 
         # A draft can only be submitted once it carries a concrete sub-type
         # for scholarships that define real ones (the "general" fallback maps

--- a/backend/app/tests/test_phone_validation.py
+++ b/backend/app/tests/test_phone_validation.py
@@ -1,0 +1,68 @@
+"""Unit tests for Taiwan mobile validation used by the contact_phone field."""
+
+from app.utils.phone_validation import (
+    TAIWAN_MOBILE_MESSAGE,
+    extract_contact_phone,
+    is_valid_taiwan_mobile,
+)
+
+
+class TestIsValidTaiwanMobile:
+    def test_accepts_valid_mobile(self):
+        assert is_valid_taiwan_mobile("0912345678") is True
+
+    def test_rejects_landline_with_dashes(self):
+        # Previously accepted by the old pattern; now mobile-only.
+        assert is_valid_taiwan_mobile("0912-345-678") is False
+
+    def test_rejects_landline_with_area_code(self):
+        assert is_valid_taiwan_mobile("02-12345678") is False
+
+    def test_rejects_too_short(self):
+        assert is_valid_taiwan_mobile("091234567") is False
+
+    def test_rejects_too_long(self):
+        assert is_valid_taiwan_mobile("09123456789") is False
+
+    def test_rejects_non_09_prefix(self):
+        assert is_valid_taiwan_mobile("0812345678") is False
+
+    def test_rejects_non_digits(self):
+        assert is_valid_taiwan_mobile("09abcd5678") is False
+
+    def test_rejects_whitespace(self):
+        assert is_valid_taiwan_mobile(" 0912345678") is False
+        assert is_valid_taiwan_mobile("0912345678 ") is False
+
+    def test_rejects_none_and_empty(self):
+        assert is_valid_taiwan_mobile(None) is False
+        assert is_valid_taiwan_mobile("") is False
+
+    def test_message_is_the_requested_text(self):
+        assert TAIWAN_MOBILE_MESSAGE == "請輸入本人有效的台灣手機 (09xxxxxx)"
+
+
+class TestExtractContactPhone:
+    def test_extracts_value_from_mapping(self):
+        fields = {
+            "contact_phone": {
+                "field_id": "contact_phone",
+                "field_type": "text",
+                "value": "0912345678",
+                "required": True,
+            }
+        }
+        assert extract_contact_phone(fields) == "0912345678"
+
+    def test_absent_field_returns_none(self):
+        assert extract_contact_phone({"bank_account": {"value": "123"}}) is None
+
+    def test_none_or_empty_fields_returns_none(self):
+        assert extract_contact_phone(None) is None
+        assert extract_contact_phone({}) is None
+
+    def test_reads_value_attribute_from_object(self):
+        class _Field:
+            value = "0987654321"
+
+        assert extract_contact_phone({"contact_phone": _Field()}) == "0987654321"

--- a/backend/app/utils/phone_validation.py
+++ b/backend/app/utils/phone_validation.py
@@ -1,0 +1,36 @@
+"""Taiwan mobile phone validation for student application contact_phone."""
+
+import re
+from typing import Any, Mapping, Optional
+
+# A valid Taiwan mobile number is pure digits, starts with 09 and is 10 digits long.
+TAIWAN_MOBILE_PATTERN = re.compile(r"^09\d{8}$")
+
+# Shown to the student and returned on rejection. Kept identical to the
+# contact_phone field's patternMessage so the client and server agree.
+TAIWAN_MOBILE_MESSAGE = "請輸入本人有效的台灣手機 (09xxxxxx)"
+
+
+def is_valid_taiwan_mobile(value: Any) -> bool:
+    """Return True if value is a valid Taiwan mobile number (09 + 8 digits)."""
+    if value is None:
+        return False
+    return bool(TAIWAN_MOBILE_PATTERN.match(str(value)))
+
+
+def extract_contact_phone(form_fields: Optional[Mapping[str, Any]]) -> Optional[str]:
+    """Pull the contact_phone value out of a submitted_form_data ``fields`` map.
+
+    Each field is stored as ``{field_id, field_type, value, required, ...}``.
+    Returns the raw value (may be ``None``/empty); returns ``None`` when the
+    field is absent so callers can skip format checks for forms without it.
+    """
+    if not form_fields:
+        return None
+    field = form_fields.get("contact_phone")
+    if field is None:
+        return None
+    if isinstance(field, Mapping):
+        return field.get("value")
+    # Pydantic model / object with a ``value`` attribute.
+    return getattr(field, "value", None)

--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -56,7 +56,11 @@ import api, {
 } from "@/lib/api";
 import { isSelectableScholarship } from "@/lib/scholarship-eligibility";
 import { clsx } from "@/lib/utils";
-import { buildApplicationFormFields } from "@/lib/utils/application-helpers";
+import {
+  buildApplicationFormFields,
+  isValidTaiwanMobile,
+  TAIWAN_MOBILE_MESSAGE,
+} from "@/lib/utils/application-helpers";
 import { useApplications } from "@/hooks/use-applications";
 import { useStudentProfile } from "@/hooks/use-student-profile";
 import {
@@ -1066,6 +1070,19 @@ export function ScholarshipApplicationStep({
 
   const handleSubmit = async () => {
     if (!selectedScholarship) return;
+
+    // Enforce the Taiwan mobile format for 聯絡電話 before submitting. The field
+    // is required across every application form; the backend rejects the same
+    // value too, but blocking here gives the student immediate feedback.
+    const contactPhone = dynamicFormData["contact_phone"];
+    if (
+      contactPhone != null &&
+      String(contactPhone) !== "" &&
+      !isValidTaiwanMobile(contactPhone)
+    ) {
+      toast.error(TAIWAN_MOBILE_MESSAGE);
+      return;
+    }
 
     // When the scholarship defines real sub-types, never fall back to the
     // synthetic "general" category (it matches no quota slot at distribution);

--- a/frontend/lib/utils/__tests__/application-helpers.test.ts
+++ b/frontend/lib/utils/__tests__/application-helpers.test.ts
@@ -7,6 +7,8 @@ import {
   getDocumentLabel,
   fetchApplicationFiles,
   buildApplicationFormFields,
+  isValidTaiwanMobile,
+  TAIWAN_MOBILE_MESSAGE,
   BadgeVariant,
 } from "../application-helpers";
 import {
@@ -542,5 +544,37 @@ describe("formatFieldName - postal account label", () => {
   it("labels account_number as the post office account", () => {
     expect(formatFieldName("account_number", "zh")).toBe("郵局帳號");
     expect(formatFieldName("account_number", "en")).toBe("Post Office Account");
+  });
+});
+
+describe("isValidTaiwanMobile", () => {
+  it("accepts a 09-prefixed 10-digit number", () => {
+    expect(isValidTaiwanMobile("0912345678")).toBe(true);
+  });
+
+  it("rejects landline / dashed formats", () => {
+    expect(isValidTaiwanMobile("0912-345-678")).toBe(false);
+    expect(isValidTaiwanMobile("02-12345678")).toBe(false);
+  });
+
+  it("rejects wrong length", () => {
+    expect(isValidTaiwanMobile("091234567")).toBe(false);
+    expect(isValidTaiwanMobile("09123456789")).toBe(false);
+  });
+
+  it("rejects a non-09 prefix and non-digits", () => {
+    expect(isValidTaiwanMobile("0812345678")).toBe(false);
+    expect(isValidTaiwanMobile("09abcd5678")).toBe(false);
+  });
+
+  it("rejects empty / non-string input", () => {
+    expect(isValidTaiwanMobile("")).toBe(false);
+    expect(isValidTaiwanMobile(undefined)).toBe(false);
+    expect(isValidTaiwanMobile(null)).toBe(false);
+    expect(isValidTaiwanMobile(912345678)).toBe(false);
+  });
+
+  it("exposes the requested help message", () => {
+    expect(TAIWAN_MOBILE_MESSAGE).toBe("請輸入本人有效的台灣手機 (09xxxxxx)");
   });
 });

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -498,6 +498,14 @@ export interface SubmittedFormFieldValue {
  * `account_number` key). If it is omitted here the account never reaches the
  * admin side, so we always fold it into the form fields.
  */
+// Taiwan mobile number: pure digits, starts with 09, exactly 10 digits.
+// Mirrors the backend contact_phone validation so client and server agree.
+export const TAIWAN_MOBILE_PATTERN = /^09\d{8}$/;
+export const TAIWAN_MOBILE_MESSAGE = "請輸入本人有效的台灣手機 (09xxxxxx)";
+
+export const isValidTaiwanMobile = (value: unknown): boolean =>
+  typeof value === "string" && TAIWAN_MOBILE_PATTERN.test(value);
+
 export const buildApplicationFormFields = (
   dynamicFormData: Record<string, unknown>,
   accountNumber?: string | null


### PR DESCRIPTION
## What

The student application **聯絡電話 (contact_phone)** field now:
- shows the help text **「請輸入本人有效的台灣手機 (09xxxxxx)」**
- only accepts a **pure-digit Taiwan mobile number** — starts with `09`, 10 digits total (`^09\d{8}$`).

Previously the field also accepted landline numbers / dashes.

## Changes

- **Migration** `contact_phone_tw_mobile_001` — updates the `contact_phone` `validation_rules` (`pattern` + `patternMessage`) across all scholarship types. Reversible (downgrade restores the old mobile-or-landline rule).
- **Backend validation** — `submit_application` and the direct non-draft create path reject invalid numbers server-side via a shared, unit-tested helper (`app/utils/phone_validation.py`).
- **Frontend validation** — the application wizard blocks submission with the same rule and shows the same message.
- Empty/absent values are deferred to the existing required-field check, so drafts and forms without the field submit unchanged.

前後端都有驗證 ✅

## Test plan

- [x] Backend: `black --check` + `flake8` clean; 14 new unit tests pass (`test_phone_validation.py`).
- [x] Frontend: `tsc --noEmit` clean, `eslint` clean, 49 jest tests pass (incl. new `isValidTaiwanMobile` cases).
- [x] Migration applies and reverts against the dev DB; field shows `^09\d{8}$` + the new help text after upgrade.