### PR TITLE
fix(preview): allow same-origin iframe framing for /api/v1/preview proxies (#942)

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -249,6 +249,21 @@ jobs:
           fi
           docker compose up -d
 
+      - name: Reload nginx config
+        run: |
+          # nginx.staging.conf is bind-mounted read-only; `docker compose up -d`
+          # does NOT recreate the nginx container when only the mounted file's
+          # contents change, so config edits (e.g. preview-iframe X-Frame-Options)
+          # would silently stay inactive until a manual reload. Validate, then
+          # hot-reload — never leave a broken config running.
+          if docker exec scholarship_nginx_staging nginx -t; then
+            docker exec scholarship_nginx_staging nginx -s reload
+            echo "✅ nginx config validated and reloaded"
+          else
+            echo "::error::nginx config test failed — keeping previously-loaded config"
+            exit 1
+          fi
+
       - name: Run database migrations
         run: |
           echo "Running Alembic migrations..."

--- a/frontend/__tests__/middleware-csp.test.ts
+++ b/frontend/__tests__/middleware-csp.test.ts
@@ -64,3 +64,60 @@ describe("middleware Content-Security-Policy", () => {
     expect(csp).toContain(`'nonce-${nonce}'`);
   });
 });
+
+describe("middleware framing for same-origin preview proxies", () => {
+  // Regression guard for the iframe "refused to connect" bug: a same-origin
+  // /api/v1/preview* response rendered inside an <iframe> must NOT carry
+  // `frame-ancestors 'none'` / `X-Frame-Options: DENY`, or the browser refuses
+  // to frame it. `frame-src 'self'` on the PARENT page (the #885 fix) is not
+  // enough — the CHILD response must also permit being framed same-origin.
+  // nginx must agree (see nginx /api/v1/preview block); a DENY/SAMEORIGIN split
+  // across the two layers is treated as invalid and still blocks.
+  const originalEnv = process.env.NODE_ENV;
+  afterEach(() => {
+    Object.defineProperty(process.env, "NODE_ENV", { value: originalEnv, configurable: true });
+  });
+  function setNodeEnv(value: string) {
+    Object.defineProperty(process.env, "NODE_ENV", { value, configurable: true });
+  }
+
+  const PREVIEW_ROUTES = [
+    "https://ss.test.nycu.edu.tw/api/v1/preview?fileId=1&applicationId=1&type=pdf",
+    "https://ss.test.nycu.edu.tw/api/v1/preview-terms?scholarshipType=phd",
+    "https://ss.test.nycu.edu.tw/api/v1/preview-document-example?documentId=1",
+  ];
+
+  it.each(PREVIEW_ROUTES)("prod: %s is framable same-origin (SAMEORIGIN + frame-ancestors 'self')", (url) => {
+    setNodeEnv("production");
+    const res = middleware(mockRequest(url));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(csp).toContain("frame-ancestors 'self'");
+    expect(csp).not.toContain("frame-ancestors 'none'");
+    // the rest of the strict CSP is unchanged
+    expect(csp).toContain("object-src 'none'");
+  });
+
+  it("dev: /api/v1/preview is framable same-origin", () => {
+    setNodeEnv("development");
+    const res = middleware(mockRequest("http://localhost:3000/api/v1/preview?fileId=1&type=pdf"));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(csp).toContain("frame-ancestors 'self'");
+  });
+
+  it("non-preview routes keep the strict DENY / frame-ancestors 'none' posture", () => {
+    setNodeEnv("production");
+    for (const url of [
+      "https://ss.test.nycu.edu.tw/",
+      "https://ss.test.nycu.edu.tw/student/apply",
+      "https://ss.test.nycu.edu.tw/api/v1/applications/87",
+    ]) {
+      const res = middleware(mockRequest(url));
+      const csp = res.headers.get("Content-Security-Policy") ?? "";
+      expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+      expect(csp).toContain("frame-ancestors 'none'");
+      expect(csp).not.toContain("frame-ancestors 'self'");
+    }
+  });
+});

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -26,6 +26,20 @@ export function middleware(request: NextRequest) {
   // Determine environment-specific CSP policy
   const isDevelopment = process.env.NODE_ENV === "development";
 
+  // Same-origin file-preview proxies (`/api/v1/preview`, `/api/v1/preview-terms`,
+  // `/api/v1/preview-document-example`) are rendered INSIDE an <iframe> by the app
+  // (file-preview-dialog, application-detail-dialog, review dialogs, the student
+  // wizard, …). The global clickjacking posture (`frame-ancestors 'none'` +
+  // `X-Frame-Options: DENY`) would make the browser refuse to frame these
+  // responses ("<host> refused to connect") — so for these routes ONLY we relax
+  // framing to same-origin. `frame-src 'self'` on the parent page is not enough:
+  // the CHILD response must also permit being framed. (This is the third distinct
+  // root cause of "preview fails" — alongside the clone-placeholder and the
+  // read-path file-data wiring — and the asymmetry that nginx's file-proxy block
+  // already carries SAMEORIGIN while /api/v1/preview did not is how it recurred.)
+  const isFramablePreview = request.nextUrl.pathname.startsWith("/api/v1/preview");
+  const frameAncestors = isFramablePreview ? "frame-ancestors 'self'" : "frame-ancestors 'none'";
+
   if (isDevelopment) {
     // Development CSP: Relaxed for HMR and debugging
     const csp = [
@@ -36,7 +50,7 @@ export function middleware(request: NextRequest) {
       "frame-src 'self' blob:", // inline file preview: same-origin /api proxy + just-selected blob: PDFs
       "font-src 'self'",
       "connect-src 'self' ws: wss:", // WebSocket for HMR
-      "frame-ancestors 'none'",
+      frameAncestors,
       "base-uri 'self'",
       "form-action 'self'",
     ].join("; ");
@@ -59,7 +73,7 @@ export function middleware(request: NextRequest) {
       "connect-src 'self' https://*.nycu.edu.tw",
       "base-uri 'self'",
       `form-action 'self' ${portalHost}`,
-      "frame-ancestors 'none'",
+      frameAncestors,
       "object-src 'none'",
       "upgrade-insecure-requests",
     ].join("; ");
@@ -67,8 +81,11 @@ export function middleware(request: NextRequest) {
     response.headers.set("Content-Security-Policy", csp);
   }
 
-  // Additional security headers (defense in depth)
-  response.headers.set("X-Frame-Options", "DENY");
+  // Additional security headers (defense in depth). Same-origin preview proxies
+  // must stay framable by the app itself, so SAMEORIGIN (not DENY) for those —
+  // a mixed DENY/SAMEORIGIN pair across nginx + middleware is treated as invalid
+  // and still blocks, so both layers must agree (see nginx /api/v1/preview block).
+  response.headers.set("X-Frame-Options", isFramablePreview ? "SAMEORIGIN" : "DENY");
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
 

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -164,6 +164,19 @@ http {
             proxy_connect_timeout 60s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
+
+            # The app renders these same-origin preview proxies inside an <iframe>
+            # (file-preview-dialog, review dialogs, the student wizard, …). Re-declare
+            # the security headers with SAMEORIGIN so the server-level
+            # `X-Frame-Options DENY` is NOT inherited — otherwise the browser refuses
+            # to frame the response ("<host> refused to connect"). This prefix also
+            # covers /api/v1/preview-terms and /api/v1/preview-document-example.
+            # NOTE: any add_header here drops ALL inherited add_headers, so all four
+            # must be re-declared (mirrors the file-proxy block below).
+            add_header X-Frame-Options SAMEORIGIN always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         }
 
         # Next.js email render API

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -154,6 +154,19 @@ http {
             proxy_connect_timeout 60s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;
+
+            # The app renders these same-origin preview proxies inside an <iframe>
+            # (file-preview-dialog, review dialogs, the student wizard, …). Re-declare
+            # the security headers with SAMEORIGIN so the server-level
+            # `X-Frame-Options DENY` is NOT inherited — otherwise the browser refuses
+            # to frame the response ("<host> refused to connect"). This prefix also
+            # covers /api/v1/preview-terms and /api/v1/preview-document-example.
+            # NOTE: any add_header here drops ALL inherited add_headers, so all four
+            # must be re-declared (mirrors the file-proxy block below).
+            add_header X-Frame-Options SAMEORIGIN always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         }
 
         # Next.js email render API


### PR DESCRIPTION
Closes #942.

## Problem
Admin reviewing 414551001 / 414551009 — clicking the uploaded **PDF** (`test-preview.pdf`) preview shows `ss.test.nycu.edu.tw refused to connect.` Images preview fine.

## Root cause
`FilePreviewDialog` renders PDFs in `<iframe src="/api/v1/preview?…">` (images via `<img>`, hence unaffected). The same-origin preview response carries `frame-ancestors 'none'` + `X-Frame-Options: DENY` **twice** (Next.js middleware **and** nginx server-level default, which `/api/v1/preview` inherited). The browser refuses to frame it. `frame-src 'self'` on the parent (#885) governs what the parent may frame; the **child** response separately forbade being framed.

Verified on staging: `GET /api/v1/files/applications/87/files/16` → 200 `application/pdf` 590 B real `%PDF-` (file is fine); the preview proxy → `frame-ancestors 'none'` + `x-frame-options: DENY` ×2.

## Fix (both layers — a mixed DENY/SAMEORIGIN pair is invalid and still blocks)
| Layer | Change |
|---|---|
| `frontend/middleware.ts` | `/api/v1/preview*` → `frame-ancestors 'self'` + `X-Frame-Options: SAMEORIGIN`; every other route keeps `DENY` / `'none'` |
| `nginx/nginx.staging.conf` + `nginx.prod.conf` | re-declare the 4 security headers on `/api/v1/preview` with `X-Frame-Options SAMEORIGIN` (prefix also covers `preview-terms` / `preview-document-example`), mirroring the `file-proxy` block |
| `.github/workflows/deploy-pipeline.yml` | `nginx -t && nginx -s reload` after `up -d` — bind-mounted config is **not** reloaded by `up -d`, so nginx edits would silently no-op |
| `frontend/__tests__/middleware-csp.test.ts` | regression guard: preview=`SAMEORIGIN`/`'self'`, non-preview=`DENY`/`'none'` |

## Why it kept recurring
Third distinct root cause of "preview fails" (after clone-placeholder #887 and read-path file-data wiring #885/#890). nginx's `file-proxy` already used `SAMEORIGIN`; `/api/v1/preview` was never brought in line — that asymmetry is the recurrence.

## Validation plan (post-merge, on staging)
Deploy auto-reloads nginx → confirm both `X-Frame-Options` occurrences are `SAMEORIGIN` + `frame-ancestors 'self'` on the preview proxy, then drive the real admin iframe in Playwright and confirm `test-preview.pdf` (app 87) **renders**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)