### PR TITLE
fix(audit): email-template change snapshots + PII key retention runbook

### DIFF
--- a/backend/app/api/v1/endpoints/admin/email_templates.py
+++ b/backend/app/api/v1/endpoints/admin/email_templates.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import require_admin
 from app.db.deps import get_db
 from app.models.system_setting import EmailTemplate
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.user import User
 from app.schemas.common import EmailTemplateSchema, EmailTemplateUpdateSchema
 from app.services.system_setting_service import EmailTemplateService
@@ -83,6 +84,29 @@ async def update_email_template(
         )
     )
 
+    # G31 (#993): EmailHistory stores每封信的完整內容, but TEMPLATE changes had
+    # no before/after snapshot — comparing「當時範本 vs 現狀」was impossible.
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.update.value,
+            resource_type="email_template",
+            resource_id=str(template.key),
+            description=f"email template '{template.key}' updated",
+            old_values={
+                "subject_template": existing_template.subject_template,
+                "body_template": existing_template.body_template,
+                "cc": existing_template.cc,
+                "bcc": existing_template.bcc,
+            },
+            new_values={
+                "subject_template": template.subject_template,
+                "body_template": template.body_template,
+                "cc": template.cc,
+                "bcc": template.bcc,
+            },
+        )
+    )
     await db.execute(stmt)
     await db.commit()
 
@@ -239,6 +263,16 @@ async def update_scholarship_email_template(
 ):
     """Update an existing per-scholarship email template (404 if not configured)."""
     payload = template_data.model_dump(exclude_unset=True)
+    # G31 (#993): snapshot the prior version before the in-place update.
+    prior = await EmailTemplateService.get_scholarship_template(db, scholarship_type_id, template_key)
+    prior_values = (
+        {
+            "subject_template": prior.subject_template,
+            "body_template": prior.body_template,
+        }
+        if prior
+        else None
+    )
     template = await EmailTemplateService.update_scholarship_template(db, scholarship_type_id, template_key, payload)
     if template is None:
         raise HTTPException(
@@ -248,6 +282,19 @@ async def update_scholarship_email_template(
                 f"scholarship_type_id={scholarship_type_id}"
             ),
         )
+
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.update.value,
+            resource_type="email_template",
+            resource_id=f"{scholarship_type_id}:{template_key}",
+            description=f"scholarship email template '{template_key}' (type {scholarship_type_id}) updated",
+            old_values=prior_values,
+            new_values={k: v for k, v in payload.items() if k in ("subject_template", "body_template", "cc", "bcc")},
+        )
+    )
+    await db.commit()
 
     logger.info(
         "scholarship-email-template updated: scholarship_type_id=%s key=%s by user_id=%s fields=%s",

--- a/docs/security/pii-key-retention-runbook.md
+++ b/docs/security/pii-key-retention-runbook.md
@@ -1,0 +1,57 @@
+# PII 加密金鑰保存與輪替 Runbook（G27 / #989）
+
+> 對象:`applications.student_data.std_pid`(身分證字號)以 AES-256-GCM
+> envelope 加密,信封內嵌**金鑰版本**(`v1`, `v2`, …),由
+> `PII_ENCRYPTION_KEYS`(JSON map `{版本: base64url 32-byte key}`)解密。
+> 解密**沒有 fallback**:信封指到的版本不在 map 裡 → 該筆資料永久不可讀。
+> 這是刻意設計(防默默用錯金鑰),代價是金鑰管理必須遵守本文件。
+
+## 鐵律
+
+1. **舊版本金鑰在「該版本最後一筆資料的保存年限屆滿」前,絕不從
+   `PII_ENCRYPTION_KEYS` 移除。** 申請紀錄保存年限以校方核定之檔案保存年
+   限區分表為準(涉撥款者建議以 10 年計,見 #995 報告第 3 節)。實務上:
+   除非完成全量 re-encrypt 並驗證,否則**永不移除舊 key**。
+2. 金鑰只能「新增版本」與「切換 active 版本」,不可原地改值。
+3. `PII_ENCRYPTION_KEYS` 的每次變更(staging/production secrets)都要在
+   變更紀錄(GitHub secret 變更 + 部署 PR)留下誰、何時、為什麼。
+
+## 輪替程序(新增 v(n+1) 並汰換 v(n))
+
+1. 產生新金鑰:
+   ```bash
+   python -c 'import os,base64;print(base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode())'
+   ```
+2. 更新 secret 為**新舊並存**:
+   `PII_ENCRYPTION_KEYS={"v1":"<old>","v2":"<new>"}`、
+   `PII_ENCRYPTION_ACTIVE_VERSION=v2`,重新部署。
+   此時:新寫入用 v2,舊資料仍以 v1 解密 — 系統正常。
+3. **Dry-run 驗證全量可解密**(輪替前的安全閥):
+   ```bash
+   docker exec scholarship_backend_staging \
+       python scripts/rotate_pii_keys.py --dry-run
+   ```
+   任何一筆解密失敗 → 停止,先調查(代表已存在用未知版本加密的資料)。
+4. 執行 re-encrypt(冪等、可重跑):
+   ```bash
+   docker exec scholarship_backend_staging \
+       python scripts/rotate_pii_keys.py
+   ```
+5. 驗證:再跑一次 `--dry-run`,確認所有信封版本 == active 版本。
+6. **僅在第 5 步全綠、且確認備份(pg_dump 歸檔)中的舊版本資料也已超過
+   保存年限或另行 re-encrypt 後**,才可從 secret 移除 v1。
+   注意:S3 異地備份裡的 dump 仍是 v1 加密 — 移除 v1 後那些備份內的
+   std_pid 等同銷毀。若備份保存年限未到,**v1 必須保留**。
+
+## 回滾
+
+把 `PII_ENCRYPTION_ACTIVE_VERSION` 設回前一版本並重跑
+`rotate_pii_keys.py`(腳本以信封內嵌版本判斷來源,冪等)。
+
+## 與稽核的關係
+
+- audit_logs 內的 PII 已在寫入時 `[REDACTED]`(`redact_dict_pii`),不受
+  金鑰輪替影響 — 金鑰遺失只影響本文資料(student_data),不影響稽核軌跡
+  的可讀性。
+- 年度稽核(內稽/會計)若需調閱 3+ 年前申請的身分證字號,前提即是本文件
+  的鐵律 1 有被遵守。


### PR DESCRIPTION
Phase 3 residual items from the 申請歷史 audit (tracking #995):

| Gap | Issue | What changed |
|---|---|---|
| G31 low | #993 | both email-template update endpoints write before/after audit snapshots (subject + body) — template edits no longer silently rewrite the evidence baseline; visible in the 稽核日誌 tab |
| G27 medium | #989 | `docs/security/pii-key-retention-runbook.md`: key-retention 鐵律 (old versions live until the retention period of the last row AND backup encrypted with them expires), the add→dry-run→re-encrypt→verify rotation procedure using `scripts/rotate_pii_keys.py --dry-run`, rollback, and the S3-backup caveat |

Closes #989 / Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)