### PR TITLE
fix(auth): warn that NYCU Portal SSO session persists after logout (#925)

### DIFF
--- a/frontend/components/__tests__/sso-login-page.test.tsx
+++ b/frontend/components/__tests__/sso-login-page.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SSOLoginPage } from "../sso-login-page";
+
+describe("SSOLoginPage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    // jsdom default location host is "localhost" → portal.test URL branch
+  });
+
+  it("always renders the Portal login button", () => {
+    render(<SSOLoginPage />);
+    expect(screen.getByText("使用 NYCU Portal 登入")).toBeInTheDocument();
+  });
+
+  it("does NOT show the logout notice on a normal visit", () => {
+    render(<SSOLoginPage />);
+    expect(screen.queryByText(/NYCU Portal 仍保持登入/)).not.toBeInTheDocument();
+    expect(screen.queryByText("前往登出 NYCU Portal")).not.toBeInTheDocument();
+  });
+
+  it("shows the Portal-still-logged-in notice after a real logout (flag set)", () => {
+    sessionStorage.setItem("nycu_portal_logout_notice", "1");
+    render(<SSOLoginPage />);
+    expect(screen.getByText(/NYCU Portal 仍保持登入/)).toBeInTheDocument();
+    // and the flag is consumed so it doesn't show again on the next mount
+    expect(sessionStorage.getItem("nycu_portal_logout_notice")).toBeNull();
+  });
+
+  it("the Portal-logout button opens the NYCU Portal", () => {
+    sessionStorage.setItem("nycu_portal_logout_notice", "1");
+    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+    render(<SSOLoginPage />);
+    fireEvent.click(screen.getByText("前往登出 NYCU Portal"));
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(String(openSpy.mock.calls[0][0])).toContain("portal");
+    openSpy.mockRestore();
+  });
+});

--- a/frontend/components/sso-login-page.tsx
+++ b/frontend/components/sso-login-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import {
   Card,
   CardContent,
@@ -8,23 +9,53 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { GraduationCap, ExternalLink } from "lucide-react";
+import { GraduationCap, ExternalLink, LogOut, AlertTriangle } from "lucide-react";
+
+// Resolve the NYCU Portal base URL for the current environment.
+function getPortalUrl(): string {
+  let portalUrl = "https://portal.nycu.edu.tw"; // default production
+  if (typeof window !== "undefined") {
+    const hostname = window.location.hostname;
+    if (
+      hostname.includes("test") ||
+      hostname.includes("staging") ||
+      hostname.includes("localhost") ||
+      hostname === "140.113.7.148"
+    ) {
+      portalUrl = "https://portal.test.nycu.edu.tw";
+    }
+  }
+  return portalUrl;
+}
 
 export function SSOLoginPage() {
+  // Shown right after a real logout. The app session is cleared, but the NYCU
+  // Portal SSO session (a host-only `userToken` cookie on portal.test) is NOT —
+  // we can't clear it cross-origin and the Portal exposes no app-initiable
+  // logout. So warn that the next login is one-click and offer a Portal logout.
+  const [justLoggedOut, setJustLoggedOut] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (sessionStorage.getItem("nycu_portal_logout_notice") === "1") {
+        setJustLoggedOut(true);
+        sessionStorage.removeItem("nycu_portal_logout_notice");
+      }
+    } catch {
+      // sessionStorage unavailable (private mode) — skip the notice.
+    }
+  }, []);
+
   const handleSSOLogin = () => {
     // Redirect to NYCU Portal for SSO authentication
-    // Detect environment from hostname to determine correct Portal URL
-    let portalUrl = 'https://portal.nycu.edu.tw'; // Default production
+    window.location.href = `${getPortalUrl()}/#/redirect/scholarship`;
+  };
 
-    if (typeof window !== 'undefined') {
-      const hostname = window.location.hostname;
-      // Use test portal for test/staging/dev environments
-      if (hostname.includes('test') || hostname.includes('staging') || hostname.includes('localhost') || hostname === '140.113.7.148') {
-        portalUrl = 'https://portal.test.nycu.edu.tw';
-      }
-    }
-
-    window.location.href = `${portalUrl}/#/redirect/scholarship`;
+  const handlePortalLogout = () => {
+    // Open the NYCU Portal so the user can complete a full SSO logout there
+    // (clicking the Portal's own LogOut clears the userToken cookie). We can't
+    // do it for them: portal.test is a different host and exposes no logout URL.
+    window.open(getPortalUrl(), "_blank", "noopener,noreferrer");
   };
 
   return (
@@ -34,13 +65,42 @@ export function SSOLoginPage() {
           <div className="nycu-gradient h-16 w-16 rounded-xl flex items-center justify-center nycu-shadow mx-auto mb-4">
             <GraduationCap className="h-8 w-8 text-white" />
           </div>
-          <CardTitle className="text-2xl text-nycu-navy-800">
-            登入系統
-          </CardTitle>
+          <CardTitle className="text-2xl text-nycu-navy-800">登入系統</CardTitle>
           <CardDescription>獎學金申請與簽核系統</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
+            {justLoggedOut && (
+              <div
+                role="status"
+                className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"
+              >
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600" />
+                  <div className="space-y-2">
+                    <p>
+                      您已登出獎學金系統，但
+                      <strong>NYCU Portal 仍保持登入</strong>
+                      。在共用電腦上，下一位使用者可一鍵進入您的帳號。
+                    </p>
+                    <p className="text-amber-800">
+                      如需完全登出，請至 NYCU Portal 點右上角頭像 →
+                      <strong> 登出 (LogOut)</strong>。
+                    </p>
+                    <Button
+                      onClick={handlePortalLogout}
+                      variant="outline"
+                      size="sm"
+                      className="border-amber-400 text-amber-900 hover:bg-amber-100"
+                    >
+                      <LogOut className="h-4 w-4 mr-2" />
+                      前往登出 NYCU Portal
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )}
+
             <Button onClick={handleSSOLogin} className="w-full">
               <ExternalLink className="h-4 w-4 mr-2" />
               使用 NYCU Portal 登入

--- a/frontend/hooks/use-auth.tsx
+++ b/frontend/hooks/use-auth.tsx
@@ -132,7 +132,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (isLocalhost) {
         router.push("/dev-login");
       } else {
-        // In production, redirect to home page or SSO login
+        // In production, redirect to home page or SSO login.
+        // Flag that this is a real logout so the login page can warn that the
+        // NYCU Portal SSO session is NOT cleared (it's a host-only cookie on
+        // portal.test we can't touch cross-origin, and the Portal exposes no
+        // app-initiable logout) — otherwise the next click re-logs in instantly.
+        try {
+          sessionStorage.setItem("nycu_portal_logout_notice", "1");
+        } catch {
+          // sessionStorage may be unavailable (private mode); the notice is best-effort.
+        }
         router.push("/");
       }
     }


### PR DESCRIPTION
## Bug (#925)

On staging, clicking **登出** returns to the login screen but the user is still effectively logged in — the next **使用 NYCU Portal 登入** click re-authenticates **instantly, with no credentials**.

## Root cause (reproduced + confirmed on staging via Playwright)

| step | observed |
|---|---|
| logged in | `auth_token` ✓, `portal.test` cookie **`userToken`** ✓ |
| after **登出** | `auth_token` → **CLEARED** ✓, login screen ✓, **`userToken` still present** ← |
| click **Portal 登入** | **instant re-login** (`/#main`, token reset, no credentials) |

The app `logout()` correctly clears the **local** session. The persisting thing is the **NYCU Portal SSO session** — `userToken`, a **host-only, non-HttpOnly cookie on `portal.test.nycu.edu.tw`**. The Portal's own LogOut is a client-side `Cookies.remove('userToken')` + reload (no server endpoint; `#/logout` → 404), and our app on `ss.test` **cannot clear a cross-host cookie**. So a clean app-initiated SLO is **not possible** against this Portal.

## Fix — make logout honest (the platform can't do auto-SLO)

- `logout()` sets a `sessionStorage` flag on the prod/staging redirect path.
- `SSOLoginPage` reads+clears it and shows an amber notice: *app logged out, but NYCU Portal is still logged in (one-click re-entry on shared machines); to fully log out, use the Portal* — plus a **前往登出 NYCU Portal** button that opens the Portal so the user can click its LogOut.

No change to the happy-path login. localhost (mock-SSO/dev-login) unaffected.

## Verification

- Staging Playwright repro confirms the root cause (above).
- `tsc` + `next lint` clean; **4 new unit tests** (`sso-login-page.test.tsx`) cover notice-shown-after-logout / hidden-on-normal-visit / flag-consumed / button-opens-Portal.

Follow-up (separate, out of our control): ask the NYCU Portal team for a standard OIDC `end_session_endpoint` so true SLO becomes possible.

Fixes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)