### PR TITLE
test+ci: unmask two silently-ignored test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,12 @@ jobs:
       - name: Frontend Lint & Format Check
         if: matrix.check == 'frontend-lint' && needs.changes.outputs.frontend == 'true'
         working-directory: ./frontend
+        # No `|| echo` fallback: that swallowed the exit code, so the
+        # frontend-lint gate could NEVER fail — lint errors sailed through
+        # green. Lint is clean today; keep it hard-gated.
         run: |
           npm ci
-          npm run lint || echo "Linting issues found"
+          npm run lint
 
       - name: Dependency Vulnerability Check
         if: matrix.check == 'dependency-check'

--- a/backend/app/tests/test_developer_profiles.py
+++ b/backend/app/tests/test_developer_profiles.py
@@ -370,12 +370,6 @@ class TestDeveloperProfileAPI:
 
         assert response.status_code in (400, 422)
 
-    @pytest.mark.xfail(
-        reason="real bug: quick_setup_developer hardcodes email_domain='dev.local'; "
-        "UserResponse rejects the reserved '.local' TLD as an invalid email, so mock-sso "
-        "login of any quick-setup dev user fails with 400 (cannot serialize the user).",
-        strict=False,
-    )
     async def test_developer_profile_authentication_flow(self, client: AsyncClient):
         """Test complete authentication flow with developer profiles"""
         # Create a developer profile
@@ -402,7 +396,9 @@ class TestDeveloperProfileAPI:
         assert auth_response.status_code == 200
         user_data = auth_response.json()
         assert user_data["success"] is True
-        assert user_data["data"]["username"] == test_username
+        # User model exposes nycu_id (the `username` column was renamed); the
+        # dev-profile "username" IS the nycu_id the mock-SSO login was made with.
+        assert user_data["data"]["nycu_id"] == test_username
 
 
 class TestProductionSafety:


### PR DESCRIPTION
Part of an audit for "tests that actually fail but are skipped/swallowed". Two live masks fixed here; the rest of the findings are tracked in a follow-up issue.

## 1. Stale xfail hiding a FIXED bug + a stale assertion
`test_developer_profile_authentication_flow` was `@pytest.mark.xfail(strict=False)` citing the dev.local email bug — but **#905 fixed that bug**: with `--runxfail` the whole flow now returns 200/200/200/200, and the only remaining failure was `user_data["data"]["username"]` — a field renamed to `nycu_id` (documented model gotcha). The non-strict xfail hid both the fix and the assertion drift indefinitely.
→ Removed the marker, fixed the assertion. `test_developer_profiles.py` now **22/22 passed** in the dev container.

## 2. frontend-lint gate could never fail
`ci.yml` Quick Checks ran `npm run lint || echo "Linting issues found"` — the `|| echo` swallows the exit code, so the job is green no matter what. Verified `npm run lint` is clean on main today, so hard-gating is a no-op now and a real gate going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)