### PR TITLE
feat(#976): system-wide audit-log viewer — backend listing + 稽核日誌 admin tab (G14)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/__init__.py
+++ b/backend/app/api/v1/endpoints/admin/__init__.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter
 # Import all modularized routers (✅ All Completed)
 from .announcements import router as announcements_router
 from .applications import router as applications_router
+from .audit_logs import router as audit_logs_router
 from .bank_verification import router as bank_verification_router
 from .cache import router as cache_router
 from .configurations import router as configurations_router
@@ -60,5 +61,6 @@ router.include_router(
     tags=["Admin - Student History"],
 )
 router.include_router(cache_router, tags=["Admin - Cache"])
+router.include_router(audit_logs_router, tags=["Admin - Audit Logs"])
 
 __all__ = ["router"]

--- a/backend/app/api/v1/endpoints/admin/audit_logs.py
+++ b/backend/app/api/v1/endpoints/admin/audit_logs.py
@@ -1,0 +1,108 @@
+"""Admin endpoint: system-wide audit-log viewer (issue #976 / audit gap G14).
+
+Until now the only audit read path was a per-scholarship trail endpoint that
+no frontend component consumed — answering「誰在某日刪了申請 X」meant raw
+SQL against the database. This endpoint exposes audit_logs (paginated,
+filterable) to admins so the trail is usable by the people responsible for
+it; the 稽核日誌 tab in AdminManagementShell renders it.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import require_admin
+from app.db.deps import get_db
+from app.models.audit_log import AuditLog
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/audit-logs")
+async def list_audit_logs(
+    page: int = Query(1, ge=1),
+    size: int = Query(50, ge=1, le=200),
+    resource_type: Optional[str] = Query(None, description="e.g. application / college_ranking / batch_import"),
+    resource_id: Optional[str] = Query(None, description="Exact resource id (string match)"),
+    action: Optional[str] = Query(None, description="AuditAction value, e.g. revoke / delete / import"),
+    user_id: Optional[int] = Query(None, description="Acting user id"),
+    date_from: Optional[datetime] = Query(None),
+    date_to: Optional[datetime] = Query(None),
+    search: Optional[str] = Query(None, description="Substring match on description / resource_name"),
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Paginated, filterable system-wide audit-log listing (admin only)."""
+    stmt = select(
+        AuditLog,
+        User.name.label("actor_name"),
+        User.nycu_id.label("actor_nycu_id"),
+    ).outerjoin(User, AuditLog.user_id == User.id)
+
+    if resource_type:
+        stmt = stmt.where(AuditLog.resource_type == resource_type)
+    if resource_id:
+        stmt = stmt.where(AuditLog.resource_id == str(resource_id))
+    if action:
+        stmt = stmt.where(AuditLog.action == action)
+    if user_id:
+        stmt = stmt.where(AuditLog.user_id == user_id)
+    if date_from:
+        stmt = stmt.where(AuditLog.created_at >= date_from)
+    if date_to:
+        stmt = stmt.where(AuditLog.created_at <= date_to)
+    if search:
+        term = f"%{search}%"
+        stmt = stmt.where(
+            or_(
+                AuditLog.description.ilike(term),
+                AuditLog.resource_name.ilike(term),
+                AuditLog.resource_id.ilike(term),
+            )
+        )
+
+    count_stmt = select(func.count()).select_from(stmt.subquery())
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    stmt = stmt.order_by(AuditLog.id.desc()).offset((page - 1) * size).limit(size)
+    rows = (await db.execute(stmt)).all()
+
+    items = [
+        {
+            "id": log.id,
+            "created_at": log.created_at.isoformat() if log.created_at else None,
+            "user_id": log.user_id,
+            "actor_name": actor_name,
+            "actor_nycu_id": actor_nycu_id,
+            "action": log.action,
+            "resource_type": log.resource_type,
+            "resource_id": log.resource_id,
+            "resource_name": log.resource_name,
+            "description": log.description,
+            "old_values": log.old_values,
+            "new_values": log.new_values,
+            "status": log.status,
+            "ip_address": log.ip_address,
+            "meta_data": log.meta_data,
+        }
+        for log, actor_name, actor_nycu_id in rows
+    ]
+
+    return {
+        "success": True,
+        "message": "Audit logs retrieved successfully",
+        "data": {
+            "items": items,
+            "total": total,
+            "page": page,
+            "size": size,
+            "pages": (total + size - 1) // size,
+        },
+    }

--- a/frontend/components/admin/AdminManagementShell.tsx
+++ b/frontend/components/admin/AdminManagementShell.tsx
@@ -24,6 +24,10 @@ const AnnouncementsPanel = dynamic(() => import("./announcements/AnnouncementsPa
   loading: () => <div className="flex items-center justify-center py-8"><div className="animate-spin rounded-full h-6 w-6 border-2 border-nycu-blue-600 border-t-transparent"></div></div>
 });
 
+const AuditLogPanel = dynamic(() => import("./audit/AuditLogPanel").then(mod => ({ default: mod.AuditLogPanel })), {
+  loading: () => <div className="flex items-center justify-center py-8"><div className="animate-spin rounded-full h-6 w-6 border-2 border-nycu-blue-600 border-t-transparent"></div></div>
+});
+
 // Import lighter components directly
 import { UserManagementPanel } from "./users/UserManagementPanel";
 import { StudentListManagement } from "./students/StudentListManagement";
@@ -100,7 +104,7 @@ function AdminManagementContent({ user }: AdminManagementShellProps) {
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <TabsList
-          className={`grid w-full ${hasQuotaPermission ? "grid-cols-[repeat(13,minmax(0,1fr))]" : "grid-cols-12"}`}
+          className={`grid w-full ${hasQuotaPermission ? "grid-cols-[repeat(14,minmax(0,1fr))]" : "grid-cols-[repeat(13,minmax(0,1fr))]"}`}
         >
           <TabsTrigger value="dashboard">系統概覽</TabsTrigger>
           <TabsTrigger value="users">使用者權限</TabsTrigger>
@@ -114,6 +118,7 @@ function AdminManagementContent({ user }: AdminManagementShellProps) {
           <TabsTrigger value="workflows">工作流程</TabsTrigger>
           <TabsTrigger value="email">郵件管理</TabsTrigger>
           <TabsTrigger value="history">歷史申請</TabsTrigger>
+          <TabsTrigger value="audit-logs">稽核日誌</TabsTrigger>
           <TabsTrigger value="announcements">系統公告</TabsTrigger>
           <TabsTrigger value="settings">系統設定</TabsTrigger>
           <TabsTrigger value="system-docs">系統文件</TabsTrigger>
@@ -167,6 +172,10 @@ function AdminManagementContent({ user }: AdminManagementShellProps) {
 
         <TabsContent value="settings" className="space-y-4">
           <SettingsPanel />
+        </TabsContent>
+
+        <TabsContent value="audit-logs" className="space-y-4">
+          <AuditLogPanel />
         </TabsContent>
 
         <TabsContent value="system-docs" className="space-y-4">

--- a/frontend/components/admin/audit/AuditLogPanel.tsx
+++ b/frontend/components/admin/audit/AuditLogPanel.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import apiClient from "@/lib/api";
+import type { AuditLogEntry, AuditLogFilters } from "@/lib/api/modules/audit-logs";
+import { logger } from "@/lib/utils/logger";
+import { AlertCircle, ChevronDown, ChevronRight, RefreshCw, Search } from "lucide-react";
+import { Fragment, useCallback, useEffect, useState } from "react";
+
+const ACTION_OPTIONS = [
+  "create",
+  "update",
+  "delete",
+  "submit",
+  "approve",
+  "reject",
+  "withdraw",
+  "import",
+  "execute_distribution",
+  "revoke",
+  "suspend",
+  "restore",
+];
+
+const RESOURCE_OPTIONS = [
+  "application",
+  "scholarship_type",
+  "scholarship_configuration",
+  "college_ranking",
+  "batch_import",
+  "payment_roster",
+];
+
+const DESTRUCTIVE_ACTIONS = new Set(["delete", "revoke", "suspend", "reject"]);
+
+export function AuditLogPanel() {
+  const [items, setItems] = useState<AuditLogEntry[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [pages, setPages] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [filters, setFilters] = useState<AuditLogFilters>({});
+
+  const fetchLogs = useCallback(
+    async (targetPage: number) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await apiClient.auditLogs.list({
+          ...filters,
+          page: targetPage,
+          size: 50,
+        });
+        if (response.success && response.data) {
+          setItems(response.data.items);
+          setTotal(response.data.total);
+          setPages(response.data.pages);
+          setPage(response.data.page);
+        } else {
+          setError(response.message || "載入稽核日誌失敗");
+        }
+      } catch (err: unknown) {
+        logger.error("載入稽核日誌失敗", { error: err });
+        setError("網路錯誤或伺服器未回應");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [filters],
+  );
+
+  useEffect(() => {
+    fetchLogs(1);
+  }, [fetchLogs]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>稽核日誌</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          系統所有敏感操作的不可竄改紀錄（誰、何時、做了什麼、變更前後值）
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* 篩選列 */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          <Select
+            value={filters.resource_type ?? "all"}
+            onValueChange={(v) =>
+              setFilters((f) => ({ ...f, resource_type: v === "all" ? undefined : v }))
+            }
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="資源類型" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全部資源</SelectItem>
+              {RESOURCE_OPTIONS.map((r) => (
+                <SelectItem key={r} value={r}>
+                  {r}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={filters.action ?? "all"}
+            onValueChange={(v) => setFilters((f) => ({ ...f, action: v === "all" ? undefined : v }))}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="操作" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全部操作</SelectItem>
+              {ACTION_OPTIONS.map((a) => (
+                <SelectItem key={a} value={a}>
+                  {a}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder="資源 ID（如申請 DB id）"
+            value={filters.resource_id ?? ""}
+            onChange={(e) =>
+              setFilters((f) => ({ ...f, resource_id: e.target.value || undefined }))
+            }
+          />
+          <div className="flex gap-2">
+            <Input
+              placeholder="描述關鍵字"
+              value={filters.search ?? ""}
+              onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value || undefined }))}
+            />
+            <Button onClick={() => fetchLogs(1)} disabled={loading} variant="outline" size="icon">
+              {loading ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+            </Button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-3 flex items-center gap-2 text-red-700 text-sm">
+            <AlertCircle className="h-4 w-4" />
+            {error}
+          </div>
+        )}
+
+        <div className="text-sm text-gray-600">共 {total} 筆紀錄</div>
+
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-8" />
+              <TableHead>時間</TableHead>
+              <TableHead>操作者</TableHead>
+              <TableHead>操作</TableHead>
+              <TableHead>資源</TableHead>
+              <TableHead>描述</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((log) => (
+              <Fragment key={log.id}>
+                <TableRow
+                  className="cursor-pointer"
+                  onClick={() => setExpanded(expanded === log.id ? null : log.id)}
+                >
+                  <TableCell>
+                    {expanded === log.id ? (
+                      <ChevronDown className="h-4 w-4" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4" />
+                    )}
+                  </TableCell>
+                  <TableCell className="font-mono text-xs whitespace-nowrap">
+                    {log.created_at ? new Date(log.created_at).toLocaleString("zh-TW") : "—"}
+                  </TableCell>
+                  <TableCell>
+                    {log.actor_name ?? "—"}
+                    {log.actor_nycu_id && (
+                      <span className="text-xs text-gray-500 ml-1">({log.actor_nycu_id})</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={DESTRUCTIVE_ACTIONS.has(log.action) ? "destructive" : "secondary"}>
+                      {log.action}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {log.resource_type}
+                    {log.resource_id ? `#${log.resource_id}` : ""}
+                  </TableCell>
+                  <TableCell className="text-sm max-w-md truncate">{log.description ?? "—"}</TableCell>
+                </TableRow>
+                {expanded === log.id && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="bg-gray-50">
+                      <div className="grid md:grid-cols-2 gap-3 text-xs p-2">
+                        <div>
+                          <div className="font-medium mb-1">變更前 (old_values)</div>
+                          <pre className="bg-white border rounded p-2 overflow-auto max-h-48">
+                            {JSON.stringify(log.old_values ?? null, null, 2)}
+                          </pre>
+                        </div>
+                        <div>
+                          <div className="font-medium mb-1">變更後 (new_values)</div>
+                          <pre className="bg-white border rounded p-2 overflow-auto max-h-48">
+                            {JSON.stringify(log.new_values ?? null, null, 2)}
+                          </pre>
+                        </div>
+                        <div className="md:col-span-2 text-gray-600">
+                          IP: {log.ip_address ?? "—"}　狀態: {log.status ?? "—"}
+                          {log.meta_data && (
+                            <>
+                              　meta: <code>{JSON.stringify(log.meta_data)}</code>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </Fragment>
+            ))}
+          </TableBody>
+        </Table>
+
+        {/* 分頁 */}
+        <div className="flex justify-between items-center">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1 || loading}
+            onClick={() => fetchLogs(page - 1)}
+          >
+            上一頁
+          </Button>
+          <span className="text-sm text-gray-600">
+            第 {page} / {pages || 1} 頁
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= pages || loading}
+            onClick={() => fetchLogs(page + 1)}
+          >
+            下一頁
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -2427,6 +2427,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/audit-logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Audit Logs
+         * @description Paginated, filterable system-wide audit-log listing (admin only).
+         */
+        get: operations["list_audit_logs_api_v1_admin_audit_logs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/scholarships": {
         parameters: {
             query?: never;
@@ -14935,6 +14955,50 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    list_audit_logs_api_v1_admin_audit_logs_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                size?: number;
+                /** @description e.g. application / college_ranking / batch_import */
+                resource_type?: string | null;
+                /** @description Exact resource id (string match) */
+                resource_id?: string | null;
+                /** @description AuditAction value, e.g. revoke / delete / import */
+                action?: string | null;
+                /** @description Acting user id */
+                user_id?: number | null;
+                date_from?: string | null;
+                date_to?: string | null;
+                /** @description Substring match on description / resource_name */
+                search?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -33,6 +33,7 @@ import { createApplicationFieldsApi } from './modules/application-fields';
 import { createUserProfilesApi } from './modules/user-profiles';
 import { createEmailManagementApi } from './modules/email-management';
 import { createAdminApi } from './modules/admin';
+import { createAuditLogsApi } from './modules/audit-logs';
 import { createDocumentRequestsApi } from './modules/document-requests';
 import { createPaymentRostersApi } from './modules/payment-rosters';
 import { createRosterSchedulesApi } from './modules/roster-schedules';
@@ -159,6 +160,7 @@ class ExtendedApiClient extends ApiClient {
   private _userProfiles?: ReturnType<typeof createUserProfilesApi>;
   private _emailManagement?: ReturnType<typeof createEmailManagementApi>;
   private _admin?: ReturnType<typeof createAdminApi>;
+  private _auditLogs?: ReturnType<typeof createAuditLogsApi>;
   private _documentRequests?: ReturnType<typeof createDocumentRequestsApi>;
   private _paymentRosters?: ReturnType<typeof createPaymentRostersApi>;
   private _rosterSchedules?: ReturnType<typeof createRosterSchedulesApi>;
@@ -256,6 +258,11 @@ class ExtendedApiClient extends ApiClient {
   get emailManagement(): ReturnType<typeof createEmailManagementApi> {
     if (!this._emailManagement) this._emailManagement = createEmailManagementApi();
     return this._emailManagement;
+  }
+
+  get auditLogs(): ReturnType<typeof createAuditLogsApi> {
+    if (!this._auditLogs) this._auditLogs = createAuditLogsApi();
+    return this._auditLogs;
   }
 
   get admin(): ReturnType<typeof createAdminApi> {

--- a/frontend/lib/api/modules/audit-logs.ts
+++ b/frontend/lib/api/modules/audit-logs.ts
@@ -1,0 +1,70 @@
+/**
+ * Audit Logs API module (#976 / G14)
+ *
+ * System-wide audit-log viewer for admins — the read side of audit_logs.
+ */
+
+import { typedClient } from '../typed-client';
+import { toApiResponse } from '../compat';
+import type { ApiResponse } from '../types';
+
+export interface AuditLogEntry {
+  id: number;
+  created_at: string | null;
+  user_id: number | null;
+  actor_name: string | null;
+  actor_nycu_id: string | null;
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  resource_name: string | null;
+  description: string | null;
+  old_values: Record<string, unknown> | null;
+  new_values: Record<string, unknown> | null;
+  status: string | null;
+  ip_address: string | null;
+  meta_data: Record<string, unknown> | null;
+}
+
+export interface AuditLogFilters {
+  page?: number;
+  size?: number;
+  resource_type?: string;
+  resource_id?: string;
+  action?: string;
+  user_id?: number;
+  date_from?: string;
+  date_to?: string;
+  search?: string;
+}
+
+export interface AuditLogPage {
+  items: AuditLogEntry[];
+  total: number;
+  page: number;
+  size: number;
+  pages: number;
+}
+
+export function createAuditLogsApi() {
+  return {
+    list: async (filters?: AuditLogFilters): Promise<ApiResponse<AuditLogPage>> => {
+      const response = await typedClient.raw.GET('/api/v1/admin/audit-logs', {
+        params: {
+          query: {
+            page: filters?.page,
+            size: filters?.size,
+            resource_type: filters?.resource_type,
+            resource_id: filters?.resource_id,
+            action: filters?.action,
+            user_id: filters?.user_id,
+            date_from: filters?.date_from,
+            date_to: filters?.date_to,
+            search: filters?.search,
+          },
+        },
+      });
+      return toApiResponse(response) as ApiResponse<AuditLogPage>;
+    },
+  };
+}


### PR DESCRIPTION
Phase 2 of the 申請歷史 audit (tracking #995), gap **G14 (high)**: audit rows were written but practically unreadable — the only read endpoint was per-scholarship and **no frontend component used it**, so compliance queries meant raw SQL.

- **Backend:** `GET /admin/audit-logs` — paginated + filterable (resource_type/resource_id/action/user_id/date range/search), actor name outer-joined, newest-first. Read-only; admin-gated.
- **Frontend:** new 稽核日誌 tab in `AdminManagementShell` (lazy-loaded `AuditLogPanel`): filter bar with the action/resource vocabularies (incl. the new revoke/suspend/restore + execute_distribution actions from #998/#1002), destructive-action badges, expandable rows rendering the old/new value diff + IP/status/meta.

This makes every trail added in this audit wave (#998 #999 #1000 #1002 #1004 #1005) actually visible to the people responsible for it.

schema.d.ts regenerated; `tsc --noEmit` clean; black + flake8 clean.

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)