### PR TITLE
fix(staging): stop deploy-time OOM (cap monitoring memory) + dedup e2e failure issue

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -286,11 +286,14 @@ jobs:
             --color "d73a4a" \
             --description "Auto-filed by the staging-e2e replica lane" \
             2>/dev/null || true
+          # Reuse a single rolling issue: comment on ANY open staging-e2e-failure
+          # issue instead of opening one per day. (Previously keyed on the date in
+          # the title, which spawned a new issue every night staging stayed down —
+          # e.g. #1023/#1025/#1027/#1030 for one underlying outage.)
           existing=$(gh issue list \
             --repo ${{ github.repository }} \
             --label staging-e2e-failure \
             --state open \
-            --search "in:title $today" \
             --json number \
             --jq '.[0].number' || echo '')
           body=$(cat <<EOF

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -141,6 +141,12 @@ services:
     depends_on:
       - backend
       - frontend
+    # Hard memory cap (issue: AP-VM OOM during deploy). The AP VM co-hosts the
+    # full app stack AND five monitoring containers; an uncapped alloy can grow
+    # large enough that `alembic upgrade head` gets OOM-killed (exit 137) during
+    # `deploy-pipeline.yml`, which then fails rollback and leaves staging down.
+    # Capping the monitoring stack keeps host headroom for the migration spike.
+    mem_limit: 256m
     logging:
       driver: "json-file"
       options:
@@ -163,6 +169,7 @@ services:
     networks:
       - scholarship_staging_network
     restart: unless-stopped
+    mem_limit: 64m  # see alloy: AP-VM OOM headroom during deploy
     logging:
       driver: "json-file"
       options:
@@ -222,6 +229,7 @@ services:
     networks:
       - scholarship_staging_network
     restart: unless-stopped
+    mem_limit: 32m  # see alloy: AP-VM OOM headroom during deploy
     logging:
       driver: "json-file"
       options:
@@ -242,6 +250,7 @@ services:
     networks:
       - scholarship_staging_network
     restart: unless-stopped
+    mem_limit: 48m  # see alloy: AP-VM OOM headroom during deploy
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## Problem — live staging is DOWN

The daily **Staging E2E** failures (#1023, #1025, #1027, #1030) and the failing **Deployment Pipeline** share one root cause: the staging deploy is OOM-killing itself.

From the latest deploy run (2026-06-17, run 27706665656):

```
Running Alembic migrations...
docker exec scholarship_backend_staging alembic upgrade head
##[error]Process completed with exit code 137        # <- SIGKILL, OOM
##[error]Rollback health check also failed. Manual intervention required.
```

The staging-e2e lane then can't reach a healthy live backend on its pre-check, so it fails and auto-files an issue — every night staging stays down.

### Why it OOMs

The AP VM co-hosts the **full app stack** (backend, frontend, redis, nginx) **plus five monitoring containers** (alloy, node-exporter, cadvisor, nginx-exporter, redis-exporter). Only `cadvisor` had a `mem_limit`. An uncapped `alloy` can grow large enough that the brief `alembic upgrade head` memory spike pushes the host over its limit and the kernel OOM-kills the alembic process. (The PII encryption migration is already batched + idempotent, so the spike is the app import + transient working set, not a runaway migration.)

## Fix

1. **Cap the four previously-uncapped monitoring containers** in `docker-compose.staging.yml` — alloy `256m`, node-exporter `64m`, nginx-exporter `32m`, redis-exporter `48m`. Self-applying: `deploy-pipeline.yml` runs `down` → `up -d` (new caps active) → `migrate`, so the **next deploy** runs the migration with restored host headroom. The caps also protect the rollback `up -d` + `/health`.

2. **Dedup the staging-e2e failure issue** — the file-issue step keyed dedup on the date in the title, so a multi-day outage opened a fresh issue each night. Now it reuses a single rolling open `staging-e2e-failure` issue (comments instead of re-opens).

## Operator note (not code-fixable)

If the OOM persists after capping, the AP VM genuinely needs **more RAM or a swapfile**. The secrets (`STUDENT_API_HMAC_KEY`, `PII_ENCRYPTION_KEYS`) are present and correct; the transient mock-key boot error seen on 2026-06-16 was a botched-recovery artifact, not a missing secret.

## Verification

- YAML validated for both edited files.
- True confirmation is the next Deployment Pipeline run reaching a green `alembic upgrade head` and staging `/health` recovering, after which the staging-e2e lane goes green and stops filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)