### PR TITLE
fix(preview): bound framable-preview matcher to exclude /api/v1/preview-* siblings

### DIFF
--- a/frontend/__tests__/middleware-csp.test.ts
+++ b/frontend/__tests__/middleware-csp.test.ts
@@ -91,7 +91,9 @@ describe("middleware framing for same-origin preview proxies", () => {
     "https://ss.test.nycu.edu.tw/api/v1/preview/examples?documentId=1",
     "https://ss.test.nycu.edu.tw/api/v1/preview/system-docs?key=regulations_url",
     "https://ss.test.nycu.edu.tw/api/v1/preview/supp-docs?id=1",
-    "https://ss.test.nycu.edu.tw/api/v1/preview/application-document?id=APP-1",
+    // numeric id — the application-document route validates /^\d+$/ and the caller
+    // passes the numeric application PK, so keep the test URL realistic.
+    "https://ss.test.nycu.edu.tw/api/v1/preview/application-document?id=87",
   ];
 
   it.each(PREVIEW_ROUTES)("prod: %s is framable same-origin (SAMEORIGIN + frame-ancestors 'self')", (url) => {
@@ -123,6 +125,10 @@ describe("middleware framing for same-origin preview proxies", () => {
       // /api/v1/preview prefix (attachment download). Guard that the framing
       // relaxation does NOT leak to it.
       "https://ss.test.nycu.edu.tw/api/v1/download?fileId=1&applicationId=1&type=pdf",
+      // String-prefix footgun guard: a `/api/v1/preview-*` SIBLING must NOT be
+      // framable. The predicate matches exactly /api/v1/preview and /preview/<child>,
+      // so this hypothetical sibling must keep the strict DENY posture.
+      "https://ss.test.nycu.edu.tw/api/v1/preview-export?id=1",
     ]) {
       const res = middleware(mockRequest(url));
       const csp = res.headers.get("Content-Security-Policy") ?? "";

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -41,12 +41,18 @@ export function middleware(request: NextRequest) {
   // not sufficient without this matching CSP relaxation.
   //
   // INVARIANT: this is why every framable file proxy MUST live under
-  // `/api/v1/preview/` — both this predicate and the nginx `location /api/v1/preview`
-  // block then cover it correct-by-construction, with no per-endpoint edits. A
-  // framable proxy placed outside this prefix recurs the "refused to connect" bug
-  // in BOTH layers. Do NOT create non-framable `/api/v1/preview*` siblings either
-  // (the nginx prefix would wrongly relax them) — keep downloads/uploads elsewhere.
-  const isFramablePreview = request.nextUrl.pathname.startsWith("/api/v1/preview");
+  // `/api/v1/preview/` — both this predicate and the nginx preview block then cover
+  // it correct-by-construction, with no per-endpoint edits. A framable proxy placed
+  // outside this prefix recurs the "refused to connect" bug in BOTH layers.
+  //
+  // Match the multiplexer EXACTLY (`/api/v1/preview`) plus its child paths
+  // (`/api/v1/preview/...`) — NOT a bare `startsWith`, which would also relax a
+  // `/api/v1/preview-export`-style sibling and silently make it framable. The nginx
+  // configs mirror this with `location ~ ^/api/v1/preview(/|$)`; the two layers MUST
+  // stay in lock-step (a tight-here / loose-there split itself breaks framing).
+  const { pathname } = request.nextUrl;
+  const isFramablePreview =
+    pathname === "/api/v1/preview" || pathname.startsWith("/api/v1/preview/");
   const frameAncestors = isFramablePreview ? "frame-ancestors 'self'" : "frame-ancestors 'none'";
 
   if (isDevelopment) {

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -173,7 +173,10 @@ http {
             proxy_buffering off;
         }
 
-        location /api/v1/preview {
+        # Bounded match: exactly /api/v1/preview and its /children — NOT
+        # /api/v1/preview-* siblings (a plain prefix would wrongly relax framing
+        # for a future /api/v1/preview-export). Mirrors the middleware predicate.
+        location ~ ^/api/v1/preview(/|$) {
             limit_req zone=frontend burst=30 nodelay;
 
             set $frontend_upstream frontend:3000;

--- a/nginx/nginx.staging-e2e.conf
+++ b/nginx/nginx.staging-e2e.conf
@@ -42,8 +42,9 @@ http {
         }
         # /api/v1/preview covers ALL framable file-preview proxies as child paths:
         # /preview/terms, /preview/examples, /preview/system-docs, /preview/supp-docs,
-        # /preview/application-document (single prefix, mirrors nginx.staging.conf).
-        location /api/v1/preview {
+        # /preview/application-document. Bounded regex (exactly /api/v1/preview and
+        # its /children, NOT /api/v1/preview-* siblings) mirrors nginx.staging.conf.
+        location ~ ^/api/v1/preview(/|$) {
             proxy_pass http://$frontend_upstream;
         }
         location /api/email/ {

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -160,7 +160,10 @@ http {
             proxy_buffering off;
         }
 
-        location /api/v1/preview {
+        # Bounded match: exactly /api/v1/preview and its /children — NOT
+        # /api/v1/preview-* siblings (a plain prefix would wrongly relax framing
+        # for a future /api/v1/preview-export). Mirrors the middleware predicate.
+        location ~ ^/api/v1/preview(/|$) {
             limit_req zone=frontend burst=20 nodelay;
 
             set $frontend_upstream frontend:3000;


### PR DESCRIPTION
Follow-up to #1056, addressing the Copilot review feedback.

## What & why

The unified preview namespace was matched with `startsWith("/api/v1/preview")` (middleware) and `location /api/v1/preview` (nginx plain-prefix). Both also match `/api/v1/preview-*` **siblings** (e.g. a future `/api/v1/preview-export`) — which would silently relax `frame-ancestors` / `X-Frame-Options` for a non-preview endpoint. No such sibling exists today, so there's no active leak, but this enforces the "framable ⟺ under `/api/v1/preview/`" invariant **mechanically** instead of relying on a comment.

## Changes

- **`middleware.ts`** — `pathname === "/api/v1/preview" || pathname.startsWith("/api/v1/preview/")` (exact multiplexer + child paths only).
- **nginx (staging / prod / e2e)** — `location ~ ^/api/v1/preview(/|$)` (matches exactly `/api/v1/preview` and `/api/v1/preview/...`, not `-` siblings). Both layers tightened **together** — a tight-here / loose-there split would itself break framing (browsers honor CSP `frame-ancestors` over `X-Frame-Options`).
- **`middleware-csp.test.ts`** — added `/api/v1/preview-export` → `DENY` as the regression guard for the footgun; switched the application-document preview test URL to a **numeric** `id` (the route validates `/^\d+$/`; the caller passes the numeric application PK).

## Verification

- 70/70 tests pass across the 4 touched suites, incl. the new sibling-exclusion guard.
- `nginx -t` syntax-ok on the self-contained e2e conf; all 3 confs brace-balanced with exactly one regex preview block and no plain-prefix preview block.
- nginx precedence checked: for `/api/v1/preview/...` the regex wins over the `/api/` prefix (no `^~`); no earlier regex location matches preview paths.