### PR TITLE
fix(audit): money-decision trail — allocation/finalize/ranking audits, restore linkage, history actor

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -645,9 +645,37 @@ async def update_ranking_order(
         service = CollegeReviewService(db)
         # #63: block once college-review deadline has passed (admins bypass).
         await service.assert_ranking_within_deadline_by_ranking(ranking_id, current_user)
+
+        # G8 (#970): capture the prior order — rank overwrites previously left
+        # no trace, so 「核配當時的名次」 could not be reconstructed.
+        prior_rows = await db.execute(
+            select(CollegeRankingItem.application_id, CollegeRankingItem.rank_position).where(
+                CollegeRankingItem.ranking_id == ranking_id
+            )
+        )
+        old_order = {str(app_id): pos for app_id, pos in prior_rows.all()}
+
         ranking = await service.update_ranking_order(
             ranking_id=ranking_id, new_order=[item.model_dump() for item in new_order]
         )
+
+        db.add(
+            AuditLog.create_log(
+                user_id=current_user.id,
+                action=AuditAction.update.value,
+                resource_type="college_ranking",
+                resource_id=str(ranking_id),
+                description=f"ranking order updated ({len(new_order)} item(s))",
+                old_values={"rank_positions": old_order},
+                new_values={
+                    "rank_positions": {
+                        str(i["application_id"]): i.get("rank_position")
+                        for i in (item.model_dump() for item in new_order)
+                    }
+                },
+            )
+        )
+        await db.commit()
 
         return ApiResponse(
             success=True,
@@ -1081,6 +1109,12 @@ async def import_ranking_from_excel(
         # college_rejected=True is the college-level "N" marker. status stays
         # 'ranked' so admin retains ability to allocate.
         rejected_index = 0
+        # G8 (#970): snapshot prior state — the import overwrites ranks and
+        # college_rejected flags in place.
+        prior_ranks = {
+            sid: {"rank_position": ri.rank_position, "college_rejected": ri.college_rejected}
+            for sid, ri in student_id_to_item.items()
+        }
         for sid, rank_item in student_id_to_item.items():
             if sid not in import_map:
                 continue
@@ -1098,6 +1132,26 @@ async def import_ranking_from_excel(
             updated_count += 1
 
         ranking.total_applications = len(ranking.items)
+
+        db.add(
+            AuditLog.create_log(
+                user_id=current_user.id,
+                action=AuditAction.import_.value,
+                resource_type="college_ranking",
+                resource_id=str(ranking_id),
+                description=(f"ranking import-excel: {updated_count} updated, {rejected_count} rejected (N)"),
+                old_values={"rank_positions": prior_ranks},
+                new_values={
+                    "rank_positions": {
+                        sid: {
+                            "rank_position": ri.rank_position,
+                            "college_rejected": ri.college_rejected,
+                        }
+                        for sid, ri in student_id_to_item.items()
+                    }
+                },
+            )
+        )
         await db.commit()
 
         return ApiResponse(

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -16,6 +16,7 @@ from app.core.deps import get_current_admin_user, get_db
 from app.db.deps import get_sync_db
 from app.db.session import AsyncSessionLocal
 from app.models.application import Application
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
 from app.models.email_management import EmailCategory
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
@@ -261,6 +262,7 @@ async def allocate(
             request.academic_year,
             request.semester,
             [a.model_dump() for a in request.allocations],
+            admin_user_id=current_user.id,
         )
         await db.commit()
         return {
@@ -285,6 +287,7 @@ async def finalize(
             request.scholarship_type_id,
             request.academic_year,
             request.semester,
+            admin_user_id=current_user.id,
         )
         await db.commit()
         return {
@@ -370,6 +373,7 @@ async def restore_from_history(
             history.academic_year,
             history.semester,
             history.allocations_snapshot,
+            admin_user_id=current_user.id,
         )
 
         await db.commit()
@@ -886,12 +890,25 @@ async def restore_application_allocation(
             admin_user_id=current_user.id,
         )
         await db.commit()
+        # G9 (#971): link the restore to the original revoke/suspend log row.
+        original_log = await db.execute(
+            select(AuditLog.id)
+            .where(
+                AuditLog.resource_type == "application",
+                AuditLog.resource_id == str(application_id),
+                AuditLog.action.in_((AuditAction.revoke.value, AuditAction.suspend.value)),
+            )
+            .order_by(AuditLog.id.desc())
+            .limit(1)
+        )
+        original_log_id = original_log.scalar_one_or_none()
         await ApplicationAuditService(db).log_application_restore(
             application_id=application_id,
             app_id=result.get("app_id", f"APP-{application_id}"),
             user=current_user,
             prior_status=result.get("restored_from", "unknown"),
             prior_reason=result.get("restored_reason"),
+            original_cancellation_log_id=original_log_id,
             request=http_request,
         )
         return {"success": True, "message": "已恢復", "data": result}

--- a/backend/app/services/application_audit_service.py
+++ b/backend/app/services/application_audit_service.py
@@ -346,6 +346,7 @@ class ApplicationAuditService:
         user: User,
         prior_status: str,
         prior_reason: Optional[str] = None,
+        original_cancellation_log_id: Optional[int] = None,
         request: Optional[Request] = None,
     ) -> Optional[AuditLog]:
         """記錄回復獎學金分發 (issue #980 / G18)
@@ -362,7 +363,9 @@ class ApplicationAuditService:
             description=f"回復申請 {app_id} 的獎學金分發（原狀態: {prior_status}）",
             old_values={"quota_allocation_status": prior_status, "reason": prior_reason},
             new_values={"quota_allocation_status": "allocated"},
-            meta_data={"app_id": app_id},
+            # G9 (#971): link back to the revoke/suspend log row so the
+            # decision chain (撤銷 → 回復) is traversable without heuristics.
+            meta_data={"app_id": app_id, "original_cancellation_log_id": original_cancellation_log_id},
         )
 
     async def log_application_create(

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
 from app.models.application import Application
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
 from app.models.enums import ApplicationStatus, ReviewStage
 from app.models.review import ApplicationReview, ApplicationReviewItem
@@ -668,6 +669,7 @@ class ManualDistributionService:
         academic_year: int,
         semester: str,
         allocations: list[dict[str, Any]],
+        admin_user_id: Optional[int] = None,
     ) -> dict[str, Any]:
         """
         Save manual allocation selections.
@@ -697,6 +699,15 @@ class ManualDistributionService:
             if not item:
                 continue
 
+            # G3 (#965): capture the prior slot state — 「誰把哪個名額配給誰」
+            # must be reconstructable from audit_logs, not only from the
+            # undo-oriented ManualDistributionHistory snapshot.
+            prior_state = {
+                "is_allocated": item.is_allocated,
+                "allocated_sub_type": item.allocated_sub_type,
+                "allocation_config_id": item.allocation_config_id,
+            }
+
             if sub_type:
                 allowed = await self._allowed_config_ids(requesting_config, sub_type)
                 if alloc_config_id not in allowed:
@@ -713,6 +724,27 @@ class ManualDistributionService:
                 item.allocation_config_id = None
                 item.status = "ranked"
                 item.allocation_reason = None
+
+            if admin_user_id is not None and item.application_id is not None:
+                self.db.add(
+                    AuditLog.create_log(
+                        user_id=admin_user_id,
+                        action=AuditAction.execute_distribution.value,
+                        resource_type="application",
+                        resource_id=str(item.application_id),
+                        description=(
+                            f"manual allocation: ranking_item {item.id} -> "
+                            f"{sub_type or 'unallocated'} (config {alloc_config_id})"
+                        ),
+                        old_values=prior_state,
+                        new_values={
+                            "is_allocated": item.is_allocated,
+                            "allocated_sub_type": item.allocated_sub_type,
+                            "allocation_config_id": item.allocation_config_id,
+                        },
+                        meta_data={"ranking_item_id": item.id},
+                    )
+                )
 
             updated_count += 1
 
@@ -763,6 +795,7 @@ class ManualDistributionService:
                     operation_type="save",
                     change_summary=f"Saved {updated_count} allocation(s)",
                     total_allocated=total_allocated,
+                    created_by=admin_user_id,
                 )
                 self.db.add(history)
                 await self.db.flush()
@@ -777,6 +810,7 @@ class ManualDistributionService:
         scholarship_type_id: int,
         academic_year: int,
         semester: str,
+        admin_user_id: Optional[int] = None,
     ) -> dict[str, Any]:
         """
         Finalize manual distribution:
@@ -829,6 +863,10 @@ class ManualDistributionService:
             if app.quota_allocation_status in ("revoked", "suspended"):
                 continue
 
+            prior_app_state = {
+                "status": app.status.value if hasattr(app.status, "value") else str(app.status),
+                "quota_allocation_status": app.quota_allocation_status,
+            }
             if item.is_allocated and item.allocated_sub_type:
                 app.status = ApplicationStatus.approved
                 app.quota_allocation_status = "allocated"
@@ -840,6 +878,24 @@ class ManualDistributionService:
                 # item's consumed config; fall back to the app's own config.
                 if app.allocation_config_id is None:
                     app.allocation_config_id = item.allocation_config_id or app.scholarship_configuration_id
+                if admin_user_id is not None:
+                    self.db.add(
+                        AuditLog.create_log(
+                            user_id=admin_user_id,
+                            action=AuditAction.execute_distribution.value,
+                            resource_type="application",
+                            resource_id=str(app.id),
+                            description=f"distribution finalized: {app.app_id} approved ({item.allocated_sub_type})",
+                            old_values=prior_app_state,
+                            new_values={
+                                "status": "approved",
+                                "quota_allocation_status": "allocated",
+                                "sub_scholarship_type": item.allocated_sub_type,
+                                "allocation_config_id": app.allocation_config_id,
+                            },
+                            meta_data={"app_id": app.app_id, "ranking_item_id": item.id},
+                        )
+                    )
                 approved_count += 1
             elif item.is_supplementary and not item.is_allocated:
                 # Supplementary students pending a second distribution pass —
@@ -856,6 +912,22 @@ class ManualDistributionService:
                 item.status = "rejected"
                 app.quota_allocation_status = "rejected"
                 app.review_stage = ReviewStage.quota_distributed
+                if admin_user_id is not None:
+                    self.db.add(
+                        AuditLog.create_log(
+                            user_id=admin_user_id,
+                            action=AuditAction.execute_distribution.value,
+                            resource_type="application",
+                            resource_id=str(app.id),
+                            description=f"distribution finalized: {app.app_id} not allocated (quota rejected)",
+                            old_values=prior_app_state,
+                            new_values={
+                                "status": prior_app_state["status"],
+                                "quota_allocation_status": "rejected",
+                            },
+                            meta_data={"app_id": app.app_id, "ranking_item_id": item.id},
+                        )
+                    )
                 rejected_count += 1
 
         # §10 quota gate — recount under SELECT FOR UPDATE before committing the
@@ -893,6 +965,7 @@ class ManualDistributionService:
                 operation_type="finalize",
                 change_summary=f"Distribution finalized: {approved_count} approved, {rejected_count} rejected",
                 total_allocated=approved_count,
+                created_by=admin_user_id,
             )
             self.db.add(history)
             await self.db.flush()
@@ -912,6 +985,7 @@ class ManualDistributionService:
         academic_year: int,
         semester: str,
         allocations_snapshot: dict[str, Any],
+        admin_user_id: Optional[int] = None,
     ) -> dict[str, Any]:
         """
         Restore allocations from a historical snapshot.
@@ -974,6 +1048,7 @@ class ManualDistributionService:
                 operation_type="revert",
                 change_summary=f"Restored {restored_count} allocation(s) from history",
                 total_allocated=restored_count,
+                created_by=admin_user_id,
             )
             self.db.add(history)
             await self.db.flush()

--- a/backend/app/tests/test_audit_wiring_invariants.py
+++ b/backend/app/tests/test_audit_wiring_invariants.py
@@ -54,6 +54,17 @@ REQUIRED_WIRING = {
         "suspend_application_allocation",
         "restore_application_allocation",
     ],
+    # G3 (#965): allocation decisions audit at the service layer (the
+    # endpoints pass admin_user_id through).
+    "services/manual_distribution_service.py": [
+        "allocate",
+        "finalize",
+    ],
+    # G8 (#970): rank overwrites must leave old/new traces.
+    "api/v1/endpoints/college_review/ranking_management.py": [
+        "import_ranking_from_excel",
+        "update_ranking_order",
+    ],
 }
 
 

--- a/backend/app/tests/test_manual_distribution_audit.py
+++ b/backend/app/tests/test_manual_distribution_audit.py
@@ -1,0 +1,171 @@
+"""G3/G22 (#965/#984): manual allocation must leave an application-level audit trail.
+
+allocate()/finalize() change who receives scholarship money, but previously
+wrote only the undo-oriented ManualDistributionHistory snapshot — the formal
+audit trail had no record of 「誰在何時把哪個名額配給哪位學生」, and the
+history rows never recorded WHO performed the operation (created_by was
+always NULL).
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.application import Application, ApplicationStatus
+from app.models.audit_log import AuditAction, AuditLog
+from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
+from app.models.enums import ReviewStage
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.services.manual_distribution_service import ManualDistributionService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def dist_fixture(db):
+    admin = User(
+        nycu_id="g3admin",
+        name="G3 Admin",
+        email="g3admin@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    student = User(
+        nycu_id="g3stu001",
+        name="G3 學生",
+        email="g3stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add_all([admin, student])
+    await db.flush()
+
+    stype = ScholarshipType(code="g3_test", name="G3 Test Scholarship", sub_type_list=["nstc"])
+    db.add(stype)
+    await db.flush()
+    cfg = ScholarshipConfiguration(
+        config_code="G3-CFG",
+        config_name="G3 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=10000,
+    )
+    db.add(cfg)
+    await db.flush()
+
+    app_row = Application(
+        app_id="APP-G3-001",
+        user_id=student.id,
+        scholarship_type_id=stype.id,
+        scholarship_configuration_id=cfg.id,
+        academic_year=114,
+        status=ApplicationStatus.submitted,
+        review_stage=ReviewStage.college_ranked,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+    )
+    db.add(app_row)
+    await db.flush()
+
+    ranking = CollegeRanking(
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        semester=None,
+        sub_type_code="nstc",
+        college_code="C",
+        created_by=admin.id,
+    )
+    db.add(ranking)
+    await db.flush()
+
+    item = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=app_row.id,
+        rank_position=1,
+        status="ranked",
+    )
+    db.add(item)
+    await db.commit()
+    return {"admin": admin, "app": app_row, "item": item, "cfg": cfg, "stype": stype}
+
+
+async def test_allocate_writes_per_application_audit_and_history_actor(db, dist_fixture):
+    svc = ManualDistributionService(db)
+    result = await svc.allocate(
+        scholarship_type_id=dist_fixture["stype"].id,
+        academic_year=114,
+        semester="yearly",
+        allocations=[
+            {
+                "ranking_item_id": dist_fixture["item"].id,
+                "sub_type_code": "nstc",
+                "allocation_config_id": dist_fixture["cfg"].id,
+            }
+        ],
+        admin_user_id=dist_fixture["admin"].id,
+    )
+    await db.commit()
+    assert result["updated_count"] == 1
+
+    rows = (
+        (
+            await db.execute(
+                select(AuditLog).where(
+                    AuditLog.resource_type == "application",
+                    AuditLog.resource_id == str(dist_fixture["app"].id),
+                    AuditLog.action == AuditAction.execute_distribution.value,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1, "allocate must write an application-level audit row (G3)"
+    row = rows[0]
+    assert row.user_id == dist_fixture["admin"].id
+    assert row.old_values["is_allocated"] in (False, None)
+    assert row.new_values["allocated_sub_type"] == "nstc"
+    assert row.meta_data["ranking_item_id"] == dist_fixture["item"].id
+
+    histories = (
+        (await db.execute(select(ManualDistributionHistory).order_by(ManualDistributionHistory.id.desc())))
+        .scalars()
+        .all()
+    )
+    assert histories, "allocate should record a history snapshot"
+    assert histories[0].created_by == dist_fixture["admin"].id, "history must record WHO acted (G22)"
+
+
+async def test_allocate_without_actor_writes_no_audit(db, dist_fixture):
+    """Back-compat: service callers without an actor (none in production —
+    all endpoints pass current_user.id) skip the audit row rather than
+    writing one with a bogus user."""
+    svc = ManualDistributionService(db)
+    await svc.allocate(
+        scholarship_type_id=dist_fixture["stype"].id,
+        academic_year=114,
+        semester="yearly",
+        allocations=[
+            {
+                "ranking_item_id": dist_fixture["item"].id,
+                "sub_type_code": "nstc",
+                "allocation_config_id": dist_fixture["cfg"].id,
+            }
+        ],
+    )
+    await db.commit()
+    rows = (
+        (
+            await db.execute(
+                select(AuditLog).where(
+                    AuditLog.resource_id == str(dist_fixture["app"].id),
+                    AuditLog.action == AuditAction.execute_distribution.value,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []

--- a/backend/app/tests/test_manual_distribution_audit.py
+++ b/backend/app/tests/test_manual_distribution_audit.py
@@ -74,7 +74,6 @@ async def dist_fixture(db):
         academic_year=114,
         semester=None,
         sub_type_code="nstc",
-        college_code="C",
         created_by=admin.id,
     )
     db.add(ranking)


### PR DESCRIPTION
Phase 2 batch from the 申請歷史 audit (tracking #995):

| Gap | Issue | What changed |
|---|---|---|
| G3 critical | #965 | `allocate()`/`finalize()` write per-application `AuditLog` rows (`execute_distribution`) with old/new slot state; endpoints pass the acting admin through |
| G22 medium | #984 | `ManualDistributionHistory.created_by` finally populated (save/finalize/revert) — the column existed but was always NULL |
| G8 high | #970 | ranking `import-excel` + `update_ranking_order` write audit rows with the **full old/new rank_position + college_rejected maps** — rank overwrites are reconstructable |
| G9 high | #971 | restore's audit row links back to the original revoke/suspend log row (`meta_data.original_cancellation_log_id`) — the 撤銷→回復 chain is traversable |

Guards: AST wiring invariants extended (+4 functions); `test_manual_distribution_audit.py` pins the allocate row shape, the no-actor fallback, and `history.created_by`.

Closes #965 / Closes #970 / Closes #971 / Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)