### PR TITLE
test(e2e): capture a screenshot for every test (screenshot: on)

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,7 +18,9 @@ export default defineConfig({
     baseURL: FRONTEND_URL,
     trace: "retain-on-failure",
     video: "retain-on-failure",
-    screenshot: "only-on-failure",
+    // "on": capture a screenshot at the end of EVERY test (pass or fail) so the
+    // GitHub Pages e2e report always shows screenshots, not only on failures.
+    screenshot: "on",
     viewport: { width: 1440, height: 900 },
   },
   projects: [


### PR DESCRIPTION
Follow-up to #1037 (e2e report → GitHub Pages). With `screenshot: only-on-failure`, a fully-passing nightly produces a report with **no screenshots**. Switch to `screenshot: "on"` so every test embeds an end-of-test screenshot → the Pages report (https://anud18.github.io/scholarship-system/) is a browsable screenshot gallery on every run, pass or fail.

`trace`/`video` stay `retain-on-failure` (those are heavy; screenshots are light).

🤖 Generated with [Claude Code](https://claude.com/claude-code)