### PR TITLE
fix(review): audit-backed review version history + truthful decision_reason + silent-decision rows

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1573,8 +1573,15 @@ class ApplicationService:
         elif status_update.status == ApplicationStatus.rejected.value:
             application.status_name = ScholarshipI18n.get_application_status_text(ApplicationStatus.rejected.value)
 
-        # Persist admin comments / rejection reason as an ApplicationReview row
-        if getattr(status_update, "comments", None) or getattr(status_update, "rejection_reason", None):
+        # Persist the decision as an ApplicationReview row. G32 (#994): also
+        # when NO comments were given — silent approvals/rejections previously
+        # left no review row at all, so the deciding actor was untraceable
+        # from the review data (only reviewer_id, overwritten by the next
+        # status touch).
+        if status_update.status in (
+            ApplicationStatus.approved.value,
+            ApplicationStatus.rejected.value,
+        ) or (getattr(status_update, "comments", None) or getattr(status_update, "rejection_reason", None)):
             combined_comments = getattr(status_update, "comments", None) or getattr(
                 status_update, "rejection_reason", None
             )

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.core.exceptions import AuthorizationError, NotFoundError
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.application import Application
 from app.models.enums import ReviewStage
 from app.models.review import ApplicationReview, ApplicationReviewItem
@@ -369,6 +370,23 @@ class ReviewService:
         rejected_items = [item for item in items if item.get("recommendation") == "reject"]
 
         if not rejected_items:
+            # G7 (#969): decision_reason is an append-only narrative. When a
+            # re-review APPROVES everything but earlier rejection text exists,
+            # append an explicit closing line — otherwise the stale rejection
+            # reads as the current decision.
+            if application.decision_reason:
+                role_value = reviewer.role.value if hasattr(reviewer.role, "value") else str(reviewer.role).lower()
+                role_name = {
+                    "professor": "教授",
+                    "college": "學院",
+                    "admin": "管理員",
+                    "super_admin": "系統管理員",
+                }.get(role_value, role_value)
+                timestamp = reviewed_at.strftime("%Y-%m-%d %H:%M:%S")
+                application.decision_reason += (
+                    f"\n\n[{timestamp}] {role_name} ({reviewer.name}): 重新審核後同意"
+                    f"（上方先前退件理由保留供稽核，不再適用）"
+                )
             return
 
         # 角色名稱對應 - 先提取 role 字符串值
@@ -515,6 +533,56 @@ class ReviewService:
 
         return application.status
 
+    def _snapshot_review(self, review) -> Dict[str, Any]:
+        """Serializable snapshot of a review + its sub-type items (G6/#968)."""
+        return {
+            "recommendation": review.recommendation,
+            "comments": review.comments,
+            "reviewed_at": review.reviewed_at.isoformat() if review.reviewed_at else None,
+            "items": [
+                {
+                    "sub_type_code": item.sub_type_code,
+                    "recommendation": item.recommendation,
+                    "comments": item.comments,
+                }
+                for item in (review.items or [])
+            ],
+        }
+
+    def _audit_review_revision(
+        self,
+        review,
+        reviewer_id: int,
+        old_snapshot: Dict[str, Any] | None,
+        new_items: List[Dict[str, Any]],
+        overall_recommendation: str,
+        combined_comments: str,
+    ) -> None:
+        """G6 (#968): re-reviews overwrite in place and hard-delete old items —
+        the ONLY durable version history is this audit row. old_values carries
+        the full prior review (incl. per-sub-type decisions); new_values the
+        replacement. Browse via the 稽核日誌 tab (resource_type
+        application_review)."""
+        self.db.add(
+            AuditLog.create_log(
+                user_id=reviewer_id,
+                action=(AuditAction.update.value if old_snapshot else AuditAction.create.value),
+                resource_type="application_review",
+                resource_id=str(review.id),
+                description=(
+                    f"review {'revised' if old_snapshot else 'created'} for application "
+                    f"{review.application_id}: {overall_recommendation}"
+                ),
+                old_values=old_snapshot,
+                new_values={
+                    "recommendation": overall_recommendation,
+                    "comments": combined_comments,
+                    "items": new_items,
+                },
+                meta_data={"application_id": review.application_id},
+            )
+        )
+
     async def create_review(
         self,
         application_id: int,
@@ -555,6 +623,10 @@ class ReviewService:
         existing_review = result.scalar_one_or_none()
 
         if existing_review:
+            # G6 (#968): preserve the prior version BEFORE overwriting — the
+            # old recommendation/comments/items would otherwise be lost.
+            prior_snapshot = self._snapshot_review(existing_review)
+
             # 更新現有記錄
             existing_review.recommendation = overall_recommendation
             existing_review.comments = combined_comments
@@ -576,8 +648,17 @@ class ReviewService:
                 reviewed_at=datetime.now(timezone.utc),
             )
             self.db.add(review)
+            prior_snapshot = None
 
         await self.db.flush()  # 取得 review.id
+        self._audit_review_revision(
+            review,
+            reviewer_id=reviewer_id,
+            old_snapshot=prior_snapshot,
+            new_items=items,
+            overall_recommendation=overall_recommendation,
+            combined_comments=combined_comments,
+        )
 
         # 建立新的子項目審查記錄
         for item in items:
@@ -656,6 +737,9 @@ class ReviewService:
         if not review:
             return None
 
+        # G6 (#968): preserve the prior version before the in-place overwrite.
+        prior_snapshot = self._snapshot_review(review)
+
         # 刪除舊的子項目
         for old_item in review.items:
             await self.db.delete(old_item)
@@ -684,6 +768,15 @@ class ReviewService:
         review.comments = combined_comments
         review.reviewed_at = datetime.now(timezone.utc)
 
+        self._audit_review_revision(
+            review,
+            reviewer_id=review.reviewer_id,
+            old_snapshot=prior_snapshot,
+            new_items=items,
+            overall_recommendation=overall_recommendation,
+            combined_comments=combined_comments,
+        )
+
         await self.db.commit()
         await self.db.refresh(review)
 
@@ -691,8 +784,9 @@ class ReviewService:
         reviewer = await self.db.get(User, review.reviewer_id)
         application = await self.db.get(Application, review.application_id)
         if application and reviewer:
-            # 清除舊的 decision_reason（因為是更新）
-            # 在實務上可能需要更複雜的邏輯來處理
+            # decision_reason is append-only by design (the audit narrative);
+            # update_decision_reason appends the latest verdict — including an
+            # explicit 同意 closing line when nothing is rejected (G7/#969).
             await self.update_decision_reason(application, reviewer, items, review.reviewed_at)
 
         # 更新申請狀態

--- a/backend/app/tests/test_review_update_preserves_history.py
+++ b/backend/app/tests/test_review_update_preserves_history.py
@@ -1,0 +1,152 @@
+"""G6/G7 (#968/#969): re-reviews must preserve the prior version.
+
+Re-review overwrites ApplicationReview in place and hard-deletes the old
+ApplicationReviewItems — the durable version history is the audit row written
+by ReviewService._audit_review_revision (old_values = full prior review incl.
+per-sub-type decisions). And when a re-review approves everything,
+decision_reason gains an explicit 同意 closing line so stale rejection text
+no longer reads as the current decision (G7).
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.application import Application
+from app.models.audit_log import AuditAction, AuditLog
+from app.models.enums import ReviewStage
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.services.review_service import ReviewService
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def review_fixture(db):
+    professor = User(
+        nycu_id="g6prof",
+        name="G6 教授",
+        email="g6prof@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.professor,
+    )
+    student = User(
+        nycu_id="g6stu001",
+        name="G6 學生",
+        email="g6stu@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add_all([professor, student])
+    await db.flush()
+    stype = ScholarshipType(code="g6_test", name="G6 Test Scholarship", sub_type_list=["nstc", "moe_1w"])
+    db.add(stype)
+    await db.flush()
+    cfg = ScholarshipConfiguration(
+        config_code="G6-CFG",
+        config_name="G6 Config",
+        is_active=True,
+        scholarship_type_id=stype.id,
+        academic_year=114,
+        amount=1000,
+    )
+    db.add(cfg)
+    await db.flush()
+    app_row = Application(
+        app_id="APP-G6-001",
+        user_id=student.id,
+        scholarship_type_id=stype.id,
+        scholarship_configuration_id=cfg.id,
+        academic_year=114,
+        status="under_review",
+        review_stage=ReviewStage.professor_review,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+    )
+    db.add(app_row)
+    await db.commit()
+    await db.refresh(app_row)
+    return {"professor": professor, "app": app_row}
+
+
+async def _revision_rows(db, review_id: int):
+    res = await db.execute(
+        select(AuditLog)
+        .where(
+            AuditLog.resource_type == "application_review",
+            AuditLog.resource_id == str(review_id),
+        )
+        .order_by(AuditLog.id)
+    )
+    return res.scalars().all()
+
+
+async def test_re_review_preserves_prior_version_in_audit(db, review_fixture):
+    svc = ReviewService(db)
+    review = await svc.create_review(
+        application_id=review_fixture["app"].id,
+        reviewer_id=review_fixture["professor"].id,
+        items=[{"sub_type_code": "nstc", "recommendation": "reject", "comments": "資料不齊"}],
+    )
+    await db.commit()
+    review_id = review.id
+
+    # Re-review (the upsert path): same reviewer, now approves.
+    await svc.create_review(
+        application_id=review_fixture["app"].id,
+        reviewer_id=review_fixture["professor"].id,
+        items=[{"sub_type_code": "nstc", "recommendation": "approve", "comments": "已補件"}],
+    )
+    await db.commit()
+
+    rows = await _revision_rows(db, review_id)
+    assert len(rows) == 2, "create + revision rows must both exist"
+    create_row, revision_row = rows
+
+    assert create_row.action == AuditAction.create.value
+    assert create_row.old_values is None
+    assert create_row.new_values["items"][0]["recommendation"] == "reject"
+
+    assert revision_row.action == AuditAction.update.value
+    # The PRIOR version (the professor's original reject) is reconstructable.
+    assert revision_row.old_values["recommendation"] == "reject"
+    assert revision_row.old_values["items"][0]["comments"] == "資料不齊"
+    assert revision_row.new_values["items"][0]["recommendation"] == "approve"
+    assert revision_row.user_id == review_fixture["professor"].id
+
+
+async def test_approve_after_reject_appends_closing_line(db, review_fixture):
+    svc = ReviewService(db)
+    await svc.create_review(
+        application_id=review_fixture["app"].id,
+        reviewer_id=review_fixture["professor"].id,
+        items=[{"sub_type_code": "nstc", "recommendation": "reject", "comments": "資料不齊"}],
+    )
+    # Mirror the submit flow: decision_reason accumulates rejections.
+    professor = review_fixture["professor"]
+    app_row = review_fixture["app"]
+    from datetime import datetime, timezone
+
+    await svc.update_decision_reason(
+        app_row,
+        professor,
+        [{"sub_type_code": "nstc", "recommendation": "reject", "comments": "資料不齊"}],
+        datetime.now(timezone.utc),
+    )
+    await db.commit()
+    await db.refresh(app_row)
+    assert "資料不齊" in (app_row.decision_reason or "")
+
+    # Re-review approves everything → an explicit closing line is appended.
+    await svc.update_decision_reason(
+        app_row,
+        professor,
+        [{"sub_type_code": "nstc", "recommendation": "approve", "comments": "已補件"}],
+        datetime.now(timezone.utc),
+    )
+    await db.commit()
+    await db.refresh(app_row)
+    assert "重新審核後同意" in app_row.decision_reason
+    # Prior rejection text is retained ABOVE the closing line (audit narrative).
+    assert app_row.decision_reason.index("資料不齊") < app_row.decision_reason.index("重新審核後同意")


### PR DESCRIPTION
Final Phase 2 batch from the 申請歷史 audit (tracking #995):

| Gap | Issue | What changed |
|---|---|---|
| G6 high | #968 | every re-review now writes an audit row (`resource_type=application_review`) whose `old_values` is the **full prior review snapshot** (recommendation/comments/per-sub-type items) — the previously unrecoverable「教授原本給的建議」is reconstructable, immutable (#1001), and browsable in the 稽核日誌 tab (#1007). Audit-row versioning is the audit plan's sanctioned no-new-table alternative |
| G7 high | #969 | approve-after-reject now appends an explicit 「重新審核後同意（先前退件理由保留供稽核，不再適用）」 line — stale rejection text no longer reads as the current decision; the narrative stays append-only |
| G32 low | #994 | approve/reject via PATCH-status **without comments** now still creates the ApplicationReview row — silent decisions are traceable from review data, not only from endpoint audit rows |

Tests: revision chain (create + update rows; prior version fully reconstructable; actor pinned) + decision_reason ordering (rejection text above the closing line).

Closes #968 / Closes #969 / Closes #994

🤖 Generated with [Claude Code](https://claude.com/claude-code)