### PR TITLE
fix(security): patch privilege escalation, XSS, and secret/token leakage

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -364,7 +364,9 @@ async def portal_sso_verify(
 
         user_info = auth_result.get("user", {})
         nycu_id = user_info.get("nycu_id", "unknown")
-        logger.info(f"Redirecting user {nycu_id} to frontend via Portal verification: {redirect_url}")
+        # SECURITY: never log the redirect_url — it contains the access token in
+        # the query string, which would persist the credential in server logs.
+        logger.info(f"Redirecting user {nycu_id} to frontend via Portal verification")
 
         # Return redirect response
         # SECURITY: Token passed via URL parameter only (no cookie).

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -324,9 +324,10 @@ async def portal_sso_verify(
         "student_id": student_id,
     }
 
-    # Log only non-None parameters
-    non_none_params = {k: v for k, v in received_params.items() if v is not None}
-    logger.info(f"Portal SSO received parameters: {non_none_params}")
+    # SECURITY: log only which parameter NAMES were provided, never their values —
+    # several of these fields carry the SSO JWT / access token.
+    present_params = [k for k, v in received_params.items() if v is not None]
+    logger.info(f"Portal SSO received parameters: {present_params}")
 
     # Extract data from form parameters (try multiple possible token field names)
     final_token = token or jwt or jwt_token or access_token or id_token

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -142,8 +142,15 @@ async def update_my_profile(
     # This automatically stays in sync with schema changes
     allowed_fields = set(update_data.model_fields.keys())
 
+    # SECURITY: privilege-controlling fields must never be self-editable via the
+    # profile endpoint, otherwise any authenticated user could escalate to
+    # super_admin by sending {"role": "super_admin"}.
+    self_protected_fields = {"role", "user_type", "status", "college_code"}
+
     update_dict = update_data.model_dump(exclude_unset=True)
     for field, value in update_dict.items():
+        if field in self_protected_fields:
+            continue
         if field in allowed_fields and hasattr(current_user, field):
             setattr(current_user, field, value)
 
@@ -354,6 +361,17 @@ async def update_user(
     allowed_fields = set(update_data.model_fields.keys())
 
     update_dict = update_data.model_dump(exclude_unset=True)
+
+    # SECURITY: restrict role changes to prevent privilege escalation.
+    # A plain admin must not be able to grant roles (e.g. promote themselves or
+    # another account to super_admin); only super_admin may change roles, and no
+    # one may change their own role.
+    if "role" in update_dict and update_dict["role"] != user.role:
+        if user.id == current_user.id:
+            raise HTTPException(status_code=403, detail="Cannot change your own role")
+        if not current_user.is_super_admin():
+            raise HTTPException(status_code=403, detail="Only super admin can change user roles")
+
     for field, value in update_dict.items():
         if field in allowed_fields and hasattr(user, field):
             setattr(user, field, value)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -318,7 +318,14 @@ class Settings(BaseSettings):
         Prevents a misconfigured production deployment from silently running with
         the mock Student API HMAC key or mock SSO enabled.
         """
-        if self.testing:
+        # Only bypass under an actual test runner. Note: the loose ``self.testing``
+        # property treats any non-empty TESTING value (even "false") as truthy, so
+        # we check explicitly here to avoid accidentally disabling the production
+        # safety checks when TESTING is set to a non-empty, non-"true" value.
+        in_test_runner = bool(os.getenv("PYTEST_CURRENT_TEST") or os.getenv("CI")) or (
+            os.getenv("TESTING", "").lower() == "true"
+        )
+        if in_test_runner:
             return self
         if self.environment == "production":
             if self.student_api_enabled and self.student_api_hmac_key == _MOCK_STUDENT_API_HMAC_KEY:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,8 +6,12 @@ Handles all environment variables and application settings.
 import os
 from typing import List, Optional
 
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Well-known insecure default for the Student API HMAC key. Used only for local
+# development against the mock student API; must never reach a real deployment.
+_MOCK_STUDENT_API_HMAC_KEY = "4d6f636b4b657946726f6d48657841424344454647484a4b4c4d4e4f505152535455565758595a"
 
 
 class Settings(BaseSettings):
@@ -116,6 +120,9 @@ class Settings(BaseSettings):
     portal_jwt_server_url: str = "https://portal.test.nycu.edu.tw/jwt/portal"
     portal_test_mode: bool = False  # Set to True for testing with mock data
     portal_sso_timeout: float = 10.0  # Timeout for Portal JWT verification
+    # Callback URL the Portal redirects to after JWT verification. Must be
+    # configured per environment via PORTAL_CALLBACK_URL rather than hardcoded.
+    portal_callback_url: str = "http://localhost:8000/api/v1/auth/portal-sso/verify"
 
     # Super Admin Configuration
     super_admin_nycu_id: str = "super_admin"  # NYCU ID that should be granted super_admin role
@@ -127,9 +134,7 @@ class Settings(BaseSettings):
     student_api_enabled: bool = True
     student_api_base_url: str = "http://localhost:8080"  # Mock API in development
     student_api_account: str = "scholarship"
-    student_api_hmac_key: str = (
-        "4d6f636b4b657946726f6d48657841424344454647484a4b4c4d4e4f505152535455565758595a"  # Mock key for development
-    )
+    student_api_hmac_key: str = _MOCK_STUDENT_API_HMAC_KEY  # Mock key for development only
     student_api_timeout: float = 10.0
     student_api_encode_type: Optional[str] = "UTF-8"
 
@@ -305,6 +310,25 @@ class Settings(BaseSettings):
     def testing(self) -> bool:
         """Check if we're in a testing environment"""
         return bool(os.getenv("PYTEST_CURRENT_TEST") or os.getenv("CI") or os.getenv("TESTING"))
+
+    @model_validator(mode="after")
+    def validate_production_secrets(self) -> "Settings":
+        """Fail fast if insecure development defaults leak into production.
+
+        Prevents a misconfigured production deployment from silently running with
+        the mock Student API HMAC key or mock SSO enabled.
+        """
+        if self.testing:
+            return self
+        if self.environment == "production":
+            if self.student_api_enabled and self.student_api_hmac_key == _MOCK_STUDENT_API_HMAC_KEY:
+                raise ValueError(
+                    "STUDENT_API_HMAC_KEY is using the development mock key in production. "
+                    "Set a real STUDENT_API_HMAC_KEY (or disable STUDENT_API_ENABLED)."
+                )
+            if self.enable_mock_sso:
+                raise ValueError("ENABLE_MOCK_SSO must be false in production.")
+        return self
 
     model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ import logging
 import uuid
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
@@ -21,6 +21,8 @@ from app.api.v1.api import api_router
 from app.core.config import settings
 from app.core.database_health import check_database_health
 from app.core.exceptions import ScholarshipException, scholarship_exception_handler
+from app.core.security import require_admin
+from app.models.user import User
 
 # Import Prometheus metrics
 from app.core.metrics import CONTENT_TYPE_LATEST, generate_latest, set_app_info, update_db_pool_metrics
@@ -313,8 +315,8 @@ async def health_check():
 
 # Database pool status endpoint (admin only)
 @app.get("/debug/pool-status")
-async def get_pool_status():
-    """Get current database connection pool status (for debugging)"""
+async def get_pool_status(current_user: User = Depends(require_admin)):
+    """Get current database connection pool status (for debugging, admin only)"""
     async_pool = async_engine.pool
     sync_pool = sync_engine.pool
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -316,7 +316,7 @@ async def health_check():
 # Database pool status endpoint (admin only)
 @app.get("/debug/pool-status")
 async def get_pool_status(current_user: User = Depends(require_admin)):
-    """Get current database connection pool status (for debugging, admin only)"""
+    """Get current database connection pool status (for debugging)"""
     async_pool = async_engine.pool
     sync_pool = sync_engine.pool
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -97,13 +97,11 @@ class AuthService:
         # Add debug data in test/development mode or when explicitly requested
         from app.core.config import settings
 
-        is_debug_mode = (
-            settings.environment in ["development", "testing"]
-            or settings.portal_test_mode
-            or settings.debug
-            # Also include for test deployments (when host contains test indicators)
-            or any(indicator in settings.base_url.lower() for indicator in ["test", "140.113.7.148", "localhost"])
-        )
+        # SECURITY: only embed raw portal/student data in the JWT for explicit
+        # local development/testing. The previous URL-substring heuristic (matching
+        # "test"/host IPs in base_url) leaked PII into signed-but-unencrypted tokens
+        # on any staging host whose URL happened to contain those substrings.
+        is_debug_mode = settings.environment in ["development", "testing"] or settings.portal_test_mode
 
         if is_debug_mode:
             if portal_data:

--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -254,7 +254,9 @@ class MinIOService:
             file_uploads_total.labels(file_type=str(file_type), status="failed").inc()
             raise
         except Exception as e:
-            logger.exception(f"Failed to upload file {file.filename}")
+            # SECURITY: sanitize the client-supplied filename before logging to
+            # avoid log injection / control-character confusion.
+            logger.exception(f"Failed to upload file {secure_filename(file.filename or '')}")
 
             # Business metric: count failures so the dashboard can show
             # the success-rate ratio without needing log-scraping.

--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -238,7 +238,9 @@ class MinIOService:
                 content_type=file.content_type,
             )
 
-            logger.info(f"Uploaded file {file.filename} as {object_name}")
+            # Log the sanitized filename (object_name is already safe) to avoid
+            # log injection from control characters in the client-supplied name.
+            logger.info(f"Uploaded file {safe_filename} as {object_name}")
 
             # Business metric: count successful application-file uploads.
             # file_type already discriminates document categories (doc,

--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Tuple
 
+from fastapi import HTTPException
 from minio import Minio
 from minio.commonconfig import CopySource
 from minio.error import S3Error
@@ -17,6 +18,7 @@ from minio.error import S3Error
 from app.core.config import settings
 from app.core.exceptions import FileStorageError
 from app.core.metrics import file_uploads_total
+from app.core.path_security import secure_filename
 
 logger = logging.getLogger(__name__)
 
@@ -202,25 +204,24 @@ class MinIOService:
 
             # 檢查檔案大小
             if file_size > settings.max_file_size:
-                from fastapi import HTTPException
-
-                raise HTTPException(status_code=500, detail="File too large")
+                raise HTTPException(status_code=413, detail="File too large")
 
             # 檢查檔案類型
             if not file.filename:
-                from fastapi import HTTPException
+                raise HTTPException(status_code=400, detail="No filename provided")
 
-                raise HTTPException(status_code=500, detail="No filename provided")
+            # Sanitize the filename first (strips path components / unsafe chars)
+            # so a payload like "evil.pdf.exe" or "../../etc/passwd" cannot survive.
+            safe_filename = secure_filename(file.filename)
 
-            file_extension = file.filename.split(".")[-1].lower()
+            # Validate the extension on the *sanitized* name, taking the final
+            # extension only (defends against double-extension bypass).
+            file_extension = safe_filename.rsplit(".", 1)[-1].lower() if "." in safe_filename else ""
             if file_extension not in settings.allowed_file_types_list:
-                from fastapi import HTTPException
-
-                raise HTTPException(status_code=500, detail="Invalid file type")
+                raise HTTPException(status_code=415, detail="Invalid file type")
 
             # 生成object名稱
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            safe_filename = file.filename.replace(" ", "_")
             # 標準化 file_type 為複數形式
             if file_type == "doc":
                 folder_name = "documents"
@@ -247,14 +248,17 @@ class MinIOService:
 
             return object_name, file_size
 
+        except HTTPException:
+            # Validation errors (size/type/filename) carry their own status code
+            # and must not be masked as a generic 500.
+            file_uploads_total.labels(file_type=str(file_type), status="failed").inc()
+            raise
         except Exception as e:
             logger.exception(f"Failed to upload file {file.filename}")
 
             # Business metric: count failures so the dashboard can show
             # the success-rate ratio without needing log-scraping.
             file_uploads_total.labels(file_type=str(file_type), status="failed").inc()
-
-            from fastapi import HTTPException
 
             raise HTTPException(status_code=500, detail="File upload failed") from e
 

--- a/backend/app/services/portal_sso_service.py
+++ b/backend/app/services/portal_sso_service.py
@@ -53,7 +53,9 @@ class PortalSSOService:
                 # Post token to Portal JWT server for verification
                 # Portal expects form data, not JSON
                 # Try multiple parameter combinations that Portal might expect
-                logger.info(f"Attempting Portal JWT verification with token: {token[:50]}...")
+                # SECURITY: do not log any portion of the token — even a prefix is
+                # a sensitive credential fragment.
+                logger.info("Attempting Portal JWT verification")
 
                 # First attempt: just the token
                 response = await client.post(
@@ -84,7 +86,8 @@ class PortalSSOService:
                     )
 
                 if response.status_code != 200:
-                    logger.error(f"Portal JWT verification failed: {response.status_code} - {response.text}")
+                    # SECURITY: don't log response body — it may echo the token / PII.
+                    logger.error(f"Portal JWT verification failed: {response.status_code}")
                     raise AuthenticationError(f"Portal token verification failed: {response.status_code}")
 
                 portal_data = response.json()
@@ -94,11 +97,12 @@ class PortalSSOService:
                     # Extract user data from nested structure
                     user_data = portal_data["data"]
                     if not self._validate_portal_response(user_data):
-                        logger.error(f"Invalid user data in portal response: {user_data}")
+                        # SECURITY: log only the field names, not the PII values.
+                        logger.error(f"Invalid user data in portal response; keys: {list(user_data.keys())}")
                         raise AuthenticationError("Invalid user data format")
                     return user_data
                 else:
-                    logger.error(f"Invalid portal response format: {portal_data}")
+                    logger.error("Invalid portal response format")
                     raise AuthenticationError("Invalid portal response format")
 
         except httpx.TimeoutException as exc:

--- a/backend/app/services/portal_sso_service.py
+++ b/backend/app/services/portal_sso_service.py
@@ -78,7 +78,7 @@ class PortalSSOService:
                         settings.portal_jwt_server_url,
                         data={
                             "token": token,
-                            "callback_url": "https://140.113.7.148/api/v1/auth/portal-sso/verify",
+                            "callback_url": settings.portal_callback_url,
                         },
                         headers={"Content-Type": "application/x-www-form-urlencoded"},
                     )

--- a/backend/app/tests/test_auth_service.py
+++ b/backend/app/tests/test_auth_service.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.exceptions import AuthenticationError, ConflictError
 from app.models.user import EmployeeStatus, User, UserRole
 from app.schemas.user import TokenResponse, UserCreate, UserLogin, UserResponse
@@ -248,8 +249,15 @@ class TestAuthService:
 
     @pytest.mark.smoke
     @pytest.mark.asyncio
-    async def test_create_tokens(self, service, mock_user):
-        """Test token creation for authenticated user"""
+    async def test_create_tokens(self, service, mock_user, monkeypatch):
+        """Test token creation for authenticated user.
+
+        Pinned to production-like settings so the result is deterministic:
+        debug data (portal/student/debug_mode) must NOT be embedded outside
+        development/testing/portal_test_mode.
+        """
+        monkeypatch.setattr(settings, "environment", "production")
+        monkeypatch.setattr(settings, "portal_test_mode", False)
         with (
             patch("app.services.auth_service.create_access_token") as mock_access_token,
             patch("app.services.auth_service.create_refresh_token") as mock_refresh_token,
@@ -275,12 +283,11 @@ class TestAuthService:
 
             result = await service.create_tokens(mock_user)
 
-            # Verify token data
+            # Verify token data (no debug_mode in production)
             expected_token_data = {
                 "sub": str(mock_user.id),
                 "nycu_id": mock_user.nycu_id,
                 "role": mock_user.role.value,
-                "debug_mode": True,
             }
 
             mock_access_token.assert_called_once_with(expected_token_data)

--- a/backend/app/tests/test_minio_service_unit.py
+++ b/backend/app/tests/test_minio_service_unit.py
@@ -79,7 +79,7 @@ async def test_upload_file_rejects_large_file(minio_service, monkeypatch):
     with pytest.raises(HTTPException) as exc:
         await MinIOService.upload_file(minio_service, upload, application_id=1, file_type="doc")
 
-    assert exc.value.status_code == 500  # currently wrapped inside generic handler
+    assert exc.value.status_code == 413  # too large -> Request Entity Too Large
     minio_service.client.put_object.assert_not_called()
 
 
@@ -92,7 +92,22 @@ async def test_upload_file_invalid_extension(minio_service, monkeypatch):
     with pytest.raises(HTTPException) as exc:
         await MinIOService.upload_file(minio_service, upload, application_id=1, file_type="doc")
 
-    assert exc.value.status_code == 500  # currently wrapped inside generic handler
+    assert exc.value.status_code == 415  # unsupported media type
+    minio_service.client.put_object.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_file_double_extension_bypass_blocked(minio_service, monkeypatch):
+    """A double-extension payload (report.pdf.exe) must be rejected by the
+    final-extension check, not silently accepted as a PDF."""
+    monkeypatch.setattr("app.services.minio_service.settings", _make_settings(allowed_file_types_list=["pdf"]))
+
+    upload = _build_upload_file("report.pdf.exe", b"data")
+
+    with pytest.raises(HTTPException) as exc:
+        await MinIOService.upload_file(minio_service, upload, application_id=1, file_type="doc")
+
+    assert exc.value.status_code == 415
     minio_service.client.put_object.assert_not_called()
 
 

--- a/backend/app/tests/test_users_endpoint_authz.py
+++ b/backend/app/tests/test_users_endpoint_authz.py
@@ -1,0 +1,163 @@
+"""
+Endpoint-level authorization tests for the user management routes.
+
+Security-critical regressions pinned (PR: fix security vulnerabilities):
+- PUT /users/me must IGNORE privilege fields (role/user_type/status/
+  college_code) — a student cannot escalate to super_admin via self-update.
+- PUT /users/{id}:
+    * a plain admin cannot change anyone's role (incl. self),
+    * nobody (even super_admin) can change their OWN role,
+    * a super_admin CAN change another user's role.
+"""
+
+from typing import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_current_user, require_admin
+from app.db.deps import get_db
+from app.main import app
+from app.models.user import User, UserRole, UserType
+
+
+async def _seed_user(
+    db: AsyncSession,
+    *,
+    nycu_id: str,
+    role: UserRole = UserRole.student,
+    college_code: str = "A",
+) -> User:
+    u = User(
+        nycu_id=nycu_id,
+        name=f"User {nycu_id}",
+        email=f"{nycu_id}@u.edu",
+        user_type=UserType.employee if role != UserRole.student else UserType.student,
+        role=role,
+        college_code=college_code,
+    )
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    return u
+
+
+def _client_as(actor: User, db: AsyncSession) -> AsyncClient:
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        yield db
+
+    async def override_current_user():
+        return actor
+
+    async def override_require_admin():
+        return actor
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[require_admin] = override_require_admin
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_self_update_ignores_role_escalation(db: AsyncSession):
+    """A student PUT /users/me with role=super_admin must NOT change the role."""
+    student = await _seed_user(db, nycu_id="self_escalate", role=UserRole.student)
+
+    async with _client_as(student, db) as ac:
+        resp = await ac.put("/api/v1/users/me", json={"role": "super_admin", "name": "New Name"})
+
+    assert resp.status_code == 200
+    # Non-privileged field is applied...
+    assert resp.json()["data"]["name"] == "New Name"
+    # ...but the role is unchanged.
+    await db.refresh(student)
+    assert student.role == UserRole.student
+
+
+@pytest.mark.asyncio
+async def test_self_update_ignores_user_type_and_college(db: AsyncSession):
+    student = await _seed_user(db, nycu_id="self_fields", role=UserRole.student, college_code="A")
+
+    async with _client_as(student, db) as ac:
+        resp = await ac.put(
+            "/api/v1/users/me",
+            json={"user_type": "employee", "college_code": "ZZ"},
+        )
+
+    assert resp.status_code == 200
+    await db.refresh(student)
+    assert student.user_type == UserType.student
+    assert student.college_code == "A"
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_change_other_user_role(db: AsyncSession):
+    admin = await _seed_user(db, nycu_id="plain_admin", role=UserRole.admin)
+    target = await _seed_user(db, nycu_id="victim", role=UserRole.student)
+
+    async with _client_as(admin, db) as ac:
+        resp = await ac.put(f"/api/v1/users/{target.id}", json={"role": "super_admin"})
+
+    assert resp.status_code == 403
+    await db.refresh(target)
+    assert target.role == UserRole.student
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_change_own_role(db: AsyncSession):
+    admin = await _seed_user(db, nycu_id="self_admin", role=UserRole.admin)
+
+    async with _client_as(admin, db) as ac:
+        resp = await ac.put(f"/api/v1/users/{admin.id}", json={"role": "super_admin"})
+
+    assert resp.status_code == 403
+    await db.refresh(admin)
+    assert admin.role == UserRole.admin
+
+
+@pytest.mark.asyncio
+async def test_super_admin_cannot_change_own_role(db: AsyncSession):
+    sa = await _seed_user(db, nycu_id="self_super", role=UserRole.super_admin)
+
+    async with _client_as(sa, db) as ac:
+        resp = await ac.put(f"/api/v1/users/{sa.id}", json={"role": "admin"})
+
+    assert resp.status_code == 403
+    await db.refresh(sa)
+    assert sa.role == UserRole.super_admin
+
+
+@pytest.mark.asyncio
+async def test_super_admin_can_change_other_user_role(db: AsyncSession):
+    sa = await _seed_user(db, nycu_id="grantor", role=UserRole.super_admin)
+    target = await _seed_user(db, nycu_id="promotee", role=UserRole.student)
+
+    async with _client_as(sa, db) as ac:
+        resp = await ac.put(f"/api/v1/users/{target.id}", json={"role": "professor"})
+
+    assert resp.status_code == 200
+    await db.refresh(target)
+    assert target.role == UserRole.professor
+
+
+@pytest.mark.asyncio
+async def test_admin_can_update_non_role_fields_of_other_user(db: AsyncSession):
+    """Non-role updates by a plain admin still work (no over-restriction)."""
+    admin = await _seed_user(db, nycu_id="editor_admin", role=UserRole.admin)
+    target = await _seed_user(db, nycu_id="editable", role=UserRole.student)
+
+    async with _client_as(admin, db) as ac:
+        resp = await ac.put(f"/api/v1/users/{target.id}", json={"name": "Renamed", "role": "student"})
+
+    assert resp.status_code == 200
+    await db.refresh(target)
+    assert target.name == "Renamed"
+    assert target.role == UserRole.student

--- a/docker-compose.staging-db.yml
+++ b/docker-compose.staging-db.yml
@@ -4,9 +4,11 @@ services:
     image: postgres:15-alpine
     container_name: scholarship_postgres_staging
     environment:
-      POSTGRES_DB: scholarship_db
-      POSTGRES_USER: scholarship_user
-      POSTGRES_PASSWORD: scholarship_pass
+      POSTGRES_DB: ${POSTGRES_DB:-scholarship_db}
+      POSTGRES_USER: ${POSTGRES_USER:-scholarship_user}
+      # SECURITY: never hardcode the password. Must be supplied via the
+      # environment (e.g. GitHub Actions secret / .env on the DB host).
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
     ports:
       - "5432:5432"
     volumes:
@@ -27,8 +29,10 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin123
+      # SECURITY: never hardcode MinIO root credentials. Must be supplied via
+      # the environment (GitHub Actions secret / .env on the DB host).
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MINIO_ROOT_USER must be set}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD must be set}
       # Allow Prometheus to scrape /minio/v2/metrics/cluster without a
       # bearer token. Newer MinIO images default to "jwt"; we want
       # "public" so Alloy → Prometheus pipeline works out of the box.

--- a/docker-compose.staging-db.yml
+++ b/docker-compose.staging-db.yml
@@ -16,7 +16,7 @@ services:
     networks:
       - scholarship_staging_db_network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U scholarship_user -d scholarship_db"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-scholarship_user} -d ${POSTGRES_DB:-scholarship_db}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/frontend/app/api/email/preview/[id]/route.ts
+++ b/frontend/app/api/email/preview/[id]/route.ts
@@ -27,9 +27,21 @@ export async function GET(
     });
   } catch (err) {
     const message = err instanceof Error ? `${err.name}: ${err.message}\n${err.stack}` : String(err);
+    // SECURITY: escape the error text before embedding it in HTML so an error
+    // message containing markup cannot execute as script in the preview frame.
+    const escaped = message
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
     return new NextResponse(
-      `<pre style="font-family:monospace;padding:1rem;white-space:pre-wrap">${message}</pre>`,
-      { status: 500, headers: { 'Content-Type': 'text/html; charset=utf-8' } }
+      `<pre style="font-family:monospace;padding:1rem;white-space:pre-wrap">${escaped}</pre>`,
+      {
+        status: 500,
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
+        },
+      }
     );
   }
 }

--- a/frontend/app/api/email/preview/[id]/route.ts
+++ b/frontend/app/api/email/preview/[id]/route.ts
@@ -20,7 +20,7 @@ export async function GET(
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Content-Security-Policy':
-          "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https:;",
+          "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https:; base-uri 'none'; form-action 'none'; frame-ancestors 'self';",
         'X-Frame-Options': 'SAMEORIGIN',
         'Cache-Control': 'no-store',
       },
@@ -39,7 +39,8 @@ export async function GET(
         status: 500,
         headers: {
           'Content-Type': 'text/html; charset=utf-8',
-          'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
+          'Content-Security-Policy':
+            "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'",
           'X-Frame-Options': 'SAMEORIGIN',
           'Cache-Control': 'no-store',
         },

--- a/frontend/app/api/email/preview/[id]/route.ts
+++ b/frontend/app/api/email/preview/[id]/route.ts
@@ -40,6 +40,8 @@ export async function GET(
         headers: {
           'Content-Type': 'text/html; charset=utf-8',
           'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'",
+          'X-Frame-Options': 'SAMEORIGIN',
+          'Cache-Control': 'no-store',
         },
       }
     );

--- a/frontend/app/api/v1/preview/route.ts
+++ b/frontend/app/api/v1/preview/route.ts
@@ -454,7 +454,7 @@ function generateRosterPreviewHTML(data: RosterPreviewPayload): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>造冊預覽 - ${roster_code}</title>
+  <title>造冊預覽 - ${escapeHtml(roster_code)}</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {

--- a/frontend/app/api/v1/preview/route.ts
+++ b/frontend/app/api/v1/preview/route.ts
@@ -383,8 +383,10 @@ async function handleRosterPreview(
           "Content-Type": "text/html; charset=utf-8",
           // Defense-in-depth: the template only needs inline styles; block all
           // scripts so any markup that slips through escaping cannot execute.
+          // base-uri/form-action are NOT covered by default-src, so set them
+          // explicitly; frame-ancestors mirrors X-Frame-Options in CSP.
           "Content-Security-Policy":
-            "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:",
+            "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:; base-uri 'none'; form-action 'none'; frame-ancestors 'self'",
           "X-Frame-Options": "SAMEORIGIN",
         },
       });

--- a/frontend/app/api/v1/preview/route.ts
+++ b/frontend/app/api/v1/preview/route.ts
@@ -381,6 +381,11 @@ async function handleRosterPreview(
       return new NextResponse(htmlContent, {
         headers: {
           "Content-Type": "text/html; charset=utf-8",
+          // Defense-in-depth: the template only needs inline styles; block all
+          // scripts so any markup that slips through escaping cannot execute.
+          "Content-Security-Policy":
+            "default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:",
+          "X-Frame-Options": "SAMEORIGIN",
         },
       });
     }
@@ -423,6 +428,21 @@ interface RosterPreviewPayload {
     warnings?: string[];
     [key: string]: unknown;
   };
+}
+
+// SECURITY: escape any backend-provided value before interpolating it into the
+// HTML template below. Without this, roster codes, column headers, validation
+// errors, or cell values containing markup (e.g. "<img src=x onerror=...>") would
+// execute as script in the rendered preview (stored/reflected XSS).
+function escapeHtml(value: unknown): string {
+  const str =
+    value === null || value === undefined ? '' : String(value);
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
 }
 
 function generateRosterPreviewHTML(data: RosterPreviewPayload): string {
@@ -549,7 +569,7 @@ function generateRosterPreviewHTML(data: RosterPreviewPayload): string {
   <div class="container">
     <div class="header">
       <h1>📋 造冊預覽</h1>
-      <p>造冊代碼: ${roster_code}</p>
+      <p>造冊代碼: ${escapeHtml(roster_code)}</p>
     </div>
 
     <div class="info-bar">
@@ -567,7 +587,7 @@ function generateRosterPreviewHTML(data: RosterPreviewPayload): string {
     <div class="validation">
       <h3>⚠️ 驗證警告</h3>
       <ul>
-        ${validation_result.errors?.map((error: string) => `<li>${error}</li>`).join('') || ''}
+        ${validation_result.errors?.map((error: string) => `<li>${escapeHtml(error)}</li>`).join('') || ''}
       </ul>
     </div>
     ` : ''}
@@ -577,7 +597,7 @@ function generateRosterPreviewHTML(data: RosterPreviewPayload): string {
       <table>
         <thead>
           <tr>
-            ${column_headers?.map((header: string) => `<th>${header}</th>`).join('') || '<th>無資料</th>'}
+            ${column_headers?.map((header: string) => `<th>${escapeHtml(header)}</th>`).join('') || '<th>無資料</th>'}
           </tr>
         </thead>
         <tbody>
@@ -588,7 +608,7 @@ function generateRosterPreviewHTML(data: RosterPreviewPayload): string {
               ${row
                 .map(
                   cell =>
-                    `<td>${cell !== null && cell !== undefined ? cell : '-'}</td>`
+                    `<td>${cell !== null && cell !== undefined ? escapeHtml(cell) : '-'}</td>`
                 )
                 .join('')}
             </tr>

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -35,15 +35,34 @@ mkdir -p "${BACKUP_PATH}"
 log "Setting up secure authentication..."
 PGPASS_FILE="${HOME}/.pgpass.backup.$$"
 
-# Create .pgpass file with error handling
-if ! echo "${POSTGRES_HOST}:${POSTGRES_PORT}:${POSTGRES_DB}:${POSTGRES_USER}:${POSTGRES_PASSWORD}" > "${PGPASS_FILE}"; then
+# Ensure the credential file is removed on any exit (including signals), so the
+# password never lingers on disk if the script is interrupted.
+trap 'rm -f "${PGPASS_FILE}"' EXIT INT TERM
+
+# SECURITY: create the file with restrictive permissions BEFORE writing the
+# password, otherwise the secret is briefly world-readable (default umask)
+# between creation and the chmod. Tighten the umask for this section so the
+# initial create is already 600.
+_old_umask=$(umask)
+umask 077
+
+if ! : > "${PGPASS_FILE}"; then
     log "ERROR: Failed to create password file"
+    umask "${_old_umask}"
     exit 1
 fi
-
-# Set secure permissions with error handling
+# Belt-and-suspenders in case umask is ignored on the target filesystem.
 if ! chmod 600 "${PGPASS_FILE}"; then
     log "ERROR: Failed to set secure permissions on password file"
+    rm -f "${PGPASS_FILE}"
+    umask "${_old_umask}"
+    exit 1
+fi
+umask "${_old_umask}"
+
+# Now write the credentials into the already-secured file.
+if ! echo "${POSTGRES_HOST}:${POSTGRES_PORT}:${POSTGRES_DB}:${POSTGRES_USER}:${POSTGRES_PASSWORD}" > "${PGPASS_FILE}"; then
+    log "ERROR: Failed to write password file"
     rm -f "${PGPASS_FILE}"
     exit 1
 fi


### PR DESCRIPTION
Closes #935

## 摘要

對 backend / frontend / infra 做完整資安稽核後,修復下列實際可利用的漏洞。

## 修復內容

### 🔴 Critical
- **權限提升(`PUT /users/me`)**:`UserUpdate` 含 `role`,任何使用者可送 `{"role":"super_admin"}` 提權。`/me` 現在忽略 `role`/`user_type`/`status`/`college_code`。
- **權限提升(`PUT /users/{id}`)**:一般 admin 可改任意 role。現在只有 `super_admin` 可改他人 role,且任何人都不能改自己的 role(403)。
- **未授權 debug endpoint**:`/debug/pool-status` 加上 `require_admin`。
- **造冊預覽 XSS**:`frontend/app/api/v1/preview/route.ts` 對所有後端資料(roster_code / headers / errors / cells)做 HTML escape,並加 CSP 封鎖 script。

### 🟠 High
- **Token 寫入 log**:Portal SSO redirect 不再 log 含 token 的 URL。
- **JWT 內嵌 PII**:移除以 `base_url` 子字串判斷 debug 的脆弱邏輯,只在 dev/testing 嵌入。
- **硬編碼 callback IP**:改用 `settings.portal_callback_url`(`PORTAL_CALLBACK_URL`)。
- **Staging DB/MinIO 硬編碼密碼**:`docker-compose.staging-db.yml` 改為必填 env。

### 🟡 Medium / Hardening
- **檔案上傳驗證**:先 `secure_filename()` 再驗最終副檔名,修正 double-extension 繞過與錯誤狀態碼。
- **生產防呆**:`config.py` 新增 validator,production 用 mock HMAC key 或開 mock SSO 會啟動失敗。
- **Email 預覽錯誤頁 XSS**:escape + CSP。
- **backup.sh `.pgpass` 競態**:`umask 077` 建檔 + `trap` 清理。

## 注意事項
- staging-db 的 5432/9000/9001 對外開放未在本 PR 變更(牽涉 DB-VM 拓樸),建議後續綁內網/反代處理。詳見 #935。

## 驗證
- `black --check --line-length=120` ✅
- `flake8 --select=B904,B014,F401,E9` ✅
- 修改檔案語法檢查通過 ✅

https://claude.ai/code/session_016mLfGoSz1tFcZoCfEUc5Fv

---
_Generated by [Claude Code](https://claude.ai/code/session_016mLfGoSz1tFcZoCfEUc5Fv)_