### PR TITLE
feat(scholarship): set MOE PhD advisor matching fund label to NT$5,000/month

### DIFF
--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -421,7 +421,7 @@ async def seed_scholarship_rules(session: AsyncSession) -> None:
             "created_by": admin_id,
             "updated_by": admin_id,
         },
-        # 博士生獎學金 教育部獎學金 (一萬元) 5. 中華民國國籍 6. 一至三年級
+        # 博士生獎學金 教育部獎學金 (每月五千) 5. 中華民國國籍 6. 一至三年級
         {
             "scholarship_type_id": 2,
             "sub_type": "moe_1w",
@@ -809,10 +809,10 @@ async def seed_scholarship_sub_type_configs(session: AsyncSession) -> None:
                     {
                         "scholarship_type_id": scholarship.id,
                         "sub_type_code": "moe_1w",
-                        "name": "教育部博士生獎學金 (指導教授配合款一萬)",
-                        "name_en": "MOE PHD Scholarship (Professor Match 10K)",
-                        "description": "教育部博士生獎學金，指導教授配合款一萬元",
-                        "description_en": "MOE PHD Scholarship with professor match of 10K",
+                        "name": "教育部博士生獎學金 (指導教授配合款每月五千)",
+                        "name_en": "MOE PHD Scholarship (Professor Match NT$5,000/month)",
+                        "description": "教育部博士生獎學金，指導教授配合款每月五千元",
+                        "description_en": "MOE PHD Scholarship with professor match of NT$5,000/month",
                         "amount": None,  # 使用主獎學金金額
                         "display_order": 2,
                         "is_active": True,

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -260,7 +260,7 @@ export const translations = {
     },
     rule_types: {
       nstc: "國科會博士生獎學金",
-      moe_1w: "教育部博士生獎學金 (指導教授配合款一萬)",
+      moe_1w: "教育部博士生獎學金 (指導教授配合款每月五千)",
       moe_2w: "教育部博士生獎學金 (指導教授配合款兩萬)",
     },
     scholarship_sections: {
@@ -773,7 +773,7 @@ export const translations = {
     },
     rule_types: {
       nstc: "NSTC PhD Scholarship",
-      moe_1w: "MOE PhD Scholarship (Advisor Matching Fund - 10K)",
+      moe_1w: "MOE PhD Scholarship (Advisor Matching Fund - NT$5,000/month)",
       moe_2w: "MOE PhD Scholarship (Advisor Matching Fund - 20K)",
     },
     scholarship_sections: {


### PR DESCRIPTION
## Summary

The Ministry of Education (教育部) doctoral scholarship's **advisor matching fund (指導教授配合款)** for the active MOE tier (`moe_1w`) is now displayed as **每月五千 / NT\$5,000/month**, replacing the previous "一萬 / 10K" label.

`moe_1w` is the only MOE PhD tier students actually see (PhD `sub_type_list = ["nstc", "moe_1w"]`).

## Changes

| Surface | Before → After |
|---|---|
| `seed_scholarship_configs.py` — `moe_1w` name/description (zh+en) | 指導教授配合款**一萬** / Professor Match **10K** → 指導教授配合款**每月五千** / Professor Match **NT\$5,000/month** |
| `seed_scholarship_configs.py` — stale rule comment | `(一萬元)` → `(每月五千)` |
| `frontend/lib/i18n.ts` — `rule_types.moe_1w` (zh L263 + en L776) | 一萬 / "10K" → 每月五千 / "NT\$5,000/month" |

## Scope decisions

- **Kept sub-type code `moe_1w`** — it's an opaque ID embedded across ~40 files plus live application/roster/ranking data; renaming would be a large, risky data migration with no display benefit. Only the human-readable label changed.
- **Left inactive `moe_2w` (兩萬) untouched** — not in PhD `sub_type_list`, no DB config row, not shown to anyone.
- **Left secondary compact strings** that still encode "1萬": Excel-export column `教育部(1萬)` and the batch-import header alias `教育部配合款1萬` (changing the import alias could break existing admin import templates).

## Notes / verification

- PhD config `amount = 40000`, sub-type `amount = NULL`, and **no payment/roster coupling** to a 配合款 number — "一萬" was descriptive label text only, so this is a pure relabel with no payout impact.
- No test/snapshot asserts the old strings; changed lines are ≤103 chars (black gate 120).
- The running **dev DB** `scholarship_sub_type_configs.name` for `moe_1w` was updated out-of-band so the config-driven label shows immediately; this PR is the source-of-truth change so fresh installs (`reset_database.sh`) seed the new label.