### PR TITLE
feat(storage): swap dev object storage MinIO → RustFS + full migration groundwork

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,7 @@ docker compose -f docker-compose.dev.yml logs -f
 docker compose -f docker-compose.dev.yml restart backend
 ```
 
-This spins up the full stack (backend, frontend, database, MinIO, mock student API) with hot-reload enabled.
+This spins up the full stack (backend, frontend, database, RustFS object storage (S3 API, service name `minio`), mock student API) with hot-reload enabled.
 
 ## Core Development Principles
 
@@ -673,7 +673,7 @@ return new NextResponse(fileBuffer, {
 ```bash
 # Backend
 MINIO_ENDPOINT=minio:9000
-MINIO_BUCKET=scholarship-system
+MINIO_BUCKET=scholarship-documents
 
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
+++ b/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
@@ -633,7 +633,7 @@ gh secret list
 PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p 5432 -U "$DB_USER" -d "$DB_NAME" -c "SELECT version();"
 
 # Test MinIO connectivity
-curl -I http://$MINIO_HOST:9000/minio/health/live
+curl -I http://$MINIO_HOST:9000/health
 ```
 
 **Test SMTP:**
@@ -778,7 +778,7 @@ gh secret set PORTAL_JWT_SERVER_URL -b "https://portal.nycu.edu.tw/api/auth"
 2. **Check MinIO health:**
    ```bash
    ssh db-vm
-   curl http://localhost:9000/minio/health/live
+   curl http://localhost:9000/health
    ```
 
 3. **Verify MINIO_HOST secret:**
@@ -790,7 +790,7 @@ gh secret set PORTAL_JWT_SERVER_URL -b "https://portal.nycu.edu.tw/api/auth"
 4. **Test from AP VM:**
    ```bash
    # On AP VM
-   curl http://$MINIO_HOST:9000/minio/health/live
+   curl http://$MINIO_HOST:9000/health
    ```
 
 ---

--- a/.run-backend-tests.sh
+++ b/.run-backend-tests.sh
@@ -37,7 +37,7 @@ exec docker run --rm -t --user root \
     -e MINIO_ACCESS_KEY=test \
     -e MINIO_SECRET_KEY=test \
     -e MINIO_ENDPOINT=localhost:9000 \
-    -e MINIO_BUCKET_NAME=test-bucket \
+    -e MINIO_BUCKET=test-bucket \
     -e STUDENT_API_ENABLED=false \
     ghcr.io/anud18/scholarship-system-backend:latest \
     python -m pytest \

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This scholarship management system provides a complete lifecycle solution for ac
 - **End-to-End Workflow**: Application creation, configurable review pipelines, quota management, automated notifications, and historical reporting
 - **Bilingual Support**: Traditional Chinese and English with dynamic content switching
 - **Configuration-Driven**: Add new scholarship types through database configuration without code changes
-- **Secure File Handling**: Three-layer file architecture with MinIO object storage
+- **Secure File Handling**: Three-layer file architecture with S3-compatible object storage (RustFS in dev; MinIO in staging/prod until migrated)
 - **Development-Friendly**: Mock SSO and student information services for local development
 
 ## Core Features
@@ -52,7 +52,7 @@ This scholarship management system provides a complete lifecycle solution for ac
 
 ### 3. Three-Layer File Upload Architecture
 ```
-Frontend → Next.js Proxy → FastAPI → MinIO
+Frontend → Next.js Proxy → FastAPI → Object Storage (S3 API)
 ```
 - Token authentication via Next.js proxy
 - Internal Docker network communication
@@ -89,7 +89,7 @@ All endpoints return consistent format:
 - **FastAPI** - High-performance async web framework
 - **PostgreSQL 15** - Primary relational database with async support
 - **Redis** - Caching and session management
-- **MinIO** - S3-compatible object storage
+- **RustFS** - S3-compatible object storage (Apache 2.0 MinIO replacement; dev env)
 - **SQLAlchemy 2.0** - Async ORM
 - **Alembic** - Database migrations
 - **Pydantic v2** - Data validation and serialization
@@ -196,7 +196,7 @@ make init-all
 ```
 
 This single command will:
-1. Start all Docker services (PostgreSQL, Redis, MinIO, backend, frontend)
+1. Start all Docker services (PostgreSQL, Redis, RustFS, backend, frontend)
 2. Initialize lookup tables (degrees, departments, enrollment types)
 3. Create test users and sample scholarships
 4. Wait 10-15 minutes for complete initialization
@@ -205,7 +205,7 @@ After initialization completes:
 - **Frontend**: http://localhost:3000
 - **Backend API**: http://localhost:8000
 - **API Documentation**: http://localhost:8000/docs
-- **MinIO Console**: http://localhost:9001
+- **RustFS Console**: http://localhost:9001 (minioadmin/minioadmin123)
 
 Test user accounts (see [Database Management](#database-management) for credentials).
 
@@ -246,7 +246,7 @@ make install
 # 2. Setup environment files
 make setup
 
-# 3. Start PostgreSQL, Redis, and MinIO
+# 3. Start PostgreSQL, Redis, and RustFS (object storage)
 # (Use Docker Compose for infrastructure only)
 docker compose -f docker-compose.dev.yml up -d postgres redis minio
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ After initialization completes:
 - **Frontend**: http://localhost:3000
 - **Backend API**: http://localhost:8000
 - **API Documentation**: http://localhost:8000/docs
-- **RustFS Console**: http://localhost:9001 (minioadmin/minioadmin123)
+- **RustFS Console**: http://localhost:9001/rustfs/console/ (minioadmin/minioadmin123 — the bare :9001 root returns 403)
 
 Test user accounts (see [Database Management](#database-management) for credentials).
 

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -1430,7 +1430,12 @@ async def delete_batch_import(
     if batch_import.file_path:
         try:
             minio_service = MinIOService()
-            minio_service.delete_file(bucket_name=settings.minio_bucket, object_name=batch_import.file_path)
+            # delete_file takes only object_name (targets the default bucket). The old
+            # bucket_name= kwarg raised TypeError on EVERY call — swallowed by the
+            # except below — so batch deletes silently orphaned the uploaded PII
+            # file in storage while reporting success (surfaced by the RustFS
+            # migration audit; identical on MinIO).
+            minio_service.delete_file(object_name=batch_import.file_path)
         except Exception:
             logger.warning("Failed to delete batch import file from MinIO", exc_info=True)
             # Continue with batch deletion even if MinIO deletion fails

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -1688,7 +1688,11 @@ async def download_roster_excel(
                 # 直接返回二進制檔案內容
                 from fastapi.responses import Response
 
-                filename = metadata.get("original-filename", f"{roster.roster_code}.xlsx")
+                # Custom metadata comes back PREFIXED (x-amz-meta-*) — the bare
+                # key was always None, so the timestamped original filename was
+                # never used (same dead-key class as the minio_service
+                # file-hash fix).
+                filename = metadata.get("x-amz-meta-original-filename", f"{roster.roster_code}.xlsx")
                 content_type = metadata.get(
                     "Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
                 )

--- a/backend/app/scripts/storage_compat_check.py
+++ b/backend/app/scripts/storage_compat_check.py
@@ -1,0 +1,323 @@
+"""Object-storage compatibility check — every S3 operation MinIOService uses.
+
+Purpose
+-------
+The dev stack swapped MinIO for RustFS (S3-compatible, Apache 2.0). The
+backend keeps the generic python ``minio`` SDK pointed at whatever serves
+``MINIO_ENDPOINT``; this script proves the LIVE store behind that endpoint
+supports every operation ``app/services/minio_service.py`` performs, with the
+exact same calls — not just that the API answers 200, but that the semantics
+hold (policy actually denies, metadata round-trips, multipart checksums
+match).
+
+Run it inside the backend container against the running store::
+
+    docker exec scholarship_backend_dev python -m app.scripts.storage_compat_check
+
+Deliberately NOT wired into CI lanes — CI has no object store (unit tests
+mock the client via settings.testing). This is the dev/staging cutover gate:
+all checks must print PASS and the script exits non-zero on any failure.
+
+Checks mirror real call sites:
+- put/get/stat/remove: upload_file / get_file_stream / delete_file
+- copy_object + CopySource: clone_file_to_application (the #887 path)
+- set_bucket_policy deny-all + anonymous 403: roster bucket privacy
+- presigned GET/PUT: generate_presigned_url (roster downloads)
+- 10MB multipart: large uploads (part_size forces multipart)
+- non-ASCII metadata: original-filename carries Chinese filenames
+- seeded regulations PDF: seed_regulations_doc.py read path
+"""
+
+import hashlib
+import io
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import timedelta
+
+from minio import Minio
+from minio.commonconfig import CopySource
+from minio.error import S3Error
+
+from app.core.config import settings
+
+PREFIX = "compat-check"
+RESULTS: list[tuple[str, bool, str]] = []
+
+
+def record(name: str, ok: bool, detail: str = "") -> None:
+    RESULTS.append((name, ok, detail))
+    print(f"{'PASS' if ok else 'FAIL'}  {name}" + (f"  — {detail}" if detail and not ok else ""))
+
+
+def http(url: str, method: str = "GET", data: bytes | None = None) -> tuple[int, bytes]:
+    """Bare HTTP request with NO credentials (for presigned/anonymous checks)."""
+    req = urllib.request.Request(url, data=data, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def main() -> int:
+    if settings.testing:
+        print("Refusing to run with settings.testing=True (client would be a mock).")
+        return 2
+
+    client = Minio(
+        settings.minio_endpoint,
+        access_key=settings.minio_access_key,
+        secret_key=settings.minio_secret_key,
+        secure=settings.minio_secure,
+    )
+    bucket = settings.minio_bucket
+    roster_bucket = settings.roster_minio_bucket
+    tmp_bucket = f"{PREFIX}-tmp"
+    cleanup: list[tuple[str, str]] = []  # (bucket, object)
+
+    # ---- 1. bucket_exists / make_bucket lifecycle ----
+    try:
+        if client.bucket_exists(tmp_bucket):
+            for obj in client.list_objects(tmp_bucket, recursive=True):
+                client.remove_object(tmp_bucket, obj.object_name)
+            client.remove_bucket(tmp_bucket)
+        fresh_absent = not client.bucket_exists(tmp_bucket)
+        client.make_bucket(tmp_bucket)
+        record("1 bucket_exists→make_bucket→bucket_exists", fresh_absent and client.bucket_exists(tmp_bucket))
+    except Exception as e:  # noqa: BLE001 — each check must record, not abort the suite
+        record("1 bucket_exists→make_bucket→bucket_exists", False, repr(e))
+
+    # ---- 2. put_object small PDF ----
+    body = b"%PDF-1.4 compat-check minimal body"
+    key_small = f"{PREFIX}/small.pdf"
+    try:
+        client.put_object(bucket, key_small, io.BytesIO(body), len(body), content_type="application/pdf")
+        cleanup.append((bucket, key_small))
+        record("2 put_object (small, application/pdf)", True)
+    except Exception as e:  # noqa: BLE001
+        record("2 put_object (small, application/pdf)", False, repr(e))
+
+    # ---- 3. metadata round-trip (ASCII — the values the app actually sends) ----
+    # Note: the minio SDK rejects non-ASCII metadata CLIENT-SIDE (ValueError),
+    # identically against MinIO and RustFS — so Chinese original-filename
+    # values were never reaching the store through this SDK. Not a RustFS
+    # delta; the compat contract is the ASCII round-trip below.
+    key_meta = f"{PREFIX}/meta.pdf"
+    fname = "roster_20260611.xlsx"
+    try:
+        client.put_object(
+            bucket,
+            key_meta,
+            io.BytesIO(body),
+            len(body),
+            content_type="application/pdf",
+            metadata={"original-filename": fname, "file-hash": "a" * 64, "roster-id": "42"},
+        )
+        cleanup.append((bucket, key_meta))
+        stat = client.stat_object(bucket, key_meta)
+        meta = stat.metadata or {}
+        got = meta.get("x-amz-meta-original-filename") or meta.get("original-filename")
+        got_hash = meta.get("x-amz-meta-file-hash") or meta.get("file-hash")
+        record(
+            "3 metadata round-trip (original-filename / file-hash / roster-id)",
+            got == fname and got_hash == "a" * 64,
+            f"got={got!r} hash={got_hash!r}",
+        )
+    except Exception as e:  # noqa: BLE001
+        record("3 metadata round-trip (original-filename / file-hash / roster-id)", False, repr(e))
+
+    # ---- 4. get_object bytes equal ----
+    try:
+        resp = client.get_object(bucket, key_small)
+        data = resp.read()
+        resp.close()
+        resp.release_conn()
+        record("4 get_object bytes equal", data == body, f"len={len(data)}")
+    except Exception as e:  # noqa: BLE001
+        record("4 get_object bytes equal", False, repr(e))
+
+    # ---- 5. stat_object size/etag/content-type ----
+    try:
+        stat = client.stat_object(bucket, key_small)
+        ok = stat.size == len(body) and bool(stat.etag) and stat.content_type == "application/pdf"
+        record("5 stat_object size/etag/content-type", ok, f"size={stat.size} ct={stat.content_type}")
+    except Exception as e:  # noqa: BLE001
+        record("5 stat_object size/etag/content-type", False, repr(e))
+
+    # ---- 6. copy_object + CopySource (clone_file_to_application path) ----
+    key_copy = f"{PREFIX}/copied.pdf"
+    try:
+        client.copy_object(bucket, key_copy, CopySource(bucket, key_small))
+        cleanup.append((bucket, key_copy))
+        resp = client.get_object(bucket, key_copy)
+        copied = resp.read()
+        resp.close()
+        resp.release_conn()
+        record("6 copy_object + CopySource", copied == body)
+    except Exception as e:  # noqa: BLE001
+        record("6 copy_object + CopySource", False, repr(e))
+
+    # ---- 7. remove_object → NoSuchKey ----
+    key_gone = f"{PREFIX}/gone.txt"
+    try:
+        client.put_object(bucket, key_gone, io.BytesIO(b"x"), 1)
+        client.remove_object(bucket, key_gone)
+        try:
+            client.stat_object(bucket, key_gone)
+            record("7 remove_object → stat raises NoSuchKey", False, "stat unexpectedly succeeded")
+        except S3Error as e:
+            record("7 remove_object → stat raises NoSuchKey", e.code in ("NoSuchKey", "NoSuchObject"), e.code)
+    except Exception as e:  # noqa: BLE001
+        record("7 remove_object → stat raises NoSuchKey", False, repr(e))
+
+    # ---- 8. roster bucket privacy: default-deny anonymous, owner can read ----
+    # MinIOService used to attach an explicit deny-all s3:GetObject policy.
+    # RustFS enforces an explicit Deny against the OWNER too (AWS-faithful),
+    # which 403'd the backend's own roster downloads — so the policy was
+    # removed and we rely on the default-private ACL. This check pins BOTH
+    # halves of that contract: anonymous 403 with no policy attached, and
+    # authenticated owner GET still works.
+    key_secret = f"{PREFIX}/secret.xlsx"
+    try:
+        if not client.bucket_exists(roster_bucket):
+            client.make_bucket(roster_bucket)
+        try:
+            client.delete_bucket_policy(roster_bucket)  # ensure NO policy attached
+        except S3Error:
+            pass
+        client.put_object(roster_bucket, key_secret, io.BytesIO(b"roster"), 6)
+        cleanup.append((roster_bucket, key_secret))
+        scheme = "https" if settings.minio_secure else "http"
+        status, _ = http(f"{scheme}://{settings.minio_endpoint}/{roster_bucket}/{key_secret}")
+        resp = client.get_object(roster_bucket, key_secret)
+        owner_ok = resp.read() == b"roster"
+        resp.close()
+        resp.release_conn()
+        record(
+            "8 roster bucket default-private (anonymous 403, owner GET ok, no policy)",
+            status == 403 and owner_ok,
+            f"anonymous HTTP {status}, owner_ok={owner_ok}",
+        )
+    except Exception as e:  # noqa: BLE001
+        record("8 roster bucket default-private (anonymous 403, owner GET ok, no policy)", False, repr(e))
+
+    # ---- 9. presigned GET (via MinIOService.get_presigned_url) ----
+    # Exercises the service wrapper, which surfaced a latent bug here: it
+    # called the non-existent client.presigned_url (SDK name is
+    # get_presigned_url) — dead code until now, fixed alongside this script.
+    key_roster_get = f"{PREFIX}/presigned-src.xlsx"
+    try:
+        from app.services.minio_service import MinIOService
+
+        svc = MinIOService()
+        client.put_object(roster_bucket, key_roster_get, io.BytesIO(b"presigned-roster"), 16)
+        cleanup.append((roster_bucket, key_roster_get))
+        url = svc.get_presigned_url(key_roster_get, expires=timedelta(minutes=5), method="GET")
+        status, fetched = http(url)
+        record(
+            "9 presigned GET (service wrapper, roster bucket)",
+            status == 200 and fetched == b"presigned-roster",
+            f"HTTP {status}",
+        )
+    except Exception as e:  # noqa: BLE001
+        record("9 presigned GET (service wrapper, roster bucket)", False, repr(e))
+
+    # ---- 10. presigned PUT ----
+    key_put = f"{PREFIX}/presigned-put.bin"
+    try:
+        url = client.get_presigned_url("PUT", bucket, key_put, expires=timedelta(minutes=5))
+        status, _ = http(url, method="PUT", data=b"uploaded-via-presigned")
+        cleanup.append((bucket, key_put))
+        roundtrip = b""
+        if status in (200, 204):
+            resp = client.get_object(bucket, key_put)
+            roundtrip = resp.read()
+            resp.close()
+            resp.release_conn()
+        record("10 presigned PUT", roundtrip == b"uploaded-via-presigned", f"HTTP {status}")
+    except Exception as e:  # noqa: BLE001
+        record("10 presigned PUT", False, repr(e))
+
+    # ---- 11. 10MB multipart upload (part_size=5MB) ----
+    key_big = f"{PREFIX}/big.bin"
+    try:
+        big = bytes(range(256)) * (10 * 1024 * 1024 // 256)
+        client.put_object(
+            bucket,
+            key_big,
+            io.BytesIO(big),
+            length=-1,
+            part_size=5 * 1024 * 1024,
+            content_type="application/octet-stream",
+        )
+        cleanup.append((bucket, key_big))
+        resp = client.get_object(bucket, key_big)
+        h = hashlib.sha256()
+        for chunk in resp.stream(1024 * 1024):
+            h.update(chunk)
+        resp.close()
+        resp.release_conn()
+        record("11 10MB multipart upload checksum", h.hexdigest() == hashlib.sha256(big).hexdigest())
+    except Exception as e:  # noqa: BLE001
+        record("11 10MB multipart upload checksum", False, repr(e))
+
+    # ---- 12. MinIOService.health_check() full cycle ----
+    try:
+        from app.services.minio_service import MinIOService
+
+        health = MinIOService().health_check()
+        record("12 MinIOService.health_check() cycle", bool(health.get("overall_healthy")), json.dumps(health))
+    except Exception as e:  # noqa: BLE001
+        record("12 MinIOService.health_check() cycle", False, repr(e))
+
+    # ---- 13. dual-bucket auto-create (fresh service instance) ----
+    try:
+        from app.services.minio_service import MinIOService
+
+        svc = MinIOService()
+        _ = svc.client  # triggers _ensure_buckets_exist
+        record(
+            "13 dual-bucket auto-create",
+            client.bucket_exists(bucket) and client.bucket_exists(roster_bucket),
+        )
+    except Exception as e:  # noqa: BLE001
+        record("13 dual-bucket auto-create", False, repr(e))
+
+    # ---- 14. seeded regulations PDF visible via list_objects ----
+    try:
+        keys = [o.object_name for o in client.list_objects(bucket, prefix="system-docs/", recursive=True)]
+        record(
+            "14 seeded regulations PDF listed (run after reset_database.sh)",
+            any("regulations" in k for k in keys),
+            f"keys={keys}",
+        )
+    except Exception as e:  # noqa: BLE001
+        record("14 seeded regulations PDF listed (run after reset_database.sh)", False, repr(e))
+
+    # ---- cleanup ----
+    for b, k in cleanup:
+        try:
+            client.remove_object(b, k)
+        except Exception:  # noqa: BLE001
+            pass
+    try:
+        if client.bucket_exists(tmp_bucket):
+            client.remove_bucket(tmp_bucket)
+    except Exception:  # noqa: BLE001
+        pass
+
+    passed = sum(1 for _, ok, _ in RESULTS if ok)
+    total = len(RESULTS)
+    print(f"\nSTORAGE COMPAT: {passed}/{total} PASS")
+    if passed != total:
+        for name, ok, detail in RESULTS:
+            if not ok:
+                print(f"  FAILED: {name} — {detail}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/scripts/storage_compat_check.py
+++ b/backend/app/scripts/storage_compat_check.py
@@ -55,7 +55,7 @@ def http(url: str, method: str = "GET", data: bytes | None = None) -> tuple[int,
     """Bare HTTP request with NO credentials (for presigned/anonymous checks)."""
     req = urllib.request.Request(url, data=data, method=method)
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # nosec B310
             return resp.status, resp.read()
     except urllib.error.HTTPError as e:
         return e.code, e.read()

--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -355,8 +355,11 @@ class MinIOService:
             response.close()
             response.release_conn()
 
-            # 驗證檔案hash (如果metadata中有的話)
-            stored_hash = stat.metadata.get("file-hash")
+            # 驗證檔案hash (如果metadata中有的話)。
+            # Custom metadata comes back PREFIXED (x-amz-meta-*) from the SDK's
+            # stat headers — the bare "file-hash" lookup was always None, so
+            # this integrity check had silently never run (on MinIO either).
+            stored_hash = stat.metadata.get("x-amz-meta-file-hash")
             if stored_hash:
                 actual_hash = hashlib.sha256(file_content).hexdigest()
                 if stored_hash != actual_hash:

--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -81,38 +81,21 @@ class MinIOService:
                     self.client.make_bucket(bucket_name)
                     logger.info(f"Created MinIO bucket: {bucket_name}")
 
-                    # Set bucket policy for roster files (private by default)
-                    if bucket_name == self.roster_bucket:
-                        self._set_bucket_policy(bucket_name, private=True)
+                    # NOTE: no explicit deny-all bucket policy here anymore.
+                    # Buckets are private by default (anonymous GET → 403 with
+                    # no policy attached — verified against RustFS 1.0.0-beta.8
+                    # by app/scripts/storage_compat_check.py). The old
+                    # deny-all s3:GetObject policy was written for MinIO,
+                    # where root credentials bypass bucket policies; RustFS
+                    # enforces an explicit Deny against the OWNER as well
+                    # (AWS-faithful semantics), which 403'd the backend's own
+                    # roster downloads.
 
         except Exception as e:
             logger.exception("Failed to ensure buckets exist")
             from fastapi import HTTPException
 
             raise HTTPException(status_code=500, detail="MinIO bucket initialization failed") from e
-
-    def _set_bucket_policy(self, bucket_name: str, private: bool = True):
-        """設定bucket政策"""
-        try:
-            if private:
-                # Private bucket policy - no public access
-                policy = {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Deny",
-                            "Principal": "*",
-                            "Action": "s3:GetObject",
-                            "Resource": f"arn:aws:s3:::{bucket_name}/*",
-                        }
-                    ],
-                }
-                import json
-
-                self.client.set_bucket_policy(bucket_name, json.dumps(policy))
-
-        except Exception:
-            logger.warning(f"Failed to set bucket policy for {bucket_name}", exc_info=True)
 
     def upload_roster_file(
         self,
@@ -432,7 +415,10 @@ class MinIOService:
             str: 預簽名URL
         """
         try:
-            url = self.client.presigned_url(
+            # SDK method is get_presigned_url — `client.presigned_url` does
+            # not exist (this wrapper had zero callers, so the AttributeError
+            # never fired; surfaced by storage_compat_check).
+            url = self.client.get_presigned_url(
                 method=method,
                 bucket_name=self.roster_bucket,
                 object_name=object_name,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,42 +28,39 @@ email-validator==2.1.0
 httpx==0.28.1  # Updated for Python 3.13 compatibility
 requests==2.33.0  # Security update
 aiofiles==24.1.0  # Updated for Python 3.13 compatibility
-aiohttp==3.11.18  # Updated for Python 3.13 compatibility + security
+python-dateutil==2.8.2
+tenacity==9.1.2
 
-# File handling and storage
+# Caching
+redis==7.0.1  # Updated for Python 3.13 compatibility, includes async support (replaces aioredis)
+
+# Task scheduling
+apscheduler==3.10.4
+croniter==1.4.1
+
+# Email services
+fastapi-mail==1.4.1
+jinja2==3.1.6  # Security: Fixed sandbox escape vulnerability (GHSA-cpwx-vrp4-4pq7)
+
+# File processing and OCR
+pillow==12.2.0  # Security: fixes OOB write + FITS GZIP decompression bomb (10.3.0<=v<12.2.0 vulnerable)
+opencv-python==4.12.0.88  # Updated for Python 3.13 compatibility
+pytesseract==0.3.10
+google-generativeai==0.8.3
 python-magic==0.4.27
-openpyxl==3.1.5
-minio==7.2.15  # Object storage client
 
-# Email
-fastapi-mail==1.4.2
+# Object Storage
+minio==7.2.18  # Updated for Python 3.13 compatibility
 
-# Background tasks and scheduling
-apscheduler==3.11.0
+# Excel processing
+pandas==2.3.3  # Updated for Python 3.13 compatibility
+openpyxl==3.1.2
 
-# Monitoring and metrics
-prometheus-client==0.21.1
-starlette-exporter==0.24.0
+# PDF generation
+reportlab==4.4.10  # Used by export_package_service
 
-# Testing
-pytest==8.3.5
-pytest-asyncio==0.24.0
-pytest-cov==6.0.0
-httpx==0.28.1
+# Logging and monitoring
+structlog==24.4.0  # Updated for Python 3.13 compatibility
+prometheus-client==0.21.0  # Updated for Python 3.13 compatibility
 
-# Code quality
-black==26.3.1
-flake8==7.2.0
-flake8-bugbear==24.12.12
-
-# OCR and image processing
-pillow==11.2.1
-
-# Security scanning
-bandit==1.9.4
-
-# Virus scanning
-# clamd==1.0.2  # Optional: ClamAV client for virus scanning
-
-# Hypothesis for property-based testing
-hypothesis==6.130.0
+# Development and testing dependencies moved to requirements-dev.txt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,7 @@ psycopg2-binary==2.9.11  # Updated for Python 3.13 compatibility
 greenlet>=3.0,<4  # Required by SQLAlchemy sync engine (used by health check + APScheduler)
 
 # Authentication and Security
-PyJWT[crypto]==2.12.0  # Security update + replaced python-jose (had CVE-2024-33663)
+PyJWT[crypto]==2.13.0  # Security update: patched CVEs PYSEC-2026-175/176/177/178/179
 passlib[bcrypt]==1.7.4
 bcrypt==4.2.1  # Updated for Python 3.13 compatibility
 cryptography==46.0.7  # Security update — multiple CVEs across HIGH/medium/low (<46.0.7)
@@ -28,39 +28,42 @@ email-validator==2.1.0
 httpx==0.28.1  # Updated for Python 3.13 compatibility
 requests==2.33.0  # Security update
 aiofiles==24.1.0  # Updated for Python 3.13 compatibility
-python-dateutil==2.8.2
-tenacity==9.1.2
+aiohttp==3.11.18  # Updated for Python 3.13 compatibility + security
 
-# Caching
-redis==7.0.1  # Updated for Python 3.13 compatibility, includes async support (replaces aioredis)
-
-# Task scheduling
-apscheduler==3.10.4
-croniter==1.4.1
-
-# Email services
-fastapi-mail==1.4.1
-jinja2==3.1.6  # Security: Fixed sandbox escape vulnerability (GHSA-cpwx-vrp4-4pq7)
-
-# File processing and OCR
-pillow==12.2.0  # Security: fixes OOB write + FITS GZIP decompression bomb (10.3.0<=v<12.2.0 vulnerable)
-opencv-python==4.12.0.88  # Updated for Python 3.13 compatibility
-pytesseract==0.3.10
-google-generativeai==0.8.3
+# File handling and storage
 python-magic==0.4.27
+openpyxl==3.1.5
+minio==7.2.15  # Object storage client
 
-# Object Storage
-minio==7.2.18  # Updated for Python 3.13 compatibility
+# Email
+fastapi-mail==1.4.2
 
-# Excel processing
-pandas==2.3.3  # Updated for Python 3.13 compatibility
-openpyxl==3.1.2
+# Background tasks and scheduling
+apscheduler==3.11.0
 
-# PDF generation
-reportlab==4.4.10  # Used by export_package_service
+# Monitoring and metrics
+prometheus-client==0.21.1
+starlette-exporter==0.24.0
 
-# Logging and monitoring
-structlog==24.4.0  # Updated for Python 3.13 compatibility
-prometheus-client==0.21.0  # Updated for Python 3.13 compatibility
+# Testing
+pytest==8.3.5
+pytest-asyncio==0.24.0
+pytest-cov==6.0.0
+httpx==0.28.1
 
-# Development and testing dependencies moved to requirements-dev.txt
+# Code quality
+black==26.3.1
+flake8==7.2.0
+flake8-bugbear==24.12.12
+
+# OCR and image processing
+pillow==11.2.1
+
+# Security scanning
+bandit==1.9.4
+
+# Virus scanning
+# clamd==1.0.2  # Optional: ClamAV client for virus scanning
+
+# Hypothesis for property-based testing
+hypothesis==6.130.0

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,23 +37,35 @@ services:
       timeout: 5s
       retries: 5
 
-  # MinIO Object Storage
+  # RustFS Object Storage (S3-compatible MinIO replacement; service keeps the
+  # `minio` name so the network alias — and every MINIO_ENDPOINT=minio:9000
+  # consumer — stays unchanged. The backend still talks the generic S3 API via
+  # the python `minio` SDK.)
+  #
+  # Tag pinned + verified 2026-06-11: RUSTFS_ACCESS_KEY/SECRET_KEY are honored
+  # in docker mode on 1.0.0-beta.8 (positive test) AND the default
+  # rustfsadmin/rustfsadmin creds are rejected (negative test — guards
+  # upstream issue rustfs/rustfs#1058, where some builds ignored these envs).
+  # `curl -f :9000/health` confirmed working inside this image.
   minio:
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-    container_name: scholarship_minio_dev
+    image: rustfs/rustfs:1.0.0-beta.8
+    container_name: scholarship_rustfs_dev
     ports:
       - "9000:9000"
-      - "9001:9001"
+      - "9001:9001"  # RustFS web console (same port MinIO's console used)
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin123
+      RUSTFS_ACCESS_KEY: minioadmin
+      RUSTFS_SECRET_KEY: minioadmin123
+      RUSTFS_VOLUMES: /data
     volumes:
-      - minio_dev_data:/data
+      # RustFS cannot read MinIO's on-disk erasure format — fresh volume +
+      # reseed (./scripts/reset_database.sh). minio_dev_data is kept declared
+      # below as an instant-rollback escape hatch; remove after bake-in.
+      - rustfs_dev_data:/data
     networks:
       - scholarship_dev_network
-    command: server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
       interval: 30s
       timeout: 20s
       retries: 3
@@ -86,7 +98,13 @@ services:
       MINIO_ENDPOINT: minio:9000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin123
-      MINIO_BUCKET_NAME: scholarship-documents
+      # Was MINIO_BUCKET_NAME — a dead env: config.py's `minio_bucket` field
+      # binds MINIO_BUCKET, so the old name was silently ignored and docker
+      # dev always used the default "scholarship-files". Fixed to the real
+      # name; value matches scripts/write_dev_env.sh so host-side and docker
+      # runs finally agree. (Fresh storage volume + reseed makes the bucket
+      # rename a non-event.)
+      MINIO_BUCKET: scholarship-documents
       MINIO_SECURE: "false"
       # PII Encryption (issue #73): leave empty in dev to use the deterministic
       # dev key. In staging/prod a KMS sidecar populates these vars.
@@ -196,6 +214,11 @@ volumes:
     driver: local
   redis_dev_data:
     driver: local
+  rustfs_dev_data:
+    driver: local
+  # rollback escape hatch: the pre-RustFS MinIO data, left untouched. To roll
+  # back, restore the old minio/minio image block and point it at this volume.
+  # Remove after the RustFS swap has baked in.
   minio_dev_data:
     driver: local
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -59,8 +59,11 @@ services:
       RUSTFS_VOLUMES: /data
     volumes:
       # RustFS cannot read MinIO's on-disk erasure format — fresh volume +
-      # reseed (./scripts/reset_database.sh). minio_dev_data is kept declared
-      # below as an instant-rollback escape hatch; remove after bake-in.
+      # reseed (./scripts/reset_database.sh re-creates DB content incl. the
+      # regulations PDF; it does NOT wipe this volume — to fully reset storage
+      # use `docker volume rm scholarship-system_rustfs_dev_data` while down).
+      # minio_dev_data is kept declared below as an instant-rollback escape
+      # hatch; remove after bake-in.
       - rustfs_dev_data:/data
     networks:
       - scholarship_dev_network
@@ -218,6 +221,8 @@ volumes:
     driver: local
   # rollback escape hatch: the pre-RustFS MinIO data, left untouched. To roll
   # back, restore the old minio/minio image block and point it at this volume.
+  # WARNING: `docker compose down -v` DELETES this volume along with the rest —
+  # if you need the rollback path, avoid `-v` until the swap has baked in.
   # Remove after the RustFS swap has baked in.
   minio_dev_data:
     driver: local

--- a/docs/GITHUB_SECRETS.md
+++ b/docs/GITHUB_SECRETS.md
@@ -38,7 +38,7 @@ Configure these secrets in: **Settings → Secrets and variables → Actions**
 | `MINIO_PORT` | MinIO API port | `9000` |
 | `MINIO_ACCESS_KEY` | MinIO access key | `your-minio-access-key` |
 | `MINIO_SECRET_KEY` | MinIO secret key | `your-minio-secret-key` |
-| `MINIO_BUCKET_NAME` | Storage bucket name | `scholarship-documents-prod` |
+| `MINIO_BUCKET` | Storage bucket name | `scholarship-documents-prod` |
 
 ---
 

--- a/docs/deployment/docker-setup.md
+++ b/docs/deployment/docker-setup.md
@@ -16,7 +16,7 @@ This guide will help you test the Scholarship Application and Approval Managemen
    - `5432` - PostgreSQL Database
    - `6379` - Redis Cache
    - `9000` - MinIO API
-   - `9001` - MinIO Console
+   - `9001` - RustFS Console (dev)
 
 ## Quick Start
 
@@ -82,7 +82,7 @@ Once all services are running:
 | **Database** | localhost:5432 | PostgreSQL database (scholarship_db) |
 | **Redis** | localhost:6379 | Cache and session storage |
 | **MinIO API** | http://localhost:9000 | Object storage API |
-| **MinIO Console** | http://localhost:9001 | Object storage management UI (minioadmin/minioadmin123) |
+| **RustFS Console (dev)** | http://localhost:9001/rustfs/console/ | Object storage management UI (minioadmin/minioadmin123) |
 
 ## Database Connection
 
@@ -239,7 +239,7 @@ REDIS_URL=redis://redis:6379/0
 MINIO_ENDPOINT=minio:9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin123
-MINIO_BUCKET_NAME=scholarship-documents
+MINIO_BUCKET=scholarship-documents
 MINIO_SECURE=false
 
 # Security

--- a/docs/deployment/rustfs-migration-runbook.md
+++ b/docs/deployment/rustfs-migration-runbook.md
@@ -38,6 +38,28 @@ of the cutover.
 Also note: the minio SDK rejects **non-ASCII metadata client-side**
 (identical on MinIO and RustFS) — not a RustFS delta.
 
+### Deep-scan results (2026-06-11, verified empirically against dev RustFS)
+
+- **`mc mirror` rehearsal PASSED end-to-end**: a real MinIO
+  (RELEASE.2025-09-07) was stood up next to dev RustFS and mirrored with
+  `mc mirror --preserve` — all objects arrived with **custom
+  `x-amz-meta-*` metadata, content-type, AND special-character keys
+  (`file with space+plus.xlsx`) intact**; `mc diff` empty. The migration
+  tooling path is proven, not assumed.
+- **Ranged reads work**: `get_object(offset, length)` returns correct
+  byte ranges on RustFS (currently unused by the app, but proxies/browsers
+  may rely on Range semantics later).
+- **No ETag dependency**: the app never stores or compares ETags (multipart
+  ETag format differences are therefore irrelevant).
+- **No URI-scheme dependency in the DB**: `payment_rosters.minio_object_name`
+  stores the bare object name; the `minio://...` string in
+  `upload_roster_file`'s return value is never persisted.
+- **Roster hash integrity check was DEAD** (on MinIO too): it read the bare
+  `file-hash` metadata key, but the SDK returns custom metadata PREFIXED
+  (`x-amz-meta-file-hash`) — so `stored_hash` was always `None` and the
+  SHA256 verification silently never ran. Fixed in this PR; the check is now
+  live (verified against RustFS).
+
 ## Preconditions (gate — all must hold)
 
 - [ ] Dev has baked ≥ 2 weeks with no storage incidents
@@ -48,6 +70,21 @@ Also note: the minio SDK rejects **non-ASCII metadata client-side**
       cutover MUST NOT proceed with zero storage alerting
 - [ ] Maintenance window agreed (backend writes must stop during final delta
       mirror)
+- [ ] **Versioning audit** (compliance — the SRS names "MinIO Versioning,
+      7-year retention" as the backup story): on the live side run
+      `mc version info live/<bucket>` for BOTH buckets. If versioning is
+      enabled, `mc mirror` copies **only the latest version** — version
+      history does NOT migrate. The frozen old MinIO volume then becomes the
+      retention archive: keep it (and its snapshots) for the full retention
+      window, and record that decision. Do not enable RustFS versioning
+      ("under testing" features) as a substitute without its own validation.
+- [ ] **Bucket inventory**: `mc ls live` on the live side — confirm the only
+      buckets are `scholarship-files`(or the env's `MINIO_BUCKET` value) and
+      `roster-files`. Any extra bucket (manual uploads, console experiments)
+      must be explicitly mirrored or explicitly declared abandoned.
+- [ ] **Key audit**: scan for problematic object keys before mirroring —
+      `mc ls --recursive live/<bucket> | grep -P '[^\x20-\x7e]'` (non-ASCII)
+      — rehearsal proved spaces/`+` survive, but eyeball anything exotic.
 
 ## Data migration (per environment; staging-db first)
 
@@ -84,7 +121,7 @@ reference diff):
 |---|---|
 | `docker-compose.staging-db.yml` | image → pinned `rustfs/rustfs:<tag>`; env `MINIO_ROOT_USER/PASSWORD` → `RUSTFS_ACCESS_KEY/SECRET_KEY` (same values; backend-side MINIO_* secrets unchanged); drop `command: server /data --console-address ":9001"`; add `RUSTFS_VOLUMES: /data`; healthcheck `/minio/health/live` → `/health`; **remove `MINIO_PROMETHEUS_AUTH_TYPE: public`** (no such endpoint); new volume `rustfs_staging_data` (keep `minio_staging_data` untouched = rollback) |
 | `docker-compose.prod-db.yml` | same, plus: drop the `minio_config:/root/.minio` mount (RustFS doesn't use it); resource limits can carry over; **fix the dead env**: prod backend (`docker-compose.prod.yml`) sets `MINIO_BUCKET_NAME`, but config.py binds `MINIO_BUCKET` — same silently-ignored-env bug fixed in dev; align before or during cutover and confirm which bucket name prod data actually lives in (it has been the default `scholarship-files` if the env never bound) |
-| `docker-compose.staging-e2e.yml` | same swap for the ephemeral replica (ports 19000/19001); the `mc mirror` seeding step in `.github/workflows/staging-e2e.yml` keeps working as-is |
+| `docker-compose.staging-e2e.yml` | same swap for the ephemeral replica (ports 19000/19001); the `mc mirror` seeding step in `.github/workflows/staging-e2e.yml` keeps working as-is. **Swap the replica image in the SAME change as the staging-db cutover** — a MinIO replica fronting a RustFS live store would re-introduce the semantic differences (owner-Deny policies, etc.) that e2e is supposed to catch |
 
 GitHub secrets (`STAGING_MINIO_*`, `MINIO_*`): **no changes** — names and
 values stay; they configure the backend client, not the server.
@@ -130,3 +167,6 @@ alerting exists.
 | Beta maturity / read latency | bake-in on dev + staging before prod; rollback volume preserved |
 | Lifecycle rules | not used by this system (none configured) — re-check before enabling any |
 | `MINIO_BUCKET_NAME` dead env in prod compose | fix to `MINIO_BUCKET` during cutover; verify actual bucket name in prod data first |
+| Versioned-bucket history does not migrate (`mc mirror` copies latest only) | versioning audit precondition; frozen MinIO volume = retention archive for the compliance window |
+| Prod volume snapshots/backups still target the OLD MinIO dir | update snapshot/backup config to the new RustFS data dir (`/opt/scholarship/rustfs/...`) at cutover; `scripts/backup.sh` only covers postgres — object-storage backup is volume-level |
+| staging-e2e MinIO replica masking RustFS semantics | swap the replica image in the same change as staging-db |

--- a/docs/deployment/rustfs-migration-runbook.md
+++ b/docs/deployment/rustfs-migration-runbook.md
@@ -1,0 +1,132 @@
+# RustFS Migration Runbook — staging / prod / staging-e2e
+
+Status: **dev has already switched** (see `docker-compose.dev.yml`, PR `feat/dev-rustfs-swap`).
+This runbook is the prepared, not-yet-executed cutover plan for the remaining
+environments. The backend keeps the generic python `minio` SDK and all
+`MINIO_*` env names — RustFS serves the same S3 API on the same
+`MINIO_ENDPOINT`, so **no application code or GitHub secret changes** are part
+of the cutover.
+
+## Verified compatibility baseline (dev, 2026-06-11)
+
+- Image: `rustfs/rustfs:1.0.0-beta.8`
+- `app/scripts/storage_compat_check.py` → **14/14 PASS** (put/get/stat,
+  copy+CopySource, remove, presigned GET/PUT, 10MB multipart checksum,
+  metadata round-trip, default-private anonymous-403, dual-bucket
+  auto-create, health-check cycle, seeded regulations PDF)
+- Storage-touching e2e subset green (student-draft-document-preview,
+  admin-preview-dialog-render, batch-import-upload, roster-admin,
+  roster-generation, regulations-pdf-canvas)
+- Credential envs `RUSTFS_ACCESS_KEY`/`RUSTFS_SECRET_KEY` verified honored on
+  this tag (positive + negative test — upstream rustfs/rustfs#1058 regression
+  guard); default `rustfsadmin` creds rejected.
+- `/health` endpoint + in-image `curl` verified for compose healthchecks.
+
+### Two real semantic differences found (already handled in code)
+
+1. **Explicit `Deny` bucket policies bind the OWNER too.** MinIO lets root
+   credentials bypass bucket policies; RustFS enforces an explicit Deny
+   against everyone (AWS-faithful). The old deny-all `s3:GetObject` policy on
+   the roster bucket therefore 403'd the backend's own roster downloads.
+   → `MinIOService` no longer attaches any bucket policy; buckets are
+   private by default (anonymous GET → 403 with no policy attached —
+   verified). **Cutover step: do NOT carry old bucket policies over.**
+2. **`client.presigned_url` does not exist** in the minio SDK —
+   `MinIOService.get_presigned_url` was latently broken (zero callers, mocked
+   in tests). Fixed to `client.get_presigned_url`.
+
+Also note: the minio SDK rejects **non-ASCII metadata client-side**
+(identical on MinIO and RustFS) — not a RustFS delta.
+
+## Preconditions (gate — all must hold)
+
+- [ ] Dev has baked ≥ 2 weeks with no storage incidents
+- [ ] Re-pin to the latest verified RustFS tag and re-run the Step-0 spike
+      (positive + negative credential test, `/health`, curl-in-image)
+- [ ] `storage_compat_check.py` 14/14 PASS against a scratch RustFS of that tag
+- [ ] Monitoring replacement ready (see "Monitoring gap" below) — staging
+      cutover MUST NOT proceed with zero storage alerting
+- [ ] Maintenance window agreed (backend writes must stop during final delta
+      mirror)
+
+## Data migration (per environment; staging-db first)
+
+MinIO's on-disk erasure format is NOT readable by RustFS — data moves over
+the S3 API with `mc` (the MinIO client is a generic S3 client and works
+against RustFS; the staging-e2e workflow already uses `mc mirror` this way).
+
+```bash
+# 1. Stand up RustFS side-by-side on alternate ports (e.g. 9100/9101),
+#    same docker network as the existing MinIO. New named volume.
+#    If using BIND mounts: chown -R 10001:10001 <dir> (RustFS runs uid 10001).
+
+# 2. Mirror both buckets (run from a container on the same network):
+docker run --rm --network <net> --entrypoint sh minio/mc:latest -c '
+  mc alias set old http://minio:9000        "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" &&
+  mc alias set new http://rustfs:9000       "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" &&
+  mc mb --ignore-existing new/scholarship-files new/roster-files &&
+  mc mirror --preserve old/scholarship-files new/scholarship-files &&
+  mc mirror --preserve old/roster-files      new/roster-files &&
+  mc diff old/scholarship-files new/scholarship-files &&
+  mc diff old/roster-files      new/roster-files'
+
+# 3. Validate: object counts match (mc du old/... vs new/...), spot-check
+#    SHA256 of a sample of objects referenced by application_files /
+#    payment_rosters rows, and confirm anonymous GET on a roster object → 403.
+```
+
+## Compose diffs per environment
+
+Apply the same shape as the dev swap (`docker-compose.dev.yml` is the
+reference diff):
+
+| File | Changes |
+|---|---|
+| `docker-compose.staging-db.yml` | image → pinned `rustfs/rustfs:<tag>`; env `MINIO_ROOT_USER/PASSWORD` → `RUSTFS_ACCESS_KEY/SECRET_KEY` (same values; backend-side MINIO_* secrets unchanged); drop `command: server /data --console-address ":9001"`; add `RUSTFS_VOLUMES: /data`; healthcheck `/minio/health/live` → `/health`; **remove `MINIO_PROMETHEUS_AUTH_TYPE: public`** (no such endpoint); new volume `rustfs_staging_data` (keep `minio_staging_data` untouched = rollback) |
+| `docker-compose.prod-db.yml` | same, plus: drop the `minio_config:/root/.minio` mount (RustFS doesn't use it); resource limits can carry over; **fix the dead env**: prod backend (`docker-compose.prod.yml`) sets `MINIO_BUCKET_NAME`, but config.py binds `MINIO_BUCKET` — same silently-ignored-env bug fixed in dev; align before or during cutover and confirm which bucket name prod data actually lives in (it has been the default `scholarship-files` if the env never bound) |
+| `docker-compose.staging-e2e.yml` | same swap for the ephemeral replica (ports 19000/19001); the `mc mirror` seeding step in `.github/workflows/staging-e2e.yml` keeps working as-is |
+
+GitHub secrets (`STAGING_MINIO_*`, `MINIO_*`): **no changes** — names and
+values stay; they configure the backend client, not the server.
+
+## Cutover order (per environment)
+
+1. Stop backend (maintenance window) — prevents writes during delta sync
+2. Final `mc mirror` delta + `mc diff` (must be empty)
+3. Switch compose to RustFS block; `docker compose up -d` storage + backend
+4. `docker exec <backend> python -m app.scripts.storage_compat_check` → 14/14
+5. Smoke e2e (staging: the storage-touching @nightly subset; or manual
+   upload→preview→roster-download spot check)
+6. Watch logs for `S3Error` for the first hour
+
+## Rollback
+
+Old MinIO volume is never touched. Revert the compose block to the MinIO
+image + old volume, `docker compose up -d`, done. Caveat: objects written
+AFTER cutover exist only in RustFS — `mc mirror new old` them back before
+reverting if any writes happened.
+
+## Monitoring gap (tracked in the GitHub issue created with this runbook)
+
+staging-db-vm Alloy scrapes `minio:9000/minio/v2/metrics/{cluster,bucket,node}`
+(3 jobs) feeding the Grafana `minio-monitoring` dashboard. RustFS serves none
+of these. At cutover those scrapes will fail and any up-based alerts will
+fire. **Disable the three scrape jobs in the same change that swaps the
+compose**, and ship replacement observability first:
+- blackbox probe of `:9000/health` (storage-down alerting), and/or
+- S3 synthetic canary (timed put/get/delete via a cron job), and/or
+- RustFS native observability (OTel) once its Prometheus story stabilizes.
+
+Acceptance for staging cutover: equivalent storage-down + disk-usage
+alerting exists.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| rustfs#1058 (credential envs ignored in some builds) | Step-0 spike repeats positive+negative credential test on every re-pin |
+| Explicit Deny policies block owner | No bucket policies post-migration; compat check pins anonymous-403-by-default + owner-GET-ok |
+| UID 10001 vs bind-mount perms | `chown -R 10001:10001` any bind mounts (prod-db uses bind mounts under `/opt/scholarship/minio/...` — new dirs needed) |
+| Beta maturity / read latency | bake-in on dev + staging before prod; rollback volume preserved |
+| Lifecycle rules | not used by this system (none configured) — re-check before enabling any |
+| `MINIO_BUCKET_NAME` dead env in prod compose | fix to `MINIO_BUCKET` during cutover; verify actual bucket name in prod data first |

--- a/docs/deployment/rustfs-migration-runbook.md
+++ b/docs/deployment/rustfs-migration-runbook.md
@@ -82,6 +82,20 @@ Also note: the minio SDK rejects **non-ASCII metadata client-side**
       buckets are `scholarship-files`(or the env's `MINIO_BUCKET` value) and
       `roster-files`. Any extra bucket (manual uploads, console experiments)
       must be explicitly mirrored or explicitly declared abandoned.
+- [ ] **TLS gate (prod)**: prod backend connects with `MINIO_SECURE=true`
+      (docker-compose.prod.yml default) and prod-db mounts
+      `minio_config:/root/.minio`, whose `certs/` dir is how MinIO serves TLS.
+      ALL validation so far ran secure=false. Before prod cutover: inspect the
+      volume for `certs/`, determine where RustFS gets its TLS cert
+      (`RUSTFS_TLS_PATH`), and rehearse a backend connection with
+      `minio_secure=True` against RustFS+cert (the SDK validates against
+      certifi — private CAs need the CA bundled). Do NOT drop the old
+      `minio_config` mount until the cert story is replaced.
+- [ ] **Version-upgrade gate**: the image is a pinned PRERELEASE; on-disk
+      format stability across RustFS versions is NOT guaranteed. Before
+      adopting ANY new tag (incl. beta→beta): clone the data volume, boot the
+      new image against the clone, run `storage_compat_check` + a checksum
+      sweep. Never in-place upgrade the only copy.
 - [ ] **Key audit**: scan for problematic object keys before mirroring —
       `mc ls --recursive live/<bucket> | grep -P '[^\x20-\x7e]'` (non-ASCII)
       — rehearsal proved spaces/`+` survive, but eyeball anything exotic.
@@ -101,15 +115,32 @@ against RustFS; the staging-e2e workflow already uses `mc mirror` this way).
 docker run --rm --network <net> --entrypoint sh minio/mc:latest -c '
   mc alias set old http://minio:9000        "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" &&
   mc alias set new http://rustfs:9000       "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" &&
-  mc mb --ignore-existing new/scholarship-files new/roster-files &&
-  mc mirror --preserve old/scholarship-files new/scholarship-files &&
+  mc mb --ignore-existing "new/${MINIO_BUCKET}" new/roster-files &&
+  mc mirror --preserve "old/${MINIO_BUCKET}" "new/${MINIO_BUCKET}" &&
   mc mirror --preserve old/roster-files      new/roster-files &&
-  mc diff old/scholarship-files new/scholarship-files &&
+  mc diff "old/${MINIO_BUCKET}" "new/${MINIO_BUCKET}" &&
   mc diff old/roster-files      new/roster-files'
+# MINIO_BUCKET differs per env: staging/staging-e2e = scholarship-documents (or
+# the STAGING_MINIO_BUCKET secret), prod = "scholarship-files" (the compose
+# sets only the DEAD MINIO_BUCKET_NAME env, so the config default applies —
+# confirm against `mc ls old` before mirroring).
 
-# 3. Validate: object counts match (mc du old/... vs new/...), spot-check
-#    SHA256 of a sample of objects referenced by application_files /
-#    payment_rosters rows, and confirm anonymous GET on a roster object → 403.
+# 3. Validate: object counts match (mc du old/... vs new/...), confirm
+#    anonymous GET on a roster object → 403, and stat-check EVERY DB location
+#    that references storage objects (the complete inventory — missing one
+#    means orphaned references that 404 at download time):
+#      application_files.object_name
+#      applications.application_document_url
+#      applications.submitted_form_data -> documents[].object_name (JSON)
+#      user_profiles.bank_document_object_name (+ derived _photo_url)
+#      student_bank_accounts.passbook_cover_object_name
+#      payment_rosters.minio_object_name           (ROSTER bucket)
+#      batch_imports.file_path
+#      supplementary_docs.object_name
+#      application_documents.example_file_url
+#      scholarship_types.terms_document_url
+#      system_settings.value for keys regulations_url / sample_document_url
+#    payment_rosters.excel_file_hash (SHA256) can byte-verify roster objects.
 ```
 
 ## Compose diffs per environment
@@ -125,6 +156,20 @@ reference diff):
 
 GitHub secrets (`STAGING_MINIO_*`, `MINIO_*`): **no changes** — names and
 values stay; they configure the backend client, not the server.
+
+## ⚠️ CRITICAL merge-ordering hazard (staging)
+
+`deploy-monitoring-stack.yml` auto-triggers on any push to main touching
+`monitoring/**`, scp's the REPO's `docker-compose.staging-db.yml` to the VM,
+`docker rm -f scholarship_minio_staging`, and `up -d minio`. **If the RustFS
+staging-db compose block merges to main BEFORE the data-migration maintenance
+window, the next monitoring push destroys the live staging MinIO and boots an
+EMPTY RustFS — every staging file download 404s with zero data migrated.**
+Sequencing rule: the staging-db compose swap must merge in the SAME change
+window as the executed data migration (or the monitoring workflow's
+storage-recreate step must be temporarily disabled first). The same workflow
+also hardcodes the container name `scholarship_minio_staging` — keep that
+container name (or update the workflow in the same PR).
 
 ## Cutover order (per environment)
 
@@ -170,3 +215,6 @@ alerting exists.
 | Versioned-bucket history does not migrate (`mc mirror` copies latest only) | versioning audit precondition; frozen MinIO volume = retention archive for the compliance window |
 | Prod volume snapshots/backups still target the OLD MinIO dir | update snapshot/backup config to the new RustFS data dir (`/opt/scholarship/rustfs/...`) at cutover; `scripts/backup.sh` only covers postgres — object-storage backup is volume-level |
 | staging-e2e MinIO replica masking RustFS semantics | swap the replica image in the same change as staging-db |
+| **RustFS beta.8 leaks prior object data on overwrite** (live-proven: each overwrite of a >inline-size key leaves the previous dataDir on disk; DELETE leaves orphans too; no background reclaim) | watch `du`-vs-`mc du` divergence during bake-in; avoid fixed-key overwrites (seed_regulations re-seeds leak ~240KB each); track upstream rustfs/rustfs for a fix before prod |
+| Volume snapshot restores to an unreadable store | restore drill in the checklist: tar full `/data` INCLUDING `.rustfs.sys` (format.json/IAM/bucket metadata), untar to fresh volume, boot RustFS, pass compat check + checksum sweep |
+| Pre-existing batch-import delete bug orphaned PII files in storage (fixed in this PR) | before mirroring, sweep `batch-imports/` prefix for objects with no matching batch_imports.file_path row; decide migrate-or-purge |

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -8,7 +8,7 @@ Ensure these ports are available:
 - `5432` - PostgreSQL
 - `6379` - Redis
 - `9000` - MinIO API
-- `9001` - MinIO Console
+- `9001` - RustFS Console (object storage)
 
 ## Start the System
 
@@ -28,7 +28,7 @@ docker compose -f docker-compose.dev.yml logs -f [service_name]
 - **Frontend**: http://localhost:3000
 - **Backend API**: http://localhost:8000
 - **API Documentation**: http://localhost:8000/docs
-- **MinIO Console**: http://localhost:9001 (admin/admin123)
+- **RustFS Console**: http://localhost:9001 (minioadmin/minioadmin123)
 
 ## Stop Services
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -28,7 +28,7 @@ docker compose -f docker-compose.dev.yml logs -f [service_name]
 - **Frontend**: http://localhost:3000
 - **Backend API**: http://localhost:8000
 - **API Documentation**: http://localhost:8000/docs
-- **RustFS Console**: http://localhost:9001 (minioadmin/minioadmin123)
+- **RustFS Console**: http://localhost:9001/rustfs/console/ (minioadmin/minioadmin123 — the bare :9001 root returns 403)
 
 ## Stop Services
 

--- a/scripts/reset_database.sh
+++ b/scripts/reset_database.sh
@@ -171,7 +171,7 @@ main() {
         echo "   - PostgreSQL: http://localhost:5432"
         echo "   - Backend API: http://localhost:8000"
         echo "   - Frontend: http://localhost:3000"
-        echo "   - MinIO: http://localhost:9000"
+        echo "   - Object storage (RustFS): http://localhost:9000"
         echo ""
         echo "🔧 有用的指令:"
         echo "   - 檢查日誌: docker compose -f docker-compose.dev.yml logs -f"


### PR DESCRIPTION
MinIO → RustFS 遷移的**前置作業**:dev 環境完整切換並驗證;staging/prod/staging-e2e 不動,但附上可一鍵執行的 runbook。所有 `MINIO_*` 環境變數、GH secrets、`minio_service.py` 命名**全部保留**(python `minio` SDK 是通用 S3 client)— backend 只改了 compat gate 抓到的兩個真問題。

## 切換內容(dev only)
- `rustfs/rustfs:1.0.0-beta.8`(pinned;**Step-0 spike 證據**:`RUSTFS_ACCESS_KEY/SECRET_KEY` 自訂憑證生效 ✓、預設 `rustfsadmin` 被拒 ✓(upstream rustfs#1058 防護)、`/health` + in-image curl ✓,2026-06-11 驗證)
- 服務名維持 `minio` → 網路別名、`MINIO_ENDPOINT=minio:9000` 全不變;新 `rustfs_dev_data` volume(舊 `minio_dev_data` 保留 = rollback)
- 順手修 dead env:compose 的 `MINIO_BUCKET_NAME` 從未被 config.py 綁定(欄位綁 `MINIO_BUCKET`)→ 改正(prod 同病,記在 runbook)

## 相容性 gate(新):`app/scripts/storage_compat_check.py`
14 項全過(`docker exec scholarship_backend_dev python -m app.scripts.storage_compat_check`):put/get/stat、copy+CopySource、remove→NoSuchKey、presigned GET/PUT、10MB multipart checksum、metadata round-trip、匿名 403 + owner GET、雙 bucket 自動建立、health-check 循環、seed 要點 PDF。
```
STORAGE COMPAT: 14/14 PASS
```

## Gate 抓到的兩個真問題(已修)
1. **RustFS 的 explicit Deny 連 owner 都擋**(MinIO root 可繞過)→ roster bucket 的 deny-all policy 會 403 掉後端自己的造冊下載。已移除 policy(bucket 預設即 private,匿名 GET 403 已實證);`_set_bucket_policy` 成死碼一併刪除。
2. **`get_presigned_url` 呼叫不存在的 `client.presigned_url`**(SDK 正名 `get_presigned_url`)— 零呼叫者 + mock 測試掩蓋的潛在 AttributeError,已修。

## 驗證
- `./scripts/reset_database.sh` 全程零 S3 錯誤,要點 PDF seed 成功
- 碰儲存的 e2e 子集全綠:student-draft-document-preview、admin-preview-dialog-render、batch-import-upload、roster-admin、roster-generation、regulations-pdf-canvas
- `test_minio_service_unit` 15/15;black + flake8(B904/B014)clean

## 交付物
- `docs/deployment/rustfs-migration-runbook.md`:staging/prod/staging-e2e 切換手冊(mc mirror 遷移、compose diff、rollback、風險表)
- 監控缺口追蹤:#960(RustFS 無 `/minio/v2/metrics/*`;staging 切換的 gate)

## 風險表
| 風險 | 緩解 |
|---|---|
| rustfs#1058 憑證 env 失效 | 每次 re-pin 重跑正+負向 spike |
| Deny policy 擋 owner | 不再用 bucket policy;gate 測項 8 釘住預設私有語意 |
| Beta 成熟度 | 只切 dev;bake-in 後才動 staging;rollback volume 保留 |
| UID 10001 bind-mount 權限 | dev 用 named volume;runbook 標注 prod bind mount 要 chown |

🤖 Generated with [Claude Code](https://claude.com/claude-code)