### PR TITLE
fix(history): revocation context in 學生領取歷史 + categorized locked-roster removal reasons

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -2178,6 +2178,7 @@ def remove_locked_roster_item(
             item_id=item_id,
             admin_user_id=current_user.id,
             reason=request.reason,
+            reason_category=request.reason_category,
         )
     except (ValueError, RosterLockedError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/backend/app/schemas/payment_roster.py
+++ b/backend/app/schemas/payment_roster.py
@@ -5,7 +5,7 @@ Payment roster Pydantic schemas
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import Literal, Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -308,10 +308,27 @@ class RosterScheduleResponse(RosterScheduleBase):
         return self.is_enabled and bool(self.cron_expression)
 
 
+# G26 (#988): structured removal-reason vocabulary so 鎖定後移除 is
+# statistically auditable — free text alone cannot be classified. Stored as
+# String(50), configuration-driven style (no DB enum); the free-text reason
+# stays as the supplementary detail.
+LOCKED_ITEM_REMOVAL_CATEGORIES = (
+    "withdrawal",  # 退學/休學
+    "verification_failed",  # 學籍/帳戶驗證失敗
+    "duplicate",  # 重複造冊
+    "revoked",  # 獎學金遭撤銷
+    "admin_decision",  # 行政決定
+    "other",  # 其他（請於 reason 補充）
+)
+
+
 class RemoveLockedItemRequest(BaseModel):
     """Body for DELETE /payment-rosters/{roster_id}/items/{item_id}"""
 
     reason: Optional[str] = Field(None, max_length=500)
+    reason_category: Optional[Literal[LOCKED_ITEM_REMOVAL_CATEGORIES]] = Field(
+        None, description="結構化移除理由分類 (G26/#988)"
+    )
 
 
 class RestoreItemRequest(BaseModel):

--- a/backend/app/schemas/student_scholarship_history.py
+++ b/backend/app/schemas/student_scholarship_history.py
@@ -53,6 +53,16 @@ class PaymentRecord(BaseModel):
     allocation_year: Optional[int] = None
     locked_at: Optional[datetime] = None
 
+    # G25 (#987): post-payment revocation/suspension context. A student whose
+    # allocation was revoked AFTER the roster locked still shows up here (the
+    # payment happened / was finalized) — the viewer must see that context
+    # instead of an unqualified「已領取」row.
+    quota_allocation_status: Optional[str] = None
+    revoked_at: Optional[datetime] = None
+    revoke_reason: Optional[str] = None
+    suspended_at: Optional[datetime] = None
+    suspend_reason: Optional[str] = None
+
 
 class HistorySummary(BaseModel):
     """Aggregates across all payment_records."""

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -2243,6 +2243,7 @@ class RosterService:
         item_id: int,
         admin_user_id: int,
         reason: Optional[str],
+        reason_category: Optional[str] = None,
     ) -> dict:
         """Soft-remove a PaymentRosterItem from a LOCKED roster (sets is_included=False; row survives for restore).
         Recompute roster totals, set excel_stale=True, write RosterAuditLog. Roster stays LOCKED."""
@@ -2257,7 +2258,10 @@ class RosterService:
             raise ValueError(f"Item {item_id} not found in roster {roster_id}")
 
         item.is_included = False
-        item.exclusion_reason = f"鎖定後移除：{reason}" if reason else "鎖定後移除"
+        # G26 (#988): keep the structured category in front of the free text
+        # so removals are classifiable (e.g. "鎖定後移除[withdrawal]：休學").
+        category_tag = f"[{reason_category}]" if reason_category else ""
+        item.exclusion_reason = f"鎖定後移除{category_tag}：{reason}" if reason else f"鎖定後移除{category_tag}"
         self.db.flush()
 
         # Recompute totals via the shared sync helper (persists

--- a/backend/app/services/student_scholarship_history_service.py
+++ b/backend/app/services/student_scholarship_history_service.py
@@ -77,7 +77,7 @@ class StudentScholarshipHistoryService:
         payment history view. The outerjoin keeps legacy items whose
         application_id is NULL (imported rows) visible."""
         stmt = (
-            select(PaymentRosterItem, PaymentRoster)
+            select(PaymentRosterItem, PaymentRoster, Application)
             .join(PaymentRoster, PaymentRosterItem.roster_id == PaymentRoster.id)
             .outerjoin(Application, PaymentRosterItem.application_id == Application.id)
             .where(
@@ -105,8 +105,15 @@ class StudentScholarshipHistoryService:
                 scholarship_subtype=item.scholarship_subtype,
                 allocation_year=item.allocation_year,
                 locked_at=roster.locked_at,
+                # G25 (#987): post-payment revocation context from the
+                # (outer-joined) application — None for legacy items.
+                quota_allocation_status=app.quota_allocation_status if app else None,
+                revoked_at=app.revoked_at if app else None,
+                revoke_reason=app.revoke_reason if app else None,
+                suspended_at=app.suspended_at if app else None,
+                suspend_reason=app.suspend_reason if app else None,
             )
-            for item, roster in rows
+            for item, roster, app in rows
         ]
         snapshot_name = rows[0][0].student_name if rows else None
         return records, snapshot_name

--- a/backend/app/tests/test_student_history_revocation_context.py
+++ b/backend/app/tests/test_student_history_revocation_context.py
@@ -1,0 +1,120 @@
+"""G25 (#987): 學生領取歷史 must surface post-payment revocation context.
+
+A student revoked AFTER the roster locked legitimately appears in payment
+history (the disbursement was finalized) — but the row must carry the
+revocation context instead of looking like an unqualified「已領取」.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from app.models.application import Application
+from app.models.enums import ReviewStage
+from app.models.payment_roster import (
+    PaymentRoster,
+    PaymentRosterItem,
+    RosterCycle,
+    RosterStatus,
+    RosterTriggerType,
+    StudentVerificationStatus,
+)
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.services.student_scholarship_history_service import (
+    StudentScholarshipHistoryService,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+STUDENT_NO = "G25S001"
+
+
+@pytest_asyncio.fixture
+async def revoked_after_lock(db):
+    admin = User(
+        nycu_id="g25admin",
+        name="G25 Admin",
+        email="g25admin@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    student = User(
+        nycu_id=STUDENT_NO,
+        name="G25 學生",
+        email="g25stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add_all([admin, student])
+    await db.flush()
+    stype = ScholarshipType(code="g25_test", name="G25 Test Scholarship")
+    db.add(stype)
+    await db.flush()
+    cfg = ScholarshipConfiguration(
+        config_code="G25-CFG",
+        config_name="G25 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=10000,
+    )
+    db.add(cfg)
+    await db.flush()
+
+    app_row = Application(
+        app_id="APP-G25-RVK",
+        user_id=student.id,
+        scholarship_type_id=stype.id,
+        scholarship_configuration_id=cfg.id,
+        academic_year=114,
+        status="cancelled",
+        review_stage=ReviewStage.quota_distributed,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        quota_allocation_status="revoked",
+        revoked_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        revoked_by=admin.id,
+        revoke_reason="違反要點第七條",
+    )
+    db.add(app_row)
+    await db.flush()
+
+    roster = PaymentRoster(
+        roster_code="G25-ROSTER",
+        scholarship_configuration_id=cfg.id,
+        period_label="114-02",
+        academic_year=114,
+        roster_cycle=RosterCycle.MONTHLY,
+        trigger_type=RosterTriggerType.MANUAL,
+        status=RosterStatus.LOCKED,
+        created_by=admin.id,
+    )
+    db.add(roster)
+    await db.flush()
+
+    item = PaymentRosterItem(
+        roster_id=roster.id,
+        application_id=app_row.id,
+        student_id_number=f"A{STUDENT_NO}",
+        student_number=STUDENT_NO,
+        student_name="G25 學生",
+        scholarship_name="G25 Test Scholarship",
+        scholarship_amount="10000",
+        verification_status=StudentVerificationStatus.VERIFIED,
+        is_included=True,
+    )
+    db.add(item)
+    await db.commit()
+    return app_row
+
+
+async def test_revoked_after_lock_payment_carries_context(db, revoked_after_lock):
+    svc = StudentScholarshipHistoryService()
+    records, _ = await svc._fetch_paid_payments(db, STUDENT_NO)
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.quota_allocation_status == "revoked"
+    assert rec.revoke_reason == "違反要點第七條"
+    assert rec.revoked_at is not None
+    assert rec.suspended_at is None

--- a/frontend/components/admin/student-history/PaymentHistoryTable.tsx
+++ b/frontend/components/admin/student-history/PaymentHistoryTable.tsx
@@ -14,6 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
 import type { PaymentRecord } from "@/lib/api/modules/student-history";
 
 interface PaymentHistoryTableProps {
@@ -61,7 +62,27 @@ export function PaymentHistoryTable({ records }: PaymentHistoryTableProps) {
             {records.map((r, idx) => (
               <TableRow key={`${r.roster_id}-${idx}`}>
                 <TableCell className="font-mono">{r.period_label}</TableCell>
-                <TableCell>{r.scholarship_name}</TableCell>
+                <TableCell>
+                  {r.scholarship_name}
+                  {r.quota_allocation_status === "revoked" && (
+                    <Badge
+                      variant="destructive"
+                      className="ml-2 text-xs"
+                      title={r.revoke_reason ?? undefined}
+                    >
+                      已撤銷
+                    </Badge>
+                  )}
+                  {r.quota_allocation_status === "suspended" && (
+                    <Badge
+                      variant="destructive"
+                      className="ml-2 text-xs"
+                      title={r.suspend_reason ?? undefined}
+                    >
+                      已停發
+                    </Badge>
+                  )}
+                </TableCell>
                 <TableCell>{r.scholarship_subtype ?? "—"}</TableCell>
                 <TableCell className="text-right font-mono">
                   {formatAmount(r.scholarship_amount)}

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -9380,6 +9380,11 @@ export interface components {
         RemoveLockedItemRequest: {
             /** Reason */
             reason?: string | null;
+            /**
+             * Reason Category
+             * @description 結構化移除理由分類 (G26/#988)
+             */
+            reason_category?: ("withdrawal" | "verification_failed" | "duplicate" | "revoked" | "admin_decision" | "other") | null;
         };
         /** ReorderItem */
         ReorderItem: {

--- a/frontend/lib/api/modules/student-history.ts
+++ b/frontend/lib/api/modules/student-history.ts
@@ -38,6 +38,13 @@ export interface PaymentRecord {
   scholarship_subtype: string | null;
   allocation_year: number | null;
   locked_at: string | null;
+  // G25 (#987): post-payment revocation/suspension context — null for
+  // legacy items without a linked application.
+  quota_allocation_status: string | null;
+  revoked_at: string | null;
+  revoke_reason: string | null;
+  suspended_at: string | null;
+  suspend_reason: string | null;
 }
 
 export interface HistorySummary {


### PR DESCRIPTION
Phase 2 batch from the 申請歷史 audit (tracking #995):

| Gap | Issue | What changed |
|---|---|---|
| G25 medium | #987 | `PaymentRecord` carries `quota_allocation_status` + revoke/suspend timestamps & reasons from the outer-joined application; `PaymentHistoryTable` shows 已撤銷/已停發 badges with the reason as tooltip — revoked-after-lock payments no longer masquerade as unqualified 已領取 rows |
| G26 medium | #988 | locked-roster item removal accepts a structured `reason_category` (withdrawal / verification_failed / duplicate / revoked / admin_decision / other), stored inside `exclusion_reason` as `鎖定後移除[category]：...` — removals become statistically classifiable while keeping free-text detail |

Tests: `test_student_history_revocation_context.py` (revoked-after-lock row carries context). schema.d.ts regenerated; `tsc --noEmit` clean.

Closes #987 / Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)