### PR TITLE
fix(nginx): route /api/v1/export-package to frontend Next.js proxy

### DIFF
--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -151,6 +151,28 @@ http {
             proxy_buffering off;
         }
 
+        # Export-package ZIP download — Next.js proxy route (token query-param -> Bearer).
+        # Must reach the frontend so app/api/v1/export-package/route.ts runs; otherwise it
+        # hits the backend directly (no /api/v1/export-package route -> 404 Not Found).
+        location /api/v1/export-package {
+            limit_req zone=frontend burst=30 nodelay;
+
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Request-ID $request_id;
+
+            # Handle large ZIP downloads (bulk application materials)
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+            proxy_buffering off;
+        }
+
         location /api/v1/preview {
             limit_req zone=frontend burst=30 nodelay;
 

--- a/nginx/nginx.staging-e2e.conf
+++ b/nginx/nginx.staging-e2e.conf
@@ -37,6 +37,9 @@ http {
         location /api/v1/download {
             proxy_pass http://$frontend_upstream;
         }
+        location /api/v1/export-package {
+            proxy_pass http://$frontend_upstream;
+        }
         location /api/v1/preview {
             proxy_pass http://$frontend_upstream;
         }

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -139,6 +139,27 @@ http {
             proxy_buffering off;
         }
 
+        # Export-package ZIP download — Next.js proxy route (token query-param -> Bearer).
+        # Must reach the frontend so app/api/v1/export-package/route.ts runs; otherwise it
+        # hits the backend directly (no /api/v1/export-package route -> 404 Not Found).
+        location /api/v1/export-package {
+            limit_req zone=frontend burst=20 nodelay;
+
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Request-ID $request_id;
+
+            # Handle large ZIP downloads (bulk application materials)
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+            proxy_buffering off;
+        }
+
         location /api/v1/preview {
             limit_req zone=frontend burst=20 nodelay;
 


### PR DESCRIPTION
## Problem

On staging, the college **匯出申請資料** (export application package) download fails:

```
GET https://ss.test.nycu.edu.tw/api/v1/export-package?scholarship_type_id=2&academic_year=114&token=…
→ {"success":false,"message":"Not Found","trace_id":"69b3cc8a-…"}
```

The `{"success":false,"message":...,"trace_id":...}` shape is the **backend's** Starlette 404 handler (`backend/app/main.py`), proving the request reached `backend:8000` — not the intended Next.js proxy.

## Root cause

`/api/v1/export-package` is a **Next.js proxy route** (`frontend/app/api/v1/export-package/route.ts`). It takes the `?token=` query param, converts it to an `Authorization: Bearer` header, and forwards to the backend's real route `/api/v1/college-review/export-package`. (The token-in-query → Bearer hop is exactly why the proxy exists — the browser triggers the download via `fetch`/navigation and the backend route only accepts a Bearer header.)

- In **dev**, the Next.js dev server serves `/api/v1/export-package` directly, so it works.
- In **staging/prod**, nginx sits in front. nginx explicitly allow-lists the sibling proxy routes (`/api/v1/download`, `/api/v1/preview`, `/api/v1/system-settings/*-proxy`) to `frontend:3000`, and sends **everything else** under `/api/` to `backend:8000` via the catch-all `location /api/`.
- `/api/v1/export-package` was **never added** to that allow-list when its `route.ts` was created (commit `e1027c42`), so it fell through to the backend, which has no such route → 404.

The nginx config even documents this exact failure mode for the system-settings proxies:
> *"Must reach the frontend so the Next.js route handlers run; otherwise these hit the backend directly (no matching route -> 405/404)."*

## Fix

Add an explicit `location /api/v1/export-package` block that proxies to `frontend:3000`, mirroring the existing `/api/v1/download` block (binary download → `proxy_buffering off`, long timeouts), in all three nginx configs:

- `nginx/nginx.staging.conf`
- `nginx/nginx.prod.conf` (same latent bug — prod would break identically once this feature ships)
- `nginx/nginx.staging-e2e.conf`

(Confirmed correct end-to-end: `rewrites()` in `next.config.mjs` returns a plain array → `afterFiles` rewrites, which run **after** filesystem routes, so the `route.ts` handler runs and is not rewritten back to the backend. `INTERNAL_API_URL=http://backend:8000` is set for the frontend in staging compose and its hostname is allow-listed in `getSafeBackendUrl()`.)

## Verification

- `nginx -t` passes on all three configs (locally validated with SSL/`http2 on;` directives stripped for nginx 1.18 compat; the `nginx:alpine` runtime supports `http2 on;`).
- Brace balance verified per file.
- New blocks are byte-for-byte consistent with the adjacent `/api/v1/download` blocks (per-env: staging `burst=20`, prod `burst=30` + `X-Forwarded-Host`, e2e minimal).

After deploy, retrying the failing `curl` should return the ZIP (`Content-Type: application/zip`, `Content-Disposition: attachment; filename*=UTF-8''…`) instead of the JSON 404.

## Related (follow-up, not in this PR)

Two sibling Next.js proxy routes share the **identical** latent gap — they exist as `route.ts` handlers, have no backend route, and are not in any nginx allow-list, so they 404 in staging/prod when exercised:

- `/api/v1/application-document-proxy` (GET — student-wizard document preview)
- `/api/v1/application-document-upload-proxy` (POST/DELETE — application document upload)

I scoped them out because the GET preview route may be iframe-rendered and need `X-Frame-Options: SAMEORIGIN` re-declared (like the `/api/v1/preview` block), which deserves its own change. A small guard test asserting *"every `frontend/app/api/v1/*/route.ts` proxy route has a matching nginx `location`"* would prevent this whole class of bug from recurring (this is at least the 4th such route).
