### PR TITLE
fix(history): deleted-records policy, revocation fields, student-history soft-delete filter, review_stage guard

### DIFF
--- a/backend/app/api/v1/endpoints/admin/applications.py
+++ b/backend/app/api/v1/endpoints/admin/applications.py
@@ -26,7 +26,7 @@ from app.core.security import require_admin
 from app.db.deps import get_db
 from app.models.application import Application, ApplicationStatus
 from app.models.college_review import CollegeRankingItem
-from app.models.enums import Semester
+from app.models.enums import Semester, ReviewStage
 from app.models.payment_roster import PaymentRosterItem
 from app.models.scholarship import ScholarshipType
 from app.models.user import User
@@ -196,7 +196,15 @@ async def get_historical_applications(
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get historical applications with advanced filtering (admin only)"""
+    """Get historical applications with advanced filtering (admin only).
+
+    Deleted-records policy (issue #974 / G12): soft-deleted applications are
+    INCLUDED here on purpose — the history view is the retention surface, and
+    a 獎學金 record must stay reviewable for its statutory retention period.
+    Each row carries deleted_at/deletion_reason + is_deleted so the UI badges
+    them; the operational list endpoint (GET /applications) keeps excluding
+    them via deleted_at IS NULL.
+    """
 
     # Build base query with joins
     stmt = (
@@ -314,6 +322,17 @@ async def get_historical_applications(
             # Review information
             professor_name=getattr(row, "professor_name", None),
             reviewer_name=getattr(row, "reviewer_name", None),
+            # Revocation / deletion context (#975 G13, #974 G12)
+            revoked_at=app.revoked_at,
+            revoked_by=app.revoked_by,
+            revoke_reason=app.revoke_reason,
+            suspended_at=app.suspended_at,
+            suspended_by=app.suspended_by,
+            suspend_reason=app.suspend_reason,
+            deleted_at=app.deleted_at,
+            deleted_by_id=app.deleted_by_id,
+            deletion_reason=app.deletion_reason,
+            is_deleted=app.deleted_at is not None,
         )
 
         historical_applications.append(historical_app)
@@ -487,6 +506,17 @@ async def delete_application(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="只有在學生申請階段（草稿或已送出）的申請才可刪除",
+        )
+
+    # G30 (#992): status alone is not enough — an application can sit at
+    # status=submitted while review_stage already advanced (e.g.
+    # professor_reviewed). Once ANY review work exists the row is part of the
+    # decision chain and must be preserved, exactly as the docstring promises.
+    stage_value = app.review_stage.value if hasattr(app.review_stage, "value") else app.review_stage
+    if stage_value and stage_value not in (ReviewStage.student_draft.value, ReviewStage.student_submitted.value):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="申請已進入審核流程（review_stage 已推進），不可刪除",
         )
 
     app_id_str = app.app_id

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -757,6 +757,24 @@ class HistoricalApplicationResponse(BaseModel):
     # Note: review_score, review_comments, rejection_reason removed
     # Get these from ApplicationReview if needed
 
+    # Revocation / suspension context (issue #975 / G13): the DB stores who
+    # revoked an allocation, when and why — compliance review must see it in
+    # the history view, not only via direct DB access.
+    revoked_at: Optional[datetime] = None
+    revoked_by: Optional[int] = None
+    revoke_reason: Optional[str] = None
+    suspended_at: Optional[datetime] = None
+    suspended_by: Optional[int] = None
+    suspend_reason: Optional[str] = None
+
+    # Soft-deletion context (issue #974 / G12 policy: soft-deleted
+    # applications REMAIN visible in the history view — they are retained
+    # records, not vanished ones — and are flagged so the UI can badge them).
+    deleted_at: Optional[datetime] = None
+    deleted_by_id: Optional[int] = None
+    deletion_reason: Optional[str] = None
+    is_deleted: bool = False
+
     # Status helpers
     @classmethod
     def get_status_label(cls, status: str) -> str:

--- a/backend/app/services/student_scholarship_history_service.py
+++ b/backend/app/services/student_scholarship_history_service.py
@@ -5,10 +5,11 @@ import logging
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import ScholarshipException
+from app.models.application import Application
 from app.models.payment_roster import PaymentRoster, PaymentRosterItem, RosterStatus
 from app.schemas.student_scholarship_history import (
     AcademicBasicInfo,
@@ -69,14 +70,21 @@ class StudentScholarshipHistoryService:
 
         ``student_number`` is the 學號 (std_stdcode) the admin looks up by, so it
         must match PaymentRosterItem.student_number — NOT student_id_number, which
-        holds the national ID (身分證字號) for the Excel payment column."""
+        holds the national ID (身分證字號) for the Excel payment column.
+
+        Soft-deleted applications are excluded (issue #977 / G15): a roster
+        item whose application was since soft-deleted must not surface in the
+        payment history view. The outerjoin keeps legacy items whose
+        application_id is NULL (imported rows) visible."""
         stmt = (
             select(PaymentRosterItem, PaymentRoster)
             .join(PaymentRoster, PaymentRosterItem.roster_id == PaymentRoster.id)
+            .outerjoin(Application, PaymentRosterItem.application_id == Application.id)
             .where(
                 PaymentRosterItem.student_number == student_number,
                 PaymentRosterItem.is_included.is_(True),
                 PaymentRoster.status.in_([RosterStatus.COMPLETED, RosterStatus.LOCKED]),
+                or_(Application.id.is_(None), Application.deleted_at.is_(None)),
             )
             .order_by(
                 PaymentRoster.academic_year.desc(),

--- a/backend/app/tests/test_history_endpoint_deleted_policy.py
+++ b/backend/app/tests/test_history_endpoint_deleted_policy.py
@@ -1,0 +1,159 @@
+"""G12/G13 (#974/#975): history-endpoint deleted-records policy + revocation fields.
+
+Policy pinned here (documented in the endpoint docstring):
+  - GET /admin/applications/history INCLUDES soft-deleted applications —
+    history is the retention surface — and flags them (is_deleted +
+    deleted_at/deletion_reason) so the UI can badge them.
+  - The response also carries the revocation context the DB already stores
+    (revoked_at/revoke_reason/...), which the old schema silently dropped.
+  - G30 (#992): the admin hard-delete endpoint refuses once review_stage has
+    advanced past the student stages, even while status is still 'submitted'.
+
+Auth pattern follows test_admin_student_history_endpoint.py.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from app.models.application import Application
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def admin_db_user(db):
+    user = User(
+        nycu_id="g12admin",
+        name="G12 Admin",
+        email="g12admin@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def authed_admin_client(client, admin_db_user):
+    from app.core.security import require_admin
+    from app.main import app
+
+    async def override_require_admin():
+        return admin_db_user
+
+    app.dependency_overrides[require_admin] = override_require_admin
+    yield client
+    del app.dependency_overrides[require_admin]
+
+
+@pytest_asyncio.fixture
+async def history_fixture(db, admin_db_user):
+    student = User(
+        nycu_id="g12stu001",
+        name="G12 學生",
+        email="g12stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(student)
+    await db.flush()
+
+    stype = ScholarshipType(code="g12_test", name="G12 Test Scholarship")
+    db.add(stype)
+    await db.flush()
+    cfg = ScholarshipConfiguration(
+        config_code="G12-CFG",
+        config_name="G12 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=5000,
+    )
+    db.add(cfg)
+    await db.flush()
+
+    def make_app(suffix: str, **extra) -> Application:
+        app_row = Application(
+            app_id=f"APP-G12-{suffix}",
+            user_id=student.id,
+            scholarship_type_id=stype.id,
+            scholarship_configuration_id=cfg.id,
+            academic_year=114,
+            sub_type_selection_mode="single",
+            status=extra.pop("status", "approved"),
+        )
+        for k, v in extra.items():
+            setattr(app_row, k, v)
+        db.add(app_row)
+        return app_row
+
+    live = make_app("LIVE")
+    deleted = make_app(
+        "DEAD",
+        status="deleted",
+        deleted_at=datetime(2026, 1, 15, tzinfo=timezone.utc),
+        deleted_by_id=admin_db_user.id,
+        deletion_reason="重複申請",
+    )
+    revoked = make_app(
+        "RVK",
+        status="cancelled",
+        quota_allocation_status="revoked",
+        revoked_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        revoked_by=admin_db_user.id,
+        revoke_reason="違反要點",
+    )
+    submitted_in_review = make_app("GUARD", status="submitted", review_stage="professor_reviewed")
+    await db.commit()
+    for row in (live, deleted, revoked, submitted_in_review):
+        await db.refresh(row)
+    return {"live": live, "deleted": deleted, "revoked": revoked, "guard": submitted_in_review}
+
+
+def _items(payload):
+    return {item["app_id"]: item for item in payload["data"]["items"]}
+
+
+async def test_history_includes_soft_deleted_with_flags(authed_admin_client, history_fixture):
+    response = await authed_admin_client.get("/api/v1/admin/applications/history?size=100&academic_year=114")
+    assert response.status_code == 200
+    items = _items(response.json())
+
+    assert "APP-G12-DEAD" in items, "soft-deleted applications must remain visible in history (G12 policy)"
+    dead = items["APP-G12-DEAD"]
+    assert dead["is_deleted"] is True
+    assert dead["deleted_at"] is not None
+    assert dead["deletion_reason"] == "重複申請"
+
+    live = items["APP-G12-LIVE"]
+    assert live["is_deleted"] is False
+    assert live["deleted_at"] is None
+
+
+async def test_history_surfaces_revocation_context(authed_admin_client, history_fixture):
+    response = await authed_admin_client.get("/api/v1/admin/applications/history?size=100&academic_year=114")
+    assert response.status_code == 200
+    items = _items(response.json())
+
+    rvk = items["APP-G12-RVK"]
+    assert rvk["revoked_at"] is not None
+    assert rvk["revoke_reason"] == "違反要點"
+    assert rvk["revoked_by"] is not None
+
+
+async def test_admin_delete_refuses_when_review_stage_advanced(authed_admin_client, history_fixture):
+    """G30: status=submitted but review_stage=professor_reviewed → 400, row survives."""
+    guard_app = history_fixture["guard"]
+    response = await authed_admin_client.request(
+        "DELETE",
+        f"/api/v1/admin/applications/{guard_app.id}",
+        json={"reason": "should be refused"},
+    )
+    assert response.status_code == 400
+    assert "審核流程" in response.text

--- a/backend/app/tests/test_student_history_excludes_deleted_applications.py
+++ b/backend/app/tests/test_student_history_excludes_deleted_applications.py
@@ -90,13 +90,13 @@ async def seeded(db):
 
     roster = PaymentRoster(
         roster_code="G15-ROSTER",
-        roster_name="G15 Roster",
+        scholarship_configuration_id=cfg.id,
         period_label="114-10",
         academic_year=114,
         roster_cycle=RosterCycle.MONTHLY,
         trigger_type=RosterTriggerType.MANUAL,
         status=RosterStatus.LOCKED,
-        created_by_user_id=admin.id,
+        created_by=admin.id,
     )
     db.add(roster)
     await db.flush()

--- a/backend/app/tests/test_student_history_excludes_deleted_applications.py
+++ b/backend/app/tests/test_student_history_excludes_deleted_applications.py
@@ -1,0 +1,147 @@
+"""G15 (#977): soft-deleted applications must not leak into 學生領取歷史.
+
+`_fetch_paid_payments` previously selected roster items by student_number
+alone — an application that was soft-deleted AFTER its roster locked still
+surfaced in the payment-history view. The fix outer-joins Application and
+filters `deleted_at IS NULL`, while keeping items whose application row is
+missing entirely (legacy/imported rows with dangling application_id) visible.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from app.models.application import Application
+from app.models.payment_roster import (
+    PaymentRoster,
+    PaymentRosterItem,
+    RosterCycle,
+    RosterStatus,
+    RosterTriggerType,
+    StudentVerificationStatus,
+)
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.student_scholarship_history_service import (
+    StudentScholarshipHistoryService,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+STUDENT_NO = "G15S001"
+
+
+@pytest_asyncio.fixture
+async def seeded(db):
+    admin = User(
+        nycu_id="g15admin",
+        name="G15 Admin",
+        email="g15admin@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    student = User(
+        nycu_id=STUDENT_NO,
+        name="G15 學生",
+        email="g15stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add_all([admin, student])
+    await db.flush()
+
+    stype = ScholarshipType(code="g15_test", name="G15 Test Scholarship")
+    db.add(stype)
+    await db.flush()
+
+    cfg = ScholarshipConfiguration(
+        config_code="G15-CFG",
+        config_name="G15 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=10000,
+    )
+    db.add(cfg)
+    await db.flush()
+
+    def make_app(suffix: str, deleted: bool) -> Application:
+        app = Application(
+            app_id=f"APP-G15-{suffix}",
+            user_id=student.id,
+            scholarship_type_id=stype.id,
+            scholarship_configuration_id=cfg.id,
+            academic_year=114,
+            sub_type_selection_mode="single",
+            status="approved",
+        )
+        if deleted:
+            app.status = "deleted"
+            app.deleted_at = datetime.now(timezone.utc)
+            app.deleted_by_id = admin.id
+            app.deletion_reason = "G15 test soft delete"
+        db.add(app)
+        return app
+
+    live_app = make_app("LIVE", deleted=False)
+    dead_app = make_app("DEAD", deleted=True)
+    await db.flush()
+
+    roster = PaymentRoster(
+        roster_code="G15-ROSTER",
+        roster_name="G15 Roster",
+        period_label="114-10",
+        academic_year=114,
+        roster_cycle=RosterCycle.MONTHLY,
+        trigger_type=RosterTriggerType.MANUAL,
+        status=RosterStatus.LOCKED,
+        created_by_user_id=admin.id,
+    )
+    db.add(roster)
+    await db.flush()
+
+    def make_item(application_id, name, amount):
+        item = PaymentRosterItem(
+            roster_id=roster.id,
+            application_id=application_id,
+            student_id_number=f"A{STUDENT_NO}",
+            student_number=STUDENT_NO,
+            student_name="G15 學生",
+            scholarship_name=name,
+            scholarship_amount=amount,
+            verification_status=StudentVerificationStatus.VERIFIED,
+            is_included=True,
+        )
+        db.add(item)
+        return item
+
+    make_item(live_app.id, "存活申請", "10000")
+    make_item(dead_app.id, "已刪申請", "5000")
+    # Dangling application_id (no Application row): legacy/imported items —
+    # the outerjoin must KEEP these (SQLite test DB doesn't enforce the FK).
+    make_item(987654321, "孤兒項目", "300")
+    await db.commit()
+    return {"live": live_app, "dead": dead_app}
+
+
+async def test_soft_deleted_applications_payments_are_hidden(db, seeded):
+    svc = StudentScholarshipHistoryService()
+    records, snapshot_name = await svc._fetch_paid_payments(db, STUDENT_NO)
+    names = {r.scholarship_name for r in records}
+    assert "存活申請" in names
+    assert "孤兒項目" in names, "items with a dangling application_id must stay visible"
+    assert "已刪申請" not in names, "soft-deleted application's payment leaked into history (G15)"
+    assert snapshot_name == "G15 學生"
+
+
+async def test_undeleting_restores_visibility(db, seeded):
+    # Sanity inverse: clearing deleted_at brings the payment back — proves the
+    # filter keys on deleted_at, not on some incidental column.
+    seeded["dead"].deleted_at = None
+    seeded["dead"].status = "approved"
+    await db.commit()
+
+    svc = StudentScholarshipHistoryService()
+    records, _ = await svc._fetch_paid_payments(db, STUDENT_NO)
+    assert "已刪申請" in {r.scholarship_name for r in records}

--- a/frontend/components/admin/history/HistoryPanel.tsx
+++ b/frontend/components/admin/history/HistoryPanel.tsx
@@ -519,6 +519,24 @@ export function HistoryPanel({ user }: HistoryPanelProps) {
                                       續領
                                     </Badge>
                                   )}
+                                  {application.is_deleted && (
+                                    <Badge
+                                      variant="destructive"
+                                      className="text-xs mt-1"
+                                      title={application.deletion_reason ?? undefined}
+                                    >
+                                      已刪除
+                                    </Badge>
+                                  )}
+                                  {application.revoked_at && (
+                                    <Badge
+                                      variant="destructive"
+                                      className="text-xs mt-1"
+                                      title={application.revoke_reason ?? undefined}
+                                    >
+                                      已撤銷
+                                    </Badge>
+                                  )}
                                 </div>
                               </TableCell>
                               <TableCell>

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -1245,7 +1245,14 @@ export interface paths {
         };
         /**
          * Get Historical Applications
-         * @description Get historical applications with advanced filtering (admin only)
+         * @description Get historical applications with advanced filtering (admin only).
+         *
+         *     Deleted-records policy (issue #974 / G12): soft-deleted applications are
+         *     INCLUDED here on purpose — the history view is the retention surface, and
+         *     a 獎學金 record must stay reviewable for its statutory retention period.
+         *     Each row carries deleted_at/deletion_reason + is_deleted so the UI badges
+         *     them; the operational list endpoint (GET /applications) keeps excluding
+         *     them via deleted_at IS NULL.
          */
         get: operations["get_historical_applications_api_v1_admin_applications_history_get"];
         put?: never;

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -974,6 +974,21 @@ export interface HistoricalApplication {
   // Review information
   professor_name?: string;
   reviewer_name?: string;
+
+  // Revocation / suspension context (#975 / G13)
+  revoked_at?: string | null;
+  revoked_by?: number | null;
+  revoke_reason?: string | null;
+  suspended_at?: string | null;
+  suspended_by?: number | null;
+  suspend_reason?: string | null;
+
+  // Soft-deletion context (#974 / G12: deleted applications stay visible in
+  // history, flagged so the UI badges them)
+  deleted_at?: string | null;
+  deleted_by_id?: number | null;
+  deletion_reason?: string | null;
+  is_deleted?: boolean;
 }
 
 export interface HistoricalApplicationFilters {


### PR DESCRIPTION
Phase 1 history-correctness batch from the 申請歷史 audit (tracking #995):

| Gap | Issue | What changed |
|---|---|---|
| G12 high | #974 | Deleted-records policy decided + documented + pinned: the history endpoint **includes** soft-deleted applications (history = retention surface) and flags them (`is_deleted`, `deleted_at`, `deletion_reason`); the operational list keeps excluding them |
| G13 high | #975 | `HistoricalApplicationResponse` now surfaces the revocation/suspension context already stored in the DB (revoked_at/by/reason, suspended_at/by/reason); `HistoryPanel` shows 已刪除 / 已撤銷 badges with the reason as tooltip; TS types + generated schema regenerated |
| G15 high | #977 | student-history payment query outer-joins `Application` + filters `deleted_at IS NULL` — a soft-deleted application's payments no longer leak into 學生領取歷史; dangling `application_id` (legacy imports) stay visible |
| G30 low | #992 | admin hard-delete refuses when `review_stage` advanced past the student stages even at `status=submitted` — closes the contradiction with the endpoint's own docstring |

Tests: `test_student_history_excludes_deleted_applications.py` (leak + un-delete inverse + dangling-FK), `test_history_endpoint_deleted_policy.py` (policy, revocation fields, G30 refusal). `tsc --noEmit` clean; black + flake8 (B904/B014) clean.

Closes #974 / Closes #975 / Closes #977 / Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)