### PR TITLE
feat: send notification email to admin on suspend/revoke (停發/撤銷) actions

### DIFF
--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -5,9 +5,7 @@ Provides endpoints for admin to manually allocate scholarships to students.
 """
 
 import logging
-from datetime import datetime, timezone
 from typing import Optional
-from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel
@@ -24,6 +22,7 @@ from app.models.user import User
 from app.schemas.application import RevokeRequest, SuspendRequest
 from app.services.email_service import EmailService
 from app.services.manual_distribution_service import ManualDistributionService
+from app.utils.date_utils import now_taipei_str
 
 logger = logging.getLogger(__name__)
 
@@ -728,7 +727,7 @@ async def _notify_admin_of_cancellation(
         student_data = application.student_data or {}
         student_name = student_data.get("std_cname", "")
         student_id = student_data.get("std_stdcode", "")
-        operated_at = datetime.now(timezone.utc).astimezone(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d %H:%M")
+        operated_at = now_taipei_str()
 
         subject = f"【獎學金系統】{action_label}操作通知 - {application.app_id}"
         body = (

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -5,7 +5,9 @@ Provides endpoints for admin to manually allocate scholarships to students.
 """
 
 import logging
+from datetime import datetime, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel
@@ -16,8 +18,11 @@ from app.core.deps import get_current_admin_user, get_db
 from app.db.deps import get_sync_db
 from app.models.application import Application
 from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
+from app.models.email_management import EmailCategory
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User
 from app.schemas.application import RevokeRequest, SuspendRequest
+from app.services.email_service import EmailService
 from app.services.manual_distribution_service import ManualDistributionService
 
 logger = logging.getLogger(__name__)
@@ -697,6 +702,64 @@ async def import_received_months(
     }
 
 
+async def _notify_admin_of_cancellation(
+    db: AsyncSession,
+    application_id: int,
+    admin_user: User,
+    action_label: str,
+    reason: str,
+) -> None:
+    """Email the acting admin a record of a 停發/撤銷 operation.
+
+    Best-effort: runs after the action is committed, and any failure is logged
+    without affecting the API response."""
+    if not admin_user.email:
+        logger.warning(
+            "Admin %s has no email address; skipping %s notification for application %s",
+            admin_user.id,
+            action_label,
+            application_id,
+        )
+        return
+
+    try:
+        result = await db.execute(select(Application).where(Application.id == application_id))
+        application = result.scalar_one()
+        student_data = application.student_data or {}
+        student_name = student_data.get("std_cname", "")
+        student_id = student_data.get("std_stdcode", "")
+        operated_at = datetime.now(timezone.utc).astimezone(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d %H:%M")
+
+        subject = f"【獎學金系統】{action_label}操作通知 - {application.app_id}"
+        body = (
+            f"{admin_user.name} 您好：\n\n"
+            f"您已對下列獎學金申請執行「{action_label}」操作：\n\n"
+            f"申請編號：{application.app_id}\n"
+            f"學生姓名：{student_name}（{student_id}）\n"
+            f"獎學金：{application.scholarship_name or ''}\n"
+            f"{action_label}原因：{reason}\n"
+            f"操作時間：{operated_at}\n\n"
+            "此郵件為系統自動發送的操作紀錄通知，請勿直接回覆。"
+        )
+
+        await EmailService().send_email(
+            to=admin_user.email,
+            subject=subject,
+            body=body,
+            db=db,
+            email_category=EmailCategory.system,
+            application_id=application_id,
+            sent_by_user_id=admin_user.id,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to send %s notification email to admin %s for application %s",
+            action_label,
+            admin_user.email,
+            application_id,
+        )
+
+
 @router.post("/applications/{application_id}/revoke")
 async def revoke_application_allocation(
     application_id: int,
@@ -713,6 +776,7 @@ async def revoke_application_allocation(
             reason=request.reason,
         )
         await db.commit()
+        await _notify_admin_of_cancellation(db, application_id, current_user, "撤銷", request.reason)
         return {"success": True, "message": "已撤銷", "data": result}
     except ValueError as e:
         msg = str(e)
@@ -737,6 +801,7 @@ async def suspend_application_allocation(
             reason=request.reason,
         )
         await db.commit()
+        await _notify_admin_of_cancellation(db, application_id, current_user, "停發", request.reason)
         return {"success": True, "message": "已停發", "data": result}
     except ValueError as e:
         msg = str(e)

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -723,15 +723,20 @@ async def _notify_admin_of_cancellation(
 
     try:
         result = await db.execute(select(Application).where(Application.id == application_id))
-        application = result.scalar_one()
+        application = result.scalar_one_or_none()
+        if application is None:
+            logger.warning("Application %s not found; skipping %s notification email", application_id, action_label)
+            return
         student_data = application.student_data or {}
         student_name = student_data.get("std_cname", "")
         student_id = student_data.get("std_stdcode", "")
         operated_at = now_taipei_str()
+        # name is nullable until SSO populates it on first login
+        admin_name = admin_user.name or admin_user.nycu_id
 
         subject = f"【獎學金系統】{action_label}操作通知 - {application.app_id}"
         body = (
-            f"{admin_user.name} 您好：\n\n"
+            f"{admin_name} 您好：\n\n"
             f"您已對下列獎學金申請執行「{action_label}」操作：\n\n"
             f"申請編號：{application.app_id}\n"
             f"學生姓名：{student_name}（{student_id}）\n"

--- a/backend/app/tests/test_revoke_suspend_endpoints.py
+++ b/backend/app/tests/test_revoke_suspend_endpoints.py
@@ -5,9 +5,23 @@ surface non-allocated as 400."""
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from app.models.user import User, UserRole, UserType
+
+
+@pytest.fixture(autouse=True)
+def email_send_mock(monkeypatch):
+    """Stub out SMTP so the admin-notification email never hits the network.
+
+    Autouse: every endpoint test in this file goes through the revoke/suspend
+    endpoints, which now send a best-effort notification to the acting admin."""
+    from app.services.email_service import EmailService
+
+    mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(EmailService, "send_email", mock)
+    return mock
+
 
 # ---------------------------------------------------------------------------
 # Helpers: build mock users for dependency injection
@@ -217,6 +231,62 @@ async def test_revoke_non_allocated_returns_400(client_admin: AsyncClient, unall
         json={"reason": "x"},
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_revoke_sends_notification_email_to_admin(
+    client_admin: AsyncClient, allocated_application, email_send_mock
+):
+    resp = await client_admin.post(
+        f"/api/v1/manual-distribution/applications/{allocated_application.id}/revoke",
+        json={"reason": "violated"},
+    )
+    assert resp.status_code == 200
+    email_send_mock.assert_awaited_once()
+    kwargs = email_send_mock.await_args.kwargs
+    assert kwargs["to"] == "admin@nycu.edu.tw"
+    assert "撤銷" in kwargs["subject"]
+    assert allocated_application.app_id in kwargs["subject"]
+    assert "violated" in kwargs["body"]
+
+
+@pytest.mark.asyncio
+async def test_suspend_sends_notification_email_to_admin(
+    client_admin: AsyncClient, allocated_application, email_send_mock
+):
+    resp = await client_admin.post(
+        f"/api/v1/manual-distribution/applications/{allocated_application.id}/suspend",
+        json={"reason": "leave"},
+    )
+    assert resp.status_code == 200
+    email_send_mock.assert_awaited_once()
+    kwargs = email_send_mock.await_args.kwargs
+    assert kwargs["to"] == "admin@nycu.edu.tw"
+    assert "停發" in kwargs["subject"]
+    assert "leave" in kwargs["body"]
+
+
+@pytest.mark.asyncio
+async def test_revoke_failed_reason_does_not_send_email(
+    client_admin: AsyncClient, unallocated_application, email_send_mock
+):
+    resp = await client_admin.post(
+        f"/api/v1/manual-distribution/applications/{unallocated_application.id}/revoke",
+        json={"reason": "x"},
+    )
+    assert resp.status_code == 400
+    email_send_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_revoke_succeeds_even_if_email_fails(client_admin: AsyncClient, allocated_application, email_send_mock):
+    email_send_mock.side_effect = RuntimeError("SMTP down")
+    resp = await client_admin.post(
+        f"/api/v1/manual-distribution/applications/{allocated_application.id}/revoke",
+        json={"reason": "violated"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["quota_allocation_status"] == "revoked"
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_revoke_suspend_endpoints.py
+++ b/backend/app/tests/test_revoke_suspend_endpoints.py
@@ -33,6 +33,8 @@ def _make_mock_admin() -> Mock:
     u.id = 1
     u.role = UserRole.admin
     u.email = "admin@nycu.edu.tw"
+    u.name = "Admin User"
+    u.nycu_id = "admin001"
     return u
 
 
@@ -253,6 +255,7 @@ async def test_cancellation_sends_notification_email_to_admin(
     assert label in kwargs["subject"]
     assert allocated_application.app_id in kwargs["subject"]
     assert reason in kwargs["body"]
+    assert "Admin User 您好" in kwargs["body"]
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_revoke_suspend_endpoints.py
+++ b/backend/app/tests/test_revoke_suspend_endpoints.py
@@ -233,60 +233,53 @@ async def test_revoke_non_allocated_returns_400(client_admin: AsyncClient, unall
     assert resp.status_code == 400
 
 
+_CANCEL_ACTIONS = [("revoke", "撤銷", "violated"), ("suspend", "停發", "leave")]
+_CANCEL_STATUS = {"revoke": "revoked", "suspend": "suspended"}
+
+
 @pytest.mark.asyncio
-async def test_revoke_sends_notification_email_to_admin(
-    client_admin: AsyncClient, allocated_application, email_send_mock
+@pytest.mark.parametrize("action,label,reason", _CANCEL_ACTIONS)
+async def test_cancellation_sends_notification_email_to_admin(
+    client_admin: AsyncClient, allocated_application, email_send_mock, action, label, reason
 ):
     resp = await client_admin.post(
-        f"/api/v1/manual-distribution/applications/{allocated_application.id}/revoke",
-        json={"reason": "violated"},
+        f"/api/v1/manual-distribution/applications/{allocated_application.id}/{action}",
+        json={"reason": reason},
     )
     assert resp.status_code == 200
     email_send_mock.assert_awaited_once()
     kwargs = email_send_mock.await_args.kwargs
     assert kwargs["to"] == "admin@nycu.edu.tw"
-    assert "撤銷" in kwargs["subject"]
+    assert label in kwargs["subject"]
     assert allocated_application.app_id in kwargs["subject"]
-    assert "violated" in kwargs["body"]
+    assert reason in kwargs["body"]
 
 
 @pytest.mark.asyncio
-async def test_suspend_sends_notification_email_to_admin(
-    client_admin: AsyncClient, allocated_application, email_send_mock
+@pytest.mark.parametrize("action,label,reason", _CANCEL_ACTIONS)
+async def test_failed_cancellation_does_not_send_email(
+    client_admin: AsyncClient, unallocated_application, email_send_mock, action, label, reason
 ):
     resp = await client_admin.post(
-        f"/api/v1/manual-distribution/applications/{allocated_application.id}/suspend",
-        json={"reason": "leave"},
-    )
-    assert resp.status_code == 200
-    email_send_mock.assert_awaited_once()
-    kwargs = email_send_mock.await_args.kwargs
-    assert kwargs["to"] == "admin@nycu.edu.tw"
-    assert "停發" in kwargs["subject"]
-    assert "leave" in kwargs["body"]
-
-
-@pytest.mark.asyncio
-async def test_revoke_failed_reason_does_not_send_email(
-    client_admin: AsyncClient, unallocated_application, email_send_mock
-):
-    resp = await client_admin.post(
-        f"/api/v1/manual-distribution/applications/{unallocated_application.id}/revoke",
-        json={"reason": "x"},
+        f"/api/v1/manual-distribution/applications/{unallocated_application.id}/{action}",
+        json={"reason": reason},
     )
     assert resp.status_code == 400
     email_send_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_revoke_succeeds_even_if_email_fails(client_admin: AsyncClient, allocated_application, email_send_mock):
+@pytest.mark.parametrize("action,label,reason", _CANCEL_ACTIONS)
+async def test_cancellation_succeeds_even_if_email_fails(
+    client_admin: AsyncClient, allocated_application, email_send_mock, action, label, reason
+):
     email_send_mock.side_effect = RuntimeError("SMTP down")
     resp = await client_admin.post(
-        f"/api/v1/manual-distribution/applications/{allocated_application.id}/revoke",
-        json={"reason": "violated"},
+        f"/api/v1/manual-distribution/applications/{allocated_application.id}/{action}",
+        json={"reason": reason},
     )
     assert resp.status_code == 200
-    assert resp.json()["data"]["quota_allocation_status"] == "revoked"
+    assert resp.json()["data"]["quota_allocation_status"] == _CANCEL_STATUS[action]
 
 
 @pytest.mark.asyncio

--- a/backend/app/utils/date_utils.py
+++ b/backend/app/utils/date_utils.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timezone, tzinfo
 from functools import lru_cache
 from typing import Optional, Union
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import dateutil.parser
 
@@ -20,16 +20,17 @@ def _taipei_tz() -> tzinfo:
     Cached so the missing-tzdata warning is logged at most once per process."""
     try:
         return ZoneInfo("Asia/Taipei")
-    except Exception:
+    except ZoneInfoNotFoundError:
         logger.warning("Asia/Taipei timezone unavailable; falling back to UTC", exc_info=True)
         return timezone.utc
 
 
-def now_taipei_str(format_string: str = "%Y-%m-%d %H:%M") -> str:
+def now_taipei_str(format_string: str = "%Y-%m-%d %H:%M %z") -> str:
     """Current time converted to the institution's locale (Asia/Taipei), formatted.
 
     Use this for human-facing timestamps (emails, exports); UTC wall-clock
-    would silently shift them 8 hours.
+    would silently shift them 8 hours. The default format includes the UTC
+    offset so a tzdata-fallback timestamp can't be mistaken for Taipei time.
     """
     return datetime.now(timezone.utc).astimezone(_taipei_tz()).strftime(format_string)
 

--- a/backend/app/utils/date_utils.py
+++ b/backend/app/utils/date_utils.py
@@ -3,7 +3,8 @@ Date and time utility functions for the scholarship system
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
+from functools import lru_cache
 from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -12,19 +13,25 @@ import dateutil.parser
 logger = logging.getLogger(__name__)
 
 
+@lru_cache(maxsize=1)
+def _taipei_tz() -> tzinfo:
+    """Asia/Taipei tzinfo, falling back to UTC if tzdata is unavailable.
+
+    Cached so the missing-tzdata warning is logged at most once per process."""
+    try:
+        return ZoneInfo("Asia/Taipei")
+    except Exception:
+        logger.warning("Asia/Taipei timezone unavailable; falling back to UTC", exc_info=True)
+        return timezone.utc
+
+
 def now_taipei_str(format_string: str = "%Y-%m-%d %H:%M") -> str:
     """Current time converted to the institution's locale (Asia/Taipei), formatted.
 
     Use this for human-facing timestamps (emails, exports); UTC wall-clock
     would silently shift them 8 hours.
     """
-    now = datetime.now(timezone.utc)
-    try:
-        now = now.astimezone(ZoneInfo("Asia/Taipei"))
-    except Exception:
-        # Missing tzdata: fall back to UTC rather than failing the caller
-        logger.warning("Asia/Taipei timezone unavailable; falling back to UTC", exc_info=True)
-    return now.strftime(format_string)
+    return datetime.now(timezone.utc).astimezone(_taipei_tz()).strftime(format_string)
 
 
 def parse_date_field(date_input: Optional[Union[str, datetime]]) -> Optional[datetime]:

--- a/backend/app/utils/date_utils.py
+++ b/backend/app/utils/date_utils.py
@@ -3,12 +3,22 @@ Date and time utility functions for the scholarship system
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Union
+from zoneinfo import ZoneInfo
 
 import dateutil.parser
 
 logger = logging.getLogger(__name__)
+
+
+def now_taipei_str(format_string: str = "%Y-%m-%d %H:%M") -> str:
+    """Current time converted to the institution's locale (Asia/Taipei), formatted.
+
+    Use this for human-facing timestamps (emails, exports); UTC wall-clock
+    would silently shift them 8 hours.
+    """
+    return datetime.now(timezone.utc).astimezone(ZoneInfo("Asia/Taipei")).strftime(format_string)
 
 
 def parse_date_field(date_input: Optional[Union[str, datetime]]) -> Optional[datetime]:

--- a/backend/app/utils/date_utils.py
+++ b/backend/app/utils/date_utils.py
@@ -18,7 +18,13 @@ def now_taipei_str(format_string: str = "%Y-%m-%d %H:%M") -> str:
     Use this for human-facing timestamps (emails, exports); UTC wall-clock
     would silently shift them 8 hours.
     """
-    return datetime.now(timezone.utc).astimezone(ZoneInfo("Asia/Taipei")).strftime(format_string)
+    now = datetime.now(timezone.utc)
+    try:
+        now = now.astimezone(ZoneInfo("Asia/Taipei"))
+    except Exception:
+        # Missing tzdata: fall back to UTC rather than failing the caller
+        logger.warning("Asia/Taipei timezone unavailable; falling back to UTC", exc_info=True)
+    return now.strftime(format_string)
 
 
 def parse_date_field(date_input: Optional[Union[str, datetime]]) -> Optional[datetime]:


### PR DESCRIPTION
## Summary

When an admin executes 停發 (suspend) or 撤銷 (revoke) on a student's scholarship allocation, the system now sends a confirmation email to the acting admin recording the operation.

- New `_notify_admin_of_cancellation` helper in `manual_distribution.py`, called from both the revoke and suspend endpoints **after** the action is committed. The zh-TW plain-text email includes: 申請編號, 學生姓名/學號, 獎學金名稱, 原因, and the operation time (Asia/Taipei).
- **Best-effort semantics**: any email failure is logged (`logger.exception`) and never affects the API response — the revoke/suspend itself always succeeds independently.
- Handles edge cases: admin without an email address (skip + warn), nullable `User.name` (falls back to `nycu_id` in the greeting), application not found (skip + warn).
- New shared `now_taipei_str()` helper in `app/utils/date_utils.py` (falls back to UTC if tzdata is unavailable).
- Email is logged to email history with `EmailCategory.system`, `application_id`, and `sent_by_user_id` metadata, and respects the existing email test mode.

## Tests

- `test_revoke_suspend_endpoints.py`: autouse fixture stubs `EmailService.send_email` so no test touches SMTP; parametrized tests over both actions verify the email is sent to the acting admin with the right label/app_id/reason/greeting, that failed (400) actions send no email, and that the endpoint still returns 200 when the email send raises.
- All 16 endpoint tests plus the 39 adjacent revoke/suspend/restore/date-utils tests pass; black + flake8 (B904/B014/F401) clean.

No API response shape changes, so no OpenAPI type regeneration is needed.

https://claude.ai/code/session_01Rp5WrFBuRRBTra2Xgce3Ej

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rp5WrFBuRRBTra2Xgce3Ej)_