### PR TITLE
fix(staging-e2e): route replica browser traffic through an nginx that mirrors live staging

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -142,14 +142,15 @@ jobs:
           $COMPOSE up -d --build
           for i in $(seq 1 90); do
             if curl -fsS http://localhost:18000/health > /dev/null 2>&1 \
-               && curl -fsS http://localhost:13000 > /dev/null 2>&1; then
+               && curl -fsS http://localhost:13080 > /dev/null 2>&1; then
               echo "Replica up after ~$((i*2))s"
               break
             fi
             sleep 2
           done
           curl -fsS http://localhost:18000/health > /dev/null
-          curl -fsS http://localhost:13000 > /dev/null
+          # 13080 = replica nginx (browser entrypoint, mirrors live routing)
+          curl -fsS http://localhost:13080 > /dev/null
 
       - name: Migrate + seed e2e fixtures (idempotent, replica only)
         run: |
@@ -201,7 +202,9 @@ jobs:
         working-directory: ./frontend
         run: npx playwright test
         env:
-          E2E_FRONTEND_URL: http://localhost:13000
+          # Browser traffic enters through the replica nginx (13080) just like
+          # live staging; direct backend access (18000) for API fixtures.
+          E2E_FRONTEND_URL: http://localhost:13080
           E2E_BACKEND_URL: http://localhost:18000
           E2E_DATABASE_URL: ${{ env.REPLICA_DB_URL }}
 
@@ -210,7 +213,7 @@ jobs:
         # Plain `docker logs` per container — does not parse the compose file,
         # so it works regardless of env/interpolation state.
         run: |
-          for c in staging_e2e_backend staging_e2e_frontend staging_e2e_postgres staging_e2e_mock_student_api staging_e2e_mailpit; do
+          for c in staging_e2e_backend staging_e2e_frontend staging_e2e_nginx staging_e2e_postgres staging_e2e_mock_student_api staging_e2e_mailpit; do
             echo "===== $c ====="
             docker logs --tail 400 "$c" 2>&1 || true
           done

--- a/docker-compose.staging-e2e.yml
+++ b/docker-compose.staging-e2e.yml
@@ -164,9 +164,29 @@ services:
     environment:
       NODE_ENV: production
       NEXT_TELEMETRY_DISABLED: 1
+      # Read at RUNTIME by the Next API route handlers (preview/download
+      # proxies). The catch-all /api rewrite however was baked at image BUILD
+      # time with the localhost fallback — which is why browser /api traffic
+      # must go through the nginx service below, exactly like live staging.
       INTERNAL_API_URL: http://backend:8000
     depends_on:
       - backend
+    restart: "no"
+
+  # Mirrors live staging's nginx routing (path split from
+  # nginx.staging.conf) so browser /api calls reach the backend instead of
+  # the frontend image's build-baked localhost rewrite. The e2e suite's
+  # E2E_FRONTEND_URL points here.
+  nginx:
+    image: nginx:alpine
+    container_name: staging_e2e_nginx
+    ports:
+      - "13080:80"
+    volumes:
+      - ./nginx/nginx.staging-e2e.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - backend
+      - frontend
     restart: "no"
 
 volumes:

--- a/nginx/nginx.staging-e2e.conf
+++ b/nginx/nginx.staging-e2e.conf
@@ -1,0 +1,72 @@
+# Nginx for the EPHEMERAL staging-e2e replica (docker-compose.staging-e2e.yml).
+#
+# Why the replica needs nginx at all: the production frontend image bakes its
+# Next.js rewrite fallback (`INTERNAL_API_URL || http://localhost:8000`) at
+# BUILD time, so browser /api calls proxied through the frontend container
+# die with ECONNREFUSED. Live staging never hits that path because its nginx
+# routes /api/* straight to the backend — this conf mirrors that routing
+# (path split copied from nginx.staging.conf), minus TLS / rate limiting /
+# logging, so the replica exercises the same architecture the live site runs.
+
+events {
+    worker_connections 256;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    resolver 127.0.0.11 valid=30s;
+
+    client_max_body_size 50m;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        set $backend_upstream backend:8000;
+        set $frontend_upstream frontend:3000;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Next.js API-route proxies that must be served by the FRONTEND
+        # (same split as nginx.staging.conf).
+        location /api/v1/download {
+            proxy_pass http://$frontend_upstream;
+        }
+        location /api/v1/preview {
+            proxy_pass http://$frontend_upstream;
+        }
+        location /api/email/ {
+            proxy_pass http://$frontend_upstream;
+        }
+        location /api/v1/system-settings/upload-proxy {
+            proxy_pass http://$frontend_upstream;
+        }
+        location /api/v1/system-settings/file-proxy {
+            proxy_pass http://$frontend_upstream;
+        }
+        location /api/v1/system-settings/supp-upload-proxy {
+            proxy_pass http://$frontend_upstream;
+        }
+        location /api/v1/system-settings/supp-file-proxy {
+            proxy_pass http://$frontend_upstream;
+        }
+
+        # Everything else under /api/ goes to the backend.
+        location /api/ {
+            proxy_pass http://$backend_upstream;
+        }
+
+        # App pages, _next assets, websockets.
+        location / {
+            proxy_pass http://$frontend_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+}


### PR DESCRIPTION
Second staging-e2e dispatch: teardown + zero-residue assert now pass; 31/36 tests green. The five remaining failures (admin-preview-dialog, revoke-suspend panel, student-history ×2, regulations-pdf-canvas) all share one root cause found via the now-working replica log dump:

> `Failed to proxy http://localhost:8000/api/v1/... ECONNREFUSED` (frontend container)

The production frontend image bakes the Next.js catch-all `/api` rewrite at **build** time with the `localhost:8000` fallback. Live staging is immune because its nginx routes `/api/*` directly to the backend — the replica had no nginx, so browser API calls died inside the frontend container.

Fix: `nginx/nginx.staging-e2e.conf` (routing split mirrored from `nginx.staging.conf`, no TLS/rate-limit) + nginx service on host port 13080; `E2E_FRONTEND_URL` now enters through it. The replica architecture now matches live staging one level deeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)