### PR TITLE
feat: per-college remaining quota matrix on manual distribution page

### DIFF
--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -532,7 +532,9 @@ class ManualDistributionService:
           "nstc": {
             "display_name": "國科會",
             "by_config": [
-              {"config_id", "config_code", "academic_year", "is_own", "total", "remaining"},
+              {"config_id", "config_code", "academic_year", "is_own", "total",
+               "remaining", "by_college"},  # by_college: {code: {total, allocated,
+                                            # remaining}} for matrix configs, else None
               ...  # own config first, then linked source configs by descending year
             ]
           },
@@ -581,6 +583,7 @@ class ManualDistributionService:
                         "is_own": col["is_own"],
                         "total": total,
                         "remaining": col["remaining"],
+                        "by_college": await self._college_breakdown(cfg, col["config_id"], sub_type),
                     }
                 )
             quota_status[sub_type] = {
@@ -589,6 +592,46 @@ class ManualDistributionService:
             }
 
         return quota_status
+
+    async def _college_breakdown(
+        self,
+        cfg: ScholarshipConfiguration | None,
+        config_id: int,
+        sub_type: str,
+    ) -> dict[str, dict[str, int]] | None:
+        """Per-college quota grid for one (config, sub_type) column (advisory).
+
+        None for non-matrix configs (no per-college split exists). Colleges
+        appear when they have quota > 0 in the matrix OR live consumers;
+        remaining is NOT clamped — negative flags over-allocation in the UI.
+        The enforced gate stays the global per-(config, sub_type) recount in
+        _assert_round_not_oversubscribed.
+        """
+        if cfg is None or not cfg.has_college_quota:
+            return None
+        matrix = (cfg.quotas or {}).get(sub_type, {})
+        if not isinstance(matrix, dict):
+            matrix = {}
+        allocated_by_college = await self.consumers_by_college(config_id, sub_type)
+
+        breakdown: dict[str, dict[str, int]] = {}
+        for code in sorted(set(matrix) | set(allocated_by_college)):
+            try:
+                college_total = int(matrix.get(code, 0) or 0)
+            except (TypeError, ValueError):
+                college_total = 0
+            allocated = allocated_by_college.get(code, 0)
+            if college_total <= 0 and allocated <= 0:
+                continue
+            breakdown = {
+                **breakdown,
+                code: {
+                    "total": college_total,
+                    "allocated": allocated,
+                    "remaining": college_total - allocated,
+                },
+            }
+        return breakdown
 
     async def _load_config(
         self,

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -225,6 +225,37 @@ class ManualDistributionService:
 
         return int(winners) + int(renewals)
 
+    async def consumers_by_college(self, config_id: int, sub_type: str) -> dict[str, int]:
+        """Per-college split of consumers_count — SAME two-half partition.
+
+        Attribution: application.student_data["std_academyno"]; a missing or
+        empty academyno lands in the "" bucket (rendered 未知 in the UI).
+        Invariant (tripwire-tested): sum(values) == consumers_count(config_id,
+        sub_type) — keep the filters of both methods identical.
+        """
+        winners_stmt = (
+            select(Application.student_data)
+            .join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id)
+            .where(
+                CollegeRankingItem.is_allocated.is_(True),
+                CollegeRankingItem.allocated_sub_type == sub_type,
+                CollegeRankingItem.allocation_config_id == config_id,
+                Application.is_renewal.is_(False),
+            )
+        )
+        renewals_stmt = select(Application.student_data).where(
+            Application.is_renewal.is_(True),
+            Application.status == ApplicationStatus.approved,
+            Application.sub_scholarship_type == sub_type,
+            Application.allocation_config_id == config_id,
+        )
+        counts: dict[str, int] = {}
+        for stmt in (winners_stmt, renewals_stmt):
+            for (student_data,) in (await self.db.execute(stmt)).all():
+                college = (student_data or {}).get("std_academyno", "") or ""
+                counts = {**counts, college: counts.get(college, 0) + 1}
+        return counts
+
     async def remaining(self, config: ScholarshipConfiguration, sub_type: str) -> int:
         """Global live remaining = pool_total - consumers_count (spec §6.2).
 

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -177,16 +177,32 @@ class ManualDistributionService:
         """
         quotas = config.quotas or {}
         if config.has_college_quota:
-            sub_type_quotas = quotas.get(sub_type, {})
-            if not isinstance(sub_type_quotas, dict):
-                return 0
-            return sum(sub_type_quotas.values())
+            return sum(self._matrix_row(config, sub_type).values())
         scalar = quotas.get(sub_type, 0)
         try:
             scalar_int = int(scalar)
         except (TypeError, ValueError):
             scalar_int = 0
         return scalar_int or int(config.total_quota or 0)
+
+    @staticmethod
+    def _matrix_row(config: ScholarshipConfiguration, sub_type: str) -> dict[str, int]:
+        """Normalized per-college quota row for one sub_type.
+
+        Single owner of the quotas-matrix parsing tolerance: a non-dict row
+        yields {}, and malformed cell values coerce to 0 — so pool_total and
+        _college_breakdown can never disagree about the same row.
+        """
+        row = (config.quotas or {}).get(sub_type, {})
+        if not isinstance(row, dict):
+            return {}
+        normalized: dict[str, int] = {}
+        for code, value in row.items():
+            try:
+                normalized[code] = int(value or 0)
+            except (TypeError, ValueError):
+                normalized[code] = 0
+        return normalized
 
     @staticmethod
     def _winner_filters(config_id: int, sub_type: str) -> tuple:
@@ -254,9 +270,9 @@ class ManualDistributionService:
         renewals_stmt = select(Application.student_data).where(*self._renewal_filters(config_id, sub_type))
         counts: dict[str, int] = {}
         for stmt in (winners_stmt, renewals_stmt):
-            for (student_data,) in (await self.db.execute(stmt)).all():
+            for student_data in (await self.db.execute(stmt)).scalars():
                 college = (student_data or {}).get("std_academyno", "") or ""
-                counts = {**counts, college: counts.get(college, 0) + 1}
+                counts[college] = counts.get(college, 0) + 1
         return counts
 
     async def remaining(self, config: ScholarshipConfiguration, sub_type: str) -> int:
@@ -583,7 +599,7 @@ class ManualDistributionService:
                         "is_own": col["is_own"],
                         "total": total,
                         "remaining": col["remaining"],
-                        "by_college": await self._college_breakdown(cfg, col["config_id"], sub_type),
+                        "by_college": await self._college_breakdown(cfg, sub_type),
                     }
                 )
             quota_status[sub_type] = {
@@ -596,7 +612,6 @@ class ManualDistributionService:
     async def _college_breakdown(
         self,
         cfg: ScholarshipConfiguration | None,
-        config_id: int,
         sub_type: str,
     ) -> dict[str, dict[str, int]] | None:
         """Per-college quota grid for one (config, sub_type) column (advisory).
@@ -609,27 +624,19 @@ class ManualDistributionService:
         """
         if cfg is None or not cfg.has_college_quota:
             return None
-        matrix = (cfg.quotas or {}).get(sub_type, {})
-        if not isinstance(matrix, dict):
-            matrix = {}
-        allocated_by_college = await self.consumers_by_college(config_id, sub_type)
+        matrix = self._matrix_row(cfg, sub_type)
+        allocated_by_college = await self.consumers_by_college(cfg.id, sub_type)
 
         breakdown: dict[str, dict[str, int]] = {}
         for code in sorted(set(matrix) | set(allocated_by_college)):
-            try:
-                college_total = int(matrix.get(code, 0) or 0)
-            except (TypeError, ValueError):
-                college_total = 0
+            college_total = matrix.get(code, 0)
             allocated = allocated_by_college.get(code, 0)
             if college_total <= 0 and allocated <= 0:
                 continue
-            breakdown = {
-                **breakdown,
-                code: {
-                    "total": college_total,
-                    "allocated": allocated,
-                    "remaining": college_total - allocated,
-                },
+            breakdown[code] = {
+                "total": college_total,
+                "allocated": allocated,
+                "remaining": college_total - allocated,
             }
         return breakdown
 

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -188,10 +188,31 @@ class ManualDistributionService:
             scalar_int = 0
         return scalar_int or int(config.total_quota or 0)
 
+    @staticmethod
+    def _winner_filters(config_id: int, sub_type: str) -> tuple:
+        """Shared half-1 predicates: allocated non-renewal winners."""
+        return (
+            CollegeRankingItem.is_allocated.is_(True),
+            CollegeRankingItem.allocated_sub_type == sub_type,
+            CollegeRankingItem.allocation_config_id == config_id,
+            Application.is_renewal.is_(False),
+        )
+
+    @staticmethod
+    def _renewal_filters(config_id: int, sub_type: str) -> tuple:
+        """Shared half-2 predicates: approved renewals."""
+        return (
+            Application.is_renewal.is_(True),
+            Application.status == ApplicationStatus.approved,
+            Application.sub_scholarship_type == sub_type,
+            Application.allocation_config_id == config_id,
+        )
+
     async def consumers_count(self, config_id: int, sub_type: str) -> int:
         """Count every LIVE consumer of (config_id, sub_type) anywhere (spec §6.2).
 
-        Guaranteed two-half partition:
+        Guaranteed two-half partition (predicates shared with
+        consumers_by_college via _winner_filters/_renewal_filters):
           half 1 — general/manual winners: allocated CollegeRankingItem whose
                    application is NOT a renewal (is_renewal==False guard).
           half 2 — approved renewals: Application(is_renewal, approved).
@@ -206,21 +227,11 @@ class ManualDistributionService:
         winners_stmt = (
             select(func.count(CollegeRankingItem.id))
             .join(Application, CollegeRankingItem.application_id == Application.id)
-            .where(
-                CollegeRankingItem.is_allocated.is_(True),
-                CollegeRankingItem.allocated_sub_type == sub_type,
-                CollegeRankingItem.allocation_config_id == config_id,
-                Application.is_renewal.is_(False),
-            )
+            .where(*self._winner_filters(config_id, sub_type))
         )
         winners = (await self.db.execute(winners_stmt)).scalar_one()
 
-        renewals_stmt = select(func.count(Application.id)).where(
-            Application.is_renewal.is_(True),
-            Application.status == ApplicationStatus.approved,
-            Application.sub_scholarship_type == sub_type,
-            Application.allocation_config_id == config_id,
-        )
+        renewals_stmt = select(func.count(Application.id)).where(*self._renewal_filters(config_id, sub_type))
         renewals = (await self.db.execute(renewals_stmt)).scalar_one()
 
         return int(winners) + int(renewals)
@@ -231,24 +242,16 @@ class ManualDistributionService:
         Attribution: application.student_data["std_academyno"]; a missing or
         empty academyno lands in the "" bucket (rendered 未知 in the UI).
         Invariant (tripwire-tested): sum(values) == consumers_count(config_id,
-        sub_type) — keep the filters of both methods identical.
+        sub_type) — both methods build their where-clauses from the shared
+        _winner_filters/_renewal_filters helpers, so the predicates cannot
+        drift.
         """
         winners_stmt = (
             select(Application.student_data)
             .join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id)
-            .where(
-                CollegeRankingItem.is_allocated.is_(True),
-                CollegeRankingItem.allocated_sub_type == sub_type,
-                CollegeRankingItem.allocation_config_id == config_id,
-                Application.is_renewal.is_(False),
-            )
+            .where(*self._winner_filters(config_id, sub_type))
         )
-        renewals_stmt = select(Application.student_data).where(
-            Application.is_renewal.is_(True),
-            Application.status == ApplicationStatus.approved,
-            Application.sub_scholarship_type == sub_type,
-            Application.allocation_config_id == config_id,
-        )
+        renewals_stmt = select(Application.student_data).where(*self._renewal_filters(config_id, sub_type))
         counts: dict[str, int] = {}
         for stmt in (winners_stmt, renewals_stmt):
             for (student_data,) in (await self.db.execute(stmt)).all():

--- a/backend/app/tests/test_get_quota_status_shared_pool.py
+++ b/backend/app/tests/test_get_quota_status_shared_pool.py
@@ -104,6 +104,10 @@ async def test_quota_status_keys_by_config_and_subtracts_renewals(db: AsyncSessi
         "is_own": True,
         "total": 3,
         "remaining": 2,
+        "by_college": {
+            "A": {"total": 3, "allocated": 0, "remaining": 3},
+            "": {"total": 0, "allocated": 1, "remaining": -1},
+        },
     }
     # linked phd_114 nstc: total 2, remaining 2
     assert by_cfg[setup["prior"].id]["total"] == 2
@@ -112,3 +116,126 @@ async def test_quota_status_keys_by_config_and_subtracts_renewals(db: AsyncSessi
     # moe_1w: own only, no linked column
     moe_cfgs = {c["config_id"] for c in status["moe_1w"]["by_config"]}
     assert moe_cfgs == {own.id}
+
+
+@pytest.mark.asyncio
+async def test_quota_status_by_college_matrix_and_linked_config(db: AsyncSession, setup):
+    sch, own, prior = setup["sch"], setup["own"], setup["prior"]
+    # Approved renewal consuming the LINKED prior config, attributed to college A.
+    user = User(
+        nycu_id="qs_bc",
+        name="BC",
+        email="qs_bc@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    ren = Application(
+        app_id="APP-115-0-bc",
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        scholarship_subtype_list=["nstc"],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+        academic_year=115,
+        semester=None,
+        status=ApplicationStatus.approved,
+        review_stage=ReviewStage.quota_distributed,
+        is_renewal=True,
+        allocation_config_id=prior.id,
+        agree_terms=True,
+        student_data={"std_academyno": "A"},
+    )
+    db.add(ren)
+    await db.commit()
+
+    svc = ManualDistributionService(db)
+    status = await svc.get_quota_status(sch.id, 115, "yearly")
+    by_cfg = {c["config_id"]: c for c in status["nstc"]["by_config"]}
+
+    # Own config: college A untouched (3/0/3).
+    assert by_cfg[own.id]["by_college"] == {"A": {"total": 3, "allocated": 0, "remaining": 3}}
+    # Linked prior-year config: its OWN matrix, minus the renewal in college A.
+    assert by_cfg[prior.id]["by_college"] == {"A": {"total": 2, "allocated": 1, "remaining": 1}}
+
+
+@pytest.mark.asyncio
+async def test_quota_status_by_college_unknown_college_negative_remaining(db: AsyncSession, setup):
+    sch, own = setup["sch"], setup["own"]
+    # Consumer whose student_data has no academyno: "" bucket, total 0 → remaining -1.
+    user = User(
+        nycu_id="qs_uk",
+        name="UK",
+        email="qs_uk@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    ren = Application(
+        app_id="APP-115-0-uk",
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        scholarship_subtype_list=["nstc"],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+        academic_year=115,
+        semester=None,
+        status=ApplicationStatus.approved,
+        review_stage=ReviewStage.quota_distributed,
+        is_renewal=True,
+        allocation_config_id=own.id,
+        agree_terms=True,
+        student_data={},
+    )
+    db.add(ren)
+    await db.commit()
+
+    svc = ManualDistributionService(db)
+    status = await svc.get_quota_status(sch.id, 115, "yearly")
+    by_cfg = {c["config_id"]: c for c in status["nstc"]["by_config"]}
+    assert by_cfg[own.id]["by_college"] == {
+        "A": {"total": 3, "allocated": 0, "remaining": 3},
+        "": {"total": 0, "allocated": 1, "remaining": -1},
+    }
+
+
+@pytest.mark.asyncio
+async def test_quota_status_by_college_null_for_non_matrix_config(db: AsyncSession):
+    sch = ScholarshipType(code="qs_flat", name="QS Flat", description="x")
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+    db.add(
+        ScholarshipSubTypeConfig(
+            scholarship_type_id=sch.id,
+            sub_type_code="nstc",
+            name="國科會",
+            display_order=1,
+            is_active=True,
+        )
+    )
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        academic_year=115,
+        semester=None,
+        config_name="flat115",
+        config_code="flat_115",
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        has_college_quota=False,
+        quotas={"nstc": 20},
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+
+    svc = ManualDistributionService(db)
+    status = await svc.get_quota_status(sch.id, 115, "yearly")
+    (entry,) = status["nstc"]["by_config"]
+    assert entry["by_college"] is None
+    assert entry["total"] == 20

--- a/backend/app/tests/test_manual_distribution_pool_math.py
+++ b/backend/app/tests/test_manual_distribution_pool_math.py
@@ -88,6 +88,7 @@ async def _make_application(
     status: ApplicationStatus,
     app_id: str,
     allocation_config_id: int | None = None,
+    student_data: dict | None = None,
 ) -> Application:
     app = Application(
         app_id=app_id,
@@ -101,6 +102,7 @@ async def _make_application(
         is_renewal=is_renewal,
         allocation_config_id=allocation_config_id,
         agree_terms=True,
+        student_data=student_data,
     )
     db.add(app)
     await db.commit()
@@ -584,3 +586,182 @@ async def test_pick_config_prefers_own_then_descending_year(db: AsyncSession):
     # Nothing left → None.
     wr = {requesting.id: 0, newer.id: 0, older.id: 0}
     assert await svc._pick_config(requesting, "nstc", wr) is None
+
+
+# --------------------------------------------------------------------------- #
+# 2.4 consumers_by_college — per-college split of consumers_count
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_consumers_by_college_attributes_winner_and_renewal(db: AsyncSession):
+    st = await _make_type(db, code="cbc1")
+    cfg = await _make_config(
+        db,
+        scholarship_type_id=st.id,
+        config_code="cbc1_115",
+        academic_year=115,
+        quotas={"nstc": {"E": 5, "C": 5}},
+    )
+    ranking = await _make_ranking(db, scholarship_type_id=st.id, sub_type_code="nstc", academic_year=115)
+
+    u1 = await _make_user(db, nycu_id="cbc1s1")
+    winner = await _make_application(
+        db,
+        user_id=u1.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=False,
+        status=ApplicationStatus.submitted,
+        app_id="APP-115-0-10001",
+        student_data={"std_academyno": "E"},
+    )
+    await _make_item(
+        db,
+        ranking_id=ranking.id,
+        application_id=winner.id,
+        rank=1,
+        is_allocated=True,
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+    )
+
+    u2 = await _make_user(db, nycu_id="cbc1s2")
+    await _make_application(
+        db,
+        user_id=u2.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+        status=ApplicationStatus.approved,
+        app_id="APP-115-0-10002",
+        allocation_config_id=cfg.id,
+        student_data={"std_academyno": "C"},
+    )
+
+    svc = ManualDistributionService(db)
+    assert await svc.consumers_by_college(cfg.id, "nstc") == {"E": 1, "C": 1}
+
+
+@pytest.mark.asyncio
+async def test_consumers_by_college_missing_academyno_lands_in_empty_bucket(db: AsyncSession):
+    st = await _make_type(db, code="cbc2")
+    cfg = await _make_config(
+        db,
+        scholarship_type_id=st.id,
+        config_code="cbc2_115",
+        academic_year=115,
+        quotas={"nstc": {"E": 5}},
+    )
+    ranking = await _make_ranking(db, scholarship_type_id=st.id, sub_type_code="nstc", academic_year=115)
+    u = await _make_user(db, nycu_id="cbc2s1")
+    # student_data omitted entirely (None) — must land in the "" bucket
+    winner = await _make_application(
+        db,
+        user_id=u.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=False,
+        status=ApplicationStatus.submitted,
+        app_id="APP-115-0-10003",
+    )
+    await _make_item(
+        db,
+        ranking_id=ranking.id,
+        application_id=winner.id,
+        rank=1,
+        is_allocated=True,
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+    )
+
+    svc = ManualDistributionService(db)
+    assert await svc.consumers_by_college(cfg.id, "nstc") == {"": 1}
+
+
+@pytest.mark.asyncio
+async def test_consumers_by_college_renewal_with_ranking_item_counted_once(db: AsyncSession):
+    """Mirror of the consumers_count is_renewal partition guard: a restored
+    renewal has BOTH an approved renewal Application and an allocated
+    CollegeRankingItem — it must be attributed exactly once."""
+    st = await _make_type(db, code="cbc3")
+    cfg = await _make_config(
+        db,
+        scholarship_type_id=st.id,
+        config_code="cbc3_115",
+        academic_year=115,
+        quotas={"nstc": {"E": 5}},
+    )
+    ranking = await _make_ranking(db, scholarship_type_id=st.id, sub_type_code="nstc", academic_year=115)
+    u = await _make_user(db, nycu_id="cbc3s1")
+    renewal = await _make_application(
+        db,
+        user_id=u.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+        status=ApplicationStatus.approved,
+        app_id="APP-115-0-10004",
+        allocation_config_id=cfg.id,
+        student_data={"std_academyno": "E"},
+    )
+    await _make_item(
+        db,
+        ranking_id=ranking.id,
+        application_id=renewal.id,
+        rank=1,
+        is_allocated=True,
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+    )
+
+    svc = ManualDistributionService(db)
+    assert await svc.consumers_by_college(cfg.id, "nstc") == {"E": 1}
+
+
+@pytest.mark.asyncio
+async def test_consumers_by_college_sums_to_consumers_count(db: AsyncSession):
+    """Drift tripwire (spec invariant): the per-college split MUST stay
+    filter-identical to consumers_count."""
+    st = await _make_type(db, code="cbc4")
+    cfg = await _make_config(
+        db,
+        scholarship_type_id=st.id,
+        config_code="cbc4_115",
+        academic_year=115,
+        quotas={"nstc": {"E": 5, "C": 5}},
+    )
+    ranking = await _make_ranking(db, scholarship_type_id=st.id, sub_type_code="nstc", academic_year=115)
+    for i, (college, is_renewal) in enumerate([("E", False), ("C", False), ("E", True)]):
+        u = await _make_user(db, nycu_id=f"cbc4s{i}")
+        app = await _make_application(
+            db,
+            user_id=u.id,
+            scholarship_type_id=st.id,
+            academic_year=115,
+            sub_scholarship_type="nstc",
+            is_renewal=is_renewal,
+            status=ApplicationStatus.approved if is_renewal else ApplicationStatus.submitted,
+            app_id=f"APP-115-0-1010{i}",
+            allocation_config_id=cfg.id if is_renewal else None,
+            student_data={"std_academyno": college},
+        )
+        if not is_renewal:
+            await _make_item(
+                db,
+                ranking_id=ranking.id,
+                application_id=app.id,
+                rank=i + 1,
+                is_allocated=True,
+                allocated_sub_type="nstc",
+                allocation_config_id=cfg.id,
+            )
+
+    svc = ManualDistributionService(db)
+    by_college = await svc.consumers_by_college(cfg.id, "nstc")
+    assert by_college == {"E": 2, "C": 1}
+    assert sum(by_college.values()) == await svc.consumers_count(cfg.id, "nstc")

--- a/backend/app/tests/test_manual_distribution_pool_math.py
+++ b/backend/app/tests/test_manual_distribution_pool_math.py
@@ -678,8 +678,31 @@ async def test_consumers_by_college_missing_academyno_lands_in_empty_bucket(db: 
         allocation_config_id=cfg.id,
     )
 
+    u2 = await _make_user(db, nycu_id="cbc2s2")
+    # student_data present but std_academyno is empty — must also land in ""
+    winner_empty = await _make_application(
+        db,
+        user_id=u2.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=False,
+        status=ApplicationStatus.submitted,
+        app_id="APP-115-0-10005",
+        student_data={"std_academyno": ""},
+    )
+    await _make_item(
+        db,
+        ranking_id=ranking.id,
+        application_id=winner_empty.id,
+        rank=2,
+        is_allocated=True,
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+    )
+
     svc = ManualDistributionService(db)
-    assert await svc.consumers_by_college(cfg.id, "nstc") == {"": 1}
+    assert await svc.consumers_by_college(cfg.id, "nstc") == {"": 2}
 
 
 @pytest.mark.asyncio

--- a/docs/superpowers/plans/2026-06-10-college-quota-matrix.md
+++ b/docs/superpowers/plans/2026-06-10-college-quota-matrix.md
@@ -1,0 +1,1004 @@
+# College Quota Matrix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show per-college remaining quota (including linked prior-year 共用往年 configs) as a college × config matrix on the admin 造冊分發 (manual distribution) page, live-updated against staged allocations.
+
+**Architecture:** Backend extends the existing `GET /api/v1/manual-distribution/quota-status` payload — each `by_config` entry gains `by_college: {college_code: {total, allocated, remaining}} | null`, computed by a new `consumers_by_college` service method that mirrors `consumers_count`'s two-half consumer partition. Frontend adds a `CollegeQuotaMatrix` component fed entirely from data the panel already loads (`quotaStatus`, `subTypeCols`, `students`, `localAllocations`).
+
+**Tech Stack:** FastAPI + SQLAlchemy (async) + pytest-asyncio; Next.js / React / TypeScript + Tailwind.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-college-quota-matrix-design.md`
+
+**Environment notes:**
+- Backend tests run inside the dev container: `docker compose -f docker-compose.dev.yml exec backend python -m pytest <path> -p no:cacheprovider`. If the dev stack isn't running, start it first (see `init-dev-env` project skill). When working in a git worktree whose files the container doesn't mount, run pytest with a venv from the worktree or temporarily point the compose mount at the worktree — do NOT silently skip the test runs.
+- Lint gates are HARD (project CLAUDE.md): `uvx --from "black==26.3.1" black --check --line-length=120 backend/app` and `flake8 app --select=B904,B014 --max-line-length=120` (run from `backend/`).
+- Git commit messages in English.
+
+---
+
+## File map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `backend/app/services/manual_distribution_service.py` | Modify | Add `consumers_by_college`; extend `get_quota_status` with `by_college` |
+| `backend/app/tests/test_manual_distribution_pool_math.py` | Modify | `student_data` param on `_make_application`; tests for `consumers_by_college` |
+| `backend/app/tests/test_get_quota_status_shared_pool.py` | Modify | Update exact-shape assertion; tests for `by_college` payload |
+| `frontend/lib/api/modules/manual-distribution.ts` | Modify | Align `ConfigQuota`/`CollegeQuota` types with the real payload |
+| `frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx` | Create | The matrix table component (pure render from props) |
+| `frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx` | Modify | Pull `academies` from `useReferenceData`; render the matrix |
+
+---
+
+### Task 1: Backend — `consumers_by_college`
+
+**Files:**
+- Modify: `backend/app/tests/test_manual_distribution_pool_math.py` (builder at `_make_application`, new test section at end of file)
+- Modify: `backend/app/services/manual_distribution_service.py` (insert after `consumers_count`, i.e. after line ~226)
+
+- [ ] **Step 1: Extend the `_make_application` builder to accept `student_data`**
+
+In `backend/app/tests/test_manual_distribution_pool_math.py`, change the builder signature and constructor call:
+
+```python
+async def _make_application(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    scholarship_type_id: int,
+    academic_year: int,
+    sub_scholarship_type: str,
+    is_renewal: bool,
+    status: ApplicationStatus,
+    app_id: str,
+    allocation_config_id: int | None = None,
+    student_data: dict | None = None,
+) -> Application:
+    app = Application(
+        app_id=app_id,
+        user_id=user_id,
+        scholarship_type_id=scholarship_type_id,
+        sub_type_selection_mode="single",
+        sub_scholarship_type=sub_scholarship_type,
+        academic_year=academic_year,
+        semester=None,
+        status=status,
+        is_renewal=is_renewal,
+        allocation_config_id=allocation_config_id,
+        agree_terms=True,
+        student_data=student_data,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+```
+
+(Only two lines change: the new keyword parameter and `student_data=student_data` in the constructor. Existing callers pass no `student_data` and are unaffected.)
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `backend/app/tests/test_manual_distribution_pool_math.py`:
+
+```python
+# --------------------------------------------------------------------------- #
+# 2.4 consumers_by_college — per-college split of consumers_count
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_consumers_by_college_attributes_winner_and_renewal(db: AsyncSession):
+    st = await _make_type(db, code="cbc1")
+    cfg = await _make_config(
+        db,
+        scholarship_type_id=st.id,
+        config_code="cbc1_115",
+        academic_year=115,
+        quotas={"nstc": {"E": 5, "C": 5}},
+    )
+    ranking = await _make_ranking(db, scholarship_type_id=st.id, sub_type_code="nstc", academic_year=115)
+
+    u1 = await _make_user(db, nycu_id="cbc1s1")
+    winner = await _make_application(
+        db,
+        user_id=u1.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=False,
+        status=ApplicationStatus.submitted,
+        app_id="APP-115-0-10001",
+        student_data={"std_academyno": "E"},
+    )
+    await _make_item(
+        db,
+        ranking_id=ranking.id,
+        application_id=winner.id,
+        rank=1,
+        is_allocated=True,
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+    )
+
+    u2 = await _make_user(db, nycu_id="cbc1s2")
+    await _make_application(
+        db,
+        user_id=u2.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+        status=ApplicationStatus.approved,
+        app_id="APP-115-0-10002",
+        allocation_config_id=cfg.id,
+        student_data={"std_academyno": "C"},
+    )
+
+    svc = ManualDistributionService(db)
+    assert await svc.consumers_by_college(cfg.id, "nstc") == {"E": 1, "C": 1}
+
+
+@pytest.mark.asyncio
+async def test_consumers_by_college_missing_academyno_lands_in_empty_bucket(db: AsyncSession):
+    st = await _make_type(db, code="cbc2")
+    cfg = await _make_config(
+        db,
+        scholarship_type_id=st.id,
+        config_code="cbc2_115",
+        academic_year=115,
+        quotas={"nstc": {"E": 5}},
+    )
+    ranking = await _make_ranking(db, scholarship_type_id=st.id, sub_type_code="nstc", academic_year=115)
+    u = await _make_user(db, nycu_id="cbc2s1")
+    # student_data omitted entirely (None) — must land in the "" bucket
+    winner = await _make_application(
+        db,
+        user_id=u.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=False,
+        status=ApplicationStatus.submitted,
+        app_id="APP-115-0-10003",
+    )
+    await _make_item(
+        db,
+        ranking_id=ranking.id,
+        application_id=winner.id,
+        rank=1,
+        is_allocated=True,
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+    )
+
+    svc = ManualDistributionService(db)
+    assert await svc.consumers_by_college(cfg.id, "nstc") == {"": 1}
+
+
+@pytest.mark.asyncio
+async def test_consumers_by_college_renewal_with_ranking_item_counted_once(db: AsyncSession):
+    """Mirror of the consumers_count is_renewal partition guard: a restored
+    renewal has BOTH an approved renewal Application and an allocated
+    CollegeRankingItem — it must be attributed exactly once."""
+    st = await _make_type(db, code="cbc3")
+    cfg = await _make_config(
+        db,
+        scholarship_type_id=st.id,
+        config_code="cbc3_115",
+        academic_year=115,
+        quotas={"nstc": {"E": 5}},
+    )
+    ranking = await _make_ranking(db, scholarship_type_id=st.id, sub_type_code="nstc", academic_year=115)
+    u = await _make_user(db, nycu_id="cbc3s1")
+    renewal = await _make_application(
+        db,
+        user_id=u.id,
+        scholarship_type_id=st.id,
+        academic_year=115,
+        sub_scholarship_type="nstc",
+        is_renewal=True,
+        status=ApplicationStatus.approved,
+        app_id="APP-115-0-10004",
+        allocation_config_id=cfg.id,
+        student_data={"std_academyno": "E"},
+    )
+    await _make_item(
+        db,
+        ranking_id=ranking.id,
+        application_id=renewal.id,
+        rank=1,
+        is_allocated=True,
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+    )
+
+    svc = ManualDistributionService(db)
+    assert await svc.consumers_by_college(cfg.id, "nstc") == {"E": 1}
+
+
+@pytest.mark.asyncio
+async def test_consumers_by_college_sums_to_consumers_count(db: AsyncSession):
+    """Drift tripwire (spec invariant): the per-college split MUST stay
+    filter-identical to consumers_count."""
+    st = await _make_type(db, code="cbc4")
+    cfg = await _make_config(
+        db,
+        scholarship_type_id=st.id,
+        config_code="cbc4_115",
+        academic_year=115,
+        quotas={"nstc": {"E": 5, "C": 5}},
+    )
+    ranking = await _make_ranking(db, scholarship_type_id=st.id, sub_type_code="nstc", academic_year=115)
+    for i, (college, is_renewal) in enumerate([("E", False), ("C", False), ("E", True)]):
+        u = await _make_user(db, nycu_id=f"cbc4s{i}")
+        app = await _make_application(
+            db,
+            user_id=u.id,
+            scholarship_type_id=st.id,
+            academic_year=115,
+            sub_scholarship_type="nstc",
+            is_renewal=is_renewal,
+            status=ApplicationStatus.approved if is_renewal else ApplicationStatus.submitted,
+            app_id=f"APP-115-0-1010{i}",
+            allocation_config_id=cfg.id if is_renewal else None,
+            student_data={"std_academyno": college},
+        )
+        if not is_renewal:
+            await _make_item(
+                db,
+                ranking_id=ranking.id,
+                application_id=app.id,
+                rank=i + 1,
+                is_allocated=True,
+                allocated_sub_type="nstc",
+                allocation_config_id=cfg.id,
+            )
+
+    svc = ManualDistributionService(db)
+    by_college = await svc.consumers_by_college(cfg.id, "nstc")
+    assert by_college == {"E": 2, "C": 1}
+    assert sum(by_college.values()) == await svc.consumers_count(cfg.id, "nstc")
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run (from repo root, dev container):
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_manual_distribution_pool_math.py -k consumers_by_college -p no:cacheprovider -q
+```
+Expected: 4 FAILED with `AttributeError: 'ManualDistributionService' object has no attribute 'consumers_by_college'`.
+
+- [ ] **Step 4: Implement `consumers_by_college`**
+
+In `backend/app/services/manual_distribution_service.py`, insert directly after the `consumers_count` method (after its `return int(winners) + int(renewals)`, before `remaining`):
+
+```python
+    async def consumers_by_college(self, config_id: int, sub_type: str) -> dict[str, int]:
+        """Per-college split of consumers_count — SAME two-half partition.
+
+        Attribution: application.student_data["std_academyno"]; a missing or
+        empty academyno lands in the "" bucket (rendered 未知 in the UI).
+        Invariant (tripwire-tested): sum(values) == consumers_count(config_id,
+        sub_type) — keep the filters of both methods identical.
+        """
+        winners_stmt = (
+            select(Application.student_data)
+            .join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id)
+            .where(
+                CollegeRankingItem.is_allocated.is_(True),
+                CollegeRankingItem.allocated_sub_type == sub_type,
+                CollegeRankingItem.allocation_config_id == config_id,
+                Application.is_renewal.is_(False),
+            )
+        )
+        renewals_stmt = select(Application.student_data).where(
+            Application.is_renewal.is_(True),
+            Application.status == ApplicationStatus.approved,
+            Application.sub_scholarship_type == sub_type,
+            Application.allocation_config_id == config_id,
+        )
+        counts: dict[str, int] = {}
+        for stmt in (winners_stmt, renewals_stmt):
+            for (student_data,) in (await self.db.execute(stmt)).all():
+                college = (student_data or {}).get("std_academyno", "") or ""
+                counts = {**counts, college: counts.get(college, 0) + 1}
+        return counts
+```
+
+(All names used — `select`, `Application`, `CollegeRankingItem`, `ApplicationStatus` — are already imported at the top of this module.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_manual_distribution_pool_math.py -p no:cacheprovider -q
+```
+Expected: all tests in the file PASS (the 4 new ones plus the pre-existing ones — the builder change must not break them).
+
+- [ ] **Step 6: Lint**
+
+Run from `backend/`:
+```bash
+uvx --from "black==26.3.1" black --check --line-length=120 app/services/manual_distribution_service.py app/tests/test_manual_distribution_pool_math.py
+flake8 app/services/manual_distribution_service.py app/tests/test_manual_distribution_pool_math.py --select=B904,B014 --max-line-length=120
+```
+Expected: no output (clean). If black fails, run it without `--check` and re-verify.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/manual_distribution_service.py backend/app/tests/test_manual_distribution_pool_math.py
+git commit -m "feat: add consumers_by_college per-college consumer split"
+```
+
+---
+
+### Task 2: Backend — `by_college` in `get_quota_status`
+
+**Files:**
+- Modify: `backend/app/tests/test_get_quota_status_shared_pool.py`
+- Modify: `backend/app/services/manual_distribution_service.py` (`get_quota_status`, lines ~488-557)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/app/tests/test_get_quota_status_shared_pool.py` (the `setup` fixture already provides `own` = phd_115 with `quotas={"nstc": {"A": 3}, "moe_1w": {"A": 4}}` sharing from `prior` = phd_114 with `quotas={"nstc": {"A": 2}}`):
+
+```python
+@pytest.mark.asyncio
+async def test_quota_status_by_college_matrix_and_linked_config(db: AsyncSession, setup):
+    sch, own, prior = setup["sch"], setup["own"], setup["prior"]
+    # Approved renewal consuming the LINKED prior config, attributed to college A.
+    user = User(
+        nycu_id="qs_bc",
+        name="BC",
+        email="qs_bc@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    ren = Application(
+        app_id="APP-115-0-bc",
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        scholarship_subtype_list=["nstc"],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+        academic_year=115,
+        semester=None,
+        status=ApplicationStatus.approved,
+        review_stage=ReviewStage.quota_distributed,
+        is_renewal=True,
+        allocation_config_id=prior.id,
+        agree_terms=True,
+        student_data={"std_academyno": "A"},
+    )
+    db.add(ren)
+    await db.commit()
+
+    svc = ManualDistributionService(db)
+    status = await svc.get_quota_status(sch.id, 115, "yearly")
+    by_cfg = {c["config_id"]: c for c in status["nstc"]["by_config"]}
+
+    # Own config: college A untouched (3/0/3).
+    assert by_cfg[own.id]["by_college"] == {"A": {"total": 3, "allocated": 0, "remaining": 3}}
+    # Linked prior-year config: its OWN matrix, minus the renewal in college A.
+    assert by_cfg[prior.id]["by_college"] == {"A": {"total": 2, "allocated": 1, "remaining": 1}}
+
+
+@pytest.mark.asyncio
+async def test_quota_status_by_college_unknown_college_negative_remaining(db: AsyncSession, setup):
+    sch, own = setup["sch"], setup["own"]
+    # Consumer whose student_data has no academyno: "" bucket, total 0 → remaining -1.
+    user = User(
+        nycu_id="qs_uk",
+        name="UK",
+        email="qs_uk@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    ren = Application(
+        app_id="APP-115-0-uk",
+        user_id=user.id,
+        scholarship_type_id=sch.id,
+        scholarship_subtype_list=["nstc"],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+        academic_year=115,
+        semester=None,
+        status=ApplicationStatus.approved,
+        review_stage=ReviewStage.quota_distributed,
+        is_renewal=True,
+        allocation_config_id=own.id,
+        agree_terms=True,
+        student_data={},
+    )
+    db.add(ren)
+    await db.commit()
+
+    svc = ManualDistributionService(db)
+    status = await svc.get_quota_status(sch.id, 115, "yearly")
+    by_cfg = {c["config_id"]: c for c in status["nstc"]["by_config"]}
+    assert by_cfg[own.id]["by_college"] == {
+        "A": {"total": 3, "allocated": 0, "remaining": 3},
+        "": {"total": 0, "allocated": 1, "remaining": -1},
+    }
+
+
+@pytest.mark.asyncio
+async def test_quota_status_by_college_null_for_non_matrix_config(db: AsyncSession):
+    sch = ScholarshipType(code="qs_flat", name="QS Flat", description="x")
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+    db.add(
+        ScholarshipSubTypeConfig(
+            scholarship_type_id=sch.id,
+            sub_type_code="nstc",
+            name="國科會",
+            display_order=1,
+            is_active=True,
+        )
+    )
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        academic_year=115,
+        semester=None,
+        config_name="flat115",
+        config_code="flat_115",
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        has_college_quota=False,
+        quotas={"nstc": 20},
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+
+    svc = ManualDistributionService(db)
+    status = await svc.get_quota_status(sch.id, 115, "yearly")
+    (entry,) = status["nstc"]["by_config"]
+    assert entry["by_college"] is None
+    assert entry["total"] == 20
+```
+
+- [ ] **Step 2: Update the existing exact-shape assertion**
+
+In `test_quota_status_keys_by_config_and_subtracts_renewals` (line ~100), the exact-dict assertion will now miss the new key. The renewal in that test is created WITHOUT `student_data`, so it lands in the `""` (unknown) bucket. Change:
+
+```python
+    assert by_cfg[own.id] == {
+        "config_id": own.id,
+        "config_code": "phd_115",
+        "academic_year": 115,
+        "is_own": True,
+        "total": 3,
+        "remaining": 2,
+    }
+```
+
+to:
+
+```python
+    assert by_cfg[own.id] == {
+        "config_id": own.id,
+        "config_code": "phd_115",
+        "academic_year": 115,
+        "is_own": True,
+        "total": 3,
+        "remaining": 2,
+        "by_college": {
+            "A": {"total": 3, "allocated": 0, "remaining": 3},
+            "": {"total": 0, "allocated": 1, "remaining": -1},
+        },
+    }
+```
+
+- [ ] **Step 3: Run to verify the new tests fail**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_get_quota_status_shared_pool.py -p no:cacheprovider -q
+```
+Expected: new tests FAIL with `KeyError: 'by_college'`; the updated existing test also FAILS (payload doesn't have the key yet).
+
+- [ ] **Step 4: Implement `by_college` in `get_quota_status`**
+
+In `backend/app/services/manual_distribution_service.py`, replace the `by_config` building loop inside `get_quota_status` (currently lines ~538-551):
+
+```python
+            by_config = []
+            for col in await self.distributable_pool(current_config, sub_type):
+                cfg = current_config if col["is_own"] else linked_by_code.get(col["config_code"])
+                total = self.pool_total(cfg, sub_type) if cfg is not None else 0
+                by_config.append(
+                    {
+                        "config_id": col["config_id"],
+                        "config_code": col["config_code"],
+                        "academic_year": col["academic_year"],
+                        "is_own": col["is_own"],
+                        "total": total,
+                        "remaining": col["remaining"],
+                    }
+                )
+```
+
+with:
+
+```python
+            by_config = []
+            for col in await self.distributable_pool(current_config, sub_type):
+                cfg = current_config if col["is_own"] else linked_by_code.get(col["config_code"])
+                total = self.pool_total(cfg, sub_type) if cfg is not None else 0
+                by_config.append(
+                    {
+                        "config_id": col["config_id"],
+                        "config_code": col["config_code"],
+                        "academic_year": col["academic_year"],
+                        "is_own": col["is_own"],
+                        "total": total,
+                        "remaining": col["remaining"],
+                        "by_college": await self._college_breakdown(cfg, col["config_id"], sub_type),
+                    }
+                )
+```
+
+Then add this helper method directly after `get_quota_status`:
+
+```python
+    async def _college_breakdown(
+        self,
+        cfg: ScholarshipConfiguration | None,
+        config_id: int,
+        sub_type: str,
+    ) -> dict[str, dict[str, int]] | None:
+        """Per-college quota grid for one (config, sub_type) column (advisory).
+
+        None for non-matrix configs (no per-college split exists). Colleges
+        appear when they have quota > 0 in the matrix OR live consumers;
+        remaining is NOT clamped — negative flags over-allocation in the UI.
+        The enforced gate stays the global per-(config, sub_type) recount in
+        _assert_round_not_oversubscribed.
+        """
+        if cfg is None or not cfg.has_college_quota:
+            return None
+        matrix = (cfg.quotas or {}).get(sub_type, {})
+        if not isinstance(matrix, dict):
+            matrix = {}
+        allocated_by_college = await self.consumers_by_college(config_id, sub_type)
+
+        breakdown: dict[str, dict[str, int]] = {}
+        for code in sorted(set(matrix) | set(allocated_by_college)):
+            try:
+                college_total = int(matrix.get(code, 0) or 0)
+            except (TypeError, ValueError):
+                college_total = 0
+            allocated = allocated_by_college.get(code, 0)
+            if college_total <= 0 and allocated <= 0:
+                continue
+            breakdown = {
+                **breakdown,
+                code: {
+                    "total": college_total,
+                    "allocated": allocated,
+                    "remaining": college_total - allocated,
+                },
+            }
+        return breakdown
+```
+
+- [ ] **Step 5: Run the test file to verify it passes**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_get_quota_status_shared_pool.py -p no:cacheprovider -q
+```
+Expected: ALL tests PASS.
+
+- [ ] **Step 6: Run the wider service test net**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_manual_distribution_pool_math.py app/tests/test_quota_service_status_math.py -p no:cacheprovider -q
+```
+Expected: PASS (catches any caller of `get_quota_status` asserting the old shape).
+
+- [ ] **Step 7: Lint**
+
+From `backend/`:
+```bash
+uvx --from "black==26.3.1" black --check --line-length=120 app/services/manual_distribution_service.py app/tests/test_get_quota_status_shared_pool.py
+flake8 app/services/manual_distribution_service.py app/tests/test_get_quota_status_shared_pool.py --select=B904,B014 --max-line-length=120
+```
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/app/services/manual_distribution_service.py backend/app/tests/test_get_quota_status_shared_pool.py
+git commit -m "feat: add per-college quota breakdown to quota-status payload"
+```
+
+---
+
+### Task 3: Frontend — types + `CollegeQuotaMatrix` component
+
+**Files:**
+- Modify: `frontend/lib/api/modules/manual-distribution.ts:46-62`
+- Create: `frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx`
+
+- [ ] **Step 1: Align the API types with the real payload**
+
+In `frontend/lib/api/modules/manual-distribution.ts`, replace the `CollegeQuota` / `ConfigQuota` block (lines 46-62):
+
+```typescript
+export interface CollegeQuota {
+  total: number;
+  allocated: number;
+  remaining: number;
+}
+
+/** Quota for one distributable config (own or linked source) under a sub_type. */
+export interface ConfigQuota {
+  config_id: number;
+  config_code: string;
+  academic_year: number;
+  is_own: boolean;
+  total: number;
+  allocated: number;
+  remaining: number;
+  by_college: Record<string, CollegeQuota>;
+}
+```
+
+with:
+
+```typescript
+export interface CollegeQuota {
+  total: number;
+  allocated: number;
+  /** total − allocated; NOT clamped — negative means over-allocated (advisory). */
+  remaining: number;
+}
+
+/** Quota for one distributable config (own or linked source) under a sub_type. */
+export interface ConfigQuota {
+  config_id: number;
+  config_code: string;
+  academic_year: number;
+  is_own: boolean;
+  total: number;
+  remaining: number;
+  /** Per-college grid keyed by college code (""=unknown); null for non-matrix configs. */
+  by_college: Record<string, CollegeQuota> | null;
+}
+```
+
+(`allocated` is dropped from `ConfigQuota` — the backend never sent a config-level `allocated`. Verify nothing reads it: `grep -rn "\.allocated" frontend/components frontend/lib --include="*.ts*" | grep -v by_college` and check any hits aren't on a `ConfigQuota`. Expected: no `ConfigQuota.allocated` usages.)
+
+- [ ] **Step 2: Verify the type change compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit
+```
+Expected: no errors. (If errors point at `by_college` now being nullable in some consumer, fix that consumer with a null guard.)
+
+- [ ] **Step 3: Create the component**
+
+Create `frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx`:
+
+```tsx
+"use client";
+
+import { useMemo } from "react";
+import { Building2 } from "lucide-react";
+import type {
+  CollegeQuota,
+  DistributionStudent,
+  QuotaStatus,
+  SubTypeConfigCol,
+} from "@/lib/api/modules/manual-distribution";
+import { getAcademyName } from "@/hooks/use-reference-data";
+
+interface CollegeQuotaMatrixProps {
+  cols: SubTypeConfigCol[];
+  quotaStatus: QuotaStatus;
+  students: DistributionStudent[];
+  /** ranking_item_id → current local allocation (null = unallocated). */
+  localAllocations: Map<number, { sub_type: string; config_id: number } | null>;
+  academies: Array<{ code: string; name: string }>;
+}
+
+const UNKNOWN_COLLEGE_LABEL = "未知";
+
+function cellKey(collegeCode: string, colKey: string) {
+  return `${collegeCode}|${colKey}`;
+}
+
+/**
+ * College × (sub_type × config) remaining-quota matrix (advisory display).
+ *
+ * liveRemaining = serverRemaining − Δlocal, where Δlocal counts the UNSAVED
+ * difference between each student's current local allocation and their
+ * server-saved allocation. The delta form avoids double-counting: server
+ * `allocated` already includes saved allocations, and `localAllocations` is
+ * seeded from them (plus auto-preview suggestions).
+ */
+export function CollegeQuotaMatrix({
+  cols,
+  quotaStatus,
+  students,
+  localAllocations,
+  academies,
+}: CollegeQuotaMatrixProps) {
+  const localDelta = useMemo(() => {
+    const delta: Record<string, number> = {};
+    const bump = (college: string, colKey: string, amount: number) => {
+      const k = cellKey(college, colKey);
+      delta[k] = (delta[k] ?? 0) + amount;
+    };
+    for (const s of students) {
+      const college = s.college_code || "";
+      if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
+        bump(college, `${s.allocated_sub_type}:${s.allocation_config_id}`, -1);
+      }
+      const local = localAllocations.get(s.ranking_item_id);
+      if (local) {
+        bump(college, `${local.sub_type}:${local.config_id}`, +1);
+      }
+    }
+    return delta;
+  }, [students, localAllocations]);
+
+  const collegeRows = useMemo(() => {
+    const codes = new Set<string>();
+    for (const stData of Object.values(quotaStatus)) {
+      for (const cData of Object.values(stData.by_config)) {
+        for (const code of Object.keys(cData.by_college ?? {})) {
+          codes.add(code);
+        }
+      }
+    }
+    return Array.from(codes).sort((a, b) => a.localeCompare(b));
+  }, [quotaStatus]);
+
+  const byColKey = useMemo(() => {
+    const map: Record<string, Record<string, CollegeQuota> | null> = {};
+    for (const [subType, stData] of Object.entries(quotaStatus)) {
+      for (const cData of Object.values(stData.by_config)) {
+        map[`${subType}:${cData.config_id}`] = cData.by_college ?? null;
+      }
+    }
+    return map;
+  }, [quotaStatus]);
+
+  const resolveCollegeName = (code: string): string => {
+    if (!code) return UNKNOWN_COLLEGE_LABEL;
+    const fromReference = getAcademyName(code, academies);
+    if (fromReference !== code && fromReference !== "-") return fromReference;
+    return students.find(s => s.college_code === code)?.college_name || code;
+  };
+
+  if (cols.length === 0 || collegeRows.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 shadow-sm mb-3">
+      <div className="px-4 py-2 border-b border-slate-100 flex items-center justify-between">
+        <h3 className="font-bold text-sm text-slate-800 flex items-center gap-2">
+          <Building2 className="h-4 w-4 text-[#003d7a]" />
+          各學院剩餘名額
+        </h3>
+        <span className="text-[10px] text-slate-400">
+          剩餘/總額；已即時扣除未儲存的勾選；超額僅供參考，鎖定時以全域名額檢查為準
+        </span>
+      </div>
+      <div className="p-3 overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-slate-500">
+              <th className="text-left font-medium py-1.5 pr-3 whitespace-nowrap">
+                學院
+              </th>
+              {cols.map(col => (
+                <th
+                  key={col.key}
+                  className="text-center font-medium py-1.5 px-2 whitespace-nowrap"
+                >
+                  {col.display_name}
+                  {!col.is_own && (
+                    <span className="ml-1 text-[9px] bg-amber-100 text-amber-700 px-1 py-0.5 rounded">
+                      共用往年
+                    </span>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {collegeRows.map(code => (
+              <tr key={code || "__unknown__"} className="border-t border-slate-100">
+                <td className="py-1.5 pr-3 font-medium text-slate-700 whitespace-nowrap">
+                  {resolveCollegeName(code)}
+                </td>
+                {cols.map(col => {
+                  const entry = byColKey[col.key]?.[code];
+                  if (!entry) {
+                    return (
+                      <td key={col.key} className="py-1.5 px-2 text-center text-slate-300">
+                        —
+                      </td>
+                    );
+                  }
+                  const liveRemaining =
+                    entry.remaining - (localDelta[cellKey(code, col.key)] ?? 0);
+                  const tone =
+                    liveRemaining < 0
+                      ? "text-red-600 font-bold"
+                      : liveRemaining === 0
+                        ? "text-slate-400"
+                        : "text-[#003d7a] font-semibold";
+                  return (
+                    <td
+                      key={col.key}
+                      className={`py-1.5 px-2 text-center font-mono tabular-nums ${tone}`}
+                      title={`總額 ${entry.total}・已儲存核配 ${entry.allocated}`}
+                    >
+                      {liveRemaining}/{entry.total}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+```
+
+**Implementation notes for this step (read before coding):**
+- Payload subtlety: the backend sends `by_config` as a **JSON array**, while the TS type says `Record<string, ConfigQuota>`. `Object.values(...)` handles both, which is exactly how the existing `subTypeCols` memo in `ManualDistributionPanel.tsx:224-252` consumes it — the memos above use the same pattern.
+- `col.key` is `makeColKey(sub_type, config_id)` = `` `${sub_type}:${config_id}` `` (see `ManualDistributionPanel.tsx:85`) — the `byColKey`/`localDelta` keys above are built with the same `${...}:${...}` template so they line up.
+- Verify `getAcademyName` is exported from `@/hooks/use-reference-data` (it is, at line 222) and that `DistributionStudent` is exported from the API module (it is, at line 12).
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/api/modules/manual-distribution.ts frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
+git commit -m "feat: add CollegeQuotaMatrix component and align quota types"
+```
+
+---
+
+### Task 4: Frontend — wire the matrix into `ManualDistributionPanel`
+
+**Files:**
+- Modify: `frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx` (import block ~line 6, `useReferenceData` destructure at line ~126, render block at lines ~1162-1165)
+
+- [ ] **Step 1: Import the component and pull `academies`**
+
+Add to the imports near the other manual-distribution imports (top of file):
+
+```tsx
+import { CollegeQuotaMatrix } from "@/components/admin/manual-distribution/CollegeQuotaMatrix";
+```
+
+Change line ~126 from:
+
+```tsx
+  const { departments } = useReferenceData();
+```
+
+to:
+
+```tsx
+  const { departments, academies } = useReferenceData();
+```
+
+- [ ] **Step 2: Render the matrix after `AvailableQuotasBlock`**
+
+At lines ~1162-1165, directly after:
+
+```tsx
+        <AvailableQuotasBlock
+          state={distributionState}
+          isLoading={isLoadingState}
+        />
+```
+
+insert:
+
+```tsx
+        <CollegeQuotaMatrix
+          cols={subTypeCols}
+          quotaStatus={quotaStatus}
+          students={students}
+          localAllocations={localAllocations}
+          academies={academies}
+        />
+```
+
+(`subTypeCols`, `quotaStatus`, `students`, `localAllocations` are all existing state/memos in this component — no new fetches or state.)
+
+- [ ] **Step 3: Type-check + build sanity**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Expected: no errors. If `localAllocations`'s `Map<number, LocalAlloc | null>` doesn't structurally satisfy the prop type, the prop type in `CollegeQuotaMatrix.tsx` already matches `LocalAlloc`'s shape (`{ sub_type: string; config_id: number }`) — fix any mismatch by adjusting the prop type, not the panel.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+git commit -m "feat: show per-college remaining quota matrix on manual distribution page"
+```
+
+---
+
+### Task 5: Regenerate OpenAPI types + full verification
+
+**Files:**
+- Possibly modify: `frontend/lib/api/generated/schema.d.ts`
+
+- [ ] **Step 1: Regenerate OpenAPI types**
+
+With the dev backend running on `localhost:8000`:
+
+```bash
+cd frontend && npm run api:generate
+git diff --stat lib/api/generated/schema.d.ts
+```
+Expected: likely **no diff** — the quota-status endpoint returns an untyped dict (no `response_model`), so the OpenAPI schema doesn't encode `by_college`. If there IS a diff, `git add lib/api/generated/schema.d.ts` and include it in the commit below.
+
+- [ ] **Step 2: Run the full backend test files touched**
+
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_manual_distribution_pool_math.py app/tests/test_get_quota_status_shared_pool.py app/tests/test_quota_service_status_math.py -p no:cacheprovider -q
+```
+Expected: ALL PASS.
+
+- [ ] **Step 3: Full lint gate**
+
+From `backend/`:
+```bash
+uvx --from "black==26.3.1" black --check --line-length=120 app
+flake8 app --select=B904,B014 --max-line-length=120
+```
+Expected: clean.
+
+- [ ] **Step 4: Localhost smoke test (manual / playwright skill)**
+
+Using the project's `playwright-test-and-debug` skill (or manually): log in as the seeded `admin` user at `http://localhost:3000`, open the 造冊分發 panel for a matrix-mode scholarship (PhD), and verify:
+1. The 「各學院剩餘名額」 table renders with one column per (sub_type × config), 共用往年 badge on linked prior-year columns.
+2. Ticking a 核配 checkbox for a student immediately decrements that student's college cell in the matching column (before saving).
+3. Un-ticking restores the number; over-allocating turns the cell red.
+4. Save, then confirm the server-refreshed numbers equal the live numbers shown before saving.
+
+Capture a screenshot for the record (per `screenshots-in-worktree` skill if in a worktree).
+
+- [ ] **Step 5: Commit any generated-type diff**
+
+```bash
+git add -A && git status --short
+git commit -m "chore: regenerate OpenAPI types" # only if schema.d.ts changed
+```
+
+---
+
+## Out of scope (per spec)
+
+- Per-college enforcement at allocate/finalize (stays global).
+- Changes to `AvailableQuotasBlock` / `/state`.
+- College-side (學院端) pages.

--- a/docs/superpowers/specs/2026-06-10-college-quota-matrix-design.md
+++ b/docs/superpowers/specs/2026-06-10-college-quota-matrix-design.md
@@ -1,0 +1,171 @@
+# College Quota Matrix on the Manual Distribution Page — Design
+
+**Date**: 2026-06-10
+**Status**: Approved
+**Related**: `docs/superpowers/specs/2026-06-08-config-shared-quota-pools-design.md` (shared quota pools, §6.x referenced below)
+
+## Problem
+
+The 造冊分發頁面 (admin manual distribution panel, `ManualDistributionPanel`) shows
+remaining quota only at the **(sub_type × config)** level — the 剩餘可分配配額 block
+and the allocation grid columns. Admins cannot see how many slots each **college**
+has left, even though matrix-mode configs define quotas per college
+(`quotas = {"nstc": {"E": 15, "C": 12, ...}}`). This also applies to linked
+prior-year configs (共用往年名額, via `shared_quota_sources`), which today surface
+only a config-level total/remaining.
+
+## Decision summary (user-approved)
+
+- Display as a dedicated **college × config matrix table** on the manual
+  distribution page: rows = colleges, columns = (sub_type × config) including
+  linked prior-year configs, cell = `剩餘/總額`.
+- Remaining counts **live-update** by subtracting locally staged (un-saved)
+  allocations on the page.
+- Data delivered by **extending the existing `/quota-status` endpoint** (no new
+  endpoint, no frontend-only computation — the frontend never receives linked
+  configs' per-college matrices nor renewal college attribution).
+
+## Backend
+
+### `GET /api/v1/manual-distribution/quota-status` (extended)
+
+Each entry of `by_config` gains a `by_college` field:
+
+```jsonc
+{
+  "nstc": {
+    "display_name": "國科會",
+    "by_config": [
+      {
+        "config_id": 12,
+        "config_code": "phd_115",
+        "academic_year": 115,
+        "is_own": true,
+        "total": 35,
+        "remaining": 7,
+        "by_college": [                       // NEW; null for non-matrix configs
+          {"college_code": "E", "college_name": "電機學院", "total": 15, "used": 13, "remaining": 2},
+          {"college_code": "C", "college_name": "資訊學院", "total": 12, "used": 10, "remaining": 2},
+          {"college_code": "",  "college_name": "未知",     "total": 0,  "used": 1,  "remaining": -1}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- `total` reads the config's `quotas[sub_type][college_code]` matrix. Works
+  identically for the own config and each linked prior-year config (both store
+  the same matrix shape). For configs with `has_college_quota == False`,
+  `by_college` is `null` (scalar pool; no per-college split exists).
+- `used` comes from a new service method
+  `consumers_by_college(config_id, sub_type) -> dict[str, int]` using the SAME
+  two-half consumer partition as `consumers_count` (spec §6.2):
+  1. allocated `CollegeRankingItem`s whose application is NOT a renewal
+     (`is_renewal == False` guard is load-bearing — see `consumers_count`
+     docstring);
+  2. approved renewal `Application`s.
+  Each consumer is attributed to a college via
+  `application.student_data["std_academyno"]` — the same attribution
+  `auto_allocate_preview` already uses. Grouping happens in Python over the
+  loaded rows (no JSON-path SQL).
+- A consumer with missing/empty `std_academyno` lands in the `""` bucket
+  (rendered 「未知」). The `""` row is included only when its `used > 0`.
+- Colleges appear in `by_college` if they are in the quota matrix OR have
+  `used > 0`; a consumer from a college absent from the matrix gets `total: 0`.
+- `remaining = total - used`, **not clamped** — negative values are reported
+  as-is and flagged in the UI. This is safe because per-college numbers are
+  advisory; the enforced gate remains the global per-(config × sub_type)
+  recount under `SELECT FOR UPDATE` (`_assert_round_not_oversubscribed`).
+- Per-college totals must satisfy `sum(by_college[].total) == total` for matrix
+  configs (same source data as `pool_total`), and
+  `sum(by_college[].used) == consumers_count(config_id, sub_type)`.
+- `college_name` reuses the same name source as
+  `get_students_for_distribution` (student_data-derived names); fall back to
+  the raw code when no name is known.
+- Response stays in the standard `{success, message, data}` wrapper.
+
+### Invariants / consistency
+
+- `consumers_by_college` and `consumers_count` MUST share the same filters.
+  Implement `consumers_count` semantics once: either have `consumers_count`
+  delegate to `sum(consumers_by_college(...).values())` or extract shared query
+  builders — implementer's choice, but the two must not drift.
+
+## Frontend
+
+### New component: `frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx`
+
+Rendered in `ManualDistributionPanel` adjacent to the existing
+剩餘可分配配額 (`AvailableQuotasBlock`) block. Target ≤ ~200 lines.
+
+- **Columns**: reuse the existing `subTypeCols` derivation (own config first,
+  then linked sources by descending `academic_year`; same
+  `國科會 · phd_114`-style labels). Columns with `is_own === false` get a
+  「共用往年」 badge. Columns with `total <= 0` stay excluded (same rule as
+  today's `subTypeCols`).
+- **Rows**: union of `college_code`s across all columns' `by_college`, sorted
+  by code. Row label `college_name || college_code`. If at least one column is
+  a non-matrix config (`by_college === null`), it renders `—` in every college
+  row; no separate 不分學院 row in v1 (the config-level card already shows its
+  numbers).
+- **Cell**: `liveRemaining/total`, where
+  `liveRemaining = serverRemaining − Δlocal(college, sub_type, config_id)` and
+  `Δlocal = (students whose CURRENT local allocation is this cell) − (students
+  whose SERVER-SAVED allocation is this cell)`.
+  - Both counts come from the already-loaded `students` array (which carries
+    `college_code`, `is_allocated`, `allocated_sub_type`,
+    `allocation_config_id`) joined with `localAllocations` (ranking_item_id →
+    `{sub_type, config_id}`).
+  - The delta form is required because `localAllocations` is SEEDED from
+    server-saved allocations (plus auto-preview suggestions), and server
+    `used` already includes saved allocations — subtracting raw local counts
+    would double-count. It also correctly handles un-allocating (Δ negative →
+    remaining goes back up) and moving a student between cells. NOTE: this is
+    intentionally NOT the existing `localAllocCounts`-vs-`total` comparison
+    used by the grid checkboxes — that ignores external consumers (approved
+    renewals, cross-config borrowers) which are only in server `used`.
+  - `—` when the college has no quota in that config and no usage.
+  - Styling: `liveRemaining < 0` → red (over-allocated), `=== 0` → grey/muted,
+    `> 0` → normal. Footnote: 「共用往年 = 往年共用名額；超額僅供參考，鎖定時以全域名額檢查為準」.
+- **No new fetch / loading state**: data arrives with the existing
+  `getQuotaStatus` calls (initial load, post-save, post-preview refreshes).
+- **Types**: extend `QuotaStatus` types in
+  `frontend/lib/api/modules/manual-distribution.ts`; regenerate OpenAPI types
+  (`cd frontend && npm run api:generate`).
+
+## Error handling
+
+- Backend: malformed matrix entries (non-int quota values) coerce to 0,
+  consistent with `pool_total`'s defensive casting; no fallback data on DB
+  errors (errors propagate per project policy).
+- Frontend: when `by_college` is absent (older payload mid-deploy) the matrix
+  renders nothing rather than crashing (`by_college ?? null` guards).
+
+## Testing
+
+Backend (async, `backend/app/tests/`, follow `test_manual_distribution_pool_math.py` style):
+
+1. `consumers_by_college` — general winner counted in own college.
+2. `consumers_by_college` — approved renewal attributed to its college.
+3. `consumers_by_college` — empty `std_academyno` lands in `""` bucket.
+4. `consumers_by_college` — revoked/restored renewal not double-counted
+   (is_renewal partition guard, mirroring existing `consumers_count` tests).
+5. `get_quota_status` — matrix config returns `by_college` with correct
+   total/used/remaining; sums match `pool_total`/`consumers_count`.
+6. `get_quota_status` — non-matrix config returns `by_college: null`.
+7. `get_quota_status` — linked prior-year config exposes its own per-college
+   matrix; consumer of the linked config decrements that config's college row.
+8. `get_quota_status` — over-allocation yields negative `remaining` (no clamp).
+
+Frontend: type-check (`tsc`) + localhost smoke test of the manual distribution
+panel (login as admin, verify the matrix renders, stage an allocation, verify
+the cell decrements and turns red when over).
+
+## Out of scope
+
+- Per-college **enforcement** at allocate/finalize time (stays global).
+- Changes to `AvailableQuotasBlock` or `/state` payloads.
+- College-side (學院端) pages — this is the admin 造冊分發 page only.

--- a/docs/superpowers/specs/2026-06-10-college-quota-matrix-design.md
+++ b/docs/superpowers/specs/2026-06-10-college-quota-matrix-design.md
@@ -43,11 +43,11 @@ Each entry of `by_config` gains a `by_college` field:
         "is_own": true,
         "total": 35,
         "remaining": 7,
-        "by_college": [                       // NEW; null for non-matrix configs
-          {"college_code": "E", "college_name": "電機學院", "total": 15, "used": 13, "remaining": 2},
-          {"college_code": "C", "college_name": "資訊學院", "total": 12, "used": 10, "remaining": 2},
-          {"college_code": "",  "college_name": "未知",     "total": 0,  "used": 1,  "remaining": -1}
-        ]
+        "by_college": {                       // NEW; null for non-matrix configs
+          "E": {"total": 15, "allocated": 13, "remaining": 2},
+          "C": {"total": 12, "allocated": 10, "remaining": 2},
+          "":  {"total": 0,  "allocated": 1,  "remaining": -1}   // 未知 bucket
+        }
       }
     ]
   }
@@ -56,11 +56,16 @@ Each entry of `by_config` gains a `by_college` field:
 
 Rules:
 
+- The shape matches the frontend `CollegeQuota` type that ALREADY exists in
+  `frontend/lib/api/modules/manual-distribution.ts` (`{total, allocated,
+  remaining}` keyed by college code) — the type predates the backend support;
+  this feature makes the backend actually send it. The field is named
+  `allocated` (not `used`) for that reason.
 - `total` reads the config's `quotas[sub_type][college_code]` matrix. Works
   identically for the own config and each linked prior-year config (both store
   the same matrix shape). For configs with `has_college_quota == False`,
   `by_college` is `null` (scalar pool; no per-college split exists).
-- `used` comes from a new service method
+- `allocated` (the "used" count) comes from a new service method
   `consumers_by_college(config_id, sub_type) -> dict[str, int]` using the SAME
   two-half consumer partition as `consumers_count` (spec §6.2):
   1. allocated `CollegeRankingItem`s whose application is NOT a renewal
@@ -72,19 +77,20 @@ Rules:
   `auto_allocate_preview` already uses. Grouping happens in Python over the
   loaded rows (no JSON-path SQL).
 - A consumer with missing/empty `std_academyno` lands in the `""` bucket
-  (rendered 「未知」). The `""` row is included only when its `used > 0`.
-- Colleges appear in `by_college` if they are in the quota matrix OR have
-  `used > 0`; a consumer from a college absent from the matrix gets `total: 0`.
-- `remaining = total - used`, **not clamped** — negative values are reported
+  (rendered 「未知」). The `""` row is included only when its `allocated > 0`.
+- Colleges appear in `by_college` if they have quota > 0 in the matrix OR have
+  `allocated > 0`; a consumer from a college absent from the matrix gets
+  `total: 0`.
+- `remaining = total - allocated`, **not clamped** — negative values are reported
   as-is and flagged in the UI. This is safe because per-college numbers are
   advisory; the enforced gate remains the global per-(config × sub_type)
   recount under `SELECT FOR UPDATE` (`_assert_round_not_oversubscribed`).
 - Per-college totals must satisfy `sum(by_college[].total) == total` for matrix
   configs (same source data as `pool_total`), and
-  `sum(by_college[].used) == consumers_count(config_id, sub_type)`.
-- `college_name` reuses the same name source as
-  `get_students_for_distribution` (student_data-derived names); fall back to
-  the raw code when no name is known.
+  `sum(by_college[].allocated) == consumers_count(config_id, sub_type)`.
+- No `college_name` in the payload: the frontend resolves display names via
+  `getAcademyName(code, academies)` from `useReferenceData`, falling back to a
+  lookup in the loaded `students` array, then the raw code.
 - Response stays in the standard `{success, message, data}` wrapper.
 
 ### Invariants / consistency
@@ -107,7 +113,8 @@ Rendered in `ManualDistributionPanel` adjacent to the existing
   「共用往年」 badge. Columns with `total <= 0` stay excluded (same rule as
   today's `subTypeCols`).
 - **Rows**: union of `college_code`s across all columns' `by_college`, sorted
-  by code. Row label `college_name || college_code`. If at least one column is
+  by code. Row label resolved via `getAcademyName(code, academies)` →
+  students-array lookup → raw code; the `""` code renders 「未知」. If a column is
   a non-matrix config (`by_college === null`), it renders `—` in every college
   row; no separate 不分學院 row in v1 (the config-level card already shows its
   numbers).

--- a/frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
+++ b/frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useMemo } from "react";
+import { Building2 } from "lucide-react";
+import type {
+  CollegeQuota,
+  DistributionStudent,
+  QuotaStatus,
+  SubTypeConfigCol,
+} from "@/lib/api/modules/manual-distribution";
+import { getAcademyName } from "@/hooks/use-reference-data";
+
+interface CollegeQuotaMatrixProps {
+  cols: SubTypeConfigCol[];
+  quotaStatus: QuotaStatus;
+  students: DistributionStudent[];
+  /** ranking_item_id → current local allocation (null = unallocated). */
+  localAllocations: Map<number, { sub_type: string; config_id: number } | null>;
+  academies: Array<{ code: string; name: string }>;
+}
+
+const UNKNOWN_COLLEGE_LABEL = "未知";
+
+function cellKey(collegeCode: string, colKey: string) {
+  return `${collegeCode}|${colKey}`;
+}
+
+/**
+ * College × (sub_type × config) remaining-quota matrix (advisory display).
+ *
+ * liveRemaining = serverRemaining − Δlocal, where Δlocal counts the UNSAVED
+ * difference between each student's current local allocation and their
+ * server-saved allocation. The delta form avoids double-counting: server
+ * `allocated` already includes saved allocations, and `localAllocations` is
+ * seeded from them (plus auto-preview suggestions).
+ */
+export function CollegeQuotaMatrix({
+  cols,
+  quotaStatus,
+  students,
+  localAllocations,
+  academies,
+}: CollegeQuotaMatrixProps) {
+  const localDelta = useMemo(() => {
+    const delta: Record<string, number> = {};
+    const bump = (college: string, colKey: string, amount: number) => {
+      const k = cellKey(college, colKey);
+      delta[k] = (delta[k] ?? 0) + amount;
+    };
+    for (const s of students) {
+      const college = s.college_code || "";
+      if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
+        bump(college, `${s.allocated_sub_type}:${s.allocation_config_id}`, -1);
+      }
+      const local = localAllocations.get(s.ranking_item_id);
+      if (local) {
+        bump(college, `${local.sub_type}:${local.config_id}`, +1);
+      }
+    }
+    return delta;
+  }, [students, localAllocations]);
+
+  const collegeRows = useMemo(() => {
+    const codes = new Set<string>();
+    for (const stData of Object.values(quotaStatus)) {
+      for (const cData of Object.values(stData.by_config)) {
+        for (const code of Object.keys(cData.by_college ?? {})) {
+          codes.add(code);
+        }
+      }
+    }
+    return Array.from(codes).sort((a, b) => a.localeCompare(b));
+  }, [quotaStatus]);
+
+  const byColKey = useMemo(() => {
+    const map: Record<string, Record<string, CollegeQuota> | null> = {};
+    for (const [subType, stData] of Object.entries(quotaStatus)) {
+      for (const cData of Object.values(stData.by_config)) {
+        map[`${subType}:${cData.config_id}`] = cData.by_college ?? null;
+      }
+    }
+    return map;
+  }, [quotaStatus]);
+
+  const resolveCollegeName = (code: string): string => {
+    if (!code) return UNKNOWN_COLLEGE_LABEL;
+    const fromReference = getAcademyName(code, academies);
+    if (fromReference !== code && fromReference !== "-") return fromReference;
+    return students.find(s => s.college_code === code)?.college_name || code;
+  };
+
+  if (cols.length === 0 || collegeRows.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 shadow-sm mb-3">
+      <div className="px-4 py-2 border-b border-slate-100 flex items-center justify-between">
+        <h3 className="font-bold text-sm text-slate-800 flex items-center gap-2">
+          <Building2 className="h-4 w-4 text-[#003d7a]" />
+          各學院剩餘名額
+        </h3>
+        <span className="text-[10px] text-slate-400">
+          剩餘/總額；已即時扣除未儲存的勾選；超額僅供參考，鎖定時以全域名額檢查為準
+        </span>
+      </div>
+      <div className="p-3 overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-slate-500">
+              <th className="text-left font-medium py-1.5 pr-3 whitespace-nowrap">
+                學院
+              </th>
+              {cols.map(col => (
+                <th
+                  key={col.key}
+                  className="text-center font-medium py-1.5 px-2 whitespace-nowrap"
+                >
+                  {col.display_name}
+                  {!col.is_own && (
+                    <span className="ml-1 text-[9px] bg-amber-100 text-amber-700 px-1 py-0.5 rounded">
+                      共用往年
+                    </span>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {collegeRows.map(code => (
+              <tr key={code || "__unknown__"} className="border-t border-slate-100">
+                <td className="py-1.5 pr-3 font-medium text-slate-700 whitespace-nowrap">
+                  {resolveCollegeName(code)}
+                </td>
+                {cols.map(col => {
+                  const entry = byColKey[col.key]?.[code];
+                  if (!entry) {
+                    return (
+                      <td key={col.key} className="py-1.5 px-2 text-center text-slate-300">
+                        —
+                      </td>
+                    );
+                  }
+                  const liveRemaining =
+                    entry.remaining - (localDelta[cellKey(code, col.key)] ?? 0);
+                  const tone =
+                    liveRemaining < 0
+                      ? "text-red-600 font-bold"
+                      : liveRemaining === 0
+                        ? "text-slate-400"
+                        : "text-[#003d7a] font-semibold";
+                  return (
+                    <td
+                      key={col.key}
+                      className={`py-1.5 px-2 text-center font-mono tabular-nums ${tone}`}
+                      title={`總額 ${entry.total}・已儲存核配 ${entry.allocated}`}
+                    >
+                      {liveRemaining}/{entry.total}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
+++ b/frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
@@ -5,17 +5,21 @@ import { Building2 } from "lucide-react";
 import type {
   CollegeQuota,
   DistributionStudent,
+  LocalAlloc,
   QuotaStatus,
   SubTypeConfigCol,
 } from "@/lib/api/modules/manual-distribution";
-import { getAcademyName } from "@/hooks/use-reference-data";
+import {
+  getSavedAllocation,
+  makeColKey,
+} from "@/lib/api/modules/manual-distribution";
 
 interface CollegeQuotaMatrixProps {
   cols: SubTypeConfigCol[];
   quotaStatus: QuotaStatus;
   students: DistributionStudent[];
   /** ranking_item_id → current local allocation (null = unallocated). */
-  localAllocations: Map<number, { sub_type: string; config_id: number } | null>;
+  localAllocations: Map<number, LocalAlloc | null>;
   academies: Array<{ code: string; name: string }>;
 }
 
@@ -25,6 +29,9 @@ function cellKey(collegeCode: string, colKey: string) {
   return `${collegeCode}|${colKey}`;
 }
 
+/** A cell for a college the matrix has no quota/consumers for (staged-only). */
+const ZERO_QUOTA_CELL: CollegeQuota = { total: 0, allocated: 0, remaining: 0 };
+
 /**
  * College × (sub_type × config) remaining-quota matrix (advisory display).
  *
@@ -33,6 +40,10 @@ function cellKey(collegeCode: string, colKey: string) {
  * server-saved allocation. The delta form avoids double-counting: server
  * `allocated` already includes saved allocations, and `localAllocations` is
  * seeded from them (plus auto-preview suggestions).
+ *
+ * Renewal students are excluded from the delta: the backend counts a
+ * renewal's consumption via its approved Application, not its ranking item,
+ * so checkbox changes on a renewal row don't move quota server-side.
  */
 export function CollegeQuotaMatrix({
   cols,
@@ -48,46 +59,69 @@ export function CollegeQuotaMatrix({
       delta[k] = (delta[k] ?? 0) + amount;
     };
     for (const s of students) {
+      if (s.is_renewal) continue;
       const college = s.college_code || "";
-      if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
-        bump(college, `${s.allocated_sub_type}:${s.allocation_config_id}`, -1);
+      const saved = getSavedAllocation(s);
+      if (saved) {
+        bump(college, makeColKey(saved.sub_type, saved.config_id), -1);
       }
       const local = localAllocations.get(s.ranking_item_id);
       if (local) {
-        bump(college, `${local.sub_type}:${local.config_id}`, +1);
+        bump(college, makeColKey(local.sub_type, local.config_id), +1);
       }
     }
     return delta;
   }, [students, localAllocations]);
 
+  // Per visible column: the server's per-college grid (null = non-matrix config).
+  const byColKey = useMemo(() => {
+    const map: Record<string, Record<string, CollegeQuota> | null> = {};
+    for (const col of cols) {
+      const cData = (quotaStatus[col.sub_type]?.by_config ?? []).find(
+        c => c.config_id === col.config_id
+      );
+      map[col.key] = cData?.by_college ?? null;
+    }
+    return map;
+  }, [cols, quotaStatus]);
+
+  // Rows: colleges known to the server, plus colleges that only exist as
+  // staged (unsaved) allocations into a matrix column — those must surface
+  // so over-allocating a zero-quota college warns BEFORE saving.
   const collegeRows = useMemo(() => {
     const codes = new Set<string>();
-    for (const stData of Object.values(quotaStatus)) {
-      for (const cData of Object.values(stData.by_config)) {
-        for (const code of Object.keys(cData.by_college ?? {})) {
-          codes.add(code);
-        }
+    for (const col of cols) {
+      for (const code of Object.keys(byColKey[col.key] ?? {})) {
+        codes.add(code);
+      }
+    }
+    for (const [key, delta] of Object.entries(localDelta)) {
+      if (delta === 0) continue;
+      const sep = key.indexOf("|");
+      const college = key.slice(0, sep);
+      const colKey = key.slice(sep + 1);
+      if (byColKey[colKey] != null) {
+        codes.add(college);
       }
     }
     return Array.from(codes).sort((a, b) => a.localeCompare(b));
-  }, [quotaStatus]);
+  }, [cols, byColKey, localDelta]);
 
-  const byColKey = useMemo(() => {
-    const map: Record<string, Record<string, CollegeQuota> | null> = {};
-    for (const [subType, stData] of Object.entries(quotaStatus)) {
-      for (const cData of Object.values(stData.by_config)) {
-        map[`${subType}:${cData.config_id}`] = cData.by_college ?? null;
+  const collegeNames = useMemo(() => {
+    const names = new Map<string, string>();
+    for (const academy of academies) {
+      names.set(academy.code, academy.name);
+    }
+    for (const s of students) {
+      if (s.college_code && s.college_name && !names.has(s.college_code)) {
+        names.set(s.college_code, s.college_name);
       }
     }
-    return map;
-  }, [quotaStatus]);
+    return names;
+  }, [academies, students]);
 
-  const resolveCollegeName = (code: string): string => {
-    if (!code) return UNKNOWN_COLLEGE_LABEL;
-    const fromReference = getAcademyName(code, academies);
-    if (fromReference !== code && fromReference !== "-") return fromReference;
-    return students.find(s => s.college_code === code)?.college_name || code;
-  };
+  const resolveCollegeName = (code: string): string =>
+    code ? (collegeNames.get(code) ?? code) : UNKNOWN_COLLEGE_LABEL;
 
   if (cols.length === 0 || collegeRows.length === 0) return null;
 
@@ -106,12 +140,16 @@ export function CollegeQuotaMatrix({
         <table className="w-full text-xs">
           <thead>
             <tr className="text-slate-500">
-              <th className="text-left font-medium py-1.5 pr-3 whitespace-nowrap">
+              <th
+                scope="col"
+                className="text-left font-medium py-1.5 pr-3 whitespace-nowrap"
+              >
                 學院
               </th>
               {cols.map(col => (
                 <th
                   key={col.key}
+                  scope="col"
                   className="text-center font-medium py-1.5 px-2 whitespace-nowrap"
                 >
                   {col.display_name}
@@ -127,11 +165,22 @@ export function CollegeQuotaMatrix({
           <tbody>
             {collegeRows.map(code => (
               <tr key={code || "__unknown__"} className="border-t border-slate-100">
-                <td className="py-1.5 pr-3 font-medium text-slate-700 whitespace-nowrap">
+                <th
+                  scope="row"
+                  className="text-left py-1.5 pr-3 font-medium text-slate-700 whitespace-nowrap"
+                >
                   {resolveCollegeName(code)}
-                </td>
+                </th>
                 {cols.map(col => {
-                  const entry = byColKey[col.key]?.[code];
+                  const colColleges = byColKey[col.key];
+                  const delta = localDelta[cellKey(code, col.key)] ?? 0;
+                  // Synthesize a 0/0 cell when a matrix column only has
+                  // staged allocations for this college (no server entry).
+                  const entry =
+                    colColleges?.[code] ??
+                    (colColleges != null && delta !== 0
+                      ? ZERO_QUOTA_CELL
+                      : undefined);
                   if (!entry) {
                     return (
                       <td key={col.key} className="py-1.5 px-2 text-center text-slate-300">
@@ -139,8 +188,7 @@ export function CollegeQuotaMatrix({
                       </td>
                     );
                   }
-                  const liveRemaining =
-                    entry.remaining - (localDelta[cellKey(code, col.key)] ?? 0);
+                  const liveRemaining = entry.remaining - delta;
                   const tone =
                     liveRemaining < 0
                       ? "text-red-600 font-bold"

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -342,6 +342,48 @@ export function ManualDistributionPanel({
     }
   }, [scholarshipTypeId, selectedAcademicYear, selectedSemester]);
 
+  /**
+   * Refetch students + quota status together and reseed local allocations
+   * from the server snapshot. Shared by save / finalize / restore so the
+   * matrix always sees a consistent server state after a mutation. Unlike
+   * fetchData, this does NOT clear saveMessage or apply auto-preview
+   * suggestions.
+   */
+  const reloadServerSnapshot = useCallback(async () => {
+    if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
+      return;
+    const [studentsResp, quotaResp] = await Promise.all([
+      apiClient.manualDistribution.getStudents(
+        scholarshipTypeId,
+        selectedAcademicYear,
+        selectedSemester
+      ),
+      apiClient.manualDistribution.getQuotaStatus(
+        scholarshipTypeId,
+        selectedAcademicYear,
+        selectedSemester
+      ),
+    ]);
+    if (studentsResp.success && studentsResp.data) {
+      setStudents(studentsResp.data);
+      const initial = new Map<number, LocalAlloc | null>();
+      for (const s of studentsResp.data) {
+        if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
+          initial.set(s.ranking_item_id, {
+            sub_type: s.allocated_sub_type,
+            config_id: s.allocation_config_id,
+          });
+        } else {
+          initial.set(s.ranking_item_id, null);
+        }
+      }
+      setLocalAllocations(initial);
+    }
+    if (quotaResp.success && quotaResp.data) {
+      setQuotaStatus(quotaResp.data);
+    }
+  }, [scholarshipTypeId, selectedAcademicYear, selectedSemester]);
+
   useEffect(() => {
     fetchData();
   }, [fetchData]);
@@ -520,38 +562,12 @@ export function ManualDistributionPanel({
         // Reload students AND quota together (same pattern as finalize/restore)
         // so the matrix sees a consistent server snapshot — refetching quota
         // alone would leave `students` stale and double-count saved allocations.
-        const [studentsResp, quotaResp] = await Promise.all([
-          apiClient.manualDistribution.getStudents(
-            scholarshipTypeId,
-            selectedAcademicYear,
-            selectedSemester
-          ),
-          apiClient.manualDistribution.getQuotaStatus(
-            scholarshipTypeId,
-            selectedAcademicYear,
-            selectedSemester
-          ),
-        ]);
-        if (studentsResp.success && studentsResp.data) {
-          setStudents(studentsResp.data);
-          const initial = new Map<number, LocalAlloc | null>();
-          for (const s of studentsResp.data) {
-            if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
-              initial.set(s.ranking_item_id, {
-                sub_type: s.allocated_sub_type,
-                config_id: s.allocation_config_id,
-              });
-            } else {
-              initial.set(s.ranking_item_id, null);
-            }
-          }
-          setLocalAllocations(initial);
-        }
-        if (quotaResp.success && quotaResp.data) setQuotaStatus(quotaResp.data);
+        await reloadServerSnapshot();
       } else {
         setSaveMessage({ type: "error", text: resp.message || "儲存失敗" });
       }
-    } catch {
+    } catch (error) {
+      logger.error("Save error", { error: error });
       setSaveMessage({ type: "error", text: "儲存時發生錯誤" });
     } finally {
       setIsSaving(false);
@@ -575,36 +591,7 @@ export function ManualDistributionPanel({
           text: `分發完成：核准 ${resp.data.approved_count} 人，拒絕 ${resp.data.rejected_count} 人`,
         });
         // Reload data directly instead of using fetchData
-        const [studentsResp, quotaResp] = await Promise.all([
-          apiClient.manualDistribution.getStudents(
-            scholarshipTypeId,
-            selectedAcademicYear,
-            selectedSemester
-          ),
-          apiClient.manualDistribution.getQuotaStatus(
-            scholarshipTypeId,
-            selectedAcademicYear,
-            selectedSemester
-          ),
-        ]);
-        if (studentsResp.success && studentsResp.data) {
-          setStudents(studentsResp.data);
-          const initial = new Map<number, LocalAlloc | null>();
-          for (const s of studentsResp.data) {
-            if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
-              initial.set(s.ranking_item_id, {
-                sub_type: s.allocated_sub_type,
-                config_id: s.allocation_config_id,
-              });
-            } else {
-              initial.set(s.ranking_item_id, null);
-            }
-          }
-          setLocalAllocations(initial);
-        }
-        if (quotaResp.success && quotaResp.data) {
-          setQuotaStatus(quotaResp.data);
-        }
+        await reloadServerSnapshot();
       } else {
         setSaveMessage({ type: "error", text: resp.message || "確認分發失敗" });
       }
@@ -717,36 +704,7 @@ export function ManualDistributionPanel({
         });
         setShowHistoryDialog(false);
         // Reload data by calling the fetch function directly
-        const [studentsResp, quotaResp] = await Promise.all([
-          apiClient.manualDistribution.getStudents(
-            scholarshipTypeId,
-            selectedAcademicYear!,
-            selectedSemester!
-          ),
-          apiClient.manualDistribution.getQuotaStatus(
-            scholarshipTypeId,
-            selectedAcademicYear!,
-            selectedSemester!
-          ),
-        ]);
-        if (studentsResp.success && studentsResp.data) {
-          setStudents(studentsResp.data);
-          const initial = new Map<number, LocalAlloc | null>();
-          for (const s of studentsResp.data) {
-            if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
-              initial.set(s.ranking_item_id, {
-                sub_type: s.allocated_sub_type,
-                config_id: s.allocation_config_id,
-              });
-            } else {
-              initial.set(s.ranking_item_id, null);
-            }
-          }
-          setLocalAllocations(initial);
-        }
-        if (quotaResp.success && quotaResp.data) {
-          setQuotaStatus(quotaResp.data);
-        }
+        await reloadServerSnapshot();
       } else {
         setSaveMessage({ type: "error", text: resp.message || "還原失敗" });
       }

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/api/modules/college";
 import type {
   DistributionStudent,
+  LocalAlloc,
   QuotaStatus,
   SubTypeConfigCol,
   DistributionHistoryRecord,
@@ -20,6 +21,10 @@ import type {
   AllocationSuggestion,
   DistributionState,
   ReleaseChainItem,
+} from "@/lib/api/modules/manual-distribution";
+import {
+  getSavedAllocation,
+  makeColKey,
 } from "@/lib/api/modules/manual-distribution";
 import { User } from "@/types/user";
 import { Button } from "@/components/ui/button";
@@ -73,18 +78,18 @@ interface ManualDistributionPanelProps {
   scholarshipType: { id: number; code: string; name: string };
 }
 
-/** Local allocation state for a student: which (sub_type, config) they're assigned to */
-interface LocalAlloc {
-  sub_type: string;
-  config_id: number;
-}
-
 const ALL_DEPTS_OWN = "__college_all__";
 const ALL_DEPTS_SYSTEM = "__all__";
 
-/** Composite key for a (sub_type, config) column: "nstc:42" */
-function makeColKey(sub_type: string, config_id: number) {
-  return `${sub_type}:${config_id}`;
+/** Seed local allocation state from the server snapshot (null = unallocated). */
+function seedAllocations(
+  students: DistributionStudent[]
+): Map<number, LocalAlloc | null> {
+  const allocMap = new Map<number, LocalAlloc | null>();
+  for (const s of students) {
+    allocMap.set(s.ranking_item_id, getSavedAllocation(s));
+  }
+  return allocMap;
 }
 
 /**
@@ -225,7 +230,7 @@ export function ManualDistributionPanel({
   const subTypeCols = useMemo<SubTypeConfigCol[]>(() => {
     const cols: SubTypeConfigCol[] = [];
     for (const [sub_type, stData] of Object.entries(quotaStatus)) {
-      const configs = Object.values(stData.by_config).sort((a, b) => {
+      const configs = [...stData.by_config].sort((a, b) => {
         if (a.is_own !== b.is_own) return a.is_own ? -1 : 1; // own first
         return b.academic_year - a.academic_year; // then descending year
       });
@@ -286,18 +291,7 @@ export function ManualDistributionPanel({
       ]);
 
       if (studentsResp.success && studentsResp.data) {
-        setStudents(studentsResp.data);
-        const allocMap = new Map<number, LocalAlloc | null>();
-        for (const s of studentsResp.data) {
-          if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
-            allocMap.set(s.ranking_item_id, {
-              sub_type: s.allocated_sub_type,
-              config_id: s.allocation_config_id,
-            });
-          } else {
-            allocMap.set(s.ranking_item_id, null);
-          }
-        }
+        const allocMap = seedAllocations(studentsResp.data);
 
         // Load preview separately (optional — failure should not break the page)
         let previewSuggestions: AllocationSuggestion[] = [];
@@ -330,8 +324,10 @@ export function ManualDistributionPanel({
             hasPreview = true;
           }
         }
+        // Commit students together with their seeded allocations so no render
+        // sees new students against stale local state (the matrix reads both).
+        setStudents(studentsResp.data);
         setPreviewApplied(hasPreview);
-
         setLocalAllocations(allocMap);
       }
       if (quotaResp.success && quotaResp.data) {
@@ -366,18 +362,10 @@ export function ManualDistributionPanel({
     ]);
     if (studentsResp.success && studentsResp.data) {
       setStudents(studentsResp.data);
-      const initial = new Map<number, LocalAlloc | null>();
-      for (const s of studentsResp.data) {
-        if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
-          initial.set(s.ranking_item_id, {
-            sub_type: s.allocated_sub_type,
-            config_id: s.allocation_config_id,
-          });
-        } else {
-          initial.set(s.ranking_item_id, null);
-        }
-      }
-      setLocalAllocations(initial);
+      setLocalAllocations(seedAllocations(studentsResp.data));
+      // The reseed is server-only, so any auto-preview suggestions are gone
+      // (saved or discarded) — clear the "已自動預設分配" notice.
+      setPreviewApplied(false);
     }
     if (quotaResp.success && quotaResp.data) {
       setQuotaStatus(quotaResp.data);
@@ -590,7 +578,6 @@ export function ManualDistributionPanel({
           type: "success",
           text: `分發完成：核准 ${resp.data.approved_count} 人，拒絕 ${resp.data.rejected_count} 人`,
         });
-        // Reload data directly instead of using fetchData
         await reloadServerSnapshot();
       } else {
         setSaveMessage({ type: "error", text: resp.message || "確認分發失敗" });
@@ -690,7 +677,7 @@ export function ManualDistributionPanel({
   };
 
   const handleRestore = async (historyId: number) => {
-    if (!scholarshipTypeId) return;
+    if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester) return;
     setIsRestoring(true);
     try {
       const resp = await apiClient.manualDistribution.restoreFromHistory(
@@ -703,7 +690,6 @@ export function ManualDistributionPanel({
           text: `成功還原 ${resp.data.restored_count} 筆分配紀錄`,
         });
         setShowHistoryDialog(false);
-        // Reload data by calling the fetch function directly
         await reloadServerSnapshot();
       } else {
         setSaveMessage({ type: "error", text: resp.message || "還原失敗" });
@@ -1407,12 +1393,19 @@ export function ManualDistributionPanel({
                                     isChallenge &&
                                     challengeMeta?.challenged_renewal
                                       ?.sub_type === col.sub_type;
+                                  // Freeze edits while a mutation is in flight:
+                                  // its success path reseeds localAllocations
+                                  // from the server, which would silently
+                                  // revert any tick made mid-request.
+                                  const isMutating =
+                                    isSaving || isFinalizing || isRestoring;
                                   const disabled =
                                     !isApplied ||
                                     isRejected ||
                                     atCapacity ||
                                     isFallbackColumn ||
-                                    isCancelled;
+                                    isCancelled ||
+                                    isMutating;
                                   return (
                                     <td
                                       key={col.key}

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -53,6 +53,7 @@ import {
   AllocationStatusControl,
   type AllocationStatus,
 } from "@/components/admin/manual-distribution/AllocationStatusControl";
+import { CollegeQuotaMatrix } from "@/components/admin/manual-distribution/CollegeQuotaMatrix";
 import {
   Loader2,
   Save,
@@ -123,7 +124,7 @@ export function ManualDistributionPanel({
   // Use the ID directly from the prop (provided by the admin available-combinations endpoint)
   const scholarshipTypeId = scholarshipType.id;
 
-  const { departments } = useReferenceData();
+  const { departments, academies } = useReferenceData();
   const [summaryDept, setSummaryDept] = useState<string>("");
 
   const visibleDepartments = useMemo(() => {
@@ -516,11 +517,36 @@ export function ManualDistributionPanel({
           type: "success",
           text: `已儲存 ${resp.data?.updated_count ?? 0} 筆分配`,
         });
-        const quotaResp = await apiClient.manualDistribution.getQuotaStatus(
-          scholarshipTypeId,
-          selectedAcademicYear,
-          selectedSemester
-        );
+        // Reload students AND quota together (same pattern as finalize/restore)
+        // so the matrix sees a consistent server snapshot — refetching quota
+        // alone would leave `students` stale and double-count saved allocations.
+        const [studentsResp, quotaResp] = await Promise.all([
+          apiClient.manualDistribution.getStudents(
+            scholarshipTypeId,
+            selectedAcademicYear,
+            selectedSemester
+          ),
+          apiClient.manualDistribution.getQuotaStatus(
+            scholarshipTypeId,
+            selectedAcademicYear,
+            selectedSemester
+          ),
+        ]);
+        if (studentsResp.success && studentsResp.data) {
+          setStudents(studentsResp.data);
+          const initial = new Map<number, LocalAlloc | null>();
+          for (const s of studentsResp.data) {
+            if (s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null) {
+              initial.set(s.ranking_item_id, {
+                sub_type: s.allocated_sub_type,
+                config_id: s.allocation_config_id,
+              });
+            } else {
+              initial.set(s.ranking_item_id, null);
+            }
+          }
+          setLocalAllocations(initial);
+        }
         if (quotaResp.success && quotaResp.data) setQuotaStatus(quotaResp.data);
       } else {
         setSaveMessage({ type: "error", text: resp.message || "儲存失敗" });
@@ -1162,6 +1188,13 @@ export function ManualDistributionPanel({
         <AvailableQuotasBlock
           state={distributionState}
           isLoading={isLoadingState}
+        />
+        <CollegeQuotaMatrix
+          cols={subTypeCols}
+          quotaStatus={quotaStatus}
+          students={students}
+          localAllocations={localAllocations}
+          academies={academies}
         />
         <ReleasePreviewSection
           releaseChain={releasePreview}

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -46,6 +46,7 @@ export interface DistributionStudent {
 export interface CollegeQuota {
   total: number;
   allocated: number;
+  /** total − allocated; NOT clamped — negative means over-allocated (advisory). */
   remaining: number;
 }
 
@@ -56,9 +57,9 @@ export interface ConfigQuota {
   academic_year: number;
   is_own: boolean;
   total: number;
-  allocated: number;
   remaining: number;
-  by_college: Record<string, CollegeQuota>;
+  /** Per-college grid keyed by college code (""=unknown); null for non-matrix configs. */
+  by_college: Record<string, CollegeQuota> | null;
 }
 
 export interface SubTypeQuotaStatus {

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -64,11 +64,34 @@ export interface ConfigQuota {
 
 export interface SubTypeQuotaStatus {
   display_name: string;
-  /** Distributable configs for this sub_type, keyed by config_id string. */
-  by_config: Record<string, ConfigQuota>;
+  /** Distributable configs for this sub_type (own config first, then linked sources). */
+  by_config: ConfigQuota[];
 }
 
 export type QuotaStatus = Record<string, SubTypeQuotaStatus>;
+
+/** Local allocation state for a student: which (sub_type, config) they're assigned to */
+export interface LocalAlloc {
+  sub_type: string;
+  config_id: number;
+}
+
+/** Composite key for a (sub_type, config) column: "nstc:42" */
+export function makeColKey(sub_type: string, config_id: number): string {
+  return `${sub_type}:${config_id}`;
+}
+
+/**
+ * The student's SERVER-SAVED allocation, or null. `is_allocated` is the live
+ * funding flag (`allocated_sub_type` is preserved across cancel), so all three
+ * fields must agree. Single source of truth for seeding local allocation state
+ * and for the matrix's saved-side delta.
+ */
+export function getSavedAllocation(s: DistributionStudent): LocalAlloc | null {
+  return s.is_allocated && s.allocated_sub_type && s.allocation_config_id != null
+    ? { sub_type: s.allocated_sub_type, config_id: s.allocation_config_id }
+    : null;
+}
 
 /** A flattened (sub_type × source-config) column descriptor for the distribution table */
 export interface SubTypeConfigCol {


### PR DESCRIPTION
## Summary
- The admin 造冊分發 (manual distribution) page now shows a 「各學院剩餘名額」 college × (sub_type × config) matrix, including linked prior-year configs (共用往年 badge), with cells showing 剩餘/總額.
- Cells live-update against locally staged (unsaved) allocations via delta math (`liveRemaining = serverRemaining − (local − saved)`); over-allocated cells turn red. The numbers are advisory — enforcement stays the global per-(config × sub_type) recount in `_assert_round_not_oversubscribed`.
- Backend: new `consumers_by_college` service method (shares `_winner_filters`/`_renewal_filters` predicates with `consumers_count`, so the two cannot drift — tripwire-tested) and a `by_college` field on every `by_config` entry of the `/manual-distribution/quota-status` payload (`null` for non-matrix configs; `""` bucket = 未知 college).
- Frontend: new pure-props `CollegeQuotaMatrix` component wired into `ManualDistributionPanel`; `ConfigQuota`/`CollegeQuota` types aligned with the real payload; `handleSave` now refetches students + quota and reseeds local allocations via a shared `reloadServerSnapshot` (also de-duplicates the finalize/restore refetch blocks).

Spec: `docs/superpowers/specs/2026-06-10-college-quota-matrix-design.md`
Plan: `docs/superpowers/plans/2026-06-10-college-quota-matrix.md`

## Test Plan
- [x] Backend: 7 new async tests (per-college attribution, "" bucket, renewal dedup guard, sum==consumers_count tripwire, linked-config matrix, negative remaining unclamped, null for non-matrix) — 20/20 in the two manual-distribution test files; the 2 failures in `test_quota_service_status_math.py` are pre-existing on main (verified)
- [x] Lint: black 26.3.1 + flake8 B904/B014 clean; frontend `tsc --noEmit` clean
- [x] OpenAPI regen: no schema diff (endpoint has no response_model)
- [x] Localhost smoke test (admin, PhD scholarship): matrix renders with 共用往年 badge; ticking 核配 immediately decrements the student's college cell; over-allocation shows red negative; live payload verified for own + linked configs
- [ ] Reviewer: verify matrix numbers after a 儲存 round-trip match pre-save live numbers