### PR TITLE
docs(skill): multi-college ranking→distribution→roster verification (Playwright)

### DIFF
--- a/.claude/skills/playwright-test-and-debug/SKILL.md
+++ b/.claude/skills/playwright-test-and-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-test-and-debug
-description: Drive browser-based actions against the scholarship-system localhost dev env (http://localhost:3000), AND when something diverges from the codebase's spec, walk an integrated diagnose-and-fix loop — tail backend logs, query Postgres, classify the gap, and patch the responsible layer. Use this skill whenever the user asks to drive a quick local browser test, screenshot a page, log in as a seeded user (admin / cs_professor / cs_college / stuphd001 / stuunder1 / etc.) and click through a flow, debug why a localhost endpoint is returning 5xx or behaving unexpectedly, dump application/review/whitelist DB state, OR — most importantly — verify a recent code change end-to-end ("I just finished feature X / fixed bug Y, smoke-test that it works"). Treat any post-change verification request, any "make sure my localhost change works" prompt, any "the e2e test in frontend/e2e failed — figure out why" debugging request, and any "log in as <seeded user> and check the dashboard" exploratory request as a trigger. Do NOT use for staging (use `nycu-sso-login` for `ss.test.nycu.edu.tw`), and do NOT use for setting up a new `@playwright/test` runner from scratch (that's a project-config task, not session tooling).
+description: Drive browser-based actions against the scholarship-system localhost dev env (http://localhost:3000), AND when something diverges from the codebase's spec, walk an integrated diagnose-and-fix loop — tail backend logs, query Postgres, classify the gap, and patch the responsible layer. Use this skill whenever the user asks to drive a quick local browser test, screenshot a page, log in as a seeded user (admin / cs_professor / cs_college / stuphd001 / stuunder1 / etc.) and click through a flow, debug why a localhost endpoint is returning 5xx or behaving unexpectedly, dump application/review/whitelist DB state, OR — most importantly — verify a recent code change end-to-end ("I just finished feature X / fixed bug Y, smoke-test that it works"). Treat any post-change verification request, any "make sure my localhost change works" prompt, any "the e2e test in frontend/e2e failed — figure out why" debugging request, and any "log in as <seeded user> and check the dashboard" exploratory request as a trigger. Includes a ready-made multi-college ranking→distribution→roster end-to-end driver (`scripts/verify-multi-college-distribution.js`) for the #1029/#1034 college-pipeline regression. Do NOT use for staging (use `nycu-sso-login` for `ss.test.nycu.edu.tw`), and do NOT use for setting up a new `@playwright/test` runner from scratch (that's a project-config task, not session tooling).
 ---
 
 # Playwright local test & debug (scholarship-system dev env)
@@ -257,6 +257,9 @@ SELECT created_at, action, status, description, trace_id
 | JWT 401 mid-script | Tokens expire (~30 min) | Re-login via `scripts/login-mock-sso.sh`; don't retry-loop |
 | Frontend shows dev login picker even after injecting `auth_token` | `useAuth` requires BOTH `auth_token` AND `user`/`dev_user` in localStorage | Use `scripts/build-storage-state.sh <nycu_id>` — it sets both |
 | `ORDER BY role` returns unexpected order (e.g. students before admins) | Postgres enum columns sort by **declaration order**, not alphabetical. The enum is declared `student, professor, college, admin, super_admin`, so `ORDER BY role` puts students first | Either `ORDER BY role::text` (alphabetical) or live with declaration order |
+| Admin 獎學金分發 grid is empty even though finalized rankings exist | The panel's 學期 `<select>` defaults to the FIRST semester, which usually has no data | Explicitly `selectOption({label:'全年'})` (yearly) / the right semester before reading the grid — `/manual-distribution/students` returns `[]` for the wrong semester |
+| Playwright wait on a college name (`電機學院`) never resolves in the distribution panel | The 所屬學院 filter `<option>`s carry that text but are **hidden** (closed `<select>`) | Wait on the visible `儲存目前配置` button instead; read colleges from the filter's `<option>` values via `evaluateAll` |
+| College `建立新排名` makes a `sub_type_code="default"` ranking, not `nstc` | The UI uses the config's first sub-type (`subTypes[0]`), which is `default` (aggregates all sub-types) | Expected — `get_students_for_distribution` reads **every** finalized ranking regardless of `sub_type`, so distribution still works |
 
 ## Regression test scenarios
 
@@ -528,6 +531,67 @@ curl -s "$SS_BASE/admin/email/scheduled?limit=5" \
 
 **Key DB tables** (localhost only, via `scripts/db-query.sh`):
 `applications` (status, professor_id), `scheduled_emails` (recipient_email, html_body, status).
+
+---
+
+### Multi-college ranking → distribution → roster (#1029 / #1034)
+
+Verifies the full college pipeline across **multiple colleges**: each college reviewer
+finalizes its own ranking, then admin distributes and generates rosters. The regression
+this guards (#1034): **finalizing one college's ranking must NOT un-finalize the others**,
+and admin distribution must surface **all** colleges — not just the last one finalized.
+
+**Trigger when**: `college_review_service.py`, `manual_distribution_service.py`,
+`roster_service.py`, or anything under `api/v1/endpoints/college_review/` changes.
+
+**Actors**: one `college` reviewer per target college + `admin`. College reviewers are
+scoped by `users.college_code`; a ranking is auto-populated with that college's apps
+(college = `student_data->>'std_academyno'`). The seed set ships `college`/`cs_college`
+(both code `C`); this session also created `hum_college`(A), `bio_college`(B), `ee_college`(E).
+If your target colleges lack a reviewer, create one per code first.
+
+**Setup — confirm there are submitted apps across ≥2 colleges** (else rankings are empty):
+```bash
+scripts/db-query.sh "SELECT student_data->>'std_academyno' college, sub_scholarship_type, count(*)
+  FROM applications WHERE scholarship_type_id=2 AND academic_year=114 AND status='submitted'
+  GROUP BY 1,2 ORDER BY 1;"   # status must be in REVIEWABLE_APPLICATION_STATUSES
+scripts/db-query.sh "SELECT nycu_id, college_code FROM users WHERE role='college' ORDER BY college_code;"
+```
+
+**Run the bundled driver** (Playwright UI + DB ground-truth at every step):
+```bash
+NODE_PATH=$(npm root -g) \
+COLLEGES='A:hum_college,B:bio_college,C:cs_college,E:ee_college' \
+TYPE_TAB='博士生獎學金' YEAR_LABEL='114 學年度' SEM_LABEL='全年' \
+OUT=/tmp/mc-verify node scripts/verify-multi-college-distribution.js
+```
+Exit 0 ⇒ all colleges stayed finalized, distribution surfaced all of them, **and** the
+distribution run completed without error. Screenshots + `result.json` + `log.txt` land in `$OUT`. The script starts from a clean slate — if rankings
+already exist (re-run), `scripts/reset-db.sh` first, since college `建立新排名` always
+`force_new`s a duplicate.
+
+**What it asserts (and the exact UI it drives):**
+1. Per college (login → tab `學生排序` → `建立新排名` → `確認排名`, toast `排名已成功鎖定`):
+   after each finalize, `SELECT DISTINCT college_code FROM college_rankings WHERE is_finalized`
+   must be a **superset** of all colleges finalized so far. Progression should be
+   `[A] → [A,B] → [A,B,C] → [A,B,C,E]` — any drop is the #1034 regression.
+2. Admin (`獎學金分發` tab → type tab → pick `學年度`+`全年` → `儲存目前配置` → `確認分發` →
+   dialog `確認執行分發？` → `確認執行`): the 所屬學院 filter lists **all** colleges; result
+   message `分發完成：核准 N 人，拒絕 M 人`; DB shows `distribution_executed=true` and the
+   apps flip to `approved`.
+3. Roster (`生成造冊` → `確認產生造冊？` → `確認產生`): `payment_rosters` count > 0 (one per
+   sub-type group). Cross-check: `scripts/db-query.sh "SELECT count(*) FROM payment_rosters;"`.
+
+**Manual cross-check (no browser)** — the backend half, useful when the UI step flakes:
+```bash
+TOKEN=$(scripts/login-mock-sso.sh admin | jq -r .data.access_token)
+curl -s "http://localhost:8000/api/v1/manual-distribution/students?scholarship_type_id=2&academic_year=114&semester=yearly" \
+  -H "Authorization: Bearer $TOKEN" | jq '.data | group_by(.college_code) | map({(.[0].college_code): length}) | add'
+# expect every target college present, e.g. {"A":2,"B":2,"C":3,"E":2}; semester=first returns [] (omitting semester is a 422)
+```
+
+**Key tables**: `college_rankings` (`college_code`, `is_finalized`, `distribution_executed`),
+`college_ranking_items`, `applications` (`status`), `payment_rosters`.
 
 ---
 

--- a/.claude/skills/playwright-test-and-debug/scripts/verify-multi-college-distribution.js
+++ b/.claude/skills/playwright-test-and-debug/scripts/verify-multi-college-distribution.js
@@ -1,0 +1,175 @@
+// Multi-college end-to-end verification: ranking -> distribution -> roster.
+// Drives the real frontend UI as each college reviewer + admin, and uses the
+// DB as ground truth at each step. Encodes the #1029 / #1034 regression check:
+// finalizing one college's ranking must NOT un-finalize the others, and admin
+// distribution must see ALL colleges (not just the last finalized one).
+//
+// Run (from the skill scripts/ dir, dev stack up):
+//   NODE_PATH=$(npm root -g) \
+//   COLLEGES='A:hum_college,B:bio_college,C:cs_college,E:ee_college' \
+//   TYPE_TAB='博士生獎學金' YEAR_LABEL='114 學年度' SEM_LABEL='全年' \
+//   OUT=/tmp/mc-verify node verify-multi-college-distribution.js
+//
+// Notes / gotchas this script bakes in (do not "fix" them away):
+//  * Auth restore needs BOTH auth_token AND a user blob in localStorage
+//    (frontend/hooks/use-auth.tsx) — same contract as build-storage-state.sh.
+//    Token-only => silently bounced to /dev-login.
+//  * College "建立新排名" creates a ranking for the config's first sub-type,
+//    which is "default" (aggregates ALL sub-types). distribution reads every
+//    finalized ranking regardless of sub_type, so "default" is fine.
+//  * The admin distribution panel defaults to the FIRST semester, which often
+//    has no data -> empty grid. You MUST select the correct semester (全年 for
+//    yearly cycles) or the grid is empty and finalize finds nothing.
+//  * The 所屬學院 filter <option>s are hidden; never wait on a college name to
+//    be "visible" — wait on the visible 儲存目前配置 button instead.
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const { chromium } = require('playwright');
+
+const FE = process.env.FE || 'http://localhost:3000';
+const API = process.env.API || 'http://localhost:8000';
+const OUT = process.env.OUT || `/tmp/mc-verify-${process.pid}`;
+const ADMIN = process.env.ADMIN || 'admin';
+const TYPE_TAB = process.env.TYPE_TAB || '博士生獎學金';
+const YEAR_LABEL = process.env.YEAR_LABEL || '114 學年度';
+const SEM_LABEL = process.env.SEM_LABEL || '全年';
+// "A:hum_college,B:bio_college,..." -> [{code,user}]
+const COLLEGES = (process.env.COLLEGES || 'A:hum_college,B:bio_college,C:cs_college,E:ee_college')
+  .split(',').map(s => { const [code, user] = s.split(':'); return { code: code.trim(), user: user.trim() }; });
+
+fs.mkdirSync(OUT, { recursive: true });
+const DBQ = path.join(__dirname, 'db-query.sh');
+const log = [];
+const say = m => { const l = `[${new Date().toISOString()}] ${m}`; console.log(l); log.push(l); };
+
+// Ground-truth: which colleges currently hold a finalized ranking.
+function finalizedColleges() {
+  const out = execFileSync('bash', [DBQ,
+    "SELECT string_agg(DISTINCT college_code, ',' ORDER BY college_code) FROM college_rankings WHERE is_finalized IS TRUE;"],
+    { encoding: 'utf8' });
+  const line = out.split('\n').map(s => s.trim()).filter(s => s && !s.startsWith('-') && !/^\(/.test(s));
+  // psql -c prints header then value then row count; the value row is the 2nd non-decoration line
+  const val = line[1] || '';
+  return val.split(',').map(s => s.trim()).filter(Boolean).sort();
+}
+
+async function mockAuth(request, nycu_id) {
+  const r = await request.post(`${API}/api/v1/auth/mock-sso/login`, { data: { nycu_id } });
+  const j = await r.json();
+  if (!j.success) throw new Error(`mock-sso login failed for ${nycu_id}: ${JSON.stringify(j)}`);
+  return { token: j.data.access_token, user: j.data.user };
+}
+
+async function authedContext(browser, auth) {
+  const ctx = await browser.newContext({ viewport: { width: 1600, height: 1300 }, locale: 'zh-TW' });
+  await ctx.addInitScript(a => {
+    localStorage.setItem('auth_token', a.token);
+    localStorage.setItem('user', JSON.stringify(a.user));
+    localStorage.setItem('dev_user', JSON.stringify(a.user));
+  }, auth);
+  return ctx;
+}
+
+async function finalizeCollege(browser, c, idx) {
+  say(`=== College ${c.code} (${c.user}): create + finalize ranking ===`);
+  const ctx = await authedContext(browser, await mockAuth(browser.__req, c.user));
+  const page = await ctx.newPage();
+  try {
+    await page.goto(`${FE}/`, { waitUntil: 'networkidle' });
+    await page.getByRole('tab', { name: '學生排序' }).first().click({ timeout: 30000 });
+    await page.getByRole('heading', { name: /學生排序管理/ }).first().waitFor({ timeout: 30000 });
+    await page.getByRole('button', { name: '建立新排名' }).first().click({ timeout: 30000 });
+    const finalize = page.getByRole('button', { name: '確認排名' }).first();
+    await finalize.waitFor({ timeout: 30000 });
+    await page.waitForTimeout(1500);
+    await finalize.click();
+    await page.getByText(/排名已成功鎖定|此排名已確認/).first().waitFor({ timeout: 30000 });
+    await page.screenshot({ path: `${OUT}/college-${c.code}-finalized.png`, fullPage: true });
+    say(`  College ${c.code} finalized OK`);
+  } catch (e) {
+    await page.screenshot({ path: `${OUT}/college-${c.code}-ERROR.png`, fullPage: true });
+    throw new Error(`College ${c.code} finalize failed: ${e.message}`);
+  } finally { await ctx.close(); }
+
+  // #1034 regression: every college finalized so far must STILL be finalized.
+  const got = finalizedColleges();
+  const want = COLLEGES.slice(0, idx + 1).map(x => x.code).sort();
+  const missing = want.filter(x => !got.includes(x));
+  say(`  finalized colleges now=[${got}] expected superset of [${want}]`);
+  if (missing.length) throw new Error(`REGRESSION (#1034): finalizing ${c.code} dropped colleges ${missing}`);
+}
+
+async function adminDistributeAndRoster(browser) {
+  say('=== Admin: distribution + roster ===');
+  const ctx = await authedContext(browser, await mockAuth(browser.__req, ADMIN));
+  const page = await ctx.newPage();
+  const res = { collegesSeen: [], distribution: null, roster: null };
+  try {
+    await page.goto(`${FE}/`, { waitUntil: 'networkidle' });
+    await page.getByRole('tab', { name: '獎學金分發' }).first().click({ timeout: 30000 });
+    try { await page.getByRole('tab', { name: new RegExp(TYPE_TAB) }).first().click({ timeout: 8000 }); } catch (_) {}
+    await page.getByRole('heading', { name: /手動分發/ }).first().waitFor({ timeout: 30000 });
+    // Native <select>s — pick year + semester so the grid actually loads.
+    const yearSel = page.locator('select').filter({ has: page.locator('option', { hasText: '選擇學年度' }) }).first();
+    const semSel = page.locator('select').filter({ has: page.locator('option', { hasText: '選擇學期' }) }).first();
+    await yearSel.selectOption({ label: YEAR_LABEL });
+    await semSel.selectOption({ label: SEM_LABEL });
+    // Grid populated <=> the visible 儲存目前配置 button renders (NOT the hidden college <option>s).
+    await page.getByRole('button', { name: '儲存目前配置' }).first().waitFor({ timeout: 30000 });
+    await page.waitForTimeout(1500);
+    const filterSel = page.locator('select').filter({ has: page.locator('option', { hasText: '全部學院' }) }).first();
+    res.collegesSeen = await filterSel.locator('option').evaluateAll(os => os.map(o => o.value).filter(Boolean));
+    say(`  distribution grid colleges=[${res.collegesSeen}]`);
+    await page.screenshot({ path: `${OUT}/distribution-allcolleges.png`, fullPage: true });
+
+    await page.getByRole('button', { name: '儲存目前配置' }).first().click({ timeout: 15000 });
+    await page.waitForTimeout(2500);
+    await page.getByRole('button', { name: /確認分發/ }).first().click({ timeout: 20000 });
+    await page.getByText('確認執行分發？').first().waitFor({ timeout: 15000 });
+    await page.getByRole('button', { name: '確認執行' }).first().click({ timeout: 15000 });
+    const dm = page.getByText(/分發完成：核准/).first();
+    await dm.waitFor({ timeout: 40000 });
+    res.distribution = (await dm.textContent())?.trim();
+    say(`  ${res.distribution}`);
+    await page.screenshot({ path: `${OUT}/distribution-done.png`, fullPage: true });
+
+    await page.getByRole('button', { name: '生成造冊' }).first().click({ timeout: 15000 });
+    await page.getByText('確認產生造冊？').first().waitFor({ timeout: 15000 });
+    await page.getByRole('button', { name: '確認產生' }).first().click({ timeout: 15000 });
+    await page.waitForTimeout(3000);
+    // Strip psql decoration (header / '----' / '(1 row)') the same way finalizedColleges does —
+    // a naive /\d+/g .pop() would grab the "1" from "(1 row)", not the real count.
+    const rosterOut = execFileSync('bash', [DBQ, 'SELECT count(*) FROM payment_rosters;'], { encoding: 'utf8' });
+    res.roster = rosterOut.split('\n').map(s => s.trim()).filter(s => s && !s.startsWith('-') && !/^\(/.test(s))[1];
+    say(`  payment_rosters=${res.roster}`);
+    await page.screenshot({ path: `${OUT}/roster.png`, fullPage: true });
+  } catch (e) {
+    await page.screenshot({ path: `${OUT}/admin-ERROR.png`, fullPage: true });
+    res.error = e.message;
+  } finally { await ctx.close(); }
+  return res;
+}
+
+(async () => {
+  say(`pre-run finalized=[${finalizedColleges()}]  (expect empty for a clean run)`);
+  const browser = await chromium.launch({ headless: true });
+  browser.__req = (await browser.newContext()).request;
+  const summary = { ok: false };
+  try {
+    for (let i = 0; i < COLLEGES.length; i++) await finalizeCollege(browser, COLLEGES[i], i);
+    summary.admin = await adminDistributeAndRoster(browser);
+    const finalized = finalizedColleges();
+    const codes = COLLEGES.map(c => c.code).sort();
+    summary.allFinalized = codes.every(c => finalized.includes(c));
+    summary.distributionSeesAll = summary.admin && codes.every(c => summary.admin.collegesSeen.includes(c));
+    summary.ok = summary.allFinalized && summary.distributionSeesAll && !!summary.admin.distribution && !summary.admin.error;
+    say(`FINAL finalized=[${finalized}] allFinalized=${summary.allFinalized} distributionSeesAll=${summary.distributionSeesAll}`);
+  } catch (e) { summary.error = e.message; say(`FATAL ${e.message}`); }
+  finally { await browser.close(); }
+  fs.writeFileSync(`${OUT}/result.json`, JSON.stringify(summary, null, 2));
+  fs.writeFileSync(`${OUT}/log.txt`, log.join('\n'));
+  say(`RESULT ok=${summary.ok}  (artifacts in ${OUT})`);
+  process.exit(summary.ok ? 0 : 1);
+})().catch(e => { console.error('FATAL (pre-run/launch):', e); process.exit(1); });


### PR DESCRIPTION
## What

Captures the multi-college **ranking → distribution → roster** verification process (developed while re-verifying #1029 on merged `main`) as a reusable part of the `playwright-test-and-debug` skill.

### Added
- **`scripts/verify-multi-college-distribution.js`** — a parameterized Playwright driver that, for each college reviewer, logs in (mock-SSO), creates + finalizes a ranking, and asserts via **direct DB queries** that finalizing one college never un-finalizes the others (the #1034 regression), then drives admin distribution + roster and confirms all colleges are surfaced. Env-configurable: `COLLEGES`, `TYPE_TAB`, `YEAR_LABEL`, `SEM_LABEL`, `OUT`, `ADMIN`.
- **Named regression scenario** in `SKILL.md`: "Multi-college ranking → distribution → roster (#1029 / #1034)" — trigger files, actor/setup notes, exact UI selectors driven, DB ground-truth assertions, and a no-browser API cross-check.
- **Three pre-debugged pitfalls** in the Common pitfalls table:
  - admin distribution grid empty because the 學期 `<select>` defaults to the first semester (no data) → must select 全年;
  - Playwright waits on a college name never resolve (hidden 所屬學院 `<option>`s) → wait on the visible `儲存目前配置` button;
  - college `建立新排名` makes a `sub_type_code="default"` ranking (aggregates all sub-types) — expected, distribution reads all finalized rankings regardless of sub_type.

## Why
The plumbing (mock-SSO login, `build-storage-state.sh`, `db-query.sh`) already existed in this skill; what was missing was the college-pipeline-specific recipe and its gotchas. Encoding it here (rather than a new skill) keeps it DRY and discoverable for future "verify the college flow" / post-change requests.

## Verification
- All 21 UI selector strings in the doc/script were re-checked against the current frontend source (RankingManagementPanel, college-ranking-table, ManualDistributionPanel, page.tsx) — all present.
- Backend/DB claims (columns, `REVIEWABLE_APPLICATION_STATUSES`, `/manual-distribution/students` semester behavior, the #1034 finalize scoping) verified against source.
- Script passes `node --check`; a roster-count psql-parsing bug found in review was fixed.
- The process itself was run end-to-end on `main` for #1029 (4 colleges, all stayed finalized, 9 approved, 2 rosters).

Docs-only; no runtime code touched.
