### PR TITLE
fix(#953): pin claude-code-action to @v1 (direct_prompt → prompt)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         # Optional: Skip review for certain conditions
         if: |
           github.event.pull_request.draft == false &&
@@ -44,8 +44,9 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Prompt for automated review (no @claude mention needed).
+          # v1 renamed the beta `direct_prompt` input to `prompt`.
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues


### PR DESCRIPTION
Fixes #953

## Problem
The `Claude Code Review` workflow has failed on **every** branch since ~2026-06-10 (incl. clean reruns of unchanged commits). The break is inside the moving `@beta` tag of `anthropics/claude-code-action`:

```
Copying slash commands from .../claude-code-action/beta/slash-commands ...
Slash commands directory not found or error copying: ShellError: Failed with exit code 1
##[error]Process completed with exit code 1.
```

Confirmed still failing today on multiple branches.

## Fix
- Pin `anthropics/claude-code-action@beta` → **`@v1`** (stable major tag; latest is `v1.0.150`). `@v1` still gets patches but won't break out from under us like the rolling `beta`.
- Migrate the beta-only `direct_prompt` input to v1's **`prompt`** (the review prompt is otherwise unchanged).

## Verification
- YAML validated.
- The workflow triggers on `pull_request` — this PR's own `Claude Code Review` run exercises the v1 action and should go green (vs. the red beta runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)