### PR TITLE
fix(prod-setup): close bare-VM provisioning blockers found by the audit

### DIFF
--- a/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
+++ b/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
@@ -276,7 +276,7 @@ These secrets configure the connection from AP VM to MinIO object storage on DB 
 | `MINIO_PORT` | MinIO API port | `9000` | ⚠️ Optional (default: 9000) |
 | `MINIO_ROOT_USER` | MinIO admin username | `minioadmin` | ✅ Yes |
 | `MINIO_ROOT_PASSWORD` | MinIO admin password | `MinIO@Secure2024!` | ✅ Yes |
-| `MINIO_BUCKET_NAME` | MinIO bucket name | `scholarship-documents` | ⚠️ Optional (default: scholarship-documents) |
+| `MINIO_BUCKET` | MinIO bucket name | `scholarship-documents` | ⚠️ Optional (default: scholarship-documents) |
 
 **How to obtain:**
 - Set during DB VM initial setup (Section 4.4 of installation manual: `.env.db`)

--- a/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
+++ b/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
@@ -191,6 +191,28 @@ ssh -p 8822 -i ~/.ssh/db_vm_deploy -v ubuntu@<DB_VM_IP>
 #      ssh-keyscan -p 8822 -H <DB_VM_IP> >> ~/.ssh/known_hosts
 ```
 
+**Sudo Requirements for AP Runner User (the self-hosted runner host):**
+
+`setting-env.yml` runs NON-INTERACTIVELY as the runner and executes ~13 local
+sudo commands (Docker install, apt keyrings, LVM extend, timesyncd, systemctl).
+Without passwordless sudo the run **hangs forever** at the first password
+prompt — the workflow's pre-flight now hard-fails early if it's missing, but
+you must configure it ON THE AP VM as the runner user before running
+`setting-env.yml`:
+
+```bash
+# On the AP VM, as the runner user (NOT root):
+sudo visudo
+# Method 1 (simpler, less secure) — full passwordless sudo:
+<runner-user> ALL=(ALL) NOPASSWD: ALL
+
+# Method 2 (recommended) — same command list as the DB VM section below
+# (apt-get / dpkg / systemctl docker / usermod -aG docker / vgs / lvextend / timedatectl).
+```
+
+(The interactive bootstrap-ap-runner.sh tolerates a sudo prompt; setting-env.yml
+does not. This is the AP-side equivalent of the DB-VM requirement below.)
+
 **Sudo Requirements for DB VM User:**
 
 The workflow automates Docker installation and image management, which requires sudo privileges. Configure passwordless sudo for the `DB_VM_USER`:

--- a/.github/production-workflows-examples/bootstrap-ap-runner.sh
+++ b/.github/production-workflows-examples/bootstrap-ap-runner.sh
@@ -59,16 +59,20 @@ trap 'on_err "$LINENO"' ERR
 REPO_URL=""
 REG_TOKEN=""
 LABELS="self-hosted,linux"
+# GitHub deprecates runners older than ~30 days and stops dispatching jobs
+# to them. Bump this (and the checksum below if you add one) when re-bootstrapping;
+# override per-run with --runner-version. Check the latest at
+# https://github.com/actions/runner/releases before provisioning.
 RUNNER_VERSION="2.319.1"
 RUNNER_NAME="$(hostname)-ap"
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo-url)        REPO_URL="$2"; shift 2 ;;
-    --token)           REG_TOKEN="$2"; shift 2 ;;
-    --labels)          LABELS="$2"; shift 2 ;;
-    --runner-version)  RUNNER_VERSION="$2"; shift 2 ;;
-    --name)            RUNNER_NAME="$2"; shift 2 ;;
+    --repo-url)        REPO_URL="${2:?--repo-url requires a value}"; shift 2 ;;
+    --token)           REG_TOKEN="${2:?--token requires a value}"; shift 2 ;;
+    --labels)          LABELS="${2:?--labels requires a value}"; shift 2 ;;
+    --runner-version)  RUNNER_VERSION="${2:?--runner-version requires a value}"; shift 2 ;;
+    --name)            RUNNER_NAME="${2:?--name requires a value}"; shift 2 ;;
     -h|--help)         grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *)                 die "Unknown argument: $1 (use --help)" ;;
   esac

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -209,7 +209,7 @@ jobs:
       MINIO_PORT: ${{ secrets.MINIO_PORT }}
       MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
       MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-      MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
+      MINIO_BUCKET: ${{ secrets.MINIO_BUCKET }}
       MINIO_SECURE: ${{ secrets.MINIO_SECURE }}
       PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
       PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
@@ -232,6 +232,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      # First-run ordering guard: a push to main can fire this deploy before
+      # the AP VM has been provisioned by setting-env.yml (Docker installed,
+      # deploy dir created, DB stack up on the DB VM). Deploying onto a
+      # half-set-up VM half-breaks production. Fail fast with a clear message
+      # instead — the operator runs setting-env.yml first, then re-triggers.
+      - name: Preflight — AP VM is provisioned
+        run: |
+          set -uo pipefail
+          fail=0
+          command -v docker >/dev/null 2>&1 || { echo "::error::Docker not installed on this runner/VM — run setting-env.yml (action: setup) first."; fail=1; }
+          docker compose version >/dev/null 2>&1 || { echo "::error::docker compose v2 plugin missing — run setting-env.yml first."; fail=1; }
+          [ -d "$HOME/scholarship-production" ] || { echo "::error::~/scholarship-production deploy dir missing — run setting-env.yml (action: setup) first."; fail=1; }
+          [ "$fail" -eq 0 ] || { echo "::error::AP VM is not provisioned — aborting deploy (this prevents an out-of-order first-run deploy)."; exit 1; }
+          echo "✅ AP VM provisioning preflight passed"
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/production-workflows-examples/setting-env.yml
+++ b/.github/production-workflows-examples/setting-env.yml
@@ -97,6 +97,7 @@ jobs:
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
           printf '%s\n' "$DB_VM_SSH_KEY" > ~/.ssh/preflight_key
           chmod 600 ~/.ssh/preflight_key
+          trap 'rm -f ~/.ssh/preflight_key /tmp/preflight_ssh' EXIT  # never leave the DB-VM key on the shared runner
           SSH="ssh -p $DB_VM_SSH_PORT -i $HOME/.ssh/preflight_key -o StrictHostKeyChecking=no -o ConnectTimeout=10 -o BatchMode=yes"
           if $SSH "$DB_VM_USER@$DB_HOST" "echo ok" >/tmp/preflight_ssh 2>&1; then
             ok "SSH to $DB_VM_USER@$DB_HOST:$DB_VM_SSH_PORT works"
@@ -300,9 +301,11 @@ jobs:
 
           # Restart and enable time sync
           echo "🔄 Restarting time synchronization service..."
-          sudo systemctl restart systemd-timesyncd
-          sudo timedatectl set-ntp true
-          echo "   ✅ Time synchronization enabled"
+          # Non-critical: a masked timesyncd or blocked NTP server must NOT abort
+          # provisioning (the whole step runs under `set -e`).
+          sudo systemctl restart systemd-timesyncd || echo "::warning::systemd-timesyncd restart failed (non-critical) — continuing"
+          sudo timedatectl set-ntp true || echo "::warning::timedatectl set-ntp failed (non-critical) — continuing"
+          echo "   ✅ Time synchronization enabled (or skipped if unavailable)"
           echo ""
 
           # Verify configuration
@@ -520,6 +523,7 @@ jobs:
           chmod 700 ~/.ssh
           echo "$DB_VM_SSH_KEY" > ~/.ssh/db_vm_key
           chmod 600 ~/.ssh/db_vm_key
+          trap 'rm -f ~/.ssh/db_vm_key' EXIT  # always wipe the root-equiv DB-VM key, even on a set -e abort
 
           # Add to known_hosts if needed
           if [ ! -f ~/.ssh/known_hosts ] || ! grep -q "$DB_HOST" ~/.ssh/known_hosts; then
@@ -569,10 +573,14 @@ jobs:
           # Check if bc is installed on DB VM (needed for floating-point comparison)
           ssh -p $DB_VM_SSH_PORT -i ~/.ssh/db_vm_key -o ConnectTimeout=15 -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$DB_VM_USER@$DB_HOST" "
             if ! command -v bc &> /dev/null; then
-              echo '📦 Installing bc (required for LVM checks)...'
-              sudo apt-get update
-              sudo apt-get install -y bc
-              echo '   ✅ bc installed'
+              echo '📦 Installing bc (optional LVM auto-extend check)...'
+              # Non-critical: an offline/locked-down DB VM may fail this apt
+              # install; do NOT let it abort the whole provisioning run.
+              if sudo apt-get update && sudo apt-get install -y bc; then
+                echo '   ✅ bc installed'
+              else
+                echo '   ⚠️  bc unavailable — skipping LVM auto-extend on the DB VM'
+              fi
             fi
           "
 
@@ -1035,6 +1043,7 @@ jobs:
           # Write SSH private key
           echo "$DB_VM_SSH_KEY" > ~/.ssh/db_vm_key
           chmod 600 ~/.ssh/db_vm_key
+          trap 'rm -f ~/.ssh/db_vm_key' EXIT  # always wipe the root-equiv DB-VM key, even on a set -e abort
 
           # Add DB_HOST to known_hosts (disable strict host key checking for automation)
           if [ ! -f ~/.ssh/known_hosts ] || ! grep -q "$DB_HOST" ~/.ssh/known_hosts; then
@@ -1194,9 +1203,15 @@ jobs:
           echo "- $POSTGRES_IMAGE"
           echo "- $MINIO_IMAGE"
           echo ""
-          echo "Next: Admin can start DB services with:"
+          echo "Next: start the DB stack ON THE DB VM. The Docker IMAGES are loaded,"
+          echo "but the compose file + init scripts + DB env are NOT auto-delivered —"
+          echo "place them on the DB VM first (data dirs auto-create via relative binds):"
           echo "  ssh -p $DB_VM_SSH_PORT $DB_VM_USER@$DB_HOST"
-          echo "  cd /srv/naass/app/naass"
+          echo "  mkdir -p ~/scholarship-production-db && cd ~/scholarship-production-db"
+          echo "  # copy these from the repo onto the DB VM (scp or git clone):"
+          echo "  #   docker-compose.prod-db.yml, database-init/, scripts/backup.sh"
+          echo "  # create .env with the DB secrets the compose interpolates:"
+          echo "  #   POSTGRES_DB / POSTGRES_USER / POSTGRES_PASSWORD / MINIO_ROOT_USER / MINIO_ROOT_PASSWORD (see SECRETS-SETUP-GUIDE.md)"
           echo "  docker compose -f docker-compose.prod-db.yml up -d"
           echo ""
 
@@ -1268,6 +1283,7 @@ jobs:
           chmod 700 ~/.ssh
           echo "$DB_VM_SSH_KEY" > ~/.ssh/db_vm_key
           chmod 600 ~/.ssh/db_vm_key
+          trap 'rm -f ~/.ssh/db_vm_key' EXIT  # always wipe the root-equiv DB-VM key, even on a set -e abort
 
           DB_DOCKER_STATUS="unknown"
 
@@ -1367,13 +1383,14 @@ jobs:
           echo "📁 Creating $DEPLOY_DIR and its volume directories..."
           mkdir -p "$DEPLOY_DIR/backend/uploads" \
                    "$DEPLOY_DIR/logs/backend" \
-                   "$DEPLOY_DIR/logs/nginx"
+                   "$DEPLOY_DIR/logs/nginx" \
+                   "$DEPLOY_DIR/app/redis/data"
           # The backend + nginx containers run as NON-root users and must be
           # able to write uploads/logs into these bind mounts. u+rwX only would
           # leave them unwritable by the container uid; 777 on the mount dirs is
           # the pragmatic choice for a single-tenant VM (the parent dir is owned
           # by the deploy user, and these hold no secrets).
-          chmod 777 "$DEPLOY_DIR/backend/uploads" "$DEPLOY_DIR/logs/backend" "$DEPLOY_DIR/logs/nginx"
+          chmod 777 "$DEPLOY_DIR/backend/uploads" "$DEPLOY_DIR/logs/backend" "$DEPLOY_DIR/logs/nginx" "$DEPLOY_DIR/app/redis/data"
           echo "   ✅ Created:"
           find "$DEPLOY_DIR" -maxdepth 2 -type d | sed 's/^/      /'
           echo ""
@@ -1406,9 +1423,9 @@ jobs:
             echo "✅ Setup completed"
             echo ""
             echo "Next steps:"
-            echo "1. Review .env.prod file: cat .env.prod"
+            echo "1. App credentials are injected by deploy.yml at deploy time (this workflow does NOT write a .env)"
             echo "2. Ensure .env.prod is not committed: git status"
-            echo "3. Verify directory structure: ls -la /opt/scholarship/"
+            echo "3. Verify directory structure: ls -la ~/scholarship-production/"
             echo "4. Deploy application with: docker compose -f docker-compose.prod.yml up -d"
           else
             echo "✅ Full check and setup completed"

--- a/.github/production-workflows-examples/setting-env.yml
+++ b/.github/production-workflows-examples/setting-env.yml
@@ -85,7 +85,11 @@ jobs:
           AP_ARCH="$(dpkg --print-architecture)"
           AP_CODENAME="$(lsb_release -cs 2>/dev/null || echo unknown)"
           echo "   arch=$AP_ARCH  ubuntu=$AP_CODENAME  host=$(hostname)"
-          if sudo -n true 2>/dev/null; then ok "passwordless sudo available"; else warn "sudo will prompt — a non-interactive runner step that needs sudo could hang. Configure passwordless sudo for the runner user if a later step stalls."; fi
+          # HARD gate: this preflight only runs for setup/full-check, which execute
+          # ~13 LOCAL sudo commands non-interactively. A runner that hits a sudo
+          # password prompt HANGS forever (no TTY to answer), so fail fast here
+          # with the fix instead of stalling mid-Docker-install.
+          if sudo -n true 2>/dev/null; then ok "passwordless sudo available"; else err "AP runner user has NO passwordless sudo — setup/full-check would HANG at the first local sudo (Docker install). Configure NOPASSWD sudo for the runner user (SECRETS-SETUP-GUIDE.md → 'Sudo Requirements for AP Runner User')."; fi
           AP_DISK_GB="$(df -BG --output=avail / | tail -1 | tr -dc '0-9')"
           echo "   root free: ${AP_DISK_GB}G"
           [ "${AP_DISK_GB:-0}" -ge 5 ] || err "AP VM has <5G free on / — image save/transfer needs headroom"

--- a/docker-compose.prod-db.yml
+++ b/docker-compose.prod-db.yml
@@ -13,8 +13,8 @@ services:
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
-      - postgres_prod_data:/var/lib/postgresql/data
-      - postgres_backups:/backups
+      - ./postgres/data:/var/lib/postgresql/data
+      - ./postgres/backups:/backups
       - ./database-init:/docker-entrypoint-initdb.d:ro
     networks:
       - scholarship_prod_db_network
@@ -50,8 +50,8 @@ services:
       - "${MINIO_API_PORT:-9000}:9000"
       - "${MINIO_CONSOLE_PORT:-9001}:9001"
     volumes:
-      - minio_prod_data:/data
-      - minio_config:/root/.minio
+      - ./minio/data:/data
+      - ./minio/config:/root/.minio
     networks:
       - scholarship_prod_db_network
     command: server /data --console-address ":9001"
@@ -92,7 +92,7 @@ services:
       BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-0 2 * * *}  # Daily at 2 AM
       BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-30}
     volumes:
-      - postgres_backups:/backups
+      - ./postgres/backups:/backups
       - ./scripts/backup.sh:/backup.sh:ro
     networks:
       - scholarship_prod_db_network
@@ -163,32 +163,10 @@ services:
   # Run monitoring services separately with:
   # docker-compose -f docker-compose.prod-db-monitoring.yml up -d
 
-volumes:
-  postgres_prod_data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: /opt/scholarship/postgres/data
-  postgres_backups:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: /opt/scholarship/postgres/backups
-  minio_prod_data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: /opt/scholarship/minio/data
-  minio_config:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: /opt/scholarship/minio/config
-
+# No named volumes: persistent data uses relative bind mounts (./postgres/data,
+# ./postgres/backups, ./minio/data, ./minio/config) that the Docker daemon
+# auto-creates under the deploy directory — no /opt/scholarship host provisioning
+# needed. Back up by snapshotting the whole deploy dir.
 networks:
   scholarship_prod_db_network:
     driver: bridge

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
     expose:
       - "6379"
     volumes:
-      - redis_prod_data:/data
+      - ./app/redis/data:/data  # relative bind — Docker auto-creates under the deploy dir (was an absolute device:bind that nothing provisioned)
     networks:
       - scholarship_prod_network
     # --maxmemory + allkeys-lru: cache namespace (cache:v1:*) is fully
@@ -57,7 +57,7 @@ services:
       MINIO_ENDPOINT: ${MINIO_HOST}:${MINIO_PORT:-9000}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
-      MINIO_BUCKET_NAME: ${MINIO_BUCKET_NAME:-scholarship-documents}
+      MINIO_BUCKET: ${MINIO_BUCKET:-scholarship-documents}
       MINIO_SECURE: ${MINIO_SECURE:-true}
       # PII Encryption keys (issue #73). JSON map of {version: base64url 32-byte key}.
       # Required in production. Populated by the KMS sidecar at deploy time.
@@ -334,14 +334,9 @@ services:
         max-size: "5m"
         max-file: "3"
 
-volumes:
-  redis_prod_data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: /opt/scholarship/app/redis/data
-
+# No named volumes: all persistent data uses relative bind mounts (./app/redis/data,
+# ./backend/uploads, ./logs) that the Docker daemon auto-creates under the deploy
+# directory — no host-path provisioning needed (matches the staging pattern).
 networks:
   scholarship_prod_network:
     driver: bridge

--- a/docs/deployment/production-deployment.md
+++ b/docs/deployment/production-deployment.md
@@ -97,7 +97,7 @@ REDIS_PASSWORD=<redis-password>
 MINIO_ENDPOINT=prod-minio:9000
 MINIO_ACCESS_KEY=<minio-access-key>
 MINIO_SECRET_KEY=<minio-secret-key>
-MINIO_BUCKET_NAME=scholarship-documents
+MINIO_BUCKET=scholarship-documents
 
 # Email
 SMTP_HOST=smtp.university.edu

--- a/docs/deployment/rustfs-migration-runbook.md
+++ b/docs/deployment/rustfs-migration-runbook.md
@@ -208,12 +208,12 @@ alerting exists.
 |---|---|
 | rustfs#1058 (credential envs ignored in some builds) | Step-0 spike repeats positive+negative credential test on every re-pin |
 | Explicit Deny policies block owner | No bucket policies post-migration; compat check pins anonymous-403-by-default + owner-GET-ok |
-| UID 10001 vs bind-mount perms | `chown -R 10001:10001` any bind mounts (prod-db uses bind mounts under `/opt/scholarship/minio/...` — new dirs needed) |
+| UID 10001 vs bind-mount perms | prod compose now uses RELATIVE bind mounts under the DB-VM deploy dir (`./minio/data`, `./minio/config`), Docker-auto-created; if RustFS (uid 10001) can't write them, `chown -R 10001:10001 <deploy-dir>/minio` |
 | Beta maturity / read latency | bake-in on dev + staging before prod; rollback volume preserved |
 | Lifecycle rules | not used by this system (none configured) — re-check before enabling any |
 | `MINIO_BUCKET_NAME` dead env in prod compose | fix to `MINIO_BUCKET` during cutover; verify actual bucket name in prod data first |
 | Versioned-bucket history does not migrate (`mc mirror` copies latest only) | versioning audit precondition; frozen MinIO volume = retention archive for the compliance window |
-| Prod volume snapshots/backups still target the OLD MinIO dir | update snapshot/backup config to the new RustFS data dir (`/opt/scholarship/rustfs/...`) at cutover; `scripts/backup.sh` only covers postgres — object-storage backup is volume-level |
+| Prod volume snapshots/backups target the storage data dir | prod data lives under the DB-VM deploy dir (`<deploy-dir>/minio/data`, `<deploy-dir>/postgres/data`) via relative binds — back up by snapshotting the whole deploy dir; `scripts/backup.sh` only covers postgres |
 | staging-e2e MinIO replica masking RustFS semantics | swap the replica image in the same change as staging-db |
 | **RustFS beta.8 leaks prior object data on overwrite** (live-proven: each overwrite of a >inline-size key leaves the previous dataDir on disk; DELETE leaves orphans too; no background reclaim) | watch `du`-vs-`mc du` divergence during bake-in; avoid fixed-key overwrites (seed_regulations re-seeds leak ~240KB each); track upstream rustfs/rustfs for a fix before prod |
 | Volume snapshot restores to an unreadable store | restore drill in the checklist: tar full `/data` INCLUDING `.rustfs.sys` (format.json/IAM/bucket metadata), untar to fresh volume, boot RustFS, pass compat check + checksum sweep |


### PR DESCRIPTION
針對 `feat/harden-vm-setup` 的 bare-VM bootstrap + setting-env 跑了多 agent 對抗式稽核(code-trace + 對照 deploy/compose,無真 VM),確認 **5 個 blocker + 多個 major**。本 PR 修掉它們,base 設成 `feat/harden-vm-setup` 讓你 review。

## 🔴 BLOCKER —— 全新 VM 第一次 `docker compose up` 起不來任何儲存容器
- **prod compose 用絕對 `device:/opt/scholarship/...` bind volume**,Docker 不會自動建(相對 bind 才會),provisioning 也從沒 mkdir → 每個儲存容器 ENOENT abort(redis 掛 → backend health gate 連鎖)。**改成相對 short-syntax bind**(`./postgres/data`、`./minio/data`、`./minio/config`、`./app/redis/data`)讓 daemon 在 deploy 目錄下自動建 —— 跟 staging + 既有 `./backend/uploads`/`./logs` 一致,零 host 佈署。(依你選的「相對 bind」方案)
- **setting-env 的 DB-stack 啟動指令** 指向 `/srv/naass/app/naass`(從沒建、跟 AP 側 `~/scholarship-production` 不一致)且漏講 compose/init/backup/env 不會自動送達 → 文件化的 `up -d` 根本不可能成功。**改寫成正確完整的操作步驟**(放檔 + 建 .env + up;資料夾現在會自動建)。

## 🟠 MAJOR
- **DB-VM root 等級 SSH 私鑰**會在 ssh/scp 於 `set -e` 下中途失敗時留在共用 runner 上 → 每個 key write 後加 `trap 'rm -f <key>' EXIT`(preflight + 3 個 provisioning 點)
- **deploy.yml(on: push main)會在 VM 還沒佈署好就觸發** → 加 preflight,docker/compose v2/deploy 目錄不存在就 fail fast
- 離線 DB VM 沒 `bc` 會 hard-fail、NTP 重啟會 abort → 都改非致命(warn)
- **死的 `MINIO_BUCKET_NAME`**(config 綁 `MINIO_BUCKET`)→ prod compose / deploy.yml / SECRETS-SETUP-GUIDE / production-deployment 全部修正

## 🟢 MINOR
- bootstrap `--repo-url`(漏帶值)會 `$2: unbound variable` crash → 每個 arm 加 `${2:?...}`;runner 版本棄用註解
- Display Summary 宣稱會產 `.env.prod` + 建 `/opt/scholarship`(都沒做)→ 改成事實
- runbook 的 backup/bind-path 列更新成相對-bind 佈局

## ❎ 對抗式驗證駁回(沒動)
make_bucket 競態(RustFS 反而更安全)、preflight 的 StrictHostKeyChecking(keyscan-TOFU 等效)、get_object 連線洩漏(urllib3 2.7 自動回收)。

所有 YAML valid;bootstrap `bash -n` clean。**無真 VM 可測 —— 盲改但每處都 code-trace 過,以 PR 形式給你 review。**

### 還沒做(critic gap,留給你判斷 prod 拓樸)
- AP→DB 防火牆 5432/9000 沒開沒驗(我沒加,因為要看你的網路設定)
- DB-VM 自動送 compose/init 檔的機制(目前改成正確的操作指引,沒寫成 workflow 自動 SCP —— 因為 DB env secret 名稱/拓樸要你定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)