### PR TITLE
ci(staging-e2e): schedule the replica lane nightly at 02:30 Asia/Taipei

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -19,13 +19,17 @@
 # `down -v`-ed in an always() step; a final assert fails the run if anything
 # survived.
 #
-# Rollout: workflow_dispatch only for now. Once green, add a cron entry
-# (e.g. '30 18 * * *' = 02:30 Asia/Taipei, clear of the 01:00 nightly).
-
 name: Staging E2E
 
 on:
   workflow_dispatch:
+  schedule:
+    # 02:30 Asia/Taipei — clear of the 01:00 nightly lane and normal deploy
+    # hours. NOTE: a deploy queued in the shared `deploy-<ref>` concurrency
+    # group CANCELS a pending run of this workflow (GitHub keeps one pending
+    # run per group), so an overnight deploy simply skips that night's run
+    # rather than racing it.
+    - cron: '30 18 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
The staging-e2e replica lane went fully green in run [27299177049](https://github.com/anud18/scholarship-system/actions/runs/27299177049) (43 passed, teardown + zero-residue clean), so this adds the planned cron: `30 18 * * *` = 02:30 Asia/Taipei, clear of the 01:00 nightly lane.

A deploy holding the shared `deploy-<ref>` concurrency group cancels that night's pending run (documented inline) — the lane simply skips a night rather than racing a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)