### PR TITLE
fix(#963): guard destructive migration 06e8a66d9437 against data loss (audit gap G1)

### DIFF
--- a/backend/alembic/versions/06e8a66d9437_cleanup_old_applications.py
+++ b/backend/alembic/versions/06e8a66d9437_cleanup_old_applications.py
@@ -5,6 +5,8 @@ Revises: 7f1085a5bbe0
 Create Date: 2025-10-23 10:02:44.400544
 
 """
+
+import os
 from typing import Sequence, Union
 
 from sqlalchemy import text
@@ -35,6 +37,39 @@ def upgrade() -> None:
     # 使用 TRUNCATE CASCADE 來自動處理所有外鍵引用
     # 這會清空表並重置序列，同時自動處理外鍵約束
 
+    # Get database connection
+    connection = op.get_bind()
+
+    # ------------------------------------------------------------------
+    # Destructive-migration guard (issue #963 / audit gap G1).
+    #
+    # This revision irreversibly TRUNCATEs every application/review/payment
+    # table. On a FRESH database (normal `alembic upgrade head` during
+    # first-time setup) the tables are empty and the truncate is a no-op, so
+    # the guard lets it through. But if it would destroy actual rows — e.g.
+    # someone restores a production dump and replays migrations, or points
+    # alembic at the wrong DATABASE_URL — refuse to run unless the operator
+    # explicitly opts in with ALLOW_DESTRUCTIVE_MIGRATIONS=true.
+    #
+    # Note: we gate on data-at-risk rather than ENVIRONMENT because staging
+    # also runs with ENVIRONMENT=production, and a fresh staging/dev rebuild
+    # must not be blocked. 申請紀錄為應依保存年限留存之檔案（會計法 §83/84、
+    # 檔案法銷毀核准程序）— 任何會銷毀它們的路徑都必須是顯式且可稽核的。
+    # ------------------------------------------------------------------
+    applications_exists = connection.execute(text("SELECT to_regclass('applications')")).scalar()
+    existing_applications = 0
+    if applications_exists:
+        existing_applications = connection.execute(text("SELECT count(*) FROM applications")).scalar() or 0
+
+    if existing_applications > 0 and os.getenv("ALLOW_DESTRUCTIVE_MIGRATIONS", "").lower() != "true":
+        raise RuntimeError(
+            f"Refusing to run destructive migration 06e8a66d9437: it would TRUNCATE "
+            f"{existing_applications} existing application row(s) plus every review/ranking/"
+            f"payment table, and downgrade() cannot restore them. If this is genuinely "
+            f"intended (e.g. a sanctioned data reset), re-run with "
+            f"ALLOW_DESTRUCTIVE_MIGRATIONS=true."
+        )
+
     # 清空所有申請相關的表（使用 TRUNCATE 避免外鍵問題）
     tables_to_truncate = [
         "payment_roster_items",
@@ -49,9 +84,6 @@ def upgrade() -> None:
         "applications",
         "application_sequences",
     ]
-
-    # Get database connection
-    connection = op.get_bind()
 
     for table in tables_to_truncate:
         # Use savepoint to isolate each TRUNCATE operation

--- a/backend/app/tests/test_destructive_migration_guard.py
+++ b/backend/app/tests/test_destructive_migration_guard.py
@@ -1,0 +1,113 @@
+"""Guard contract for the destructive migration 06e8a66d9437 (issue #963 / audit gap G1).
+
+That revision TRUNCATE CASCADEs every application/review/payment table and its
+downgrade() is a documented no-op — replayed against a database that holds real
+申請紀錄 it would destroy years of audit-relevant history in one shot. These
+tests pin the data-at-risk guard:
+
+  - rows present + no override  -> RuntimeError, NOTHING truncated
+  - rows present + ALLOW_DESTRUCTIVE_MIGRATIONS=true -> proceeds
+  - fresh/empty database        -> proceeds (truncate is a no-op there)
+
+Sync tests on purpose: they run in the CI `unit` lane.
+"""
+
+import importlib.util
+import pathlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+MIGRATION_PATH = (
+    pathlib.Path(__file__).resolve().parents[2] / "alembic" / "versions" / "06e8a66d9437_cleanup_old_applications.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_06e8a66d9437", MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeConnection:
+    """Stands in for the alembic bind. Records every executed statement."""
+
+    def __init__(self, application_count: int, applications_table_exists: bool = True):
+        self.application_count = application_count
+        self.applications_table_exists = applications_table_exists
+        self.statements: list[str] = []
+
+    def execute(self, clause):
+        sql = str(clause)
+        self.statements.append(sql)
+        if "to_regclass" in sql:
+            return SimpleNamespace(scalar=lambda: ("applications" if self.applications_table_exists else None))
+        if "count(*)" in sql.lower():
+            return SimpleNamespace(scalar=lambda: self.application_count)
+        # SAVEPOINT / TRUNCATE / RELEASE — nothing to return.
+        return SimpleNamespace(scalar=lambda: None)
+
+    def truncate_statements(self) -> list[str]:
+        return [s for s in self.statements if s.upper().startswith("TRUNCATE")]
+
+
+def _run_upgrade(connection, monkeypatch, allow: str | None):
+    migration = _load_migration()
+    if allow is None:
+        monkeypatch.delenv("ALLOW_DESTRUCTIVE_MIGRATIONS", raising=False)
+    else:
+        monkeypatch.setenv("ALLOW_DESTRUCTIVE_MIGRATIONS", allow)
+    with patch.object(migration.op, "get_bind", return_value=connection):
+        migration.upgrade()
+
+
+def test_refuses_when_applications_exist_and_no_override(monkeypatch):
+    connection = FakeConnection(application_count=137)
+    with pytest.raises(RuntimeError) as exc:
+        _run_upgrade(connection, monkeypatch, allow=None)
+    assert "137" in str(exc.value)
+    assert "ALLOW_DESTRUCTIVE_MIGRATIONS" in str(exc.value)
+    # The guard must fire BEFORE any destructive statement.
+    assert connection.truncate_statements() == []
+
+
+def test_explicit_override_allows_truncation(monkeypatch):
+    connection = FakeConnection(application_count=137)
+    _run_upgrade(connection, monkeypatch, allow="true")
+    truncated = connection.truncate_statements()
+    assert any("applications" in s for s in truncated)
+    assert len(truncated) == 11  # all listed tables attempted
+
+
+def test_fresh_database_proceeds_without_override(monkeypatch):
+    # Empty applications table — the truncate is a no-op, first-time setup
+    # (alembic upgrade head on a fresh DB) must not be blocked.
+    connection = FakeConnection(application_count=0)
+    _run_upgrade(connection, monkeypatch, allow=None)
+    assert len(connection.truncate_statements()) == 11
+
+
+def test_missing_applications_table_proceeds(monkeypatch):
+    # to_regclass returns NULL on a database created before that table existed.
+    connection = FakeConnection(application_count=0, applications_table_exists=False)
+    _run_upgrade(connection, monkeypatch, allow=None)
+    # No count query should have been issued against a missing table.
+    assert not any("count(*)" in s.lower() for s in connection.statements)
+    assert len(connection.truncate_statements()) == 11
+
+
+def test_non_true_override_values_still_refuse(monkeypatch):
+    # Only the literal "true" (case-insensitive) opts in — not "1"/"yes".
+    for value in ("1", "yes", "false", ""):
+        connection = FakeConnection(application_count=5)
+        with pytest.raises(RuntimeError):
+            _run_upgrade(connection, monkeypatch, allow=value)
+        assert connection.truncate_statements() == []
+
+
+def test_override_is_case_insensitive(monkeypatch):
+    connection = FakeConnection(application_count=5)
+    _run_upgrade(connection, monkeypatch, allow="TRUE")
+    assert len(connection.truncate_statements()) == 11


### PR DESCRIPTION
First fix from the 申請歷史 audit (tracking: #995). Gap **G1 (critical)**: migration `06e8a66d9437` TRUNCATE CASCADEs 11 application/review/payment tables, `downgrade()` is a no-op, and the deploy pipeline runs `alembic upgrade head` unconditionally — replaying it against a DB with real data (restored prod dump / wrong DATABASE_URL) would destroy all application history irreversibly.

**Guard design — data-at-risk, not ENVIRONMENT:** staging also runs `ENVIRONMENT=production`, and fresh staging/dev rebuilds must keep working. So the guard counts `applications` rows: any rows present → `RuntimeError` *before the first TRUNCATE*, unless the operator explicitly sets `ALLOW_DESTRUCTIVE_MIGRATIONS=true`. Fresh/empty DBs (where the truncate is a no-op) proceed unchanged — first-time setup, `reset_database.sh`, and CI are unaffected.

**Tests** (`test_destructive_migration_guard.py`, sync → unit lane, 6 cases): refuse-with-rows + nothing truncated before refusal; explicit override truncates all 11 tables; fresh DB proceeds; missing `applications` table proceeds (matches the migration's tolerate-missing-tables design); only literal `"true"` (case-insensitive) opts in.

Verified: 6/6 pass in the backend image; black + flake8 (B904/B014) clean.

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)