### PR TITLE
fix: honest roster regeneration response + structured config FKs (#1033)

### DIFF
--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -527,6 +527,23 @@ class GenerateRostersRequest(BaseModel):
     force_regenerate: bool = False
 
 
+def _build_roster_generation_message(created: int, skipped: int, locked: int) -> str:
+    """Honest summary of a batch roster generation (issue #1033).
+
+    Existing rosters are never silently reported as a blank success: skipped
+    ones name how to rebuild (force_regenerate), and locked ones say why they
+    could not be rebuilt. Pure function so the wording stays under test.
+    """
+    message = f"成功產生 {created} 個造冊"
+    if skipped:
+        message += (
+            f"；另有 {skipped} 個造冊已存在、未重新產生。" "如需以最新分發/學生資料重建，請帶 force_regenerate=true。"
+        )
+    if locked:
+        message += f"；有 {locked} 個造冊已鎖定，無法重新產生。"
+    return message
+
+
 @router.post("/generate-rosters-from-distribution")
 async def generate_rosters_from_distribution(
     request: GenerateRostersRequest,
@@ -543,7 +560,7 @@ async def generate_rosters_from_distribution(
 
     service = RosterService(sync_db)
     try:
-        rosters = service.generate_rosters_from_distribution(
+        result = service.generate_rosters_from_distribution(
             scholarship_type_id=request.scholarship_type_id,
             academic_year=request.academic_year,
             semester=request.semester,
@@ -552,8 +569,8 @@ async def generate_rosters_from_distribution(
             force_regenerate=request.force_regenerate,
         )
 
-        roster_summaries = [
-            {
+        def _summarize(r):
+            return {
                 "id": r.id,
                 "roster_code": r.roster_code,
                 "sub_type": r.sub_type,
@@ -565,15 +582,23 @@ async def generate_rosters_from_distribution(
                 "disqualified_count": r.disqualified_count,
                 "total_amount": str(r.total_amount),
             }
-            for r in rosters
-        ]
+
+        roster_summaries = [_summarize(r) for r in result.created]
+        skipped_summaries = [_summarize(r) for r in result.skipped]
+        locked_summaries = [_summarize(r) for r in result.locked]
+
+        message = _build_roster_generation_message(len(result.created), len(result.skipped), len(result.locked))
 
         return {
             "success": True,
-            "message": f"成功產生 {len(rosters)} 個造冊",
+            "message": message,
             "data": {
-                "rosters_created": len(rosters),
+                "rosters_created": len(result.created),
+                "rosters_skipped": len(result.skipped),
+                "rosters_locked": len(result.locked),
                 "rosters": roster_summaries,
+                "skipped_rosters": skipped_summaries,
+                "locked_rosters": locked_summaries,
             },
         }
     except ValueError as e:

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -69,6 +69,23 @@ def _require_admin(user: User) -> None:
 _HEAVY_ITEM_FIELDS = {"rule_validation_result", "verification_snapshot"}
 
 
+def _roster_config_fields(roster: PaymentRoster) -> dict:
+    """Structured links to the owning scholarship config (issue #1033).
+
+    The roster only stores scholarship_configuration_id; scholarship_type_id
+    and semester live on the related ScholarshipConfiguration. Surface them
+    (plus config_id, the frontend's name for the config FK) so reports/audits
+    can filter without parsing roster_code. Requires scholarship_configuration
+    to be eager-loaded to avoid MissingGreenlet under async.
+    """
+    config = roster.scholarship_configuration
+    return {
+        "config_id": roster.scholarship_configuration_id,
+        "scholarship_type_id": config.scholarship_type_id if config else None,
+        "semester": config.semester.value if config and config.semester else None,
+    }
+
+
 def _roster_item_dict_with_display_year(item: PaymentRosterItem, roster: PaymentRoster, *, slim: bool = False) -> dict:
     """Serialize a roster item for the UI, resolving the display year.
 
@@ -406,6 +423,7 @@ async def list_payment_rosters(
     skip: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
     scholarship_configuration_id: Optional[int] = Query(None),
+    scholarship_type_id: Optional[int] = Query(None, description="依獎學金類型過濾（透過所屬配置）"),
     status_filter: Optional[RosterStatus] = Query(None),
     period_label: Optional[str] = Query(None),
     academic_year: Optional[int] = Query(None),
@@ -416,6 +434,8 @@ async def list_payment_rosters(
     取得造冊清單
     Get payment roster list
     """
+    from app.models.scholarship import ScholarshipConfiguration
+
     try:
         # Build query with eager loading to avoid MissingGreenlet errors
         stmt = select(PaymentRoster).options(
@@ -429,6 +449,13 @@ async def list_payment_rosters(
         # 套用篩選條件
         if scholarship_configuration_id:
             stmt = stmt.where(PaymentRoster.scholarship_configuration_id == scholarship_configuration_id)
+        if scholarship_type_id is not None:
+            # Filter by scholarship type via the owning config (issue #1033):
+            # rosters don't store scholarship_type_id directly.
+            stmt = stmt.join(
+                ScholarshipConfiguration,
+                PaymentRoster.scholarship_configuration_id == ScholarshipConfiguration.id,
+            ).where(ScholarshipConfiguration.scholarship_type_id == scholarship_type_id)
         if status_filter:
             stmt = stmt.where(PaymentRoster.status == status_filter)
         if period_label:
@@ -460,6 +487,7 @@ async def list_payment_rosters(
             roster_dict["student_count"] = roster.qualified_count + roster.disqualified_count
             roster_dict["roster_name"] = roster.roster_code
             roster_dict["roster_period"] = roster.roster_cycle.value
+            roster_dict.update(_roster_config_fields(roster))
 
             # 添加關聯資料（已 eager loaded，避免 MissingGreenlet）
             if roster.items:
@@ -1268,10 +1296,12 @@ async def get_payment_roster(
 
         # 使用 Pydantic model_validate 自動處理 Field alias 映射
         response_data = RosterResponse.model_validate(roster)
+        data = response_data.model_dump() if hasattr(response_data, "model_dump") else response_data.dict()
+        data.update(_roster_config_fields(roster))  # structured config FKs (issue #1033)
         return ApiResponse(
             success=True,
             message="查詢成功",
-            data=response_data.model_dump() if hasattr(response_data, "model_dump") else response_data.dict(),
+            data=data,
         )
 
     except HTTPException:

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -216,15 +216,21 @@ class RosterNotFoundError(NotFoundError):
 class RosterAlreadyExistsError(ConflictError):
     """Raised when trying to create roster that already exists"""
 
-    def __init__(self, message: str):
+    def __init__(self, message: str, existing_roster=None):
         super().__init__(message)
+        # Lets a batch caller report which roster was skipped (issue #1033)
+        # without re-querying. Optional — single-roster callers omit it.
+        self.existing_roster = existing_roster
 
 
 class RosterLockedError(BusinessLogicError):
     """Raised when trying to modify locked roster"""
 
-    def __init__(self, message: str):
+    def __init__(self, message: str, roster=None):
         super().__init__(message)
+        # Lets a batch caller report which locked roster blocked a rebuild
+        # (issue #1033) instead of aborting the whole batch. Optional.
+        self.roster = roster
 
 
 class StudentVerificationError(ScholarshipException):

--- a/backend/app/schemas/roster.py
+++ b/backend/app/schemas/roster.py
@@ -100,6 +100,13 @@ class RosterResponse(BaseModel):
     id: int
     roster_code: str
     scholarship_configuration_id: int
+    # Structured links to the owning scholarship config, derived from the
+    # related ScholarshipConfiguration so reports/audits can filter without
+    # parsing roster_code (issue #1033). config_id duplicates
+    # scholarship_configuration_id under the name the frontend expects.
+    config_id: Optional[int] = None
+    scholarship_type_id: Optional[int] = None
+    semester: Optional[str] = None
     ranking_id: Optional[int] = None  # 關聯的排名ID（可選）
     period_label: str
     roster_cycle: RosterCycle

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -4,6 +4,7 @@ Roster service core logic for scholarship payment roster generation
 """
 
 import logging
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -39,6 +40,24 @@ from app.services.student_verification_service import StudentVerificationService
 from app.utils.pii_masking import mask_id_number
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RosterGenerationResult:
+    """Outcome of a batch roster generation (issue #1033).
+
+    `created` are the rosters newly produced (or rebuilt under
+    force_regenerate); `skipped` are pre-existing rosters left untouched
+    because they already existed and force_regenerate was not set; `locked`
+    are pre-existing rosters that force_regenerate could NOT rebuild because
+    they are locked. Carrying these lets the API tell the admin honestly what
+    happened instead of returning a misleading "produced 0" success — or, for
+    locked rosters under force, aborting the whole batch with a 500.
+    """
+
+    created: List["PaymentRoster"] = field(default_factory=list)
+    skipped: List["PaymentRoster"] = field(default_factory=list)
+    locked: List["PaymentRoster"] = field(default_factory=list)
 
 
 class RosterService:
@@ -1455,7 +1474,7 @@ class RosterService:
         created_by_user_id: int,
         student_verification_enabled: bool = True,
         force_regenerate: bool = False,
-    ) -> List[PaymentRoster]:
+    ) -> "RosterGenerationResult":
         """
         從矩陣分發結果批次產生造冊
 
@@ -1473,7 +1492,8 @@ class RosterService:
             force_regenerate: 是否強制重新產生已存在的造冊
 
         Returns:
-            List[PaymentRoster]: 已產生的造冊列表
+            RosterGenerationResult: `.created` 為新產生的造冊，`.skipped` 為
+            已存在且未重新產生的造冊（force_regenerate=False 時）。
 
         Raises:
             ValueError: 找不到排名、尚未完成分發、或其他驗證錯誤
@@ -1563,6 +1583,8 @@ class RosterService:
 
         # 4. 為每個分組建立造冊（以該分組的消耗配置為準）
         created_rosters: List[PaymentRoster] = []
+        skipped_rosters: List[PaymentRoster] = []
+        locked_rosters: List[PaymentRoster] = []
 
         for (alloc_config_id, sub_type), group_items in groups.items():
             application_ids_in_group = {item.application_id for item in group_items}
@@ -1580,16 +1602,32 @@ class RosterService:
                     force_regenerate=force_regenerate,
                 )
                 created_rosters.append(roster)
-            except RosterAlreadyExistsError:
+            except RosterAlreadyExistsError as e:
                 logger.info(f"Roster for (cfg={alloc_config_id}, {sub_type}) already exists, skipping.")
+                if e.existing_roster is not None:
+                    skipped_rosters.append(e.existing_roster)
+                continue
+            except RosterLockedError as e:
+                # force_regenerate can't rebuild a locked roster. Report it
+                # rather than aborting the whole batch (issue #1033) — the
+                # honest message tells admins to use force, so don't let that
+                # advice 500 when one roster in the batch is locked.
+                logger.info(f"Roster for (cfg={alloc_config_id}, {sub_type}) is locked, cannot rebuild.")
+                if e.roster is not None:
+                    locked_rosters.append(e.roster)
                 continue
             except Exception:
                 logger.exception(f"Failed to generate roster for (cfg={alloc_config_id}, {sub_type})")
                 raise
 
         self.db.commit()
-        logger.info(f"Generated {len(created_rosters)} rosters from distribution rankings {ranking_ids}")
-        return created_rosters
+        logger.info(
+            f"Generated {len(created_rosters)} rosters "
+            f"({len(skipped_rosters)} skipped as already-existing, "
+            f"{len(locked_rosters)} locked) "
+            f"from distribution rankings {ranking_ids}"
+        )
+        return RosterGenerationResult(created=created_rosters, skipped=skipped_rosters, locked=locked_rosters)
 
     def _generate_one_sub_type_roster(
         self,
@@ -1640,11 +1678,15 @@ class RosterService:
 
         if existing_roster and not force_regenerate:
             raise RosterAlreadyExistsError(
-                f"造冊已存在：{sub_type} {allocation_year} 年度。使用 force_regenerate=True 可覆蓋。"
+                f"造冊已存在：{sub_type} {allocation_year} 年度。使用 force_regenerate=True 可覆蓋。",
+                existing_roster=existing_roster,
             )
 
         if existing_roster and existing_roster.is_locked:
-            raise RosterLockedError(f"無法重新產生已鎖定的造冊：{existing_roster.roster_code}")
+            raise RosterLockedError(
+                f"無法重新產生已鎖定的造冊：{existing_roster.roster_code}",
+                roster=existing_roster,
+            )
 
         user = self.db.query(User).filter(User.id == created_by_user_id).first()
         user_name = user.name if user else "Unknown"

--- a/backend/app/tests/test_payment_rosters_api.py
+++ b/backend/app/tests/test_payment_rosters_api.py
@@ -707,3 +707,85 @@ async def test_restore_endpoint_missing_item_returns_404(client_admin: AsyncClie
     roster_id, _item_id = locked_roster_with_removed_item
     resp = await client_admin.post(f"/api/v1/payment-rosters/{roster_id}/items/99999999/restore", json={})
     assert resp.status_code == 404
+
+
+# ===========================================================================
+# Structured config fields + scholarship_type filter (issue #1033)
+# ===========================================================================
+
+
+@pytest_asyncio.fixture
+async def roster_with_real_config(db) -> PaymentRoster:
+    """A roster linked to a real ScholarshipConfiguration so the derived
+    scholarship_type_id / semester / config_id fields are non-null."""
+    from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+
+    u = await _seed_admin_user(db, "cfg")
+    sch = ScholarshipType(code="pr_cfg_sch", name="PR Cfg", description="x")
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        config_code="PR-CFG-114",
+        config_name="PR Cfg 114",
+        academic_year=114,
+        semester="first",
+        amount=50000,
+        has_quota_limit=False,
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+
+    r = PaymentRoster(
+        roster_code="ROSTER-PR-CFG",
+        scholarship_configuration_id=cfg.id,
+        period_label="114",
+        academic_year=114,
+        roster_cycle=RosterCycle.YEARLY,
+        status=RosterStatus.COMPLETED,
+        trigger_type=RosterTriggerType.MANUAL,
+        created_by=u.id,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+    )
+    db.add(r)
+    await db.commit()
+    await db.refresh(r)
+    r._test_type_id = sch.id
+    r._test_config_id = cfg.id
+    return r
+
+
+@pytest.mark.asyncio
+async def test_get_roster_exposes_structured_config_fields(client_admin: AsyncClient, roster_with_real_config):
+    """GET /{id}: scholarship_type_id / semester / config_id are populated from
+    the related config, not null (issue #1033 problem 2)."""
+    resp = await client_admin.get(f"/api/v1/payment-rosters/{roster_with_real_config.id}")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    assert data["config_id"] == roster_with_real_config._test_config_id
+    assert data["scholarship_type_id"] == roster_with_real_config._test_type_id
+    assert data["semester"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_scholarship_type_id(client_admin: AsyncClient, roster_with_real_config):
+    """GET ?scholarship_type_id= filters via the owning config and the returned
+    items carry the structured fields (issue #1033 problem 2)."""
+    type_id = roster_with_real_config._test_type_id
+
+    resp = await client_admin.get(f"/api/v1/payment-rosters?scholarship_type_id={type_id}")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["data"]["items"]
+    codes = {it["roster_code"] for it in items}
+    assert "ROSTER-PR-CFG" in codes
+    assert all(it["scholarship_type_id"] == type_id for it in items)
+
+    # A different type id must not return this roster.
+    resp2 = await client_admin.get(f"/api/v1/payment-rosters?scholarship_type_id={type_id + 99999}")
+    assert resp2.status_code == 200, resp2.text
+    codes2 = {it["roster_code"] for it in resp2.json()["data"]["items"]}
+    assert "ROSTER-PR-CFG" not in codes2

--- a/backend/app/tests/test_roster_generate_per_config_group.py
+++ b/backend/app/tests/test_roster_generate_per_config_group.py
@@ -6,7 +6,8 @@ config's."""
 
 from app.models.application import Application, ApplicationStatus
 from app.models.college_review import CollegeRanking, CollegeRankingItem
-from app.models.payment_roster import PaymentRoster
+from app.api.v1.endpoints.manual_distribution import _build_roster_generation_message
+from app.models.payment_roster import PaymentRoster, RosterStatus
 from app.models.scholarship import (
     ScholarshipConfiguration,
     ScholarshipType,
@@ -125,13 +126,15 @@ def test_generate_groups_by_allocation_config(db_sync):
     db_sync.commit()
 
     svc = RosterService(db_sync)
-    rosters = svc.generate_rosters_from_distribution(
+    result = svc.generate_rosters_from_distribution(
         scholarship_type_id=sch.id,
         academic_year=115,
         semester="first",
         created_by_user_id=admin.id,
         student_verification_enabled=False,
     )
+    rosters = result.created
+    assert result.skipped == []
 
     by_config = {r.allocation_config_id: r for r in rosters}
     assert set(by_config) == {own.id, prior.id}
@@ -142,3 +145,149 @@ def test_generate_groups_by_allocation_config(db_sync):
     assert by_config[prior.id].allocation_year == 114
     assert by_config[prior.id].project_number == "114R000001"
     assert by_config[prior.id].scholarship_configuration_id == own.id
+
+
+def test_regenerate_reports_existing_as_skipped_not_silent(db_sync):
+    """Issue #1033: a second generate (force_regenerate=False) must report the
+    pre-existing rosters as `skipped` instead of silently returning created=[],
+    so the API can tell the admin nothing was rebuilt."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="skip_sch", name="Skip", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    own = _config(db_sync, sch, academic_year=115, code="SKIP-115", project_numbers={"nstc": "115R000001"})
+
+    ua = _student(db_sync, "skip_a")
+    app_a = _application(db_sync, ua, sch, own, app_id="APP-SKIP-A", std_code="115A", alloc_config_id=own.id)
+
+    ranking = CollegeRanking(
+        scholarship_type_id=sch.id,
+        sub_type_code="nstc",
+        academic_year=115,
+        semester="first",
+        ranking_name="R",
+        is_finalized=True,
+        ranking_status="finalized",
+        distribution_executed=True,
+    )
+    db_sync.add(ranking)
+    db_sync.flush()
+    db_sync.add(
+        CollegeRankingItem(
+            ranking_id=ranking.id,
+            application_id=app_a.id,
+            rank_position=1,
+            is_allocated=True,
+            allocated_sub_type="nstc",
+            allocation_config_id=own.id,
+            status="allocated",
+        )
+    )
+    db_sync.flush()
+    db_sync.commit()
+
+    svc = RosterService(db_sync)
+    kwargs = dict(
+        scholarship_type_id=sch.id,
+        academic_year=115,
+        semester="first",
+        created_by_user_id=admin.id,
+        student_verification_enabled=False,
+    )
+
+    first = svc.generate_rosters_from_distribution(**kwargs)
+    assert len(first.created) == 1
+    assert first.skipped == []
+
+    # Second run without force: the roster already exists → reported as skipped,
+    # nothing created (the silent "produced 0" success this fixes).
+    second = svc.generate_rosters_from_distribution(**kwargs)
+    assert second.created == []
+    assert len(second.skipped) == 1
+    assert second.skipped[0].id == first.created[0].id
+
+    # With force: the existing roster is rebuilt (created), not skipped.
+    forced = svc.generate_rosters_from_distribution(**kwargs, force_regenerate=True)
+    assert len(forced.created) == 1
+    assert forced.skipped == []
+    assert forced.created[0].id == first.created[0].id
+
+
+def test_force_regenerate_on_locked_roster_is_reported_not_500(db_sync):
+    """Issue #1033: force_regenerate on a LOCKED roster must be reported as
+    `locked` (so the API can say so), not raise and abort the whole batch."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="lock_sch", name="Lock", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    own = _config(db_sync, sch, academic_year=115, code="LOCK-115", project_numbers={"nstc": "115R000001"})
+
+    ua = _student(db_sync, "lock_a")
+    app_a = _application(db_sync, ua, sch, own, app_id="APP-LOCK-A", std_code="115A", alloc_config_id=own.id)
+
+    ranking = CollegeRanking(
+        scholarship_type_id=sch.id,
+        sub_type_code="nstc",
+        academic_year=115,
+        semester="first",
+        ranking_name="R",
+        is_finalized=True,
+        ranking_status="finalized",
+        distribution_executed=True,
+    )
+    db_sync.add(ranking)
+    db_sync.flush()
+    db_sync.add(
+        CollegeRankingItem(
+            ranking_id=ranking.id,
+            application_id=app_a.id,
+            rank_position=1,
+            is_allocated=True,
+            allocated_sub_type="nstc",
+            allocation_config_id=own.id,
+            status="allocated",
+        )
+    )
+    db_sync.flush()
+    db_sync.commit()
+
+    svc = RosterService(db_sync)
+    kwargs = dict(
+        scholarship_type_id=sch.id,
+        academic_year=115,
+        semester="first",
+        created_by_user_id=admin.id,
+        student_verification_enabled=False,
+    )
+
+    first = svc.generate_rosters_from_distribution(**kwargs)
+    assert len(first.created) == 1
+
+    # Lock the roster, then force-regenerate: it must not raise.
+    roster = first.created[0]
+    roster.status = RosterStatus.LOCKED
+    db_sync.commit()
+
+    forced = svc.generate_rosters_from_distribution(**kwargs, force_regenerate=True)
+    assert forced.created == []
+    assert forced.skipped == []
+    assert len(forced.locked) == 1
+    assert forced.locked[0].id == roster.id
+
+
+def test_build_roster_generation_message():
+    """The admin-facing summary never hides skipped/locked rosters (issue #1033)."""
+    assert _build_roster_generation_message(3, 0, 0) == "成功產生 3 個造冊"
+
+    only_skipped = _build_roster_generation_message(0, 2, 0)
+    assert "成功產生 0 個造冊" in only_skipped
+    assert "2 個造冊已存在" in only_skipped
+    assert "force_regenerate=true" in only_skipped
+
+    locked = _build_roster_generation_message(1, 0, 1)
+    assert "成功產生 1 個造冊" in locked
+    assert "1 個造冊已鎖定" in locked
+
+    both = _build_roster_generation_message(1, 2, 3)
+    assert "2 個造冊已存在" in both
+    assert "3 個造冊已鎖定" in both

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -20627,6 +20627,8 @@ export interface operations {
                 skip?: number;
                 limit?: number;
                 scholarship_configuration_id?: number | null;
+                /** @description 依獎學金類型過濾（透過所屬配置） */
+                scholarship_type_id?: number | null;
                 status_filter?: components["schemas"]["RosterStatus"] | null;
                 period_label?: string | null;
                 academic_year?: number | null;


### PR DESCRIPTION
Fixes #1033.

## Problem 1 — roster regeneration silently no-ops
`POST /manual-distribution/generate-rosters-from-distribution` returned `{"success": true, "message": "成功產生 0 個造冊", "rosters_created": 0}` when rosters already existed — hiding both that rosters were skipped and that `force_regenerate` (which already rebuilds with the latest data) exists. Admins who fixed student data saw "success" but no change.

- `RosterService.generate_rosters_from_distribution` now returns `RosterGenerationResult{created, skipped, locked}` instead of a bare list.
- The endpoint reports an honest message naming skipped rosters and how to rebuild (`force_regenerate=true`), plus `rosters_skipped` / `skipped_rosters` in the payload.
- `force_regenerate` on a **locked** roster is now reported as `locked` rather than raising `RosterLockedError` and 500-ing the whole batch — important now that the message actively tells admins to retry with force. (Surfaced by code review.)

> Note: `force_regenerate` and its "rebuild with fresh data" behavior already existed — the bug was purely visibility, so no new rebuild logic was added.

## Problem 2 — `scholarship_type_id` / `semester` / `config_id` null on roster responses
Rosters link to scholarship type/semester/config only via `scholarship_configuration_id → ScholarshipConfiguration`; the structured values were never surfaced.

- Derive `config_id` / `scholarship_type_id` / `semester` from the eager-loaded config in the list and single-get endpoints (added as optional fields on `RosterResponse`).
- Add a `scholarship_type_id` query filter to the list endpoint (joins via the config).

> Note: **no DB migration** — the structured FK already exists through `scholarship_configuration_id`; deriving avoids a migration and write-time sync bugs.

## Test plan
- [x] 4 new regression tests: skip/force/locked reporting, message builder, derived config fields, `scholarship_type_id` filter (both directions).
- [x] 1 existing test updated for the new return type.
- [x] 576 roster/distribution/exception tests pass locally (SQLite test DB).
- [ ] CI green.

## Follow-up (out of scope, not blocking)
Frontend types are hand-maintained TS (no OpenAPI client); the new fields/message are additive, but the admin UI won't surface the skip/locked message until the frontend is updated to render `rosters_skipped` / `rosters_locked` / `message`.