### PR TITLE
feat: eligibility status and rule-comparison detail columns in roster detail view

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -74,6 +74,10 @@ def _roster_item_dict_with_display_year(item: PaymentRosterItem, roster: Payment
     data = RosterItemResponse.model_validate(item).model_dump()
     if data.get("allocation_year") is None:
         data["allocation_year"] = roster.academic_year
+    # 符合資格 flag for the 查看名單 table — prefer the generation-time snapshot
+    # verdict; legacy items without a snapshot fall back to "no failed rules".
+    rule_result = data.get("rule_validation_result") or {}
+    data["is_eligible"] = bool(rule_result.get("is_eligible", not data.get("failed_rules")))
     return data
 
 

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -63,7 +63,12 @@ def _require_admin(user: User) -> None:
         raise HTTPException(status_code=403, detail="Admin role required")
 
 
-def _roster_item_dict_with_display_year(item: PaymentRosterItem, roster: PaymentRoster) -> dict:
+# Large per-item JSON snapshots that only the 查看名單 detail view reads;
+# list views serialize many rosters × items and must not ship them.
+_HEAVY_ITEM_FIELDS = {"rule_validation_result", "verification_snapshot"}
+
+
+def _roster_item_dict_with_display_year(item: PaymentRosterItem, roster: PaymentRoster, *, slim: bool = False) -> dict:
     """Serialize a roster item for the UI, resolving the display year.
 
     Uses the per-item snapshot when set (the consumed/borrowed prior-year quota
@@ -71,13 +76,9 @@ def _roster_item_dict_with_display_year(item: PaymentRosterItem, roster: Payment
     every 分發名單 row shows which year's quota it draws from. Monthly/legacy
     rosters never snapshot allocation_year, so without this they'd show no year.
     """
-    data = RosterItemResponse.model_validate(item).model_dump()
+    data = RosterItemResponse.model_validate(item).model_dump(exclude=_HEAVY_ITEM_FIELDS if slim else None)
     if data.get("allocation_year") is None:
         data["allocation_year"] = roster.academic_year
-    # 符合資格 flag for the 查看名單 table — prefer the generation-time snapshot
-    # verdict; legacy items without a snapshot fall back to "no failed rules".
-    rule_result = data.get("rule_validation_result") or {}
-    data["is_eligible"] = bool(rule_result.get("is_eligible", not data.get("failed_rules")))
     return data
 
 
@@ -461,7 +462,9 @@ async def list_payment_rosters(
 
             # 添加關聯資料（已 eager loaded，避免 MissingGreenlet）
             if roster.items:
-                roster_dict["items"] = [_roster_item_dict_with_display_year(item, roster) for item in roster.items]
+                roster_dict["items"] = [
+                    _roster_item_dict_with_display_year(item, roster, slim=True) for item in roster.items
+                ]
             if roster.audit_logs:
                 roster_dict["audit_logs"] = [
                     RosterAuditLogResponse.model_validate(log).model_dump() for log in roster.audit_logs

--- a/backend/app/models/payment_roster.py
+++ b/backend/app/models/payment_roster.py
@@ -273,8 +273,20 @@ class PaymentRosterItem(Base):
 
     @property
     def is_qualified(self) -> bool:
-        """檢查是否合格"""
+        """撥款合格：學籍驗證通過 + 納入造冊 + 有郵局帳號"""
         return self.verification_status == StudentVerificationStatus.VERIFIED and self.is_included and self.bank_account
+
+    @property
+    def is_eligible(self) -> bool | None:
+        """規則資格：造冊產生當下的獎學金規則驗證快照判定。
+
+        Distinct from is_qualified (payment readiness) — this reflects the
+        rule engine's verdict frozen at generation time. None when the item
+        predates rule-validation snapshots.
+        """
+        if not self.rule_validation_result:
+            return None
+        return bool(self.rule_validation_result.get("is_eligible", not self.failed_rules))
 
     def generate_excel_remarks(self, period_label: str, scholarship_code: str) -> str:
         """產生Excel說明欄內容"""

--- a/backend/app/schemas/roster.py
+++ b/backend/app/schemas/roster.py
@@ -55,9 +55,16 @@ class RosterItemResponse(BaseModel):
     allocation_year: Optional[int] = None
     bank_account: Optional[str] = None
     verification_status: StudentVerificationStatus
+    verification_message: Optional[str] = None
     verification_snapshot: Optional[Dict[str, Any]] = None
     is_included: bool
     exclusion_reason: Optional[str] = None
+    # 資格驗證結果（造冊產生時快照，儲存於 DB）
+    rule_validation_result: Optional[Dict[str, Any]] = None
+    failed_rules: Optional[List[str]] = None
+    warning_rules: Optional[List[str]] = None
+    # 是否符合資格 — derived from rule_validation_result by the serializer helper
+    is_eligible: Optional[bool] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
     # 學生學院/系所資訊（從 application.student_data 取得，非 ORM 欄位）

--- a/backend/app/schemas/roster.py
+++ b/backend/app/schemas/roster.py
@@ -59,11 +59,9 @@ class RosterItemResponse(BaseModel):
     verification_snapshot: Optional[Dict[str, Any]] = None
     is_included: bool
     exclusion_reason: Optional[str] = None
-    # 資格驗證結果（造冊產生時快照，儲存於 DB）
+    # 資格驗證快照（造冊產生當下；failed_rules/warning_rules/details 都在快照內）
     rule_validation_result: Optional[Dict[str, Any]] = None
-    failed_rules: Optional[List[str]] = None
-    warning_rules: Optional[List[str]] = None
-    # 是否符合資格 — derived from rule_validation_result by the serializer helper
+    # PaymentRosterItem.is_eligible model property; None = 無快照（較舊造冊）
     is_eligible: Optional[bool] = None
     created_at: datetime
     updated_at: Optional[datetime] = None

--- a/backend/app/tests/test_payment_roster_model.py
+++ b/backend/app/tests/test_payment_roster_model.py
@@ -11,11 +11,12 @@ The lock-state transitions are immutability invariants: a locked
 roster MUST NOT be re-locked (would overwrite the `locked_by`
 attribution → audit-trail forgery).
 
-7 helpers / properties covered (15 cases):
+8 helpers / properties covered:
 - `PaymentRoster.is_locked / can_be_modified / is_completed`
 - `PaymentRoster.lock()`
 - `PaymentRoster.generate_excel_filename()`
 - `PaymentRosterItem.is_qualified`
+- `PaymentRosterItem.is_eligible`
 - `PaymentRosterItem.generate_excel_remarks()`
 """
 
@@ -151,6 +152,31 @@ def test_is_qualified_false_when_no_bank_account():
     """Missing bank account blocks payment (can't wire money to nowhere)."""
     assert not _item(bank_account=None).is_qualified
     assert not _item(bank_account="").is_qualified
+
+
+# ─── PaymentRosterItem.is_eligible ─────────────────────────────────
+
+
+def test_is_eligible_none_without_snapshot():
+    """Items predating rule-validation snapshots have no verdict; the
+    UI renders '-' rather than a reconstructed (possibly stale) one."""
+    assert _item(rule_validation_result=None).is_eligible is None
+    assert _item(rule_validation_result={}).is_eligible is None
+
+
+def test_is_eligible_reflects_snapshot_verdict():
+    """The generation-time verdict wins — including a False verdict with
+    empty failed_rules (e.g. a verification-error snapshot)."""
+    assert _item(rule_validation_result={"is_eligible": True, "failed_rules": []}).is_eligible is True
+    assert _item(rule_validation_result={"is_eligible": False, "failed_rules": []}).is_eligible is False
+
+
+def test_is_eligible_distinct_from_is_qualified():
+    """規則資格 (is_eligible) vs 撥款合格 (is_qualified): a student can
+    pass the scholarship rules yet be unpayable (no bank account)."""
+    item = _item(bank_account=None, rule_validation_result={"is_eligible": True})
+    assert item.is_eligible is True
+    assert not item.is_qualified
 
 
 # ─── PaymentRosterItem.generate_excel_remarks ──────────────────────

--- a/backend/app/tests/test_roster_items_display_year.py
+++ b/backend/app/tests/test_roster_items_display_year.py
@@ -53,3 +53,35 @@ def test_keeps_borrowed_snapshot_over_roster_year():
     # allocation_year=114; the fallback must NOT overwrite it with 115.
     out = _roster_item_dict_with_display_year(_item(allocation_year=114), SimpleNamespace(academic_year=115))
     assert out["allocation_year"] == 114
+
+
+# ─── is_eligible derivation (符合資格 column) ───────────────────────
+
+
+_ROSTER = SimpleNamespace(academic_year=114)
+
+
+def test_is_eligible_prefers_snapshot_verdict():
+    # The generation-time snapshot verdict wins, even when failed_rules is
+    # empty (e.g. a verification-error snapshot stores is_eligible=False).
+    item = _item(rule_validation_result={"is_eligible": False, "failed_rules": [], "details": {}})
+    assert _roster_item_dict_with_display_year(item, _ROSTER)["is_eligible"] is False
+
+
+def test_is_eligible_snapshot_true_passes_through():
+    item = _item(
+        rule_validation_result={"is_eligible": True, "failed_rules": [], "details": {}},
+        failed_rules=[],
+        warning_rules=["GPA 偏低"],
+    )
+    out = _roster_item_dict_with_display_year(item, _ROSTER)
+    assert out["is_eligible"] is True
+    assert out["warning_rules"] == ["GPA 偏低"]
+
+
+def test_is_eligible_legacy_falls_back_to_failed_rules():
+    # Legacy items (no rule_validation_result snapshot): eligible iff no
+    # failed_rules were recorded.
+    assert _roster_item_dict_with_display_year(_item(), _ROSTER)["is_eligible"] is True
+    item = _item(failed_rules=["不符合獎學金規則: GPA < 3.0"])
+    assert _roster_item_dict_with_display_year(item, _ROSTER)["is_eligible"] is False

--- a/backend/app/tests/test_roster_items_display_year.py
+++ b/backend/app/tests/test_roster_items_display_year.py
@@ -55,33 +55,26 @@ def test_keeps_borrowed_snapshot_over_roster_year():
     assert out["allocation_year"] == 114
 
 
-# ─── is_eligible derivation (符合資格 column) ───────────────────────
+# ─── slim mode (list endpoints) ─────────────────────────────────────
 
 
 _ROSTER = SimpleNamespace(academic_year=114)
+_SNAPSHOT = {"is_eligible": True, "failed_rules": [], "warning_rules": [], "details": {}}
 
 
-def test_is_eligible_prefers_snapshot_verdict():
-    # The generation-time snapshot verdict wins, even when failed_rules is
-    # empty (e.g. a verification-error snapshot stores is_eligible=False).
-    item = _item(rule_validation_result={"is_eligible": False, "failed_rules": [], "details": {}})
-    assert _roster_item_dict_with_display_year(item, _ROSTER)["is_eligible"] is False
-
-
-def test_is_eligible_snapshot_true_passes_through():
-    item = _item(
-        rule_validation_result={"is_eligible": True, "failed_rules": [], "details": {}},
-        failed_rules=[],
-        warning_rules=["GPA 偏低"],
-    )
-    out = _roster_item_dict_with_display_year(item, _ROSTER)
+def test_slim_drops_heavy_snapshot_fields():
+    # The roster LIST endpoint serializes every item of every roster on the
+    # page; no list consumer reads the per-item JSON snapshots, so slim mode
+    # must drop them while keeping the scalar 符合資格 flag.
+    item = _item(rule_validation_result=_SNAPSHOT, is_eligible=True)
+    out = _roster_item_dict_with_display_year(item, _ROSTER, slim=True)
+    assert "rule_validation_result" not in out
+    assert "verification_snapshot" not in out
     assert out["is_eligible"] is True
-    assert out["warning_rules"] == ["GPA 偏低"]
 
 
-def test_is_eligible_legacy_falls_back_to_failed_rules():
-    # Legacy items (no rule_validation_result snapshot): eligible iff no
-    # failed_rules were recorded.
-    assert _roster_item_dict_with_display_year(_item(), _ROSTER)["is_eligible"] is True
-    item = _item(failed_rules=["不符合獎學金規則: GPA < 3.0"])
-    assert _roster_item_dict_with_display_year(item, _ROSTER)["is_eligible"] is False
+def test_full_mode_keeps_snapshot_for_detail_view():
+    # The 查看名單 detail view needs the full rule-comparison snapshot.
+    item = _item(rule_validation_result=_SNAPSHOT, is_eligible=True)
+    out = _roster_item_dict_with_display_year(item, _ROSTER)
+    assert out["rule_validation_result"] == _SNAPSHOT

--- a/backend/app/tests/test_roster_schemas.py
+++ b/backend/app/tests/test_roster_schemas.py
@@ -232,6 +232,28 @@ def test_item_response_display_fields_optional():
     assert r.allocated_sub_type is None
 
 
+def test_item_response_eligibility_fields_optional():
+    # Pin: the 符合資格 column fields (rule_validation_result, failed_rules,
+    # warning_rules, verification_message, is_eligible) are Optional so
+    # legacy items without a validation snapshot still serialize.
+    r = RosterItemResponse(
+        id=1,
+        roster_id=1,
+        application_id=1,
+        student_id_number="A1",
+        student_name="王",
+        scholarship_amount=Decimal("1000"),
+        verification_status=StudentVerificationStatus.VERIFIED,
+        is_included=True,
+        created_at=datetime(2025, 10, 22, tzinfo=timezone.utc),
+    )
+    assert r.rule_validation_result is None
+    assert r.failed_rules is None
+    assert r.warning_rules is None
+    assert r.verification_message is None
+    assert r.is_eligible is None
+
+
 # ─── RosterStatisticsResponse ───────────────────────────────────────
 
 

--- a/backend/app/tests/test_roster_schemas.py
+++ b/backend/app/tests/test_roster_schemas.py
@@ -233,9 +233,10 @@ def test_item_response_display_fields_optional():
 
 
 def test_item_response_eligibility_fields_optional():
-    # Pin: the 符合資格 column fields (rule_validation_result, failed_rules,
-    # warning_rules, verification_message, is_eligible) are Optional so
-    # legacy items without a validation snapshot still serialize.
+    # Pin: the 符合資格 column fields (rule_validation_result,
+    # verification_message, is_eligible) are Optional so legacy items
+    # without a validation snapshot still serialize (is_eligible=None
+    # renders as "-" in the UI).
     r = RosterItemResponse(
         id=1,
         roster_id=1,
@@ -248,8 +249,6 @@ def test_item_response_eligibility_fields_optional():
         created_at=datetime(2025, 10, 22, tzinfo=timezone.utc),
     )
     assert r.rule_validation_result is None
-    assert r.failed_rules is None
-    assert r.warning_rules is None
     assert r.verification_message is None
     assert r.is_eligible is None
 

--- a/frontend/components/roster/EligibilityDetailDialog.tsx
+++ b/frontend/components/roster/EligibilityDetailDialog.tsx
@@ -17,19 +17,19 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { AlertCircle, CheckCircle, XCircle } from "lucide-react";
+import { formatDisplayValue } from "@/lib/utils/application-helpers";
+import { RULE_OPERATOR_LABELS } from "@/lib/constants/rule-operators";
 
 /** One evaluated rule from rule_validation_result.details (rule_<id> keys). */
 export interface RuleComparisonEntry {
   passed: boolean;
   rule_name: string;
-  rule_type?: string;
   actual_value?: unknown;
   expected_value?: string | null;
   operator?: string;
   message?: string;
   is_hard_rule?: boolean;
   is_warning?: boolean;
-  error?: string;
 }
 
 /** Generation-time validation snapshot stored on each roster item. */
@@ -43,9 +43,7 @@ export interface RuleValidationResult {
 export interface EligibilityDetailItem {
   student_name: string;
   student_id?: string;
-  is_eligible?: boolean;
-  failed_rules?: string[];
-  warning_rules?: string[];
+  is_eligible?: boolean | null;
   verification_message?: string | null;
   rule_validation_result?: RuleValidationResult | null;
 }
@@ -55,26 +53,31 @@ interface EligibilityDetailDialogProps {
   onClose: () => void;
 }
 
-const OPERATOR_LABELS: Record<string, string> = {
-  ">=": "≥",
-  "<=": "≤",
-  ">": ">",
-  "<": "<",
-  "==": "等於",
-  "!=": "不等於",
-  in: "屬於",
-  not_in: "不屬於",
-  contains: "包含",
-  not_contains: "不包含",
-};
-
 const isRuleEntry = (value: unknown): value is RuleComparisonEntry =>
   typeof value === "object" && value !== null && "rule_name" in value;
 
-const formatValue = (value: unknown): string => {
-  if (value === null || value === undefined || value === "") return "-";
-  return String(value);
+const formatValue = (value: unknown): string => formatDisplayValue(value) || "-";
+
+type StatusTone = "pass" | "warn" | "fail";
+
+const STATUS_TONES: Record<
+  StatusTone,
+  { variant: "default" | "outline" | "destructive"; className?: string; Icon: typeof CheckCircle }
+> = {
+  pass: { variant: "default", Icon: CheckCircle },
+  warn: { variant: "outline", className: "text-yellow-600 border-yellow-600", Icon: AlertCircle },
+  fail: { variant: "destructive", Icon: XCircle },
 };
+
+function StatusBadge({ tone, label }: { tone: StatusTone; label: string }) {
+  const { variant, className, Icon } = STATUS_TONES[tone];
+  return (
+    <Badge variant={variant} className={`gap-1 no-underline ${className ?? ""}`}>
+      <Icon className="h-3 w-3" />
+      {label}
+    </Badge>
+  );
+}
 
 /** 符合資格 badge shared by the roster detail table and this dialog. */
 export function EligibilityBadge({ item }: { item: EligibilityDetailItem }) {
@@ -82,29 +85,54 @@ export function EligibilityBadge({ item }: { item: EligibilityDetailItem }) {
     return <span className="text-muted-foreground">-</span>;
   }
   if (!item.is_eligible) {
-    return (
-      <Badge variant="destructive" className="gap-1 no-underline">
-        <XCircle className="h-3 w-3" />
-        不符合
-      </Badge>
-    );
+    return <StatusBadge tone="fail" label="不符合" />;
   }
-  if (item.warning_rules && item.warning_rules.length > 0) {
-    return (
-      <Badge
-        variant="outline"
-        className="gap-1 text-yellow-600 border-yellow-600 no-underline"
-      >
-        <AlertCircle className="h-3 w-3" />
-        符合(警告)
-      </Badge>
-    );
+  if (item.rule_validation_result?.warning_rules?.length) {
+    return <StatusBadge tone="warn" label="符合(警告)" />;
   }
+  return <StatusBadge tone="pass" label="符合" />;
+}
+
+const RULE_LIST_TONES = {
+  fail: {
+    box: "bg-red-50 border-red-200",
+    header: "text-red-900",
+    item: "text-red-700",
+    Icon: XCircle,
+  },
+  warn: {
+    box: "bg-yellow-50 border-yellow-200",
+    header: "text-yellow-900",
+    item: "text-yellow-700",
+    Icon: AlertCircle,
+  },
+} as const;
+
+function RuleList({
+  rules,
+  label,
+  tone,
+}: {
+  rules: string[] | undefined;
+  label: string;
+  tone: keyof typeof RULE_LIST_TONES;
+}) {
+  if (!rules || rules.length === 0) return null;
+  const { box, header, item, Icon } = RULE_LIST_TONES[tone];
   return (
-    <Badge variant="default" className="gap-1 no-underline">
-      <CheckCircle className="h-3 w-3" />
-      符合
-    </Badge>
+    <div className={`p-3 border rounded ${box}`}>
+      <div className={`font-semibold text-sm mb-1 flex items-center gap-1 ${header}`}>
+        <Icon className="h-4 w-4" />
+        {label} ({rules.length})
+      </div>
+      <ul className="space-y-1">
+        {rules.map((rule, idx) => (
+          <li key={idx} className={`text-sm ${item}`}>
+            • {rule}
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -113,138 +141,95 @@ export function EligibilityBadge({ item }: { item: EligibilityDetailItem }) {
  * evaluated scholarship rule (actual vs expected) plus failed/warning lists.
  */
 export function EligibilityDetailDialog({ item, onClose }: EligibilityDetailDialogProps) {
-  const ruleEntries = Object.entries(item?.rule_validation_result?.details ?? {})
-    .filter((entry): entry is [string, RuleComparisonEntry] => isRuleEntry(entry[1]));
-  const hasNoRules = item?.rule_validation_result?.details?.no_rules_found === true;
+  if (!item) return null;
+
+  const snapshot = item.rule_validation_result;
+  const ruleEntries = Object.entries(snapshot?.details ?? {}).filter(
+    (entry): entry is [string, RuleComparisonEntry] => isRuleEntry(entry[1])
+  );
+  const hasNoRules = snapshot?.details?.no_rules_found === true;
 
   return (
-    <Dialog open={!!item} onOpenChange={open => !open && onClose()}>
+    <Dialog open onOpenChange={open => !open && onClose()}>
       <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>資格對比結果 - {item?.student_name}</DialogTitle>
+          <DialogTitle>資格對比結果 - {item.student_name}</DialogTitle>
           <DialogDescription>
-            {item?.student_id && <span>學號: {item.student_id}</span>}
-            <span className="ml-3">
-              造冊產生當下的獎學金規則驗證快照
-            </span>
+            {item.student_id && <span>學號: {item.student_id}</span>}
+            <span className="ml-3">造冊產生當下的獎學金規則驗證快照</span>
           </DialogDescription>
         </DialogHeader>
 
-        {item && (
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">驗證結果:</span>
-              <EligibilityBadge item={item} />
-            </div>
-
-            {item.failed_rules && item.failed_rules.length > 0 && (
-              <div className="p-3 bg-red-50 border border-red-200 rounded">
-                <div className="font-semibold text-red-900 text-sm mb-1 flex items-center gap-1">
-                  <XCircle className="h-4 w-4" />
-                  未通過規則 ({item.failed_rules.length})
-                </div>
-                <ul className="space-y-1">
-                  {item.failed_rules.map((rule, idx) => (
-                    <li key={idx} className="text-red-700 text-sm">
-                      • {rule}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {item.warning_rules && item.warning_rules.length > 0 && (
-              <div className="p-3 bg-yellow-50 border border-yellow-200 rounded">
-                <div className="font-semibold text-yellow-900 text-sm mb-1 flex items-center gap-1">
-                  <AlertCircle className="h-4 w-4" />
-                  警告 ({item.warning_rules.length})
-                </div>
-                <ul className="space-y-1">
-                  {item.warning_rules.map((rule, idx) => (
-                    <li key={idx} className="text-yellow-700 text-sm">
-                      • {rule}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {item.verification_message && (
-              <div className="p-3 bg-blue-50 border border-blue-200 rounded text-sm text-blue-800">
-                驗證訊息: {item.verification_message}
-              </div>
-            )}
-
-            {ruleEntries.length > 0 ? (
-              <div>
-                <h4 className="text-sm font-semibold mb-2">規則逐項對比</h4>
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>規則</TableHead>
-                      <TableHead>學生實際值</TableHead>
-                      <TableHead>條件</TableHead>
-                      <TableHead>要求值</TableHead>
-                      <TableHead className="text-right">結果</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {ruleEntries.map(([key, rule]) => (
-                      <TableRow key={key}>
-                        <TableCell>
-                          <div className="font-medium">{rule.rule_name}</div>
-                          {rule.message && (
-                            <div className="text-xs text-muted-foreground">
-                              {rule.message}
-                            </div>
-                          )}
-                        </TableCell>
-                        <TableCell className="font-mono text-sm">
-                          {formatValue(rule.actual_value)}
-                        </TableCell>
-                        <TableCell className="text-sm">
-                          {rule.operator
-                            ? (OPERATOR_LABELS[rule.operator] ?? rule.operator)
-                            : "-"}
-                        </TableCell>
-                        <TableCell className="font-mono text-sm">
-                          {formatValue(rule.expected_value)}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          {rule.passed ? (
-                            <Badge variant="default" className="gap-1">
-                              <CheckCircle className="h-3 w-3" />
-                              通過
-                            </Badge>
-                          ) : rule.is_warning && !rule.is_hard_rule ? (
-                            <Badge
-                              variant="outline"
-                              className="gap-1 text-yellow-600 border-yellow-600"
-                            >
-                              <AlertCircle className="h-3 w-3" />
-                              警告
-                            </Badge>
-                          ) : (
-                            <Badge variant="destructive" className="gap-1">
-                              <XCircle className="h-3 w-3" />
-                              未通過
-                            </Badge>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                {hasNoRules
-                  ? "此獎學金於造冊期間無設定驗證規則，視為符合資格。"
-                  : "此造冊項目無規則對比快照（較舊造冊或未啟用規則驗證）。"}
-              </p>
-            )}
+        <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">驗證結果:</span>
+            <EligibilityBadge item={item} />
           </div>
-        )}
+
+          <RuleList rules={snapshot?.failed_rules} label="未通過規則" tone="fail" />
+          <RuleList rules={snapshot?.warning_rules} label="警告" tone="warn" />
+
+          {item.verification_message && (
+            <div className="p-3 bg-blue-50 border border-blue-200 rounded text-sm text-blue-800">
+              驗證訊息: {item.verification_message}
+            </div>
+          )}
+
+          {ruleEntries.length > 0 ? (
+            <div>
+              <h4 className="text-sm font-semibold mb-2">規則逐項對比</h4>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>規則</TableHead>
+                    <TableHead>學生實際值</TableHead>
+                    <TableHead>條件</TableHead>
+                    <TableHead>要求值</TableHead>
+                    <TableHead className="text-right">結果</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {ruleEntries.map(([key, rule]) => (
+                    <TableRow key={key}>
+                      <TableCell>
+                        <div className="font-medium">{rule.rule_name}</div>
+                        {rule.message && (
+                          <div className="text-xs text-muted-foreground">{rule.message}</div>
+                        )}
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatValue(rule.actual_value)}
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        {rule.operator
+                          ? (RULE_OPERATOR_LABELS[rule.operator] ?? rule.operator)
+                          : "-"}
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">
+                        {formatValue(rule.expected_value)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {rule.passed ? (
+                          <StatusBadge tone="pass" label="通過" />
+                        ) : rule.is_warning && !rule.is_hard_rule ? (
+                          <StatusBadge tone="warn" label="警告" />
+                        ) : (
+                          <StatusBadge tone="fail" label="未通過" />
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {hasNoRules
+                ? "此獎學金於造冊期間無設定驗證規則，視為符合資格。"
+                : "此造冊項目無規則對比快照（較舊造冊或未啟用規則驗證）。"}
+            </p>
+          )}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/components/roster/EligibilityDetailDialog.tsx
+++ b/frontend/components/roster/EligibilityDetailDialog.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { AlertCircle, CheckCircle, XCircle } from "lucide-react";
+
+/** One evaluated rule from rule_validation_result.details (rule_<id> keys). */
+export interface RuleComparisonEntry {
+  passed: boolean;
+  rule_name: string;
+  rule_type?: string;
+  actual_value?: unknown;
+  expected_value?: string | null;
+  operator?: string;
+  message?: string;
+  is_hard_rule?: boolean;
+  is_warning?: boolean;
+  error?: string;
+}
+
+/** Generation-time validation snapshot stored on each roster item. */
+export interface RuleValidationResult {
+  is_eligible?: boolean;
+  failed_rules?: string[];
+  warning_rules?: string[];
+  details?: Record<string, unknown>;
+}
+
+export interface EligibilityDetailItem {
+  student_name: string;
+  student_id?: string;
+  is_eligible?: boolean;
+  failed_rules?: string[];
+  warning_rules?: string[];
+  verification_message?: string | null;
+  rule_validation_result?: RuleValidationResult | null;
+}
+
+interface EligibilityDetailDialogProps {
+  item: EligibilityDetailItem | null;
+  onClose: () => void;
+}
+
+const OPERATOR_LABELS: Record<string, string> = {
+  ">=": "≥",
+  "<=": "≤",
+  ">": ">",
+  "<": "<",
+  "==": "等於",
+  "!=": "不等於",
+  in: "屬於",
+  not_in: "不屬於",
+  contains: "包含",
+  not_contains: "不包含",
+};
+
+const isRuleEntry = (value: unknown): value is RuleComparisonEntry =>
+  typeof value === "object" && value !== null && "rule_name" in value;
+
+const formatValue = (value: unknown): string => {
+  if (value === null || value === undefined || value === "") return "-";
+  return String(value);
+};
+
+/** 符合資格 badge shared by the roster detail table and this dialog. */
+export function EligibilityBadge({ item }: { item: EligibilityDetailItem }) {
+  if (item.is_eligible === undefined || item.is_eligible === null) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+  if (!item.is_eligible) {
+    return (
+      <Badge variant="destructive" className="gap-1 no-underline">
+        <XCircle className="h-3 w-3" />
+        不符合
+      </Badge>
+    );
+  }
+  if (item.warning_rules && item.warning_rules.length > 0) {
+    return (
+      <Badge
+        variant="outline"
+        className="gap-1 text-yellow-600 border-yellow-600 no-underline"
+      >
+        <AlertCircle className="h-3 w-3" />
+        符合(警告)
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="default" className="gap-1 no-underline">
+      <CheckCircle className="h-3 w-3" />
+      符合
+    </Badge>
+  );
+}
+
+/**
+ * Per-student 資格對比 dialog: shows the generation-time snapshot of every
+ * evaluated scholarship rule (actual vs expected) plus failed/warning lists.
+ */
+export function EligibilityDetailDialog({ item, onClose }: EligibilityDetailDialogProps) {
+  const ruleEntries = Object.entries(item?.rule_validation_result?.details ?? {})
+    .filter((entry): entry is [string, RuleComparisonEntry] => isRuleEntry(entry[1]));
+  const hasNoRules = item?.rule_validation_result?.details?.no_rules_found === true;
+
+  return (
+    <Dialog open={!!item} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>資格對比結果 - {item?.student_name}</DialogTitle>
+          <DialogDescription>
+            {item?.student_id && <span>學號: {item.student_id}</span>}
+            <span className="ml-3">
+              造冊產生當下的獎學金規則驗證快照
+            </span>
+          </DialogDescription>
+        </DialogHeader>
+
+        {item && (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">驗證結果:</span>
+              <EligibilityBadge item={item} />
+            </div>
+
+            {item.failed_rules && item.failed_rules.length > 0 && (
+              <div className="p-3 bg-red-50 border border-red-200 rounded">
+                <div className="font-semibold text-red-900 text-sm mb-1 flex items-center gap-1">
+                  <XCircle className="h-4 w-4" />
+                  未通過規則 ({item.failed_rules.length})
+                </div>
+                <ul className="space-y-1">
+                  {item.failed_rules.map((rule, idx) => (
+                    <li key={idx} className="text-red-700 text-sm">
+                      • {rule}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {item.warning_rules && item.warning_rules.length > 0 && (
+              <div className="p-3 bg-yellow-50 border border-yellow-200 rounded">
+                <div className="font-semibold text-yellow-900 text-sm mb-1 flex items-center gap-1">
+                  <AlertCircle className="h-4 w-4" />
+                  警告 ({item.warning_rules.length})
+                </div>
+                <ul className="space-y-1">
+                  {item.warning_rules.map((rule, idx) => (
+                    <li key={idx} className="text-yellow-700 text-sm">
+                      • {rule}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {item.verification_message && (
+              <div className="p-3 bg-blue-50 border border-blue-200 rounded text-sm text-blue-800">
+                驗證訊息: {item.verification_message}
+              </div>
+            )}
+
+            {ruleEntries.length > 0 ? (
+              <div>
+                <h4 className="text-sm font-semibold mb-2">規則逐項對比</h4>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>規則</TableHead>
+                      <TableHead>學生實際值</TableHead>
+                      <TableHead>條件</TableHead>
+                      <TableHead>要求值</TableHead>
+                      <TableHead className="text-right">結果</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {ruleEntries.map(([key, rule]) => (
+                      <TableRow key={key}>
+                        <TableCell>
+                          <div className="font-medium">{rule.rule_name}</div>
+                          {rule.message && (
+                            <div className="text-xs text-muted-foreground">
+                              {rule.message}
+                            </div>
+                          )}
+                        </TableCell>
+                        <TableCell className="font-mono text-sm">
+                          {formatValue(rule.actual_value)}
+                        </TableCell>
+                        <TableCell className="text-sm">
+                          {rule.operator
+                            ? (OPERATOR_LABELS[rule.operator] ?? rule.operator)
+                            : "-"}
+                        </TableCell>
+                        <TableCell className="font-mono text-sm">
+                          {formatValue(rule.expected_value)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {rule.passed ? (
+                            <Badge variant="default" className="gap-1">
+                              <CheckCircle className="h-3 w-3" />
+                              通過
+                            </Badge>
+                          ) : rule.is_warning && !rule.is_hard_rule ? (
+                            <Badge
+                              variant="outline"
+                              className="gap-1 text-yellow-600 border-yellow-600"
+                            >
+                              <AlertCircle className="h-3 w-3" />
+                              警告
+                            </Badge>
+                          ) : (
+                            <Badge variant="destructive" className="gap-1">
+                              <XCircle className="h-3 w-3" />
+                              未通過
+                            </Badge>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                {hasNoRules
+                  ? "此獎學金於造冊期間無設定驗證規則，視為符合資格。"
+                  : "此造冊項目無規則對比快照（較舊造冊或未啟用規則驗證）。"}
+              </p>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/roster/RosterDetailDialog.tsx
+++ b/frontend/components/roster/RosterDetailDialog.tsx
@@ -38,7 +38,7 @@ import { RevokedSuspendedSection } from "@/components/roster/RevokedSuspendedSec
 import {
   EligibilityBadge,
   EligibilityDetailDialog,
-  type RuleValidationResult,
+  type EligibilityDetailItem,
 } from "@/components/roster/EligibilityDetailDialog";
 
 interface Period {
@@ -76,7 +76,7 @@ interface RosterDetailDialogProps {
   onRosterChanged?: () => void;
 }
 
-interface RosterItem {
+interface RosterItem extends EligibilityDetailItem {
   id: number;
   student_name: string;
   student_id: string;
@@ -93,12 +93,6 @@ interface RosterItem {
   exclusion_reason?: string | null;
   application_identity?: string;
   allocated_sub_type?: string;
-  // 資格驗證快照（造冊產生當下）
-  is_eligible?: boolean;
-  failed_rules?: string[];
-  warning_rules?: string[];
-  verification_message?: string | null;
-  rule_validation_result?: RuleValidationResult | null;
 }
 
 type RosterAuditLogEntry = {

--- a/frontend/components/roster/RosterDetailDialog.tsx
+++ b/frontend/components/roster/RosterDetailDialog.tsx
@@ -35,6 +35,11 @@ import { toast } from "sonner";
 import { apiClient } from "@/lib/api";
 import type { RevokedSuspendedList, DistributionDiff, DistributionDiffEntry } from "@/lib/api/modules/payment-rosters";
 import { RevokedSuspendedSection } from "@/components/roster/RevokedSuspendedSection";
+import {
+  EligibilityBadge,
+  EligibilityDetailDialog,
+  type RuleValidationResult,
+} from "@/components/roster/EligibilityDetailDialog";
 
 interface Period {
   label: string;
@@ -88,6 +93,12 @@ interface RosterItem {
   exclusion_reason?: string | null;
   application_identity?: string;
   allocated_sub_type?: string;
+  // 資格驗證快照（造冊產生當下）
+  is_eligible?: boolean;
+  failed_rules?: string[];
+  warning_rules?: string[];
+  verification_message?: string | null;
+  rule_validation_result?: RuleValidationResult | null;
 }
 
 type RosterAuditLogEntry = {
@@ -120,6 +131,9 @@ export function RosterDetailDialog({
 
   const [isLocking, setIsLocking] = useState(false);
   const [isUnlocking, setIsUnlocking] = useState(false);
+
+  // 資格對比 detail dialog state
+  const [eligibilityTarget, setEligibilityTarget] = useState<RosterItem | null>(null);
 
   // #66: exclude-item dialog state
   const [excludeTarget, setExcludeTarget] = useState<RosterItem | null>(null);
@@ -507,6 +521,8 @@ export function RosterDetailDialog({
             <TableHead>系所</TableHead>
             <TableHead>申請身分</TableHead>
             <TableHead>分發獎學金</TableHead>
+            <TableHead>符合資格</TableHead>
+            <TableHead>資格詳情</TableHead>
             <TableHead className="text-right">金額</TableHead>
             <TableHead className="text-right w-20">操作</TableHead>
           </TableRow>
@@ -566,6 +582,20 @@ export function RosterDetailDialog({
                   ) : (
                     <span className="text-muted-foreground">-</span>
                   )}
+                </TableCell>
+                <TableCell>
+                  <EligibilityBadge item={item} />
+                </TableCell>
+                <TableCell>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-primary no-underline"
+                    onClick={() => setEligibilityTarget(item)}
+                    title="查看資格對比結果"
+                  >
+                    詳情
+                  </Button>
                 </TableCell>
                 <TableCell className="text-right font-medium">
                   {formatCurrency(item.scholarship_amount)}
@@ -925,6 +955,12 @@ export function RosterDetailDialog({
           )}
         </div>
       </DialogContent>
+
+      {/* 資格對比 detail dialog */}
+      <EligibilityDetailDialog
+        item={eligibilityTarget}
+        onClose={() => setEligibilityTarget(null)}
+      />
 
       {/* 比對分發名單 — single-row confirm */}
       <Dialog

--- a/frontend/components/scholarship-rule-modal.tsx
+++ b/frontend/components/scholarship-rule-modal.tsx
@@ -18,6 +18,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Save, X } from "lucide-react";
 import { ScholarshipRule, SubTypeOption, api } from "@/lib/api";
+import { RULE_OPERATORS } from "@/lib/constants/rule-operators";
 
 interface ScholarshipRuleModalProps {
   isOpen: boolean;
@@ -33,19 +34,6 @@ interface ScholarshipRuleModalProps {
 const RULE_TYPES = [
   { value: "student", label: "學生資料" },
   { value: "student_term", label: "學生學期資料" },
-];
-
-const OPERATORS = [
-  { value: "==", label: "等於 (==)" },
-  { value: "!=", label: "不等於 (!=)" },
-  { value: ">", label: "大於 (>)" },
-  { value: "<", label: "小於 (<)" },
-  { value: ">=", label: "大於等於 (>=)" },
-  { value: "<=", label: "小於等於 (<=)" },
-  { value: "in", label: "包含於 (in)" },
-  { value: "not_in", label: "不包含於 (not_in)" },
-  { value: "contains", label: "包含 (contains)" },
-  { value: "not_contains", label: "不包含 (not_contains)" },
 ];
 
 const STUDENT_FIELDS = [
@@ -447,7 +435,7 @@ export function ScholarshipRuleModal({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {OPERATORS.map(op => (
+                  {RULE_OPERATORS.map(op => (
                     <SelectItem key={op.value} value={op.value}>
                       {op.label}
                     </SelectItem>

--- a/frontend/lib/constants/rule-operators.ts
+++ b/frontend/lib/constants/rule-operators.ts
@@ -1,0 +1,22 @@
+/**
+ * Scholarship rule operators — single source for the rule editor select
+ * (scholarship-rule-modal) and rule-comparison displays
+ * (EligibilityDetailDialog). Values match backend
+ * RosterService._evaluate_condition.
+ */
+export const RULE_OPERATORS = [
+  { value: "==", label: "等於 (==)" },
+  { value: "!=", label: "不等於 (!=)" },
+  { value: ">", label: "大於 (>)" },
+  { value: "<", label: "小於 (<)" },
+  { value: ">=", label: "大於等於 (>=)" },
+  { value: "<=", label: "小於等於 (<=)" },
+  { value: "in", label: "包含於 (in)" },
+  { value: "not_in", label: "不包含於 (not_in)" },
+  { value: "contains", label: "包含 (contains)" },
+  { value: "not_contains", label: "不包含 (not_contains)" },
+] as const;
+
+export const RULE_OPERATOR_LABELS: Record<string, string> = Object.fromEntries(
+  RULE_OPERATORS.map(op => [op.value, op.label])
+);


### PR DESCRIPTION
## Summary

The 造冊管理 → 查看名單 (roster detail) student table gains two new columns so admins can see at a glance whether each 領獎人 met the scholarship rules, and drill into the exact rule-by-rule comparison:

- **符合資格** — badge per recipient: 符合 / 符合(警告) / 不符合, derived from the rule-validation snapshot frozen at roster generation time. Items predating snapshots show "-".
- **資格詳情** — opens a per-student dialog with a rule-by-rule comparison table (規則 / 學生實際值 / 條件 / 要求值 / 結果), plus failed-rule and warning lists and the verification message.

## Implementation notes

- **No migration, no new endpoint** — `payment_roster_items` already stores the full validation snapshot (`rule_validation_result`, `failed_rules`, `warning_rules`); it just wasn't exposed.
- `is_eligible` is a `PaymentRosterItem` model property next to `is_qualified`, with docstrings distinguishing 規則資格 (rule verdict) from 撥款合格 (payment readiness). All `RosterItemResponse` serialization paths pick it up via `from_attributes`.
- The roster LIST endpoint serializes items in **slim mode** (drops `rule_validation_result` / `verification_snapshot`) since no list consumer reads them — avoids shipping potentially MBs of snapshot JSON per page.
- `RULE_OPERATORS` is now a shared constant between the rule editor modal and the comparison dialog.

## Test plan

- [x] 90 backend tests pass (5 new: `is_eligible` property semantics, slim-mode exclusion, schema optionality pins)
- [x] `black --check`, `flake8 --select=B904,B014,F401` clean
- [x] `tsc --noEmit`, ESLint clean
- [ ] Manual: open 造冊管理 → 查看名單 on a roster generated with rule validation enabled; verify badges and the 詳情 comparison dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)