### PR TITLE
feat(backend): mask national ID before sending in API responses

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/application_review.py
+++ b/backend/app/api/v1/endpoints/college_review/application_review.py
@@ -24,6 +24,7 @@ from app.schemas.college_review import StudentTermData
 from app.schemas.response import ApiResponse
 from app.services.college_review_service import CollegeReviewService, ReviewPermissionError
 from app.services.student_service import StudentService
+from app.utils.pii_masking import mask_id_number
 
 from ._helpers import _check_academic_year_permission, _check_scholarship_permission
 
@@ -205,11 +206,17 @@ async def get_student_preview(
                         logger.debug(f"Could not fetch term data for {student_id} {year}-{term}: {str(term_err)}")
                         continue
 
+        # Mask 身分證字號 at the response boundary — the preview is display
+        # only, so the full national ID never leaves the server.
+        basic = dict(student_data)
+        if "std_pid" in basic:
+            basic["std_pid"] = mask_id_number(basic.get("std_pid"))
+
         return ApiResponse(
             success=True,
             message="Student preview retrieved successfully",
             data={
-                "basic": student_data,
+                "basic": basic,
                 "recent_terms": [term.model_dump() for term in recent_terms],
             },
         )

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -51,6 +51,7 @@ from app.services.excel_export_service import ExcelExportService
 from app.services.roster_service import RosterService
 from app.services.student_verification_service import StudentVerificationService
 from app.utils.academic_period import get_roster_period_dates
+from app.utils.pii_masking import mask_id_number
 
 logger = logging.getLogger(__name__)
 
@@ -663,7 +664,9 @@ async def preview_roster_students(
                 "application_id": application.id,
                 "student_name": student_name or "",
                 "student_id": student_id_number or "",
-                "student_id_number": student_data.get("std_pid", ""),
+                # 身分證字號 masked at the response boundary — only the display
+                # is needed here, so the full national ID never leaves the server.
+                "student_id_number": mask_id_number(student_data.get("std_pid", "")),
                 "email": student_data.get("com_email", ""),
                 "college": college,
                 "department": student_data.get("std_depno", ""),

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -36,6 +36,7 @@ from app.models.user import User
 from app.schemas.payment_roster import DistributionDiffEntry, RevokedSuspendedEntry
 from app.services.audit_service import audit_service
 from app.services.student_verification_service import StudentVerificationService
+from app.utils.pii_masking import mask_id_number
 
 logger = logging.getLogger(__name__)
 
@@ -1837,7 +1838,10 @@ class RosterService:
             entry = RevokedSuspendedEntry(
                 application_id=app.id,
                 student_name=item.student_name,
-                student_id_number=item.student_id_number,
+                # 身分證字號 masked for the needs-attention panel (display only).
+                # The roster Excel export reads item.student_id_number directly
+                # and keeps the full national ID for the payment process.
+                student_id_number=mask_id_number(item.student_id_number),
                 event_at=(app.revoked_at if app.quota_allocation_status == "revoked" else app.suspended_at),
                 reason=(app.revoke_reason if app.quota_allocation_status == "revoked" else app.suspend_reason),
                 item_id=item.id,

--- a/backend/app/tests/test_pii_masking.py
+++ b/backend/app/tests/test_pii_masking.py
@@ -1,0 +1,44 @@
+"""Unit tests for ``app.utils.pii_masking``.
+
+These pin the backend national-ID (身分證字號) masking to be byte-for-byte
+identical to the frontend ``maskIdNumber`` helper
+(``frontend/lib/utils/mask.ts``). Masking now happens at the API response
+boundary, so the full plaintext national ID never leaves the server for
+display-only endpoints. The transform must also be idempotent so the frontend
+mask (still applied as defense in depth) does not corrupt an already-masked
+value.
+"""
+
+from app.utils.pii_masking import mask_id_number
+
+
+def test_keeps_first_char_and_last_three_for_typical_10_char_id():
+    assert mask_id_number("A123456789") == "A******789"
+    assert mask_id_number("F229876543") == "F******543"
+
+
+def test_masks_middle_for_other_lengths():
+    assert mask_id_number("AB12345") == "A***345"
+    assert mask_id_number("A1234") == "A*234"
+
+
+def test_keeps_only_first_char_for_four_or_fewer():
+    assert mask_id_number("ABCD") == "A***"
+    assert mask_id_number("ABC") == "A**"
+    assert mask_id_number("AB") == "A*"
+    assert mask_id_number("A") == "A"
+
+
+def test_empty_or_missing_values_return_empty_string():
+    assert mask_id_number("") == ""
+    assert mask_id_number(None) == ""
+
+
+def test_trims_surrounding_whitespace_before_masking():
+    assert mask_id_number("  A123456789  ") == "A******789"
+    assert mask_id_number("   ") == ""
+
+
+def test_idempotent_on_already_masked_value():
+    once = mask_id_number("A123456789")
+    assert mask_id_number(once) == once == "A******789"

--- a/backend/app/tests/test_roster_item_removal_service.py
+++ b/backend/app/tests/test_roster_item_removal_service.py
@@ -107,7 +107,7 @@ def locked_roster_two_items(db_sync, admin_db_user_sync):
             PaymentRosterItem(
                 roster_id=r.id,
                 application_id=a1.id,
-                student_id_number="B1",
+                student_id_number="A123456789",
                 student_name="W",
                 scholarship_name="NSTC",
                 scholarship_amount=40000,
@@ -116,7 +116,7 @@ def locked_roster_two_items(db_sync, admin_db_user_sync):
             PaymentRosterItem(
                 roster_id=r.id,
                 application_id=a2.id,
-                student_id_number="B2",
+                student_id_number="B987654321",
                 student_name="L",
                 scholarship_name="NSTC",
                 scholarship_amount=40000,
@@ -134,8 +134,10 @@ def test_get_revoked_suspended_splits_by_status(db_sync, locked_roster_two_items
     out = svc.get_revoked_suspended_for_roster(locked_roster_two_items.id)
     assert len(out["revoked"]) == 1
     assert len(out["suspended"]) == 1
-    assert out["revoked"][0].student_id_number == "B1"
-    assert out["suspended"][0].student_id_number == "B2"
+    # 身分證字號 is masked at the response boundary (keep first char + last 3),
+    # so the needs-attention panel never receives the full national ID.
+    assert out["revoked"][0].student_id_number == "A******789"
+    assert out["suspended"][0].student_id_number == "B******321"
 
 
 def test_remove_item_from_locked_roster_deletes_item_and_marks_stale(
@@ -170,7 +172,7 @@ def test_remove_suspended_item_from_locked_roster_deletes_item_and_marks_stale(
     roster. remove_item_from_locked_roster is status-agnostic (deletes by
     item_id), so the suspend remove-path the new UI exposes behaves identically
     to the revoked one — recompute totals, set excel_stale, stay LOCKED."""
-    suspended_item = next(i for i in locked_roster_two_items.items if i.student_id_number == "B2")
+    suspended_item = next(i for i in locked_roster_two_items.items if i.student_id_number == "B987654321")
     item_id = suspended_item.id
     svc = RosterService(db_sync)
     svc.remove_item_from_locked_roster(

--- a/backend/app/utils/pii_masking.py
+++ b/backend/app/utils/pii_masking.py
@@ -1,0 +1,48 @@
+"""Masking helpers for personally identifiable information (PII).
+
+These mirror the frontend ``maskIdNumber`` helper
+(``frontend/lib/utils/mask.ts``) so a national ID rendered after the backend
+has masked it looks identical whether or not the frontend masks it again.
+
+Masking happens at the API response boundary (the data the backend *sends*),
+so the full plaintext national ID never leaves the server for display-only
+endpoints. Exports that legitimately need the full ID (e.g. the payment
+roster Excel) read the raw value directly and must not call these helpers.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Keep this many trailing characters visible (e.g. "...789").
+_VISIBLE_TAIL = 3
+# Below this length, keeping the tail would expose almost the whole value,
+# so only the first character is kept.
+_MIN_LEN_FOR_TAIL = 4
+
+
+def mask_id_number(id_number: Optional[str]) -> str:
+    """Mask a national ID number (身分證字號) for display.
+
+    Keeps the first character and the last three characters, replacing
+    everything in between with asterisks. Values of four characters or fewer
+    keep only the first character (the rest masked).
+
+    The transform is idempotent: masking an already-masked value returns the
+    same string, so it is safe even if the frontend masks again.
+
+    Mirrors ``maskIdNumber`` in ``frontend/lib/utils/mask.ts`` exactly.
+
+    Examples::
+
+        mask_id_number("A123456789")  # -> "A******789"
+        mask_id_number("ABCD")        # -> "A***"
+        mask_id_number("")            # -> ""
+        mask_id_number(None)          # -> ""
+    """
+    if not id_number:
+        return ""
+    value = id_number.strip()
+    if len(value) <= _MIN_LEN_FOR_TAIL:
+        return value[:1] + "*" * max(len(value) - 1, 0)
+    return value[:1] + "*" * (len(value) - _VISIBLE_TAIL - 1) + value[-_VISIBLE_TAIL:]


### PR DESCRIPTION
## Summary

Follow-up to #939. That PR masked 身分證字號 (national ID) in the **frontend display only**, so the full plaintext ID still traveled over the wire in API responses. This PR masks at the **backend response boundary** — the full national ID never leaves the server for display-only endpoints (應該後端送過去的就要先 mask).

## Changes

- **New helper** `backend/app/utils/pii_masking.py` — `mask_id_number()` keeps the first char + last 3 chars (`A123456789` → `A******789`), mirroring the frontend `maskIdNumber` (`frontend/lib/utils/mask.ts`) **exactly**. The transform is **idempotent**, so the frontend mask (kept as defense in depth) does not corrupt an already-masked value.
- **`GET /payment-rosters/preview-students`** — `students[].student_id_number` is masked (feeds `StudentRosterPreview.tsx`).
- **`GET /payment-rosters/{id}/revoked-suspended`** (`RosterService.get_revoked_suspended_for_roster`) — `student_id_number` masked for the revoked/suspended needs-attention panel (`RevokedSuspendedSection.tsx`).
- **`GET /college-review/students/{id}/preview`** — `basic.std_pid` masked in the application review dialog (`ApplicationReviewDialog.tsx`). Masked into a copy of the dict (no mutation).

## What is intentionally NOT masked

- The **payment roster Excel export** (`STD_UP_MIXLISTA.xlsx`) and college ranking export read the raw national ID directly and keep the **full** value — required by the downstream payment process. These read from `PaymentRosterItem.student_id_number` / `student_data` directly, independent of the three display builders changed here, so they are unaffected.

## Tests

- `backend/app/tests/test_pii_masking.py` — new unit tests pinning byte-for-byte parity with the frontend helper, plus an idempotency test.
- `backend/app/tests/test_roster_item_removal_service.py` — updated the revoked/suspended test to use realistic 10-char IDs and expect masked output.
- `python -m pytest` on the masking, revoke/suspend, roster-core, college-review, and excel-export suites: **all pass** (export keeps full ID confirmed). `black --check` clean; no new `flake8` findings.