### PR TITLE
fix(roster): include all colleges when generating matrix roster without ranking_id

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -243,6 +243,27 @@ def _generate_payment_roster_inner(
             finally:
                 independent_db.close()
 
+        # generate_roster wraps every internal failure in RosterGenerationError,
+        # preserving the original exception as __cause__ (contract pinned by
+        # test_roster_generate_concurrency). Re-dispatch on that cause so the
+        # client sees the REAL reason + correct HTTP status instead of an opaque
+        # 「造冊產生失敗」. Only curated domain messages are surfaced; raw/unexpected
+        # causes stay generic so internal detail (filesystem paths, SQL, SDK
+        # errors) never leaks — see test_no_exception_leak_in_endpoints.
+        cause = e.__cause__
+        if isinstance(cause, RosterAlreadyExistsError):
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(cause)) from e
+        if isinstance(cause, RosterLockedError):
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(cause)) from e
+        if isinstance(cause, RosterNotFoundError):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(cause)) from e
+        if isinstance(cause, ValueError):
+            # Curated validation messages (missing config/ranking, distribution
+            # not executed, no allocated ranking) — safe and actionable.
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(cause)) from e
+        if isinstance(cause, RosterGenerationError):
+            # Curated data-consistency summary from validate_roster_consistency.
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(cause)) from e
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="造冊產生失敗") from e
 
     except ValueError as e:

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -588,22 +588,10 @@ async def preview_roster_students(
         # Check if has matrix distribution
         has_matrix_distribution = config.quota_management_mode == QuotaManagementMode.matrix_based
 
-        # Auto-detect ranking_id if needed
-        if has_matrix_distribution and not ranking_id:
-            ranking = (
-                db.query(CollegeRanking)
-                .filter(
-                    and_(
-                        CollegeRanking.scholarship_type_id == config.scholarship_type_id,
-                        CollegeRanking.distribution_executed.is_(True),
-                    )
-                )
-                .order_by(CollegeRanking.created_at.desc())
-                .first()
-            )
-            if ranking:
-                ranking_id = ranking.id
-                logger.info(f"Auto-detected ranking_id: {ranking_id}")
+        # NOTE: 不在此處自挑單一排名。ranking_id 為 None 時交由
+        # roster_service._get_eligible_applications 聚合「所有」已執行分發的排名
+        # （= 全院），與 generate_roster 走同一條路 → 預覽與產生保證一致。
+        # 明確指定 ranking_id 時則只預覽該排名。
 
         # Get eligible applications using RosterService
         logger.info(

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -700,21 +700,19 @@ class RosterService:
                     f"all-college roster (type {config.scholarship_type_id}, year {academic_year})"
                 )
 
-                # 聚合所有排名的正取申請。一個申請最多屬於一份排名，故 .in_() 不會重複。
-                query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(
-                    and_(
-                        CollegeRankingItem.ranking_id.in_(ranking_ids),
-                        CollegeRankingItem.is_allocated.is_(True),
-                    )
-                )
+                # 聚合所有排名：一個申請最多屬於一份排名，故 .in_() 不會重複。
+                ranking_filter = CollegeRankingItem.ranking_id.in_(ranking_ids)
             else:
-                # 明確指定排名：僅該排名的正取申請（管理員刻意選擇單一排名）。
-                query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(
-                    and_(
-                        CollegeRankingItem.ranking_id == ranking_id,
-                        CollegeRankingItem.is_allocated.is_(True),
-                    )
+                # 明確指定排名：僅該排名（管理員刻意選擇單一排名）。
+                ranking_filter = CollegeRankingItem.ranking_id == ranking_id
+
+            # 只選取 ranking 中已分配(正取)的申請。
+            query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(
+                and_(
+                    ranking_filter,
+                    CollegeRankingItem.is_allocated.is_(True),
                 )
+            )
         else:
             # 非 Matrix 模式 (none/simple/college_based)：直接從 approved 狀態選取
             logger.info(

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -868,7 +868,11 @@ class RosterService:
                     logger.info(f"Application {application.id} has backup allocations: {len(backup_info)} positions")
                 allocated_sub_type = ranking_item.allocated_sub_type
 
-        # 若無 ranking_id（月份造冊），從同學年度已分發排名中查詢子類型
+        # 若無 ranking_id（月份造冊），從同學年度已分發排名中查詢子類型。
+        # 此處僅 gate 在 is_allocated + academic_year（未含 is_finalized /
+        # distribution_executed）。其正確性依賴 _get_eligible_applications 已先以
+        # 「finalized + executed」篩選過申請：一個申請在同學年度只會有一筆有效正取
+        # （finalize 時會反鎖同 slot 的其他排名），故 .first() 取到的即為授權子類型。
         if not allocated_sub_type:
             alloc_item = (
                 self.db.query(CollegeRankingItem)

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -671,45 +671,50 @@ class RosterService:
             # Matrix 模式：必須使用 ranking + is_allocated 過濾
             logger.info(f"Using matrix-based filtering for scholarship config {scholarship_configuration_id}")
 
-            # 如果沒有提供 ranking_id，自動偵測最新的已執行分發的 ranking
+            # 未指定 ranking_id：聚合「所有」已執行分發的排名 → 多學院全院納入。
+            # matrix 分發下每個學院各有一份 CollegeRanking；過去只取最新一份
+            # (.order_by(finalized_at.desc()).first()) 會讓造冊只含最後鎖定的那一院。
             if ranking_id is None:
-                # 從 period_label 推導學期
-                semester = self._extract_semester_from_period(period_label)
-
-                # 查詢最新的已完成分發的 ranking
-                ranking = (
+                rankings = (
                     self.db.query(CollegeRanking)
                     .filter(
                         and_(
                             CollegeRanking.scholarship_type_id == config.scholarship_type_id,
                             CollegeRanking.academic_year == academic_year,
-                            CollegeRanking.is_finalized.is_(True),  # 必須已完成
-                            CollegeRanking.distribution_executed.is_(True),  # 必須已執行分發
+                            CollegeRanking.is_finalized.is_(True),
+                            CollegeRanking.distribution_executed.is_(True),
                         )
                     )
-                    .order_by(CollegeRanking.finalized_at.desc())
-                    .first()
+                    .all()
                 )
 
-                if not ranking:
+                if not rankings:
                     raise ValueError(
                         f"找不到已執行分發的排名。Matrix 模式獎學金必須先執行矩陣分發才能產生造冊。"
                         f"獎學金類型ID: {config.scholarship_type_id}, 學年度: {academic_year}"
                     )
 
-                ranking_id = ranking.id
+                ranking_ids = [r.id for r in rankings]
                 logger.info(
-                    f"Auto-detected ranking ID {ranking_id} "
-                    f"(finalized at {ranking.finalized_at}, {ranking.allocated_count} students allocated)"
+                    f"Aggregating {len(ranking_ids)} executed ranking(s) {ranking_ids} for "
+                    f"all-college roster (type {config.scholarship_type_id}, year {academic_year})"
                 )
 
-            # 只選取該 ranking 中已分配(正取)的申請
-            query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(
-                and_(
-                    CollegeRankingItem.ranking_id == ranking_id,
-                    CollegeRankingItem.is_allocated.is_(True),  # 只選正取學生
+                # 聚合所有排名的正取申請。一個申請最多屬於一份排名，故 .in_() 不會重複。
+                query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(
+                    and_(
+                        CollegeRankingItem.ranking_id.in_(ranking_ids),
+                        CollegeRankingItem.is_allocated.is_(True),
+                    )
                 )
-            )
+            else:
+                # 明確指定排名：僅該排名的正取申請（管理員刻意選擇單一排名）。
+                query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(
+                    and_(
+                        CollegeRankingItem.ranking_id == ranking_id,
+                        CollegeRankingItem.is_allocated.is_(True),
+                    )
+                )
         else:
             # 非 Matrix 模式 (none/simple/college_based)：直接從 approved 狀態選取
             logger.info(

--- a/backend/app/tests/test_roster_generation_error_detail.py
+++ b/backend/app/tests/test_roster_generation_error_detail.py
@@ -1,0 +1,186 @@
+"""
+Regression: roster generation failures must surface the REAL reason.
+
+Bug report: 造冊失敗時 UI 只顯示「產生造冊失敗: 造冊產生失敗」(generic), never the
+actual cause (e.g. 找不到已執行分發的排名 / 尚未執行分發 / 造冊資料一致性驗證失敗).
+
+Root cause: RosterService.generate_roster wraps every internal failure in
+RosterGenerationError(...) preserving the original as __cause__ (a contract
+pinned by test_roster_generate_concurrency). The endpoint handler
+(_generate_payment_roster_inner) caught RosterGenerationError but raised a
+hard-coded detail="造冊產生失敗", discarding the cause — so the curated reason
+never reached the client.
+
+Fix: the handler re-dispatches on e.__cause__ — surfacing the curated message +
+correct HTTP status for known domain causes, staying generic for raw/unexpected
+causes so internal detail (paths, SQL, SDK errors) never leaks
+(test_no_exception_leak_in_endpoints pins that invariant).
+
+These tests drive _generate_payment_roster_inner directly (the same approach
+test_roster_generate_concurrency uses for the service) and assert on the raised
+HTTPException's status_code + detail — the observable client-facing contract.
+"""
+
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.endpoints.payment_rosters import _generate_payment_roster_inner
+from app.core.exceptions import RosterGenerationError
+from app.models.enums import QuotaManagementMode, Semester
+from app.models.payment_roster import PaymentRoster, RosterCycle, RosterStatus, RosterTriggerType
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.schemas.roster import RosterCreateRequest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def patch_dependencies():
+    """No-op SIS verification + audit emits (mirrors the roster test suites)."""
+    with (
+        patch("app.services.roster_service.StudentVerificationService") as svs,
+        patch("app.services.roster_service.audit_service"),
+    ):
+        svs.return_value.verify_student.return_value = {"status": "verified", "verified": True, "data": {}}
+        yield
+
+
+def _admin(db_sync) -> User:
+    u = User(
+        nycu_id="roster_err_admin",
+        email="roster_err_admin@nycu.edu.tw",
+        name="Roster Err Admin",
+        role=UserRole.admin,
+        user_type=UserType.employee,
+    )
+    db_sync.add(u)
+    db_sync.commit()
+    db_sync.refresh(u)
+    return u
+
+
+def _scholarship(db_sync) -> ScholarshipType:
+    s = ScholarshipType(code="roster_err_sch", name="Roster Err Scholarship", description="x")
+    db_sync.add(s)
+    db_sync.commit()
+    db_sync.refresh(s)
+    return s
+
+
+def _config(db_sync, scholarship, *, quota_mode=QuotaManagementMode.simple) -> ScholarshipConfiguration:
+    c = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        config_code="RE-113-1",
+        config_name="Roster Err Config",
+        academic_year=113,
+        semester=Semester.first,
+        quota_management_mode=quota_mode,
+        has_quota_limit=False,
+        amount=50000,
+    )
+    db_sync.add(c)
+    db_sync.commit()
+    db_sync.refresh(c)
+    return c
+
+
+def _request(config, **overrides) -> RosterCreateRequest:
+    base = dict(
+        scholarship_configuration_id=config.id,
+        period_label="113-1",
+        roster_cycle=RosterCycle.MONTHLY,
+        academic_year=113,
+        student_verification_enabled=False,
+        ranking_id=None,
+        auto_export_excel=False,
+        force_regenerate=False,
+    )
+    base.update(overrides)
+    return RosterCreateRequest(**base)
+
+
+def test_matrix_no_executed_ranking_surfaces_reason(db_sync, patch_dependencies):
+    """Matrix config with no executed ranking → the service raises
+    ValueError('找不到已執行分發的排名…'); the endpoint must surface THAT reason
+    (400), not the opaque「造冊產生失敗」."""
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _config(db_sync, sch, quota_mode=QuotaManagementMode.matrix_based)
+
+    with pytest.raises(HTTPException) as ei:
+        _generate_payment_roster_inner(_request(cfg), db_sync, admin)
+
+    assert ei.value.status_code == 400
+    assert "找不到已執行分發的排名" in ei.value.detail
+    assert ei.value.detail != "造冊產生失敗"
+
+
+def test_duplicate_roster_surfaces_already_exists_as_409(db_sync, patch_dependencies):
+    """A second generation for the same (config, period) → the service raises
+    RosterAlreadyExistsError (wrapped); the endpoint must translate __cause__ to
+    409 with the real 'already exists' reason, not a generic 500."""
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _config(db_sync, sch)
+    # Pre-create the existing roster row directly (no need to run a full success).
+    existing = PaymentRoster(
+        roster_code="ROSTER-113-113-1-RE-113-1",
+        scholarship_configuration_id=cfg.id,
+        period_label="113-1",
+        academic_year=113,
+        roster_cycle=RosterCycle.MONTHLY,
+        status=RosterStatus.COMPLETED,
+        trigger_type=RosterTriggerType.MANUAL,
+        created_by=admin.id,
+    )
+    db_sync.add(existing)
+    db_sync.commit()
+
+    with pytest.raises(HTTPException) as ei:
+        _generate_payment_roster_inner(_request(cfg), db_sync, admin)
+
+    assert ei.value.status_code == 409
+    assert "already exists" in ei.value.detail.lower()
+
+
+_SECRET = "secret-internal-token-/app/backend/exports/x.xlsx"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        OSError(f"[Errno 13] Permission denied: '{_SECRET}'"),  # chmod/exports class
+        KeyError(_SECRET),  # missing internal key
+        RuntimeError(f"connection to db://{_SECRET} failed"),  # generic infra error
+        Exception(f"boom {_SECRET}"),  # bare unexpected
+    ],
+    ids=["oserror", "keyerror", "runtimeerror", "exception"],
+)
+def test_raw_cause_stays_generic_no_leak(db_sync, patch_dependencies, raw):
+    """SECURITY: when the wrapped cause is a RAW exception (the chmod/exports
+    class of failure, a DB/infra error, an unexpected bug), the detail must stay
+    the generic「造冊產生失敗」and must NOT echo the internal message. This is the
+    behavioural guard against a future edit adding an isinstance branch for a raw
+    type — stronger than the AST name-check in test_no_exception_leak_in_endpoints,
+    which would miss `detail=str(cause)`."""
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _config(db_sync, sch)
+
+    wrapped = RosterGenerationError(f"Failed to generate roster: {raw}")
+    wrapped.__cause__ = raw  # model the service's `raise RosterGenerationError(...) from raw`
+
+    with patch(
+        "app.api.v1.endpoints.payment_rosters.RosterService.generate_roster",
+        side_effect=wrapped,
+    ):
+        with pytest.raises(HTTPException) as ei:
+            _generate_payment_roster_inner(_request(cfg), db_sync, admin)
+
+    assert ei.value.status_code == 500
+    assert ei.value.detail == "造冊產生失敗"
+    assert _SECRET not in ei.value.detail

--- a/backend/app/tests/test_roster_matrix_aggregate_all_colleges.py
+++ b/backend/app/tests/test_roster_matrix_aggregate_all_colleges.py
@@ -111,12 +111,12 @@ def _approved_app(db_sync, user, scholarship, config, *, std_code, sub_type) -> 
     return a
 
 
-def _ranking(db_sync, scholarship, college_code, *, finalized=True, executed=True) -> CollegeRanking:
+def _ranking(db_sync, scholarship, college_code, *, finalized=True, executed=True, year=YEAR) -> CollegeRanking:
     r = CollegeRanking(
         scholarship_type_id=scholarship.id,
         college_code=college_code,
         sub_type_code="default",
-        academic_year=YEAR,
+        academic_year=year,
         semester=None,
         ranking_name=f"R-{college_code}",
         is_finalized=finalized,
@@ -257,3 +257,114 @@ def test_no_executed_ranking_raises(db_sync, patch_dependencies):
     # No rankings created at all.
     with pytest.raises(RosterGenerationError, match="找不到已執行分發的排名"):
         _generate(db_sync, cfg, admin)
+
+
+def test_null_ranking_derives_allocated_sub_type_from_ranking(db_sync, patch_dependencies):
+    """The aggregated (roster.ranking_id IS NULL) path must derive each item's
+    allocated_sub_type from that student's ranking item, NOT from the
+    application. We make them DIVERGE: the application says 'nstc' but the
+    matrix allocated 'moe_2w'. The roster item must carry the *allocated* value.
+    (test_aggregation_preserves_per_student_subtype only checks
+    scholarship_subtype, which is sourced unconditionally from the application,
+    so it never exercises the per-application ranking derivation at
+    roster_service.py:874-888 — the heart of the all-college aggregation.)"""
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="moe_2w")  # allocated subtype ≠ application subtype
+
+    roster = _generate(db_sync, cfg, admin)
+
+    item = _item_numbers(db_sync, roster)[0]
+    assert item.allocated_sub_type == "moe_2w"  # derived from the ranking item
+    assert item.scholarship_subtype == "nstc"  # echoes the application's own field
+
+
+def test_non_finalized_ranking_excluded(db_sync, patch_dependencies):
+    """is_finalized.is_(True) is one of the two gating conditions the fix added.
+    A draft/in-progress college ranking's allocations must NOT leak into a real
+    payment roster."""
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A", finalized=True)
+    rB = _ranking(db_sync, sch, "B", finalized=False)  # not finalized → excluded
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rB, b1, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    assert roster.total_applications == 1
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001"}
+
+
+def test_non_executed_ranking_excluded(db_sync, patch_dependencies):
+    """distribution_executed.is_(True) is the second gating condition the fix
+    added. A ranking that is finalized but whose matrix distribution has not run
+    has no valid allocations and must be excluded."""
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A", executed=True)
+    rB = _ranking(db_sync, sch, "B", finalized=True, executed=False)  # not executed → excluded
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rB, b1, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    assert roster.total_applications == 1
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001"}
+
+
+def test_other_academic_year_ranking_excluded(db_sync, patch_dependencies):
+    """The aggregation filters CollegeRanking.academic_year == academic_year.
+    A prior-year ranking (sharing the same scholarship_type_id) must not pull a
+    student into the current-year roster, even though the student's application
+    is itself in the current year."""
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A", year=YEAR)
+    rPrev = _ranking(db_sync, sch, "P", year=YEAR - 1)  # prior-year ranking → excluded
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rPrev, b1, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    assert roster.total_applications == 1
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001"}
+
+
+def test_application_allocated_in_two_rankings_counted_once(db_sync, patch_dependencies):
+    """Guards the comment 'a single application belongs to at most one ranking,
+    so .in_() does not duplicate'. The invariant is enforced two services away
+    (finalize-time un-finalize), not by a DB constraint here. We force the
+    boundary case — the SAME application allocated in two finalized+executed
+    rankings — and assert it is counted ONCE, locking in the de-duplication
+    behaviour the aggregation relies on for total_applications / item rows."""
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    rB = _ranking(db_sync, sch, "B")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rB, a1, sub_type="nstc")  # same application in a second ranking
+
+    roster = _generate(db_sync, cfg, admin)
+
+    assert roster.total_applications == 1
+    items = _item_numbers(db_sync, roster)
+    assert len(items) == 1
+    assert items[0].student_number == "A001"

--- a/backend/app/tests/test_roster_matrix_aggregate_all_colleges.py
+++ b/backend/app/tests/test_roster_matrix_aggregate_all_colleges.py
@@ -1,0 +1,259 @@
+"""
+Regression + contract tests: matrix-mode roster generation must include ALL
+colleges' allocated students, not just the latest-finalized ranking.
+
+Root cause was RosterService._get_eligible_applications: matrix mode with no
+ranking_id picked ONE ranking via .order_by(finalized_at.desc()).first(), so a
+multi-college distribution (one CollegeRanking per college) produced a roster
+covering only the last-finalized college.
+
+Assertions are on observable I/O (PaymentRoster.total_applications,
+PaymentRosterItem rows) per the leaf-node-containment philosophy in
+test_roster_service_generation.py. A yearly (semester=None) matrix config is
+used so the period-based semester filter is skipped, isolating the
+multi-college ranking aggregation under test.
+"""
+
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from app.core.exceptions import RosterGenerationError
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import QuotaManagementMode
+from app.models.payment_roster import PaymentRosterItem, RosterCycle, RosterTriggerType
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.services.roster_service import RosterService
+
+pytestmark = pytest.mark.integration
+
+YEAR = 114
+PERIOD = "114"  # yearly period label → no semester filter
+
+
+@pytest.fixture
+def patch_dependencies():
+    """Patch RosterService collaborators so tests stay in-process (mirrors
+    test_roster_service_generation.py). verify_student is never called because
+    student_verification_enabled=False, but RosterService.__init__ constructs
+    StudentVerificationService, and audit_service is invoked during generation."""
+    with (
+        patch("app.services.roster_service.StudentVerificationService") as svs,
+        patch("app.services.roster_service.audit_service"),
+    ):
+        svs.return_value.verify_student.return_value = {"status": "verified", "verified": True, "data": {}}
+        yield
+
+
+def _admin(db_sync) -> User:
+    u = User(
+        nycu_id="matrix_admin",
+        email="matrix_admin@nycu.edu.tw",
+        name="Matrix Admin",
+        role=UserRole.admin,
+        user_type=UserType.employee,
+    )
+    db_sync.add(u)
+    db_sync.commit()
+    db_sync.refresh(u)
+    return u
+
+
+def _scholarship(db_sync) -> ScholarshipType:
+    s = ScholarshipType(code="matrix_sch", name="Matrix Scholarship", description="x")
+    db_sync.add(s)
+    db_sync.commit()
+    db_sync.refresh(s)
+    return s
+
+
+def _matrix_config(db_sync, scholarship) -> ScholarshipConfiguration:
+    # semester=None ⇒ yearly ⇒ period-based semester filter skipped.
+    c = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        config_code="MX-114-1",
+        config_name="Matrix Config",
+        academic_year=YEAR,
+        semester=None,
+        quota_management_mode=QuotaManagementMode.matrix_based,
+        has_quota_limit=False,
+        amount=50000,
+    )
+    db_sync.add(c)
+    db_sync.commit()
+    db_sync.refresh(c)
+    return c
+
+
+def _approved_app(db_sync, user, scholarship, config, *, std_code, sub_type) -> Application:
+    a = Application(
+        user_id=user.id,
+        app_id=f"APP-{std_code}",
+        scholarship_type_id=scholarship.id,
+        scholarship_configuration_id=config.id,
+        academic_year=YEAR,
+        semester=None,
+        status="approved",
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        scholarship_subtype_list=[],
+        sub_scholarship_type=sub_type,
+        student_data={"std_stdcode": std_code, "std_pid": f"A{std_code}", "std_cname": f"學生{std_code}"},
+        submitted_form_data={"fields": {"postal_account": {"value": "0001234567"}}},
+        agree_terms=True,
+        amount=Decimal("50000"),
+    )
+    db_sync.add(a)
+    db_sync.commit()
+    db_sync.refresh(a)
+    return a
+
+
+def _ranking(db_sync, scholarship, college_code, *, finalized=True, executed=True) -> CollegeRanking:
+    r = CollegeRanking(
+        scholarship_type_id=scholarship.id,
+        college_code=college_code,
+        sub_type_code="default",
+        academic_year=YEAR,
+        semester=None,
+        ranking_name=f"R-{college_code}",
+        is_finalized=finalized,
+        ranking_status="finalized" if finalized else "draft",
+        distribution_executed=executed,
+    )
+    db_sync.add(r)
+    db_sync.commit()
+    db_sync.refresh(r)
+    return r
+
+
+def _alloc_item(db_sync, ranking, application, *, sub_type, allocated=True):
+    it = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=application.id,
+        rank_position=1,
+        is_allocated=allocated,
+        allocated_sub_type=sub_type if allocated else None,
+        allocation_config_id=None,
+        status="allocated" if allocated else "ranked",
+    )
+    db_sync.add(it)
+    db_sync.commit()
+    return it
+
+
+def _generate(db_sync, config, admin, *, ranking_id=None, period=PERIOD):
+    return RosterService(db_sync).generate_roster(
+        scholarship_configuration_id=config.id,
+        period_label=period,
+        roster_cycle=RosterCycle.YEARLY,
+        academic_year=YEAR,
+        created_by_user_id=admin.id,
+        trigger_type=RosterTriggerType.MANUAL,
+        student_verification_enabled=False,
+        ranking_id=ranking_id,
+    )
+
+
+def _item_numbers(db_sync, roster):
+    rows = db_sync.query(PaymentRosterItem).filter(PaymentRosterItem.roster_id == roster.id).all()
+    return rows
+
+
+def test_no_ranking_id_aggregates_all_colleges(db_sync, patch_dependencies):
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    rB = _ranking(db_sync, sch, "B")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    a2 = _approved_app(db_sync, admin, sch, cfg, std_code="A002", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rA, a2, sub_type="nstc")
+    _alloc_item(db_sync, rB, b1, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    assert roster.total_applications == 3
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001", "A002", "B001"}
+
+
+def test_unallocated_students_excluded(db_sync, patch_dependencies):
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    a2 = _approved_app(db_sync, admin, sch, cfg, std_code="A002", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc", allocated=True)
+    _alloc_item(db_sync, rA, a2, sub_type="nstc", allocated=False)
+
+    roster = _generate(db_sync, cfg, admin)
+
+    assert roster.total_applications == 1
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001"}
+
+
+def test_explicit_ranking_id_scopes_to_that_ranking(db_sync, patch_dependencies):
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    rB = _ranking(db_sync, sch, "B")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rB, b1, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin, ranking_id=rA.id)
+
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001"}
+
+
+def test_single_ranking_unchanged(db_sync, patch_dependencies):
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    a2 = _approved_app(db_sync, admin, sch, cfg, std_code="A002", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rA, a2, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001", "A002"}
+
+
+def test_aggregation_preserves_per_student_subtype(db_sync, patch_dependencies):
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    rB = _ranking(db_sync, sch, "B")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="moe_1w")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rB, b1, sub_type="moe_1w")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    by_num = {i.student_number: i for i in _item_numbers(db_sync, roster)}
+    assert by_num["A001"].scholarship_subtype == "nstc"
+    assert by_num["B001"].scholarship_subtype == "moe_1w"
+
+
+def test_no_executed_ranking_raises(db_sync, patch_dependencies):
+    admin = _admin(db_sync)
+    sch = _scholarship(db_sync)
+    cfg = _matrix_config(db_sync, sch)
+    # No rankings created at all.
+    with pytest.raises(RosterGenerationError, match="找不到已執行分發的排名"):
+        _generate(db_sync, cfg, admin)

--- a/backend/app/tests/test_roster_preview_ranking_consistency.py
+++ b/backend/app/tests/test_roster_preview_ranking_consistency.py
@@ -12,13 +12,29 @@ from pathlib import Path
 ENDPOINT = Path(__file__).resolve().parents[2] / "app" / "api" / "v1" / "endpoints" / "payment_rosters.py"
 
 
-def test_preview_does_not_self_select_single_ranking():
+def _preview_function_source() -> str:
+    """Slice out just the preview_roster_students function body so the guards
+    below cannot pass vacuously on substrings that live in other endpoints
+    (e.g. _get_eligible_applications is also called by other handlers)."""
     source = ENDPOINT.read_text(encoding="utf-8")
+    start = source.index("async def preview_roster_students")
+    nxt = source.find("\n@router.", start)
+    return source[start : nxt if nxt != -1 else len(source)]
+
+
+def test_preview_does_not_self_select_single_ranking():
+    fn = _preview_function_source()
     # The divergent single-ranking auto-detect (ordered by created_at) must be gone.
-    assert "CollegeRanking.created_at.desc()" not in source
+    assert "CollegeRanking.created_at.desc()" not in fn
+    # And it must never reassign ranking_id from a self-picked ranking — that
+    # reassignment (e.g. `ranking_id = ranking.id`) WAS the bug. The signature
+    # declares `ranking_id:` (colon), so this does not match the parameter.
+    assert "ranking_id = " not in fn
 
 
 def test_preview_delegates_ranking_resolution_to_service():
-    source = ENDPOINT.read_text(encoding="utf-8")
-    # preview still hands ranking_id (None when unspecified) to the shared selector.
-    assert "_get_eligible_applications(" in source
+    fn = _preview_function_source()
+    # Preview delegates selection to the shared service selector...
+    assert "_get_eligible_applications(" in fn
+    # ...passing the caller's ranking_id through UNCHANGED (None ⇒ all colleges).
+    assert "ranking_id=ranking_id" in fn

--- a/backend/app/tests/test_roster_preview_ranking_consistency.py
+++ b/backend/app/tests/test_roster_preview_ranking_consistency.py
@@ -1,0 +1,24 @@
+"""Source-invariant guard: preview_roster_students must NOT self-select a single
+ranking. It must defer ranking resolution to
+RosterService._get_eligible_applications, which (after the all-college fix)
+aggregates ALL executed rankings — so the preview matches what generate_roster
+produces. Same technique as test_payment_roster_allocation_map.py, used because
+preview_roster_students opens its own SessionLocal and is awkward to drive
+through the DI test client. Behavioural coverage lives in
+test_roster_matrix_aggregate_all_colleges.py."""
+
+from pathlib import Path
+
+ENDPOINT = Path(__file__).resolve().parents[2] / "app" / "api" / "v1" / "endpoints" / "payment_rosters.py"
+
+
+def test_preview_does_not_self_select_single_ranking():
+    source = ENDPOINT.read_text(encoding="utf-8")
+    # The divergent single-ranking auto-detect (ordered by created_at) must be gone.
+    assert "CollegeRanking.created_at.desc()" not in source
+
+
+def test_preview_delegates_ranking_resolution_to_service():
+    source = ENDPOINT.read_text(encoding="utf-8")
+    # preview still hands ranking_id (None when unspecified) to the shared selector.
+    assert "_get_eligible_applications(" in source

--- a/docs/superpowers/plans/2026-06-22-roster-matrix-aggregate-all-colleges.md
+++ b/docs/superpowers/plans/2026-06-22-roster-matrix-aggregate-all-colleges.md
@@ -1,0 +1,512 @@
+# Matrix Roster — Include All Colleges Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When an admin generates a payment roster for a multi-college matrix scholarship without choosing a specific ranking, include **all** colleges' allocated students in one roster (instead of only the latest-finalized college), and make the preview match what gets generated.
+
+**Architecture:** The defect is in `RosterService._get_eligible_applications` (backend service layer): in matrix mode with no `ranking_id` it picks a single `CollegeRanking` via `.order_by(finalized_at.desc()).first()`. Fix: aggregate **all** `is_finalized + distribution_executed` rankings for the (type, year) and select every `is_allocated` item via `.in_(ranking_ids)`. The per-item sub_type/amount derivation in `_create_roster_item` already works per-application when `roster.ranking_id` is NULL, so a single mixed-sub_type roster is correct. Separately, `preview_roster_students` (endpoint layer) has its own divergent single-ranking auto-detect — remove it so the preview delegates to the same selector.
+
+**Tech Stack:** Python 3.10, FastAPI, SQLAlchemy (sync `Session`), pytest (in-memory SQLite via `app/tests/conftest.py`).
+
+## Global Constraints
+
+- **Decision B1:** one roster containing all colleges, mixed sub_type (uses existing `STD_UP_MIXLISTA` Excel template). Do NOT split per sub_type in this path.
+- **Roster contains only allocated students:** keep the `CollegeRankingItem.is_allocated.is_(True)` filter. Do not add un-allocated / backup students.
+- **Explicit `ranking_id` unchanged:** when a caller passes a specific `ranking_id`, still scope to that single ranking.
+- **Do NOT change:** `generate_rosters_from_distribution` (the 獎學金分發 path), `RosterCreateRequest` schema, frontend, semester filtering, borrowed-quota per-item snapshots, `backup_info`.
+- **Tests assert on observable I/O only** (`PaymentRoster.total_applications`, `PaymentRosterItem` rows / source text) — never on the private helper signature. Follows the leaf-node-containment philosophy already documented in `test_roster_service_generation.py`.
+- **Running backend tests (host, from the worktree).** The dev container mounts `main`, not this worktree, and lacks pytest. Run on the host from the worktree `backend/` dir, supplying dummy settings env vars (conftest swaps in SQLite at import) and disabling the 20% coverage gate for focused runs:
+
+  ```bash
+  cd backend && \
+  DATABASE_URL='sqlite:///:memory:' DATABASE_URL_SYNC='sqlite:///:memory:' \
+  SECRET_KEY='test-secret-key-at-least-32-characters-long-xx' \
+  MINIO_ACCESS_KEY='test' MINIO_SECRET_KEY='test' ENVIRONMENT='test' \
+  python3 -m pytest <target> -q --no-cov
+  ```
+
+  This is referenced below as **[TEST CMD]** `<target>`.
+
+---
+
+## File Structure
+
+- **Modify** `backend/app/services/roster_service.py` — `_get_eligible_applications` (lines 674–712): aggregate all rankings when `ranking_id is None`.
+- **Modify** `backend/app/api/v1/endpoints/payment_rosters.py` — `preview_roster_students` (lines 591–606): delete the self-contained single-ranking auto-detect; delegate to the service.
+- **Create** `backend/app/tests/test_roster_matrix_aggregate_all_colleges.py` — behavioural tests for the service change.
+- **Create** `backend/app/tests/test_roster_preview_ranking_consistency.py` — source-invariant test for the endpoint change.
+
+---
+
+## Task 1: Aggregate all colleges in `_get_eligible_applications`
+
+**Files:**
+- Modify: `backend/app/services/roster_service.py:674-712`
+- Test: `backend/app/tests/test_roster_matrix_aggregate_all_colleges.py`
+
+**Interfaces:**
+- Consumes: `RosterService.generate_roster(scholarship_configuration_id:int, period_label:str, roster_cycle:RosterCycle, academic_year:int, created_by_user_id:int, trigger_type, student_verification_enabled:bool, ranking_id:Optional[int])` → `PaymentRoster` (PROCESSING, not committed). Each eligible application yields one `PaymentRosterItem`; `roster.total_applications == len(eligible applications)`.
+- Produces: behaviour relied on by Task 2 — `_get_eligible_applications(config_id, period_label, academic_year, ranking_id=None)` returns **all** colleges' allocated `Application`s.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/app/tests/test_roster_matrix_aggregate_all_colleges.py`:
+
+```python
+"""
+Regression + contract tests: matrix-mode roster generation must include ALL
+colleges' allocated students, not just the latest-finalized ranking.
+
+Root cause was RosterService._get_eligible_applications: matrix mode with no
+ranking_id picked ONE ranking via .order_by(finalized_at.desc()).first(), so a
+multi-college distribution (one CollegeRanking per college) produced a roster
+covering only the last-finalized college.
+
+Assertions are on observable I/O (PaymentRoster.total_applications,
+PaymentRosterItem rows) per the leaf-node-containment philosophy in
+test_roster_service_generation.py. A yearly (semester=None) matrix config is
+used so the period-based semester filter is skipped, isolating the
+multi-college ranking aggregation under test.
+"""
+
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from app.core.exceptions import RosterGenerationError
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import QuotaManagementMode
+from app.models.payment_roster import PaymentRosterItem, RosterCycle, RosterTriggerType
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.services.roster_service import RosterService
+
+pytestmark = pytest.mark.integration
+
+YEAR = 114
+PERIOD = "114"  # yearly period label → no semester filter
+
+
+@pytest.fixture
+def patch_dependencies():
+    """Patch RosterService collaborators so tests stay in-process (mirrors
+    test_roster_service_generation.py). verify_student is never called because
+    student_verification_enabled=False, but RosterService.__init__ constructs
+    StudentVerificationService, and audit_service is invoked during generation."""
+    with (
+        patch("app.services.roster_service.StudentVerificationService") as svs,
+        patch("app.services.roster_service.audit_service"),
+    ):
+        svs.return_value.verify_student.return_value = {"status": "verified", "verified": True, "data": {}}
+        yield
+
+
+def _admin(db_sync) -> User:
+    u = User(nycu_id="matrix_admin", email="matrix_admin@nycu.edu.tw", name="Matrix Admin",
+             role=UserRole.admin, user_type=UserType.employee)
+    db_sync.add(u); db_sync.commit(); db_sync.refresh(u)
+    return u
+
+
+def _scholarship(db_sync) -> ScholarshipType:
+    s = ScholarshipType(code="matrix_sch", name="Matrix Scholarship", description="x")
+    db_sync.add(s); db_sync.commit(); db_sync.refresh(s)
+    return s
+
+
+def _matrix_config(db_sync, scholarship) -> ScholarshipConfiguration:
+    # semester=None ⇒ yearly ⇒ period-based semester filter skipped.
+    c = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id, config_code="MX-114-1", config_name="Matrix Config",
+        academic_year=YEAR, semester=None, quota_management_mode=QuotaManagementMode.matrix_based,
+        has_quota_limit=False, amount=50000,
+    )
+    db_sync.add(c); db_sync.commit(); db_sync.refresh(c)
+    return c
+
+
+def _approved_app(db_sync, user, scholarship, config, *, std_code, sub_type) -> Application:
+    a = Application(
+        user_id=user.id, app_id=f"APP-{std_code}", scholarship_type_id=scholarship.id,
+        scholarship_configuration_id=config.id, academic_year=YEAR, semester=None, status="approved",
+        sub_type_selection_mode=SubTypeSelectionMode.single, scholarship_subtype_list=[],
+        sub_scholarship_type=sub_type,
+        student_data={"std_stdcode": std_code, "std_pid": f"A{std_code}", "std_cname": f"學生{std_code}"},
+        submitted_form_data={"fields": {"postal_account": {"value": "0001234567"}}},
+        agree_terms=True, amount=Decimal("50000"),
+    )
+    db_sync.add(a); db_sync.commit(); db_sync.refresh(a)
+    return a
+
+
+def _ranking(db_sync, scholarship, college_code, *, finalized=True, executed=True) -> CollegeRanking:
+    r = CollegeRanking(
+        scholarship_type_id=scholarship.id, college_code=college_code, sub_type_code="default",
+        academic_year=YEAR, semester=None, ranking_name=f"R-{college_code}",
+        is_finalized=finalized, ranking_status="finalized" if finalized else "draft",
+        distribution_executed=executed,
+    )
+    db_sync.add(r); db_sync.commit(); db_sync.refresh(r)
+    return r
+
+
+def _alloc_item(db_sync, ranking, application, *, sub_type, allocated=True):
+    it = CollegeRankingItem(
+        ranking_id=ranking.id, application_id=application.id, rank_position=1,
+        is_allocated=allocated, allocated_sub_type=sub_type if allocated else None,
+        allocation_config_id=None, status="allocated" if allocated else "ranked",
+    )
+    db_sync.add(it); db_sync.commit()
+    return it
+
+
+def _generate(db_sync, config, admin, *, ranking_id=None, period=PERIOD):
+    return RosterService(db_sync).generate_roster(
+        scholarship_configuration_id=config.id, period_label=period, roster_cycle=RosterCycle.YEARLY,
+        academic_year=YEAR, created_by_user_id=admin.id, trigger_type=RosterTriggerType.MANUAL,
+        student_verification_enabled=False, ranking_id=ranking_id,
+    )
+
+
+def _item_numbers(db_sync, roster):
+    rows = db_sync.query(PaymentRosterItem).filter(PaymentRosterItem.roster_id == roster.id).all()
+    return rows
+
+
+def test_no_ranking_id_aggregates_all_colleges(db_sync, patch_dependencies):
+    admin = _admin(db_sync); sch = _scholarship(db_sync); cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A"); rB = _ranking(db_sync, sch, "B")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    a2 = _approved_app(db_sync, admin, sch, cfg, std_code="A002", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rA, a2, sub_type="nstc")
+    _alloc_item(db_sync, rB, b1, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    assert roster.total_applications == 3
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001", "A002", "B001"}
+
+
+def test_unallocated_students_excluded(db_sync, patch_dependencies):
+    admin = _admin(db_sync); sch = _scholarship(db_sync); cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    a2 = _approved_app(db_sync, admin, sch, cfg, std_code="A002", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc", allocated=True)
+    _alloc_item(db_sync, rA, a2, sub_type="nstc", allocated=False)
+
+    roster = _generate(db_sync, cfg, admin)
+
+    assert roster.total_applications == 1
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001"}
+
+
+def test_explicit_ranking_id_scopes_to_that_ranking(db_sync, patch_dependencies):
+    admin = _admin(db_sync); sch = _scholarship(db_sync); cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A"); rB = _ranking(db_sync, sch, "B")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rB, b1, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin, ranking_id=rA.id)
+
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001"}
+
+
+def test_single_ranking_unchanged(db_sync, patch_dependencies):
+    admin = _admin(db_sync); sch = _scholarship(db_sync); cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    a2 = _approved_app(db_sync, admin, sch, cfg, std_code="A002", sub_type="nstc")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rA, a2, sub_type="nstc")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    nums = {i.student_number for i in _item_numbers(db_sync, roster)}
+    assert nums == {"A001", "A002"}
+
+
+def test_aggregation_preserves_per_student_subtype(db_sync, patch_dependencies):
+    admin = _admin(db_sync); sch = _scholarship(db_sync); cfg = _matrix_config(db_sync, sch)
+    rA = _ranking(db_sync, sch, "A"); rB = _ranking(db_sync, sch, "B")
+    a1 = _approved_app(db_sync, admin, sch, cfg, std_code="A001", sub_type="nstc")
+    b1 = _approved_app(db_sync, admin, sch, cfg, std_code="B001", sub_type="moe_1w")
+    _alloc_item(db_sync, rA, a1, sub_type="nstc")
+    _alloc_item(db_sync, rB, b1, sub_type="moe_1w")
+
+    roster = _generate(db_sync, cfg, admin)
+
+    by_num = {i.student_number: i for i in _item_numbers(db_sync, roster)}
+    assert by_num["A001"].scholarship_subtype == "nstc"
+    assert by_num["B001"].scholarship_subtype == "moe_1w"
+
+
+def test_no_executed_ranking_raises(db_sync, patch_dependencies):
+    admin = _admin(db_sync); sch = _scholarship(db_sync); cfg = _matrix_config(db_sync, sch)
+    # No rankings created at all.
+    with pytest.raises(RosterGenerationError, match="找不到已執行分發的排名"):
+        _generate(db_sync, cfg, admin)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run **[TEST CMD]** `app/tests/test_roster_matrix_aggregate_all_colleges.py`
+
+Expected: `test_no_ranking_id_aggregates_all_colleges` and `test_aggregation_preserves_per_student_subtype` FAIL (current code picks one ranking → only college A appears, so `total_applications == 2` and `B001` missing). The single-ranking / explicit-ranking / 0-ranking tests may already pass. At least the two multi-college tests must fail for the right reason (only one college selected).
+
+- [ ] **Step 3: Implement the aggregation**
+
+In `backend/app/services/roster_service.py`, replace the block at lines 674–712 (the `# 如果沒有提供 ranking_id，自動偵測...` comment through the closing `)` of the single-ranking `query = query.join(...)`):
+
+Replace this existing code:
+
+```python
+            # 如果沒有提供 ranking_id，自動偵測最新的已執行分發的 ranking
+            if ranking_id is None:
+                # 從 period_label 推導學期
+                semester = self._extract_semester_from_period(period_label)
+
+                # 查詢最新的已完成分發的 ranking
+                ranking = (
+                    self.db.query(CollegeRanking)
+                    .filter(
+                        and_(
+                            CollegeRanking.scholarship_type_id == config.scholarship_type_id,
+                            CollegeRanking.academic_year == academic_year,
+                            CollegeRanking.is_finalized.is_(True),  # 必須已完成
+                            CollegeRanking.distribution_executed.is_(True),  # 必須已執行分發
+                        )
+                    )
+                    .order_by(CollegeRanking.finalized_at.desc())
+                    .first()
+                )
+
+                if not ranking:
+                    raise ValueError(
+                        f"找不到已執行分發的排名。Matrix 模式獎學金必須先執行矩陣分發才能產生造冊。"
+                        f"獎學金類型ID: {config.scholarship_type_id}, 學年度: {academic_year}"
+                    )
+
+                ranking_id = ranking.id
+                logger.info(
+                    f"Auto-detected ranking ID {ranking_id} "
+                    f"(finalized at {ranking.finalized_at}, {ranking.allocated_count} students allocated)"
+                )
+
+            # 只選取該 ranking 中已分配(正取)的申請
+            query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(
+                and_(
+                    CollegeRankingItem.ranking_id == ranking_id,
+                    CollegeRankingItem.is_allocated.is_(True),  # 只選正取學生
+                )
+            )
+```
+
+With:
+
+```python
+            # 未指定 ranking_id：聚合「所有」已執行分發的排名 → 多學院全院納入。
+            # matrix 分發下每個學院各有一份 CollegeRanking；過去只取最新一份
+            # (.order_by(finalized_at.desc()).first()) 會讓造冊只含最後鎖定的那一院。
+            if ranking_id is None:
+                rankings = (
+                    self.db.query(CollegeRanking)
+                    .filter(
+                        and_(
+                            CollegeRanking.scholarship_type_id == config.scholarship_type_id,
+                            CollegeRanking.academic_year == academic_year,
+                            CollegeRanking.is_finalized.is_(True),
+                            CollegeRanking.distribution_executed.is_(True),
+                        )
+                    )
+                    .all()
+                )
+
+                if not rankings:
+                    raise ValueError(
+                        f"找不到已執行分發的排名。Matrix 模式獎學金必須先執行矩陣分發才能產生造冊。"
+                        f"獎學金類型ID: {config.scholarship_type_id}, 學年度: {academic_year}"
+                    )
+
+                ranking_ids = [r.id for r in rankings]
+                logger.info(
+                    f"Aggregating {len(ranking_ids)} executed ranking(s) {ranking_ids} for "
+                    f"all-college roster (type {config.scholarship_type_id}, year {academic_year})"
+                )
+
+                # 聚合所有排名的正取申請。一個申請最多屬於一份排名，故 .in_() 不會重複。
+                query = query.join(
+                    CollegeRankingItem, CollegeRankingItem.application_id == Application.id
+                ).filter(
+                    and_(
+                        CollegeRankingItem.ranking_id.in_(ranking_ids),
+                        CollegeRankingItem.is_allocated.is_(True),
+                    )
+                )
+            else:
+                # 明確指定排名：僅該排名的正取申請（管理員刻意選擇單一排名）。
+                query = query.join(
+                    CollegeRankingItem, CollegeRankingItem.application_id == Application.id
+                ).filter(
+                    and_(
+                        CollegeRankingItem.ranking_id == ranking_id,
+                        CollegeRankingItem.is_allocated.is_(True),
+                    )
+                )
+```
+
+(The now-unused `semester = self._extract_semester_from_period(period_label)` line is intentionally dropped — that local was computed but never used in this block; semester filtering happens later in the function and is unchanged.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run **[TEST CMD]** `app/tests/test_roster_matrix_aggregate_all_colleges.py`
+
+Expected: `6 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/roster_service.py backend/app/tests/test_roster_matrix_aggregate_all_colleges.py
+git commit -m "fix(roster): aggregate all colleges when generating matrix roster without ranking_id"
+```
+
+---
+
+## Task 2: Preview delegates ranking resolution (preview == generate)
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/payment_rosters.py:591-606`
+- Test: `backend/app/tests/test_roster_preview_ranking_consistency.py`
+
+**Interfaces:**
+- Consumes: Task 1's aggregating `RosterService._get_eligible_applications(config_id, period_label, academic_year, ranking_id=None)`.
+- Produces: nothing downstream; this is the final task.
+
+**Why a source-invariant test:** `preview_roster_students` opens its own `SessionLocal()` (payment_rosters.py:539) instead of the DI-injected test session, so it cannot be driven through the async test client against the in-memory DB. The codebase already guards this endpoint at the source level — see `test_payment_roster_allocation_map.py`. Behavioural coverage of the shared aggregation comes from Task 1.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/app/tests/test_roster_preview_ranking_consistency.py`:
+
+```python
+"""Source-invariant guard: preview_roster_students must NOT self-select a single
+ranking. It must defer ranking resolution to
+RosterService._get_eligible_applications, which (after the all-college fix)
+aggregates ALL executed rankings — so the preview matches what generate_roster
+produces. Same technique as test_payment_roster_allocation_map.py, used because
+preview_roster_students opens its own SessionLocal and is awkward to drive
+through the DI test client. Behavioural coverage lives in
+test_roster_matrix_aggregate_all_colleges.py."""
+
+from pathlib import Path
+
+ENDPOINT = Path(__file__).resolve().parents[2] / "app" / "api" / "v1" / "endpoints" / "payment_rosters.py"
+
+
+def test_preview_does_not_self_select_single_ranking():
+    source = ENDPOINT.read_text(encoding="utf-8")
+    # The divergent single-ranking auto-detect (ordered by created_at) must be gone.
+    assert "CollegeRanking.created_at.desc()" not in source
+
+
+def test_preview_delegates_ranking_resolution_to_service():
+    source = ENDPOINT.read_text(encoding="utf-8")
+    # preview still hands ranking_id (None when unspecified) to the shared selector.
+    assert "_get_eligible_applications(" in source
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run **[TEST CMD]** `app/tests/test_roster_preview_ranking_consistency.py`
+
+Expected: `test_preview_does_not_self_select_single_ranking` FAILS (the string `CollegeRanking.created_at.desc()` is still present at line 601). `test_preview_delegates_ranking_resolution_to_service` PASSES already.
+
+- [ ] **Step 3: Remove the divergent auto-detect**
+
+In `backend/app/api/v1/endpoints/payment_rosters.py`, replace the block at lines 591–606:
+
+Replace this existing code:
+
+```python
+        # Auto-detect ranking_id if needed
+        if has_matrix_distribution and not ranking_id:
+            ranking = (
+                db.query(CollegeRanking)
+                .filter(
+                    and_(
+                        CollegeRanking.scholarship_type_id == config.scholarship_type_id,
+                        CollegeRanking.distribution_executed.is_(True),
+                    )
+                )
+                .order_by(CollegeRanking.created_at.desc())
+                .first()
+            )
+            if ranking:
+                ranking_id = ranking.id
+                logger.info(f"Auto-detected ranking_id: {ranking_id}")
+```
+
+With:
+
+```python
+        # NOTE: 不在此處自挑單一排名。ranking_id 為 None 時交由
+        # roster_service._get_eligible_applications 聚合「所有」已執行分發的排名
+        # （= 全院），與 generate_roster 走同一條路 → 預覽與產生保證一致。
+        # 明確指定 ranking_id 時則只預覽該排名。
+```
+
+(`has_matrix_distribution` is still computed above and returned in the response payload; only the single-ranking auto-detect is removed. `ranking_id` flows unchanged into `_get_eligible_applications` at the call site below.)
+
+- [ ] **Step 4: Run the test to verify it passes, then run the full roster suite**
+
+Run **[TEST CMD]** `app/tests/test_roster_preview_ranking_consistency.py`
+Expected: `2 passed`.
+
+Then regression-check the roster suites together (omit `--no-cov` here so the coverage gate is satisfied by the larger run):
+
+```bash
+cd backend && \
+DATABASE_URL='sqlite:///:memory:' DATABASE_URL_SYNC='sqlite:///:memory:' \
+SECRET_KEY='test-secret-key-at-least-32-characters-long-xx' \
+MINIO_ACCESS_KEY='test' MINIO_SECRET_KEY='test' ENVIRONMENT='test' \
+python3 -m pytest app/tests/ -q -k "roster" --no-cov
+```
+
+Expected: all selected tests pass (in particular `test_roster_service_generation.py`, `test_roster_distribution_reconcile_*`, `test_payment_roster_allocation_map.py`, and the two new files).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/v1/endpoints/payment_rosters.py backend/app/tests/test_roster_preview_ranking_consistency.py
+git commit -m "fix(roster): preview defers ranking resolution to service so preview matches generation"
+```
+
+---
+
+## Post-implementation verification (manual, optional)
+
+The dev container serves `main`, not this worktree, so end-to-end verification against the live app requires re-pointing the container at the worktree (or doing it after merge). To confirm against the existing dev data (4 colleges, 9 allocated), after the fix is live, force-regenerate the 2-person monthly roster and expect 9 items across colleges A/B/C/E:
+
+```bash
+docker exec -u root scholarship_backend_dev python -c "REGENERATE roster 15 (period 114-09) with force_regenerate=True"
+# then: SELECT count(*) FROM payment_roster_items WHERE roster_id=15;  -- expect 9, not 2
+```
+
+The end-to-end script `.claude/skills/playwright-test-and-debug/scripts/verify-multi-college-distribution.js` already exercises ranking→distribution→roster; extend its final assertion from `payment_rosters` batch count to "roster items cover every college's allocated count".
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §4.1 core fix → Task 1. §4.2 per-item sub_type (no change) → asserted by `test_aggregation_preserves_per_student_subtype`. §4.3 preview consistency → Task 2. §3 "only allocated" → `test_unallocated_students_excluded`. §5 behaviour matrix rows → Task 1 tests (0 / 1 / ≥2 rankings, explicit ranking_id). §7 test plan → Tasks 1–2 + post-impl note. §6 deferred items (semester / backup_info / borrowed-quota) → explicitly untouched per Global Constraints.
+- **Placeholders:** none — every code/test block is concrete; the post-impl shell line is marked optional/manual.
+- **Type consistency:** `_get_eligible_applications(config_id, period_label, academic_year, ranking_id)`, `generate_roster(..., ranking_id=None)`, `PaymentRosterItem.student_number` / `.scholarship_subtype`, `RosterGenerationError`, `RosterCycle.YEARLY` used consistently across tasks and match the source files read during planning.

--- a/docs/superpowers/specs/2026-06-21-roster-matrix-aggregate-all-colleges-design.md
+++ b/docs/superpowers/specs/2026-06-21-roster-matrix-aggregate-all-colleges-design.md
@@ -1,0 +1,135 @@
+# 造冊（payment roster）matrix 模式：生成時納入全院 — 設計
+
+- 日期：2026-06-21
+- 分支：`worktree-fix-roster-matrix-aggregate-all-colleges`
+- 相關 issue 脈絡：#1029 / #1034（分發須看見所有學院）的下游延伸
+
+## 1. 問題
+
+管理員對多學院的 matrix 獎學金完成分發後，透過「單一配置／月份」的 `/generate` 造冊流程產生造冊，名單卻只包含**最後一個被鎖定的學院**的學生（實測：博士獎學金 114，4 個學院共 9 人正取，但 `/generate` 產生的 roster 15 只有電機院 2 人）。
+
+完整名單其實存在 —— 來自「獎學金分發 → 生成造冊」按鈕（`generate_rosters_from_distribution`，roster 13+14 共 9 人）。問題只發生在 `/generate` 這條路。
+
+## 2. 根本原因
+
+`backend/app/services/roster_service.py` 的 `_get_eligible_applications()`（約 674–712 行）：matrix 模式且未帶 `ranking_id` 時，用
+
+```python
+ranking = (... CollegeRanking ... is_finalized, distribution_executed ...)
+    .order_by(CollegeRanking.finalized_at.desc())
+    .first()           # ← 只取「最後鎖定」的單一排名
+query = query.join(CollegeRankingItem ...).filter(
+    CollegeRankingItem.ranking_id == ranking_id,    # ← 僅該排名
+    CollegeRankingItem.is_allocated.is_(True))
+```
+
+matrix 分發下**每個學院各有一份 `CollegeRanking`**，`.first()` 只挑一份 → 其他學院的正取者被靜默忽略。
+
+延伸問題：`backend/app/api/v1/endpoints/payment_rosters.py` 的 `preview_roster_students()`（約 591–606 行）**另外自寫一份**單一排名自動偵測，且用 `created_at.desc()`、未過濾 `academic_year` / `is_finalized`，與實際產生用的 `finalized_at.desc()` 不一致 → **預覽看到的人可能與最終造冊不同**。
+
+## 3. 目標行為（決議）
+
+- **B1**：matrix 模式 `/generate` 未指定 `ranking_id` 時，**聚合所有** `is_finalized + distribution_executed` 的排名，把全院正取者納入**單一一張**造冊（混合 sub_type，沿用 `STD_UP_MIXLISTA` 範本）。
+- 造冊只含**已分發（`is_allocated=True`）**者；不納入未分發/備取者。
+- 預覽與產生**保證一致**（走同一段邏輯）。
+- 管理員若**明確指定** `ranking_id`（從 `available-rankings` 選）→ 維持只做該排名（刻意選擇，不變）。
+
+## 4. 設計
+
+### 4.1 核心修正 — `_get_eligible_applications()`（roster_service.py）
+
+matrix 分支、`ranking_id is None` 時，把「挑單一排名」改為「聚合全部排名」：
+
+```python
+if ranking_id is None:
+    rankings = (
+        self.db.query(CollegeRanking)
+        .filter(and_(
+            CollegeRanking.scholarship_type_id == config.scholarship_type_id,
+            CollegeRanking.academic_year == academic_year,
+            CollegeRanking.is_finalized.is_(True),
+            CollegeRanking.distribution_executed.is_(True),
+        ))
+        .all()
+    )
+    if not rankings:
+        raise ValueError("找不到已執行分發的排名…")   # 維持原錯誤
+    ranking_ids = [r.id for r in rankings]
+    query = query.join(CollegeRankingItem, CollegeRankingItem.application_id == Application.id).filter(and_(
+        CollegeRankingItem.ranking_id.in_(ranking_ids),
+        CollegeRankingItem.is_allocated.is_(True),
+    ))
+else:
+    # 明確指定排名 → 維持單一排名行為（現狀）
+    query = query.join(CollegeRankingItem, ...).filter(and_(
+        CollegeRankingItem.ranking_id == ranking_id,
+        CollegeRankingItem.is_allocated.is_(True),
+    ))
+```
+
+- 去重：`.in_(ranking_ids)` + join 可能讓同一 application 出現多列（理論上一個 application 只會在一個排名被分配，但仍以 `.distinct()` 或結果集去重保險）。實作時用 `query.distinct()` 或在 Python 端依 `application.id` 去重。
+- 不加 semester 過濾（與目前單張路徑現狀一致；見 §6 已知差異）。
+
+### 4.2 逐項 sub_type 正確性（無需改）
+
+`_create_roster_item()`（roster_service.py:850–883）在 `roster.ranking_id` 為 NULL 時，已會**針對每個學生**從其所屬「同學年度已分發排名」查 `allocated_sub_type`。因此聚合後單張造冊的每一列 sub_type 各自正確 —— **此處不需修改**。
+
+> 註：`roster.ranking_id` 在 `/generate` 月份造冊本就為 NULL（roster 15 即如此），故走的就是這條逐項查 sub_type 的分支。
+
+### 4.3 預覽一致性 — `preview_roster_students()`（payment_rosters.py）
+
+刪除其自寫的單一排名自動偵測（約 591–606 行），改為直接把 `ranking_id`（前端未選時為 `None`）丟進 `roster_service._get_eligible_applications(...)`。如此預覽與產生共用 §4.1 同一段邏輯 → 全院、且與最終造冊一致。下游的 `allocation_map` 查詢（payment_rosters.py:621–650）本就跨排名依 `is_allocated + academic_year` 查詢，無需改。
+
+### 4.4 不變更
+
+- `generate_rosters_from_distribution()`（分發面板路徑）：本就正確，不動。
+- 帶明確 `ranking_id` 的所有流程：不動。
+- `RosterCreateRequest` schema、前端 API 形狀：不動（仍是「一次 generate 一張」）。
+
+## 5. 行為矩陣
+
+| 觸發 | 已分發排名數 | 修正後 |
+|---|---|---|
+| `/generate`，未帶 ranking_id | 0 | 維持報錯「找不到已執行分發的排名」 |
+| `/generate`，未帶 ranking_id | 1 | 該排名全部正取（等同現狀） |
+| `/generate`，未帶 ranking_id | ≥2（多院）| **全院正取，單張混合造冊**（本次修正重點）|
+| `/generate`，帶 ranking_id | 任意 | 僅該排名正取（不變）|
+| 預覽 preview-students | ≥2（多院）| 與產生一致：全院正取 |
+| 分發面板 生成造冊 | ≥2 | 依 sub_type 拆多張（不變）|
+
+## 6. 已知差異 / 本次不做（明確標註）
+
+- **semester 過濾**：分發面板路徑用 `_build_semester_filter()`，本路徑現狀不過濾；本次維持不過濾以免改變行為。若日後要對齊，於 §4.1 查詢加 semester 條件。
+- **backup_info（備取資訊）**：ranking_id 為 NULL 的造冊本就不帶；依「不放未分發/備取者」決議，**不做**。
+- **borrowed quota 逐項 allocation_year 快照**：單張造冊路徑本就無逐項快照（分發面板路徑才有）。同學年度情境不受影響；跨年度借用配額屬邊界，沿用現狀。
+
+## 7. 測試計畫
+
+### 7.1 後端單元測試（pytest，主要驗證層）
+新增於 `backend/app/tests/`（沿用既有 `test_roster_service_generation.py` / `test_roster_service_core.py` 模式與 fixtures）：
+
+1. **多院聚合**：建立 ≥2 個 `is_finalized+distribution_executed` 排名、各有正取 item，`generate_roster(ranking_id=None)` → 造冊 item 數 = 全部排名正取總和；涵蓋多個學院。
+2. **未分發者排除**：排名含 `is_allocated=False` 的 item → 不得進入造冊。
+3. **明確 ranking_id**：帶單一 `ranking_id` → 僅該排名正取（回歸保護）。
+4. **單一排名**：只有一個排名時，結果與現狀相同（回歸保護）。
+5. **0 排名**：維持 `ValueError`。
+6. **逐項 sub_type**：跨排名/跨 sub_type 學生 → 每列 `scholarship_subtype` 各自正確。
+7. **預覽=產生**：`preview_roster_students` 與 `generate_roster` 對同一情境回傳相同學生集合。
+
+### 7.2 端到端（既有腳本）
+`/.claude/skills/playwright-test-and-debug/scripts/verify-multi-college-distribution.js` 已涵蓋 ranking→distribution→roster 全鏈；修正後，把斷言由 `payment_rosters` 批數擴充為「roster items 涵蓋全部學院正取人數」。
+
+### 7.3 對既有資料的人工驗證
+dev DB（4 院、9 人正取）：以 `force_regenerate` 重生 roster 15（period 114-09）→ 期望 item 數由 2 變 9，涵蓋 A/B/C/E 四院。
+
+## 8. 風險
+
+- **混合 sub_type 的 Excel 匯出**：`STD_UP_MIXLISTA` 範本名稱即「混合清單」，預期支援；測試 7.1/7.3 後以實際 Excel 匯出檢查金額/欄位正確。
+- **去重**：join `.in_()` 需確保不重複計列（§4.1）。
+- **與分發面板路徑並存**：兩條路徑可能對重疊學生各產一張造冊（period_label 不同：`114` vs `114-09`）。屬既有狀況，非本次引入；如需防雙重撥款另議。
+
+## 9. 範圍外
+
+- 重構兩條造冊路徑為單一實作。
+- semester 對齊、borrowed-quota 逐項快照、backup_info 補齊。
+- 前端 UI 變更（本次純後端邏輯修正，前端行為自動受益）。


### PR DESCRIPTION
## Problem

Generating a payment roster (造冊) for a **multi-college matrix-mode** scholarship without picking a specific ranking only included the **latest-finalized college's** allocated students. In production: a doctoral scholarship with 4 colleges / 9 allocated students produced a roster with only the 電機院 (2 students). The full name list existed only via the 獎學金分發 → 生成造冊 path (`generate_rosters_from_distribution`); the `/generate` (single-config/period) path was broken.

**Root cause:** `RosterService._get_eligible_applications` (matrix mode, no `ranking_id`) selected **one** `CollegeRanking` via `.order_by(finalized_at.desc()).first()`. Under matrix distribution each college has its own `CollegeRanking`, so `.first()` silently dropped every other college's 正取者.

A second, divergent copy of the bug lived in the `preview_roster_students` endpoint (it self-detected a single ranking via `created_at.desc()`, missing `academic_year`/`is_finalized` filters), so the preview could disagree with the generated roster.

## Fix

1. **`_get_eligible_applications`** — when `ranking_id is None`, aggregate **all** `is_finalized + distribution_executed` rankings for `(scholarship_type_id, academic_year)` and select every `is_allocated` `CollegeRankingItem` via `.in_(ranking_ids)`. Produces **one** roster across all colleges with mixed sub_type (decision **B1**, existing `STD_UP_MIXLISTA` template). An explicit `ranking_id` still scopes to that single ranking.
2. **`preview_roster_students`** — removed its self-contained single-ranking auto-detect so the preview delegates ranking resolution to the same service selector → **preview == generate**.
3. The per-application sub_type/amount derivation in `_create_roster_item` already resolves each student's `allocated_sub_type` per-application when `roster.ranking_id` is NULL — so the aggregated single roster itemizes each row correctly. **Unchanged.**

Net production change: **+29 / −36** lines across `roster_service.py` and `payment_rosters.py`.

## Behavior matrix

| Trigger | Executed rankings | After fix |
|---|---|---|
| `/generate`, no ranking_id | 0 | error 「找不到已執行分發的排名」 (unchanged) |
| `/generate`, no ranking_id | 1 | that ranking's 正取 (== current) |
| `/generate`, no ranking_id | ≥2 (multi-college) | **all colleges, one mixed roster** (the fix) |
| `/generate`, explicit ranking_id | any | that ranking only (unchanged) |
| preview-students | ≥2 | matches generation: all colleges |
| 分發面板 生成造冊 | ≥2 | per-sub_type split (unchanged) |

## Deliberately not changed (per approved spec)

- `generate_rosters_from_distribution` (分發面板 path), `RosterCreateRequest` schema, frontend, semester filtering, borrowed-quota per-item snapshots, `backup_info`.
- **No `.distinct()`** despite the spec's suggestion: the legacy `db.query(Application).all()` already dedupes single-entity rows by PK identity (proven by `test_application_allocated_in_two_rankings_counted_once`), and `SELECT DISTINCT` over the `json` `student_data` column errors on Postgres. Relying on identity-dedup is the correct, test-guarded choice.

## Known follow-ups (out of scope)

- Preview's `allocation_map` enrichment query is not `is_finalized`/`distribution_executed`-scoped (display enrichment only; protected by the one-app-one-allocation invariant).
- Pre-existing N+1 in `_create_roster_item` per-application allocation lookup on the NULL-ranking path.
- Three "find this app's allocation" queries could share one helper.

## Tests

New `backend/app/tests/test_roster_matrix_aggregate_all_colleges.py` (11 behavioural tests via the real `generate_roster` chain, only `StudentVerificationService`/`audit_service` patched) and `test_roster_preview_ranking_consistency.py` (2 scoped source-invariant guards):

- multi-college aggregation; un-allocated excluded; explicit ranking_id scoping; single-ranking regression; 0-rankings raises
- per-student sub_type derivation where allocated sub_type **diverges** from the application's own field (exercises the NULL-ranking derivation path)
- gating: non-finalized excluded; non-executed excluded; prior-year excluded
- dedup invariant (same app in two rankings → counted once)
- preview must not self-select a ranking and must pass `ranking_id` through unchanged

**Run** (host, from `backend/`, dummy env + SQLite — the dev container mounts `main`):
```bash
cd backend && DATABASE_URL='sqlite:///:memory:' DATABASE_URL_SYNC='sqlite:///:memory:' \
  SECRET_KEY='test-secret-key-at-least-32-characters-long-xx' \
  MINIO_ACCESS_KEY='test' MINIO_SECRET_KEY='test' ENVIRONMENT='test' \
  python3 -m pytest app/tests/ -k roster --no-cov
```

Result: **13 focused pass; broader `-k roster` 452 pass**; black 26.3.1 + flake8 (B904/B014/F401/E501) clean.

## Manual verification TODO (post-merge / on a worktree-mounted container)

- [ ] Force-regenerate the dev-data monthly roster (period 114-09) → expect items go from 2 → 9 across colleges A/B/C/E.
- [ ] Export the mixed-sub_type roster Excel (`STD_UP_MIXLISTA`) and confirm per-row amount/fields.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
