### PR TITLE
fix(integrity): status-transition state machine + bank-correction original preservation

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1542,10 +1542,66 @@ class ApplicationService:
 
         return response_applications
 
+    # G16 (#978): legal staff transitions for PATCH /applications/{id}/status.
+    # Anything outside this table needs an admin/super_admin override WITH a
+    # written reason (and the endpoint's audit row records old→new+reason).
+    # `draft` and `deleted` are never reachable through this endpoint — drafts
+    # belong to the student flow, deletion to the delete endpoints.
+    _STAFF_STATUS_TRANSITIONS: Dict[str, set] = {
+        ApplicationStatus.submitted.value: {
+            ApplicationStatus.under_review.value,
+            ApplicationStatus.pending_documents.value,
+            ApplicationStatus.returned.value,
+            ApplicationStatus.approved.value,
+            ApplicationStatus.partial_approved.value,
+            ApplicationStatus.rejected.value,
+            ApplicationStatus.cancelled.value,
+            ApplicationStatus.manual_excluded.value,
+        },
+        ApplicationStatus.under_review.value: {
+            ApplicationStatus.pending_documents.value,
+            ApplicationStatus.returned.value,
+            ApplicationStatus.approved.value,
+            ApplicationStatus.partial_approved.value,
+            ApplicationStatus.rejected.value,
+            ApplicationStatus.cancelled.value,
+            ApplicationStatus.manual_excluded.value,
+        },
+        ApplicationStatus.pending_documents.value: {
+            ApplicationStatus.under_review.value,
+            ApplicationStatus.returned.value,
+            ApplicationStatus.approved.value,
+            ApplicationStatus.partial_approved.value,
+            ApplicationStatus.rejected.value,
+            ApplicationStatus.cancelled.value,
+        },
+        # Forward movement out of `returned` happens via the student's own
+        # resubmit; staff may only cancel.
+        ApplicationStatus.returned.value: {ApplicationStatus.cancelled.value},
+        # Reversing a final decision is an override-only operation.
+        ApplicationStatus.approved.value: {ApplicationStatus.cancelled.value},
+        ApplicationStatus.partial_approved.value: {ApplicationStatus.cancelled.value},
+        ApplicationStatus.rejected.value: set(),
+        ApplicationStatus.withdrawn.value: set(),
+        ApplicationStatus.cancelled.value: set(),
+        ApplicationStatus.manual_excluded.value: {ApplicationStatus.under_review.value},
+        ApplicationStatus.cancelled_by_challenge.value: set(),
+        ApplicationStatus.draft.value: set(),
+        ApplicationStatus.deleted.value: set(),
+    }
+
     async def update_application_status(
         self, application_id: int, user: User, status_update: ApplicationStatusUpdate
     ) -> ApplicationResponse:
-        """Update application status (staff only)"""
+        """Update application status (staff only).
+
+        G16 (#978): transitions are validated against
+        ``_STAFF_STATUS_TRANSITIONS``. An illegal transition is allowed only
+        as an explicit admin/super_admin override carrying a written reason —
+        previously ANY staff account could set ANY status (approved→draft,
+        submitted→approved, …), making the review flow bypassable without a
+        trace.
+        """
         if not (
             user.has_role(UserRole.admin)
             or user.has_role(UserRole.college)
@@ -1561,6 +1617,34 @@ class ApplicationService:
         if not application:
             raise NotFoundError("Application", str(application_id))
 
+        # ── G16 transition gate ──────────────────────────────────────────
+        old_status = application.status.value if hasattr(application.status, "value") else str(application.status)
+        new_status = status_update.status
+        if new_status != old_status:
+            allowed = self._STAFF_STATUS_TRANSITIONS.get(old_status, set())
+            if new_status not in allowed:
+                is_admin = user.has_role(UserRole.admin) or user.has_role(UserRole.super_admin)
+                override_reason = getattr(status_update, "comments", None) or getattr(
+                    status_update, "rejection_reason", None
+                )
+                if new_status in (ApplicationStatus.draft.value, ApplicationStatus.deleted.value):
+                    raise ValidationError(
+                        f"狀態 '{new_status}' 不可經由狀態更新設定（draft 屬學生流程、deleted 屬刪除流程）"
+                    )
+                if not (is_admin and override_reason):
+                    raise ValidationError(
+                        f"不允許的狀態轉移：{old_status} → {new_status}。"
+                        f"僅 admin 可強制覆寫，且必須附上理由（comments）。"
+                    )
+                logger.warning(
+                    "Admin override status transition %s -> %s on application %s by user %s: %s",
+                    old_status,
+                    new_status,
+                    application.app_id,
+                    user.id,
+                    override_reason,
+                )
+
         # Update status
         application.status = status_update.status
         application.reviewer_id = user.id
@@ -1571,7 +1655,12 @@ class ApplicationService:
             application.approved_at = datetime.now(timezone.utc)
             application.status_name = ScholarshipI18n.get_application_status_text(ApplicationStatus.approved.value)
         elif status_update.status == ApplicationStatus.rejected.value:
+            # G16: a rejected application must not keep its approved_at —
+            # otherwise「某期間核准清單」queries include later-rejected rows.
+            application.approved_at = None
             application.status_name = ScholarshipI18n.get_application_status_text(ApplicationStatus.rejected.value)
+        elif status_update.status in (ApplicationStatus.returned.value, ApplicationStatus.cancelled.value):
+            application.approved_at = None
 
         # Persist admin comments / rejection reason as an ApplicationReview row
         if getattr(status_update, "comments", None) or getattr(status_update, "rejection_reason", None):

--- a/backend/app/services/bank_verification_service.py
+++ b/backend/app/services/bank_verification_service.py
@@ -569,6 +569,19 @@ class BankVerificationService:
             if "fields" not in updated_form_data:
                 updated_form_data["fields"] = {}
 
+            # G19 (#981): capture the student's pre-correction values BEFORE
+            # any overwrite. submitted_form_data is the submission snapshot —
+            # silently rewriting it destroys「學生當時實際填了什麼」.
+            def _field_value(key: str):
+                field = (application.submitted_form_data or {}).get("fields", {}).get(key)
+                return field.get("value") if isinstance(field, dict) else None
+
+            prior_bank_fields = {
+                key: _field_value(key)
+                for key in ("postal_account", "bank_account", "account_number", "account_holder", "account_name")
+                if _field_value(key) is not None
+            }
+
             # Track what was updated
             account_number_updated = False
             account_holder_updated = False
@@ -659,6 +672,17 @@ class BankVerificationService:
             from sqlalchemy.orm.attributes import flag_modified
 
             application.meta_data = application.meta_data or {}
+            # G19: the FIRST correction permanently preserves the student's
+            # original bank fields; later corrections keep their own
+            # prior_values in verification_details below.
+            if (account_number_corrected or account_holder_corrected) and "original_bank_fields" not in (
+                application.meta_data or {}
+            ):
+                application.meta_data["original_bank_fields"] = {
+                    "fields": prior_bank_fields,
+                    "preserved_at": datetime.now(timezone.utc).isoformat(),
+                    "preserved_reason": "first manual bank correction (G19/#981)",
+                }
             application.meta_data["bank_verification"] = {
                 "overall_status": overall_status,
                 "account_number_status": account_number_status,
@@ -686,11 +710,21 @@ class BankVerificationService:
                     "account_number": {
                         "status": account_number_status,
                         "corrected_value": account_number_corrected,
+                        "prior_values": {
+                            k: prior_bank_fields.get(k)
+                            for k in ("postal_account", "bank_account", "account_number")
+                            if k in prior_bank_fields
+                        },
                         "approved": account_number_approved,
                     },
                     "account_holder": {
                         "status": account_holder_status,
                         "corrected_value": account_holder_corrected,
+                        "prior_values": {
+                            k: prior_bank_fields.get(k)
+                            for k in ("account_holder", "account_name")
+                            if k in prior_bank_fields
+                        },
                         "approved": account_holder_approved,
                     },
                     "notes": review_notes,

--- a/backend/app/tests/test_bank_verification_preserves_original_form_data.py
+++ b/backend/app/tests/test_bank_verification_preserves_original_form_data.py
@@ -1,0 +1,132 @@
+"""G19 (#981): manual bank correction must not destroy the student's submission.
+
+manual_review_bank_info overwrites submitted_form_data in place. The first
+correction must permanently preserve the student's original bank fields
+(meta_data.original_bank_fields), and every correction must record the
+prior values it replaced in verification_details — otherwise「學生當時
+實際填了什麼」is unanswerable.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.models.application import Application
+from app.models.enums import ReviewStage
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.services.bank_verification_service import BankVerificationService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def app_with_bank_fields(db):
+    student = User(
+        nycu_id="g19stu001",
+        name="G19 學生",
+        email="g19stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(student)
+    await db.flush()
+    stype = ScholarshipType(code="g19_test", name="G19 Test Scholarship")
+    db.add(stype)
+    await db.flush()
+    cfg = ScholarshipConfiguration(
+        config_code="G19-CFG",
+        config_name="G19 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=1000,
+    )
+    db.add(cfg)
+    await db.flush()
+
+    app_row = Application(
+        app_id="APP-G19-001",
+        user_id=student.id,
+        scholarship_type_id=stype.id,
+        scholarship_configuration_id=cfg.id,
+        academic_year=114,
+        status="submitted",
+        review_stage=ReviewStage.student_submitted,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        submitted_form_data={
+            "fields": {
+                "postal_account": {
+                    "field_id": "postal_account",
+                    "field_type": "text",
+                    "value": "0001234567890123",
+                    "required": True,
+                },
+                "account_holder": {
+                    "field_id": "account_holder",
+                    "field_type": "text",
+                    "value": "王原始",
+                    "required": True,
+                },
+            },
+            "documents": [],
+        },
+    )
+    db.add(app_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return app_row
+
+
+async def test_first_correction_preserves_original_fields(db, app_with_bank_fields):
+    svc = BankVerificationService(db)
+    await svc.manual_review_bank_info(
+        application_id=app_with_bank_fields.id,
+        account_number_approved=None,
+        account_number_corrected="7000999988887777",
+        account_holder_approved=True,
+        account_holder_corrected=None,
+        review_notes="G19 test correction",
+        reviewer_username="g19admin",
+    )
+    await db.commit()
+    await db.refresh(app_with_bank_fields)
+
+    # The live form now carries the corrected value...
+    assert app_with_bank_fields.submitted_form_data["fields"]["postal_account"]["value"] == "7000999988887777"
+    # ...but the student's original is permanently preserved.
+    original = app_with_bank_fields.meta_data["original_bank_fields"]
+    assert original["fields"]["postal_account"] == "0001234567890123"
+    assert original["fields"]["account_holder"] == "王原始"
+    assert original["preserved_at"]
+    # (prior_values per correction are recorded in roster items'
+    # bank_verification_details — no roster item exists in this fixture, so
+    # the meta_data assertions above are the contract here.)
+
+
+async def test_second_correction_does_not_clobber_original(db, app_with_bank_fields):
+    svc = BankVerificationService(db)
+    await svc.manual_review_bank_info(
+        application_id=app_with_bank_fields.id,
+        account_number_approved=None,
+        account_number_corrected="1111111111111111",
+        account_holder_approved=None,
+        account_holder_corrected=None,
+        review_notes="first",
+        reviewer_username="g19admin",
+    )
+    await db.commit()
+    await svc.manual_review_bank_info(
+        application_id=app_with_bank_fields.id,
+        account_number_approved=None,
+        account_number_corrected="2222222222222222",
+        account_holder_approved=None,
+        account_holder_corrected=None,
+        review_notes="second",
+        reviewer_username="g19admin",
+    )
+    await db.commit()
+    await db.refresh(app_with_bank_fields)
+
+    # original = the STUDENT's value, not the first correction.
+    assert app_with_bank_fields.meta_data["original_bank_fields"]["fields"]["postal_account"] == "0001234567890123"
+    assert app_with_bank_fields.submitted_form_data["fields"]["postal_account"]["value"] == "2222222222222222"

--- a/backend/app/tests/test_bank_verification_preserves_original_form_data.py
+++ b/backend/app/tests/test_bank_verification_preserves_original_form_data.py
@@ -82,7 +82,7 @@ async def test_first_correction_preserves_original_fields(db, app_with_bank_fiel
     await svc.manual_review_bank_info(
         application_id=app_with_bank_fields.id,
         account_number_approved=None,
-        account_number_corrected="7000999988887777",
+        account_number_corrected="70009999888877",
         account_holder_approved=True,
         account_holder_corrected=None,
         review_notes="G19 test correction",
@@ -92,7 +92,7 @@ async def test_first_correction_preserves_original_fields(db, app_with_bank_fiel
     await db.refresh(app_with_bank_fields)
 
     # The live form now carries the corrected value...
-    assert app_with_bank_fields.submitted_form_data["fields"]["postal_account"]["value"] == "7000999988887777"
+    assert app_with_bank_fields.submitted_form_data["fields"]["postal_account"]["value"] == "70009999888877"
     # ...but the student's original is permanently preserved.
     original = app_with_bank_fields.meta_data["original_bank_fields"]
     assert original["fields"]["postal_account"] == "0001234567890123"
@@ -108,7 +108,7 @@ async def test_second_correction_does_not_clobber_original(db, app_with_bank_fie
     await svc.manual_review_bank_info(
         application_id=app_with_bank_fields.id,
         account_number_approved=None,
-        account_number_corrected="1111111111111111",
+        account_number_corrected="11111111111111",
         account_holder_approved=None,
         account_holder_corrected=None,
         review_notes="first",
@@ -118,7 +118,7 @@ async def test_second_correction_does_not_clobber_original(db, app_with_bank_fie
     await svc.manual_review_bank_info(
         application_id=app_with_bank_fields.id,
         account_number_approved=None,
-        account_number_corrected="2222222222222222",
+        account_number_corrected="22222222222222",
         account_holder_approved=None,
         account_holder_corrected=None,
         review_notes="second",
@@ -129,4 +129,4 @@ async def test_second_correction_does_not_clobber_original(db, app_with_bank_fie
 
     # original = the STUDENT's value, not the first correction.
     assert app_with_bank_fields.meta_data["original_bank_fields"]["fields"]["postal_account"] == "0001234567890123"
-    assert app_with_bank_fields.submitted_form_data["fields"]["postal_account"]["value"] == "2222222222222222"
+    assert app_with_bank_fields.submitted_form_data["fields"]["postal_account"]["value"] == "22222222222222"

--- a/backend/app/tests/test_bank_verification_preserves_original_form_data.py
+++ b/backend/app/tests/test_bank_verification_preserves_original_form_data.py
@@ -4,13 +4,13 @@ manual_review_bank_info overwrites submitted_form_data in place. The first
 correction must permanently preserve the student's original bank fields
 (meta_data.original_bank_fields), and every correction must record the
 prior values it replaced in verification_details — otherwise「學生當時
-實際填了什麼」is unanswerable.
+實際填了什麼」 is unanswerable.
 """
 
 import pytest
 import pytest_asyncio
 
-from app.models.application import Application
+from app.models.application import Application, ApplicationFile
 from app.models.enums import ReviewStage
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
 from app.models.user import User, UserRole, UserType
@@ -68,10 +68,25 @@ async def app_with_bank_fields(db):
                     "required": True,
                 },
             },
-            "documents": [],
+            "documents": [
+                {
+                    "document_id": "bank_account_cover",
+                    "filename": "bank_cover_g19.jpg",
+                }
+            ],
         },
     )
     db.add(app_row)
+    await db.flush()
+
+    bank_file = ApplicationFile(
+        application_id=app_row.id,
+        filename="bank_cover_g19.jpg",
+        object_name="tests/g19/bank_cover_g19.jpg",
+        mime_type="image/jpeg",
+    )
+    db.add(bank_file)
+
     await db.commit()
     await db.refresh(app_row)
     return app_row

--- a/backend/app/tests/test_status_transition_state_machine.py
+++ b/backend/app/tests/test_status_transition_state_machine.py
@@ -1,0 +1,139 @@
+"""G16 (#978): PATCH-status transitions are validated by a state machine.
+
+Previously any staff account could set ANY status (approved→draft,
+submitted→approved without review, …) — the e2e suite even documented it.
+Now: legal transitions pass; illegal ones need admin + a written reason;
+draft/deleted are never settable here; reject/return/cancel clear
+approved_at so「核准清單」period queries stay truthful.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.core.exceptions import ValidationError
+from app.models.application import Application, ApplicationStatus
+from app.models.enums import ReviewStage
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.schemas.application import ApplicationStatusUpdate
+from app.services.application_service import ApplicationService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def actors(db):
+    admin = User(
+        nycu_id="g16admin",
+        name="G16 Admin",
+        email="g16admin@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    professor = User(
+        nycu_id="g16prof",
+        name="G16 Prof",
+        email="g16prof@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.professor,
+    )
+    student = User(
+        nycu_id="g16stu001",
+        name="G16 學生",
+        email="g16stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add_all([admin, professor, student])
+    await db.flush()
+    stype = ScholarshipType(code="g16_test", name="G16 Test Scholarship")
+    db.add(stype)
+    await db.flush()
+    cfg = ScholarshipConfiguration(
+        config_code="G16-CFG",
+        config_name="G16 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=1000,
+    )
+    db.add(cfg)
+    await db.commit()
+    return {"admin": admin, "professor": professor, "student": student, "stype": stype, "cfg": cfg}
+
+
+def _update(status, comments=None):
+    return ApplicationStatusUpdate(status=status, comments=comments)
+
+
+async def _make_app(db, actors, suffix, status):
+    app_row = Application(
+        app_id=f"APP-G16-{suffix}",
+        user_id=actors["student"].id,
+        scholarship_type_id=actors["stype"].id,
+        scholarship_configuration_id=actors["cfg"].id,
+        academic_year=114,
+        status=status,
+        review_stage=ReviewStage.student_submitted,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+    )
+    db.add(app_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return app_row
+
+
+async def test_legal_transition_submitted_to_returned(db, actors):
+    app_row = await _make_app(db, actors, "LEGAL", "submitted")
+    svc = ApplicationService(db)
+    result = await svc.update_application_status(app_row.id, actors["admin"], _update("returned"))
+    assert result is not None
+    await db.refresh(app_row)
+    assert app_row.status == ApplicationStatus.returned
+
+
+async def test_illegal_transition_refused_for_non_admin(db, actors):
+    app_row = await _make_app(db, actors, "PROF", "approved")
+    svc = ApplicationService(db)
+    with pytest.raises(ValidationError, match="不允許的狀態轉移"):
+        await svc.update_application_status(app_row.id, actors["professor"], _update("submitted", "trying"))
+
+
+async def test_illegal_transition_refused_for_admin_without_reason(db, actors):
+    app_row = await _make_app(db, actors, "NOREASON", "rejected")
+    svc = ApplicationService(db)
+    with pytest.raises(ValidationError, match="不允許的狀態轉移"):
+        await svc.update_application_status(app_row.id, actors["admin"], _update("approved"))
+
+
+async def test_admin_override_with_reason_passes(db, actors):
+    app_row = await _make_app(db, actors, "OVERRIDE", "rejected")
+    svc = ApplicationService(db)
+    await svc.update_application_status(
+        app_row.id, actors["admin"], _update("approved", "申訴成功，依教務會議決議改核准")
+    )
+    await db.refresh(app_row)
+    assert app_row.status == ApplicationStatus.approved
+    assert app_row.approved_at is not None
+
+
+async def test_draft_and_deleted_never_settable_even_by_admin(db, actors):
+    svc = ApplicationService(db)
+    for target in ("draft", "deleted"):
+        app_row = await _make_app(db, actors, f"BAN-{target}", "submitted")
+        with pytest.raises(ValidationError, match="不可經由狀態更新設定"):
+            await svc.update_application_status(app_row.id, actors["admin"], _update(target, "even with reason"))
+
+
+async def test_reject_clears_approved_at(db, actors):
+    app_row = await _make_app(db, actors, "CLEAR", "submitted")
+    svc = ApplicationService(db)
+    await svc.update_application_status(app_row.id, actors["admin"], _update("approved"))
+    await db.refresh(app_row)
+    assert app_row.approved_at is not None
+
+    # approved → rejected is an override (needs reason).
+    await svc.update_application_status(app_row.id, actors["admin"], _update("rejected", "覆審不符資格"))
+    await db.refresh(app_row)
+    assert app_row.status == ApplicationStatus.rejected
+    assert app_row.approved_at is None, "rejected applications must not keep approved_at (G16)"


### PR DESCRIPTION
Phase 2 batch from the 申請歷史 audit (tracking #995):

| Gap | Issue | What changed |
|---|---|---|
| G16 high | #978 | `PATCH /applications/{id}/status` validates against an explicit transition table. Legal moves pass for any staff; illegal moves need **admin + written reason** (WARNING-logged; endpoint audit row keeps old→new+reason); `draft`/`deleted` are never settable here. Also: rejected/returned/cancelled clear `approved_at` so period-scoped 核准清單 queries stay truthful |
| G19 medium | #981 | first manual bank correction permanently preserves the student's original bank fields in `meta_data.original_bank_fields`; each correction's replaced values live in roster items' `verification_details`. The submission snapshot is no longer silently rewritten |

**Compatibility check:** existing e2e flows stay legal — `submitted→returned` (admin-returns), `submitted→approved/rejected` (approve-reject), same-status no-ops skip the gate. The previously-documented "service sets status without validating FROM state" behavior in `admin-returns-application.spec.ts` is now exactly the bypass this closes.

Tests: full transition matrix (6 cases) + original-preservation (2 cases incl. second-correction-doesn't-clobber).

Closes #978 / Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)