### PR TITLE
fix(prod): go-live blockers P1/P5/P9/P10 + SUPER_ADMIN env — compose, deploy template, monitoring, nginx, docs

### DIFF
--- a/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
+++ b/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
@@ -326,6 +326,39 @@ openssl rand -base64 24
 
 ---
 
+### PII Encryption Secrets (REQUIRED — go-live blocker P4)
+
+The backend encrypts 身分證字號 (`std_pid`) at rest with AES-256-GCM. Missing
+or malformed keys hard-fail the encrypt migration and every PII read.
+
+| Secret | Description | Example | Required |
+|--------|-------------|---------|----------|
+| `PII_ENCRYPTION_KEYS` | JSON map of {version: base64url 32-byte key} | `{"v1":"<key>"}` | ✅ Yes |
+| `PII_ENCRYPTION_ACTIVE_VERSION` | Version used for NEW encryptions | `v1` | ✅ Yes |
+
+```bash
+# Generate a key
+python -c 'import os,base64;print(base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode())'
+gh secret set PII_ENCRYPTION_KEYS --body '{"v1":"<KEY>"}'
+gh secret set PII_ENCRYPTION_ACTIVE_VERSION --body 'v1'
+```
+
+- 🔐 **Losing a key version = the PII encrypted with it is permanently
+  unreadable.** Keep an offline copy in the team's secure vault.
+- 🔐 Old versions stay in the map until the retention period of the LAST row
+  (and backup) encrypted with them expires — see
+  `docs/security/pii-key-retention-runbook.md` for the rotation procedure.
+- 🔐 Production keys MUST differ from staging keys.
+
+### Super Admin Secret (REQUIRED)
+
+| Secret | Description | Example | Required |
+|--------|-------------|---------|----------|
+| `SUPER_ADMIN_NYCU_ID` | NYCU ID granted super_admin at Portal SSO login | `E12345` | ✅ Yes |
+
+Without it the in-code default `super_admin` applies and no real 承辦人
+account can ever elevate.
+
 ### Email Configuration Secrets
 
 These secrets configure SMTP for sending system emails (notifications, password resets, etc.).

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -1,5 +1,19 @@
-# Example Production Deployment Workflow
-# Copy this file to your production repository at: .github/workflows/deploy.yml
+# Production Deployment Workflow (issue #74 / go-live blocker P5)
+# Copy this file to the PRIVATE production repository at .github/workflows/deploy.yml
+#
+# Modeled on the PROVEN staging deploy job (dev repo deploy-pipeline.yml
+# deploy-staging) instead of the previous SSH-based template, which was
+# unusable: ubuntu-latest runner (cannot reach campus VMs), no migration/seed,
+# no nginx validation, placeholder smoke URLs, and a `git checkout HEAD~1`
+# "rollback" that would have desynced the working tree from the images.
+#
+# Prerequisites (one-time, see SECRETS-SETUP-GUIDE.md):
+#   - A self-hosted runner registered on the production AP VM with labels
+#     [self-hosted, linux] (same pattern as setting-env.yml).
+#   - GitHub `production` environment with required reviewers (blocker P6).
+#   - Repository variable PRODUCTION_URL = https://ss.nycu.edu.tw
+#   - All secrets listed in the validate-secrets job below.
+#   - docker-compose.prod-db.yml stack already running on the DB VM.
 
 name: Deploy to Production
 
@@ -9,147 +23,348 @@ on:
       - main
   workflow_dispatch:
     inputs:
-      environment:
-        description: 'Target environment'
-        required: true
-        type: choice
-        options:
-          - production
-          - staging
-        default: 'production'
+      tag:
+        description: 'Image tag to deploy (default: build from current commit)'
+        required: false
+        type: string
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
 
 jobs:
-  deploy:
-    name: Deploy Application
+  # ── Gate 0: fail fast on misconfigured secrets BEFORE touching anything ──
+  # Closes go-live blockers P3/P4/P7/P8: config.py ships staging/dev defaults
+  # (portal.test auth, localhost student API, "(測試)" mail sender), so a
+  # missing secret would not crash — it would silently run production against
+  # test infrastructure. The backend boot guard (#936) is the second line of
+  # defense; this is the first.
+  validate-secrets:
+    name: Validate Production Secrets
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment || 'production' }}
+    steps:
+      - name: Validate
+        env:
+          DOMAIN: ${{ secrets.DOMAIN }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          MINIO_HOST: ${{ secrets.MINIO_HOST }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PORTAL_JWT_SERVER_URL: ${{ secrets.PORTAL_JWT_SERVER_URL }}
+          STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
+          STUDENT_API_HMAC_KEY: ${{ secrets.STUDENT_API_HMAC_KEY }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
+          SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
+        run: |
+          fail=0
+          err() { echo "::error::$1"; fail=1; }
 
+          [ -n "$DOMAIN" ] || err "DOMAIN is not set"
+          [ -n "$DB_HOST" ] || err "DB_HOST is not set"
+          [ -n "$DB_PASSWORD" ] || err "DB_PASSWORD is not set"
+          [ -n "$REDIS_PASSWORD" ] || err "REDIS_PASSWORD is not set"
+          [ -n "$MINIO_HOST" ] || err "MINIO_HOST is not set"
+          [ -n "$MINIO_ACCESS_KEY" ] || err "MINIO_ACCESS_KEY is not set"
+          [ -n "$MINIO_SECRET_KEY" ] || err "MINIO_SECRET_KEY is not set"
+          [ -n "$SUPER_ADMIN_NYCU_ID" ] || err "SUPER_ADMIN_NYCU_ID is not set (no one could elevate to super_admin)"
+
+          [ "${#SECRET_KEY}" -ge 32 ] || err "SECRET_KEY must be >= 32 chars (and MUST differ from staging)"
+
+          # P4: PII keys — missing keys hard-fail the encrypt migration / first
+          # PII read; malformed JSON fails at boot. Catch both here.
+          if [ -z "$PII_ENCRYPTION_KEYS" ]; then
+            err "PII_ENCRYPTION_KEYS is not set. Generate a key per docs/architecture/pii-encryption.md then set '{\"v1\":\"<KEY>\"}'"
+          elif ! echo "$PII_ENCRYPTION_KEYS" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
+            err "PII_ENCRYPTION_KEYS is not valid JSON"
+          fi
+
+          # P3: production must never authenticate against the staging portal.
+          case "$PORTAL_JWT_SERVER_URL" in
+            "") err "PORTAL_JWT_SERVER_URL is not set (config.py would default to portal.test — STAGING auth)" ;;
+            *portal.test*) err "PORTAL_JWT_SERVER_URL points at portal.test (staging) — set the production Portal endpoint" ;;
+            https://*) : ;;
+            *) err "PORTAL_JWT_SERVER_URL must be https://" ;;
+          esac
+
+          # P8: student API must be the real campus API, with a real HMAC key.
+          case "$STUDENT_API_BASE_URL" in
+            "") err "STUDENT_API_BASE_URL is not set (would default to the localhost mock; verification fails SILENTLY)" ;;
+            *localhost*|*127.0.0.1*|*mock*) err "STUDENT_API_BASE_URL looks like a mock/localhost endpoint: $STUDENT_API_BASE_URL" ;;
+          esac
+          if [ "$STUDENT_API_HMAC_KEY" = "4d6f636b4b657946726f6d48657841424344454647484a4b4c4d4e4f505152535455565758595a" ]; then
+            err "STUDENT_API_HMAC_KEY is the well-known MOCK key"
+          fi
+
+          # P7: real applicants must not receive '(測試)' mail from ss-test.
+          [ -n "$SMTP_HOST" ] || err "SMTP_HOST is not set (would default to the staging relay)"
+          case "$EMAIL_FROM" in
+            "") err "EMAIL_FROM is not set (would default to ss-test.aa@nycu.edu.tw)" ;;
+            *ss-test*) err "EMAIL_FROM still uses the staging address: $EMAIL_FROM" ;;
+          esac
+          case "$EMAIL_FROM_NAME" in
+            "") err "EMAIL_FROM_NAME is not set (would default to '(測試)獎學金申請與簽核系統')" ;;
+            *測試*) err "EMAIL_FROM_NAME still contains 測試: $EMAIL_FROM_NAME" ;;
+          esac
+
+          [ "$fail" -eq 0 ] || exit 1
+          echo "✅ All production secrets validated"
+
+  build-images:
+    name: Build & Push Images
+    runs-on: ubuntu-latest
+    needs: validate-secrets
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+          else
+            # Prefer the auto-tag-on-merge tag; fall back to short SHA.
+            VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Deploying version: $VERSION"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub (or your registry)
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./backend
           push: true
           tags: |
-            your-org/scholarship-backend:latest
-            your-org/scholarship-backend:${{ github.sha }}
-          cache-from: type=registry,ref=your-org/scholarship-backend:buildcache
-          cache-to: type=registry,ref=your-org/scholarship-backend:buildcache,mode=max
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-backend:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-backend:latest
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,scope=backend,mode=max
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./frontend
           push: true
           tags: |
-            your-org/scholarship-frontend:latest
-            your-org/scholarship-frontend:${{ github.sha }}
-          cache-from: type=registry,ref=your-org/scholarship-frontend:buildcache
-          cache-to: type=registry,ref=your-org/scholarship-frontend:buildcache,mode=max
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-frontend:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-frontend:latest
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max
 
-      - name: Deploy to production server
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
+  deploy:
+    name: Deploy to Production
+    # The runner lives ON the production AP VM (campus network) — GitHub-hosted
+    # runners cannot reach it. Register with: [self-hosted, linux].
+    runs-on: [self-hosted, linux]
+    needs: [validate-secrets, build-images]
+    environment:
+      name: production
+      url: ${{ vars.PRODUCTION_URL }}
+
+    # One env block shared by deploy + rollback so the compose interpolation
+    # is identical in both paths. Covers every ${VAR} in docker-compose.prod.yml.
+    env:
+      TAG: ${{ needs.build-images.outputs.version }}
+      DOMAIN: ${{ secrets.DOMAIN }}
+      SECRET_KEY: ${{ secrets.SECRET_KEY }}
+      CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+      MINIO_HOST: ${{ secrets.MINIO_HOST }}
+      MINIO_PORT: ${{ secrets.MINIO_PORT }}
+      MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+      MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+      MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
+      MINIO_SECURE: ${{ secrets.MINIO_SECURE }}
+      PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+      PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
+      SMTP_HOST: ${{ secrets.SMTP_HOST }}
+      SMTP_PORT: ${{ secrets.SMTP_PORT }}
+      SMTP_USER: ${{ secrets.SMTP_USER }}
+      SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+      EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+      EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
+      PORTAL_SSO_ENABLED: "true"
+      PORTAL_JWT_SERVER_URL: ${{ secrets.PORTAL_JWT_SERVER_URL }}
+      PORTAL_TEST_MODE: "false"
+      STUDENT_API_ENABLED: "true"
+      STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
+      STUDENT_API_ACCOUNT: ${{ secrets.STUDENT_API_ACCOUNT }}
+      STUDENT_API_HMAC_KEY: ${{ secrets.STUDENT_API_HMAC_KEY }}
+      SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
+      NEXT_PUBLIC_NYCU_PORTAL_URL: ${{ secrets.NEXT_PUBLIC_NYCU_PORTAL_URL }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull images
         run: |
-          # Setup SSH
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-backend:${TAG}
+          docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-frontend:${TAG}
 
-          # Deploy via SSH
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << 'ENDSSH'
-            cd /opt/scholarship-system
-
-            # Pull latest images
-            docker compose pull
-
-            # Backup database
-            docker compose exec -T postgres pg_dump -U scholarship_user scholarship_db > backup-$(date +%Y%m%d-%H%M%S).sql
-
-            # Restart services with zero downtime
-            docker compose up -d --remove-orphans
-
-            # Wait for health checks
-            sleep 10
-
-            # Verify services are healthy
-            docker compose ps
-          ENDSSH
-
-          echo "✅ Deployment completed successfully"
-
-      - name: Run smoke tests
+      - name: Prepare deployment files
         run: |
-          # Wait for application to be ready
-          sleep 30
+          mkdir -p ~/scholarship-production/logs/nginx
+          cp docker-compose.prod.yml ~/scholarship-production/docker-compose.yml
+          if [ -d nginx ]; then cp -r nginx ~/scholarship-production/; fi
+          if [ -d monitoring ]; then
+            sudo rm -rf ~/scholarship-production/monitoring
+            cp -r monitoring ~/scholarship-production/
+          fi
 
-          # Test API health
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" https://api.production.example.com/health)
-          if [ "$RESPONSE" != "200" ]; then
-            echo "::error::API health check failed"
+      - name: Save last-good deployment tag
+        run: |
+          CURRENT_RUNNING=""
+          if docker inspect scholarship_backend_prod >/dev/null 2>&1; then
+            CURRENT_RUNNING=$(docker inspect --format='{{index .Config.Labels "org.opencontainers.image.version"}}' scholarship_backend_prod 2>/dev/null || echo "")
+          fi
+          if [ -n "$CURRENT_RUNNING" ]; then
+            echo "$CURRENT_RUNNING" > ~/scholarship-production/last-good-tag
+            echo "Saved running tag: $CURRENT_RUNNING"
+          fi
+
+      - name: Start new containers
+        run: |
+          cd ~/scholarship-production
+          docker compose down || true
+          docker compose up -d
+
+      - name: Validate and reload nginx config
+        run: |
+          # Config is bind-mounted read-only; `compose up -d` does not reload
+          # nginx when only the file contents change. Validate first — never
+          # leave a broken config running.
+          if docker exec scholarship_nginx_prod nginx -t; then
+            docker exec scholarship_nginx_prod nginx -s reload
+            echo "✅ nginx config validated and reloaded"
+          else
+            echo "::error::nginx config test failed — keeping previously-loaded config"
             exit 1
           fi
 
-          # Test frontend
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" https://production.example.com)
-          if [ "$RESPONSE" != "200" ]; then
-            echo "::error::Frontend health check failed"
+      - name: Run database migrations
+        run: |
+          # NO error swallowing: a half-applied migration with a green deploy
+          # is the worst possible state (and /health does not verify schema).
+          docker exec scholarship_backend_prod alembic upgrade head
+          docker exec scholarship_backend_prod alembic current
+
+      - name: Seed production baseline
+        run: |
+          # --prod creates ONLY admin/lookup/settings/email templates — never
+          # test users. Idempotent. Must succeed (no '|| echo' swallowing).
+          docker exec scholarship_backend_prod python -m app.seed --prod
+
+      - name: Health check
+        run: |
+          # Backend has no published port in production (expose-only) —
+          # check from inside the container, then end-to-end through nginx.
+          max_retries=10
+          retry_count=0
+          until docker exec scholarship_backend_prod curl -fsS http://localhost:8000/health >/dev/null 2>&1 || [ $retry_count -eq $max_retries ]; do
+            echo "Backend not ready yet... ($retry_count/$max_retries)"
+            sleep 5
+            retry_count=$((retry_count + 1))
+          done
+          if [ $retry_count -eq $max_retries ]; then
+            echo "::error::Backend health check failed"
+            docker logs --tail 100 scholarship_backend_prod
             exit 1
           fi
+          echo "✅ Backend healthy"
 
+          retry_count=0
+          until curl -fsk https://localhost/health >/dev/null 2>&1 || [ $retry_count -eq $max_retries ]; do
+            echo "nginx→backend not ready yet... ($retry_count/$max_retries)"
+            sleep 5
+            retry_count=$((retry_count + 1))
+          done
+          if [ $retry_count -eq $max_retries ]; then
+            echo "::error::End-to-end health check via nginx failed"
+            docker logs --tail 50 scholarship_nginx_prod
+            exit 1
+          fi
+          echo "✅ nginx → backend healthy"
+
+      - name: Smoke tests
+        run: |
+          curl -fsk "https://localhost/health" -H "Host: ${DOMAIN}" >/dev/null || exit 1
+          curl -fsk "https://localhost/api/v1/docs" -H "Host: ${DOMAIN}" >/dev/null || exit 1
+          # Frontend through nginx
+          code=$(curl -sk -o /dev/null -w '%{http_code}' "https://localhost/" -H "Host: ${DOMAIN}")
+          [ "$code" = "200" ] || { echo "::error::Frontend returned $code"; exit 1; }
           echo "✅ Smoke tests passed"
 
-      - name: Notify on success
+      - name: Record successful deployment tag
         if: success()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const message = `
-            🚀 **Deployment Successful**
-
-            - Environment: ${{ github.event.inputs.environment || 'production' }}
-            - Commit: ${context.sha.substring(0, 7)}
-            - Deployed by: ${context.actor}
-            - URL: https://production.example.com
-            `;
-
-            // Post to Slack/Discord/etc or create deployment
-            console.log(message);
-
-      - name: Rollback on failure
-        if: failure()
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
+          echo "${TAG}" > ~/scholarship-production/last-good-tag
+          echo "Saved last-good tag: ${TAG}"
 
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << 'ENDSSH'
-            cd /opt/scholarship-system
+      - name: Rollback to last-good deployment
+        if: failure()
+        run: |
+          cd ~/scholarship-production
+          if [ -f last-good-tag ]; then
+            PREV_TAG=$(cat last-good-tag)
+            echo "::warning::Deploy of ${TAG} failed — rolling back to ${PREV_TAG}"
+            TAG=$PREV_TAG docker compose up -d
+            sleep 15
+            if docker exec scholarship_backend_prod curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+              echo "::notice::Rollback to ${PREV_TAG} succeeded."
+            else
+              echo "::error::Rollback health check ALSO failed — manual intervention required."
+              echo "::error::If a migration was applied, evaluate 'alembic downgrade' or restore the latest backup (see DR runbook)."
+            fi
+          else
+            echo "::warning::No last-good-tag — cannot auto-rollback."
+          fi
 
-            # Rollback to previous version
-            docker compose down
-            git checkout HEAD~1
-            docker compose pull
-            docker compose up -d
-          ENDSSH
-
-          echo "⚠️ Rolled back to previous version"
+      - name: Deployment summary
+        if: success()
+        run: |
+          {
+            echo "## ✅ Production Deployment Successful"
+            echo ""
+            echo "**Version**: ${TAG}"
+            echo "**URL**: ${{ vars.PRODUCTION_URL }}"
+            echo "**Migrations**: $(docker exec scholarship_backend_prod alembic current 2>/dev/null | tail -1)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.prod-db-monitoring.yml
+++ b/docker-compose.prod-db-monitoring.yml
@@ -57,7 +57,11 @@ services:
     image: prometheuscommunity/postgres-exporter:v0.18.1
     container_name: postgres_exporter_prod
     environment:
-      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-scholarship_user}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-scholarship_db}?sslmode=require"
+      # Postgres in this compose has no SSL configured, so sslmode=disable
+      # matches reality. With sslmode=require the exporter shows up=1
+      # (process running) but every pg_* metric is missing — the same bug
+      # was fixed on staging in commit 888ee744 and never backported (P9).
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-scholarship_user}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-scholarship_db}?sslmode=disable"
     ports:
       - "9187:9187"
     networks:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -84,6 +84,14 @@ services:
       STUDENT_API_ENCODE_TYPE: ${STUDENT_API_ENCODE_TYPE:-UTF-8}
       # Mock SSO disabled in production
       ENABLE_MOCK_SSO: "false"
+      # NYCU ID granted super_admin on Portal SSO login (portal_sso_service
+      # .py:198). Was missing here (issue #74 review): without it the default
+      # "super_admin" applies and no real承辦人 account can ever elevate.
+      SUPER_ADMIN_NYCU_ID: ${SUPER_ADMIN_NYCU_ID}
+      # Public origin for ABSOLUTE URLs in file download links, email links
+      # and API responses (P1 / issue #74 go-live blocker — config.py defaults
+      # to http://localhost:8000; staging hit this as issue #889/#891).
+      BASE_URL: https://${DOMAIN}
       # Frontend URLs
       FRONTEND_URL: https://${DOMAIN}  # External URL (for user redirects)
       FRONTEND_INTERNAL_URL: http://frontend:3000  # Internal Docker network URL (for API calls)

--- a/docs/deployment/production-deployment.md
+++ b/docs/deployment/production-deployment.md
@@ -194,12 +194,19 @@ sudo -u postgres createdb scholarship_prod -O scholarship_prod
 # Run migrations
 docker compose -f docker-compose.prod.yml run --rm backend alembic upgrade head
 
-# Create initial admin user
-docker compose -f docker-compose.prod.yml run --rm backend python -c "
-from app.core.init_db import create_initial_admin
-create_initial_admin()
-"
+# Seed the production baseline (admin user, lookup tables, system settings,
+# email templates — NEVER test users). `create_initial_admin()` referenced in
+# older versions of this doc does not exist.
+docker compose -f docker-compose.prod.yml run --rm backend python -m app.seed --prod
 ```
+
+> **Destructive-migration guard**: migration `06e8a66d9437` TRUNCATEs all
+> application tables. On a FRESH production database it is a no-op and passes
+> automatically. If you ever restore an existing dump and then re-run
+> `alembic upgrade head`, the guard refuses with a `RuntimeError` whenever
+> real `applications` rows would be destroyed — that refusal is a feature.
+> Do NOT set `ALLOW_DESTRUCTIVE_MIGRATIONS=true` unless you are executing a
+> sanctioned, documented data reset.
 
 ### 4. Deploy Services
 
@@ -438,7 +445,10 @@ curl -f https://scholarship.university.edu/health
 - **Recovery Time Objective (RTO)**: 4 hours
 - **Recovery Point Objective (RPO)**: 1 hour
 - **Backup Frequency**: Daily database, hourly file sync
-- **Failover**: Automated with health checks
+- **Failover**: ⚠️ NOT yet automated — the HA diagram above is the target
+  architecture. The current deployment is a SINGLE PostgreSQL instance; RTO/RPO
+  rest entirely on the daily backups + manual restore. Communicate this to
+  stakeholders before go-live.
 
 ## Maintenance Procedures
 

--- a/monitoring/config/alloy/prod-ap-vm.alloy
+++ b/monitoring/config/alloy/prod-ap-vm.alloy
@@ -129,6 +129,19 @@ prometheus.scrape "nginx_exporter" {
   scrape_interval = "15s"
 }
 
+// Scrape Redis Exporter (P9 / issue #74: was missing on prod — redis
+// dashboards showed No data for production)
+prometheus.scrape "redis_exporter" {
+  targets = [{
+    __address__ = "redis-exporter:9121",
+  }]
+
+  forward_to = [prometheus.relabel.add_labels.receiver]
+
+  job_name = "redis"
+  scrape_interval = "15s"
+}
+
 // Scrape Backend application metrics (if exposed)
 prometheus.scrape "backend" {
   targets = [{

--- a/monitoring/config/alloy/prod-db-vm.alloy
+++ b/monitoring/config/alloy/prod-db-vm.alloy
@@ -96,6 +96,33 @@ prometheus.scrape "postgres_exporter" {
   scrape_interval = "15s"
 }
 
+// MinIO ships built-in Prometheus metrics on the same port as the API
+// (P9 / issue #74: these three scrapes existed on staging only — prod MinIO
+// dashboards would show No data).
+prometheus.scrape "minio" {
+  targets    = [{ __address__ = "minio:9000" }]
+  forward_to = [prometheus.relabel.add_labels.receiver]
+  job_name   = "minio"
+  scrape_interval = "15s"
+  metrics_path = "/minio/v2/metrics/cluster"
+}
+
+prometheus.scrape "minio_bucket" {
+  targets    = [{ __address__ = "minio:9000" }]
+  forward_to = [prometheus.relabel.add_labels.receiver]
+  job_name   = "minio"
+  scrape_interval = "30s"
+  metrics_path = "/minio/v2/metrics/bucket"
+}
+
+prometheus.scrape "minio_node" {
+  targets    = [{ __address__ = "minio:9000" }]
+  forward_to = [prometheus.relabel.add_labels.receiver]
+  job_name   = "minio"
+  scrape_interval = "15s"
+  metrics_path = "/minio/v2/metrics/node"
+}
+
 prometheus.relabel "add_labels" {
   forward_to = [prometheus.remote_write.default.receiver]
   rule {

--- a/monitoring/config/grafana/provisioning/alerting/rules-application-logs-prod.yml
+++ b/monitoring/config/grafana/provisioning/alerting/rules-application-logs-prod.yml
@@ -1,0 +1,230 @@
+apiVersion: 1
+# Application log-based alerts (Loki) — PRODUCTION variant (P9 / issue #74).
+# Duplicated from rules-application-logs.yml with loki-prod-uid +
+# environment="prod" labels (matching prod-*.alloy relabel rules) so
+# production error logs alert through the same GitHub-issue pipeline.
+#
+# These rules query Loki tenants instead of Prometheus, so they catch
+# things metrics can't see: stack traces, application-level ERROR lines,
+# unhandled exceptions. They go through the same notification policy as
+# Prometheus alerts, so a firing rule eventually opens / updates a GitHub
+# issue via the repository_dispatch webhook.
+#
+# Grafana alert pipeline for Loki count_over_time queries needs three
+# stages: A (query) -> B (reduce last) -> C (threshold). Without the
+# reducer, evaluation fails with "looks like time series data, only
+# reduced data can be alerted on."
+groups:
+  - orgId: 1
+    name: application_logs_prod
+    folder: Alerts
+    interval: 1m
+    rules:
+      # Detects an abnormal rate of ERROR-level log lines. Threshold tuned
+      # for the post-2026-05-15 traceback-preservation sweep (PRs #574-#588):
+      # every endpoint + service emits `logger.exception(...)` at ERROR
+      # level on caught-exception paths, so the baseline ERROR rate during
+      # normal traffic + integration tests can easily exceed >5/5min. The
+      # raised threshold + 5m cooldown only fires on genuine spikes that
+      # indicate an upstream dependency outage or a hot-path regression.
+      - uid: alert-backend-error-spike-prod
+        title: BackendErrorSpike (production)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: loki-prod-uid
+            model:
+              datasource:
+                type: loki
+                uid: loki-prod-uid
+              expr: |
+                sum(count_over_time({environment="prod", container=~"scholarship_backend.*"} |~ "(?i)\\bERROR\\b" [5m]))
+              refId: A
+              queryType: instant
+          - refId: B
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              refId: C
+              type: threshold
+              conditions:
+                - evaluator:
+                    params: [50]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [C]
+                  reducer:
+                    type: last
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        labels:
+          severity: warning
+          category: application
+          environment: staging
+        annotations:
+          summary: "Backend error log spike (>50/5min) on {{ $labels.environment }}"
+          description: "scholarship_backend has emitted more than 50 ERROR-level log lines in the last 5 minutes — above the post-sweep baseline. Investigate via Loki: {environment=\"prod\", container=~\"scholarship_backend.*\"} |~ \"ERROR\""
+        isPaused: false
+
+      # Detects a sustained burst of Python tracebacks. Threshold tuned for
+      # the post-2026-05-15 traceback-preservation sweep (PRs #574–#588):
+      # every endpoint + service now emits `logger.exception(...)` on
+      # error paths, so background-noise tracebacks are *expected* and
+      # don't represent a crash. A genuine unhandled-exception storm
+      # still produces tens of stack traces per minute and trips the
+      # raised threshold + 5m cooldown.
+      - uid: alert-backend-traceback-prod
+        title: BackendUnhandledTraceback (production)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: loki-prod-uid
+            model:
+              datasource:
+                type: loki
+                uid: loki-prod-uid
+              expr: |
+                sum(count_over_time({environment="prod", container=~"scholarship_backend.*"} |= "Traceback (most recent call last)" [5m]))
+              refId: A
+              queryType: instant
+          - refId: B
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              refId: C
+              type: threshold
+              conditions:
+                - evaluator:
+                    params: [25]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [C]
+                  reducer:
+                    type: last
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        labels:
+          severity: high
+          category: application
+          environment: staging
+        annotations:
+          summary: "Backend traceback burst (>25/5min) on {{ $labels.environment }}"
+          description: "More than 25 Python tracebacks appeared in scholarship_backend logs over a 5-minute window — that exceeds the expected background rate from `logger.exception(...)` and suggests an unhandled-exception storm. Investigate via Loki: {environment=\"prod\", container=~\"scholarship_backend.*\"} |= \"Traceback\""
+        isPaused: false
+
+      - uid: alert-postgres-error-log-prod
+        title: PostgresErrorLog (production)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: loki-prod-uid
+            model:
+              datasource:
+                type: loki
+                uid: loki-prod-uid
+              expr: |
+                sum(count_over_time({environment="prod", container="scholarship_postgres_prod"} |~ "(?i)\\b(ERROR|FATAL)\\b" [5m]))
+              refId: A
+              queryType: instant
+          - refId: B
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: B
+              refId: C
+              type: threshold
+              conditions:
+                - evaluator:
+                    params: [3]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [C]
+                  reducer:
+                    type: last
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 1m
+        labels:
+          severity: warning
+          category: database
+          environment: staging
+        annotations:
+          summary: "Postgres ERROR/FATAL log spike on {{ $labels.environment }}"
+          description: "scholarship_postgres_prod emitted >3 ERROR/FATAL lines in 5 minutes. Inspect via Loki: {environment=\"prod\", container=\"scholarship_postgres_prod\"} |~ \"ERROR|FATAL\""
+        isPaused: false

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -76,6 +76,9 @@ http {
         ssl_session_timeout 10m;
         ssl_stapling on;
         ssl_stapling_verify on;
+    # P10 (issue #74): ssl_stapling_verify requires the issuer chain to
+    # verify OCSP responses — without it stapling silently never activates.
+    ssl_trusted_certificate /etc/nginx/ssl/chain.pem;
 
         # Gzip compression
         gzip on;


### PR DESCRIPTION
Dev-repo half of the go-live blockers from the [readiness review on #74](https://github.com/anud18/scholarship-system/issues/74#issuecomment-4689413385). (P2 = #936 merged separately; P4/P6 are prod-repo operator actions, now documented.)

| Blocker | Change |
|---|---|
| **P1** | `docker-compose.prod.yml` + `BASE_URL=https://${DOMAIN}` (prod links would have been `http://localhost:8000`); **also adds the entirely-missing `SUPER_ADMIN_NYCU_ID` passthrough** — `portal_sso_service.py:198` compares against it, so without it no real 承辦人 could ever elevate |
| **P5** | `production-workflows-examples/deploy.yml` rewritten from the unusable SSH template to the proven staging-deploy shape: **validate-secrets gate** (PII JSON, `portal.test` ban, localhost/mock student-API ban, mock-HMAC ban, `(測試)`/`ss-test` sender ban, SECRET_KEY ≥32), `[self-hosted, linux]` runner, GHCR build+pull, last-good-tag rollback, `nginx -t`→reload, `alembic upgrade head` + `seed --prod` **without error swallowing**, expose-only-aware health checks, Host-header smoke tests |
| **P9** | postgres-exporter `sslmode=disable` backport (staging fix `888ee744`); prod-ap alloy + redis scrape; prod-db alloy + 3 MinIO scrapes; `rules-application-logs-prod.yml` (3 Loki alerts on `loki-prod-uid` + `environment="prod"` matching the prod relabel value) |
| **P10** | `nginx.prod.conf` + `ssl_trusted_certificate` so OCSP stapling actually activates |
| Docs | SECRETS-SETUP-GUIDE + PII-encryption & SUPER_ADMIN sections; production-deployment.md: nonexistent `create_initial_admin()` → `python -m app.seed --prod`, destructive-migration-guard note, honest single-instance/failover statement |

All YAML validated. Remaining operator actions (cannot be done from this repo): P4 set PII secrets on prod repo, P6 create `production` environment + branch protection, register the prod AP-VM runner — checklist on #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)