### PR TITLE
test(e2e): always-recorded showcase replay for the nightly Pages report

### DIFF
--- a/.github/workflows/nightly-failure-cleanup.yml
+++ b/.github/workflows/nightly-failure-cleanup.yml
@@ -1,0 +1,65 @@
+name: Nightly failure report cleanup
+
+# Issue-bound retention for nightly e2e failure evidence.
+#
+# nightly.yml uploads a 90-day `nightly-failure-report-<run_id>` artifact on
+# e2e-full failure and links its name in the auto-filed `nightly-failure` issue.
+# "Keep until fixed" = keep until that issue is closed: when a nightly-failure
+# issue is closed, delete every failure-report artifact it references, instead
+# of waiting out the full 90-day cap. (90 days is GitHub's hard maximum for
+# artifact retention, so an issue left open longer than that will still lose its
+# artifact — that is a platform limit, not a policy choice.)
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  actions: write   # required to delete workflow artifacts
+  issues: read
+
+jobs:
+  cleanup:
+    name: Delete failure-report artifacts for the closed issue
+    runs-on: ubuntu-latest
+    # Only act on the auto-filed nightly-failure issues.
+    if: ${{ contains(github.event.issue.labels.*.name, 'nightly-failure') }}
+    steps:
+      - name: Delete artifacts referenced by the issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The dedup issue can reference several runs (one per failing day,
+          # appended as comments), so scan the body AND every comment.
+          gh issue view "$ISSUE" --repo "$REPO" --json body,comments \
+            --jq '.body, (.comments[].body)' > issue_text.txt
+
+          names=$(grep -oE 'nightly-failure-report-[0-9]+' issue_text.txt | sort -u || true)
+          if [ -z "$names" ]; then
+            echo "Issue #$ISSUE references no failure-report artifacts; nothing to delete."
+            exit 0
+          fi
+          echo "Referenced artifacts:"
+          echo "$names"
+
+          for name in $names; do
+            # An artifact name may have several uploads over time; delete all.
+            ids=$(gh api --paginate \
+              "repos/$REPO/actions/artifacts?per_page=100" \
+              --jq ".artifacts[] | select(.name==\"$name\") | .id" || true)
+            if [ -z "$ids" ]; then
+              echo "  $name: not found (already expired or deleted)"
+              continue
+            fi
+            for id in $ids; do
+              if gh api -X DELETE "repos/$REPO/actions/artifacts/$id"; then
+                echo "  deleted $name (id=$id)"
+              else
+                echo "  failed to delete $name (id=$id)" >&2
+              fi
+            done
+          done

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -232,6 +232,23 @@ jobs:
             frontend/test-results/
           retention-days: 14
 
+      # On failure, keep a SECOND, run-scoped copy with the maximum retention
+      # GitHub allows (90 days). The 14-day copy above (and the Pages site) get
+      # overwritten by the next nightly — this one survives so the failure's
+      # video/trace/screenshots stay available until the bug is fixed. The
+      # file-issue-on-failure job links this artifact name in the issue, and
+      # nightly-failure-cleanup.yml deletes it when that issue is closed (= the
+      # failure is fixed), rather than waiting out the full 90 days.
+      - name: Upload failure report (retained until the nightly-failure issue is closed)
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: nightly-failure-report-${{ github.run_id }}
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          retention-days: 90
+
       - name: Tear down compose
         if: always()
         run: docker compose -f docker-compose.dev.yml down -v || true
@@ -316,6 +333,15 @@ jobs:
             --search "in:title $today" \
             --json number \
             --jq '.[0].number' || echo '')
+          # When e2e-full failed, point at the 90-day failure-report artifact so
+          # the video/trace/screenshots stay reachable until this issue is
+          # closed. nightly-failure-cleanup.yml greps the issue for this exact
+          # `nightly-failure-report-<run_id>` name to delete it on close, so keep
+          # the literal name in the body.
+          evidence_line=""
+          if [ "${{ needs.e2e-full.result }}" = "failure" ]; then
+            evidence_line="- E2E failure evidence (video/trace/screenshots), retained until this issue is closed: download artifact \`nightly-failure-report-${{ github.run_id }}\` from the run page above, or browse the latest report at https://anud18.github.io/scholarship-system/"
+          fi
           body=$(cat <<EOF
           One or more jobs in the nightly long-running lane failed today.
 
@@ -324,6 +350,7 @@ jobs:
             - backend-slow: ${{ needs.backend-slow.result }}
             - audit-log-contract: ${{ needs.audit-log-contract.result }}
             - e2e-full: ${{ needs.e2e-full.result }}
+          $evidence_line
 
           (Auto-filed by .github/workflows/nightly.yml — Phase 5 of
           test-surface-hardening plan. Feel free to close once the

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -3,15 +3,18 @@ import { BACKEND_URL, FRONTEND_URL } from "./env";
 
 const API_BASE = BACKEND_URL;
 
-export interface LoginResult {
-  context: BrowserContext;
+export interface AuthSession {
   token: string;
   userId: number;
   user: Record<string, unknown>;
   traceId: string | null;
 }
 
-export async function loginAs(browser: Browser, nycuId: string): Promise<LoginResult> {
+export interface LoginResult extends AuthSession {
+  context: BrowserContext;
+}
+
+async function fetchMockSsoSession(nycuId: string): Promise<AuthSession> {
   const r = await fetch(`${API_BASE}/api/v1/auth/mock-sso/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -20,11 +23,14 @@ export async function loginAs(browser: Browser, nycuId: string): Promise<LoginRe
   const body = (await r.json()) as {
     success?: boolean;
     message?: string;
-    data?: { access_token?: string; user?: Record<string, unknown> & { id?: number } };
+    data?: {
+      access_token?: string;
+      user?: Record<string, unknown> & { id?: number };
+    };
   };
   if (!r.ok || !body.success || !body.data?.access_token || !body.data?.user) {
     throw new Error(
-      `mock-sso login failed for ${nycuId}: HTTP ${r.status} ${body.message ?? "(no message)"}`,
+      `mock-sso login failed for ${nycuId}: HTTP ${r.status} ${body.message ?? "(no message)"}`
     );
   }
   const token = body.data.access_token;
@@ -33,17 +39,42 @@ export async function loginAs(browser: Browser, nycuId: string): Promise<LoginRe
   if (!Number.isFinite(userId)) {
     throw new Error(`mock-sso login for ${nycuId}: missing numeric user.id`);
   }
+  return { token, userId, user, traceId: r.headers.get("x-trace-id") };
+}
 
-  const context = await browser.newContext({ baseURL: FRONTEND_URL });
+/**
+ * Inject an authenticated mock-SSO session into an EXISTING context.
+ *
+ * Use this with the built-in `context`/`page` test fixtures (which the runner
+ * owns) when you need Playwright to record + attach video/trace — manually
+ * created `browser.newContext()` contexts (see {@link loginAs}) only get trace,
+ * never video, because `recordVideo` is a creation-time-only option the runner
+ * does not retrofit onto contexts it did not create.
+ */
+export async function authContext(
+  context: BrowserContext,
+  nycuId: string
+): Promise<AuthSession> {
+  const session = await fetchMockSsoSession(nycuId);
   // useAuth (frontend/hooks/use-auth.tsx:38-62) reads BOTH 'auth_token' and 'user'.
   await context.addInitScript(
     ({ t, u }: { t: string; u: string }) => {
       localStorage.setItem("auth_token", t);
       localStorage.setItem("user", u);
     },
-    { t: token, u: JSON.stringify(user) },
+    { t: session.token, u: JSON.stringify(session.user) }
   );
-  await context.setExtraHTTPHeaders({ Authorization: `Bearer ${token}` });
+  await context.setExtraHTTPHeaders({
+    Authorization: `Bearer ${session.token}`,
+  });
+  return session;
+}
 
-  return { context, token, userId, user, traceId: r.headers.get("x-trace-id") };
+export async function loginAs(
+  browser: Browser,
+  nycuId: string
+): Promise<LoginResult> {
+  const context = await browser.newContext({ baseURL: FRONTEND_URL });
+  const session = await authContext(context, nycuId);
+  return { context, ...session };
 }

--- a/frontend/e2e/specs/showcase-replay.spec.ts
+++ b/frontend/e2e/specs/showcase-replay.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * E2E "showcase" flow — the always-recorded walkthrough.
+ *
+ * Why this file exists:
+ *   The published nightly report (https://anud18.github.io/scholarship-system)
+ *   keeps video + trace only `retain-on-failure` (see playwright.config.ts) to
+ *   stay small. But the nightly suite almost always passes, so a green report
+ *   has NO watchable recording at all. This one spec opts INTO video + trace on
+ *   EVERY run so the report always contains at least one Cursor-agent-style
+ *   replay (the interactive Trace viewer) plus a video of a real happy path.
+ *
+ * It MUST use the built-in `page` fixture (a runner-owned context): video is a
+ * creation-time `recordVideo` option the runner only applies to its own
+ * fixtures, so a manually-created `browser.newContext()` (helpers/auth.loginAs)
+ * records trace but never video. We inject auth onto the fixture context via
+ * `authContext` instead.
+ *
+ * Flow: admin → 系統管理 → 學生領取歷史 → query seeded stuphd001 → result renders.
+ * Kept assertion-light on purpose: the value is the recording, and it must stay
+ * green every night.
+ */
+
+import { test, expect } from "@playwright/test";
+import { authContext } from "../helpers/auth";
+
+// Record video + an interactive trace on EVERY run, not just on failure.
+test.use({ video: "on", trace: "on" });
+
+test("showcase: admin looks up a student's scholarship history", async ({
+  page,
+}) => {
+  await authContext(page.context(), "admin");
+  await page.goto("/");
+
+  // AdminManagementShell renders inside the top-level "系統管理" tab.
+  await page.getByRole("tab", { name: "系統管理" }).click();
+  await page.getByRole("tab", { name: "學生領取歷史" }).click();
+
+  await page.getByLabel("學號").fill("stuphd001");
+  await page.getByRole("button", { name: "查詢" }).click();
+
+  // Either a result table or an empty / not-found state is a valid render — the
+  // point is the page responded without error (see admin-student-history.spec).
+  await expect(
+    page.getByText(/領取明細|查無此學生資料|尚無領取記錄/).first()
+  ).toBeVisible({ timeout: 10000 });
+});


### PR DESCRIPTION
## What

Two related improvements to the nightly Playwright e2e report published at https://anud18.github.io/scholarship-system.

### 1. Always-recorded showcase replay

Today the report keeps **video + trace only `retain-on-failure`** — but the suite almost always passes, so a green report has **screenshots only, no watchable recording**.

This adds one dedicated **showcase** spec (`frontend/e2e/specs/showcase-replay.spec.ts`) that opts into `video: "on"` + `trace: "on"` on **every** run, so each nightly report always contains:

- an interactive **Trace viewer** replay (timeline + DOM snapshots + network + action log — the closest thing to a Cursor-agent-style replay), and
- a **video** of a real happy path (`admin → 系統管理 → 學生領取歷史 → query seeded stuphd001`).

The rest of the suite stays `retain-on-failure` to keep the report small (showcase artifacts ≈ 3.4 MB). `screenshot: "on"` unchanged.

**Auth refactor:** `recordVideo` is a creation-time-only option the runner applies only to its built-in `page`/`context` fixtures. The existing `loginAs` builds its context by hand via `browser.newContext()`, which the runner retrofits **trace** onto but **never video** — so the showcase must run on a runner-owned fixture context. `auth.ts` now exposes `authContext(context, nycuId)` (inject a mock-SSO session onto an existing context); `loginAs` is built on top of it. No behaviour change for existing callers.

### 2. Keep failure evidence until the bug is fixed

The Pages report is overwritten nightly and the `playwright-report-nightly` artifact is deleted after 14 days, so a failing run's video/trace/screenshots can vanish before anyone fixes it. Retention is now **bound to the auto-filed `nightly-failure` issue**:

- `e2e-full` also uploads, on failure, a run-scoped `nightly-failure-report-<run_id>` artifact at the **90-day** max retention.
- `file-issue-on-failure` links that artifact name (+ the Pages report) in the issue body.
- New `nightly-failure-cleanup.yml` triggers on `issues: closed`; for a `nightly-failure` issue it greps the body + comments for the referenced artifact names and deletes them via the Actions API — freeing evidence **when the issue is closed (= fixed)**, not on a blind timer.

> 90 days is GitHub's hard cap for artifact retention, so an issue left open longer than that still loses its artifact — a platform limit, documented in both workflows.

## Verification (local, against dev stack)

- Showcase run → report `data/` bundles `webm` (video) + `zip` (trace) + `png` (screenshot). ✅
- A passing `loginAs`-based spec (`admin-student-history`) → `png` only — global default untouched. ✅
- Existing `admin-student-history` passes 3/3 after the `auth.ts` refactor. ✅
- ESLint + Prettier clean on touched TS; both workflow YAMLs parse; cleanup script `bash -n` clean + regex extraction verified. ✅

The retention path (failure artifact + issue link + cleanup-on-close) only exercises on a real nightly failure, so it's verified statically here; first live exercise will be the next failing nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEMYp9dNmZhYPgqZx7dYTW