### PR TITLE
fix(resilience): MinIO orphan detection, audit-survival tests, evidence-table FK policies

### DIFF
--- a/backend/alembic/versions/audit_evidence_fk_policy_001.py
+++ b/backend/alembic/versions/audit_evidence_fk_policy_001.py
@@ -1,0 +1,74 @@
+"""Explicit FK delete policies for evidence tables (issues #979/#983, gaps G17/G21)
+
+- email_history.application_id / scheduled_emails.application_id → ON DELETE
+  SET NULL: emails are delivery EVIDENCE — they must survive the referenced
+  application being hard-deleted, and must not make that deletion fail with
+  an FK violation (draft hard-delete previously rolled back silently when a
+  related email existed).
+- audit_logs.user_id → ON DELETE RESTRICT (explicit): audit rows carry no
+  independent actor snapshot, so the users row they point at must not be
+  deletable while audit history exists. RESTRICT pins what was previously an
+  implicit NO ACTION default.
+
+Revision ID: audit_evidence_fk_001
+Revises: contact_phone_tw_mobile_001
+Create Date: 2026-06-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "audit_evidence_fk_001"
+down_revision: Union[str, None] = "contact_phone_tw_mobile_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _existing_fk_names(inspector, table: str, column: str) -> list:
+    return [
+        fk["name"]
+        for fk in inspector.get_foreign_keys(table)
+        if column in fk.get("constrained_columns", []) and fk.get("name")
+    ]
+
+
+def _retarget_fk(table: str, column: str, referred: str, ondelete: str) -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if table not in inspector.get_table_names():
+        return
+    for name in _existing_fk_names(inspector, table, column):
+        op.drop_constraint(name, table, type_="foreignkey")
+    op.create_foreign_key(
+        f"fk_{table}_{column}_{ondelete.replace(' ', '_').lower()}",
+        table,
+        referred,
+        [column],
+        ["id"],
+        ondelete=ondelete,
+    )
+
+
+def upgrade() -> None:
+    _retarget_fk("email_history", "application_id", "applications", "SET NULL")
+    _retarget_fk("scheduled_emails", "application_id", "applications", "SET NULL")
+    _retarget_fk("audit_logs", "user_id", "users", "RESTRICT")
+
+
+def downgrade() -> None:
+    # Back to unspecified (NO ACTION) delete policies.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table, column, referred in (
+        ("email_history", "application_id", "applications"),
+        ("scheduled_emails", "application_id", "applications"),
+        ("audit_logs", "user_id", "users"),
+    ):
+        if table not in inspector.get_table_names():
+            continue
+        for name in _existing_fk_names(inspector, table, column):
+            op.drop_constraint(name, table, type_="foreignkey")
+        op.create_foreign_key(f"fk_{table}_{column}", table, referred, [column], ["id"])

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -55,7 +55,13 @@ class AuditLog(Base):
     __tablename__ = "audit_logs"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    # RESTRICT (issue #983 / G21): audit rows carry NO independent actor
+    # snapshot, so user_id must never be nulled or cascaded away — deleting a
+    # users row that audit history points at would either anonymize or
+    # destroy the trail. Accounts with audit history are deactivated, not
+    # deleted. (Explicit RESTRICT pins what was previously an implicit
+    # NO ACTION default.)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="RESTRICT"), nullable=False)
 
     # 活動資訊
     action = Column(String(50), nullable=False)

--- a/backend/app/models/email_management.py
+++ b/backend/app/models/email_management.py
@@ -69,7 +69,15 @@ class EmailHistory(Base):
     email_category = Column(String(100), nullable=True, index=True)
 
     # Related entities (for permission filtering)
-    application_id = Column(Integer, ForeignKey("applications.id"), nullable=True, index=True)
+    application_id = Column(
+        # SET NULL (issue #979 / G17): emails are delivery EVIDENCE — they must
+        # survive the referenced application being hard-deleted (and must not
+        # make that deletion fail with an FK violation).
+        Integer,
+        ForeignKey("applications.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     scholarship_type_id = Column(Integer, ForeignKey("scholarship_types.id"), nullable=True, index=True)
 
     # Sender information
@@ -153,7 +161,15 @@ class ScheduledEmail(Base):
     )
 
     # Related entities (for permission filtering)
-    application_id = Column(Integer, ForeignKey("applications.id"), nullable=True, index=True)
+    application_id = Column(
+        # SET NULL (issue #979 / G17): emails are delivery EVIDENCE — they must
+        # survive the referenced application being hard-deleted (and must not
+        # make that deletion fail with an FK violation).
+        Integer,
+        ForeignKey("applications.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     scholarship_type_id = Column(Integer, ForeignKey("scholarship_types.id"), nullable=True, index=True)
 
     # Approval workflow

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -17,6 +17,7 @@ from app.core.cache import invalidate as cache_invalidate
 from app.core.exceptions import AuthorizationError, BusinessLogicError, NotFoundError, ValidationError
 from app.core.metrics import scholarship_applications_total, scholarship_reviews_total
 from app.core.schema_validation import serialize_value
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.application import Application, ApplicationStatus
 from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, ReviewStage, Semester
 from app.models.review import ApplicationReview, ApplicationReviewItem
@@ -1985,17 +1986,44 @@ class ApplicationService:
             # Hard delete for draft applications
             logger.info(f"Performing hard delete for draft application {application.app_id}")
 
-            # Delete associated files from MinIO
+            # Delete associated files from MinIO. delete_file() never raises —
+            # it swallows errors internally and returns False (issue #982 /
+            # G20: the old try/except was dead code and the bool was ignored,
+            # so failures orphaned objects with no trace).
             deleted_files_count = 0
+            orphaned_objects = []
             if application.files:
                 for app_file in application.files:
                     if app_file.object_name:
-                        try:
-                            minio_service.delete_file(app_file.object_name)
+                        if minio_service.delete_file(app_file.object_name):
                             deleted_files_count += 1
                             logger.info(f"Deleted file from MinIO: {app_file.object_name}")
-                        except Exception:
-                            logger.exception(f"Failed to delete file {app_file.object_name} from MinIO")
+                        else:
+                            orphaned_objects.append(app_file.object_name)
+                            logger.error(
+                                "MinIO deletion failed for %s (application %s) — object orphaned",
+                                app_file.object_name,
+                                application.app_id,
+                            )
+
+            if orphaned_objects:
+                # Leave a queryable trace so the orphans can be swept later —
+                # DB deletion proceeds regardless (storage cleanup must not
+                # block the user-facing operation).
+                self.db.add(
+                    AuditLog.create_log(
+                        user_id=current_user.id,
+                        action=AuditAction.delete.value,
+                        resource_type="application",
+                        resource_id=str(application.id),
+                        description=(
+                            f"MinIO cleanup incomplete for {application.app_id}: "
+                            f"{len(orphaned_objects)} orphaned object(s)"
+                        ),
+                        status="failed",
+                        meta_data={"app_id": application.app_id, "orphaned_objects": orphaned_objects},
+                    )
+                )
 
             logger.info(f"Deleted {deleted_files_count} files from MinIO for application {application.app_id}")
 

--- a/backend/app/tests/test_audit_log_survives_application_deletion.py
+++ b/backend/app/tests/test_audit_log_survives_application_deletion.py
@@ -1,0 +1,179 @@
+"""G5 (#967): audit rows must survive application deletion, queryably.
+
+The audit design stores attribution (scholarship_type_id / student_name /
+app_id) in AuditLog.meta_data precisely so the trail keeps working after the
+applications row is hard-deleted — but until now nothing pinned that
+property end-to-end, so any refactor (an FK with CASCADE, an over-eager
+cleanup) could silently destroy the legal trail. These tests delete real
+application rows and assert the trail remains.
+
+Also pins the FK delete policies from #979/#983 (G17/G21) at the model
+level — the test DB does not enforce FKs, so the declared policy is the
+testable contract and the alembic migration applies it to real databases.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.application import Application
+from app.models.audit_log import AuditAction, AuditLog
+from app.models.email_management import EmailHistory, ScheduledEmail
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.application_audit_service import ApplicationAuditService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def actors(db):
+    admin = User(
+        nycu_id="g5admin",
+        name="G5 Admin",
+        email="g5admin@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    student = User(
+        nycu_id="g5stu001",
+        name="G5 學生",
+        email="g5stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add_all([admin, student])
+    await db.flush()
+
+    stype = ScholarshipType(code="g5_test", name="G5 Test Scholarship")
+    db.add(stype)
+    await db.flush()
+    cfg = ScholarshipConfiguration(
+        config_code="G5-CFG",
+        config_name="G5 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=1000,
+    )
+    db.add(cfg)
+    await db.commit()
+    return {"admin": admin, "student": student, "stype": stype, "cfg": cfg}
+
+
+async def _make_application(db, actors, suffix: str) -> Application:
+    app_row = Application(
+        app_id=f"APP-G5-{suffix}",
+        user_id=actors["student"].id,
+        scholarship_type_id=actors["stype"].id,
+        scholarship_configuration_id=actors["cfg"].id,
+        academic_year=114,
+        sub_type_selection_mode="single",
+        status="draft",
+    )
+    db.add(app_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return app_row
+
+
+async def _trail_for(db, application_db_id: int):
+    res = await db.execute(
+        select(AuditLog)
+        .where(AuditLog.resource_type == "application", AuditLog.resource_id == str(application_db_id))
+        .order_by(AuditLog.id)
+    )
+    return res.scalars().all()
+
+
+async def test_audit_trail_survives_hard_delete(db, actors):
+    app_row = await _make_application(db, actors, "HARD")
+    app_db_id, app_id, stype_id = app_row.id, app_row.app_id, app_row.scholarship_type_id
+
+    svc = ApplicationAuditService(db)
+    await svc.log_application_create(
+        application_id=app_db_id,
+        app_id=app_id,
+        user=actors["student"],
+        scholarship_type=str(stype_id),
+        is_draft=True,
+    )
+    await svc.log_delete_application(
+        application_id=app_db_id,
+        app_id=app_id,
+        user=actors["admin"],
+        reason="G5 hard-delete survival test",
+        scholarship_type_id=stype_id,
+        student_name="G5 學生",
+    )
+
+    # Hard-delete the application row itself.
+    await db.delete(app_row)
+    await db.commit()
+
+    gone = await db.execute(select(Application).where(Application.id == app_db_id))
+    assert gone.scalar_one_or_none() is None
+
+    trail = await _trail_for(db, app_db_id)
+    assert len(trail) == 2, "audit rows must survive the application hard-delete"
+    actions = [row.action for row in trail]
+    assert actions == [AuditAction.create.value, AuditAction.delete.value]
+
+    delete_row = trail[-1]
+    # Attribution must be reconstructable WITHOUT the applications row.
+    assert delete_row.meta_data["app_id"] == app_id
+    assert delete_row.meta_data["scholarship_type_id"] == stype_id
+    assert delete_row.meta_data["student_name"] == "G5 學生"
+    assert delete_row.meta_data["deletion_reason"] == "G5 hard-delete survival test"
+    assert delete_row.user_id == actors["admin"].id
+
+
+async def test_audit_trail_survives_soft_delete(db, actors):
+    app_row = await _make_application(db, actors, "SOFT")
+    app_db_id, app_id = app_row.id, app_row.app_id
+
+    svc = ApplicationAuditService(db)
+    await svc.log_delete_application(
+        application_id=app_db_id,
+        app_id=app_id,
+        user=actors["admin"],
+        reason="G5 soft-delete survival test",
+        scholarship_type_id=app_row.scholarship_type_id,
+        student_name="G5 學生",
+    )
+
+    app_row.status = "deleted"
+    app_row.deleted_at = datetime.now(timezone.utc)
+    app_row.deleted_by_id = actors["admin"].id
+    app_row.deletion_reason = "G5 soft-delete survival test"
+    await db.commit()
+
+    trail = await _trail_for(db, app_db_id)
+    assert len(trail) == 1
+    assert trail[0].meta_data["deletion_reason"] == "G5 soft-delete survival test"
+
+
+# ── FK delete-policy contracts (#979 G17 / #983 G21) ────────────────────
+# The sqlite test DB doesn't enforce FKs, so the declared policy on the
+# model metadata is the testable contract here; migration
+# audit_evidence_fk_001 applies it to real databases.
+
+
+def _fk_of(column):
+    return next(iter(column.foreign_keys))
+
+
+def test_email_history_application_fk_is_set_null():
+    assert _fk_of(EmailHistory.__table__.c.application_id).ondelete == "SET NULL"
+
+
+def test_scheduled_email_application_fk_is_set_null():
+    assert _fk_of(ScheduledEmail.__table__.c.application_id).ondelete == "SET NULL"
+
+
+def test_audit_log_user_fk_is_restrict_and_not_nullable():
+    fk = _fk_of(AuditLog.__table__.c.user_id)
+    assert fk.ondelete == "RESTRICT"
+    assert AuditLog.__table__.c.user_id.nullable is False

--- a/backend/app/tests/test_delete_application_minio_failure.py
+++ b/backend/app/tests/test_delete_application_minio_failure.py
@@ -1,0 +1,125 @@
+"""G20 (#982): MinIO deletion failures must be detected and leave a trace.
+
+minio_service.delete_file() never raises — it swallows errors internally and
+returns False. The old delete path ignored that bool (and wrapped the call in
+a dead try/except), so a storage failure orphaned the object with zero trace.
+Now a False return must (a) not block the DB deletion — storage cleanup never
+holds the user-facing operation hostage — and (b) leave a queryable 'failed'
+AuditLog row listing the orphaned object names for a later sweep.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.application import Application, ApplicationFile
+from app.models.audit_log import AuditLog
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.application_service import ApplicationService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def draft_with_file(db):
+    admin = User(
+        nycu_id="g20admin",
+        name="G20 Admin",
+        email="g20admin@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    student = User(
+        nycu_id="g20stu001",
+        name="G20 學生",
+        email="g20stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add_all([admin, student])
+    await db.flush()
+
+    stype = ScholarshipType(code="g20_test", name="G20 Test Scholarship")
+    db.add(stype)
+    await db.flush()
+    cfg = ScholarshipConfiguration(
+        config_code="G20-CFG",
+        config_name="G20 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=1000,
+    )
+    db.add(cfg)
+    await db.flush()
+
+    app_row = Application(
+        app_id="APP-G20-DRAFT",
+        user_id=student.id,
+        scholarship_type_id=stype.id,
+        scholarship_configuration_id=cfg.id,
+        academic_year=114,
+        sub_type_selection_mode="single",
+        status="draft",
+    )
+    db.add(app_row)
+    await db.flush()
+
+    file_row = ApplicationFile(
+        application_id=app_row.id,
+        file_type="transcript",
+        filename="g20.pdf",
+        object_name="applications/g20/transcript.pdf",
+    )
+    db.add(file_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return {"admin": admin, "app": app_row}
+
+
+async def test_minio_failure_leaves_failed_audit_row_and_db_delete_proceeds(db, draft_with_file):
+    app_db_id = draft_with_file["app"].id
+
+    with patch("app.services.application_service.minio_service") as mock_minio:
+        mock_minio.delete_file.return_value = False  # storage failure, no exception
+        svc = ApplicationService(db)
+        await svc.delete_application(app_db_id, draft_with_file["admin"], reason="G20 test")
+
+    mock_minio.delete_file.assert_called_once_with("applications/g20/transcript.pdf")
+
+    # DB deletion proceeded despite the storage failure.
+    gone = await db.execute(select(Application).where(Application.id == app_db_id))
+    assert gone.scalar_one_or_none() is None
+
+    # ...and the orphan left a queryable trace.
+    res = await db.execute(
+        select(AuditLog).where(
+            AuditLog.resource_type == "application",
+            AuditLog.resource_id == str(app_db_id),
+            AuditLog.status == "failed",
+        )
+    )
+    failed_rows = res.scalars().all()
+    assert len(failed_rows) == 1
+    assert failed_rows[0].meta_data["orphaned_objects"] == ["applications/g20/transcript.pdf"]
+    assert failed_rows[0].meta_data["app_id"] == "APP-G20-DRAFT"
+
+
+async def test_minio_success_leaves_no_failed_row(db, draft_with_file):
+    app_db_id = draft_with_file["app"].id
+
+    with patch("app.services.application_service.minio_service") as mock_minio:
+        mock_minio.delete_file.return_value = True
+        svc = ApplicationService(db)
+        await svc.delete_application(app_db_id, draft_with_file["admin"], reason="G20 test")
+
+    res = await db.execute(
+        select(AuditLog).where(
+            AuditLog.resource_id == str(app_db_id),
+            AuditLog.status == "failed",
+        )
+    )
+    assert res.scalars().all() == []


### PR DESCRIPTION
Phase 1 resilience batch from the 申請歷史 audit (tracking #995):

| Gap | Issue | What changed |
|---|---|---|
| G20 medium | #982 | `delete_application` checks `minio_service.delete_file()`'s bool (it **never raises** — the old try/except was dead code). Failure ≠ blocker: DB deletion proceeds, but an ERROR log + a `status='failed'` AuditLog row listing the orphaned object names is written for a later sweep |
| G5 critical | #967 | new integration tests pin that audit rows **survive hard- and soft-deletion** of the application and stay attributable purely from `meta_data` — the legal-trail property the design relies on but nothing guarded |
| G17 high | #979 | `email_history.application_id` + `scheduled_emails.application_id` → `ON DELETE SET NULL` (emails are delivery evidence; they must survive application hard-deletes and must not abort them with FK violations) |
| G21 medium | #983 | `audit_logs.user_id` → explicit `ON DELETE RESTRICT`. **Deviation from the audit report**: it assumed a `user_name` snapshot column exists on AuditLog — it does not, so `SET NULL` would anonymize trails. RESTRICT = accounts with audit history get deactivated, never deleted |

Migration `audit_evidence_fk_001` retargets the three FKs with existence checks (CLAUDE.md migration rules). Model-level contract tests pin the declared policies; the sqlite test DB doesn't enforce FKs, so metadata is the testable contract and the migration applies it to real DBs.

Tests: `test_audit_log_survives_application_deletion.py` (hard/soft survival + FK policy contracts), `test_delete_application_minio_failure.py` (orphan trace + success-path negative). black + flake8 clean.

Closes #967 / Closes #979 / Closes #982 / Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)