### PR TITLE
fix(#966): make audit_logs append-only — DB trigger + ORM guard (G4)

### DIFF
--- a/backend/alembic/versions/audit_logs_immutability_001.py
+++ b/backend/alembic/versions/audit_logs_immutability_001.py
@@ -1,0 +1,74 @@
+"""Make audit_logs append-only at the database level (issue #966 / gap G4)
+
+ISO 27001 A.8.15 / 資通系統防護基準: no privilege level — including the
+application's own DB role and administrators — may alter or delete event
+logs in place. Until now audit_logs was an ordinary mutable table, so a
+compromised credential (or future code) could rewrite history untraceably.
+
+- UPDATE is blocked unconditionally.
+- DELETE is blocked unless the session sets the escape-hatch GUC
+  `app.audit_purge = 'allowed'` — the hook for a future sanctioned
+  destruction workflow (檔案法: 銷毀須經核准造冊), executed deliberately:
+
+      BEGIN;
+      SET LOCAL app.audit_purge = 'allowed';
+      DELETE FROM audit_logs WHERE created_at < ...;
+      COMMIT;
+
+An ORM-level guard in app/models/audit_log.py provides the same property
+for non-PostgreSQL test databases and fails faster in app code.
+
+Revision ID: audit_logs_immutability_001
+Revises: audit_evidence_fk_001
+Create Date: 2026-06-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "audit_logs_immutability_001"
+down_revision: Union[str, None] = "audit_evidence_fk_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TRIGGER_FN = """
+CREATE OR REPLACE FUNCTION audit_logs_block_mutation() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE'
+       AND current_setting('app.audit_purge', true) = 'allowed' THEN
+        RETURN OLD;
+    END IF;
+    RAISE EXCEPTION
+        'audit_logs is append-only: % rejected (set app.audit_purge=allowed inside a sanctioned destruction workflow to purge)',
+        TG_OP
+        USING ERRCODE = 'raise_exception';
+END
+$$ LANGUAGE plpgsql;
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    inspector = sa.inspect(bind)
+    if "audit_logs" not in inspector.get_table_names():
+        return
+    op.execute(TRIGGER_FN)
+    op.execute("DROP TRIGGER IF EXISTS audit_logs_append_only ON audit_logs")
+    op.execute("""
+        CREATE TRIGGER audit_logs_append_only
+        BEFORE UPDATE OR DELETE ON audit_logs
+        FOR EACH ROW EXECUTE FUNCTION audit_logs_block_mutation()
+        """)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    op.execute("DROP TRIGGER IF EXISTS audit_logs_append_only ON audit_logs")
+    op.execute("DROP FUNCTION IF EXISTS audit_logs_block_mutation()")

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -4,11 +4,15 @@ Audit log model for tracking system activities
 
 import enum
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String, Text, event
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.db.base_class import Base
+
+
+class AuditLogImmutableError(RuntimeError):
+    """Raised when application code tries to mutate or delete an audit row."""
 
 
 class AuditAction(enum.Enum):
@@ -140,3 +144,26 @@ class AuditLog(Base):
             description=description,
             **kwargs,
         )
+
+
+# ── Append-only guard (issue #966 / gap G4) ──────────────────────────────
+# ISO 27001 A.8.15: event logs must not be modifiable or deletable by any
+# privilege level. The PostgreSQL trigger (migration
+# audit_logs_immutability_001) enforces this at the database; these ORM
+# listeners enforce the same property on every backend (incl. the sqlite
+# test DB) and fail fast when application code regresses. A sanctioned
+# destruction workflow must bypass the ORM on purpose (raw SQL +
+# `SET LOCAL app.audit_purge = 'allowed'`), never silently.
+
+
+@event.listens_for(AuditLog, "before_update")
+def _audit_log_block_update(mapper, connection, target):  # noqa: ARG001
+    raise AuditLogImmutableError(f"audit_logs is append-only: refusing UPDATE of AuditLog id={target.id}")
+
+
+@event.listens_for(AuditLog, "before_delete")
+def _audit_log_block_delete(mapper, connection, target):  # noqa: ARG001
+    raise AuditLogImmutableError(
+        f"audit_logs is append-only: refusing DELETE of AuditLog id={target.id} "
+        "(sanctioned destruction must use the raw-SQL purge workflow)"
+    )

--- a/backend/app/tests/test_audit_log_immutability.py
+++ b/backend/app/tests/test_audit_log_immutability.py
@@ -1,0 +1,100 @@
+"""G4 (#966): audit_logs is append-only — UPDATE/DELETE must be refused.
+
+Two enforcement layers, two test surfaces:
+
+- ORM listeners (app/models/audit_log.py) — backend-agnostic, exercised here
+  against the test DB: flushing an UPDATE or DELETE of an AuditLog row must
+  raise AuditLogImmutableError and leave the row intact.
+- PostgreSQL trigger (migration audit_logs_immutability_001) — the test DB
+  is created from metadata (no alembic), so the trigger itself can't run
+  here; its DDL contract is pinned statically instead (UPDATE blocked
+  unconditionally, DELETE only via the sanctioned `app.audit_purge` GUC).
+"""
+
+import pathlib
+
+import pytest
+from sqlalchemy import select
+
+from app.models.audit_log import AuditLog, AuditLogImmutableError
+from app.models.user import User, UserRole, UserType
+
+pytestmark = pytest.mark.integration
+
+MIGRATION = pathlib.Path(__file__).resolve().parents[2] / "alembic" / "versions" / "audit_logs_immutability_001.py"
+
+
+async def _make_log(db) -> AuditLog:
+    user = User(
+        nycu_id="g4actor",
+        name="G4 Actor",
+        email="g4actor@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(user)
+    await db.flush()
+    row = AuditLog.create_log(
+        user_id=user.id,
+        action="create",
+        resource_type="application",
+        resource_id="424242",
+        description="G4 immutability fixture",
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+async def test_orm_update_is_refused_and_row_unchanged(db):
+    row = await _make_log(db)
+    row_id, original = row.id, row.description
+
+    row.description = "tampered"
+    with pytest.raises(AuditLogImmutableError):
+        await db.commit()
+    await db.rollback()
+
+    res = await db.execute(select(AuditLog).where(AuditLog.id == row_id))
+    persisted = res.scalar_one()
+    assert persisted.description == original
+
+
+async def test_orm_delete_is_refused_and_row_survives(db):
+    row = await _make_log(db)
+    row_id = row.id
+
+    await db.delete(row)
+    with pytest.raises(AuditLogImmutableError):
+        await db.commit()
+    await db.rollback()
+
+    res = await db.execute(select(AuditLog).where(AuditLog.id == row_id))
+    assert res.scalar_one_or_none() is not None
+
+
+async def test_inserts_still_work(db):
+    row = await _make_log(db)
+    assert row.id is not None
+
+
+# ── Static contract of the DB-level trigger ─────────────────────────────
+
+
+def test_migration_defines_append_only_trigger():
+    text = MIGRATION.read_text()
+    assert "BEFORE UPDATE OR DELETE ON audit_logs" in text
+    assert "audit_logs_block_mutation" in text
+    # The sanctioned-destruction escape hatch exists for DELETE only.
+    assert "app.audit_purge" in text
+    assert "TG_OP = 'DELETE'" in text
+
+
+def test_orm_listeners_are_registered():
+    from sqlalchemy import event
+
+    from app.models import audit_log as m
+
+    assert event.contains(AuditLog, "before_update", m._audit_log_block_update)
+    assert event.contains(AuditLog, "before_delete", m._audit_log_block_delete)


### PR DESCRIPTION
Phase 2 of the 申請歷史 audit (tracking #995) — the remaining **critical** gap: `audit_logs` was fully mutable at the DB level, violating ISO 27001 A.8.15 (no privilege level may alter its own event logs) and the 資通系統防護基準 log-integrity requirement.

Two layers:
1. **PostgreSQL trigger** (`audit_logs_immutability_001`): `UPDATE` blocked unconditionally; `DELETE` blocked unless the session sets `SET LOCAL app.audit_purge = 'allowed'` — the deliberate, explicit escape hatch a future sanctioned destruction workflow needs (檔案法 destruction is approved-then-executed, never ambient). No-op on non-PostgreSQL binds.
2. **ORM listeners** on `AuditLog` raising `AuditLogImmutableError` on update/delete — backend-agnostic (covers the sqlite test DB) and fails fast in app code.

Safety checks done: no existing code path updates or ORM-deletes audit rows; the e2e cascade helper never touches the table (its comment about an FK cascade is wrong — there is no FK, by design).

Tests: ORM refusal with row-intact assertions, insert-still-works, listener registration, trigger DDL contract.

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)