### PR TITLE
feat(#985): export the filtered 歷史申請 view to Excel (G23)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/applications.py
+++ b/backend/app/api/v1/endpoints/admin/applications.py
@@ -13,6 +13,9 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 
+from urllib.parse import quote
+
+from fastapi.responses import StreamingResponse
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import delete as sqla_delete
@@ -346,6 +349,139 @@ async def get_historical_applications(
         "message": "Historical applications retrieved successfully",
         "data": response_data.model_dump() if hasattr(response_data, "model_dump") else response_data.dict(),
     }
+
+
+@router.get("/applications/history/export")
+async def export_historical_applications(
+    status: Optional[str] = Query(None, description="Filter by status"),
+    scholarship_type: Optional[str] = Query(None, description="Filter by scholarship type"),
+    academic_year: Optional[int] = Query(None, description="Filter by academic year"),
+    semester: Optional[str] = Query(None, description="Filter by semester"),
+    search: Optional[str] = Query(None, description="Search by student name or ID"),
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Export the filtered 歷史申請 view to XLSX (issue #985 / G23).
+
+    Same filters and deleted-records policy as GET /applications/history
+    (soft-deleted rows are included and flagged), but unpaginated — the
+    export is the audit-friendly artifact 財務稽核 previously had to
+    screenshot together by hand.
+    """
+    from io import BytesIO
+
+    from openpyxl import Workbook
+
+    stmt = (
+        select(
+            Application,
+            User.name.label("student_name"),
+            User.nycu_id.label("student_nycu_id"),
+            User.email.label("student_email"),
+            ScholarshipType.name.label("scholarship_name"),
+            ScholarshipType.code.label("scholarship_type_code"),
+        )
+        .join(User, Application.user_id == User.id)
+        .outerjoin(ScholarshipType, Application.scholarship_type_id == ScholarshipType.id)
+    )
+    if status:
+        stmt = stmt.where(Application.status == status)
+    if scholarship_type:
+        stmt = stmt.where(ScholarshipType.code == scholarship_type)
+    if academic_year:
+        stmt = stmt.where(Application.academic_year == academic_year)
+    if semester and semester != "all":
+        if semester == "first":
+            stmt = stmt.where(Application.semester == Semester.first)
+        elif semester == "second":
+            stmt = stmt.where(Application.semester == Semester.second)
+        elif semester == "yearly":
+            stmt = stmt.where(Application.semester == Semester.yearly)
+    if search:
+        search_term = f"%{search}%"
+        stmt = stmt.where(
+            or_(
+                User.name.ilike(search_term),
+                User.nycu_id.ilike(search_term),
+                User.email.ilike(search_term),
+                Application.app_id.ilike(search_term),
+                ScholarshipType.name.ilike(search_term),
+            )
+        )
+    stmt = stmt.order_by(Application.created_at.desc())
+
+    result = await db.execute(stmt)
+    rows = result.fetchall()
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "歷史申請"
+    headers = [
+        "申請編號",
+        "學生姓名",
+        "學號",
+        "Email",
+        "獎學金",
+        "子類型",
+        "金額",
+        "學年",
+        "學期",
+        "狀態",
+        "是否續領",
+        "提交時間",
+        "核准時間",
+        "撤銷時間",
+        "撤銷原因",
+        "停發時間",
+        "停發原因",
+        "已刪除",
+        "刪除時間",
+        "刪除原因",
+        "建立時間",
+    ]
+    ws.append(headers)
+
+    def _dt(value):
+        return value.strftime("%Y-%m-%d %H:%M") if value else ""
+
+    for row in rows:
+        app = row.Application
+        ws.append(
+            [
+                app.app_id,
+                row.student_name,
+                row.student_nycu_id,
+                row.student_email,
+                row.scholarship_name,
+                app.sub_scholarship_type or "",
+                float(app.amount) if app.amount is not None else "",
+                app.academic_year,
+                app.semester.value if app.semester else "yearly",
+                app.status.value if hasattr(app.status, "value") else str(app.status),
+                "是" if app.is_renewal else "否",
+                _dt(app.submitted_at),
+                _dt(app.approved_at),
+                _dt(app.revoked_at),
+                app.revoke_reason or "",
+                _dt(app.suspended_at),
+                app.suspend_reason or "",
+                "是" if app.deleted_at is not None else "否",
+                _dt(app.deleted_at),
+                app.deletion_reason or "",
+                _dt(app.created_at),
+            ]
+        )
+
+    buffer = BytesIO()
+    wb.save(buffer)
+    buffer.seek(0)
+
+    filename = f"歷史申請_{academic_year or 'all'}.xlsx"
+    return StreamingResponse(
+        buffer,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename)}"},
+    )
 
 
 @router.put("/applications/{id}/assign-professor")

--- a/frontend/components/admin/history/HistoryPanel.tsx
+++ b/frontend/components/admin/history/HistoryPanel.tsx
@@ -41,7 +41,7 @@ import {
   getDisplayStatusInfo,
 } from "@/lib/utils/application-helpers";
 import { Locale } from "@/lib/validators";
-import { AlertCircle, Eye, FileText, RefreshCw } from "lucide-react";
+import { AlertCircle, Download, Eye, FileText, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
 interface User {
@@ -156,6 +156,32 @@ export function HistoryPanel({ user }: HistoryPanelProps) {
       setLoadingHistoricalApplications(false);
     }
   }, [historicalApplicationsFilters, activeHistoricalTab, user]);
+
+  // 匯出目前篩選後的歷史申請為 Excel (#985 / G23)
+  const [exporting, setExporting] = useState(false);
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    try {
+      const blob = await apiClient.admin.exportHistoricalApplications({
+        ...historicalApplicationsFilters,
+        scholarship_type:
+          activeHistoricalTab === "all" ? undefined : activeHistoricalTab,
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `歷史申請_${historicalApplicationsFilters.academic_year ?? "all"}.xlsx`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (error: unknown) {
+      logger.error("匯出歷史申請失敗", { error });
+      setHistoricalApplicationsError("匯出歷史申請失敗");
+    } finally {
+      setExporting(false);
+    }
+  }, [historicalApplicationsFilters, activeHistoricalTab]);
 
   // 獲取所有歷史申請以建立 tab 列表
   const fetchAllHistoricalApplicationsForTabs = useCallback(async () => {
@@ -392,17 +418,28 @@ export function HistoryPanel({ user }: HistoryPanelProps) {
                 <div className="text-sm text-gray-600">
                   共 {historicalApplicationsPagination.total} 筆申請記錄
                 </div>
-                <Button
-                  onClick={fetchHistoricalApplications}
-                  disabled={loadingHistoricalApplications}
-                  variant="outline"
-                  size="sm"
-                >
-                  <RefreshCw
-                    className={`h-4 w-4 mr-2 ${loadingHistoricalApplications ? "animate-spin" : ""}`}
-                  />
-                  刷新
-                </Button>
+                <div className="flex gap-2">
+                  <Button
+                    onClick={handleExport}
+                    disabled={exporting || loadingHistoricalApplications}
+                    variant="outline"
+                    size="sm"
+                  >
+                    <Download className="h-4 w-4 mr-2" />
+                    {exporting ? "匯出中…" : "匯出 Excel"}
+                  </Button>
+                  <Button
+                    onClick={fetchHistoricalApplications}
+                    disabled={loadingHistoricalApplications}
+                    variant="outline"
+                    size="sm"
+                  >
+                    <RefreshCw
+                      className={`h-4 w-4 mr-2 ${loadingHistoricalApplications ? "animate-spin" : ""}`}
+                    />
+                    刷新
+                  </Button>
+                </div>
               </div>
 
               {/* 錯誤顯示 */}

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -1263,6 +1263,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/applications/history/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export Historical Applications
+         * @description Export the filtered 歷史申請 view to XLSX (issue #985 / G23).
+         *
+         *     Same filters and deleted-records policy as GET /applications/history
+         *     (soft-deleted rows are included and flagged), but unpaginated — the
+         *     export is the audit-friendly artifact 財務稽核 previously had to
+         *     screenshot together by hand.
+         */
+        get: operations["export_historical_applications_api_v1_admin_applications_history_export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/applications/{id}/assign-professor": {
         parameters: {
             query?: never;
@@ -12762,6 +12787,46 @@ export interface operations {
                 page?: number;
                 /** @description Page size */
                 size?: number;
+                /** @description Filter by status */
+                status?: string | null;
+                /** @description Filter by scholarship type */
+                scholarship_type?: string | null;
+                /** @description Filter by academic year */
+                academic_year?: number | null;
+                /** @description Filter by semester */
+                semester?: string | null;
+                /** @description Search by student name or ID */
+                search?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_historical_applications_api_v1_admin_applications_history_export_get: {
+        parameters: {
+            query?: {
                 /** @description Filter by status */
                 status?: string | null;
                 /** @description Filter by scholarship type */

--- a/frontend/lib/api/modules/__tests__/admin.test.ts
+++ b/frontend/lib/api/modules/__tests__/admin.test.ts
@@ -364,9 +364,7 @@ describe("createAdminApi", () => {
       "scholarship-permissions"
     );
     expect(mockedRaw.PUT.mock.calls[0][0]).toContain("scholarship-permissions");
-    expect(mockedRaw.DELETE.mock.calls[0][0]).toContain(
-      "scholarship-permissions"
-    );
+    expect(mockedRaw.DELETE.mock.calls[0][0]).toContain("scholarship-permissions");
   });
 
   // ─── Email template CRUD ──────────────────────────────────────────
@@ -481,7 +479,7 @@ describe("createAdminApi", () => {
     // Pin: conditional spread (NOT included as undefined) when
     // changeReason is undefined. Pin so refactor doesn't send
     // change_reason: undefined which audit log treats as
-    // "explicitly null".
+    // \"explicitly null\".
     mockedRaw.PUT.mockResolvedValueOnce({});
     const api = createAdminApi();
     await api.updateConfigurationsBulk([{ key: "x", value: 1 }]);
@@ -491,11 +489,11 @@ describe("createAdminApi", () => {
 
   // ─── Method count invariant ───────────────────────────────────────
 
-  it("module exposes exactly 77 methods", async () => {
-    // Pin: 77 methods is the current admin surface. Pin so
+  it("module exposes exactly 79 methods", async () => {
+    // Pin: 79 methods is the current admin surface. Pin so
     // refactor adding/removing methods requires explicit review.
     // SECURITY-critical surface — every change should be deliberate.
     const api = createAdminApi();
-    expect(Object.keys(api).length).toBe(78);
+    expect(Object.keys(api).length).toBe(79);
   });
 });

--- a/frontend/lib/api/modules/admin.ts
+++ b/frontend/lib/api/modules/admin.ts
@@ -116,6 +116,38 @@ export function createAdminApi() {
     },
 
     /**
+     * Export the filtered 歷史申請 view to XLSX (#985 / G23).
+     * Returns a Blob for download.
+     */
+    exportHistoricalApplications: async (
+      filters?: Omit<HistoricalApplicationFilters, "page" | "size">
+    ): Promise<Blob> => {
+      const token = typedClient.getToken();
+      const baseURL =
+        typeof window !== "undefined" ? "" : process.env.INTERNAL_API_URL || "http://localhost:8000";
+      const params = new URLSearchParams();
+      if (filters?.status) params.set("status", filters.status);
+      if (filters?.scholarship_type) params.set("scholarship_type", filters.scholarship_type);
+      if (filters?.academic_year != null) params.set("academic_year", String(filters.academic_year));
+      if (filters?.semester) params.set("semester", filters.semester);
+      if (filters?.search) params.set("search", filters.search);
+      const qs = params.toString();
+      const response = await fetch(
+        `${baseURL}/api/v1/admin/applications/history/export${qs ? `?${qs}` : ""}`,
+        {
+          method: "GET",
+          headers: {
+            ...(token && { Authorization: `Bearer ${token}` }),
+          },
+        }
+      );
+      if (!response.ok) {
+        throw new Error("匯出歷史申請失敗");
+      }
+      return response.blob();
+    },
+
+    /**
      * Update application status
      * Type-safe: Path parameter and request body validated against OpenAPI
      */


### PR DESCRIPTION
Phase 2 of the 申請歷史 audit (tracking #995), gap **G23**: the history view had no export — financial audits hand-copied screen data.

- **Backend:** `GET /admin/applications/history/export` (admin-only) streams XLSX with the same filters + deleted-records policy as the history endpoint, unpaginated. Columns include the revocation/suspension/deletion context surfaced in #999 (撤銷/停發/刪除時間與原因), 續領 flag, amounts and the full date trail.
- **Frontend:** `HistoryPanel` 匯出 Excel button bound to the live filters (status/year/semester/search/scholarship tab); standard blob-download pattern from the whitelist module.

schema.d.ts regenerated; `tsc --noEmit` clean; black + flake8 clean.

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)