### PR TITLE
fix(staging): wait for backend boot before migrating (stop deploy OOM)

### DIFF
--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -266,6 +266,19 @@ jobs:
 
       - name: Run database migrations
         run: |
+          # Wait for the backend to finish booting before migrating. The AP VM is
+          # memory-tight: if `alembic upgrade head` (a second full app import) runs
+          # while uvicorn is still mid-boot, the two memory spikes overlap and the
+          # kernel OOM-kills alembic (exit 137), failing the deploy. /health only
+          # checks DB connectivity, not schema, so it is safe to wait on pre-migration.
+          echo "Waiting for backend to finish booting (settle boot memory spike)..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/health >/dev/null; then
+              echo "Backend up after ${i} attempt(s)"
+              break
+            fi
+            sleep 2
+          done
           echo "Running Alembic migrations..."
           docker exec scholarship_backend_staging alembic upgrade head
 


### PR DESCRIPTION
## Problem

Even after #1039 capped the monitoring containers, the **Deployment Pipeline** still fails: `alembic upgrade head` is OOM-killed (exit 137) **~1.4s after it starts** (run 27760746776).

That timing is the tell: the backend container is reported `Started` only ~2.5s before the migration `docker exec` fires, so uvicorn is **still mid-boot**. The backend boot memory spike and alembic's second full-app-import spike **overlap**, tipping the memory-tight AP VM over its ceiling — the kernel kills alembic before it does meaningful work.

## Fix

Serialize the two spikes: poll `/health` (up to 60s) before running the migration, so the backend boot spike settles first. `/health` checks DB **connectivity only, not schema**, so waiting on it pre-migration is deadlock-free.

This stacks with #1039's host-headroom caps.

## Verification

- YAML validated.
- True confirmation is the next Deployment Pipeline run reaching a green `alembic upgrade head` and staging `/health` recovering.

If it still OOMs after this, the AP VM genuinely needs more RAM / a swapfile (operator note from #1039) — not code-fixable.