### PR TITLE
feat(frontend): mask national ID numbers displayed in the UI

### DIFF
--- a/frontend/components/common/ApplicationReviewDialog.tsx
+++ b/frontend/components/common/ApplicationReviewDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { logger } from "@/lib/utils/logger";
+import { maskIdNumber } from "@/lib/utils/mask";
 import {
   Dialog,
   DialogContent,
@@ -302,7 +303,7 @@ function StudentPreviewDisplay({
             />
             <FieldDisplay
               label={locale === "zh" ? "身分證字號" : "ID Number"}
-              value={previewData?.basic?.std_pid}
+              value={maskIdNumber(previewData?.basic?.std_pid) || undefined}
               locale={locale}
             />
             <FieldDisplay

--- a/frontend/components/roster/RevokedSuspendedSection.tsx
+++ b/frontend/components/roster/RevokedSuspendedSection.tsx
@@ -1,4 +1,5 @@
 import type { RevokedSuspendedEntry } from "@/lib/api/modules/payment-rosters";
+import { maskIdNumber } from "@/lib/utils/mask";
 
 interface RevokedSuspendedSectionProps {
   kind: "revoked" | "suspended";
@@ -44,7 +45,10 @@ export function RevokedSuspendedSection({
             <div>
               <div>
                 <span className="font-medium">{s.student_name}</span>
-                <span className="text-slate-500"> ({s.student_id_number})</span>
+                <span className="text-slate-500">
+                  {" "}
+                  ({maskIdNumber(s.student_id_number)})
+                </span>
                 <span className="text-xs text-slate-500 ml-2">
                   {verb}於 {new Date(s.event_at).toLocaleDateString()}
                 </span>

--- a/frontend/components/roster/RevokedSuspendedSection.tsx
+++ b/frontend/components/roster/RevokedSuspendedSection.tsx
@@ -45,10 +45,11 @@ export function RevokedSuspendedSection({
             <div>
               <div>
                 <span className="font-medium">{s.student_name}</span>
-                <span className="text-slate-500">
-                  {" "}
-                  ({maskIdNumber(s.student_id_number)})
-                </span>
+                {s.student_id_number && (
+                  <span className="text-slate-500">
+                    {` (${maskIdNumber(s.student_id_number)})`}
+                  </span>
+                )}
                 <span className="text-xs text-slate-500 ml-2">
                   {verb}於 {new Date(s.event_at).toLocaleDateString()}
                 </span>

--- a/frontend/components/roster/StudentRosterPreview.tsx
+++ b/frontend/components/roster/StudentRosterPreview.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { logger } from "@/lib/utils/logger";
+import { maskIdNumber } from "@/lib/utils/mask";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -208,7 +209,7 @@ export function StudentRosterPreview({
                 {student.student_id}
               </TableCell>
               <TableCell className="font-mono text-sm whitespace-nowrap">
-                {student.student_id_number}
+                {maskIdNumber(student.student_id_number)}
               </TableCell>
               <TableCell className="text-sm whitespace-nowrap">
                 {student.email}

--- a/frontend/lib/utils/mask.test.ts
+++ b/frontend/lib/utils/mask.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit tests for PII masking utilities
+ */
+
+import { maskIdNumber } from './mask';
+
+describe('maskIdNumber', () => {
+  it('should keep the first character and last three characters of a typical 10-char ID', () => {
+    expect(maskIdNumber('A123456789')).toBe('A******789');
+    expect(maskIdNumber('F229876543')).toBe('F******543');
+  });
+
+  it('should mask everything between the first and last three characters for other lengths', () => {
+    expect(maskIdNumber('AB12345')).toBe('A***345');
+    expect(maskIdNumber('A1234')).toBe('A*234');
+  });
+
+  it('should keep only the first character for values of four characters or fewer', () => {
+    expect(maskIdNumber('ABCD')).toBe('A***');
+    expect(maskIdNumber('ABC')).toBe('A**');
+    expect(maskIdNumber('AB')).toBe('A*');
+    expect(maskIdNumber('A')).toBe('A');
+  });
+
+  it('should return an empty string for empty or missing values', () => {
+    expect(maskIdNumber('')).toBe('');
+    expect(maskIdNumber(null)).toBe('');
+    expect(maskIdNumber(undefined)).toBe('');
+  });
+
+  it('should trim surrounding whitespace before masking', () => {
+    expect(maskIdNumber('  A123456789  ')).toBe('A******789');
+    expect(maskIdNumber('   ')).toBe('');
+  });
+});

--- a/frontend/lib/utils/mask.ts
+++ b/frontend/lib/utils/mask.ts
@@ -1,0 +1,19 @@
+/**
+ * Masking helpers for personally identifiable information shown in the UI.
+ */
+
+/**
+ * Mask a national ID number (身分證字號) for display.
+ * Keeps the first character and the last three characters,
+ * replacing everything in between with asterisks.
+ *
+ * Example: "A123456789" -> "A******789"
+ */
+export function maskIdNumber(idNumber?: string | null): string {
+  if (!idNumber) return "";
+  const value = idNumber.trim();
+  if (value.length <= 4) {
+    return value.charAt(0) + "*".repeat(Math.max(value.length - 1, 0));
+  }
+  return value.charAt(0) + "*".repeat(value.length - 4) + value.slice(-3);
+}

--- a/frontend/lib/utils/mask.ts
+++ b/frontend/lib/utils/mask.ts
@@ -7,7 +7,11 @@
  * Keeps the first character and the last three characters,
  * replacing everything in between with asterisks.
  *
- * Example: "A123456789" -> "A******789"
+ * Values of four characters or fewer are too short to keep the last
+ * three characters without exposing almost the whole value, so only
+ * the first character is kept and the rest is masked.
+ *
+ * Examples: "A123456789" -> "A******789", "ABCD" -> "A***", "" -> ""
  */
 export function maskIdNumber(idNumber?: string | null): string {
   if (!idNumber) return "";


### PR DESCRIPTION
## Summary

All national ID numbers (身分證字號) rendered in the UI are now masked to show only the **first character and last three characters**, e.g. `A123456789` → `A******789`.

## Changes

- **New helper** `frontend/lib/utils/mask.ts` — `maskIdNumber()` keeps the first char and last 3 chars, masking everything in between with `*`. Handles empty/short values gracefully.
- **Payment roster preview table** (`StudentRosterPreview.tsx`) — 身分證字號 column is masked.
- **Revoked/suspended student notice** (`RevokedSuspendedSection.tsx`) — ID shown next to the student name is masked.
- **Application review dialog** (`ApplicationReviewDialog.tsx`) — 身分證字號 field in the student basic-info preview is masked.

## Notes

- These are all the locations in the frontend that render the national ID (`student_id_number` / `std_pid`). `RosterDetailDialog.tsx` declares the field in its interface but never renders it.
- The Excel export (`STD_UP_MIXLISTA.xlsx`) intentionally keeps the **full** ID, since it is required by the downstream payment process — only on-screen display is masked.
- `npm run type-check` passes. Pre-existing Prettier warnings in two touched files were left untouched to keep the diff minimal.

https://claude.ai/code/session_015Dudcx5JfuF1vF1oDAvktd

---
_Generated by [Claude Code](https://claude.ai/code/session_015Dudcx5JfuF1vF1oDAvktd)_