### PR TITLE
feat(roster): show cumulative received-months (已領月份數) in 察看名單 / 資格詳情

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -48,6 +48,7 @@ from app.schemas.roster import (
     RosterStatisticsResponse,
 )
 from app.services.excel_export_service import ExcelExportService
+from app.services.received_months_service import calculate_received_months_bulk_async
 from app.services.roster_service import RosterService
 from app.services.student_verification_service import StudentVerificationService
 from app.utils.academic_period import get_roster_period_dates
@@ -1360,6 +1361,13 @@ async def get_roster_items(
         result = await db.execute(stmt)
         items = result.scalars().all()
 
+        # 累計已領月份數（含本期）：用共用的 received_months_service 一次批次計算，
+        # 與 PhD 36 個月上限資格檢查同一來源。以學號 (student_number) 對應。
+        student_numbers = [item.student_number for item in items if item.student_number]
+        received_by_student = await calculate_received_months_bulk_async(
+            db, student_numbers, roster.scholarship_configuration_id
+        )
+
         items_data = []
         for item in items:
             item_dict = _roster_item_dict_with_display_year(item, roster)
@@ -1371,6 +1379,7 @@ async def get_roster_items(
                 item_dict["college_code"] = sd.get("std_academyno") or sd.get("trm_academyno")
                 item_dict["college_name"] = sd.get("trm_academyname")
                 item_dict["department_name"] = sd.get("trm_depname")
+            item_dict["received_months"] = received_by_student.get(item.student_number, 0) if item.student_number else 0
             items_data.append(item_dict)
 
         return ApiResponse(

--- a/backend/app/schemas/roster.py
+++ b/backend/app/schemas/roster.py
@@ -63,6 +63,8 @@ class RosterItemResponse(BaseModel):
     rule_validation_result: Optional[Dict[str, Any]] = None
     # PaymentRosterItem.is_eligible model property; None = 無快照（較舊造冊）
     is_eligible: Optional[bool] = None
+    # 已領月份數（累計含本期；由 received_months_service 計算，非 ORM 欄位）
+    received_months: Optional[int] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
     # 學生學院/系所資訊（從 application.student_data 取得，非 ORM 欄位）

--- a/backend/app/tests/test_payment_rosters_api.py
+++ b/backend/app/tests/test_payment_rosters_api.py
@@ -789,3 +789,184 @@ async def test_list_filters_by_scholarship_type_id(client_admin: AsyncClient, ro
     assert resp2.status_code == 200, resp2.text
     codes2 = {it["roster_code"] for it in resp2.json()["data"]["items"]}
     assert "ROSTER-PR-CFG" not in codes2
+
+
+# ===========================================================================
+# GET /{id}/items — 已領月份數 (cumulative received_months) on every item
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_roster_items_includes_cumulative_received_months(client_admin: AsyncClient, db):
+    """Each returned item carries `received_months` = the student's cumulative
+    months under the SAME scholarship config, weighted by roster cycle
+    (MONTHLY=1, YEARLY=12) and counting only is_included items — INCLUDING the
+    roster being viewed (the shared received_months_service source of truth).
+
+    Setup: two COMPLETED rosters (monthly + yearly) under one config, both with
+    an included item for the same student → 1 + 12 = 13. A third yearly roster
+    with an EXCLUDED item for that student must NOT add 12.
+    """
+    u = await _seed_admin_user(db, "rm_items")
+    config_id = 9911
+    student_no = "RM99001"
+
+    def _roster(code: str, cycle: RosterCycle, period: str) -> PaymentRoster:
+        return PaymentRoster(
+            roster_code=code,
+            scholarship_configuration_id=config_id,
+            period_label=period,
+            academic_year=114,
+            roster_cycle=cycle,
+            status=RosterStatus.COMPLETED,
+            trigger_type=RosterTriggerType.MANUAL,
+            created_by=u.id,
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+        )
+
+    viewed = _roster("ROSTER-RM-A", RosterCycle.MONTHLY, "2026-01")
+    yearly = _roster("ROSTER-RM-B", RosterCycle.YEARLY, "2026")
+    excluded = _roster("ROSTER-RM-C", RosterCycle.YEARLY, "2025")
+    db.add_all([viewed, yearly, excluded])
+    await db.commit()
+    for r in (viewed, yearly, excluded):
+        await db.refresh(r)
+
+    def _item(roster_id: int, included: bool) -> PaymentRosterItem:
+        return PaymentRosterItem(
+            roster_id=roster_id,
+            application_id=1,  # no Application row needed for this contract check
+            student_id_number="A123456789",
+            student_number=student_no,
+            student_name="RM Student",
+            scholarship_name="RM Scholarship",
+            scholarship_amount=Decimal("10000"),
+            is_included=included,
+        )
+
+    db.add_all([_item(viewed.id, True), _item(yearly.id, True), _item(excluded.id, False)])
+    await db.commit()
+
+    resp = await client_admin.get(f"/api/v1/payment-rosters/{viewed.id}/items")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    _assert_api_response_envelope(body)
+
+    items = body["data"]
+    assert len(items) == 1, items
+    assert "received_months" in items[0], items[0]
+    # 1 (monthly, viewed) + 12 (yearly, included) + 0 (yearly but excluded) = 13
+    assert items[0]["received_months"] == 13, items[0]
+
+
+@pytest.mark.asyncio
+async def test_get_roster_items_received_months_zero_for_lone_item(client_admin: AsyncClient, db):
+    """A student whose only included item is in another config does not bleed
+    into this roster's count; an item with no cross-roster history returns its
+    own cycle's months (yearly=12 here)."""
+    u = await _seed_admin_user(db, "rm_zero")
+    other = PaymentRoster(
+        roster_code="ROSTER-RM-OTHER",
+        scholarship_configuration_id=5000,  # different config — must not count
+        period_label="2026",
+        academic_year=114,
+        roster_cycle=RosterCycle.YEARLY,
+        status=RosterStatus.COMPLETED,
+        trigger_type=RosterTriggerType.MANUAL,
+        created_by=u.id,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+    )
+    target = PaymentRoster(
+        roster_code="ROSTER-RM-TARGET",
+        scholarship_configuration_id=5001,
+        period_label="2026",
+        academic_year=114,
+        roster_cycle=RosterCycle.YEARLY,
+        status=RosterStatus.COMPLETED,
+        trigger_type=RosterTriggerType.MANUAL,
+        created_by=u.id,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+    )
+    db.add_all([other, target])
+    await db.commit()
+    await db.refresh(other)
+    await db.refresh(target)
+
+    db.add_all(
+        [
+            PaymentRosterItem(
+                roster_id=other.id,
+                application_id=1,
+                student_id_number="B123456789",
+                student_number="RM-ZERO-1",
+                student_name="Zero Student",
+                scholarship_name="RM Scholarship",
+                scholarship_amount=Decimal("10000"),
+                is_included=True,
+            ),
+            PaymentRosterItem(
+                roster_id=target.id,
+                application_id=1,
+                student_id_number="B123456789",
+                student_number="RM-ZERO-1",
+                student_name="Zero Student",
+                scholarship_name="RM Scholarship",
+                scholarship_amount=Decimal("10000"),
+                is_included=True,
+            ),
+        ]
+    )
+    await db.commit()
+
+    resp = await client_admin.get(f"/api/v1/payment-rosters/{target.id}/items")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["data"]
+    assert len(items) == 1, items
+    # only the target config's yearly roster counts → 12, not 24
+    assert items[0]["received_months"] == 12, items[0]
+
+
+@pytest.mark.asyncio
+async def test_get_roster_items_received_months_zero_when_student_number_missing(client_admin: AsyncClient, db):
+    """An item with no student_number (學號) can't be matched for cumulative
+    counting, so it must report received_months=0 rather than raising or
+    matching the bulk dict's None key."""
+    u = await _seed_admin_user(db, "rm_null")
+    roster = PaymentRoster(
+        roster_code="ROSTER-RM-NULL",
+        scholarship_configuration_id=6001,
+        period_label="2026",
+        academic_year=114,
+        roster_cycle=RosterCycle.YEARLY,
+        status=RosterStatus.COMPLETED,
+        trigger_type=RosterTriggerType.MANUAL,
+        created_by=u.id,
+        started_at=datetime.now(timezone.utc),
+        completed_at=datetime.now(timezone.utc),
+    )
+    db.add(roster)
+    await db.commit()
+    await db.refresh(roster)
+
+    db.add(
+        PaymentRosterItem(
+            roster_id=roster.id,
+            application_id=1,
+            student_id_number="C123456789",
+            student_number=None,  # no 學號 — unmatchable
+            student_name="No Number Student",
+            scholarship_name="RM Scholarship",
+            scholarship_amount=Decimal("10000"),
+            is_included=True,
+        )
+    )
+    await db.commit()
+
+    resp = await client_admin.get(f"/api/v1/payment-rosters/{roster.id}/items")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["data"]
+    assert len(items) == 1, items
+    assert items[0]["received_months"] == 0, items[0]

--- a/frontend/components/roster/EligibilityDetailDialog.tsx
+++ b/frontend/components/roster/EligibilityDetailDialog.tsx
@@ -46,6 +46,8 @@ export interface EligibilityDetailItem {
   is_eligible?: boolean | null;
   verification_message?: string | null;
   rule_validation_result?: RuleValidationResult | null;
+  /** 累計已領月份數（含本期）；null/undefined = 無資料 */
+  received_months?: number | null;
 }
 
 interface EligibilityDetailDialogProps {
@@ -161,9 +163,17 @@ export function EligibilityDetailDialog({ item, onClose }: EligibilityDetailDial
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">驗證結果:</span>
-            <EligibilityBadge item={item} />
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">驗證結果:</span>
+              <EligibilityBadge item={item} />
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">已領月份數:</span>
+              <span className="text-sm font-medium">
+                {item.received_months != null ? `${item.received_months} 個月` : "-"}
+              </span>
+            </div>
           </div>
 
           <RuleList rules={snapshot?.failed_rules} label="未通過規則" tone="fail" />

--- a/frontend/components/roster/RosterDetailDialog.tsx
+++ b/frontend/components/roster/RosterDetailDialog.tsx
@@ -517,6 +517,7 @@ export function RosterDetailDialog({
             <TableHead>分發獎學金</TableHead>
             <TableHead>符合資格</TableHead>
             <TableHead>資格詳情</TableHead>
+            <TableHead className="text-right">已領月份數</TableHead>
             <TableHead className="text-right">金額</TableHead>
             <TableHead className="text-right w-20">操作</TableHead>
           </TableRow>
@@ -590,6 +591,9 @@ export function RosterDetailDialog({
                   >
                     詳情
                   </Button>
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {item.received_months != null ? item.received_months : "-"}
                 </TableCell>
                 <TableCell className="text-right font-medium">
                   {formatCurrency(item.scholarship_amount)}


### PR DESCRIPTION
## Summary

Adds a cumulative **已領月份數 (received-months)** display to the 造冊 (payment roster) **察看名單** UI, so admins can see how many months each student has already received under a scholarship config — the same figure the PhD 36-month eligibility cap is checked against.

It appears in **two places** (per requirement):
- A new right-aligned **已領月份數** column in the roster detail table (`RosterDetailDialog`).
- A **已領月份數: X 個月** line next to 驗證結果 in the **資格詳情** dialog (`EligibilityDetailDialog`).

## What changed

**Backend**
- `GET /api/v1/payment-rosters/{id}/items` now bulk-computes `received_months` per item via the shared `received_months_service.calculate_received_months_bulk_async` — one grouped query per page — and attaches it to each item.
- Keyed on `PaymentRosterItem.student_number` (學號 / `std_stdcode`), scoped to the roster's `scholarship_configuration_id`; missing 學號 → `0`.
- `received_months: Optional[int]` documented on `RosterItemResponse`.

**Frontend**
- `EligibilityDetailItem` gains `received_months?: number | null`; `RosterItem` inherits it, so both placements share one field. `0` renders as `0`; only missing data renders `-`.

## Design decisions (confirmed with requester)

1. **Cumulative, INCLUDING the roster being viewed.** Reuses `received_months_service` directly (cycle-weighted: monthly=1 / semi-yearly=6 / yearly=12, counting only `is_included` items). No subtraction of the current roster.
2. **Both** the 資格詳情 dialog and the 察看名單 table.
3. **Out of scope:** the manual-distribution "imported override" (`CollegeRankingItem.received_months`). The 36-month cap uses the system-computed value, so this view intentionally mirrors that and stays faithful to the actual eligibility decision.

## Testing

- 3 new endpoint tests in `test_payment_rosters_api.py`: cumulative across cycles (1+12=13), `is_included=False` exclusion, config isolation (no cross-config bleed), and missing-學號 → 0.
- Full affected suites green: `test_payment_rosters_api.py` + `test_received_months_with_roster.py` + `test_received_months_service.py` → **59 passed** (plus the new one).
- `black --check` clean; `flake8` B904/B014 clean; frontend `tsc --noEmit` clean; ESLint clean on changed files.
- `openapi-typescript` regen produced no diff (`RosterItemResponse` is not a `response_model`, so it's not in the OpenAPI surface).

## Notes
- No DB schema change / migration (value is derived on read).
- Screenshots not attached — the dev frontend container is bound to a different checkout; happy to add UI captures of the column + dialog on request.