### PR TITLE
test(e2e)+fix(email): close 5 nightly coverage gaps; fix silent admin-notification email loss (#951)

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -1,0 +1,267 @@
+# Staging E2E — full Playwright suite against an EPHEMERAL replica of the
+# live staging deployment, on the staging host itself.
+#
+# What "replica" means here:
+#   - backend/frontend images = exactly what is deployed right now (resolved
+#     via `docker inspect scholarship_*_staging`), NOT a rebuild.
+#   - database = pg_dump snapshot of the live staging DB taken at run start,
+#     restored into a throwaway Postgres.
+#   - outbound email = captured by a bundled Mailpit (full SMTP pipeline runs,
+#     nothing leaves the VM; inspect at host port 18025 during a run).
+#
+# Why a replica instead of testing the live site and restoring it after:
+#   restoring a pre-test dump would delete any legitimate writes made during
+#   the window, a failed restore would brick staging overnight, and the suite
+#   needs mock SSO which must never be enabled on the live endpoint.
+#
+# Zero-residue guarantee: live staging is only ever READ (one pg_dump, two
+# docker inspect). The replica lives in compose project `staging-e2e` and is
+# `down -v`-ed in an always() step; a final assert fails the run if anything
+# survived.
+#
+# Rollout: workflow_dispatch only for now. Once green, add a cron entry
+# (e.g. '30 18 * * *' = 02:30 Asia/Taipei, clear of the 01:00 nightly).
+
+name: Staging E2E
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+# Same group as the Deployment Pipeline → never runs concurrently with a
+# staging deploy (which would swap images / restart containers under us).
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '22'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  COMPOSE: docker compose -p staging-e2e -f docker-compose.staging-e2e.yml
+  DUMP: /tmp/staging-e2e.dump
+  REPLICA_DB_URL: postgresql://scholarship_user:scholarship_pass@localhost:15432/scholarship_db
+
+jobs:
+  staging-e2e:
+    name: E2E against staging replica
+    runs-on: [self-hosted, scholarship, test]
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resource guard (fail fast, touch nothing)
+        run: |
+          avail_kb=$(df --output=avail / | tail -1 | tr -d ' ')
+          avail_gb=$((avail_kb / 1024 / 1024))
+          mem_avail_mb=$(awk '/MemAvailable/ {print int($2/1024)}' /proc/meminfo)
+          echo "disk_avail=${avail_gb}GB mem_avail=${mem_avail_mb}MB"
+          if [ "$avail_gb" -lt 5 ] || [ "$mem_avail_mb" -lt 2048 ]; then
+            echo "::error::Staging host lacks headroom for the replica (need >=5GB disk, >=2GB RAM available). Aborting before creating anything."
+            exit 1
+          fi
+
+      # Topology note: staging is TWO VMs. The runner lives on the AP VM
+      # (backend/frontend/nginx containers); Postgres + MinIO live on the DB
+      # VM and are only reachable over the network — `docker exec
+      # scholarship_postgres_staging` does NOT work here. All DB access goes
+      # through a postgres:15-alpine client container using the same
+      # STAGING_DATABASE_URL_SYNC the backend uses.
+      - name: Verify live staging stack is healthy
+        env:
+          STAGING_DB_URL: ${{ secrets.STAGING_DATABASE_URL_SYNC }}
+        run: |
+          docker inspect --format '{{.Name}} {{.State.Status}}' \
+            scholarship_backend_staging scholarship_frontend_staging
+          curl -fsS http://localhost:8000/health > /dev/null
+          docker run --rm postgres:15-alpine pg_isready -d "$STAGING_DB_URL"
+
+      - name: Resolve currently deployed images
+        id: images
+        run: |
+          backend=$(docker inspect scholarship_backend_staging --format '{{.Config.Image}}')
+          frontend=$(docker inspect scholarship_frontend_staging --format '{{.Config.Image}}')
+          echo "backend=$backend"  | tee -a "$GITHUB_OUTPUT"
+          echo "frontend=$frontend" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Snapshot staging DB (read-only against live)
+        env:
+          STAGING_DB_URL: ${{ secrets.STAGING_DATABASE_URL_SYNC }}
+        run: |
+          # pg_dump runs in a client container on the AP VM, over the network
+          # to the DB VM (~15MB database as of 2026-06 — seconds, not minutes).
+          docker run --rm postgres:15-alpine \
+            pg_dump "$STAGING_DB_URL" -Fc > "$DUMP"
+          ls -lh "$DUMP"
+
+      - name: Pre-clean any leftover replica from a crashed run
+        run: $COMPOSE down -v --remove-orphans 2>/dev/null || true
+
+      - name: Start replica Postgres and restore the snapshot
+        env:
+          BACKEND_IMAGE: ${{ steps.images.outputs.backend }}
+          FRONTEND_IMAGE: ${{ steps.images.outputs.frontend }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
+          MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
+        run: |
+          $COMPOSE up -d --wait postgres
+          # --clean/--if-exists tolerate the fresh DB; pg_restore exits 1 on
+          # ignorable warnings, so verify with a row-count probe instead.
+          docker exec -i staging_e2e_postgres \
+            pg_restore -U scholarship_user -d scholarship_db \
+            --clean --if-exists --no-owner --no-acl < "$DUMP" || true
+          users=$(docker exec staging_e2e_postgres \
+            psql -U scholarship_user -d scholarship_db -tAc "SELECT count(*) FROM users")
+          echo "restored users rows: $users"
+          test "$users" -gt 0
+
+      - name: Start the rest of the replica stack
+        env:
+          BACKEND_IMAGE: ${{ steps.images.outputs.backend }}
+          FRONTEND_IMAGE: ${{ steps.images.outputs.frontend }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
+          MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
+        run: |
+          $COMPOSE up -d --build
+          for i in $(seq 1 90); do
+            if curl -fsS http://localhost:18000/health > /dev/null 2>&1 \
+               && curl -fsS http://localhost:13000 > /dev/null 2>&1; then
+              echo "Replica up after ~$((i*2))s"
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS http://localhost:18000/health > /dev/null
+          curl -fsS http://localhost:13000 > /dev/null
+
+      - name: Migrate + seed e2e fixtures (idempotent, replica only)
+        run: |
+          docker exec staging_e2e_backend alembic upgrade head
+          docker exec staging_e2e_backend python -m app.seed || echo "seed completed with warnings"
+
+      - name: Route replica email to Mailpit + ensure MinIO bucket
+        env:
+          MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
+        run: |
+          # SMTP settings live in system_settings (restored from the staging
+          # dump → they point at the real NYCU relay). Repoint them at the
+          # bundled Mailpit so the full send pipeline runs without any mail
+          # leaving the VM.
+          docker exec staging_e2e_postgres psql -U scholarship_user -d scholarship_db -c "
+            UPDATE system_settings SET value = 'mailpit' WHERE key = 'smtp_host';
+            UPDATE system_settings SET value = '1025'    WHERE key = 'smtp_port';
+            UPDATE system_settings SET value = 'false'   WHERE key = 'smtp_use_tls';
+          "
+          # Empty bucket is enough — specs upload what they later read.
+          docker run --rm --network staging-e2e_default --entrypoint sh \
+            minio/mc:latest -c \
+            "mc alias set replica http://minio:9000 minioadmin minioadmin123 && mc mb -p replica/${MINIO_BUCKET:-scholarship-documents}"
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install Playwright browsers
+        working-directory: ./frontend
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run full Playwright suite against the replica
+        working-directory: ./frontend
+        run: npx playwright test
+        env:
+          E2E_FRONTEND_URL: http://localhost:13000
+          E2E_BACKEND_URL: http://localhost:18000
+          E2E_DATABASE_URL: ${{ env.REPLICA_DB_URL }}
+
+      - name: Dump replica logs on failure
+        if: failure()
+        run: $COMPOSE logs --tail=300 || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report-staging-e2e
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 14
+
+      - name: Tear down replica (zero residue)
+        if: always()
+        run: |
+          $COMPOSE down -v --remove-orphans || true
+          rm -f "$DUMP"
+
+      - name: Assert zero residue
+        if: always()
+        run: |
+          leftover=$(docker ps -a --filter "name=staging_e2e_" --format '{{.Names}}')
+          volumes=$(docker volume ls --filter "name=staging-e2e_" --format '{{.Name}}')
+          if [ -n "$leftover" ] || [ -n "$volumes" ]; then
+            echo "::error::Replica residue survived teardown: containers=[$leftover] volumes=[$volumes]"
+            exit 1
+          fi
+          echo "Clean: no replica containers or volumes remain."
+
+  file-issue-on-failure:
+    name: File issue on failure
+    runs-on: ubuntu-latest
+    needs: [staging-e2e]
+    if: failure()
+    permissions:
+      issues: write
+
+    steps:
+      - name: gh issue create
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          today=$(date -u +%F)
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          gh label create staging-e2e-failure \
+            --repo ${{ github.repository }} \
+            --color "d73a4a" \
+            --description "Auto-filed by the staging-e2e replica lane" \
+            2>/dev/null || true
+          existing=$(gh issue list \
+            --repo ${{ github.repository }} \
+            --label staging-e2e-failure \
+            --state open \
+            --search "in:title $today" \
+            --json number \
+            --jq '.[0].number' || echo '')
+          body=$(cat <<EOF
+          The staging-e2e lane (full Playwright suite against an ephemeral
+          replica of the live staging deployment) failed.
+
+          - Run: $run_url
+          - staging-e2e: ${{ needs.staging-e2e.result }}
+
+          The replica uses the images deployed on staging at run time plus a
+          fresh snapshot of the staging DB, so a failure here usually means
+          either a real bug surfaced by staging's data shape, or the deployed
+          image pair is broken. Live staging itself was not modified.
+
+          (Auto-filed by .github/workflows/staging-e2e.yml. Close once a
+          subsequent run is green.)
+          EOF
+          )
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo ${{ github.repository }} --body "$body"
+          else
+            gh issue create \
+              --repo ${{ github.repository }} \
+              --title "Staging E2E $today: replica lane failed" \
+              --body "$body" \
+              --label staging-e2e-failure
+          fi

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -9,6 +9,7 @@ from html.parser import HTMLParser
 from typing import List, Optional
 
 import aiosmtplib
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -112,13 +113,19 @@ class EmailService:
             return False, {}
 
         try:
-            # Get test mode configuration with row-level locking to prevent race conditions
             from sqlalchemy import select
 
             from app.models.system_setting import SystemSetting
 
-            # Use SELECT FOR UPDATE to lock the row while checking/updating
-            stmt = select(SystemSetting).where(SystemSetting.key == "email_test_mode").with_for_update()
+            # Plain read — NO row lock. This used to be SELECT ... FOR UPDATE,
+            # which kept the email_test_mode row locked for the whole open
+            # transaction — i.e. through a potentially 60-second SMTP send.
+            # Concurrent sends then blocked on this lock until their query
+            # timed out, which poisoned that session (PendingRollbackError on
+            # the next config read) and silently dropped the email WITHOUT an
+            # email_history row. The lock is only needed for the rare
+            # expiry-update, which takes it explicitly below.
+            stmt = select(SystemSetting).where(SystemSetting.key == "email_test_mode")
             result = await self.db.execute(stmt)
             config_row = result.scalar_one_or_none()
 
@@ -131,26 +138,45 @@ class EmailService:
             enabled = test_mode_config.get("enabled", False)
             expires_at_str = test_mode_config.get("expires_at")
 
-            # Check if expired (with row locked, only one request will update)
+            # Check if expired
             if enabled and expires_at_str:
                 expires_at = datetime.fromisoformat(expires_at_str)
                 if datetime.now(timezone.utc) > expires_at:
-                    # Auto-disable if expired
-                    test_mode_config["enabled"] = False
+                    # Auto-disable if expired. Re-select FOR UPDATE so only one
+                    # concurrent request performs the update; the lock is held
+                    # only for this short write, never across the SMTP send.
+                    locked = await self.db.execute(
+                        select(SystemSetting).where(SystemSetting.key == "email_test_mode").with_for_update()
+                    )
+                    locked_row = locked.scalar_one_or_none()
+                    if locked_row is not None:
+                        test_mode_config = (
+                            json.loads(locked_row.value) if isinstance(locked_row.value, str) else locked_row.value
+                        )
+                        if test_mode_config.get("enabled", False):
+                            test_mode_config["enabled"] = False
 
-                    # Log expiration event
-                    audit_log = EmailTestModeAudit.log_expired(test_mode_config)
-                    self.db.add(audit_log)
+                            # Log expiration event
+                            audit_log = EmailTestModeAudit.log_expired(test_mode_config)
+                            self.db.add(audit_log)
 
-                    # Update configuration
-                    config_row.value = json.dumps(test_mode_config)
-                    await self.db.commit()
+                            # Update configuration
+                            locked_row.value = json.dumps(test_mode_config)
+                            await self.db.commit()
                     enabled = False
 
             return enabled, test_mode_config
 
         except Exception:
             logger.exception("Error checking test mode")
+            # Un-poison the session: without this rollback a failed query here
+            # (e.g. a lock-wait timeout) left the transaction invalid, so EVERY
+            # subsequent query in this send raised PendingRollbackError and the
+            # email vanished without even a failed email_history row.
+            try:
+                await self.db.rollback()
+            except Exception:
+                logger.exception("Rollback after test-mode check failure also failed")
             return False, {}
 
     def _transform_recipients_for_test(
@@ -483,6 +509,26 @@ class EmailService:
                 audit_db.add(history)
                 await audit_db.commit()
                 logger.debug(f"Email history logged for {recipient_email}")
+
+            except IntegrityError:
+                # The referenced application/scholarship row can disappear
+                # between the send and this audit write (e.g. a delayed
+                # background send racing an application delete) — the FK
+                # violation must not erase the audit trail. Retry once with
+                # the references stripped.
+                await audit_db.rollback()
+                logger.warning(
+                    "Email history FK reference vanished for %s; retrying without application/scholarship refs",
+                    recipient_email,
+                )
+                try:
+                    history.application_id = None
+                    history.scholarship_type_id = None
+                    audit_db.add(history)
+                    await audit_db.commit()
+                except Exception:
+                    logger.exception("Failed to log email history (retry without refs)")
+                    await audit_db.rollback()
 
             except Exception:
                 logger.exception("Failed to log email history")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -95,6 +95,13 @@ services:
       # Mock SSO Configuration
       ENABLE_MOCK_SSO: "true"
       MOCK_SSO_DOMAIN: dev.university.edu
+      # SMTP: point at a closed local port so sends fail FAST (connection
+      # refused) instead of hanging 60s against the unreachable campus relay
+      # (140.113.7.200:25). Email delivery is not expected to work in dev;
+      # what matters is that the failed attempt is recorded in email_history
+      # immediately — e2e specs assert on that row.
+      SMTP_HOST: 127.0.0.1
+      SMTP_PORT: "2525"
       # Student API Configuration (Mock)
       STUDENT_API_ENABLED: "true"
       STUDENT_API_BASE_URL: "http://mock-student-api:8080"

--- a/docker-compose.staging-e2e.yml
+++ b/docker-compose.staging-e2e.yml
@@ -1,0 +1,168 @@
+# =============================================================================
+# Ephemeral staging-replica stack for the staging-e2e lane
+# (.github/workflows/staging-e2e.yml)
+#
+# Runs ON the staging host, NEXT TO the live staging stack, with the SAME
+# backend/frontend images currently deployed (resolved by the workflow via
+# `docker inspect scholarship_*_staging`) and a pg_dump snapshot of the live
+# staging DB restored into a throwaway Postgres.
+#
+# Design rules:
+#   - Live staging is never written to. This stack is created fresh, the e2e
+#     suite runs against it, and `docker compose -p staging-e2e down -v`
+#     removes every container/volume/network afterwards.
+#   - No host port collides with the live stack (5432/8000/3000/9000/443):
+#       postgres 15432 / backend 18000 / frontend 13000 / minio 19000-19001 /
+#       mailpit UI 18025.
+#   - Outbound email goes to the bundled Mailpit (fake SMTP + HTTP API), never
+#     to the real NYCU relay — the workflow points system_settings.smtp_host
+#     at `mailpit` after restoring the dump. The full send pipeline still
+#     executes, and delivered mail is inspectable at http://localhost:18025.
+#   - Mock SSO is enabled HERE ONLY (the replica is bound to localhost ports
+#     on the staging host; the live site keeps ENABLE_MOCK_SSO=false).
+#   - PII_ENCRYPTION_KEYS must be the live staging keys, otherwise the
+#     restored dump's encrypted columns cannot be decrypted.
+#
+# Usage (from the workflow):
+#   BACKEND_IMAGE=... FRONTEND_IMAGE=... PII_ENCRYPTION_KEYS=... \
+#     docker compose -p staging-e2e -f docker-compose.staging-e2e.yml up -d
+# =============================================================================
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: staging_e2e_postgres
+    environment:
+      POSTGRES_DB: scholarship_db
+      POSTGRES_USER: scholarship_user
+      POSTGRES_PASSWORD: scholarship_pass
+    ports:
+      - "15432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U scholarship_user -d scholarship_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    restart: "no"
+
+  redis:
+    image: redis:7-alpine
+    container_name: staging_e2e_redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    restart: "no"
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: staging_e2e_minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin123
+    ports:
+      - "19000:9000"
+      - "19001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 10s
+      retries: 12
+    restart: "no"
+
+  # Fake SMTP sink with an HTTP API (http://localhost:18025/api/v1/messages).
+  # The workflow repoints system_settings.smtp_host/smtp_port here, so the
+  # real EmailService → aiosmtplib pipeline is exercised end-to-end without a
+  # single byte leaving the VM.
+  mailpit:
+    image: axllent/mailpit:v1.21
+    container_name: staging_e2e_mailpit
+    ports:
+      - "18025:8025"
+    restart: "no"
+
+  mock-student-api:
+    build:
+      context: ./mock-student-api
+      dockerfile: Dockerfile
+    container_name: staging_e2e_mock_student_api
+    command: uvicorn main:app --host 0.0.0.0 --port 8080
+    environment:
+      DATABASE_URL: postgresql://scholarship_user:scholarship_pass@postgres:5432/scholarship_db
+      MOCK_HMAC_KEY_HEX: 4d6f636b4b657946726f6d48657841424344454647484a4b4c4d4e4f505152535455565758595a
+      STRICT_TIME_CHECK: "false"
+      STRICT_ENCODE_CHECK: "false"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  backend:
+    image: ${BACKEND_IMAGE:?set BACKEND_IMAGE to the currently deployed staging backend image}
+    container_name: staging_e2e_backend
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    ports:
+      - "18000:8000"
+    environment:
+      DATABASE_URL: postgresql+asyncpg://scholarship_user:scholarship_pass@postgres:5432/scholarship_db
+      DATABASE_URL_SYNC: postgresql://scholarship_user:scholarship_pass@postgres:5432/scholarship_db
+      REDIS_URL: redis://redis:6379/0
+      SECRET_KEY: staging-e2e-throwaway-secret-key
+      DEBUG: "true"
+      CORS_ORIGINS: "http://localhost:13000,http://localhost:18000"
+      ENVIRONMENT: development
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin123
+      MINIO_BUCKET: ${MINIO_BUCKET:-scholarship-documents}
+      MINIO_SECURE: "false"
+      # MUST be the live staging keys so the restored dump decrypts.
+      PII_ENCRYPTION_KEYS: ${PII_ENCRYPTION_KEYS:?pass the staging PII keys}
+      PII_ENCRYPTION_ACTIVE_VERSION: ${PII_ENCRYPTION_ACTIVE_VERSION:-v1}
+      # Replica-only auth: mock SSO on, real Portal off.
+      ENABLE_MOCK_SSO: "true"
+      PORTAL_SSO_ENABLED: "false"
+      BASE_URL: http://localhost:18000
+      FRONTEND_URL: http://localhost:13000
+      FRONTEND_INTERNAL_URL: http://frontend:3000
+      BYPASS_TIME_RESTRICTIONS: "false"
+      # SIS API → bundled mock (the e2e fixture students only exist there).
+      STUDENT_API_ENABLED: "true"
+      STUDENT_API_BASE_URL: http://mock-student-api:8080
+      STUDENT_API_ACCOUNT: scholarship
+      STUDENT_API_HMAC_KEY: 4d6f636b4b657946726f6d48657841424344454647484a4b4c4d4e4f505152535455565758595a
+      STUDENT_API_TIMEOUT: "10.0"
+      STUDENT_API_ENCODE_TYPE: "UTF-8"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      mock-student-api:
+        condition: service_started
+    restart: "no"
+
+  frontend:
+    image: ${FRONTEND_IMAGE:?set FRONTEND_IMAGE to the currently deployed staging frontend image}
+    container_name: staging_e2e_frontend
+    ports:
+      - "13000:3000"
+    environment:
+      NODE_ENV: production
+      NEXT_TELEMETRY_DISABLED: 1
+      INTERNAL_API_URL: http://backend:8000
+    depends_on:
+      - backend
+    restart: "no"
+
+volumes:
+  postgres_data:
+  minio_data:

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,5 +1,6 @@
-const FRONTEND_URL = "http://localhost:3000";
-const BACKEND_HEALTH_URL = "http://localhost:8000/health";
+import { BACKEND_URL, FRONTEND_URL } from "./helpers/env";
+
+const BACKEND_HEALTH_URL = `${BACKEND_URL}/health`;
 
 const BRING_UP_HINT = `
 E2E pre-flight failed.

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -1,4 +1,6 @@
-const API_V1 = "http://localhost:8000/api/v1";
+import { BACKEND_URL } from "./env";
+
+const API_V1 = `${BACKEND_URL}/api/v1`;
 
 export interface ApiResult<T> {
   status: number;

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -1,6 +1,7 @@
 import type { Browser, BrowserContext } from "@playwright/test";
+import { BACKEND_URL, FRONTEND_URL } from "./env";
 
-const API_BASE = "http://localhost:8000";
+const API_BASE = BACKEND_URL;
 
 export interface LoginResult {
   context: BrowserContext;
@@ -33,7 +34,7 @@ export async function loginAs(browser: Browser, nycuId: string): Promise<LoginRe
     throw new Error(`mock-sso login for ${nycuId}: missing numeric user.id`);
   }
 
-  const context = await browser.newContext({ baseURL: "http://localhost:3000" });
+  const context = await browser.newContext({ baseURL: FRONTEND_URL });
   // useAuth (frontend/hooks/use-auth.tsx:38-62) reads BOTH 'auth_token' and 'user'.
   await context.addInitScript(
     ({ t, u }: { t: string; u: string }) => {

--- a/frontend/e2e/helpers/env.ts
+++ b/frontend/e2e/helpers/env.ts
@@ -1,0 +1,16 @@
+/**
+ * Single source of truth for which deployment the e2e suite targets.
+ *
+ * Defaults match the localhost dev stack (docker-compose.dev.yml). The
+ * staging-e2e lane (.github/workflows/staging-e2e.yml) points these at the
+ * ephemeral staging-replica stack instead:
+ *
+ *   E2E_FRONTEND_URL=http://localhost:13000
+ *   E2E_BACKEND_URL=http://localhost:18000
+ *   E2E_DATABASE_URL=postgresql://...@localhost:15432/scholarship_db
+ *
+ * (E2E_DATABASE_URL is consumed by helpers/db.ts.)
+ */
+export const FRONTEND_URL =
+  process.env.E2E_FRONTEND_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+export const BACKEND_URL = process.env.E2E_BACKEND_URL ?? "http://localhost:8000";

--- a/frontend/e2e/specs/admin-restores-professor-reject.spec.ts
+++ b/frontend/e2e/specs/admin-restores-professor-reject.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * E2E spec: the 回發 path — college/admin reverting a professor full-reject.
+ *
+ * CLAUDE.md Review-Flow Policy: "a professor full-reject is terminal for the
+ * professor: it sets application.status = rejected, and the professor cannot
+ * re-review (403). Only college/admin may revert it (回發) — that is a
+ * separate, explicit edit path, not a professor re-submit."
+ *
+ * professor-reject-upsert.spec.ts pins the terminal half (reject → rejected,
+ * re-review → 403). The REVERT half had no e2e coverage — this spec pins it:
+ *
+ *   stuphd001 → submit
+ *   professor → full reject            → status=rejected
+ *   professor → re-review              → 403   (precondition re-assert)
+ *   admin     → PATCH status=under_review (the 回發)
+ *   professor → re-review (approve)    → 200, review row UPSERTED (still 1 row)
+ *
+ * This is the product semantics #869 left hanging between unit and e2e: the
+ * professor cannot self-reopen, but the staff edit path restores
+ * reviewability.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../helpers/auth";
+import { apiAs } from "../helpers/api";
+import { deleteApplicationCascade, getActiveConfig, getApplication, getReviews, pool } from "../helpers/db";
+import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
+import { captureDiagnostics } from "../helpers/diagnose";
+
+const STUDENT_ID = "stuphd001";
+const SCHOLARSHIP_CODE = "phd";
+const SUB_TYPE = "nstc";
+const PROFESSOR_NYCU_ID = "professor";
+
+async function purgeStudentApps(studentNycuId: string, scholarshipCode: string): Promise<void> {
+  const { rows } = await pool.query<{ app_id: string }>(
+    `SELECT a.app_id
+       FROM applications a
+       JOIN users u ON u.id = a.user_id
+       JOIN scholarship_types st ON st.id = a.scholarship_type_id
+      WHERE u.nycu_id = $1 AND st.code = $2`,
+    [studentNycuId, scholarshipCode],
+  );
+  for (const row of rows) {
+    await deleteApplicationCascade(row.app_id).catch(() => undefined);
+  }
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Admin 回發 restores professor reviewability after a full reject", () => {
+  let runState: RunState;
+  let createdAppId: string | undefined;
+
+  test.beforeEach(() => {
+    runState = newRunState();
+    createdAppId = undefined;
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    if (createdAppId) runState.appId = createdAppId;
+    await captureDiagnostics(testInfo, runState);
+    await attachRunState(testInfo, runState);
+  });
+
+  test.afterAll(async () => {
+    if (createdAppId) {
+      await deleteApplicationCascade(createdAppId).catch(() => undefined);
+    }
+  });
+
+  test("@nightly professor full-reject → 403 re-review → admin PATCH under_review → professor re-review 200 (upsert)", async ({
+    browser,
+  }) => {
+    await purgeStudentApps(STUDENT_ID, SCHOLARSHIP_CODE);
+
+    // 1. Student submits.
+    const studentLogin = await loginAs(browser, STUDENT_ID);
+    pushTrace(runState, studentLogin.traceId);
+    const config = await getActiveConfig(SCHOLARSHIP_CODE);
+    const createRes = await apiAs<{ success: boolean; data: { id: number; app_id: string } }>(
+      studentLogin.token,
+      "POST",
+      "/applications?is_draft=false",
+      {
+        scholarship_type: SCHOLARSHIP_CODE,
+        configuration_id: config.id,
+        scholarship_subtype_list: [SUB_TYPE],
+        sub_type_preferences: [SUB_TYPE],
+        form_data: { fields: {}, documents: [] },
+        agree_terms: true,
+      },
+    );
+    pushTrace(runState, createRes.traceId);
+    expect(
+      createRes.ok,
+      `create failed: HTTP ${createRes.status} body=${JSON.stringify(createRes.body)}`,
+    ).toBe(true);
+    const appDbId = createRes.body.data.id;
+    createdAppId = createRes.body.data.app_id;
+    runState.appId = createdAppId;
+
+    // 2. Assign the professor (same test-setup hack as professor-reject-upsert:
+    //    advisor auto-assign needs SIS advisor data the seeded student lacks).
+    const { rows: profRows } = await pool.query<{ id: number }>(
+      "SELECT id FROM users WHERE nycu_id = $1",
+      [PROFESSOR_NYCU_ID],
+    );
+    expect(profRows[0], `seeded user ${PROFESSOR_NYCU_ID} missing`).toBeDefined();
+    await pool.query("UPDATE applications SET professor_id = $1 WHERE id = $2", [
+      profRows[0].id,
+      appDbId,
+    ]);
+
+    // 3. Professor FULL-rejects → terminal: status becomes rejected.
+    const professorLogin = await loginAs(browser, PROFESSOR_NYCU_ID);
+    pushTrace(runState, professorLogin.traceId);
+    const rejectRes = await apiAs<{ success: boolean }>(
+      professorLogin.token,
+      "POST",
+      `/professor/applications/${appDbId}/review`,
+      {
+        items: [{ sub_type_code: SUB_TYPE, recommendation: "reject", comments: "E2E 回發 spec reject" }],
+      },
+    );
+    pushTrace(runState, rejectRes.traceId);
+    expect(
+      rejectRes.ok,
+      `professor reject failed: HTTP ${rejectRes.status} body=${JSON.stringify(rejectRes.body)}`,
+    ).toBe(true);
+    const afterReject = await getApplication(createdAppId);
+    expect(afterReject!.status, "professor full-reject must set status=rejected").toBe("rejected");
+
+    // 4. Precondition re-assert: the professor cannot self-reopen (403).
+    const reReviewBlocked = await apiAs<{ success: boolean }>(
+      professorLogin.token,
+      "POST",
+      `/professor/applications/${appDbId}/review`,
+      {
+        items: [{ sub_type_code: SUB_TYPE, recommendation: "approve", comments: "self-reopen attempt" }],
+      },
+    );
+    pushTrace(runState, reReviewBlocked.traceId);
+    expect(
+      reReviewBlocked.status,
+      `professor re-review of a rejected app must be 403, got ${reReviewBlocked.status}`,
+    ).toBe(403);
+
+    // 5. THE 回發: admin explicitly moves the application back to review.
+    const adminLogin = await loginAs(browser, "admin");
+    pushTrace(runState, adminLogin.traceId);
+    const revertRes = await apiAs<{ success: boolean }>(
+      adminLogin.token,
+      "PATCH",
+      `/applications/${appDbId}/status`,
+      { status: "under_review", comments: "E2E 回發 — revert professor full-reject" },
+    );
+    pushTrace(runState, revertRes.traceId);
+    expect(
+      revertRes.ok,
+      `admin 回發 (PATCH status=under_review) failed: HTTP ${revertRes.status} body=${JSON.stringify(
+        revertRes.body,
+      )}`,
+    ).toBe(true);
+    const afterRevert = await getApplication(createdAppId);
+    expect(afterRevert!.status, "回發 must clear the rejected status").toBe("under_review");
+
+    // 6. The professor can review again — and it UPSERTS (still exactly one
+    //    review row, recommendation now approve).
+    const reReviewOk = await apiAs<{ success: boolean }>(
+      professorLogin.token,
+      "POST",
+      `/professor/applications/${appDbId}/review`,
+      {
+        items: [{ sub_type_code: SUB_TYPE, recommendation: "approve", comments: "E2E re-review after 回發" }],
+      },
+    );
+    pushTrace(runState, reReviewOk.traceId);
+    expect(
+      reReviewOk.ok,
+      `professor re-review after 回發 should succeed: HTTP ${reReviewOk.status} body=${JSON.stringify(
+        reReviewOk.body,
+      )}`,
+    ).toBe(true);
+
+    // Scope the upsert invariant to the PROFESSOR's review row: the admin's
+    // status edit may legitimately record its own review/audit row, so assert
+    // on (application, reviewer) — the professor must still have exactly ONE
+    // row, now carrying the post-回發 recommendation.
+    const reviews = await getReviews(appDbId);
+    const professorReviews = reviews.filter((r) => r.reviewer_id === profRows[0].id);
+    expect(
+      professorReviews.length,
+      `professor review must UPSERT — expected exactly 1 row for reviewer ${profRows[0].id}, got ${
+        professorReviews.length
+      } (all reviews: ${JSON.stringify(reviews)})`,
+    ).toBe(1);
+    expect(professorReviews[0].recommendation).toBe("approve");
+  });
+});

--- a/frontend/e2e/specs/admin-revoke-suspend.spec.ts
+++ b/frontend/e2e/specs/admin-revoke-suspend.spec.ts
@@ -35,6 +35,7 @@ import {
   type RunState,
 } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL, FRONTEND_URL } from "../helpers/env";
 
 test.describe.configure({ mode: "serial" });
 
@@ -50,7 +51,7 @@ const SETUP_SCHOLARSHIP = "phd";
 const SETUP_SCHOLARSHIP_NAME = "博士生獎學金"; // display name of "phd" in seed data
 
 async function getApiToken(nycuId: string): Promise<string> {
-  const r = await fetch("http://localhost:8000/api/v1/auth/mock-sso/login", {
+  const r = await fetch(`${BACKEND_URL}/api/v1/auth/mock-sso/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ nycu_id: nycuId }),
@@ -257,7 +258,7 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
       const adminLogin = await loginAs(browser, "admin");
       pushTrace(runState, adminLogin.traceId);
       const page = await adminLogin.context.newPage();
-      await page.goto("http://localhost:3000/");
+      await page.goto(`${FRONTEND_URL}/`);
 
       await page.getByRole("tab", { name: "獎學金分發" }).click();
       await page.getByRole("tab", { name: SETUP_SCHOLARSHIP_NAME }).waitFor({ timeout: 10_000 });
@@ -290,7 +291,7 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
       const adminLogin = await loginAs(browser, "admin");
       pushTrace(runState, adminLogin.traceId);
       const page = await adminLogin.context.newPage();
-      await page.goto("http://localhost:3000/");
+      await page.goto(`${FRONTEND_URL}/`);
 
       await page.getByRole("tab", { name: "獎學金分發" }).click();
       await page.getByRole("tab", { name: SETUP_SCHOLARSHIP_NAME }).waitFor({ timeout: 10_000 });
@@ -345,7 +346,7 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
       const page = await adminLogin.context.newPage();
 
       // loginAs injects auth_token + user into localStorage; navigate root.
-      await page.goto("http://localhost:3000/");
+      await page.goto(`${FRONTEND_URL}/`);
 
       // Admin defaults to the "dashboard" tab.  Click "獎學金分發".
       await page.getByRole("tab", { name: "獎學金分發" }).click();

--- a/frontend/e2e/specs/admin-revoke-suspend.spec.ts
+++ b/frontend/e2e/specs/admin-revoke-suspend.spec.ts
@@ -895,4 +895,53 @@ test.describe("locked roster dialog — revoked student panel + item removal", (
       ).not.toBeNull();
     },
   );
+
+  test(
+    "@nightly revoke/suspend queues the admin notification email (email_history row, #938)",
+    async () => {
+      // #938 wired _notify_admin_of_cancellation into the revoke/suspend
+      // endpoints; #946 moved SMTP delivery to a background task. The durable,
+      // SMTP-independent signal is the email_history audit row that
+      // EmailService.send_email always writes (status sent OR failed). The
+      // fixture above already revoked lockedFixtureAppDbId and suspended
+      // lockedFixtureSuspendAppDbId — assert both notifications were queued.
+      // Poll: the send runs AFTER the API response, and a dev SMTP timeout can
+      // delay the history write.
+      for (const [appDbId, label] of [
+        [lockedFixtureAppDbId, "撤銷"],
+        [lockedFixtureSuspendAppDbId, "停發"],
+      ] as Array<[number | undefined, string]>) {
+        expect(appDbId, `fixture app for ${label} missing`).toBeTruthy();
+        await expect
+          .poll(
+            async () => {
+              const { rows } = await pool.query<{ subject: string; recipient_email: string }>(
+                `SELECT subject, recipient_email
+                   FROM email_history
+                  WHERE application_id = $1
+                    AND subject LIKE $2
+                  ORDER BY id DESC
+                  LIMIT 1`,
+                [appDbId, `%${label}操作通知%`],
+              );
+              return rows[0] ?? null;
+            },
+            {
+              timeout: 60_000,
+              message: `no email_history row for ${label} notification of application ${appDbId} — the #938 admin-notification wiring regressed`,
+            },
+          )
+          .not.toBeNull();
+
+        const { rows } = await pool.query<{ recipient_email: string }>(
+          `SELECT recipient_email FROM email_history
+            WHERE application_id = $1 AND subject LIKE $2
+            ORDER BY id DESC LIMIT 1`,
+          [appDbId, `%${label}操作通知%`],
+        );
+        // The notification goes to the ACTING admin (the fixture acted as 'admin').
+        expect(rows[0].recipient_email).toBe("admin@nycu.edu.tw");
+      }
+    },
+  );
 });

--- a/frontend/e2e/specs/batch-import-upload.spec.ts
+++ b/frontend/e2e/specs/batch-import-upload.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * E2E spec: 批次匯入 (batch import) upload-data parses a CSV and returns a
+ * preview batch — the first e2e coverage for the batch-import surface.
+ *
+ * Scope: the upload→parse→preview contract (POST
+ * /college-review/batch-import/upload-data). The downstream
+ * validate/documents/confirm pipeline mutates student/application state and
+ * depends on external SIS data, so it stays out of scope here — this spec
+ * pins that:
+ *   - a college user can upload a CSV with the required columns (學號/學生姓名)
+ *   - the parser returns a persisted batch_id + per-row preview data
+ *   - a malformed CSV (missing required columns) is REJECTED, not silently
+ *     accepted as zero rows
+ *   - the batch shows up in /history
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../helpers/auth";
+import { apiAs } from "../helpers/api";
+import { pool } from "../helpers/db";
+import { BACKEND_URL } from "../helpers/env";
+import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
+import { captureDiagnostics } from "../helpers/diagnose";
+
+const COLLEGE_USER = "cs_college";
+const SCHOLARSHIP_CODE = "phd";
+const ACADEMIC_YEAR = 114;
+const CSV_STUDENT_ID = "313551099";
+const CSV_STUDENT_NAME = "批次匯入測試生";
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("College batch-import upload parses CSV into a preview batch", () => {
+  let runState: RunState;
+  let createdBatchId: number | undefined;
+
+  test.beforeEach(() => {
+    runState = newRunState();
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    await captureDiagnostics(testInfo, runState);
+    await attachRunState(testInfo, runState);
+  });
+
+  test.afterAll(async () => {
+    if (createdBatchId) {
+      await pool
+        .query("DELETE FROM batch_imports WHERE id = $1", [createdBatchId])
+        .catch(() => undefined);
+    }
+  });
+
+  test("@nightly cs_college uploads CSV → batch_id + preview row; malformed CSV rejected", async ({
+    browser,
+  }) => {
+    const collegeLogin = await loginAs(browser, COLLEGE_USER);
+    pushTrace(runState, collegeLogin.traceId);
+
+    // 1. Valid CSV with the required columns (Chinese header variant).
+    const csv = `學號,學生姓名\n${CSV_STUDENT_ID},${CSV_STUDENT_NAME}\n`;
+    const form = new FormData();
+    form.append("file", new Blob([csv], { type: "text/csv" }), "e2e-batch.csv");
+
+    const uploadResp = await fetch(
+      `${BACKEND_URL}/api/v1/college-review/batch-import/upload-data` +
+        `?scholarship_type=${SCHOLARSHIP_CODE}&academic_year=${ACADEMIC_YEAR}`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${collegeLogin.token}` },
+        body: form,
+      },
+    );
+    const uploadBody = (await uploadResp.json()) as {
+      success?: boolean;
+      message?: string;
+      data?: {
+        batch_id?: number;
+        total_records?: number;
+        preview_data?: Array<Record<string, unknown>>;
+        validation_summary?: { valid_count?: number; invalid_count?: number };
+      };
+    };
+    expect(
+      uploadResp.ok,
+      `upload-data failed: HTTP ${uploadResp.status} body=${JSON.stringify(uploadBody)}`,
+    ).toBe(true);
+    expect(uploadBody.success).toBe(true);
+    expect(uploadBody.data?.batch_id, "parser must persist and return a batch_id").toBeTruthy();
+    createdBatchId = uploadBody.data?.batch_id;
+    expect(uploadBody.data?.total_records, "exactly the one CSV row must be parsed").toBe(1);
+    const previewRow = JSON.stringify(uploadBody.data?.preview_data ?? []);
+    expect(previewRow, "preview must carry the uploaded student id").toContain(CSV_STUDENT_ID);
+
+    // 2. The persisted batch is retrievable via /details. (NOT /history —
+    //    history intentionally lists only CONFIRMED imports; a freshly-parsed
+    //    batch is still pending.)
+    const detailsRes = await apiAs<{ success: boolean; data: Record<string, unknown> }>(
+      collegeLogin.token,
+      "GET",
+      `/college-review/batch-import/${createdBatchId}/details`,
+    );
+    pushTrace(runState, detailsRes.traceId);
+    expect(
+      detailsRes.ok,
+      `details for batch ${createdBatchId} failed: HTTP ${detailsRes.status} body=${JSON.stringify(
+        detailsRes.body,
+      )}`,
+    ).toBe(true);
+    expect(detailsRes.body.success).toBe(true);
+    // Per-row student data lives in the upload-data preview (asserted above);
+    // /details carries the batch envelope — pin its contract.
+    const details = detailsRes.body.data as {
+      file_name?: string;
+      total_records?: number;
+      import_status?: string;
+    };
+    expect(details.file_name).toBe("e2e-batch.csv");
+    expect(details.total_records).toBe(1);
+    expect(details.import_status, "an unconfirmed batch must stay pending").toBe("pending");
+
+    // 3. Negative case: a CSV MISSING the required columns must be rejected —
+    //    not silently parsed into an empty batch.
+    const badCsv = `foo,bar\n1,2\n`;
+    const badForm = new FormData();
+    badForm.append("file", new Blob([badCsv], { type: "text/csv" }), "e2e-bad.csv");
+    const badResp = await fetch(
+      `${BACKEND_URL}/api/v1/college-review/batch-import/upload-data` +
+        `?scholarship_type=${SCHOLARSHIP_CODE}&academic_year=${ACADEMIC_YEAR}`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${collegeLogin.token}` },
+        body: badForm,
+      },
+    );
+    const badBody = (await badResp.json()) as {
+      success?: boolean;
+      data?: { validation_summary?: { invalid_count?: number }; total_records?: number };
+      message?: string;
+    };
+    const rejected =
+      !badResp.ok ||
+      badBody.success === false ||
+      (badBody.data?.validation_summary?.invalid_count ?? 0) > 0;
+    expect(
+      rejected,
+      `CSV without 學號/學生姓名 columns must be rejected or flagged invalid; got HTTP ${
+        badResp.status
+      } body=${JSON.stringify(badBody)}`,
+    ).toBe(true);
+  });
+});

--- a/frontend/e2e/specs/college-dept-summary-export.spec.ts
+++ b/frontend/e2e/specs/college-dept-summary-export.spec.ts
@@ -39,13 +39,14 @@ import { apiAs } from "../helpers/api";
 import { deleteApplicationCascade, getActiveConfig, getApplication, pool } from "../helpers/db";
 import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL } from "../helpers/env";
 
 const STUDENT_ID = "stuphd001";
 const SCHOLARSHIP_CODE = "phd";
 const SUB_TYPE = "nstc";
 /** std_depno returned by the mock SIS API for stuphd001 */
 const DEPT_CODE = "3551";
-const API_V1 = "http://localhost:8000/api/v1";
+const API_V1 = `${BACKEND_URL}/api/v1`;
 
 async function purgeStudentApps(studentNycuId: string, scholarshipCode: string): Promise<void> {
   const { rows } = await pool.query<{ app_id: string }>(

--- a/frontend/e2e/specs/college-ranking-import-excel.spec.ts
+++ b/frontend/e2e/specs/college-ranking-import-excel.spec.ts
@@ -32,6 +32,7 @@ import {
   type RunState,
 } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL } from "../helpers/env";
 
 const STUDENT_NYCU_ID = "csphd0001";
 const STUDENT_STD_CODE = "csphd0001"; // std_stdcode returned by mock SIS API
@@ -43,7 +44,7 @@ const SUB_TYPE = "nstc";
 test.describe.configure({ mode: "serial" });
 
 async function getApiToken(nycuId: string): Promise<string> {
-  const r = await fetch("http://localhost:8000/api/v1/auth/mock-sso/login", {
+  const r = await fetch(`${BACKEND_URL}/api/v1/auth/mock-sso/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ nycu_id: nycuId }),

--- a/frontend/e2e/specs/regulations-pdf-canvas.spec.ts
+++ b/frontend/e2e/specs/regulations-pdf-canvas.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * E2E spec: the 獎學金要點 (regulations) PDF actually RENDERS in the consent
+ * step — react-pdf canvas pages appear, no 「無法載入文件」.
+ *
+ * Why: #928 — a pdfjs API↔worker version mismatch made react-pdf reject
+ * getDocument BEFORE fetching the PDF, so the consent step showed 「無法載入
+ * 文件」 and blocked EVERY application. The worker asset itself served 200,
+ * and no test drove the actual canvas render, so nightly stayed green.
+ * admin-preview-dialog-render.spec.ts pins the worker-version contract; this
+ * spec pins the END RESULT the user sees: real canvas pages in the dialog.
+ *
+ * This is the OTHER preview mechanism — react-pdf canvas (InlinePdfViewer),
+ * NOT the iframe + /api/v1/preview proxy — so the iframe specs cannot cover
+ * it.
+ *
+ * Pre-req: the dev seed ships a regulations PDF
+ * (system_settings.regulations_url = system-docs/regulations_url_seed.pdf).
+ * If that ever disappears the spec fails on the explicit pre-check with a
+ * clear message rather than a silent skip.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../helpers/auth";
+import { deleteApplicationCascade, pool } from "../helpers/db";
+import { attachRunState, newRunState, type RunState } from "../helpers/runState";
+import { captureDiagnostics } from "../helpers/diagnose";
+
+const STUDENT_ID = "stuphd001";
+const SCHOLARSHIP_CODE = "phd";
+
+async function purgeStudentApps(studentNycuId: string, scholarshipCode: string): Promise<void> {
+  const { rows } = await pool.query<{ app_id: string }>(
+    `SELECT a.app_id
+       FROM applications a
+       JOIN users u ON u.id = a.user_id
+       JOIN scholarship_types st ON st.id = a.scholarship_type_id
+      WHERE u.nycu_id = $1 AND st.code = $2`,
+    [studentNycuId, scholarshipCode],
+  );
+  for (const row of rows) {
+    await deleteApplicationCascade(row.app_id).catch(() => undefined);
+  }
+}
+
+test.describe("Regulations PDF renders as react-pdf canvas in the consent step", () => {
+  let runState: RunState;
+
+  test.beforeEach(() => {
+    runState = newRunState();
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    await captureDiagnostics(testInfo, runState);
+    await attachRunState(testInfo, runState);
+  });
+
+  test("@nightly stuphd001 opens 閱讀獎學金要點 → canvas pages render, no 無法載入文件", async ({
+    browser,
+  }) => {
+    // Pre-check: the seed regulations PDF must be configured — fail loudly,
+    // never skip silently.
+    const { rows } = await pool.query<{ value: string }>(
+      "SELECT value FROM system_settings WHERE key = 'regulations_url'",
+    );
+    expect(
+      rows[0]?.value,
+      "dev seed must configure system_settings.regulations_url (regulations PDF) — the consent step depends on it",
+    ).toBeTruthy();
+
+    // A leftover application can make the scholarship non-selectable and
+    // change the portal's new-application rendering — purge first.
+    await purgeStudentApps(STUDENT_ID, SCHOLARSHIP_CODE);
+
+    const studentLogin = await loginAs(browser, STUDENT_ID);
+    const page = await studentLogin.context.newPage();
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.getByRole("tab", { name: "學生申請" }).click();
+
+    // Step 1 of the wizard = NoticeAgreementStep.
+    const openButton = page.getByRole("button", { name: /閱讀獎學金要點/ });
+    await openButton.waitFor({ timeout: 15_000 });
+
+    // The #928 failure mode shows the missing/blocked copy instead of the
+    // button working — assert the blocking copy is absent up front.
+    await expect(page.getByText("系統管理員尚未上傳獎學金要點")).toHaveCount(0);
+
+    await openButton.click();
+    const dialog = page.getByRole("dialog").first();
+    await dialog.waitFor({ timeout: 10_000 });
+    await expect(dialog.getByText("獎學金要點").first()).toBeVisible();
+
+    // The dispositive assertion: react-pdf rendered REAL canvas pages.
+    // With a version-mismatched worker (#928) getDocument rejects before any
+    // canvas exists and InlinePdfViewer shows 「無法載入文件」 instead.
+    await expect
+      .poll(async () => dialog.locator("canvas").count(), {
+        timeout: 20_000,
+        message: "react-pdf never rendered a canvas page (the #928 failure mode)",
+      })
+      .toBeGreaterThan(0);
+    await expect(dialog.getByText("無法載入文件")).toHaveCount(0);
+
+    await studentLogin.context.close();
+  });
+});

--- a/frontend/e2e/specs/student-draft-document-preview.spec.ts
+++ b/frontend/e2e/specs/student-draft-document-preview.spec.ts
@@ -35,9 +35,10 @@ import { apiAs } from "../helpers/api";
 import { deleteApplicationCascade, getActiveConfig, getApplication, pool } from "../helpers/db";
 import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL, FRONTEND_URL } from "../helpers/env";
 
-const API_V1 = "http://localhost:8000/api/v1";
-const FRONTEND = "http://localhost:3000";
+const API_V1 = `${BACKEND_URL}/api/v1`;
+const FRONTEND = FRONTEND_URL;
 
 const STUDENT_ID = "stuphd001";
 const SCHOLARSHIP_CODE = "phd";

--- a/frontend/e2e/specs/whitelist-grant.spec.ts
+++ b/frontend/e2e/specs/whitelist-grant.spec.ts
@@ -29,6 +29,7 @@ import {
   type RunState,
 } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL } from "../helpers/env";
 
 const SCHOLARSHIP_CODE = "undergraduate_freshman";
 const STUDENT = "stuunder1";
@@ -59,7 +60,7 @@ test.describe("Whitelist grants access to undergraduate_freshman", () => {
   test.afterAll(async () => {
     if (configId && whitelisted) {
       try {
-        const r = await fetch("http://localhost:8000/api/v1/auth/mock-sso/login", {
+        const r = await fetch(`${BACKEND_URL}/api/v1/auth/mock-sso/login`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ nycu_id: "admin" }),

--- a/frontend/e2e/specs/whitelist-remove.spec.ts
+++ b/frontend/e2e/specs/whitelist-remove.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * E2E spec: removing a student from the whitelist revokes eligibility.
+ *
+ * whitelist-grant.spec.ts pins the GRANT direction (not eligible → add →
+ * eligible). This pins the inverse, which had no coverage: a student already
+ * whitelisted loses access the moment the admin removes them — the eligible
+ * list must NOT keep serving a stale grant.
+ *
+ * Flow:
+ *   admin  → POST /scholarship-configurations/{id}/whitelist/batch (grant)
+ *   student → GET /scholarships/eligible → contains undergraduate_freshman
+ *   admin  → DELETE /scholarship-configurations/{id}/whitelist/batch (remove)
+ *            → DB whitelist no longer contains the student
+ *   student → GET /scholarships/eligible → undergraduate_freshman GONE
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../helpers/auth";
+import { apiAs } from "../helpers/api";
+import { getActiveConfig, getWhitelist } from "../helpers/db";
+import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
+import { captureDiagnostics } from "../helpers/diagnose";
+
+const SCHOLARSHIP_CODE = "undergraduate_freshman";
+const STUDENT = "stuunder1";
+const SUB_TYPE = "general";
+
+interface EligibleScholarship {
+  code: string;
+  name?: string;
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Whitelist removal revokes access to undergraduate_freshman", () => {
+  let runState: RunState;
+  let configId: number | undefined;
+  let whitelisted = false;
+
+  test.beforeEach(() => {
+    runState = newRunState();
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    if (configId) runState.configId = configId;
+    await captureDiagnostics(testInfo, runState);
+    await attachRunState(testInfo, runState);
+  });
+
+  test.afterAll(async () => {
+    // Best-effort: never leave the grant behind if the removal step failed.
+    if (configId && whitelisted) {
+      try {
+        const r = await fetch("http://localhost:8000/api/v1/auth/mock-sso/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ nycu_id: "admin" }),
+        });
+        const body = (await r.json()) as { data?: { access_token?: string } };
+        const token = body?.data?.access_token;
+        if (token) {
+          await apiAs(token, "DELETE", `/scholarship-configurations/${configId}/whitelist/batch`, {
+            nycu_ids: [STUDENT],
+            sub_type: SUB_TYPE,
+          });
+        }
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  test("@nightly admin grant → student eligible → admin REMOVE → student no longer eligible", async ({
+    browser,
+  }) => {
+    const config = await getActiveConfig(SCHOLARSHIP_CODE);
+    configId = config.id;
+
+    // 1. Admin grants (setup — the grant direction itself is pinned by
+    //    whitelist-grant.spec.ts).
+    const adminLogin = await loginAs(browser, "admin");
+    pushTrace(runState, adminLogin.traceId);
+    const addRes = await apiAs<{ success: boolean; data: { added_count: number } }>(
+      adminLogin.token,
+      "POST",
+      `/scholarship-configurations/${config.id}/whitelist/batch`,
+      { students: [{ nycu_id: STUDENT, sub_type: SUB_TYPE }] },
+    );
+    pushTrace(runState, addRes.traceId);
+    expect(addRes.ok, `grant failed: HTTP ${addRes.status} ${JSON.stringify(addRes.body)}`).toBe(true);
+    whitelisted = true;
+
+    // 2. Student is eligible while whitelisted.
+    const studentLogin = await loginAs(browser, STUDENT);
+    pushTrace(runState, studentLogin.traceId);
+    const during = await apiAs<{ success: boolean; data: EligibleScholarship[] }>(
+      studentLogin.token,
+      "GET",
+      "/scholarships/eligible",
+    );
+    pushTrace(runState, during.traceId);
+    expect(during.ok).toBe(true);
+    const duringCodes = (during.body.data ?? []).map((s) => s.code);
+    expect(
+      duringCodes,
+      `${STUDENT} should see ${SCHOLARSHIP_CODE} while whitelisted; got ${JSON.stringify(duringCodes)}`,
+    ).toContain(SCHOLARSHIP_CODE);
+
+    // 3. Admin removes the student from the whitelist.
+    const removeRes = await apiAs<{ success: boolean }>(
+      adminLogin.token,
+      "DELETE",
+      `/scholarship-configurations/${config.id}/whitelist/batch`,
+      { nycu_ids: [STUDENT], sub_type: SUB_TYPE },
+    );
+    pushTrace(runState, removeRes.traceId);
+    expect(
+      removeRes.ok,
+      `whitelist remove failed: HTTP ${removeRes.status} body=${JSON.stringify(removeRes.body)}`,
+    ).toBe(true);
+    expect(removeRes.body.success).toBe(true);
+    whitelisted = false;
+
+    // 4. DB no longer lists the student.
+    const wl = await getWhitelist(config.id);
+    expect(wl[SUB_TYPE] ?? [], "DB whitelist must not contain the student after removal").not.toContain(
+      STUDENT,
+    );
+
+    // 5. The dispositive assertion: a fresh eligibility check no longer
+    //    serves the revoked grant.
+    const studentLogin2 = await loginAs(browser, STUDENT);
+    pushTrace(runState, studentLogin2.traceId);
+    const after = await apiAs<{ success: boolean; data: EligibleScholarship[] }>(
+      studentLogin2.token,
+      "GET",
+      "/scholarships/eligible",
+    );
+    pushTrace(runState, after.traceId);
+    expect(after.ok).toBe(true);
+    const afterCodes = (after.body.data ?? []).map((s) => s.code);
+    expect(
+      afterCodes,
+      `${STUDENT} must NOT see ${SCHOLARSHIP_CODE} after whitelist removal; got ${JSON.stringify(afterCodes)}`,
+    ).not.toContain(SCHOLARSHIP_CODE);
+  });
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { FRONTEND_URL } from "./e2e/helpers/env";
 
 export default defineConfig({
   testDir: "./e2e/specs",
@@ -14,7 +15,7 @@ export default defineConfig({
   globalSetup: "./e2e/global-setup.ts",
   globalTeardown: "./e2e/global-teardown.ts",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: FRONTEND_URL,
     trace: "retain-on-failure",
     video: "retain-on-failure",
     screenshot: "only-on-failure",


### PR DESCRIPTION
**Stacked on #950** (the new specs use its `e2e/helpers/env.ts`); merge after it, or merge this into it.

## 5 coverage gaps closed (all @nightly, 11/11 green locally)

| Spec | Pins | Why it was missing |
|---|---|---|
| `regulations-pdf-canvas.spec.ts` | 要點 PDF renders real react-pdf **canvas** pages in the consent step, no 「無法載入文件」 | #928 (worker version mismatch) blocked ALL applications while every asset fetch stayed 200 — only a canvas-level assertion catches the class |
| `admin-restores-professor-reject.spec.ts` | the **回發** path: full-reject → `rejected` + 403 self-reopen → admin `PATCH status=under_review` → professor re-review 200 + upsert (exactly 1 professor row) | CLAUDE.md Review-Flow Policy's revert half; #869 left it untested |
| `whitelist-remove.spec.ts` | removal revokes eligibility (DB + `/scholarships/eligible`) | only the grant direction was covered |
| `batch-import-upload.spec.ts` | CSV → persisted batch + preview; malformed CSV rejected; `/details` contract | 批次匯入 had zero e2e |
| `admin-revoke-suspend.spec.ts` (+1 test) | revoke/suspend queues the #938 admin notification — `email_history` audit row exists, recipient = acting admin | #938/#946 shipped with no delivery-side assertion |

## Real bug caught & fixed (closes #951)
The new email test exposed that **#938 notifications were silently lost whenever two sends overlapped**:
1. `_check_test_mode` held `SELECT … FOR UPDATE` on `email_test_mode` across the whole SMTP send (60s timeout against the unreachable dev relay) → concurrent sends blocked on the lock
2. the blocked query's timeout was swallowed **without rollback** → poisoned session
3. next config read → `PendingRollbackError` **before** the send AND before the `email_history` write → no email, no audit row

**Fixes** (`backend/app/services/email_service.py`):
- plain read in `_check_test_mode` (lock only the rare expiry-update, briefly); `rollback()` on failure
- `_log_email_history`: FK-violation retry with refs stripped (audit row survives an application deleted mid-flight)
- `docker-compose.dev.yml`: `SMTP_HOST=127.0.0.1:2525` → dev/CI sends fail fast instead of 60s hangs (spec runtime 3.4m → 25s); `seed_system_settings` snapshots env per environment, so staging/prod keep their real relay

Backend email tests: **270 passed**. Black + flake8 (B904/B014) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)