### PR TITLE
feat(ci): staging-e2e lane — full e2e against an ephemeral replica of the live staging deploy

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -1,0 +1,267 @@
+# Staging E2E — full Playwright suite against an EPHEMERAL replica of the
+# live staging deployment, on the staging host itself.
+#
+# What "replica" means here:
+#   - backend/frontend images = exactly what is deployed right now (resolved
+#     via `docker inspect scholarship_*_staging`), NOT a rebuild.
+#   - database = pg_dump snapshot of the live staging DB taken at run start,
+#     restored into a throwaway Postgres.
+#   - outbound email = captured by a bundled Mailpit (full SMTP pipeline runs,
+#     nothing leaves the VM; inspect at host port 18025 during a run).
+#
+# Why a replica instead of testing the live site and restoring it after:
+#   restoring a pre-test dump would delete any legitimate writes made during
+#   the window, a failed restore would brick staging overnight, and the suite
+#   needs mock SSO which must never be enabled on the live endpoint.
+#
+# Zero-residue guarantee: live staging is only ever READ (one pg_dump, two
+# docker inspect). The replica lives in compose project `staging-e2e` and is
+# `down -v`-ed in an always() step; a final assert fails the run if anything
+# survived.
+#
+# Rollout: workflow_dispatch only for now. Once green, add a cron entry
+# (e.g. '30 18 * * *' = 02:30 Asia/Taipei, clear of the 01:00 nightly).
+
+name: Staging E2E
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+# Same group as the Deployment Pipeline → never runs concurrently with a
+# staging deploy (which would swap images / restart containers under us).
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '22'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  COMPOSE: docker compose -p staging-e2e -f docker-compose.staging-e2e.yml
+  DUMP: /tmp/staging-e2e.dump
+  REPLICA_DB_URL: postgresql://scholarship_user:scholarship_pass@localhost:15432/scholarship_db
+
+jobs:
+  staging-e2e:
+    name: E2E against staging replica
+    runs-on: [self-hosted, scholarship, test]
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resource guard (fail fast, touch nothing)
+        run: |
+          avail_kb=$(df --output=avail / | tail -1 | tr -d ' ')
+          avail_gb=$((avail_kb / 1024 / 1024))
+          mem_avail_mb=$(awk '/MemAvailable/ {print int($2/1024)}' /proc/meminfo)
+          echo "disk_avail=${avail_gb}GB mem_avail=${mem_avail_mb}MB"
+          if [ "$avail_gb" -lt 5 ] || [ "$mem_avail_mb" -lt 2048 ]; then
+            echo "::error::Staging host lacks headroom for the replica (need >=5GB disk, >=2GB RAM available). Aborting before creating anything."
+            exit 1
+          fi
+
+      # Topology note: staging is TWO VMs. The runner lives on the AP VM
+      # (backend/frontend/nginx containers); Postgres + MinIO live on the DB
+      # VM and are only reachable over the network — `docker exec
+      # scholarship_postgres_staging` does NOT work here. All DB access goes
+      # through a postgres:15-alpine client container using the same
+      # STAGING_DATABASE_URL_SYNC the backend uses.
+      - name: Verify live staging stack is healthy
+        env:
+          STAGING_DB_URL: ${{ secrets.STAGING_DATABASE_URL_SYNC }}
+        run: |
+          docker inspect --format '{{.Name}} {{.State.Status}}' \
+            scholarship_backend_staging scholarship_frontend_staging
+          curl -fsS http://localhost:8000/health > /dev/null
+          docker run --rm postgres:15-alpine pg_isready -d "$STAGING_DB_URL"
+
+      - name: Resolve currently deployed images
+        id: images
+        run: |
+          backend=$(docker inspect scholarship_backend_staging --format '{{.Config.Image}}')
+          frontend=$(docker inspect scholarship_frontend_staging --format '{{.Config.Image}}')
+          echo "backend=$backend"  | tee -a "$GITHUB_OUTPUT"
+          echo "frontend=$frontend" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Snapshot staging DB (read-only against live)
+        env:
+          STAGING_DB_URL: ${{ secrets.STAGING_DATABASE_URL_SYNC }}
+        run: |
+          # pg_dump runs in a client container on the AP VM, over the network
+          # to the DB VM (~15MB database as of 2026-06 — seconds, not minutes).
+          docker run --rm postgres:15-alpine \
+            pg_dump "$STAGING_DB_URL" -Fc > "$DUMP"
+          ls -lh "$DUMP"
+
+      - name: Pre-clean any leftover replica from a crashed run
+        run: $COMPOSE down -v --remove-orphans 2>/dev/null || true
+
+      - name: Start replica Postgres and restore the snapshot
+        env:
+          BACKEND_IMAGE: ${{ steps.images.outputs.backend }}
+          FRONTEND_IMAGE: ${{ steps.images.outputs.frontend }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
+          MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
+        run: |
+          $COMPOSE up -d --wait postgres
+          # --clean/--if-exists tolerate the fresh DB; pg_restore exits 1 on
+          # ignorable warnings, so verify with a row-count probe instead.
+          docker exec -i staging_e2e_postgres \
+            pg_restore -U scholarship_user -d scholarship_db \
+            --clean --if-exists --no-owner --no-acl < "$DUMP" || true
+          users=$(docker exec staging_e2e_postgres \
+            psql -U scholarship_user -d scholarship_db -tAc "SELECT count(*) FROM users")
+          echo "restored users rows: $users"
+          test "$users" -gt 0
+
+      - name: Start the rest of the replica stack
+        env:
+          BACKEND_IMAGE: ${{ steps.images.outputs.backend }}
+          FRONTEND_IMAGE: ${{ steps.images.outputs.frontend }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
+          MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
+        run: |
+          $COMPOSE up -d --build
+          for i in $(seq 1 90); do
+            if curl -fsS http://localhost:18000/health > /dev/null 2>&1 \
+               && curl -fsS http://localhost:13000 > /dev/null 2>&1; then
+              echo "Replica up after ~$((i*2))s"
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS http://localhost:18000/health > /dev/null
+          curl -fsS http://localhost:13000 > /dev/null
+
+      - name: Migrate + seed e2e fixtures (idempotent, replica only)
+        run: |
+          docker exec staging_e2e_backend alembic upgrade head
+          docker exec staging_e2e_backend python -m app.seed || echo "seed completed with warnings"
+
+      - name: Route replica email to Mailpit + ensure MinIO bucket
+        env:
+          MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
+        run: |
+          # SMTP settings live in system_settings (restored from the staging
+          # dump → they point at the real NYCU relay). Repoint them at the
+          # bundled Mailpit so the full send pipeline runs without any mail
+          # leaving the VM.
+          docker exec staging_e2e_postgres psql -U scholarship_user -d scholarship_db -c "
+            UPDATE system_settings SET value = 'mailpit' WHERE key = 'smtp_host';
+            UPDATE system_settings SET value = '1025'    WHERE key = 'smtp_port';
+            UPDATE system_settings SET value = 'false'   WHERE key = 'smtp_use_tls';
+          "
+          # Empty bucket is enough — specs upload what they later read.
+          docker run --rm --network staging-e2e_default --entrypoint sh \
+            minio/mc:latest -c \
+            "mc alias set replica http://minio:9000 minioadmin minioadmin123 && mc mb -p replica/${MINIO_BUCKET:-scholarship-documents}"
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install Playwright browsers
+        working-directory: ./frontend
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run full Playwright suite against the replica
+        working-directory: ./frontend
+        run: npx playwright test
+        env:
+          E2E_FRONTEND_URL: http://localhost:13000
+          E2E_BACKEND_URL: http://localhost:18000
+          E2E_DATABASE_URL: ${{ env.REPLICA_DB_URL }}
+
+      - name: Dump replica logs on failure
+        if: failure()
+        run: $COMPOSE logs --tail=300 || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report-staging-e2e
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 14
+
+      - name: Tear down replica (zero residue)
+        if: always()
+        run: |
+          $COMPOSE down -v --remove-orphans || true
+          rm -f "$DUMP"
+
+      - name: Assert zero residue
+        if: always()
+        run: |
+          leftover=$(docker ps -a --filter "name=staging_e2e_" --format '{{.Names}}')
+          volumes=$(docker volume ls --filter "name=staging-e2e_" --format '{{.Name}}')
+          if [ -n "$leftover" ] || [ -n "$volumes" ]; then
+            echo "::error::Replica residue survived teardown: containers=[$leftover] volumes=[$volumes]"
+            exit 1
+          fi
+          echo "Clean: no replica containers or volumes remain."
+
+  file-issue-on-failure:
+    name: File issue on failure
+    runs-on: ubuntu-latest
+    needs: [staging-e2e]
+    if: failure()
+    permissions:
+      issues: write
+
+    steps:
+      - name: gh issue create
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          today=$(date -u +%F)
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh label create staging-e2e-failure \
+            --repo ${{ github.repository }} \
+            --color "d73a4a" \
+            --description "Auto-filed by the staging-e2e replica lane" \
+            2>/dev/null || true
+          existing=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --label staging-e2e-failure \
+            --state open \
+            --search "in:title $today" \
+            --json number \
+            --jq '.[0].number' || echo '')
+          body=$(cat <<EOF
+          The staging-e2e lane (full Playwright suite against an ephemeral
+          replica of the live staging deployment) failed.
+
+          - Run: $run_url
+          - staging-e2e: ${{ needs.staging-e2e.result }}
+
+          The replica uses the images deployed on staging at run time plus a
+          fresh snapshot of the staging DB, so a failure here usually means
+          either a real bug surfaced by staging's data shape, or the deployed
+          image pair is broken. Live staging itself was not modified.
+
+          (Auto-filed by .github/workflows/staging-e2e.yml. Close once a
+          subsequent run is green.)
+          EOF
+          )
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo ${{ github.repository }} --body "$body"
+          else
+            gh issue create \
+              --repo ${{ github.repository }} \
+              --title "Staging E2E $today: replica lane failed" \
+              --body "$body" \
+              --label staging-e2e-failure
+          fi

--- a/docker-compose.staging-e2e.yml
+++ b/docker-compose.staging-e2e.yml
@@ -1,0 +1,168 @@
+# =============================================================================
+# Ephemeral staging-replica stack for the staging-e2e lane
+# (.github/workflows/staging-e2e.yml)
+#
+# Runs ON the staging host, NEXT TO the live staging stack, with the SAME
+# backend/frontend images currently deployed (resolved by the workflow via
+# `docker inspect scholarship_*_staging`) and a pg_dump snapshot of the live
+# staging DB restored into a throwaway Postgres.
+#
+# Design rules:
+#   - Live staging is never written to. This stack is created fresh, the e2e
+#     suite runs against it, and `docker compose -p staging-e2e down -v`
+#     removes every container/volume/network afterwards.
+#   - No host port collides with the live stack (5432/8000/3000/9000/443):
+#       postgres 15432 / backend 18000 / frontend 13000 / minio 19000-19001 /
+#       mailpit UI 18025.
+#   - Outbound email goes to the bundled Mailpit (fake SMTP + HTTP API), never
+#     to the real NYCU relay — the workflow points system_settings.smtp_host
+#     at `mailpit` after restoring the dump. The full send pipeline still
+#     executes, and delivered mail is inspectable at http://localhost:18025.
+#   - Mock SSO is enabled HERE ONLY (the replica is bound to localhost ports
+#     on the staging host; the live site keeps ENABLE_MOCK_SSO=false).
+#   - PII_ENCRYPTION_KEYS must be the live staging keys, otherwise the
+#     restored dump's encrypted columns cannot be decrypted.
+#
+# Usage (from the workflow):
+#   BACKEND_IMAGE=... FRONTEND_IMAGE=... PII_ENCRYPTION_KEYS=... \
+#     docker compose -p staging-e2e -f docker-compose.staging-e2e.yml up -d
+# =============================================================================
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: staging_e2e_postgres
+    environment:
+      POSTGRES_DB: scholarship_db
+      POSTGRES_USER: scholarship_user
+      POSTGRES_PASSWORD: scholarship_pass
+    ports:
+      - "15432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U scholarship_user -d scholarship_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    restart: "no"
+
+  redis:
+    image: redis:7-alpine
+    container_name: staging_e2e_redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    restart: "no"
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: staging_e2e_minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin123
+    ports:
+      - "19000:9000"
+      - "19001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 10s
+      retries: 12
+    restart: "no"
+
+  # Fake SMTP sink with an HTTP API (http://localhost:18025/api/v1/messages).
+  # The workflow repoints system_settings.smtp_host/smtp_port here, so the
+  # real EmailService → aiosmtplib pipeline is exercised end-to-end without a
+  # single byte leaving the VM.
+  mailpit:
+    image: axllent/mailpit:v1.21
+    container_name: staging_e2e_mailpit
+    ports:
+      - "18025:8025"
+    restart: "no"
+
+  mock-student-api:
+    build:
+      context: ./mock-student-api
+      dockerfile: Dockerfile
+    container_name: staging_e2e_mock_student_api
+    command: uvicorn main:app --host 0.0.0.0 --port 8080
+    environment:
+      DATABASE_URL: postgresql://scholarship_user:scholarship_pass@postgres:5432/scholarship_db
+      MOCK_HMAC_KEY_HEX: 4d6f636b4b657946726f6d48657841424344454647484a4b4c4d4e4f505152535455565758595a
+      STRICT_TIME_CHECK: "false"
+      STRICT_ENCODE_CHECK: "false"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  backend:
+    image: ${BACKEND_IMAGE:?set BACKEND_IMAGE to the currently deployed staging backend image}
+    container_name: staging_e2e_backend
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    ports:
+      - "18000:8000"
+    environment:
+      DATABASE_URL: postgresql+asyncpg://scholarship_user:scholarship_pass@postgres:5432/scholarship_db
+      DATABASE_URL_SYNC: postgresql://scholarship_user:scholarship_pass@postgres:5432/scholarship_db
+      REDIS_URL: redis://redis:6379/0
+      SECRET_KEY: staging-e2e-throwaway-secret-key
+      DEBUG: "true"
+      CORS_ORIGINS: "http://localhost:13000,http://localhost:18000"
+      ENVIRONMENT: development
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin123
+      MINIO_BUCKET: ${MINIO_BUCKET:-scholarship-documents}
+      MINIO_SECURE: "false"
+      # MUST be the live staging keys so the restored dump decrypts.
+      PII_ENCRYPTION_KEYS: ${PII_ENCRYPTION_KEYS:?pass the staging PII keys}
+      PII_ENCRYPTION_ACTIVE_VERSION: ${PII_ENCRYPTION_ACTIVE_VERSION:-v1}
+      # Replica-only auth: mock SSO on, real Portal off.
+      ENABLE_MOCK_SSO: "true"
+      PORTAL_SSO_ENABLED: "false"
+      BASE_URL: http://localhost:18000
+      FRONTEND_URL: http://localhost:13000
+      FRONTEND_INTERNAL_URL: http://frontend:3000
+      BYPASS_TIME_RESTRICTIONS: "false"
+      # SIS API → bundled mock (the e2e fixture students only exist there).
+      STUDENT_API_ENABLED: "true"
+      STUDENT_API_BASE_URL: http://mock-student-api:8080
+      STUDENT_API_ACCOUNT: scholarship
+      STUDENT_API_HMAC_KEY: 4d6f636b4b657946726f6d48657841424344454647484a4b4c4d4e4f505152535455565758595a
+      STUDENT_API_TIMEOUT: "10.0"
+      STUDENT_API_ENCODE_TYPE: "UTF-8"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      mock-student-api:
+        condition: service_started
+    restart: "no"
+
+  frontend:
+    image: ${FRONTEND_IMAGE:?set FRONTEND_IMAGE to the currently deployed staging frontend image}
+    container_name: staging_e2e_frontend
+    ports:
+      - "13000:3000"
+    environment:
+      NODE_ENV: production
+      NEXT_TELEMETRY_DISABLED: 1
+      INTERNAL_API_URL: http://backend:8000
+    depends_on:
+      - backend
+    restart: "no"
+
+volumes:
+  postgres_data:
+  minio_data:

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,5 +1,6 @@
-const FRONTEND_URL = "http://localhost:3000";
-const BACKEND_HEALTH_URL = "http://localhost:8000/health";
+import { BACKEND_URL, FRONTEND_URL } from "./helpers/env";
+
+const BACKEND_HEALTH_URL = `${BACKEND_URL}/health`;
 
 const BRING_UP_HINT = `
 E2E pre-flight failed.

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -1,4 +1,6 @@
-const API_V1 = "http://localhost:8000/api/v1";
+import { BACKEND_URL } from "./env";
+
+const API_V1 = `${BACKEND_URL}/api/v1`;
 
 export interface ApiResult<T> {
   status: number;

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -1,6 +1,7 @@
 import type { Browser, BrowserContext } from "@playwright/test";
+import { BACKEND_URL, FRONTEND_URL } from "./env";
 
-const API_BASE = "http://localhost:8000";
+const API_BASE = BACKEND_URL;
 
 export interface LoginResult {
   context: BrowserContext;
@@ -33,7 +34,7 @@ export async function loginAs(browser: Browser, nycuId: string): Promise<LoginRe
     throw new Error(`mock-sso login for ${nycuId}: missing numeric user.id`);
   }
 
-  const context = await browser.newContext({ baseURL: "http://localhost:3000" });
+  const context = await browser.newContext({ baseURL: FRONTEND_URL });
   // useAuth (frontend/hooks/use-auth.tsx:38-62) reads BOTH 'auth_token' and 'user'.
   await context.addInitScript(
     ({ t, u }: { t: string; u: string }) => {

--- a/frontend/e2e/helpers/env.ts
+++ b/frontend/e2e/helpers/env.ts
@@ -1,0 +1,16 @@
+/**
+ * Single source of truth for which deployment the e2e suite targets.
+ *
+ * Defaults match the localhost dev stack (docker-compose.dev.yml). The
+ * staging-e2e lane (.github/workflows/staging-e2e.yml) points these at the
+ * ephemeral staging-replica stack instead:
+ *
+ *   E2E_FRONTEND_URL=http://localhost:13000
+ *   E2E_BACKEND_URL=http://localhost:18000
+ *   E2E_DATABASE_URL=postgresql://...@localhost:15432/scholarship_db
+ *
+ * (E2E_DATABASE_URL is consumed by helpers/db.ts.)
+ */
+export const FRONTEND_URL =
+  process.env.E2E_FRONTEND_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+export const BACKEND_URL = process.env.E2E_BACKEND_URL ?? "http://localhost:8000";

--- a/frontend/e2e/specs/admin-revoke-suspend.spec.ts
+++ b/frontend/e2e/specs/admin-revoke-suspend.spec.ts
@@ -35,6 +35,7 @@ import {
   type RunState,
 } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL, FRONTEND_URL } from "../helpers/env";
 
 test.describe.configure({ mode: "serial" });
 
@@ -50,7 +51,7 @@ const SETUP_SCHOLARSHIP = "phd";
 const SETUP_SCHOLARSHIP_NAME = "博士生獎學金"; // display name of "phd" in seed data
 
 async function getApiToken(nycuId: string): Promise<string> {
-  const r = await fetch("http://localhost:8000/api/v1/auth/mock-sso/login", {
+  const r = await fetch(`${BACKEND_URL}/api/v1/auth/mock-sso/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ nycu_id: nycuId }),
@@ -257,7 +258,7 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
       const adminLogin = await loginAs(browser, "admin");
       pushTrace(runState, adminLogin.traceId);
       const page = await adminLogin.context.newPage();
-      await page.goto("http://localhost:3000/");
+      await page.goto(`${FRONTEND_URL}/`);
 
       await page.getByRole("tab", { name: "獎學金分發" }).click();
       await page.getByRole("tab", { name: SETUP_SCHOLARSHIP_NAME }).waitFor({ timeout: 10_000 });
@@ -290,7 +291,7 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
       const adminLogin = await loginAs(browser, "admin");
       pushTrace(runState, adminLogin.traceId);
       const page = await adminLogin.context.newPage();
-      await page.goto("http://localhost:3000/");
+      await page.goto(`${FRONTEND_URL}/`);
 
       await page.getByRole("tab", { name: "獎學金分發" }).click();
       await page.getByRole("tab", { name: SETUP_SCHOLARSHIP_NAME }).waitFor({ timeout: 10_000 });
@@ -345,7 +346,7 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
       const page = await adminLogin.context.newPage();
 
       // loginAs injects auth_token + user into localStorage; navigate root.
-      await page.goto("http://localhost:3000/");
+      await page.goto(`${FRONTEND_URL}/`);
 
       // Admin defaults to the "dashboard" tab.  Click "獎學金分發".
       await page.getByRole("tab", { name: "獎學金分發" }).click();

--- a/frontend/e2e/specs/college-dept-summary-export.spec.ts
+++ b/frontend/e2e/specs/college-dept-summary-export.spec.ts
@@ -39,13 +39,14 @@ import { apiAs } from "../helpers/api";
 import { deleteApplicationCascade, getActiveConfig, getApplication, pool } from "../helpers/db";
 import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL } from "../helpers/env";
 
 const STUDENT_ID = "stuphd001";
 const SCHOLARSHIP_CODE = "phd";
 const SUB_TYPE = "nstc";
 /** std_depno returned by the mock SIS API for stuphd001 */
 const DEPT_CODE = "3551";
-const API_V1 = "http://localhost:8000/api/v1";
+const API_V1 = `${BACKEND_URL}/api/v1`;
 
 async function purgeStudentApps(studentNycuId: string, scholarshipCode: string): Promise<void> {
   const { rows } = await pool.query<{ app_id: string }>(

--- a/frontend/e2e/specs/college-ranking-import-excel.spec.ts
+++ b/frontend/e2e/specs/college-ranking-import-excel.spec.ts
@@ -32,6 +32,7 @@ import {
   type RunState,
 } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL } from "../helpers/env";
 
 const STUDENT_NYCU_ID = "csphd0001";
 const STUDENT_STD_CODE = "csphd0001"; // std_stdcode returned by mock SIS API
@@ -43,7 +44,7 @@ const SUB_TYPE = "nstc";
 test.describe.configure({ mode: "serial" });
 
 async function getApiToken(nycuId: string): Promise<string> {
-  const r = await fetch("http://localhost:8000/api/v1/auth/mock-sso/login", {
+  const r = await fetch(`${BACKEND_URL}/api/v1/auth/mock-sso/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ nycu_id: nycuId }),

--- a/frontend/e2e/specs/student-draft-document-preview.spec.ts
+++ b/frontend/e2e/specs/student-draft-document-preview.spec.ts
@@ -35,9 +35,10 @@ import { apiAs } from "../helpers/api";
 import { deleteApplicationCascade, getActiveConfig, getApplication, pool } from "../helpers/db";
 import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL, FRONTEND_URL } from "../helpers/env";
 
-const API_V1 = "http://localhost:8000/api/v1";
-const FRONTEND = "http://localhost:3000";
+const API_V1 = `${BACKEND_URL}/api/v1`;
+const FRONTEND = FRONTEND_URL;
 
 const STUDENT_ID = "stuphd001";
 const SCHOLARSHIP_CODE = "phd";

--- a/frontend/e2e/specs/whitelist-grant.spec.ts
+++ b/frontend/e2e/specs/whitelist-grant.spec.ts
@@ -29,6 +29,7 @@ import {
   type RunState,
 } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL } from "../helpers/env";
 
 const SCHOLARSHIP_CODE = "undergraduate_freshman";
 const STUDENT = "stuunder1";
@@ -59,7 +60,7 @@ test.describe("Whitelist grants access to undergraduate_freshman", () => {
   test.afterAll(async () => {
     if (configId && whitelisted) {
       try {
-        const r = await fetch("http://localhost:8000/api/v1/auth/mock-sso/login", {
+        const r = await fetch(`${BACKEND_URL}/api/v1/auth/mock-sso/login`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ nycu_id: "admin" }),

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { FRONTEND_URL } from "./e2e/helpers/env";
 
 export default defineConfig({
   testDir: "./e2e/specs",
@@ -14,7 +15,7 @@ export default defineConfig({
   globalSetup: "./e2e/global-setup.ts",
   globalTeardown: "./e2e/global-teardown.ts",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: FRONTEND_URL,
     trace: "retain-on-failure",
     video: "retain-on-failure",
     screenshot: "only-on-failure",


### PR DESCRIPTION
## Summary

Adds the staging-e2e lane: a self-hosted workflow that runs the **entire Playwright suite against a throwaway replica of the live staging deployment**, on the staging host itself.

**Replica =** the exact backend/frontend images currently deployed (`docker inspect scholarship_*_staging`, not a rebuild) **+** a fresh `pg_dump` snapshot of the live staging DB **+** a bundled Mailpit capturing all outbound mail.

**Why a replica instead of testing live ss.test and restoring afterwards** (first-principles):
- restoring a pre-test dump would destroy legitimate writes made during the window;
- a failed restore would brick staging overnight;
- the suite needs mock SSO, which must never be enabled on the live endpoint;
- live staging is therefore only ever **read** (one `pg_dump`, two `docker inspect`) — "restore to original state" is guaranteed by never modifying it.

## Changes

- **`frontend/e2e/helpers/env.ts`** — `E2E_FRONTEND_URL` / `E2E_BACKEND_URL` (defaults unchanged: `localhost:3000/8000`). Helpers (`auth`, `api`), `global-setup`, `playwright.config` and the five specs with hardcoded URLs now read from it. Zero behavior change for the existing dev-stack lanes (verified: full local suite green).
- **`docker-compose.staging-e2e.yml`** — replica stack on non-conflicting ports (pg 15432 / backend 18000 / frontend 13000 / minio 19000 / mailpit UI 18025). Mock SSO on **replica-only**; SIS calls go to the bundled mock student API; staging `PII_ENCRYPTION_KEYS` passed through so the dump decrypts.
- **`.github/workflows/staging-e2e.yml`** — `workflow_dispatch` only for now:
  1. resource guard (aborts before creating anything if the host lacks headroom)
  2. snapshot live DB (read-only) + resolve deployed images
  3. start replica, `pg_restore`, `alembic upgrade head` + idempotent `app.seed`
  4. repoint `system_settings.smtp_host/port` at Mailpit → the real EmailService→SMTP pipeline executes end-to-end, mail inspectable via Mailpit API, **nothing leaves the VM**
  5. run the full suite with `E2E_*` env pointed at the replica
  6. `always()`: upload report, `down -v`, then a final **assert-zero-residue** step that fails the run if any replica container/volume survived
  - shares `concurrency: deploy-${{ github.ref }}` with the Deployment Pipeline → can never race a staging deploy.

## Verification

- Full local Playwright suite against the dev stack with default env: **38 passed / 1 pre-existing conditional skip** → URL parametrization is a no-op for existing lanes.
- `docker compose -f docker-compose.staging-e2e.yml config` validates; `axllent/mailpit:v1.21` tag exists.
- First real validation happens post-merge: `gh workflow run staging-e2e.yml`, then zero-residue check (`docker ps -a | grep staging_e2e_` empty, staging `pg_dump` hash unchanged).

## Rollout

After the first green dispatch runs, a follow-up adds the cron entry (`30 18 * * *` = 02:30 Taipei, clear of the 01:00 nightly and deploy windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)