### PR TITLE
fix(audit): wire audit logging into batch-import, whitelist, renewal; normalize revoke/suspend/restore

### DIFF
--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -21,7 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.path_security import validate_object_name_minio
 from app.core.security import get_current_user
 from app.db.deps import get_db
-from app.models.application import Application, ApplicationStatus
+from app.models.application import Application, ApplicationFile, ApplicationStatus
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.batch_import import BatchImport
 from app.models.enums import BatchImportStatus
 from app.models.scholarship import ScholarshipType
@@ -261,6 +262,24 @@ async def upload_batch_import_data(
         ],
     }
 
+    # 批次匯入可大量建立申請 — 從上傳起留稽核軌跡 (issue #964 / G2)。
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.create.value,
+            resource_type="batch_import",
+            resource_id=str(batch_import.id),
+            resource_name=file.filename,
+            description=f"batch import upload: {file.filename} ({len(parsed_data)} records)",
+            new_values={
+                "scholarship_type_id": scholarship.id,
+                "academic_year": academic_year,
+                "semester": normalized_semester,
+                "total_records": len(parsed_data),
+                "error_count": len(validation_errors),
+            },
+        )
+    )
     await db.commit()
 
     # Return preview (first 10 rows) and validation summary
@@ -372,6 +391,16 @@ async def update_batch_record(
 
     # Update in database
     batch_import.parsed_data["data"] = parsed_data
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.update.value,
+            resource_type="batch_import",
+            resource_id=str(batch_id),
+            description=f"batch import: update record #{request.record_index}",
+            new_values={"record_index": request.record_index, "updates": request.updates},
+        )
+    )
     await db.commit()
 
     return {
@@ -607,6 +636,16 @@ async def delete_batch_record(
                 w["row_number"] -= 1
         batch_import.parsed_data["warnings"] = warnings
 
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.delete.value,
+            resource_type="batch_import",
+            resource_id=str(batch_id),
+            description=f"batch import: delete record #{record_index}",
+            old_values={"record_index": record_index, "deleted_record": deleted_record},
+        )
+    )
     await db.commit()
 
     return {
@@ -926,6 +965,16 @@ async def upload_batch_documents(
             error_count += 1
 
     # Commit all ApplicationFile records
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.update.value,
+            resource_type="batch_import",
+            resource_id=str(batch_id),
+            description=f"batch import: upload documents ZIP ({matched_count} matched, {unmatched_count} unmatched)",
+            new_values={"matched_count": matched_count, "unmatched_count": unmatched_count, "error_count": error_count},
+        )
+    )
     await db.commit()
 
     response_data = BatchDocumentUploadResponse(
@@ -1080,6 +1129,29 @@ async def confirm_batch_import(
             update(Application)
             .where(Application.batch_import_id == batch_id)
             .values(status=ApplicationStatus.under_review.value)
+        )
+        # 每筆由批次建立的申請各留一筆稽核 (issue #964 / G2) — 沒有這些紀錄，
+        # 數百筆申請的「誰建立、來自哪個檔案」將無從追溯。
+        for created_id in created_ids:
+            db.add(
+                AuditLog.create_log(
+                    user_id=current_user.id,
+                    action=AuditAction.import_.value,
+                    resource_type="application",
+                    resource_id=str(created_id),
+                    description=f"application created via batch import {batch_id} ({batch_import.file_name})",
+                    meta_data={"batch_id": batch_id, "file_name": batch_import.file_name},
+                )
+            )
+        db.add(
+            AuditLog.create_log(
+                user_id=current_user.id,
+                action=AuditAction.import_.value,
+                resource_type="batch_import",
+                resource_id=str(batch_id),
+                description=f"batch import confirmed: {len(created_ids)} application(s) created, {len(creation_errors)} failed",
+                new_values={"created_application_ids": list(created_ids), "failed_count": len(creation_errors)},
+            )
         )
         await db.commit()
 
@@ -1422,9 +1494,53 @@ async def delete_batch_import(
     # Get application count for response
     application_count = len(applications)
 
+    # Collect the applications' uploaded files BEFORE deleting — the DB rows
+    # cascade away with the applications, but the MinIO objects do not
+    # (issue #964 / G2: orphaned objects accumulated silently).
+    application_ids = [a.id for a in applications]
+    orphan_candidates = []
+    if application_ids:
+        files_result = await db.execute(
+            select(ApplicationFile).where(ApplicationFile.application_id.in_(application_ids))
+        )
+        orphan_candidates = [(f.application_id, f.object_name) for f in files_result.scalars().all() if f.object_name]
+
+    # 每筆被刪除的申請各留一筆稽核 (G2) — 批次刪除後仍能解釋申請為何消失。
+    for application in applications:
+        db.add(
+            AuditLog.create_log(
+                user_id=current_user.id,
+                action=AuditAction.delete.value,
+                resource_type="application",
+                resource_id=str(application.id),
+                description=f"application hard-deleted with batch import {batch_id} ({batch_import.file_name})",
+                meta_data={
+                    "batch_id": batch_id,
+                    "app_id": application.app_id,
+                    "scholarship_type_id": application.scholarship_type_id,
+                    "academic_year": application.academic_year,
+                },
+            )
+        )
+
     # Delete related applications
     for application in applications:
         await db.delete(application)
+
+    # Delete the applications' MinIO objects (best-effort, logged on failure).
+    if orphan_candidates:
+        minio_cleanup = MinIOService()
+        for app_db_id, object_name in orphan_candidates:
+            try:
+                minio_cleanup.delete_file(bucket_name=settings.minio_bucket, object_name=object_name)
+            except Exception:
+                logger.error(
+                    "Failed to delete MinIO object %s for application %s during batch %s deletion",
+                    object_name,
+                    app_db_id,
+                    batch_id,
+                    exc_info=True,
+                )
 
     # Delete MinIO file if exists
     if batch_import.file_path:
@@ -1436,6 +1552,22 @@ async def delete_batch_import(
             # Continue with batch deletion even if MinIO deletion fails
 
     # Delete batch import record
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.delete.value,
+            resource_type="batch_import",
+            resource_id=str(batch_id),
+            resource_name=batch_import.file_name,
+            description=f"batch import deleted with {application_count} application(s)",
+            old_values={
+                "file_name": batch_import.file_name,
+                "scholarship_type_id": batch_import.scholarship_type_id,
+                "academic_year": batch_import.academic_year,
+                "deleted_application_count": application_count,
+            },
+        )
+    )
     await db.delete(batch_import)
     await db.commit()
 

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -7,7 +7,7 @@ Provides endpoints for admin to manually allocate scholarships to students.
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, Request, UploadFile, status
 from pydantic import BaseModel
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,6 +21,7 @@ from app.models.email_management import EmailCategory
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User
 from app.schemas.application import RevokeRequest, SuspendRequest
+from app.services.application_audit_service import ApplicationAuditService
 from app.services.email_service import EmailService
 from app.services.manual_distribution_service import ManualDistributionService
 from app.utils.date_utils import now_taipei_str
@@ -806,6 +807,7 @@ async def revoke_application_allocation(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     current_user=Depends(get_current_admin_user),
+    http_request: Request = None,
 ):
     """撤銷已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/revoked。"""
     service = ManualDistributionService(db)
@@ -816,6 +818,14 @@ async def revoke_application_allocation(
             reason=request.reason,
         )
         await db.commit()
+        await ApplicationAuditService(db).log_application_revoke(
+            application_id=application_id,
+            app_id=result.get("app_id", f"APP-{application_id}"),
+            user=current_user,
+            reason=request.reason,
+            affected_unlocked_rosters=result.get("affected_unlocked_rosters"),
+            request=http_request,
+        )
         await _notify_admin_of_cancellation(db, background_tasks, application_id, current_user, "撤銷", request.reason)
         return {"success": True, "message": "已撤銷", "data": result}
     except ValueError as e:
@@ -832,6 +842,7 @@ async def suspend_application_allocation(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     current_user=Depends(get_current_admin_user),
+    http_request: Request = None,
 ):
     """停發已分發學生：從未鎖定造冊移除 + 標記 application 為 cancelled/suspended。"""
     service = ManualDistributionService(db)
@@ -842,6 +853,14 @@ async def suspend_application_allocation(
             reason=request.reason,
         )
         await db.commit()
+        await ApplicationAuditService(db).log_application_suspend(
+            application_id=application_id,
+            app_id=result.get("app_id", f"APP-{application_id}"),
+            user=current_user,
+            reason=request.reason,
+            affected_unlocked_rosters=result.get("affected_unlocked_rosters"),
+            request=http_request,
+        )
         await _notify_admin_of_cancellation(db, background_tasks, application_id, current_user, "停發", request.reason)
         return {"success": True, "message": "已停發", "data": result}
     except ValueError as e:
@@ -856,6 +875,7 @@ async def restore_application_allocation(
     application_id: int,
     db: AsyncSession = Depends(get_db),
     current_user=Depends(get_current_admin_user),
+    http_request: Request = None,
 ):
     """恢復已撤銷/停發學生為正常分發（quota_allocation_status -> allocated）。
     不會自動還原造冊項目，需重新生成造冊。"""
@@ -866,6 +886,14 @@ async def restore_application_allocation(
             admin_user_id=current_user.id,
         )
         await db.commit()
+        await ApplicationAuditService(db).log_application_restore(
+            application_id=application_id,
+            app_id=result.get("app_id", f"APP-{application_id}"),
+            user=current_user,
+            prior_status=result.get("restored_from", "unknown"),
+            prior_reason=result.get("restored_reason"),
+            request=http_request,
+        )
         return {"success": True, "message": "已恢復", "data": result}
     except ValueError as e:
         msg = str(e)

--- a/backend/app/api/v1/endpoints/renewal.py
+++ b/backend/app/api/v1/endpoints/renewal.py
@@ -18,7 +18,7 @@ fields from `ScholarshipConfiguration` for the *current* academic year
 
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -31,6 +31,8 @@ from app.models.enums import ApplicationStatus
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User
 from app.schemas.renewal import CreateChallengeRequest, CreateRenewalRequest
+from app.models.audit_log import AuditAction
+from app.services.application_audit_service import ApplicationAuditService
 from app.services.application_service import ApplicationService
 from app.services.renewal_audit_service import RenewalAuditService
 from app.services.renewal_distribution_service import RenewalDistributionService
@@ -130,6 +132,7 @@ async def create_renewal_application(
     body: CreateRenewalRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    request: Request = None,
 ):
     """Create a renewal application from a prior approved application.
 
@@ -189,6 +192,24 @@ async def create_renewal_application(
     await db.commit()
     await db.refresh(new_app)
 
+    # Audit the creation (issue #973 / G11) — renewal applications previously
+    # left no trace while ordinary creations do.
+    await ApplicationAuditService(db).log_application_operation(
+        application_id=new_app.id,
+        action=AuditAction.create,
+        user=current_user,
+        request=request,
+        description=f"建立續領申請 {new_app.app_id}（自 {prev.app_id}）",
+        new_values={
+            "app_id": new_app.app_id,
+            "is_renewal": True,
+            "previous_application_id": new_app.previous_application_id,
+            "sub_scholarship_type": new_app.sub_scholarship_type,
+            "academic_year": new_app.academic_year,
+        },
+        meta_data={"app_id": new_app.app_id, "renewal": True},
+    )
+
     return {
         "success": True,
         "message": "續領申請已建立",
@@ -210,6 +231,7 @@ async def create_challenge_application(
     body: CreateChallengeRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
+    request: Request = None,
 ):
     """Create a challenge application from an approved renewal.
 
@@ -284,6 +306,22 @@ async def create_challenge_application(
     )
     await db.commit()
     await db.refresh(new_app)
+
+    # Audit the creation (issue #973 / G11).
+    await ApplicationAuditService(db).log_application_operation(
+        application_id=new_app.id,
+        action=AuditAction.create,
+        user=current_user,
+        request=request,
+        description=f"建立挑戰申請 {new_app.app_id}（挑戰 {renewal.app_id}，目標 {body.target_sub_type}）",
+        new_values={
+            "app_id": new_app.app_id,
+            "challenges_application_id": new_app.challenges_application_id,
+            "sub_scholarship_type": new_app.sub_scholarship_type,
+            "academic_year": new_app.academic_year,
+        },
+        meta_data={"app_id": new_app.app_id, "challenge": True},
+    )
 
     return {
         "success": True,

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -23,6 +23,7 @@ from app.db.deps import get_db
 # Student model removed - student data now fetched from external API
 from app.models.application import Application, ApplicationStatus
 from app.models.enums import Semester
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import AdminScholarship, User
 from app.schemas.response import ApiResponse
@@ -1547,6 +1548,17 @@ async def batch_add_whitelist(
         config.add_student_to_whitelist(nycu_id, sub_type)
         added_count += 1
 
+    # 白名單控制申請資格 — 異動必須留稽核軌跡 (issue #972 / G10)。
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.update.value,
+            resource_type="scholarship_configuration",
+            resource_id=str(id),
+            description=f"whitelist: batch add {added_count} student(s) to config {config.config_code}",
+            new_values={"added_students": [st["nycu_id"] for st in request.students], "added_count": added_count},
+        )
+    )
     # Mark the field as modified for JSON update
     flag_modified(config, "whitelist_student_ids")
     config.updated_by = current_user.id
@@ -1594,6 +1606,21 @@ async def batch_remove_whitelist(
         if removed:
             removed_count += 1
 
+    # 白名單控制申請資格 — 異動必須留稽核軌跡 (issue #972 / G10)。
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.update.value,
+            resource_type="scholarship_configuration",
+            resource_id=str(id),
+            description=f"whitelist: batch remove {removed_count} student(s) from config {config.config_code}",
+            new_values={
+                "removed_students": request.nycu_ids,
+                "sub_type": request.sub_type,
+                "removed_count": removed_count,
+            },
+        )
+    )
     # Mark the field as modified for JSON update
     flag_modified(config, "whitelist_student_ids")
     config.updated_by = current_user.id
@@ -1665,6 +1692,22 @@ async def import_whitelist_excel(
     if added_count > 0:
         flag_modified(config, "whitelist_student_ids")
         config.updated_by = current_user.id
+        # 白名單控制申請資格 — 異動必須留稽核軌跡 (issue #972 / G10)。
+        db.add(
+            AuditLog.create_log(
+                user_id=current_user.id,
+                action=AuditAction.import_.value,
+                resource_type="scholarship_configuration",
+                resource_id=str(id),
+                description=f"whitelist: import {added_count} student(s) from Excel into config {config.config_code}",
+                new_values={
+                    "imported_students": [st["nycu_id"] for st in success_data],
+                    "added_count": added_count,
+                    "error_count": len(all_errors),
+                    "filename": file.filename,
+                },
+            )
+        )
         await db.commit()
         await invalidate("refdata:")
 

--- a/backend/app/api/v1/endpoints/scholarships.py
+++ b/backend/app/api/v1/endpoints/scholarships.py
@@ -12,6 +12,7 @@ from app.core.deps import get_db
 from app.core.path_security import validate_upload_file
 from app.core.security import get_current_user, require_admin
 from app.models.enums import Semester
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User
 from app.schemas.response import ApiResponse
@@ -430,6 +431,18 @@ async def add_student_to_whitelist(
     if student_id not in scholarship.whitelist_student_ids:
         scholarship.whitelist_student_ids.append(student_id)
         scholarship.whitelist_enabled = True
+    # 白名單控制誰能申請 — 異動必須留稽核軌跡 (issue #972 / G10)。
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.update.value,
+            resource_type="scholarship_type",
+            resource_id=str(id),
+            resource_name=scholarship.name,
+            description=f"whitelist: add student {student_id} to {scholarship.code} (dev endpoint)",
+            new_values={"added_student_id": student_id, "whitelist_size": len(scholarship.whitelist_student_ids)},
+        )
+    )
     await db.commit()
     return ApiResponse(
         success=True,
@@ -661,6 +674,19 @@ async def toggle_scholarship_whitelist(
     scholarship.whitelist_enabled = request.enabled
     scholarship.updated_by = current_user.id
 
+    # 白名單開關決定資格 gate — 異動必須留稽核軌跡 (issue #972 / G10)。
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.update.value,
+            resource_type="scholarship_type",
+            resource_id=str(id),
+            resource_name=scholarship.name,
+            description=f"whitelist: toggle {scholarship.code} enabled {previous_state} -> {request.enabled}",
+            old_values={"whitelist_enabled": previous_state},
+            new_values={"whitelist_enabled": request.enabled},
+        )
+    )
     await db.commit()
     await db.refresh(scholarship)
 

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -48,6 +48,14 @@ class AuditAction(enum.Enum):
     # to a user (e.g. Excel ranking export).
     pii_access = "pii_access"
 
+    # Allocation lifecycle (issue #980 / audit gap G18): 撤銷/停發/回復.
+    # Previously written as ad-hoc `application.<verb>` strings bypassing
+    # this enum — normalized so the audit vocabulary stays typed and the
+    # contract suite covers them.
+    revoke = "revoke"
+    suspend = "suspend"
+    restore = "restore"
+
 
 class AuditLog(Base):
     """Audit log model for tracking user activities"""

--- a/backend/app/services/application_audit_service.py
+++ b/backend/app/services/application_audit_service.py
@@ -289,6 +289,82 @@ class ApplicationAuditService:
             meta_data={"app_id": app_id},
         )
 
+    async def log_application_revoke(
+        self,
+        application_id: int,
+        app_id: str,
+        user: User,
+        reason: str,
+        affected_unlocked_rosters: Optional[list] = None,
+        request: Optional[Request] = None,
+    ) -> Optional[AuditLog]:
+        """記錄撤銷獎學金分發 (issue #980 / G18)"""
+        return await self.log_application_operation(
+            application_id=application_id,
+            action=AuditAction.revoke,
+            user=user,
+            request=request,
+            description=f"撤銷申請 {app_id} 的獎學金分發，原因: {reason}",
+            old_values={"quota_allocation_status": "allocated"},
+            new_values={
+                "quota_allocation_status": "revoked",
+                "reason": reason,
+                "affected_unlocked_rosters": affected_unlocked_rosters or [],
+            },
+            meta_data={"app_id": app_id},
+        )
+
+    async def log_application_suspend(
+        self,
+        application_id: int,
+        app_id: str,
+        user: User,
+        reason: str,
+        affected_unlocked_rosters: Optional[list] = None,
+        request: Optional[Request] = None,
+    ) -> Optional[AuditLog]:
+        """記錄停發獎學金分發 (issue #980 / G18)"""
+        return await self.log_application_operation(
+            application_id=application_id,
+            action=AuditAction.suspend,
+            user=user,
+            request=request,
+            description=f"停發申請 {app_id} 的獎學金分發，原因: {reason}",
+            old_values={"quota_allocation_status": "allocated"},
+            new_values={
+                "quota_allocation_status": "suspended",
+                "reason": reason,
+                "affected_unlocked_rosters": affected_unlocked_rosters or [],
+            },
+            meta_data={"app_id": app_id},
+        )
+
+    async def log_application_restore(
+        self,
+        application_id: int,
+        app_id: str,
+        user: User,
+        prior_status: str,
+        prior_reason: Optional[str] = None,
+        request: Optional[Request] = None,
+    ) -> Optional[AuditLog]:
+        """記錄回復獎學金分發 (issue #980 / G18)
+
+        ``prior_reason`` preserves the original revoke/suspend reason that the
+        restore operation clears from the application row — without it the
+        original cancellation context would survive only in earlier log rows.
+        """
+        return await self.log_application_operation(
+            application_id=application_id,
+            action=AuditAction.restore,
+            user=user,
+            request=request,
+            description=f"回復申請 {app_id} 的獎學金分發（原狀態: {prior_status}）",
+            old_values={"quota_allocation_status": prior_status, "reason": prior_reason},
+            new_values={"quota_allocation_status": "allocated"},
+            meta_data={"app_id": app_id},
+        )
+
     async def log_application_create(
         self,
         application_id: int,

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -17,7 +17,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
 from app.models.application import Application
-from app.models.audit_log import AuditLog
 from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
 from app.models.enums import ApplicationStatus, ReviewStage
 from app.models.review import ApplicationReview, ApplicationReviewItem
@@ -1370,6 +1369,9 @@ class ManualDistributionService:
             raise ValueError(
                 f"Application {application_id} is not revoked/suspended " f"(quota_allocation_status={prior_status})"
             )
+        # Capture the original cancellation reason BEFORE clearing it below —
+        # the endpoint's audit log preserves it as old_values (G18/G9).
+        prior_reason = app.revoke_reason if prior_status == "revoked" else app.suspend_reason
 
         ranking_items_result = await self.db.execute(
             select(CollegeRankingItem).where(CollegeRankingItem.application_id == application_id)
@@ -1395,22 +1397,18 @@ class ManualDistributionService:
             if ri.allocated_sub_type:
                 ri.is_allocated = True
 
-        log = AuditLog.create_log(
-            user_id=admin_user_id,
-            action="application.restore",
-            resource_type="application",
-            resource_id=str(application_id),
-            description=f"restore application {application_id} from {prior_status}",
-            new_values={"from": prior_status, "to": "allocated"},
-        )
-        self.db.add(log)
+        # Audit logging moved to the endpoint (ApplicationAuditService.
+        # log_application_restore) so the row carries the acting User +
+        # request IP/UA and the action lives in the AuditAction enum (G18).
         await self.db.flush()
 
         return {
             "application_id": application_id,
+            "app_id": app.app_id,
             "ranking_item_id": ranking_item_id,
             "quota_allocation_status": app.quota_allocation_status,
             "restored_from": prior_status,
+            "restored_reason": prior_reason,
             "restored_at": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -1490,23 +1488,16 @@ class ManualDistributionService:
         for roster_id in affected_roster_ids:
             await self._recompute_roster_totals(roster_id)
 
-        # 7. Audit log
-        action = "application.revoke" if mode == "revoke" else "application.suspend"
-        log = AuditLog.create_log(
-            user_id=admin_user_id,
-            action=action,
-            resource_type="application",
-            resource_id=str(application_id),
-            description=f"{mode} application {application_id}",
-            new_values={"reason": reason, "affected_unlocked_rosters": affected_roster_ids},
-        )
-        self.db.add(log)
-
+        # 7. Audit logging moved to the endpoint (ApplicationAuditService.
+        # log_application_revoke / log_application_suspend) so the row carries
+        # the acting User + request IP/UA and the action lives in the
+        # AuditAction enum instead of an ad-hoc string (G18).
         await self.db.flush()
 
         timestamp_key = "revoked_at" if mode == "revoke" else "suspended_at"
         return {
             "application_id": application_id,
+            "app_id": app.app_id,
             "ranking_item_id": ranking_item_id,
             "quota_allocation_status": app.quota_allocation_status,
             timestamp_key: now.isoformat(),

--- a/backend/app/tests/test_application_audit_service_contract.py
+++ b/backend/app/tests/test_application_audit_service_contract.py
@@ -197,3 +197,56 @@ class TestApplicationAuditServiceContract:
         assert row.meta_data["deletion_reason"] == "duplicate submission"
         assert row.meta_data["scholarship_type_id"] == 42
         assert row.meta_data["student_name"] == "王小明"
+
+    # ── Allocation lifecycle (issue #980 / audit gap G18) ──────────────
+    # revoke/suspend/restore previously wrote ad-hoc strings
+    # ("application.revoke") via AuditLog.create_log directly, bypassing
+    # this service AND this contract suite. These rows pin the normalized
+    # API so the high-risk money operations stay inside the audited
+    # vocabulary.
+
+    async def test_log_application_revoke(self, db, audit_user):
+        svc = ApplicationAuditService(db)
+        await svc.log_application_revoke(
+            application_id=1011,
+            app_id="APP-113-1-00011",
+            user=audit_user,
+            reason="違反獎學金要點",
+            affected_unlocked_rosters=[3, 7],
+        )
+        row = await _last_log_for(db, 1011)
+        assert row.action == AuditAction.revoke.value
+        assert row.old_values["quota_allocation_status"] == "allocated"
+        assert row.new_values["quota_allocation_status"] == "revoked"
+        assert row.new_values["reason"] == "違反獎學金要點"
+        assert row.new_values["affected_unlocked_rosters"] == [3, 7]
+
+    async def test_log_application_suspend(self, db, audit_user):
+        svc = ApplicationAuditService(db)
+        await svc.log_application_suspend(
+            application_id=1012,
+            app_id="APP-113-1-00012",
+            user=audit_user,
+            reason="休學",
+        )
+        row = await _last_log_for(db, 1012)
+        assert row.action == AuditAction.suspend.value
+        assert row.new_values["quota_allocation_status"] == "suspended"
+        assert row.new_values["reason"] == "休學"
+
+    async def test_log_application_restore(self, db, audit_user):
+        svc = ApplicationAuditService(db)
+        # prior_reason preserves the original cancellation reason that the
+        # restore operation clears from the application row (G9 linkage).
+        await svc.log_application_restore(
+            application_id=1013,
+            app_id="APP-113-1-00013",
+            user=audit_user,
+            prior_status="suspended",
+            prior_reason="休學",
+        )
+        row = await _last_log_for(db, 1013)
+        assert row.action == AuditAction.restore.value
+        assert row.old_values["quota_allocation_status"] == "suspended"
+        assert row.old_values["reason"] == "休學"
+        assert row.new_values["quota_allocation_status"] == "allocated"

--- a/backend/app/tests/test_audit_log_factory_and_enum.py
+++ b/backend/app/tests/test_audit_log_factory_and_enum.py
@@ -152,7 +152,11 @@ def test_all_action_values_are_unique_strings():
 
 
 def test_known_action_count_for_change_review():
-    """Pin: 24 actions defined. A refactor adding an action without
+    """Pin: 27 actions defined. A refactor adding an action without
     updating the audit dashboard's allowlist would silently hide the
-    new events. This test forces a code review when count changes."""
-    assert len(list(AuditAction)) == 24
+    new events. This test forces a code review when count changes.
+
+    2026-06-11 (#980 / G18): +3 — revoke / suspend / restore moved from
+    ad-hoc `application.<verb>` strings into the enum. No frontend switch
+    enumerates AuditAction values, so no UI allowlist needed updating."""
+    assert len(list(AuditAction)) == 27

--- a/backend/app/tests/test_audit_wiring_invariants.py
+++ b/backend/app/tests/test_audit_wiring_invariants.py
@@ -1,0 +1,111 @@
+"""AST invariants: history-critical mutation endpoints must write audit logs.
+
+Born from the 2026-06-11 申請歷史 audit (tracking #995). Three whole modules
+mutated long-retention, money-relevant records with ZERO audit trail:
+
+  - batch_import.py (G2 / #964): create/update/delete hundreds of
+    applications per call;
+  - whitelist mutations (G10 / #972): control who is eligible to apply;
+  - renewal.py creations (G11 / #973): renewal/challenge applications.
+
+These tests walk the AST of each module and fail when a listed function no
+longer references an audit emitter (`AuditLog` / `ApplicationAuditService`),
+so the wiring added for those gaps cannot silently regress. They also pin
+that manual_distribution writes audit through the typed service rather than
+ad-hoc action strings (G18 / #980).
+
+Sync + pure-AST on purpose: they run in the CI `unit` lane with no DB.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+BACKEND = pathlib.Path(__file__).resolve().parents[1]
+
+AUDIT_MARKERS = {"AuditLog", "ApplicationAuditService"}
+
+# module path (relative to app/) -> async endpoint functions that MUST audit
+REQUIRED_WIRING = {
+    "api/v1/endpoints/batch_import.py": [
+        "upload_batch_import_data",
+        "update_batch_record",
+        "delete_batch_record",
+        "upload_batch_documents",
+        "confirm_batch_import",
+        "delete_batch_import",
+    ],
+    "api/v1/endpoints/scholarships.py": [
+        "add_student_to_whitelist",
+        "toggle_scholarship_whitelist",
+    ],
+    "api/v1/endpoints/scholarship_configurations.py": [
+        "batch_add_whitelist",
+        "batch_remove_whitelist",
+        "import_whitelist_excel",
+    ],
+    "api/v1/endpoints/renewal.py": [
+        "create_renewal_application",
+        "create_challenge_application",
+    ],
+    "api/v1/endpoints/manual_distribution.py": [
+        "revoke_application_allocation",
+        "suspend_application_allocation",
+        "restore_application_allocation",
+    ],
+}
+
+
+def _function_references_audit(fn: ast.AST) -> bool:
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Name) and node.id in AUDIT_MARKERS:
+            return True
+        if isinstance(node, ast.Attribute) and node.attr in AUDIT_MARKERS:
+            return True
+    return False
+
+
+def _functions_of(path: pathlib.Path) -> dict:
+    tree = ast.parse(path.read_text())
+    return {node.name: node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
+
+
+@pytest.mark.parametrize(
+    "module, function_name",
+    [(m, f) for m, fns in REQUIRED_WIRING.items() for f in fns],
+)
+def test_mutation_endpoint_writes_audit(module, function_name):
+    path = BACKEND / module
+    assert path.exists(), f"{module} moved — update REQUIRED_WIRING"
+    functions = _functions_of(path)
+    assert function_name in functions, (
+        f"{module}::{function_name} not found — if it was renamed, update "
+        f"REQUIRED_WIRING; if it was removed, its audit obligation moved somewhere."
+    )
+    assert _function_references_audit(functions[function_name]), (
+        f"{module}::{function_name} mutates history-critical records but no "
+        f"longer references AuditLog/ApplicationAuditService — re-wire the "
+        f"audit emit (see #995 gaps G2/G10/G11/G18)."
+    )
+
+
+def test_no_adhoc_application_action_strings():
+    """G18: allocation lifecycle actions must live in the AuditAction enum.
+
+    The old code wrote action="application.revoke"/"application.suspend"/
+    "application.restore" — strings invisible to the enum and the contract
+    suite. Any reappearance anywhere under app/ is a regression.
+    """
+    offenders = []
+    for path in BACKEND.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        text = path.read_text()
+        for needle in ('"application.revoke"', '"application.suspend"', '"application.restore"'):
+            if needle in text:
+                offenders.append(f"{path.relative_to(BACKEND)}: {needle}")
+    assert not offenders, (
+        "ad-hoc audit action strings found (use AuditAction.revoke/suspend/"
+        f"restore + ApplicationAuditService instead): {offenders}"
+    )

--- a/backend/app/tests/test_restore_allocation_service.py
+++ b/backend/app/tests/test_restore_allocation_service.py
@@ -150,7 +150,11 @@ async def test_restore_flips_status_and_clears_metadata(db, allocated_applicatio
     assert allocated_application.suspend_reason is None
     assert result["restored_from"] == "revoked"
 
-    # An audit log row records the restore transition.
+    # G18 (#980): the service no longer writes the legacy ad-hoc audit row —
+    # the endpoint emits AuditAction.restore via ApplicationAuditService
+    # (wiring pinned by test_audit_wiring_invariants.py). The service instead
+    # returns the context the endpoint logs, including the original
+    # cancellation reason it just cleared from the application row.
     logs = (
         (
             await db.execute(
@@ -163,7 +167,9 @@ async def test_restore_flips_status_and_clears_metadata(db, allocated_applicatio
         .scalars()
         .all()
     )
-    assert len(logs) == 1
+    assert logs == []
+    assert result["app_id"] == allocated_application.app_id
+    assert result["restored_reason"] is not None
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_revoke_suspend_service.py
+++ b/backend/app/tests/test_revoke_suspend_service.py
@@ -233,19 +233,23 @@ async def test_revoke_non_allocated_raises(db, unallocated_application, admin_db
 
 
 @pytest.mark.asyncio
-async def test_revoke_writes_audit_log(db, allocated_application, admin_db_user):
+async def test_revoke_result_carries_audit_context_and_writes_no_adhoc_log(db, allocated_application, admin_db_user):
+    """G18 (#980): audit moved to the endpoint via ApplicationAuditService.
+
+    The service must (a) no longer emit the legacy `application.revoke`
+    ad-hoc row, and (b) return everything the endpoint's typed audit call
+    needs (app_id + affected rosters). The endpoint-side wiring is pinned by
+    test_audit_wiring_invariants.py; the row shape by the contract suite.
+    """
     from sqlalchemy import select
 
     svc = ManualDistributionService(db)
-    await svc.revoke_allocation(allocated_application.id, admin_db_user.id, "reason text")
+    result = await svc.revoke_allocation(allocated_application.id, admin_db_user.id, "reason text")
     await db.commit()
     rows = (await db.execute(select(AuditLog).where(AuditLog.action == "application.revoke"))).scalars().all()
-    assert len(rows) == 1
-    log = rows[0]
-    assert log.resource_id == str(allocated_application.id)
-    assert log.user_id == admin_db_user.id
-    assert log.new_values["reason"] == "reason text"
-    assert "affected_unlocked_rosters" in log.new_values
+    assert rows == []
+    assert result["app_id"] == allocated_application.app_id
+    assert "affected_unlocked_rosters" in result
 
 
 # ---------------------------------------------------------------------------
@@ -275,11 +279,13 @@ async def test_suspend_then_revoke_raises_conflict(db, allocated_application, ad
 
 
 @pytest.mark.asyncio
-async def test_suspend_writes_audit_log_with_suspend_action(db, allocated_application, admin_db_user):
+async def test_suspend_result_carries_audit_context_and_writes_no_adhoc_log(db, allocated_application, admin_db_user):
+    """G18 (#980): see the revoke twin above."""
     from sqlalchemy import select
 
     svc = ManualDistributionService(db)
-    await svc.suspend_allocation(allocated_application.id, admin_db_user.id, "x")
+    result = await svc.suspend_allocation(allocated_application.id, admin_db_user.id, "x")
     await db.commit()
-    log = (await db.execute(select(AuditLog).where(AuditLog.action == "application.suspend"))).scalar_one()
-    assert log.resource_id == str(allocated_application.id)
+    rows = (await db.execute(select(AuditLog).where(AuditLog.action == "application.suspend"))).scalars().all()
+    assert rows == []
+    assert result["app_id"] == allocated_application.app_id


### PR DESCRIPTION
Phase 1 audit-wiring batch from the 申請歷史 audit (tracking #995). Four confirmed gaps closed:

| Gap | Issue | What changed |
|---|---|---|
| G2 critical | #964 | `batch_import.py`: all 6 mutation endpoints now write `AuditLog` — confirm emits **one row per created application**, batch delete emits **one row per destroyed application** + a batch-level row, and batch deletion now deletes the applications' **MinIO objects** (collected before the cascade) instead of orphaning them |
| G10 high | #972 | all 5 whitelist mutation endpoints (dev add / enabled toggle / batch add / batch remove / Excel import) write audit rows with old/new values |
| G11 high | #973 | renewal + challenge creation audit via `ApplicationAuditService` (with request IP/UA), matching ordinary creation |
| G18 high | #980 | `AuditAction` gains `revoke`/`suspend`/`restore`; new `log_application_revoke/suspend/restore` service methods; manual-distribution endpoints call them **after commit with the acting User + request context**; the service stops writing ad-hoc `application.<verb>` strings and returns `app_id` + `restored_reason` so restore's audit row preserves the original cancellation reason it clears (partial G9) |

**Regression guards:**
- `test_audit_wiring_invariants.py` (unit lane, pure AST): each of the 16 listed mutation endpoints must reference an audit emitter; ad-hoc `application.<verb>` action strings are banned repo-wide. (The repo's proven AST-invariant pattern.)
- Contract suite +3 cases pinning the revoke/suspend/restore row shapes (old/new values incl. preserved cancellation reason).
- The two service tests that pinned the legacy ad-hoc rows are rewritten to the new contract.

Verified locally: AST invariants 23/23, `black` clean, `flake8 --select=B904,B014` clean. The contract/integration cases run in the CI integration lane.

Closes #964 / Closes #972 / Closes #973 / Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)