### PR TITLE
fix(staging-e2e): teardown env bug, MinIO mirror, parametrize new specs, full-roster import

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -100,6 +100,18 @@ jobs:
       - name: Pre-clean any leftover replica from a crashed run
         run: $COMPOSE down -v --remove-orphans 2>/dev/null || true
 
+      - name: Validate required secrets/inputs
+        env:
+          BACKEND_IMAGE: ${{ steps.images.outputs.backend }}
+          FRONTEND_IMAGE: ${{ steps.images.outputs.frontend }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+        run: |
+          # The compose file deliberately has no `:?` required-var guards (they
+          # would break env-less invocations like `down -v`), so enforce here.
+          test -n "$BACKEND_IMAGE"  || { echo "::error::could not resolve deployed backend image"; exit 1; }
+          test -n "$FRONTEND_IMAGE" || { echo "::error::could not resolve deployed frontend image"; exit 1; }
+          test -n "$PII_ENCRYPTION_KEYS" || { echo "::error::secrets.PII_ENCRYPTION_KEYS missing — replica cannot decrypt the staging dump"; exit 1; }
+
       - name: Start replica Postgres and restore the snapshot
         env:
           BACKEND_IMAGE: ${{ steps.images.outputs.backend }}
@@ -144,9 +156,12 @@ jobs:
           docker exec staging_e2e_backend alembic upgrade head
           docker exec staging_e2e_backend python -m app.seed || echo "seed completed with warnings"
 
-      - name: Route replica email to Mailpit + ensure MinIO bucket
+      - name: Route replica email to Mailpit + mirror MinIO bucket
         env:
           MINIO_BUCKET: ${{ secrets.STAGING_MINIO_BUCKET }}
+          STAGING_MINIO_ENDPOINT: ${{ secrets.STAGING_MINIO_ENDPOINT }}
+          STAGING_MINIO_ACCESS_KEY: ${{ secrets.STAGING_MINIO_ACCESS_KEY }}
+          STAGING_MINIO_SECRET_KEY: ${{ secrets.STAGING_MINIO_SECRET_KEY }}
         run: |
           # SMTP settings live in system_settings (restored from the staging
           # dump → they point at the real NYCU relay). Repoint them at the
@@ -157,10 +172,18 @@ jobs:
             UPDATE system_settings SET value = '1025'    WHERE key = 'smtp_port';
             UPDATE system_settings SET value = 'false'   WHERE key = 'smtp_use_tls';
           "
-          # Empty bucket is enough — specs upload what they later read.
+          # Mirror the live bucket into the replica (read-only against live).
+          # The restored DB references objects that live in staging MinIO —
+          # e.g. the 獎學金要點 regulations PDF and previously uploaded
+          # documents — so an empty bucket breaks preview/regulations specs.
           docker run --rm --network staging-e2e_default --entrypoint sh \
-            minio/mc:latest -c \
-            "mc alias set replica http://minio:9000 minioadmin minioadmin123 && mc mb -p replica/${MINIO_BUCKET:-scholarship-documents}"
+            minio/mc:latest -c "
+              mc alias set live    http://${STAGING_MINIO_ENDPOINT} ${STAGING_MINIO_ACCESS_KEY} ${STAGING_MINIO_SECRET_KEY} &&
+              mc alias set replica http://minio:9000 minioadmin minioadmin123 &&
+              mc mb -p replica/${MINIO_BUCKET:-scholarship-documents} &&
+              mc mirror --overwrite live/${MINIO_BUCKET:-scholarship-documents} replica/${MINIO_BUCKET:-scholarship-documents} &&
+              mc du replica/${MINIO_BUCKET:-scholarship-documents}
+            "
 
       - uses: actions/setup-node@v5
         with:
@@ -184,7 +207,13 @@ jobs:
 
       - name: Dump replica logs on failure
         if: failure()
-        run: $COMPOSE logs --tail=300 || true
+        # Plain `docker logs` per container — does not parse the compose file,
+        # so it works regardless of env/interpolation state.
+        run: |
+          for c in staging_e2e_backend staging_e2e_frontend staging_e2e_postgres staging_e2e_mock_student_api staging_e2e_mailpit; do
+            echo "===== $c ====="
+            docker logs --tail 400 "$c" 2>&1 || true
+          done
 
       - name: Upload Playwright report
         if: always()

--- a/docker-compose.staging-e2e.yml
+++ b/docker-compose.staging-e2e.yml
@@ -104,7 +104,11 @@ services:
     restart: "no"
 
   backend:
-    image: ${BACKEND_IMAGE:?set BACKEND_IMAGE to the currently deployed staging backend image}
+    # No `:?` here — required-var errors would break EVERY compose invocation
+    # that runs without env (down/logs/pre-clean), which is exactly what
+    # silently kept the first run's replica alive. The workflow validates
+    # these explicitly before `up`.
+    image: ${BACKEND_IMAGE:-ghcr.io/anud18/scholarship-system-backend:latest}
     container_name: staging_e2e_backend
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000
     ports:
@@ -123,7 +127,9 @@ services:
       MINIO_BUCKET: ${MINIO_BUCKET:-scholarship-documents}
       MINIO_SECURE: "false"
       # MUST be the live staging keys so the restored dump decrypts.
-      PII_ENCRYPTION_KEYS: ${PII_ENCRYPTION_KEYS:?pass the staging PII keys}
+      # (Validated by the workflow before `up`; no `:?` so that env-less
+      # compose invocations like `down -v` still parse.)
+      PII_ENCRYPTION_KEYS: ${PII_ENCRYPTION_KEYS:-}
       PII_ENCRYPTION_ACTIVE_VERSION: ${PII_ENCRYPTION_ACTIVE_VERSION:-v1}
       # Replica-only auth: mock SSO on, real Portal off.
       ENABLE_MOCK_SSO: "true"
@@ -151,7 +157,7 @@ services:
     restart: "no"
 
   frontend:
-    image: ${FRONTEND_IMAGE:?set FRONTEND_IMAGE to the currently deployed staging frontend image}
+    image: ${FRONTEND_IMAGE:-ghcr.io/anud18/scholarship-system-frontend:latest}
     container_name: staging_e2e_frontend
     ports:
       - "13000:3000"

--- a/frontend/e2e/specs/admin-preview-dialog-render.spec.ts
+++ b/frontend/e2e/specs/admin-preview-dialog-render.spec.ts
@@ -39,9 +39,10 @@ import { apiAs } from "../helpers/api";
 import { deleteApplicationCascade, getActiveConfig, pool } from "../helpers/db";
 import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL, FRONTEND_URL } from "../helpers/env";
 
-const API_V1 = "http://localhost:8000/api/v1";
-const FRONTEND = "http://localhost:3000";
+const API_V1 = `${BACKEND_URL}/api/v1`;
+const FRONTEND = FRONTEND_URL;
 
 const STUDENT_ID = "stuphd001";
 const ADMIN_ID = "super_admin";

--- a/frontend/e2e/specs/college-ranking-import-excel.spec.ts
+++ b/frontend/e2e/specs/college-ranking-import-excel.spec.ts
@@ -15,8 +15,8 @@
  *     1. csphd0001 submits phd/nstc application
  *     2. cs_college creates ranking (force_new=true) — auto-includes the app
  *   Test 1: GET ranking → items array has csphd0001, college_rejected=false
- *   Test 2: POST import-excel [rank=1] → updated_count=1, rejected_count=0
- *   Test 3: POST import-excel [rank="N"] → updated_count=1, rejected_count=1
+ *   Test 2: POST import-excel [rank=1, full roster] → all rows updated, rejected_count=0
+ *   Test 3: POST import-excel [rank="N", full roster] → all rows updated, rejected_count=1
  *   Test 4: GET ranking after "N" import → college_rejected=true
  *   afterAll: SQL cleanup (ranking items → ranking → application)
  *
@@ -68,6 +68,50 @@ test.describe("College ranking import-excel @nightly", () => {
   let fixtureAppId: string | undefined;
   let fixtureAppDbId: number | undefined;
   let collegeToken: string;
+
+  /**
+   * Build an import payload covering EVERY student in the ranking — the
+   * backend strictly requires the import set to equal the ranking's
+   * application set (排名連續、學號完全吻合). Against the dev seed the ranking
+   * only contains csphd0001, but on the staging-replica lane the force_new
+   * ranking sweeps in the real staging applications for the same
+   * (scholarship, year), so a single-row payload 422s with
+   * 「以下學號未包含在匯入檔案中」.
+   */
+  async function buildFullImportRows(
+    fixtureRank: number | "N",
+  ): Promise<Array<{ student_id: string; student_name: string; rank_position: number | "N" }>> {
+    const res = await apiAs<{
+      success: boolean;
+      data: {
+        items: Array<{
+          student_id: string;
+          student_name?: string;
+          application: { id: number };
+        }>;
+      };
+    }>(collegeToken, "GET", `/college-review/rankings/${rankingId}`);
+    if (!res.ok || !res.body.success) {
+      throw new Error(
+        `buildFullImportRows: GET ranking ${rankingId} failed HTTP ${res.status} body=${JSON.stringify(res.body)}`,
+      );
+    }
+    const items = res.body.data.items ?? [];
+    let nextRank = fixtureRank === "N" ? 1 : 2;
+    return items.map((item) =>
+      item.application.id === fixtureAppDbId
+        ? {
+            student_id: item.student_id,
+            student_name: STUDENT_NAME,
+            rank_position: fixtureRank,
+          }
+        : {
+            student_id: item.student_id,
+            student_name: item.student_name ?? "學生",
+            rank_position: nextRank++,
+          },
+    );
+  }
 
   test.beforeAll(async () => {
     const config = await getActiveConfig(SCHOLARSHIP_CODE);
@@ -223,8 +267,9 @@ test.describe("College ranking import-excel @nightly", () => {
   );
 
   test(
-    "@nightly POST import-excel [rank=1] → updated_count=1, rejected_count=0",
+    "@nightly POST import-excel [rank=1] → all rows updated, rejected_count=0",
     async () => {
+      const rows = await buildFullImportRows(1);
       const res = await apiAs<{
         success: boolean;
         data: {
@@ -237,13 +282,7 @@ test.describe("College ranking import-excel @nightly", () => {
         collegeToken,
         "POST",
         `/college-review/rankings/${rankingId}/import-excel`,
-        [
-          {
-            student_id: STUDENT_STD_CODE,
-            student_name: STUDENT_NAME,
-            rank_position: 1,
-          },
-        ],
+        rows,
       );
       pushTrace(runState, res.traceId);
 
@@ -253,15 +292,16 @@ test.describe("College ranking import-excel @nightly", () => {
       ).toBe(true);
       expect(res.body.success).toBe(true);
       expect(res.body.data.ranking_id).toBe(rankingId);
-      expect(res.body.data.updated_count).toBe(1);
+      expect(res.body.data.updated_count).toBe(rows.length);
       expect(res.body.data.rejected_count).toBe(0);
-      expect(res.body.data.total_imported).toBe(1);
+      expect(res.body.data.total_imported).toBe(rows.length);
     },
   );
 
   test(
-    "@nightly POST import-excel [rank='N'] → updated_count=1, rejected_count=1",
+    "@nightly POST import-excel [rank='N'] → all rows updated, rejected_count=1",
     async () => {
+      const rows = await buildFullImportRows("N");
       const res = await apiAs<{
         success: boolean;
         data: {
@@ -274,13 +314,7 @@ test.describe("College ranking import-excel @nightly", () => {
         collegeToken,
         "POST",
         `/college-review/rankings/${rankingId}/import-excel`,
-        [
-          {
-            student_id: STUDENT_STD_CODE,
-            student_name: STUDENT_NAME,
-            rank_position: "N",
-          },
-        ],
+        rows,
       );
       pushTrace(runState, res.traceId);
 
@@ -289,7 +323,9 @@ test.describe("College ranking import-excel @nightly", () => {
         `import-excel (N) failed: HTTP ${res.status} body=${JSON.stringify(res.body)}`,
       ).toBe(true);
       expect(res.body.success).toBe(true);
-      expect(res.body.data.updated_count).toBe(1);
+      // updated_count counts every imported row ("N" rows included);
+      // rejected_count counts only our fixture's "N".
+      expect(res.body.data.updated_count).toBe(rows.length);
       expect(res.body.data.rejected_count).toBe(1);
     },
   );

--- a/frontend/e2e/specs/whitelist-remove.spec.ts
+++ b/frontend/e2e/specs/whitelist-remove.spec.ts
@@ -19,6 +19,7 @@ import { apiAs } from "../helpers/api";
 import { getActiveConfig, getWhitelist } from "../helpers/db";
 import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
 import { captureDiagnostics } from "../helpers/diagnose";
+import { BACKEND_URL } from "../helpers/env";
 
 const SCHOLARSHIP_CODE = "undergraduate_freshman";
 const STUDENT = "stuunder1";
@@ -50,7 +51,7 @@ test.describe("Whitelist removal revokes access to undergraduate_freshman", () =
     // Best-effort: never leave the grant behind if the removal step failed.
     if (configId && whitelisted) {
       try {
-        const r = await fetch("http://localhost:8000/api/v1/auth/mock-sso/login", {
+        const r = await fetch(`${BACKEND_URL}/api/v1/auth/mock-sso/login`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ nycu_id: "admin" }),


### PR DESCRIPTION
Fixes from the first real staging-e2e dispatch (run 27294892581 — 28 passed / 6 failed / residue assert tripped):

1. **Teardown env bug (the residue):** compose `${VAR:?}` guards broke every env-less compose call (`down -v`, logs, pre-clean) — all silently swallowed by `|| true`, so the replica survived. `:?` dropped; the workflow validates required inputs explicitly before `up`; log dump now uses plain `docker logs`.
2. **MinIO mirror:** replica DB references objects that only exist in staging MinIO (regulations PDF etc.) — now `mc mirror`ed (read-only against live) instead of an empty bucket.
3. **Two specs merged after the URL parametrization** hardcoded `localhost` again and accidentally hit LIVE staging from the replica lane (correctly 401'd — the isolation held). Routed through `helpers/env.ts`.
4. **import-excel data shape:** with staging data in the ranking, single-row import 422s by design; payload is now built from the ranking's actual items.

Remaining open from run 1 (need the now-working log dump to diagnose): admin-student-history 500 + 審核管理 panel 權限設置問題 on the replica. Next dispatch will tell.

Verified: 3 touched spec files pass locally against the dev stack (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)