### PR TITLE
fix(preview): clear PDF preview skeleton via fallback timer (onLoad unreliable)

### DIFF
--- a/frontend/components/__tests__/file-preview-dialog.test.tsx
+++ b/frontend/components/__tests__/file-preview-dialog.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * Regression test for the PDF-preview "stuck loading" bug.
+ *
+ * `FilePreviewDialog` renders PDFs in an <iframe> and hides it behind a
+ * skeleton until `isLoading` clears. `isLoading` was only ever cleared by the
+ * iframe's onLoad/onError — but Chrome's built-in PDF viewer frequently never
+ * fires the iframe load event, so a PDF preview stayed on a permanent skeleton
+ * (opacity-0 iframe) even though the proxy returned the file. The fix adds a
+ * fallback timer; this test pins that the iframe becomes visible after it
+ * elapses WITHOUT any onLoad firing.
+ */
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { FilePreviewDialog } from "../file-preview-dialog";
+
+describe("FilePreviewDialog PDF loading fallback", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const pdfFile = {
+    url: "/api/v1/preview?fileId=16&type=pdf&applicationId=87&token=t",
+    filename: "test-preview.pdf",
+    type: "application/pdf",
+  };
+
+  it("clears the loading skeleton via the fallback timer even if the iframe onLoad never fires", () => {
+    render(
+      <FilePreviewDialog isOpen onClose={() => {}} file={pdfFile} locale="zh-TW" />
+    );
+
+    // The iframe exists but starts hidden (opacity-0) behind the skeleton —
+    // and we deliberately never dispatch its onLoad event.
+    const iframe = screen.getByTitle("test-preview.pdf") as HTMLIFrameElement;
+    expect(iframe.className).toContain("opacity-0");
+
+    // Fallback timer (1500ms) elapses → loading clears → iframe is revealed.
+    act(() => {
+      jest.advanceTimersByTime(1600);
+    });
+
+    expect(iframe.className).toContain("opacity-100");
+    expect(iframe.getAttribute("src")).toContain("/api/v1/preview");
+  });
+});

--- a/frontend/components/file-preview-dialog.tsx
+++ b/frontend/components/file-preview-dialog.tsx
@@ -35,10 +35,20 @@ export function FilePreviewDialog({
   const [isLoading, setIsLoading] = useState(true);
   const t = (k: string) => getTranslation(locale, k);
 
-  // Reset loading state when dialog opens or file changes
+  // Reset loading state when dialog opens or file changes.
+  //
+  // The skeleton overlay is gated on `isLoading`, and `isLoading` is otherwise
+  // only cleared by the iframe's onLoad/onError. That is reliable for images
+  // (<img> fires onLoad), but Chrome's built-in PDF viewer frequently NEVER
+  // fires the iframe load event — which left the skeleton covering an
+  // opacity-0 iframe forever, so a PDF preview showed a permanent "loading…"
+  // even though the proxy returned the file (HTTP 200). Fall back to clearing
+  // the loading state on a short timer so the preview always becomes visible.
   useEffect(() => {
     if (isOpen && file) {
       setIsLoading(true);
+      const fallback = setTimeout(() => setIsLoading(false), 1500);
+      return () => clearTimeout(fallback);
     }
   }, [isOpen, file?.url]);
 


### PR DESCRIPTION
Follow-up to #943 (issue #942).

## Problem
After #943 removed the `X-Frame-Options`/`frame-ancestors` block, the PDF preview iframe loads the file (HTTP 200 `application/pdf`) but the dialog stays on a permanent **「載入中…」** skeleton. Verified on staging: the iframe `src` is correct and the proxy returns 200, but the iframe stays `opacity:0` for 16s+.

## Root cause
`FilePreviewDialog` gates the skeleton on `isLoading`, which is **only** cleared by the iframe's `onLoad`/`onError`. That's fine for images (`<img>` fires `onLoad`), but Chrome's built-in PDF viewer frequently **never fires the iframe load event** — so `setIsLoading(false)` is never called and the skeleton covers the `opacity-0` iframe forever. The PDF was loaded the whole time, just hidden.

This is the layer the framing fix exposed: before #943 the framing block produced a visible error, so the PDF-load path (and this latent skeleton bug) was never reached.

## Fix
Add a 1.5s fallback timer in the existing reset effect (cleared on unmount / `file.url` change) so loading always clears even when `onLoad` doesn't fire. `onLoad` remains the fast path for images.

## Test
`frontend/components/__tests__/file-preview-dialog.test.tsx` — renders a PDF, asserts the iframe starts `opacity-0` and becomes `opacity-100` after the timer **without** dispatching `onLoad`.

## Validation
Post-merge on staging: re-open app 87's `test-preview.pdf` in the admin review dialog and confirm the PDF actually renders (skeleton clears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)