### PR TITLE
feat(mirror): deliver production CI/CD through the mirror — the only channel into the prod repo

### DIFF
--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -1,6 +1,24 @@
 # Production Workflows Examples
 
-這個目錄包含用於 **production repository** 的 workflow 範例。這些 workflows 是專門為 production 環境設計的，不會從 development repository 同步過去。
+這個目錄包含用於 **production repository** 的 workflows。
+
+## 🚚 自動安裝（2026-06-13 起）
+
+**不需要再手動複製。** `mirror-to-production.yml` 是進入私有 prod repo 的唯一通道，
+因此它會在每次 mirror 時自動把本目錄的 workflows 安裝到 prod repo 的
+`.github/workflows/`：
+
+- prod repo **還沒有**的檔案 → 自動安裝（首次 mirror 即完成 CI/CD bootstrap）
+- prod repo **已有**的檔案 → 一律不覆寫（prod 端客製優先）；若範本與 prod 版本
+  不同，mirror log 會以 notice 提示，由人工決定是否移植
+- `README.md` / `SECRETS-SETUP-GUIDE.md` / `IT-BACKUP-TRANSFER-GUIDE.md`
+  會放到 prod repo 的 `.github/production-setup/`（mirror 會剝除其餘 *.md）
+
+> ⚠️ 前提：`GH_PAT` secret 必須具備 **`workflow` scope**，否則推送
+> `.github/workflows/**` 會被 GitHub 拒絕（"refusing to allow a Personal
+> Access Token to create or update workflow"）。
+
+以下原手動安裝說明保留作參考（適用於需要在 prod repo 直接修改的情境）。
 
 ## ⚠️ 重要：關於 Here-Document 錯誤
 

--- a/.github/workflows/mirror-to-production.yml
+++ b/.github/workflows/mirror-to-production.yml
@@ -189,6 +189,23 @@ jobs:
 
           echo "::endgroup::"
 
+      - name: Stage production workflow templates
+        # The mirror strips .github/workflows AND production-workflows-examples
+        # from the tree, but this workflow is the ONLY channel into the private
+        # prod repo — its CI/CD has to be carried over from here. Stage the
+        # templates before the removal steps so the install step (after
+        # production-workflow preservation) can seed them.
+        run: |
+          echo "::group::Staging production workflow templates"
+          rm -rf /tmp/prod-workflow-templates
+          if [ -d ".github/production-workflows-examples" ]; then
+            cp -r .github/production-workflows-examples /tmp/prod-workflow-templates
+            echo "::notice::Staged $(ls /tmp/prod-workflow-templates | wc -l) template file(s)"
+          else
+            echo "::warning::.github/production-workflows-examples not found — nothing to stage"
+          fi
+          echo "::endgroup::"
+
       - name: Remove development workflows
         run: |
           echo "::group::Removing development workflows"
@@ -430,6 +447,93 @@ jobs:
           # Cleanup temp directory
           rm -rf /tmp/production-workflows
 
+          echo "::endgroup::"
+
+      - name: Install production workflows from templates
+        id: install-workflows
+        env:
+          PRESERVED_COUNT: ${{ steps.preserve-workflows.outputs.preserved_count }}
+        run: |
+          echo "::group::Installing production workflows from templates"
+
+          # Bootstrap + drift policy:
+          #   - A workflow file the prod repo ALREADY has (just preserved from
+          #     prod-repo/main) wins — prod-side customizations are never
+          #     overwritten by the mirror.
+          #   - A workflow file the prod repo does NOT have yet is installed
+          #     from the staged templates (first mirror seeds the whole CI/CD).
+          #   - When a template differs from the preserved prod copy we only
+          #     surface a notice so the diff can be ported deliberately.
+          #
+          # NOTE: pushing .github/workflows/** to the prod repo requires the
+          # GH_PAT to carry the `workflow` scope — without it the push step
+          # fails with "refusing to allow a Personal Access Token to create or
+          # update workflow".
+          INSTALLED=""
+          SKIPPED=""
+          DIFFERS=""
+
+          if [ ! -d /tmp/prod-workflow-templates ]; then
+            echo "::warning::No staged templates — skipping install"
+            echo "installed=" >> $GITHUB_OUTPUT
+            echo "::endgroup::"
+            exit 0
+          fi
+
+          mkdir -p .github/workflows .github/production-setup
+
+          for f in deploy.yml health-check.yml backup.yml auto-tag-on-merge.yml setting-env.yml; do
+            src="/tmp/prod-workflow-templates/$f"
+            [ -f "$src" ] || continue
+            dest=".github/workflows/$f"
+            if [ -f "$dest" ]; then
+              if cmp -s "$src" "$dest"; then
+                SKIPPED="$SKIPPED $f"
+              else
+                DIFFERS="$DIFFERS $f"
+                echo "::notice::$f: prod repo has a customized copy — template differs, NOT overwriting (port changes manually if intended)"
+              fi
+            else
+              cp "$src" "$dest"
+              INSTALLED="$INSTALLED $f"
+              echo "::notice::Installed $f"
+            fi
+          done
+
+          # Operational guides ride along under .github/production-setup/ —
+          # the mirror removes all *.md from the app tree, but the operator
+          # working in the prod repo still needs these.
+          for g in README.md SECRETS-SETUP-GUIDE.md IT-BACKUP-TRANSFER-GUIDE.md; do
+            if [ -f "/tmp/prod-workflow-templates/$g" ]; then
+              cp "/tmp/prod-workflow-templates/$g" ".github/production-setup/$g"
+            fi
+          done
+
+          git add .github/workflows/ .github/production-setup/ 2>/dev/null || true
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: install/update production CI-CD from templates
+
+          Installed:${INSTALLED:- (none)}
+          Already present (identical):${SKIPPED:- (none)}
+          Present but template differs (NOT overwritten):${DIFFERS:- (none)}
+
+          Seeded from dev-repo .github/production-workflows-examples/ — this
+          mirror is the only channel into this repository, so its CI/CD is
+          versioned and delivered through it. Prod-side customizations are
+          never overwritten.
+          "
+            echo "::notice::✅ Production CI/CD committed"
+          else
+            echo "::notice::Nothing to install — prod workflows already up to date"
+          fi
+
+          {
+            echo "## Production CI/CD install"
+            echo "- Installed:${INSTALLED:- (none)}"
+            echo "- Already present:${SKIPPED:- (none)}"
+            echo "- Differs (not overwritten):${DIFFERS:- (none)}"
+          } >> $GITHUB_STEP_SUMMARY
+          echo "installed=${INSTALLED}" >> $GITHUB_OUTPUT
           echo "::endgroup::"
 
       - name: Calculate next version


### PR DESCRIPTION
Closes the bootstrap hole in the production path (issue #74): the mirror is the **only** way into the private prod repo, yet it stripped both the dev workflows *and* `production-workflows-examples/` — so the prod repo could never receive its own CI/CD, and the README's「手動複製」instruction was physically impossible.

**Mechanism (two new steps in `mirror-to-production.yml`):**
1. *Stage production workflow templates* — copies the examples to `/tmp` **before** the removal steps run.
2. *Install production workflows from templates* — runs **after** the existing「preserve prod-repo workflows」step, with a strict precedence policy:
   - file already in prod repo → **never overwritten** (prod customization wins; a `::notice` flags template drift for deliberate porting)
   - file missing in prod repo → installed (first mirror seeds `deploy.yml`, `health-check.yml`, `backup.yml`, `auto-tag-on-merge.yml`, `setting-env.yml`)
   - setup guides land in `.github/production-setup/` (every other `*.md` is stripped by the mirror)

**Operator note:** `GH_PAT` must carry the **`workflow` scope** — GitHub refuses pushes touching `.github/workflows/**` otherwise. Documented in the README.

Combined with #1012 (the rewritten `deploy.yml` template), one mirror dispatch now delivers code **and** a complete validated production CI/CD (secrets gate → migrate/seed → nginx check → health/smoke → last-good-tag rollback) in the same prod-repo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)