### PR TITLE
test(#990 #991): student-history component coverage + revoke/suspend compliance-path e2e

### DIFF
--- a/frontend/components/admin/student-history/__tests__/AcademicInfoCard.test.tsx
+++ b/frontend/components/admin/student-history/__tests__/AcademicInfoCard.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { AcademicInfoCard } from "../AcademicInfoCard";
+
+// AcademicInfoCard resolves degree/status/academy labels via the
+// reference-data hook; stub it so the test exercises the component's own
+// rendering logic, not the network.
+jest.mock("@/hooks/use-reference-data", () => ({
+  useReferenceData: () => ({ degrees: [], studyingStatuses: [], academies: [] }),
+  getDegreeName: () => "博士",
+  getStudyingStatusName: () => "在學",
+  getAcademyName: () => "電機學院",
+}));
+
+describe("AcademicInfoCard (G28/#990)", () => {
+  it("renders the SIS-degraded state with the roster snapshot name", () => {
+    render(
+      <AcademicInfoCard
+        academicInfo={{ available: false, error: "SIS timeout", basic_info: null }}
+        snapshotName="王小明"
+      />,
+    );
+    expect(screen.getByText("無即時學籍資料")).toBeInTheDocument();
+    expect(screen.getByText("SIS timeout")).toBeInTheDocument();
+    expect(screen.getByText("王小明")).toBeInTheDocument();
+  });
+
+  it("renders the degraded state without a snapshot name gracefully", () => {
+    render(
+      <AcademicInfoCard
+        academicInfo={{ available: false, error: null, basic_info: null }}
+        snapshotName={null}
+      />,
+    );
+    expect(screen.getByText("無即時學籍資料")).toBeInTheDocument();
+    expect(screen.queryByText("造冊快照姓名:")).not.toBeInTheDocument();
+  });
+
+  it("renders SIS basic info when available", () => {
+    render(
+      <AcademicInfoCard
+        academicInfo={{
+          available: true,
+          error: null,
+          basic_info: {
+            std_cname: "王小明",
+            std_ename: "WANG,HSIAO-MING",
+            std_degree: "1",
+            std_studingstatus: "1",
+            std_academyno: "E",
+            std_aca_cname: "電機學院",
+            std_depname: "電機工程學系博士班",
+            std_depno: "3551",
+            com_email: "wang@nycu.edu.tw",
+          },
+        }}
+        snapshotName={null}
+      />,
+    );
+    expect(screen.getByText("學籍資料")).toBeInTheDocument();
+    expect(screen.getByText("王小明")).toBeInTheDocument();
+    expect(screen.getByText("電機工程學系博士班")).toBeInTheDocument();
+  });
+
+  it("renders nothing when available but basic_info missing", () => {
+    const { container } = render(
+      <AcademicInfoCard
+        academicInfo={{ available: true, error: null, basic_info: null }}
+        snapshotName={null}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/components/admin/student-history/__tests__/PaymentHistoryTable.test.tsx
+++ b/frontend/components/admin/student-history/__tests__/PaymentHistoryTable.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { PaymentHistoryTable } from "../PaymentHistoryTable";
+import type { PaymentRecord } from "@/lib/api/modules/student-history";
+
+function record(overrides: Partial<PaymentRecord> = {}): PaymentRecord {
+  return {
+    roster_id: 1,
+    roster_code: "ROSTER-114-10",
+    period_label: "114-10",
+    academic_year: 114,
+    roster_cycle: "monthly",
+    scholarship_name: "博士生獎學金",
+    scholarship_amount: "20000",
+    scholarship_subtype: "nstc",
+    allocation_year: 114,
+    locked_at: "2026-05-01T00:00:00Z",
+    quota_allocation_status: null,
+    revoked_at: null,
+    revoke_reason: null,
+    suspended_at: null,
+    suspend_reason: null,
+    ...overrides,
+  };
+}
+
+describe("PaymentHistoryTable (G28/#990)", () => {
+  it("renders the empty state when there are no records", () => {
+    render(<PaymentHistoryTable records={[]} />);
+    expect(screen.getByText("尚無領取記錄")).toBeInTheDocument();
+  });
+
+  it("renders rows with formatted amounts and the record count", () => {
+    render(
+      <PaymentHistoryTable
+        records={[record(), record({ period_label: "114-09", scholarship_amount: "5000" })]}
+      />,
+    );
+    expect(screen.getByText("領取明細 (2 筆)")).toBeInTheDocument();
+    expect(screen.getByText("114-10")).toBeInTheDocument();
+    expect(screen.getByText(/20,000/)).toBeInTheDocument();
+    expect(screen.getByText(/5,000/)).toBeInTheDocument();
+  });
+
+  it("shows the 已撤銷 badge with the reason tooltip for revoked-after-lock payments (G25)", () => {
+    render(
+      <PaymentHistoryTable
+        records={[
+          record({
+            quota_allocation_status: "revoked",
+            revoked_at: "2026-06-01T00:00:00Z",
+            revoke_reason: "違反要點第七條",
+          }),
+        ]}
+      />,
+    );
+    const badge = screen.getByText("已撤銷");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "違反要點第七條");
+  });
+
+  it("shows the 已停發 badge for suspended payments (G25)", () => {
+    render(
+      <PaymentHistoryTable
+        records={[
+          record({
+            quota_allocation_status: "suspended",
+            suspended_at: "2026-06-01T00:00:00Z",
+            suspend_reason: "休學",
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("已停發")).toHaveAttribute("title", "休學");
+  });
+
+  it("shows NO status badge for normal payments", () => {
+    render(<PaymentHistoryTable records={[record()]} />);
+    expect(screen.queryByText("已撤銷")).not.toBeInTheDocument();
+    expect(screen.queryByText("已停發")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/admin/student-history/__tests__/SummaryCards.test.tsx
+++ b/frontend/components/admin/student-history/__tests__/SummaryCards.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { SummaryCards } from "../SummaryCards";
+
+describe("SummaryCards (G28/#990)", () => {
+  it("renders count, TWD-formatted total, and type count", () => {
+    render(
+      <SummaryCards
+        summary={{
+          total_records: 12,
+          total_amount: "240000",
+          scholarship_type_count: 2,
+          snapshot_name: "王小明",
+        }}
+      />,
+    );
+    expect(screen.getByText("總筆數")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    // 貨幣符號 (NT$ vs $) 依 ICU 而異 — 斷言數值部分即可
+    expect(screen.getByText(/240,000/)).toBeInTheDocument();
+    expect(screen.getByText("獎學金類型數")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("passes through unparseable amounts verbatim instead of NaN", () => {
+    render(
+      <SummaryCards
+        summary={{
+          total_records: 0,
+          total_amount: "not-a-number",
+          scholarship_type_count: 0,
+          snapshot_name: null,
+        }}
+      />,
+    );
+    expect(screen.getByText("not-a-number")).toBeInTheDocument();
+  });
+});

--- a/frontend/e2e/specs/admin-revoke-suspend.spec.ts
+++ b/frontend/e2e/specs/admin-revoke-suspend.spec.ts
@@ -944,4 +944,74 @@ test.describe("locked roster dialog — revoked student panel + item removal", (
       }
     },
   );
+  test(
+    "@nightly suspend is queryable via /admin/audit-logs and visible in 學生領取歷史 (G29 #991)",
+    async ({ browser }) => {
+      // The fixture suspended csphd0002 AFTER the roster locked (its item is
+      // untouched by earlier tests — the revoked student's item gets removed
+      // by the DELETE test above, so the suspend twin is the stable probe).
+      // Two compliance read paths must surface it:
+      //   1. the system-wide audit-log endpoint (#1007) carries the typed
+      //      suspend event with the reason;
+      //   2. 學生領取歷史 (#1005) shows the paid row WITH the suspension
+      //      context instead of an unqualified 已領取.
+      const adminLogin = await loginAs(browser, "admin");
+      pushTrace(runState, adminLogin.traceId);
+
+      // 1. Audit-log queryability.
+      const auditRes = await apiAs<{
+        success: boolean;
+        data: {
+          items: Array<{
+            action: string;
+            resource_id: string;
+            new_values: { reason?: string } | null;
+            actor_nycu_id: string | null;
+          }>;
+        };
+      }>(
+        adminLogin.token,
+        "GET",
+        `/admin/audit-logs?resource_type=application&resource_id=${lockedFixtureSuspendAppDbId}&action=suspend`,
+      );
+      pushTrace(runState, auditRes.traceId);
+      expect(
+        auditRes.ok,
+        `GET /admin/audit-logs failed: HTTP ${auditRes.status} body=${JSON.stringify(auditRes.body)}`,
+      ).toBe(true);
+      const suspendEvents = auditRes.body.data.items;
+      expect(
+        suspendEvents.length,
+        `no suspend audit event for application ${lockedFixtureSuspendAppDbId}`,
+      ).toBeGreaterThan(0);
+      expect(suspendEvents[0].new_values?.reason).toContain("E2E locked-roster fixture");
+      expect(suspendEvents[0].actor_nycu_id).toBe("admin");
+
+      // 2. 學生領取歷史 suspension context.
+      const historyRes = await apiAs<{
+        success: boolean;
+        data: {
+          payment_records: Array<{
+            quota_allocation_status: string | null;
+            suspend_reason: string | null;
+            suspended_at: string | null;
+          }>;
+        };
+      }>(adminLogin.token, "GET", `/admin/student-history/${SETUP_STUDENT2}`);
+      pushTrace(runState, historyRes.traceId);
+      expect(
+        historyRes.ok,
+        `GET student-history failed: HTTP ${historyRes.status} body=${JSON.stringify(historyRes.body)}`,
+      ).toBe(true);
+      const suspendedRecords = historyRes.body.data.payment_records.filter(
+        (r) => r.quota_allocation_status === "suspended",
+      );
+      expect(
+        suspendedRecords.length,
+        "suspended-after-lock payment must carry suspension context in 學生領取歷史 (G25)",
+      ).toBeGreaterThan(0);
+      expect(suspendedRecords[0].suspend_reason).toContain("E2E locked-roster fixture");
+      expect(suspendedRecords[0].suspended_at).toBeTruthy();
+    },
+  );
 });


### PR DESCRIPTION
Final test-backlog items from the 申請歷史 audit (tracking #995):

| Gap | Issue | What changed |
|---|---|---|
| G28 medium | #990 | jest suites for the untested student-history components: `PaymentHistoryTable` (incl. the G25 已撤銷/已停發 badges + tooltips), `SummaryCards`, `AcademicInfoCard` (SIS-degraded paths) — 11 cases |
| G29 medium | #991 | new @nightly e2e: post-suspend, the **system audit-log endpoint** (#1007) returns the typed event with reason+actor, and **學生領取歷史** (#1005) carries the suspension context. First e2e exercising both compliance read paths end-to-end |

Local verification: full `admin-revoke-suspend.spec.ts` **8/8** against the dev stack with today's migrations applied (live-validated the audit_logs immutability trigger + FK-policy migrations on `alembic upgrade head`). Jest suites run in CI (host node 22.1 predates require-ESM; CI's node 22.x runs them).

Closes #990 / Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)