### PR TITLE
fix(e2e+api): clear nightly e2e-full failures; background the revoke/suspend admin email

### DIFF
--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -7,13 +7,14 @@ Provides endpoints for admin to manually allocate scholarships to students.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_admin_user, get_db
 from app.db.deps import get_sync_db
+from app.db.session import AsyncSessionLocal
 from app.models.application import Application
 from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
 from app.models.email_management import EmailCategory
@@ -701,17 +702,51 @@ async def import_received_months(
     }
 
 
+async def _send_cancellation_email(
+    to: str,
+    subject: str,
+    body: str,
+    action_label: str,
+    application_id: int,
+    sent_by_user_id: int,
+) -> None:
+    """Background task: deliver a prepared 停發/撤銷 notification email.
+
+    Opens its own session — it runs after the request's session is closed.
+    Best-effort: any failure is logged and never surfaces to the admin."""
+    try:
+        async with AsyncSessionLocal() as session:
+            await EmailService().send_email(
+                to=to,
+                subject=subject,
+                body=body,
+                db=session,
+                email_category=EmailCategory.system,
+                application_id=application_id,
+                sent_by_user_id=sent_by_user_id,
+            )
+    except Exception:
+        logger.exception(
+            "Failed to send %s notification email to admin %s for application %s",
+            action_label,
+            to,
+            application_id,
+        )
+
+
 async def _notify_admin_of_cancellation(
     db: AsyncSession,
+    background_tasks: BackgroundTasks,
     application_id: int,
     admin_user: User,
     action_label: str,
     reason: str,
 ) -> None:
-    """Email the acting admin a record of a 停發/撤銷 operation.
+    """Queue a record of a 停發/撤銷 operation to be emailed to the acting admin.
 
-    Best-effort: runs after the action is committed, and any failure is logged
-    without affecting the API response."""
+    The message is composed here (the action is already committed), but the
+    SMTP delivery runs as a background task AFTER the response is sent — an
+    unreachable/slow mail server must not stall the revoke/suspend API."""
     if not admin_user.email:
         logger.warning(
             "Admin %s has no email address; skipping %s notification for application %s",
@@ -746,18 +781,18 @@ async def _notify_admin_of_cancellation(
             "此郵件為系統自動發送的操作紀錄通知，請勿直接回覆。"
         )
 
-        await EmailService().send_email(
-            to=admin_user.email,
-            subject=subject,
-            body=body,
-            db=db,
-            email_category=EmailCategory.system,
-            application_id=application_id,
-            sent_by_user_id=admin_user.id,
+        background_tasks.add_task(
+            _send_cancellation_email,
+            admin_user.email,
+            subject,
+            body,
+            action_label,
+            application_id,
+            admin_user.id,
         )
     except Exception:
         logger.exception(
-            "Failed to send %s notification email to admin %s for application %s",
+            "Failed to queue %s notification email to admin %s for application %s",
             action_label,
             admin_user.email,
             application_id,
@@ -768,6 +803,7 @@ async def _notify_admin_of_cancellation(
 async def revoke_application_allocation(
     application_id: int,
     request: RevokeRequest,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     current_user=Depends(get_current_admin_user),
 ):
@@ -780,7 +816,7 @@ async def revoke_application_allocation(
             reason=request.reason,
         )
         await db.commit()
-        await _notify_admin_of_cancellation(db, application_id, current_user, "撤銷", request.reason)
+        await _notify_admin_of_cancellation(db, background_tasks, application_id, current_user, "撤銷", request.reason)
         return {"success": True, "message": "已撤銷", "data": result}
     except ValueError as e:
         msg = str(e)
@@ -793,6 +829,7 @@ async def revoke_application_allocation(
 async def suspend_application_allocation(
     application_id: int,
     request: SuspendRequest,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     current_user=Depends(get_current_admin_user),
 ):
@@ -805,7 +842,7 @@ async def suspend_application_allocation(
             reason=request.reason,
         )
         await db.commit()
-        await _notify_admin_of_cancellation(db, application_id, current_user, "停發", request.reason)
+        await _notify_admin_of_cancellation(db, background_tasks, application_id, current_user, "停發", request.reason)
         return {"success": True, "message": "已停發", "data": result}
     except ValueError as e:
         msg = str(e)

--- a/frontend/e2e/specs/admin-config-deadline.spec.ts
+++ b/frontend/e2e/specs/admin-config-deadline.spec.ts
@@ -58,6 +58,10 @@ import { captureDiagnostics } from "../helpers/diagnose";
 
 const STUDENT_NYCU_ID = "stuphd001";
 const SCHOLARSHIP_CODE = "phd";
+// phd defines real sub-types (nstc / moe_1w), and submission rejects the
+// "general" fallback for such scholarships (PR #845) — so both apply calls
+// must select a concrete sub-type or they 422 for the wrong reason.
+const SUB_TYPE = "nstc";
 const ACADEMIC_YEAR = 115;
 const CONFIG_CODE = "phd_115_e2e_deadline";
 const CONFIG_NAME = "E2E Deadline Test 115";
@@ -269,8 +273,8 @@ test.describe("Admin config CRUD pins application_end_date deadline enforcement"
     }>(studentLogin.token, "POST", "/applications?is_draft=false", {
       scholarship_type: SCHOLARSHIP_CODE,
       configuration_id: createdConfigId,
-      scholarship_subtype_list: [],
-      sub_type_preferences: null,
+      scholarship_subtype_list: [SUB_TYPE],
+      sub_type_preferences: [SUB_TYPE],
       form_data: { fields: {}, documents: [] },
       agree_terms: true,
     });
@@ -324,8 +328,8 @@ test.describe("Admin config CRUD pins application_end_date deadline enforcement"
     }>(studentLogin.token, "POST", "/applications?is_draft=false", {
       scholarship_type: SCHOLARSHIP_CODE,
       configuration_id: createdConfigId,
-      scholarship_subtype_list: [],
-      sub_type_preferences: null,
+      scholarship_subtype_list: [SUB_TYPE],
+      sub_type_preferences: [SUB_TYPE],
       form_data: { fields: {}, documents: [] },
       agree_terms: true,
     });

--- a/frontend/e2e/specs/admin-returns-application.spec.ts
+++ b/frontend/e2e/specs/admin-returns-application.spec.ts
@@ -168,7 +168,9 @@ test.describe("Admin returns application; student edits and re-submits", () => {
         contact_phone: {
           field_id: "contact_phone",
           field_type: "text",
-          value: "0987-654-321",
+          // Must satisfy the Taiwan-mobile format guard (PR #923): pure
+          // digits, 09 + 8 digits — re-submit rejects anything else with 422.
+          value: "0987654321",
           required: false,
         },
       },

--- a/frontend/e2e/specs/admin-revoke-suspend.spec.ts
+++ b/frontend/e2e/specs/admin-revoke-suspend.spec.ts
@@ -416,6 +416,22 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
 // Second student for describe #2 suspend sub-fixture (csphd0002).
 const SETUP_STUDENT2 = "csphd0002";
 
+// Roster generation marks an item is_included=false ("缺少銀行帳戶資訊") when
+// the application has no bank account, and get_revoked_suspended_for_roster
+// only returns is_included=true items (PR #916 soft-delete gate) — so the
+// fixture applications must carry one for the revoked entry to surface.
+const SETUP_FORM_DATA = {
+  fields: {
+    bank_account: {
+      field_id: "bank_account",
+      field_type: "text",
+      value: "0001234567890123",
+      required: false,
+    },
+  },
+  documents: [],
+};
+
 test.describe("locked roster dialog — revoked student panel + item removal", () => {
   let runState: RunState;
   let lockedFixtureAppId: string | undefined;
@@ -482,7 +498,7 @@ test.describe("locked roster dialog — revoked student panel + item removal", (
       configuration_id: config.id,
       scholarship_subtype_list: [SETUP_SUB_TYPE],
       sub_type_preferences: [SETUP_SUB_TYPE],
-      form_data: { fields: {}, documents: [] },
+      form_data: SETUP_FORM_DATA,
       agree_terms: true,
     });
     if (!createRes.ok || !createRes.body.success) {
@@ -504,7 +520,7 @@ test.describe("locked roster dialog — revoked student panel + item removal", (
       configuration_id: config.id,
       scholarship_subtype_list: [SETUP_SUB_TYPE],
       sub_type_preferences: [SETUP_SUB_TYPE],
-      form_data: { fields: {}, documents: [] },
+      form_data: SETUP_FORM_DATA,
       agree_terms: true,
     });
     if (!createRes2.ok || !createRes2.body.success) {

--- a/frontend/e2e/specs/student-draft-save.spec.ts
+++ b/frontend/e2e/specs/student-draft-save.spec.ts
@@ -138,7 +138,9 @@ test.describe("Student saves draft, updates, then submits an application", () =>
         contact_phone: {
           field_id: "contact_phone",
           field_type: "text",
-          value: "0912-345-678",
+          // Must satisfy the Taiwan-mobile format guard (PR #923): pure
+          // digits, 09 + 8 digits — submit rejects anything else with 422.
+          value: "0912345678",
           required: false,
         },
       },
@@ -187,7 +189,7 @@ test.describe("Student saves draft, updates, then submits an application", () =>
     expect(
       persistedFields.contact_phone?.value,
       `expected GET to return our updated contact_phone, got body=${JSON.stringify(getRes.body)}`,
-    ).toBe("0912-345-678");
+    ).toBe("0912345678");
 
     // 4. Submit the draft. submit_application requires status in
     //    {draft, returned} (ApplicationService.submit_application), so this


### PR DESCRIPTION
## Summary

Clears all four failing tests in the nightly **e2e-full** lane (issues #910 #914 #921 #932) and fixes one real API bug found along the way.

### Root causes — e2e specs lagging behind intentional product changes

| Failing test | Broke on | Cause | Fix |
|---|---|---|---|
| `admin-config-deadline.spec.ts` | 06-06 nightly | PR #845 rejects the `general` sub-type fallback for scholarships with real sub-types (phd → nstc/moe_1w); the spec applied with `scholarship_subtype_list: []` | apply with `["nstc"]` so the 422/200 contract under test is the **deadline**, not the sub-type guard |
| `admin-revoke-suspend.spec.ts:714` | 06-08 nightly | PR #916 gates `GET /payment-rosters/{id}/revoked-suspended` on `is_included=true`; the fixture students had no bank account, so generation excluded their items (`缺少銀行帳戶資訊`) and the revoked entry vanished | fixture applications now carry a `bank_account` field |
| `student-draft-save.spec.ts` | 06-09 nightly | PR #923 enforces `^09\d{8}$` on `contact_phone` at submit; spec used `0912-345-678` | digits-only `0912345678` |
| `admin-returns-application.spec.ts` | 06-09 nightly | same as above (`0987-654-321`) | digits-only `0987654321` |

### Real bug fixed: revoke/suspend API stalled ~60s by inline SMTP send

PR #938 (merged 06-10, **after** the last nightly — it would have failed tonight's run) awaits the 停發/撤銷 admin-notification email inline in the request path. With an unreachable/slow SMTP server (always the case in dev/CI), `aiosmtplib` blocks the response until `SMTPConnectTimeoutError` (~60s), which timed out the revoke-dialog e2e test (`已撤銷 ...` toast never appears).

`manual_distribution.py` now composes the message in the request path but delivers it via FastAPI `BackgroundTasks` with its own `AsyncSessionLocal` session (the request session is closed by the time background tasks run). Failures remain best-effort logged.

## Verification

- Full local Playwright suite against `docker-compose.dev.yml`: **36 passed, 1 pre-existing conditional skip** (previously 4 failed)
- Revoke-dialog test runtime dropped 17s → 5.8s after backgrounding the email
- `black --check` clean; `flake8 --select=B904,B014` clean

Closes #910
Closes #914
Closes #921
Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)