### PR TITLE
feat(student-apply): hide already-submitted / no-eligible scholarships from apply flow

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -129,7 +129,11 @@ async def create_application(
         logger.debug(f"Fetching scholarship configuration: {application_data.configuration_id}")
         from sqlalchemy import and_, select
 
-        from app.models.application import Application, ApplicationStatus
+        from app.models.application import (
+            Application,
+            ApplicationStatus,
+            build_config_match_filters,
+        )
         from app.models.scholarship import ScholarshipConfiguration
 
         config_stmt = select(ScholarshipConfiguration).where(
@@ -155,13 +159,11 @@ async def create_application(
         # 排除已撤回/拒絕/取消/刪除的申請 (shared set — see app.models.enums)
         excluded_statuses = REAPPLY_ALLOWED_APPLICATION_STATUSES
 
-        # 查詢是否已有申請 - using values from scholarship configuration
+        # 查詢是否已有申請 - shared (user, type, year, semester) key, see
+        # build_config_match_filters
         duplicate_check_stmt = select(Application).where(
             and_(
-                Application.user_id == current_user.id,
-                Application.scholarship_type_id == scholarship_config.scholarship_type_id,
-                Application.academic_year == scholarship_config.academic_year,
-                Application.semester == scholarship_config.semester,
+                *build_config_match_filters(current_user.id, scholarship_config),
                 Application.status.notin_(excluded_statuses),
             )
         )

--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -16,6 +16,7 @@ from app.core.exceptions import AuthorizationError, NotFoundError, ScholarshipEx
 from app.core.security import get_current_user, require_staff, require_student
 from app.db.deps import get_db
 from app.models.audit_log import AuditAction
+from app.models.enums import REAPPLY_ALLOWED_APPLICATION_STATUSES
 from app.models.user import User
 from app.schemas.application import (
     ApplicationCreate,
@@ -151,13 +152,8 @@ async def create_application(
         # Check for duplicate applications (同一獎學金類型、學年度、學期只能有一個申請)
         logger.debug("Checking for duplicate applications")
 
-        # 排除已撤回/拒絕/取消/刪除的申請
-        excluded_statuses = [
-            ApplicationStatus.withdrawn,
-            ApplicationStatus.rejected,
-            ApplicationStatus.cancelled,
-            ApplicationStatus.deleted,
-        ]
+        # 排除已撤回/拒絕/取消/刪除的申請 (shared set — see app.models.enums)
+        excluded_statuses = REAPPLY_ALLOWED_APPLICATION_STATUSES
 
         # 查詢是否已有申請 - using values from scholarship configuration
         duplicate_check_stmt = select(Application).where(

--- a/backend/app/api/v1/endpoints/scholarships.py
+++ b/backend/app/api/v1/endpoints/scholarships.py
@@ -250,6 +250,7 @@ async def get_scholarship_eligibility(
             warnings=[],  # Hide warnings from student view - they don't need to see these
             errors=scholarship.get("errors", []),  # Error messages from eligibility check
             created_at=scholarship.get("created_at"),
+            already_submitted=scholarship.get("already_submitted", False),
         )
         response_data.append(response_item)
 

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -394,3 +394,25 @@ class ApplicationFile(Base):
     def download_url(self, value: Optional[str]):
         """Set file download URL"""
         self._download_url = value
+
+
+def build_config_match_filters(user_id: int, config):
+    """SQLAlchemy filter clauses matching a student's applications to a
+    scholarship configuration by (user, type, year, semester).
+
+    Shared by the eligible-scholarships "already submitted" check
+    (EligibilityService.has_blocking_application) and the DUPLICATE_APPLICATION
+    guard in the applications endpoint, so the two cannot drift on the
+    semester-NULL handling. Each caller appends its own status clause. ``config``
+    only needs ``scholarship_type_id``, ``academic_year`` and ``semester``.
+    """
+    if config.semester:
+        semester_filter = Application.semester == config.semester
+    else:
+        semester_filter = Application.semester.is_(None)
+    return [
+        Application.user_id == user_id,
+        Application.scholarship_type_id == config.scholarship_type_id,
+        Application.academic_year == config.academic_year,
+        semester_filter,
+    ]

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -55,6 +55,45 @@ REVIEWABLE_APPLICATION_STATUSES = [
 ]
 
 
+# ── Apply-flow visibility sets ───────────────────────────────────────
+# Partition every ApplicationStatus value into three buckets that decide
+# whether a scholarship is shown in the STUDENT APPLY FLOW.
+# Invariant: shown ⟺ a fresh/continued application is still submittable
+# (kept consistent with the DUPLICATE_APPLICATION guard in applications.py).
+
+# Terminal/withdrawn states the duplicate guard does NOT block — the student may
+# re-apply, so the scholarship stays visible. Mirrors the guard's exclude set;
+# `deleted` is a soft-delete tombstone, intentionally treated as re-applyable.
+REAPPLY_ALLOWED_APPLICATION_STATUSES = [
+    ApplicationStatus.withdrawn.value,
+    ApplicationStatus.rejected.value,
+    ApplicationStatus.cancelled.value,
+    ApplicationStatus.deleted.value,
+]
+
+# In-progress states the student finishes IN PLACE via the edit flow — the
+# scholarship stays visible so the draft/returned item can be completed.
+EDITABLE_APPLICATION_STATUSES = [
+    ApplicationStatus.draft.value,
+    ApplicationStatus.returned.value,
+]
+
+# "已送出/處理中" — a blocking application exists that is NOT continuable in
+# place, so the scholarship is HIDDEN from the apply flow. Exactly the complement
+# of REAPPLY_ALLOWED ∪ EDITABLE over the full enum. `manual_excluded` and
+# `cancelled_by_challenge` are here because the duplicate guard blocks them too
+# (showing them would only lead to a DUPLICATE_APPLICATION error on submit).
+HIDDEN_APPLICATION_STATUSES = [
+    ApplicationStatus.submitted.value,
+    ApplicationStatus.under_review.value,
+    ApplicationStatus.pending_documents.value,
+    ApplicationStatus.approved.value,
+    ApplicationStatus.partial_approved.value,
+    ApplicationStatus.manual_excluded.value,
+    ApplicationStatus.cancelled_by_challenge.value,
+]
+
+
 class ReviewStage(enum.Enum):
     """
     Review stage - Internal workflow position

--- a/backend/app/schemas/scholarship.py
+++ b/backend/app/schemas/scholarship.py
@@ -282,6 +282,7 @@ class EligibleScholarshipResponse(BaseModel):
     created_at: datetime
     all_sub_type_list: List[str] = []
     subtype_eligibility: Dict[str, SubtypeEligibilityInfo] = {}
+    already_submitted: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/eligibility_service.py
+++ b/backend/app/services/eligibility_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import DEV_SCHOLARSHIP_SETTINGS, settings
 from app.models.application import Application, ApplicationStatus
+from app.models.enums import HIDDEN_APPLICATION_STATUSES
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipRule
 
 logger = logging.getLogger(__name__)
@@ -474,6 +475,36 @@ class EligibilityService:
 
         # Default to basic student API
         return "student"
+
+    async def has_blocking_application(self, user_id: int, config) -> bool:
+        """Whether the student already has a submitted-and-beyond application
+        for this scholarship configuration — i.e. one that should HIDE the
+        scholarship from the apply flow.
+
+        Uses the same (user, type, year, semester) key and semester comparison
+        as the DUPLICATE_APPLICATION guard so 'shown ⟺ submittable' holds. An
+        EXISTS query: deterministic, no None edge, safe with multiple rows.
+        """
+        if config.semester:
+            semester_filter = Application.semester == config.semester
+        else:
+            semester_filter = Application.semester.is_(None)
+
+        stmt = (
+            select(Application.id)
+            .where(
+                and_(
+                    Application.user_id == user_id,
+                    Application.scholarship_type_id == config.scholarship_type_id,
+                    Application.academic_year == config.academic_year,
+                    semester_filter,
+                    Application.status.in_(HIDDEN_APPLICATION_STATUSES),
+                )
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none() is not None
 
     async def get_application_status(self, user_id: int, config: ScholarshipConfiguration) -> Dict[str, Any]:
         """Get application status for a specific scholarship configuration

--- a/backend/app/services/eligibility_service.py
+++ b/backend/app/services/eligibility_service.py
@@ -7,11 +7,11 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, exists, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import DEV_SCHOLARSHIP_SETTINGS, settings
-from app.models.application import Application, ApplicationStatus
+from app.models.application import Application, ApplicationStatus, build_config_match_filters
 from app.models.enums import HIDDEN_APPLICATION_STATUSES
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipRule
 
@@ -481,114 +481,21 @@ class EligibilityService:
         for this scholarship configuration — i.e. one that should HIDE the
         scholarship from the apply flow.
 
-        Uses the same (user, type, year, semester) key and semester comparison
-        as the DUPLICATE_APPLICATION guard so 'shown ⟺ submittable' holds. An
-        EXISTS query: deterministic, no None edge, safe with multiple rows.
+        Uses the shared (user, type, year, semester) match key
+        (build_config_match_filters) so it stays consistent with the
+        DUPLICATE_APPLICATION guard ("shown ⟺ submittable"). An EXISTS query:
+        deterministic, no None edge, safe with multiple rows.
         """
-        if config.semester:
-            semester_filter = Application.semester == config.semester
-        else:
-            semester_filter = Application.semester.is_(None)
-
-        stmt = (
-            select(Application.id)
-            .where(
+        stmt = select(
+            exists().where(
                 and_(
-                    Application.user_id == user_id,
-                    Application.scholarship_type_id == config.scholarship_type_id,
-                    Application.academic_year == config.academic_year,
-                    semester_filter,
+                    *build_config_match_filters(user_id, config),
                     Application.status.in_(HIDDEN_APPLICATION_STATUSES),
                 )
             )
-            .limit(1)
         )
         result = await self.db.execute(stmt)
-        return result.scalar_one_or_none() is not None
-
-    async def get_application_status(self, user_id: int, config: ScholarshipConfiguration) -> Dict[str, Any]:
-        """Get application status for a specific scholarship configuration
-
-        Returns:
-            Dictionary with application status info:
-            - has_application: bool - whether user has any application for this config
-            - application_status: str - current application status (draft, submitted, etc.)
-            - can_apply: bool - whether user can submit new/edit existing application
-            - status_display: str - display text for frontend
-        """
-
-        # Check for any existing application
-        active_statuses = [
-            ApplicationStatus.draft.value,
-            ApplicationStatus.submitted.value,
-            ApplicationStatus.under_review.value,
-            ApplicationStatus.approved.value,
-            ApplicationStatus.rejected.value,
-            ApplicationStatus.returned.value,
-            ApplicationStatus.cancelled.value,
-            ApplicationStatus.withdrawn.value,
-        ]
-
-        # Handle semester comparison - use enum name for PostgreSQL compatibility
-        # PostgreSQL stores enum as the name (FIRST, SECOND) not the value (first, second)
-        if config.semester:
-            # Use enum name for comparison
-            semester_filter = Application.semester == config.semester.name
-        else:
-            # If no semester in config, check for NULL
-            semester_filter = Application.semester.is_(None)
-
-        stmt = select(Application).filter(
-            and_(
-                Application.user_id == user_id,
-                Application.scholarship_type_id == config.scholarship_type_id,
-                Application.academic_year == config.academic_year,
-                semester_filter,
-                Application.status.in_(active_statuses),
-            )
-        )
-
-        result = await self.db.execute(stmt)
-        existing_application = result.scalar_one_or_none()
-
-        if not existing_application:
-            return {
-                "has_application": False,
-                "application_status": None,
-                "can_apply": True,
-                "status_display": "可申請",
-                "application_id": None,
-            }
-
-        status = existing_application.status
-
-        # Determine if user can apply/edit
-        can_apply = status in [
-            ApplicationStatus.draft.value,
-            ApplicationStatus.returned.value,
-        ]
-
-        # Determine display status
-        status_display_mapping = {
-            ApplicationStatus.draft.value: "草稿",
-            ApplicationStatus.submitted.value: "已申請",
-            ApplicationStatus.under_review.value: "審核中",
-            ApplicationStatus.approved.value: "已核准",
-            ApplicationStatus.rejected.value: "已拒絕",
-            ApplicationStatus.returned.value: "已退回",
-            ApplicationStatus.cancelled.value: "已取消",
-            ApplicationStatus.withdrawn.value: "已撤回",
-        }
-
-        status_display = status_display_mapping.get(status, "未知狀態")
-
-        return {
-            "has_application": True,
-            "application_status": status,
-            "can_apply": can_apply,
-            "status_display": status_display,
-            "application_id": existing_application.id,
-        }
+        return bool(result.scalar())
 
     def _evaluate_rule(self, student_data: Dict[str, Any], rule: ScholarshipRule) -> Optional[bool]:
         """Evaluate a single rule against student data

--- a/backend/app/services/scholarship_service.py
+++ b/backend/app/services/scholarship_service.py
@@ -149,10 +149,11 @@ class ScholarshipService:
                 eligibility_details,
             ) = await eligibility_service.get_detailed_eligibility_check(current_student_data, config, user_id)
 
-            # Always get application status if user_id is provided, regardless of eligibility
-            application_status = {}
+            # Whether the student already has a submitted-and-beyond application
+            # for this configuration → hides it from the apply flow (see spec).
+            already_submitted = False
             if user_id:
-                application_status = await eligibility_service.get_application_status(user_id, config)
+                already_submitted = await eligibility_service.has_blocking_application(user_id, config)
 
             if is_eligible:
                 # Build scholarship response with configuration data
@@ -229,12 +230,8 @@ class ScholarshipService:
                         "passed": eligibility_details.get("passed", []),
                         "warnings": eligibility_details.get("warnings", []),
                         "errors": eligibility_details.get("errors", []),
-                        # Add application status information
-                        "application_status": application_status.get("application_status"),
-                        "can_apply": application_status.get("can_apply", True),
-                        "status_display": application_status.get("status_display", "可申請"),
-                        "has_application": application_status.get("has_application", False),
-                        "application_id": application_status.get("application_id"),
+                        # Hide already-submitted scholarships from the apply flow
+                        "already_submitted": already_submitted,
                     }
                 )
 

--- a/backend/app/services/scholarship_service.py
+++ b/backend/app/services/scholarship_service.py
@@ -149,15 +149,16 @@ class ScholarshipService:
                 eligibility_details,
             ) = await eligibility_service.get_detailed_eligibility_check(current_student_data, config, user_id)
 
-            # Whether the student already has a submitted-and-beyond application
-            # for this configuration → hides it from the apply flow (see spec).
-            already_submitted = False
-            if user_id:
-                already_submitted = await eligibility_service.has_blocking_application(user_id, config)
-
             if is_eligible:
                 # Build scholarship response with configuration data
                 scholarship_type = config.scholarship_type
+
+                # Whether the student already has a submitted-and-beyond
+                # application for this configuration → hides it from the apply
+                # flow (see spec). Computed only for eligible configs.
+                already_submitted = False
+                if user_id:
+                    already_submitted = await eligibility_service.has_blocking_application(user_id, config)
 
                 # Filter sub_type_list based on student eligibility
                 (

--- a/backend/app/tests/test_application_status_sets.py
+++ b/backend/app/tests/test_application_status_sets.py
@@ -1,0 +1,49 @@
+"""Pin: the apply-flow visibility sets partition every ApplicationStatus value.
+
+These three sets decide whether a scholarship is shown in the student apply
+flow. They MUST stay a partition of the full enum so a newly-added status is
+forced into a deliberate classification (and never silently both-shown-and-hidden).
+"""
+
+from app.models.enums import (
+    ApplicationStatus,
+    EDITABLE_APPLICATION_STATUSES,
+    HIDDEN_APPLICATION_STATUSES,
+    REAPPLY_ALLOWED_APPLICATION_STATUSES,
+)
+
+
+def test_sets_are_value_strings():
+    all_values = {s.value for s in ApplicationStatus}
+    for bucket in (
+        REAPPLY_ALLOWED_APPLICATION_STATUSES,
+        EDITABLE_APPLICATION_STATUSES,
+        HIDDEN_APPLICATION_STATUSES,
+    ):
+        assert set(bucket) <= all_values
+
+
+def test_sets_partition_the_enum():
+    reapply = set(REAPPLY_ALLOWED_APPLICATION_STATUSES)
+    editable = set(EDITABLE_APPLICATION_STATUSES)
+    hidden = set(HIDDEN_APPLICATION_STATUSES)
+
+    # disjoint
+    assert reapply & editable == set()
+    assert reapply & hidden == set()
+    assert editable & hidden == set()
+
+    # cover every enum value
+    assert reapply | editable | hidden == {s.value for s in ApplicationStatus}
+
+
+def test_hidden_set_is_exactly_the_submitted_and_beyond_statuses():
+    assert set(HIDDEN_APPLICATION_STATUSES) == {
+        "submitted",
+        "under_review",
+        "pending_documents",
+        "approved",
+        "partial_approved",
+        "manual_excluded",
+        "cancelled_by_challenge",
+    }

--- a/backend/app/tests/test_eligibility_blocking_service.py
+++ b/backend/app/tests/test_eligibility_blocking_service.py
@@ -1,0 +1,89 @@
+"""Integration tests for EligibilityService.has_blocking_application.
+
+A scholarship is hidden from the apply flow iff the student has a 'blocking'
+(submitted-and-beyond) application for the same (type, year, semester).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import Semester
+from app.models.scholarship import ScholarshipType
+from app.models.user import User
+from app.services.eligibility_service import EligibilityService
+
+_SEQ = 0
+
+
+async def _make_application(db: AsyncSession, user: User, scholarship: ScholarshipType, status: str) -> Application:
+    global _SEQ
+    _SEQ += 1
+    app = Application(
+        user_id=user.id,
+        scholarship_type_id=scholarship.id,
+        sub_type_selection_mode="single",
+        status=status,
+        app_id=f"TEST-BLOCK-{_SEQ:06d}",
+        academic_year=2024,
+        semester="first",
+        student_data={"name": "Test Student"},
+        submitted_form_data={},
+        agree_terms=True,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+def _config(scholarship: ScholarshipType) -> SimpleNamespace:
+    return SimpleNamespace(
+        scholarship_type_id=scholarship.id,
+        academic_year=2024,
+        semester=Semester.first,
+    )
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        ("submitted", True),
+        ("under_review", True),
+        ("pending_documents", True),
+        ("approved", True),
+        ("partial_approved", True),
+        ("manual_excluded", True),
+        ("cancelled_by_challenge", True),
+        ("draft", False),
+        ("returned", False),
+        ("rejected", False),
+        ("withdrawn", False),
+        ("cancelled", False),
+        ("deleted", False),
+    ],
+)
+async def test_has_blocking_application_truth_table(db, test_user, test_scholarship, status, expected):
+    await _make_application(db, test_user, test_scholarship, status)
+    service = EligibilityService(db)
+    result = await service.has_blocking_application(test_user.id, _config(test_scholarship))
+    assert result is expected
+
+
+async def test_no_application_is_not_blocking(db, test_user, test_scholarship):
+    service = EligibilityService(db)
+    assert await service.has_blocking_application(test_user.id, _config(test_scholarship)) is False
+
+
+# NOTE: there is intentionally no "rejected + fresh draft" multi-row test.
+# Two pure-new applications for the same (user, type, year, semester) can never
+# coexist: the `uq_user_pure_new_app` partial unique index in
+# Application.__table_args__ forbids it on PostgreSQL, and the SQLite test
+# harness ignores the partial `postgresql_where` clause, treating it as a FULL
+# unique index — so ANY two same-config rows collide there. The re-applyable
+# semantics are already covered by the ("rejected", False) truth-table case
+# above. `has_blocking_application` is structurally single-row via `.limit(1)`,
+# which still matters: a soft-deleted row CAN coexist with a live one on
+# PostgreSQL (excluded from the partial index by `deleted_at IS NULL`).

--- a/backend/app/tests/test_eligibility_blocking_service.py
+++ b/backend/app/tests/test_eligibility_blocking_service.py
@@ -84,6 +84,7 @@ async def test_no_application_is_not_blocking(db, test_user, test_scholarship):
 # harness ignores the partial `postgresql_where` clause, treating it as a FULL
 # unique index — so ANY two same-config rows collide there. The re-applyable
 # semantics are already covered by the ("rejected", False) truth-table case
-# above. `has_blocking_application` is structurally single-row via `.limit(1)`,
-# which still matters: a soft-deleted row CAN coexist with a live one on
-# PostgreSQL (excluded from the partial index by `deleted_at IS NULL`).
+# above. `has_blocking_application` is multi-row safe by construction: it uses a
+# native `exists()` query, which always yields a single boolean no matter how
+# many rows match (a soft-deleted row CAN coexist with a live one on PostgreSQL —
+# excluded from the partial index by `deleted_at IS NULL`).

--- a/backend/app/tests/test_eligibility_service_unit.py
+++ b/backend/app/tests/test_eligibility_service_unit.py
@@ -314,34 +314,6 @@ async def test_determine_required_student_api_type():
 
 
 @pytest.mark.asyncio
-async def test_get_application_status(monkeypatch):
-    config = build_config()
-
-    empty_session = StubSession([StubResult(scalar=None)])
-    service = EligibilityService(db=empty_session)
-    status = await service.get_application_status(user_id=1, config=config)
-
-    assert status["has_application"] is False
-    assert status["can_apply"] is True
-
-    submitted_app = SimpleNamespace(
-        id=99,
-        status=ApplicationStatus.submitted.value,
-        scholarship_type_id=config.scholarship_type_id,
-        academic_year=config.academic_year,
-    )
-    filled_session = StubSession([StubResult(scalar=submitted_app)])
-    service.db = filled_session
-
-    status_existing = await service.get_application_status(user_id=1, config=config)
-
-    assert status_existing["has_application"] is True
-    assert status_existing["application_id"] == 99
-    assert status_existing["status_display"] == "已申請"
-    assert status_existing["can_apply"] is False
-
-
-@pytest.mark.asyncio
 async def test_check_existing_applications(monkeypatch):
     config = build_config()
     session = StubSession(

--- a/docs/superpowers/plans/2026-06-29-hide-submitted-scholarships-from-apply-flow.md
+++ b/docs/superpowers/plans/2026-06-29-hide-submitted-scholarships-from-apply-flow.md
@@ -1,0 +1,793 @@
+# Hide Submitted / No-Eligible Scholarships From Apply Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide scholarships a student has already submitted (and show a clear message when none are applyable) from the student apply flow, while keeping the read-only catalog complete.
+
+**Architecture:** The backend computes a single boolean `already_submitted` per eligible scholarship via a dedicated `EXISTS` query over an explicit `HIDDEN_APPLICATION_STATUSES` allow-list, and surfaces it on `EligibleScholarshipResponse`. The frontend adds an `isApplyableScholarship` predicate and applies it only in the two apply-flow surfaces (wizard dropdown + portal "新申請" gate); the catalog is untouched.
+
+**Tech Stack:** FastAPI + SQLAlchemy (async) + PostgreSQL; Next.js + React + TypeScript; pytest (unit + integration suites); jest (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-06-29-hide-submitted-scholarships-from-apply-flow-design.md`
+
+## Global Constraints
+
+- Branch: `worktree-hide-applied-scholarships`. Commit messages in English, conventional-commits format. No co-author/attribution trailer (disabled globally).
+- API responses keep the ApiResponse wrapper `{success, message, data}`; do NOT introduce `response_model`.
+- Status constants are `.value` strings, matching the existing `REVIEWABLE_APPLICATION_STATUSES` convention in `backend/app/models/enums.py`.
+- The hide-set invariant: a scholarship is shown in the apply flow ⟺ a fresh/continued application is submittable (consistent with the `DUPLICATE_APPLICATION` guard in `applications.py`).
+- Backend lint is hard-gated: `uvx --from "black==26.3.1" black --check --line-length=120 backend/app` and `flake8 app --select=B904,B014 --max-line-length=120` must pass.
+- Run backend pytest inside the dev container; async/`*_service*` tests land in the integration suite, sync tests in the unit suite.
+- `ApplicationStatus` has exactly 13 values: draft, submitted, under_review, pending_documents, approved, partial_approved, rejected, returned, withdrawn, cancelled, manual_excluded, cancelled_by_challenge, deleted. Do NOT change enum values (would trip the enum-pin tripwire `test_shared_enums_value_contract.py`).
+
+---
+
+### Task 1: Status sets + DRY the duplicate-application guard
+
+**Files:**
+- Modify: `backend/app/models/enums.py` (add 3 constants after `REVIEWABLE_APPLICATION_STATUSES`, ~line 56)
+- Modify: `backend/app/api/v1/endpoints/applications.py:154-159` (use the shared constant) + its enums import
+- Test: `backend/app/tests/test_application_status_sets.py` (new, sync unit test)
+
+**Interfaces:**
+- Produces: `REAPPLY_ALLOWED_APPLICATION_STATUSES`, `EDITABLE_APPLICATION_STATUSES`, `HIDDEN_APPLICATION_STATUSES` — each a `list[str]` of `ApplicationStatus.*.value`, importable from `app.models.enums`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/app/tests/test_application_status_sets.py`:
+
+```python
+"""Pin: the apply-flow visibility sets partition every ApplicationStatus value.
+
+These three sets decide whether a scholarship is shown in the student apply
+flow. They MUST stay a partition of the full enum so a newly-added status is
+forced into a deliberate classification (and never silently both-shown-and-hidden).
+"""
+
+from app.models.enums import (
+    ApplicationStatus,
+    EDITABLE_APPLICATION_STATUSES,
+    HIDDEN_APPLICATION_STATUSES,
+    REAPPLY_ALLOWED_APPLICATION_STATUSES,
+)
+
+
+def test_sets_are_value_strings():
+    all_values = {s.value for s in ApplicationStatus}
+    for bucket in (
+        REAPPLY_ALLOWED_APPLICATION_STATUSES,
+        EDITABLE_APPLICATION_STATUSES,
+        HIDDEN_APPLICATION_STATUSES,
+    ):
+        assert set(bucket) <= all_values
+
+
+def test_sets_partition_the_enum():
+    reapply = set(REAPPLY_ALLOWED_APPLICATION_STATUSES)
+    editable = set(EDITABLE_APPLICATION_STATUSES)
+    hidden = set(HIDDEN_APPLICATION_STATUSES)
+
+    # disjoint
+    assert reapply & editable == set()
+    assert reapply & hidden == set()
+    assert editable & hidden == set()
+
+    # cover every enum value
+    assert reapply | editable | hidden == {s.value for s in ApplicationStatus}
+
+
+def test_hidden_set_is_exactly_the_submitted_and_beyond_statuses():
+    assert set(HIDDEN_APPLICATION_STATUSES) == {
+        "submitted",
+        "under_review",
+        "pending_documents",
+        "approved",
+        "partial_approved",
+        "manual_excluded",
+        "cancelled_by_challenge",
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_application_status_sets.py -p no:cacheprovider -q`
+Expected: FAIL with `ImportError: cannot import name 'REAPPLY_ALLOWED_APPLICATION_STATUSES'`.
+
+- [ ] **Step 3: Add the constants**
+
+In `backend/app/models/enums.py`, immediately after the `REVIEWABLE_APPLICATION_STATUSES = [...]` block (before `class ReviewStage`), add:
+
+```python
+# ── Apply-flow visibility sets ───────────────────────────────────────
+# Partition every ApplicationStatus value into three buckets that decide
+# whether a scholarship is shown in the STUDENT APPLY FLOW.
+# Invariant: shown ⟺ a fresh/continued application is still submittable
+# (kept consistent with the DUPLICATE_APPLICATION guard in applications.py).
+
+# Terminal/withdrawn states the duplicate guard does NOT block — the student may
+# re-apply, so the scholarship stays visible. Mirrors the guard's exclude set;
+# `deleted` is a soft-delete tombstone, intentionally treated as re-applyable.
+REAPPLY_ALLOWED_APPLICATION_STATUSES = [
+    ApplicationStatus.withdrawn.value,
+    ApplicationStatus.rejected.value,
+    ApplicationStatus.cancelled.value,
+    ApplicationStatus.deleted.value,
+]
+
+# In-progress states the student finishes IN PLACE via the edit flow — the
+# scholarship stays visible so the draft/returned item can be completed.
+EDITABLE_APPLICATION_STATUSES = [
+    ApplicationStatus.draft.value,
+    ApplicationStatus.returned.value,
+]
+
+# "已送出/處理中" — a blocking application exists that is NOT continuable in
+# place, so the scholarship is HIDDEN from the apply flow. Exactly the complement
+# of REAPPLY_ALLOWED ∪ EDITABLE over the full enum. `manual_excluded` and
+# `cancelled_by_challenge` are here because the duplicate guard blocks them too
+# (showing them would only lead to a DUPLICATE_APPLICATION error on submit).
+HIDDEN_APPLICATION_STATUSES = [
+    ApplicationStatus.submitted.value,
+    ApplicationStatus.under_review.value,
+    ApplicationStatus.pending_documents.value,
+    ApplicationStatus.approved.value,
+    ApplicationStatus.partial_approved.value,
+    ApplicationStatus.manual_excluded.value,
+    ApplicationStatus.cancelled_by_challenge.value,
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_application_status_sets.py -p no:cacheprovider -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: DRY the duplicate guard to use the shared constant**
+
+In `backend/app/api/v1/endpoints/applications.py`, add the import (alongside the existing enum imports near the top of the file):
+
+```python
+from app.models.enums import REAPPLY_ALLOWED_APPLICATION_STATUSES
+```
+
+Then replace the inline list at `applications.py:154-159`:
+
+```python
+        # 排除已撤回/拒絕/取消/刪除的申請
+        excluded_statuses = [
+            ApplicationStatus.withdrawn,
+            ApplicationStatus.rejected,
+            ApplicationStatus.cancelled,
+            ApplicationStatus.deleted,
+        ]
+```
+
+with:
+
+```python
+        # 排除已撤回/拒絕/取消/刪除的申請 (shared set — see app.models.enums)
+        excluded_statuses = REAPPLY_ALLOWED_APPLICATION_STATUSES
+```
+
+(`Application.status.notin_(excluded_statuses)` with `.value` strings matches how the sibling `get_application_status` already uses `Application.status.in_([.value strings])` against this enum column. Task 2's integration test exercises the same value-string membership and de-risks this change.)
+
+- [ ] **Step 6: Verify no regression in application endpoint tests + lint**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests -k "application and (duplicate or create)" -p no:cacheprovider -q
+docker compose -f docker-compose.dev.yml exec backend bash -lc 'uvx --from "black==26.3.1" black --check --line-length=120 app/models/enums.py app/api/v1/endpoints/applications.py && flake8 app/models/enums.py app/api/v1/endpoints/applications.py --select=B904,B014 --max-line-length=120'
+```
+Expected: tests PASS (or no tests collected for the `-k` filter — acceptable), lint clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/models/enums.py backend/app/api/v1/endpoints/applications.py backend/app/tests/test_application_status_sets.py
+git commit -m "feat(enums): add apply-flow status sets and DRY the duplicate guard"
+```
+
+---
+
+### Task 2: `has_blocking_application` query method
+
+**Files:**
+- Modify: `backend/app/services/eligibility_service.py` (add method to `EligibilityService`)
+- Test: `backend/app/tests/test_eligibility_blocking_service.py` (new, async integration test)
+
+**Interfaces:**
+- Consumes: `HIDDEN_APPLICATION_STATUSES` (Task 1).
+- Produces: `EligibilityService.has_blocking_application(user_id: int, config) -> bool` — returns `True` iff the student has an application for `(user_id, config.scholarship_type_id, config.academic_year, config.semester)` whose status is in `HIDDEN_APPLICATION_STATUSES`. `config` only needs `.scholarship_type_id`, `.academic_year`, `.semester`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/app/tests/test_eligibility_blocking_service.py`:
+
+```python
+"""Integration tests for EligibilityService.has_blocking_application.
+
+A scholarship is hidden from the apply flow iff the student has a 'blocking'
+(submitted-and-beyond) application for the same (type, year, semester).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.enums import Semester
+from app.models.scholarship import ScholarshipType
+from app.models.user import User
+from app.services.eligibility_service import EligibilityService
+
+_SEQ = 0
+
+
+async def _make_application(db: AsyncSession, user: User, scholarship: ScholarshipType, status: str) -> Application:
+    global _SEQ
+    _SEQ += 1
+    app = Application(
+        user_id=user.id,
+        scholarship_type_id=scholarship.id,
+        sub_type_selection_mode="single",
+        status=status,
+        app_id=f"TEST-BLOCK-{_SEQ:06d}",
+        academic_year=2024,
+        semester="first",
+        student_data={"name": "Test Student"},
+        submitted_form_data={},
+        agree_terms=True,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+def _config(scholarship: ScholarshipType) -> SimpleNamespace:
+    return SimpleNamespace(
+        scholarship_type_id=scholarship.id,
+        academic_year=2024,
+        semester=Semester.first,
+    )
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        ("submitted", True),
+        ("under_review", True),
+        ("pending_documents", True),
+        ("approved", True),
+        ("partial_approved", True),
+        ("manual_excluded", True),
+        ("cancelled_by_challenge", True),
+        ("draft", False),
+        ("returned", False),
+        ("rejected", False),
+        ("withdrawn", False),
+        ("cancelled", False),
+        ("deleted", False),
+    ],
+)
+async def test_has_blocking_application_truth_table(db, test_user, test_scholarship, status, expected):
+    await _make_application(db, test_user, test_scholarship, status)
+    service = EligibilityService(db)
+    result = await service.has_blocking_application(test_user.id, _config(test_scholarship))
+    assert result is expected
+
+
+async def test_no_application_is_not_blocking(db, test_user, test_scholarship):
+    service = EligibilityService(db)
+    assert await service.has_blocking_application(test_user.id, _config(test_scholarship)) is False
+
+
+async def test_rejected_plus_new_draft_is_not_blocking_and_does_not_crash(db, test_user, test_scholarship):
+    # A student who was rejected then started a fresh draft has TWO rows for the
+    # same config. EXISTS over the hidden set must return False (re-applyable)
+    # and must not raise MultipleResultsFound.
+    await _make_application(db, test_user, test_scholarship, "rejected")
+    await _make_application(db, test_user, test_scholarship, "draft")
+    service = EligibilityService(db)
+    assert await service.has_blocking_application(test_user.id, _config(test_scholarship)) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_eligibility_blocking_service.py -p no:cacheprovider -q`
+Expected: FAIL with `AttributeError: 'EligibilityService' object has no attribute 'has_blocking_application'`.
+
+- [ ] **Step 3: Implement the method**
+
+In `backend/app/services/eligibility_service.py`, add the import near the other enums import (`from app.models.application import Application, ApplicationStatus` already exists; add a separate line):
+
+```python
+from app.models.enums import HIDDEN_APPLICATION_STATUSES
+```
+
+Then add this method to the `EligibilityService` class (e.g. directly above `get_application_status`, ~line 478). `select` and `and_` are already imported at the top of the file.
+
+```python
+    async def has_blocking_application(self, user_id: int, config) -> bool:
+        """Whether the student already has a submitted-and-beyond application
+        for this scholarship configuration — i.e. one that should HIDE the
+        scholarship from the apply flow.
+
+        Uses the same (user, type, year, semester) key and semester comparison
+        as the DUPLICATE_APPLICATION guard so 'shown ⟺ submittable' holds. An
+        EXISTS query: deterministic, no None edge, safe with multiple rows.
+        """
+        if config.semester:
+            semester_filter = Application.semester == config.semester
+        else:
+            semester_filter = Application.semester.is_(None)
+
+        stmt = (
+            select(Application.id)
+            .where(
+                and_(
+                    Application.user_id == user_id,
+                    Application.scholarship_type_id == config.scholarship_type_id,
+                    Application.academic_year == config.academic_year,
+                    semester_filter,
+                    Application.status.in_(HIDDEN_APPLICATION_STATUSES),
+                )
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none() is not None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests/test_eligibility_blocking_service.py -p no:cacheprovider -q`
+Expected: PASS (15 passed).
+
+- [ ] **Step 5: Lint**
+
+Run: `docker compose -f docker-compose.dev.yml exec backend bash -lc 'uvx --from "black==26.3.1" black --check --line-length=120 app/services/eligibility_service.py && flake8 app/services/eligibility_service.py --select=B904,B014 --max-line-length=120'`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/eligibility_service.py backend/app/tests/test_eligibility_blocking_service.py
+git commit -m "feat(eligibility): add has_blocking_application EXISTS query"
+```
+
+---
+
+### Task 3: Surface `already_submitted` on the eligible endpoint
+
+**Files:**
+- Modify: `backend/app/services/scholarship_service.py:152-156` and `:224-239` (replace status call, set `already_submitted`)
+- Modify: `backend/app/schemas/scholarship.py:259-286` (add field)
+- Modify: `backend/app/api/v1/endpoints/scholarships.py:225-253` (pass through)
+
+**Interfaces:**
+- Consumes: `EligibilityService.has_blocking_application` (Task 2).
+- Produces: `EligibleScholarshipResponse.already_submitted: bool` (default `False`) — `True` when the student has a blocking application for that configuration.
+
+- [ ] **Step 1: Replace the status call in the service**
+
+In `backend/app/services/scholarship_service.py`, at `:152-156`, replace:
+
+```python
+            # Always get application status if user_id is provided, regardless of eligibility
+            application_status = {}
+            if user_id:
+                application_status = await eligibility_service.get_application_status(user_id, config)
+```
+
+with:
+
+```python
+            # Whether the student already has a submitted-and-beyond application
+            # for this configuration → hides it from the apply flow (see spec).
+            already_submitted = False
+            if user_id:
+                already_submitted = await eligibility_service.has_blocking_application(user_id, config)
+```
+
+- [ ] **Step 2: Set `already_submitted` on the scholarship dict (drop the stripped status fields)**
+
+In the same file at `:224-239`, replace the `scholarship_dict.update({...})` block's application-status fields. Change:
+
+```python
+                scholarship_dict.update(
+                    {
+                        "quota_available": quota_available,
+                        "quota_info": quota_info,
+                        # Add rule evaluation results
+                        "passed": eligibility_details.get("passed", []),
+                        "warnings": eligibility_details.get("warnings", []),
+                        "errors": eligibility_details.get("errors", []),
+                        # Add application status information
+                        "application_status": application_status.get("application_status"),
+                        "can_apply": application_status.get("can_apply", True),
+                        "status_display": application_status.get("status_display", "可申請"),
+                        "has_application": application_status.get("has_application", False),
+                        "application_id": application_status.get("application_id"),
+                    }
+                )
+```
+
+to:
+
+```python
+                scholarship_dict.update(
+                    {
+                        "quota_available": quota_available,
+                        "quota_info": quota_info,
+                        # Add rule evaluation results
+                        "passed": eligibility_details.get("passed", []),
+                        "warnings": eligibility_details.get("warnings", []),
+                        "errors": eligibility_details.get("errors", []),
+                        # Hide already-submitted scholarships from the apply flow
+                        "already_submitted": already_submitted,
+                    }
+                )
+```
+
+(The removed `application_status`/`can_apply`/`status_display`/`has_application`/`application_id` keys were already stripped by `EligibleScholarshipResponse` and unused downstream.)
+
+- [ ] **Step 3: Add the schema field**
+
+In `backend/app/schemas/scholarship.py`, inside `class EligibleScholarshipResponse` (after `subtype_eligibility: Dict[...] = {}`, before `model_config`), add:
+
+```python
+    already_submitted: bool = False
+```
+
+- [ ] **Step 4: Pass it through in the endpoint**
+
+In `backend/app/api/v1/endpoints/scholarships.py`, in the `EligibleScholarshipResponse(...)` constructor (~`:225-253`), add a line (e.g. after `created_at=scholarship.get("created_at"),`):
+
+```python
+            already_submitted=scholarship.get("already_submitted", False),
+```
+
+- [ ] **Step 5: Verify the full eligible suite + lint**
+
+Run:
+```bash
+docker compose -f docker-compose.dev.yml exec backend python -m pytest app/tests -k "eligible or eligibility or scholarship_service" -p no:cacheprovider -q
+docker compose -f docker-compose.dev.yml exec backend bash -lc 'uvx --from "black==26.3.1" black --check --line-length=120 app/services/scholarship_service.py app/schemas/scholarship.py app/api/v1/endpoints/scholarships.py && flake8 app/services/scholarship_service.py app/schemas/scholarship.py app/api/v1/endpoints/scholarships.py --select=B904,B014 --max-line-length=120'
+```
+Expected: tests PASS, lint clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/scholarship_service.py backend/app/schemas/scholarship.py backend/app/api/v1/endpoints/scholarships.py
+git commit -m "feat(scholarships): expose already_submitted on the eligible response"
+```
+
+---
+
+### Task 4: Frontend type + `isApplyableScholarship` predicate
+
+**Files:**
+- Modify: `frontend/lib/api/types.ts:209-244` (add field to `ScholarshipType`)
+- Modify: `frontend/lib/scholarship-eligibility.ts` (add predicate)
+- Test: `frontend/lib/__tests__/scholarship-eligibility.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `ScholarshipType.already_submitted?: boolean`, `isSelectableScholarship`.
+- Produces: `isApplyableScholarship(scholarship: ScholarshipType): boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/lib/__tests__/scholarship-eligibility.test.ts`:
+
+```ts
+import type { ScholarshipType } from "@/lib/api/types";
+import {
+  isApplyableScholarship,
+  isSelectableScholarship,
+} from "@/lib/scholarship-eligibility";
+
+const selectable = {
+  eligible_sub_types: [
+    { value: "nstc", label: "NSTC", label_en: "NSTC", is_default: true },
+  ],
+  errors: [],
+} as unknown as ScholarshipType;
+
+describe("isApplyableScholarship", () => {
+  it("is true for a selectable scholarship with no submission", () => {
+    expect(isSelectableScholarship(selectable)).toBe(true);
+    expect(isApplyableScholarship(selectable)).toBe(true);
+  });
+
+  it("is false when already submitted", () => {
+    const submitted = { ...selectable, already_submitted: true } as ScholarshipType;
+    expect(isApplyableScholarship(submitted)).toBe(false);
+  });
+
+  it("is true when already_submitted is explicitly false", () => {
+    const notSubmitted = { ...selectable, already_submitted: false } as ScholarshipType;
+    expect(isApplyableScholarship(notSubmitted)).toBe(true);
+  });
+
+  it("is false when not selectable, even if not submitted", () => {
+    const notSelectable = {
+      eligible_sub_types: [],
+      errors: [],
+      already_submitted: false,
+    } as unknown as ScholarshipType;
+    expect(isApplyableScholarship(notSelectable)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx jest lib/__tests__/scholarship-eligibility.test.ts`
+Expected: FAIL with `isApplyableScholarship is not a function` (or a TS error that the export is missing).
+
+- [ ] **Step 3: Add the field to the type**
+
+In `frontend/lib/api/types.ts`, inside `interface ScholarshipType` (e.g. after `terms_document_url?: string;`), add:
+
+```ts
+  already_submitted?: boolean;
+```
+
+- [ ] **Step 4: Add the predicate**
+
+In `frontend/lib/scholarship-eligibility.ts`, append:
+
+```ts
+// Apply-flow predicate: a scholarship is offered in the student apply flow only
+// when it is selectable AND the student has not already submitted it. The
+// backend computes `already_submitted` (see EligibleScholarshipResponse).
+export function isApplyableScholarship(scholarship: ScholarshipType): boolean {
+  return isSelectableScholarship(scholarship) && !scholarship.already_submitted;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd frontend && npx jest lib/__tests__/scholarship-eligibility.test.ts`
+Expected: PASS (4 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/lib/api/types.ts frontend/lib/scholarship-eligibility.ts frontend/lib/__tests__/scholarship-eligibility.test.ts
+git commit -m "feat(frontend): add isApplyableScholarship predicate and already_submitted type"
+```
+
+---
+
+### Task 5: Apply the filter in the two apply-flow surfaces + empty-state copy
+
+**Files:**
+- Modify: `frontend/lib/i18n.ts:337-340` (zh) and `:851-855` (en) — add `all_eligible_already_submitted`
+- Modify: `frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx:57` (import) and `:744` (filter)
+- Modify: `frontend/components/enhanced-student-portal.tsx:36` (import) and `:1336-1355` (gate + empty state)
+
+**Interfaces:**
+- Consumes: `isApplyableScholarship` (Task 4), `t("messages.all_eligible_already_submitted")`.
+
+- [ ] **Step 1: Add i18n strings (zh + en)**
+
+In `frontend/lib/i18n.ts`, in the **zh** `messages` block (after `no_eligible_scholarships_desc`, ~`:340`):
+
+```ts
+      all_eligible_already_submitted: "您可申請的獎學金皆已送出，請至「我的申請」查看進度",
+```
+
+In the **en** `messages` block (after `no_eligible_scholarships_desc`, ~`:855`):
+
+```ts
+      all_eligible_already_submitted:
+        "You have already submitted every scholarship you can apply for. See progress under \"My Applications\".",
+```
+
+- [ ] **Step 2: Verify i18n parity test still passes**
+
+Run: `cd frontend && npx jest lib/__tests__/i18n.test.ts`
+Expected: PASS (zh/en key parity holds because the key was added to both trees).
+
+- [ ] **Step 3: Switch the wizard dropdown to the apply-flow predicate**
+
+In `frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx`, change the import at `:57`:
+
+```ts
+import { isSelectableScholarship } from "@/lib/scholarship-eligibility";
+```
+
+to:
+
+```ts
+import { isApplyableScholarship } from "@/lib/scholarship-eligibility";
+```
+
+Then at `:744`, change:
+
+```ts
+        setEligibleScholarships(response.data.filter(isSelectableScholarship));
+```
+
+to:
+
+```ts
+        setEligibleScholarships(response.data.filter(isApplyableScholarship));
+```
+
+(`isSelectableScholarship` has no other use in this file; the import swap is complete.)
+
+- [ ] **Step 4: Switch the portal gate + differentiate the empty state**
+
+In `frontend/components/enhanced-student-portal.tsx`, change the import at `:36`:
+
+```ts
+import { isSelectableScholarship } from "@/lib/scholarship-eligibility";
+```
+
+to (keep both — `isSelectableScholarship` is still used at `:1363` for the catalog):
+
+```ts
+import {
+  isApplyableScholarship,
+  isSelectableScholarship,
+} from "@/lib/scholarship-eligibility";
+```
+
+Then replace the new-application gate block at `:1336-1355`:
+
+```tsx
+      {activeTab === "new-application" &&
+        (editingApplication ||
+        eligibleScholarships.some(isSelectableScholarship) ? (
+          <StudentApplicationWizard
+            user={user}
+            locale={locale}
+            onApplicationComplete={handleApplicationComplete}
+            editingApplication={editingApplication}
+            initialStep={editingApplication ? 2 : undefined}
+          />
+        ) : (
+          <Card>
+            <CardContent className="p-6 text-center">
+              <AlertTriangle className="h-8 w-8 text-orange-500 mx-auto mb-4" />
+              <h3 className="text-lg font-semibold">
+                {t("messages.no_eligible_scholarships")}
+              </h3>
+            </CardContent>
+          </Card>
+        ))}
+```
+
+with:
+
+```tsx
+      {activeTab === "new-application" &&
+        (editingApplication ||
+        eligibleScholarships.some(isApplyableScholarship) ? (
+          <StudentApplicationWizard
+            user={user}
+            locale={locale}
+            onApplicationComplete={handleApplicationComplete}
+            editingApplication={editingApplication}
+            initialStep={editingApplication ? 2 : undefined}
+          />
+        ) : (
+          <Card>
+            <CardContent className="p-6 text-center">
+              <AlertTriangle className="h-8 w-8 text-orange-500 mx-auto mb-4" />
+              <h3 className="text-lg font-semibold">
+                {eligibleScholarships.some(isSelectableScholarship)
+                  ? t("messages.all_eligible_already_submitted")
+                  : t("messages.no_eligible_scholarships")}
+              </h3>
+            </CardContent>
+          </Card>
+        ))}
+```
+
+(When some scholarships are selectable but none are applyable → all were submitted → show the "皆已送出" message; otherwise the student is simply not eligible → keep the existing message.)
+
+- [ ] **Step 5: Typecheck + lint the frontend**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit && npx eslint components/enhanced-student-portal.tsx components/student-wizard/steps/ScholarshipApplicationStep.tsx lib/scholarship-eligibility.ts lib/i18n.ts
+```
+Expected: no type errors, no lint errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/lib/i18n.ts frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx frontend/components/enhanced-student-portal.tsx
+git commit -m "feat(frontend): hide already-submitted scholarships from the apply flow"
+```
+
+---
+
+### Task 6: Regenerate OpenAPI types
+
+**Files:**
+- Modify: `frontend/lib/api/generated/schema.d.ts` (generated)
+
+**Interfaces:** none (keeps generated types in sync with the new backend field; CI validates sync).
+
+- [ ] **Step 1: Ensure the backend is running with the new field**
+
+Run: `docker compose -f docker-compose.dev.yml up -d backend` (or confirm it's already up and hot-reloaded with Task 3's changes).
+Verify: `curl -s localhost:8000/openapi.json | grep -q already_submitted && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 2: Regenerate**
+
+Run: `cd frontend && npm run api:generate`
+Expected: `lib/api/generated/schema.d.ts` updated to include `already_submitted` on the eligible-scholarship schema.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/lib/api/generated/schema.d.ts
+git commit -m "chore(api): regenerate OpenAPI types for already_submitted"
+```
+
+---
+
+### Task 7 (optional): E2E — submitted scholarship hidden from apply flow but kept in catalog
+
+**Files:**
+- Create: `frontend/e2e/specs/student-hide-submitted-scholarship.spec.ts`
+
+**Interfaces:** Consumes the full stack behavior from Tasks 1-6.
+
+- [ ] **Step 1: Write the E2E spec**
+
+Create `frontend/e2e/specs/student-hide-submitted-scholarship.spec.ts`. Follow the existing student E2E patterns in `frontend/e2e/specs/student-duplicate-reapply.spec.ts` (auth/setup helpers, seeded data). The assertions:
+
+```ts
+// After a student has a SUBMITTED application for scholarship X:
+// 1) the "學生申請" wizard scholarship <Select> does NOT list X
+// 2) the "獎學金列表" catalog DOES still list X
+// (Reuse the spec's login + seed helpers; do not hand-roll auth.)
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cd frontend && npx playwright test e2e/specs/student-hide-submitted-scholarship.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/e2e/specs/student-hide-submitted-scholarship.spec.ts
+git commit -m "test(e2e): submitted scholarship hidden from apply flow, kept in catalog"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Backend `HIDDEN_APPLICATION_STATUSES` + DRY guard → Task 1. ✅
+- `has_blocking_application` EXISTS query, semester parity with guard, multi-row safety → Task 2. ✅
+- `already_submitted` wired into service + schema + endpoint (with default `False`) → Task 3. ✅
+- `/eligible` no longer calls `get_application_status` (crash path removed from hot path) → Task 3, Step 1. ✅
+- Frontend type + `isApplyableScholarship` → Task 4. ✅
+- Wizard dropdown filter + portal gate + differentiated empty state → Task 5. ✅
+- i18n in `frontend/lib/i18n.ts` zh + en → Task 5, Steps 1-2. ✅
+- Catalog unchanged → Task 5 keeps `isSelectableScholarship` at `:1363`. ✅
+- OpenAPI regen → Task 6. ✅
+- Tests (backend truth table incl. manual_excluded/cancelled_by_challenge, multi-row; frontend unit; optional E2E) → Tasks 1, 2, 4, 7. ✅
+- Out-of-scope (catalog, guard behavior, renewal/challenge cards) → respected; no tasks touch them.
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. Task 7 is explicitly optional and points at an existing spec to mirror rather than inventing auth scaffolding.
+
+**Type consistency:** `has_blocking_application(user_id, config) -> bool` is defined in Task 2 and consumed identically in Task 3. `already_submitted` is `bool` (backend) / `boolean?` (frontend) throughout. `isApplyableScholarship` signature defined in Task 4 and used unchanged in Task 5. Status constant names identical across Tasks 1-3.

--- a/docs/superpowers/specs/2026-06-29-hide-submitted-scholarships-from-apply-flow-design.md
+++ b/docs/superpowers/specs/2026-06-29-hide-submitted-scholarships-from-apply-flow-design.md
@@ -1,0 +1,159 @@
+# 申請流程隱藏「已送出 / 無可申請」獎學金 — 設計文件
+
+- **日期**: 2026-06-29
+- **狀態**: 已核准（待寫實作計畫）；經三路對抗式審查修正
+- **分支**: `worktree-hide-applied-scholarships`
+
+## 背景與問題
+
+學生端有三個顯示獎學金的介面：
+
+1. **「獎學金列表」分頁** — 唯讀型錄，列出所有符合資格的獎學金（含資格/不符資格徽章）。
+2. **「學生申請」分頁** — 若至少有一個可選獎學金即掛載申請精靈，否則顯示空狀態提示。
+3. **申請精靈的獎學金下拉選單**（`ScholarshipApplicationStep`）— 學生實際挑選要申請的獎學金。
+
+目前後端 `GET /api/v1/scholarships/eligible` 回傳「符合規則且在申請期間內」的獎學金，但**不會**排除學生已申請過的獎學金。結果：學生可以在申請精靈下拉選單選到一個已送出的獎學金，一路填到送出才被後端的 `DUPLICATE_APPLICATION` 守衛擋下（`applications.py`）。這是不好的體驗。
+
+## 目標
+
+- 在**申請流程**（學生申請分頁 + 精靈下拉選單）隱藏「已送出/處理中」的獎學金。
+- 當沒有任何可申請的獎學金時，顯示清楚的提示訊息，並區分「皆已送出」與「不符資格」兩種情境。
+- **核心不變式**：獎學金出現在申請流程 ⟺ 學生此刻能成功送出（新建或續填）。亦即「顯示 ⟹ 可送出」，與送出時的 `DUPLICATE_APPLICATION` 守衛保持一致，避免「看得到卻送不出」的矛盾。
+
+## 非目標（Out of Scope）
+
+- 不更動「獎學金列表」唯讀型錄 — 維持完整清單（之後若要在型錄上加狀態徽章，可沿用本次新增的後端欄位，但不在本次範圍）。
+- 不改變送出守衛「擋哪些狀態」的實質行為（只把它的狀態集合抽成共用常數）。
+- 不改變申請期間（application period）開關的既有行為。
+- **Renewal / Challenge 申請卡**（`frontend/components/student/RenewalApplicationCard.tsx`、`ChallengeApplicationCard.tsx`）不在範圍：它們走獨立端點 `/api/v1/renewals/*`（非 `/scholarships/eligible`），且自身在伺服器端做名單收斂與前端在地去重，不需要本欄位。
+
+## 已確認的決策
+
+| # | 問題 | 決策 |
+|---|------|------|
+| 1 | 哪些申請狀態算「已送出」而要隱藏？ | **只隱藏已送出以上**：見下方〈狀態語意〉的 `HIDDEN_APPLICATION_STATUSES`。`draft`（草稿可續填）、`returned`（退回可修改）保留；`rejected` / `withdrawn` / `cancelled` / `deleted`（守衛允許重新申請）保留。 |
+| 2 | 在哪些介面隱藏？ | **只在申請流程**（學生申請分頁 + 精靈下拉）。「獎學金列表」型錄維持完整。 |
+| 3 | 可申請數為 0 時怎麼處理？ | **顯示提示訊息**（保留分頁），並**區分兩種訊息**：全部已送出 vs. 不符資格。 |
+
+## 狀態語意（單一真相來源）
+
+`ApplicationStatus` enum（`backend/app/models/enums.py`，共 **13** 個值）：
+`draft`、`submitted`、`under_review`、`pending_documents`、`approved`、`partial_approved`、`rejected`、`returned`、`withdrawn`、`cancelled`、`manual_excluded`、`cancelled_by_challenge`、`deleted`。
+
+送出守衛（`applications.py`）以「排除集合」定義可重新申請的狀態：`{withdrawn, rejected, cancelled, deleted}`（這些不擋、允許重新申請）。`deleted` 為軟刪除墓碑，與守衛排除集合一致，刻意視為「可重新申請」。
+
+由此定義三組互斥語意（皆以 `.value` 字串表示，沿用既有 `REVIEWABLE_APPLICATION_STATUSES` 慣例）：
+
+- **REAPPLY_ALLOWED_APPLICATION_STATUSES**（可重新申請，保留可見）：`{withdrawn, rejected, cancelled, deleted}`
+- **EDITABLE_APPLICATION_STATUSES**（編輯中，保留可見）：`{draft, returned}`
+- **HIDDEN_APPLICATION_STATUSES**（已送出/處理中，**隱藏**）= 全集 − 前兩者 = `{submitted, under_review, pending_documents, approved, partial_approved, manual_excluded, cancelled_by_challenge}`（7 個）
+
+> **設計時不變式**：`HIDDEN = ALL − REAPPLY_ALLOWED − EDITABLE`。`HIDDEN` 恰好是「送出守衛會擋、且無法就地續填」的狀態 → 滿足「顯示 ⟹ 可送出」。`manual_excluded`、`cancelled_by_challenge` 守衛**不**排除（會擋重複申請），故歸入 `HIDDEN`（隱藏）；若產品要讓它們可重新申請，須一併修改守衛的排除集合（屬非目標，需另行決策）。
+>
+> **實作為顯式 allow-list**：程式以顯式的 `HIDDEN_APPLICATION_STATUSES` 常數判斷（非執行期取補集），對未來新增 enum 值是安全預設（新值預設「顯示」，並由 enum-pin tripwire 測試強制做出有意識的分類決策）。
+
+## 採用方案
+
+### 方案 A（採用）— 後端用專屬 `EXISTS` 查詢算出 `already_submitted`，前端據此過濾申請流程
+
+後端針對每個獎學金設定，用一支專屬查詢判斷學生是否已有「隱藏集合」狀態的申請，回傳布林欄位 `already_submitted`。前端在申請流程過濾，而共用的 `/eligible` 請求仍可餵給完整型錄。單一真相來源、無客戶端重算、改動面最小。
+
+> **與初版的差異（經審查修正）**：初版打算複用 `eligibility_service.get_application_status` 的單列輸出推導，但該函式 (a) 的 `active_statuses` 白名單**漏掉** `pending_documents`、`partial_approved` 等狀態，會讓兩個應隱藏的狀態查不到而漏隱藏；(b) 用 `scalar_one_or_none()` 在多列時會丟例外讓 `/eligible` 噴 500；(c) 取補集的公式缺 `has_application` 守衛會把「沒申請」誤判為隱藏，將整批未申請獎學金全部隱藏。改用專屬 `EXISTS` 查詢可一次避開三者。
+
+### 方案 B（否決）— 純前端 join
+
+前端同抓 `/eligible` 與 `/my-applications` 比對過濾。否決：把後端狀態/守衛規則在前端重做，型錄與精靈各自抓資料要寫兩處，易與後端權威規則漂移。
+
+### 方案 C（否決）— 後端直接從 `/eligible` 移除已申請設定
+
+否決：同支端點也餵給「獎學金列表」型錄，移除會讓型錄也空掉（或被迫加第二種端點模式），與決策 #2 衝突。
+
+## 詳細設計
+
+### 後端
+
+1. **共用狀態常數** — 在 `backend/app/models/enums.py` 新增三個 `.value` 字串清單（緊鄰既有 `REVIEWABLE_APPLICATION_STATUSES`，沿用同風格）：`REAPPLY_ALLOWED_APPLICATION_STATUSES`、`EDITABLE_APPLICATION_STATUSES`、`HIDDEN_APPLICATION_STATUSES`，並以註解寫明上方不變式。
+
+2. **重複申請守衛改用共用常數（DRY）** — `applications.py` 的 `excluded_statuses` 改用 `REAPPLY_ALLOWED_APPLICATION_STATUSES`。
+   - 注意：守衛現用 enum **members** 搭 `.notin_()`；改用 `.value` 字串。同檔 `get_application_status` 的 `active_statuses`（`.value` 字串）已用 `.in_()` 成功比對同一 enum 欄位，故 `.notin_()` 搭 `.value` 字串同樣可行（`ApplicationStatus` 以 `values_callable` 存值）。實作時以一筆既有重複申請測試驗證行為不變。
+
+3. **新增 `has_blocking_application(user_id, config) -> bool`**（置於 `eligibility_service` 或 `scholarship_service`）：對 `(user_id, scholarship_type_id, academic_year, semester)` 且 `status IN HIDDEN_APPLICATION_STATUSES` 做 `EXISTS`/`select(...).limit(1)` 查詢。
+   - 確定性、無 `None` 邊界、無多列例外（不需排序、不需 `scalar_one_or_none`）。
+   - **semester 比較須與守衛一致**：守衛用 `Application.semester == config.semester`（enum 物件，`None` 時比 `IS NULL`）。本查詢**完全沿用守衛的比較方式**（非 `get_application_status` 的 `config.semester.name` 寫法），確保 `already_submitted` 與守衛選到同一批列 → 維持「顯示 ⟹ 可送出」不變式。建議抽一個共用 semester 述詞 helper 供兩處共用。
+
+4. **產生 `already_submitted`** — 在 `ScholarshipService.get_eligible_scholarships`（目前 `:155` 呼叫 `get_application_status`、`:224-238` attach 狀態欄位處）：以 `already_submitted = await ...has_blocking_application(user_id, config)` 取代原本被回應層丟棄的狀態欄位。移除 `scholarship_dict` 內那些被丟棄的欄位（`can_apply`/`status_display`/`application_status`/`has_application`/`application_id`），只保留 `already_submitted`。
+   - 連帶結果：`/eligible` 路徑**不再呼叫** `get_application_status`，原本多列 `scalar_one_or_none()` 的 500 風險在此路徑消失（符合先前同意的「修掉當機」目標）。`get_application_status` 屆時只剩自身單元測試引用；本次**保留不動**（其 `active_statuses`/`scalar_one_or_none` 屬已知潛在問題，已不在關鍵路徑，徹底移除/修正列為後續）。
+
+5. **暴露欄位** — 在 `EligibleScholarshipResponse`（`backend/app/schemas/scholarship.py:259-286`）新增 `already_submitted: bool = False`（給預設值，對舊/缺值 payload 具韌性，並與前端 optional 欄位對稱）；於端點建構處（`backend/app/api/v1/endpoints/scholarships.py:225-253`）帶出。
+
+> 註：回應維持 ApiResponse 包裝格式（`{success, message, data}`），不引入 `response_model`。新增為單一構造點（`scholarships.py:225`），admin/college 不使用 `EligibleScholarshipResponse`，無其他後端消費者受影響。
+
+### 前端
+
+6. **型別** — 在 `frontend/lib/api/types.ts` 的 `ScholarshipType`（`:210` 一帶）新增 `already_submitted?: boolean`；依 CLAUDE.md §8 於後端執行中跑 `cd frontend && npm run api:generate` 並提交 `lib/api/generated/schema.d.ts`。
+
+7. **共用判斷式** — 在 `frontend/lib/scholarship-eligibility.ts` 新增：
+
+   ```ts
+   export function isApplyableScholarship(scholarship: ScholarshipType): boolean {
+     return isSelectableScholarship(scholarship) && !scholarship.already_submitted;
+   }
+   ```
+
+8. **精靈下拉選單** — `frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx:744` 由 `filter(isSelectableScholarship)` 改為 `filter(isApplyableScholarship)`。
+   - 編輯既有草稿/退回件不受影響：`draft`/`returned` 的 `already_submitted` 皆為 `false`，仍在清單中（`editingApplication` 由 code 在清單中尋得，`:621`）。
+
+9. **入口「學生申請」分頁** — `frontend/components/enhanced-student-portal.tsx`：
+   - 掛載精靈的條件位於 **`:1338`**：`editingApplication || eligibleScholarships.some(isSelectableScholarship)`。**只把 `.some(...)` 子句**改為 `isApplyableScholarship`，保留 `editingApplication ||` 守衛不動。
+   - 空狀態訊息**區分兩種**（純前端推導）：
+     - `hasAnySelectable = eligibleScholarships.some(isSelectableScholarship)`、`hasAnyApplyable = eligibleScholarships.some(isApplyableScholarship)`。
+     - 當 `!hasAnyApplyable && hasAnySelectable` → 顯示新訊息「您可申請的獎學金皆已送出，請至『我的申請』查看進度」。
+     - 否則 → 沿用現有 `messages.no_eligible_scholarships`。
+
+10. **i18n** — 字串實際位於 `frontend/lib/i18n.ts`（**非** portal 元件）。新增 key（例如 `messages.all_eligible_already_submitted`，zh + desc）於 **zh 樹（~`:338`）與 en 樹（~`:853`）兩處**；`frontend/lib/__tests__/i18n.test.ts` 會驗 zh/en 對等，務必兩邊都加。「不符資格」分支沿用既有 `messages.no_eligible_scholarships`。
+
+11. **「獎學金列表」型錄分頁** — 不變，維持完整清單。
+
+## 資料流
+
+```
+GET /api/v1/scholarships/eligible
+  → ScholarshipService.get_eligible_scholarships
+      → has_blocking_application(user_id, config):
+          EXISTS Application WHERE user_id, scholarship_type_id, academic_year,
+                 semester(同守衛比較), status IN HIDDEN_APPLICATION_STATUSES
+      → already_submitted = <該 EXISTS 結果>
+  → EligibleScholarshipResponse { ..., already_submitted: bool = False }
+  → 前端
+      ├─ 獎學金列表型錄：用完整清單（不過濾）
+      └─ 申請流程（分頁掛載條件 + 精靈下拉）：filter(isApplyableScholarship)
+```
+
+## 邊界情況
+
+- **沒有任何申請（常見情況）**：`EXISTS` 為偽 → `already_submitted = False` → 顯示。（專屬查詢天然處理，無 `None` 反轉風險。）
+- **多年度設定共用同一 type code（114 + 115）**：查詢以 `academic_year` + `semester` 為鍵，逐設定計算，申請 114 不會隱藏 115。與精靈以 `configuration_id` 為選取鍵一致。
+- **同一設定多列（被拒/撤回 + 新草稿）**：`EXISTS(隱藏集合)` 與排序無關 → 終態（被拒/撤回）不屬隱藏集合、草稿也不屬 → `already_submitted = False` → 顯示，可重新申請/續填。同時天然避開 `scalar_one_or_none` 多列例外。
+- **續填草稿 / 修改退回件**：`draft`、`returned` 不在隱藏集合，仍顯示，可由「我的申請」進編輯流程（`editingApplication`）續填。
+- **`returned` 在全新精靈直接新建**：因 `returned` 保留可見（決策 #1），若學生不走編輯而在全新精靈選它並按新建，仍會撞既有守衛（守衛只對 `draft` 回傳既有件續填，`returned` 會回 `DUPLICATE_APPLICATION`）。此為既有守衛行為、屬非目標；正常路徑是由「我的申請」編輯退回件。記錄為已知限制。
+- **`manual_excluded` / `cancelled_by_challenge`**：屬隱藏集合 → 不顯示（與守衛一致，避免顯示後送出撞 `DUPLICATE_APPLICATION`）。
+
+## 測試
+
+- **後端（async / integration suite）**：
+  - `has_blocking_application` / `already_submitted` 真值表：`submitted`、`under_review`、`pending_documents`、`approved`、`partial_approved`、`manual_excluded`、`cancelled_by_challenge` → `True`；`draft`、`returned`、`rejected`、`withdrawn`、`cancelled`、`deleted`、**無申請** → `False`。（明確涵蓋 `manual_excluded`/`cancelled_by_challenge`，把分類釘住，未來新增 enum 值會強制重新分類。）
+  - 多列情境：（被拒 + 新草稿）→ `False` 且不丟例外。
+  - 守衛重構回歸：一筆既有「重複申請被擋」案例行為不變。
+  - 新查詢需自備測試 stub（支援 `EXISTS`/`limit(1)` 形狀）；不沿用 `get_application_status` 的 stub。
+- **前端（unit）**：`isApplyableScholarship` 真值表（`already_submitted` × `isSelectableScholarship` 組合）。
+- **前端（E2E，選配）**：學生已送出某獎學金 → 精靈下拉看不到該獎學金，但「獎學金列表」型錄仍看得到。
+
+## 發佈注意事項
+
+- 後端執行中時跑 `cd frontend && npm run api:generate`，提交 `lib/api/generated/schema.d.ts`（CI 驗型別同步）。
+- 後端 lint 硬性門檻：`black --check --line-length=120`、`flake8 --select=B904,B014`，touched 檔案跑對應 pytest。
+- enum-pin tripwire（`test_shared_enums_value_contract.py`）：本次**不改 enum 值**（只加 module 常數），不應觸發；新查詢的真值表即作為分類契約。
+
+## 開放問題
+
+- `manual_excluded` / `cancelled_by_challenge` 採「隱藏（不可重新申請）」分類，與送出守衛一致。若產品實際希望這兩種可重新申請，需另案修改守衛排除集合（非目標）。其餘決策 #1–#3 與兩個附帶小修正皆已確認。

--- a/docs/superpowers/specs/2026-06-29-hide-submitted-scholarships-from-apply-flow-design.md
+++ b/docs/superpowers/specs/2026-06-29-hide-submitted-scholarships-from-apply-flow-design.md
@@ -133,7 +133,7 @@ GET /api/v1/scholarships/eligible
 
 - **沒有任何申請（常見情況）**：`EXISTS` 為偽 → `already_submitted = False` → 顯示。（專屬查詢天然處理，無 `None` 反轉風險。）
 - **多年度設定共用同一 type code（114 + 115）**：查詢以 `academic_year` + `semester` 為鍵，逐設定計算，申請 114 不會隱藏 115。與精靈以 `configuration_id` 為選取鍵一致。
-- **同一設定多列（被拒/撤回 + 新草稿）**：`EXISTS(隱藏集合)` 與排序無關 → 終態（被拒/撤回）不屬隱藏集合、草稿也不屬 → `already_submitted = False` → 顯示，可重新申請/續填。同時天然避開 `scalar_one_or_none` 多列例外。
+- **同一設定多列**：實作時確認 `Application` 的部分唯一索引 `uq_user_pure_new_app`（`postgresql_where: is_renewal=false AND challenges_application_id IS NULL AND deleted_at IS NULL`）使**兩筆 pure-new 申請無法在同一設定共存**（含「被拒 pure-new + 新草稿」——兩者都 pure-new，會相撞）。唯一可共存的多列情境是「軟刪除（deleted_at）的舊件 + 一筆 live 件」（僅 PostgreSQL；SQLite 測試環境忽略 partial WHERE，視為完整唯一索引，故任何同設定兩列皆不可建）。此情境下 `EXISTS(隱藏集合)` 仍正確（軟刪除/終態不屬隱藏集合）。`has_blocking_application` 以 `.limit(1)` 結構性保證單列、不會丟 `scalar_one_or_none` 多列例外（防禦性；該多列路徑在 SQLite harness 不可重現，故以註解記錄而非整合測試）。
 - **續填草稿 / 修改退回件**：`draft`、`returned` 不在隱藏集合，仍顯示，可由「我的申請」進編輯流程（`editingApplication`）續填。
 - **`returned` 在全新精靈直接新建**：因 `returned` 保留可見（決策 #1），若學生不走編輯而在全新精靈選它並按新建，仍會撞既有守衛（守衛只對 `draft` 回傳既有件續填，`returned` 會回 `DUPLICATE_APPLICATION`）。此為既有守衛行為、屬非目標；正常路徑是由「我的申請」編輯退回件。記錄為已知限制。
 - **`manual_excluded` / `cancelled_by_challenge`**：屬隱藏集合 → 不顯示（與守衛一致，避免顯示後送出撞 `DUPLICATE_APPLICATION`）。

--- a/docs/superpowers/specs/2026-06-29-hide-submitted-scholarships-from-apply-flow-design.md
+++ b/docs/superpowers/specs/2026-06-29-hide-submitted-scholarships-from-apply-flow-design.md
@@ -79,10 +79,10 @@
 
 3. **新增 `has_blocking_application(user_id, config) -> bool`**（置於 `eligibility_service` 或 `scholarship_service`）：對 `(user_id, scholarship_type_id, academic_year, semester)` 且 `status IN HIDDEN_APPLICATION_STATUSES` 做 `EXISTS`/`select(...).limit(1)` 查詢。
    - 確定性、無 `None` 邊界、無多列例外（不需排序、不需 `scalar_one_or_none`）。
-   - **semester 比較須與守衛一致**：守衛用 `Application.semester == config.semester`（enum 物件，`None` 時比 `IS NULL`）。本查詢**完全沿用守衛的比較方式**（非 `get_application_status` 的 `config.semester.name` 寫法），確保 `already_submitted` 與守衛選到同一批列 → 維持「顯示 ⟹ 可送出」不變式。建議抽一個共用 semester 述詞 helper 供兩處共用。
+   - **semester 比較須與守衛一致**：守衛用 `Application.semester == config.semester`（enum 物件，`None` 時比 `IS NULL`）。本查詢與守衛**共用** `app.models.application.build_config_match_filters(user_id, config)`（/simplify 後抽出的 (user, type, year, semester) + semester-NULL 共用述詞），結構性保證兩者不漂移 → 維持「顯示 ⟹ 可送出」不變式。`has_blocking_application` 以原生 `exists()` 實作（非 `select(...).limit(1)`）。
 
 4. **產生 `already_submitted`** — 在 `ScholarshipService.get_eligible_scholarships`（目前 `:155` 呼叫 `get_application_status`、`:224-238` attach 狀態欄位處）：以 `already_submitted = await ...has_blocking_application(user_id, config)` 取代原本被回應層丟棄的狀態欄位。移除 `scholarship_dict` 內那些被丟棄的欄位（`can_apply`/`status_display`/`application_status`/`has_application`/`application_id`），只保留 `already_submitted`。
-   - 連帶結果：`/eligible` 路徑**不再呼叫** `get_application_status`，原本多列 `scalar_one_or_none()` 的 500 風險在此路徑消失（符合先前同意的「修掉當機」目標）。`get_application_status` 屆時只剩自身單元測試引用；本次**保留不動**（其 `active_statuses`/`scalar_one_or_none` 屬已知潛在問題，已不在關鍵路徑，徹底移除/修正列為後續）。
+   - 連帶結果：`/eligible` 路徑**不再呼叫** `get_application_status`，原本多列 `scalar_one_or_none()` 的 500 風險在此路徑消失（符合先前同意的「修掉當機」目標）。`get_application_status` 移除最後一個生產呼叫端後已成死碼；**已於 /simplify 清理階段連同其單元測試一併移除**（含其 `active_statuses`/`scalar_one_or_none`/`config.semester.name` 等已知潛在問題）。
 
 5. **暴露欄位** — 在 `EligibleScholarshipResponse`（`backend/app/schemas/scholarship.py:259-286`）新增 `already_submitted: bool = False`（給預設值，對舊/缺值 payload 具韌性，並與前端 optional 欄位對稱）；於端點建構處（`backend/app/api/v1/endpoints/scholarships.py:225-253`）帶出。
 

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -33,7 +33,10 @@ import { DocumentRequestAlert } from "@/components/document-request-alert";
 import { RenewalApplicationCard } from "@/components/student/RenewalApplicationCard";
 import { ChallengeApplicationCard } from "@/components/student/ChallengeApplicationCard";
 import type { StudentDocumentRequest } from "@/lib/api/modules/document-requests";
-import { isSelectableScholarship } from "@/lib/scholarship-eligibility";
+import {
+  isApplyableScholarship,
+  isSelectableScholarship,
+} from "@/lib/scholarship-eligibility";
 import {
   Edit,
   Eye,
@@ -1335,7 +1338,7 @@ export function EnhancedStudentPortal({
 
       {activeTab === "new-application" &&
         (editingApplication ||
-        eligibleScholarships.some(isSelectableScholarship) ? (
+        eligibleScholarships.some(isApplyableScholarship) ? (
           <StudentApplicationWizard
             user={user}
             locale={locale}
@@ -1348,7 +1351,9 @@ export function EnhancedStudentPortal({
             <CardContent className="p-6 text-center">
               <AlertTriangle className="h-8 w-8 text-orange-500 mx-auto mb-4" />
               <h3 className="text-lg font-semibold">
-                {t("messages.no_eligible_scholarships")}
+                {eligibleScholarships.some(isSelectableScholarship)
+                  ? t("messages.all_eligible_already_submitted")
+                  : t("messages.no_eligible_scholarships")}
               </h3>
             </CardContent>
           </Card>

--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -54,7 +54,7 @@ import api, {
   ApplicationCreate,
   Application,
 } from "@/lib/api";
-import { isSelectableScholarship } from "@/lib/scholarship-eligibility";
+import { isApplyableScholarship } from "@/lib/scholarship-eligibility";
 import { clsx } from "@/lib/utils";
 import {
   buildApplicationFormFields,
@@ -741,7 +741,7 @@ export function ScholarshipApplicationStep({
     try {
       const response = await api.scholarships.getEligible();
       if (response.success && response.data) {
-        setEligibleScholarships(response.data.filter(isSelectableScholarship));
+        setEligibleScholarships(response.data.filter(isApplyableScholarship));
       } else {
         setError(response.message || text.loadError);
       }

--- a/frontend/lib/__tests__/scholarship-eligibility.test.ts
+++ b/frontend/lib/__tests__/scholarship-eligibility.test.ts
@@ -15,7 +15,11 @@
  *
  * 7 cases.
  */
-import { isSelectableScholarship } from "../scholarship-eligibility";
+import type { ScholarshipType } from "@/lib/api/types";
+import {
+  isApplyableScholarship,
+  isSelectableScholarship,
+} from "../scholarship-eligibility";
 
 // Minimal ScholarshipType shape — only the fields the predicate reads.
 type _Sch = {
@@ -90,5 +94,44 @@ describe("isSelectableScholarship", () => {
     expect(
       isSelectableScholarship(scholarship({ eligible_sub_types: [] })),
     ).toBe(false);
+  });
+});
+
+const applyableSelectable = {
+  eligible_sub_types: [
+    { value: "nstc", label: "NSTC", label_en: "NSTC", is_default: true },
+  ],
+  errors: [],
+} as unknown as ScholarshipType;
+
+describe("isApplyableScholarship", () => {
+  it("is true for a selectable scholarship with no submission", () => {
+    expect(isSelectableScholarship(applyableSelectable)).toBe(true);
+    expect(isApplyableScholarship(applyableSelectable)).toBe(true);
+  });
+
+  it("is false when already submitted", () => {
+    const submitted = {
+      ...applyableSelectable,
+      already_submitted: true,
+    } as ScholarshipType;
+    expect(isApplyableScholarship(submitted)).toBe(false);
+  });
+
+  it("is true when already_submitted is explicitly false", () => {
+    const notSubmitted = {
+      ...applyableSelectable,
+      already_submitted: false,
+    } as ScholarshipType;
+    expect(isApplyableScholarship(notSubmitted)).toBe(true);
+  });
+
+  it("is false when not selectable, even if not submitted", () => {
+    const notSelectable = {
+      eligible_sub_types: [],
+      errors: [],
+      already_submitted: false,
+    } as unknown as ScholarshipType;
+    expect(isApplyableScholarship(notSelectable)).toBe(false);
   });
 });

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -8985,6 +8985,11 @@ export interface components {
             subtype_eligibility: {
                 [key: string]: components["schemas"]["SubtypeEligibilityInfo"];
             };
+            /**
+             * Already Submitted
+             * @default false
+             */
+            already_submitted: boolean;
         };
         /** EmailAutomationRuleCreate */
         EmailAutomationRuleCreate: {

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -222,6 +222,7 @@ export interface ScholarshipType {
   application_end_date?: string;
   sub_type_selection_mode?: "single" | "multiple" | "hierarchical";
   terms_document_url?: string;
+  already_submitted?: boolean;
   whitelist_enabled?: boolean;
   eligible_sub_types?: Array<{
     value: string | null;

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -338,6 +338,7 @@ export const translations = {
       no_eligible_scholarships: "目前沒有符合資格的獎學金",
       no_eligible_scholarships_desc:
         "很抱歉，您目前沒有符合申請資格的獎學金。請稍後再試或聯繫獎學金辦公室。",
+      all_eligible_already_submitted: "您可申請的獎學金皆已送出，請至「我的申請」查看進度",
       eligible: "可申請",
       not_eligible: "不符合申請資格",
       loading_data: "正在載入資料...",
@@ -853,6 +854,8 @@ export const translations = {
       no_eligible_scholarships: "No Eligible Scholarships",
       no_eligible_scholarships_desc:
         "Sorry, you are not currently eligible for any scholarships. Please try again later or contact the scholarship office.",
+      all_eligible_already_submitted:
+        "You have already submitted every scholarship you can apply for. See progress under \"My Applications\".",
       eligible: "Eligible",
       not_eligible: "Not Eligible",
       loading_data: "Loading data...",

--- a/frontend/lib/scholarship-eligibility.ts
+++ b/frontend/lib/scholarship-eligibility.ts
@@ -9,3 +9,10 @@ export function isSelectableScholarship(scholarship: ScholarshipType): boolean {
     !hasCommonErrors
   );
 }
+
+// Apply-flow predicate: a scholarship is offered in the student apply flow only
+// when it is selectable AND the student has not already submitted it. The
+// backend computes `already_submitted` (see EligibleScholarshipResponse).
+export function isApplyableScholarship(scholarship: ScholarshipType): boolean {
+  return isSelectableScholarship(scholarship) && !scholarship.already_submitted;
+}


### PR DESCRIPTION
## What & why

On the student application flow, scholarships the student has **already submitted** still appeared in the wizard dropdown and the "學生申請" gate — the student could pick one and only get blocked at submit time with `DUPLICATE_APPLICATION`. This PR hides already-submitted scholarships from the **apply flow**, and shows a clearer empty state, while keeping the read-only "獎學金列表" catalog complete.

Invariant: a scholarship is shown in the apply flow ⟺ a fresh/continued application is still submittable (kept consistent with the `DUPLICATE_APPLICATION` guard).

## Decisions

- **Hide:** `submitted, under_review, pending_documents, approved, partial_approved, manual_excluded, cancelled_by_challenge`.
- **Keep visible:** `draft`/`returned` (continue/edit in place) and `rejected`/`withdrawn`/`cancelled`/`deleted` (re-applyable — mirrors the duplicate guard's exclude set).
- **Scope:** only the apply flow (wizard dropdown + new-application gate). The catalog stays full.
- **Empty state:** differentiates "皆已送出" vs "不符資格".

## Changes

**Backend**
- `enums.py`: add `REAPPLY_ALLOWED_APPLICATION_STATUSES` / `EDITABLE_APPLICATION_STATUSES` / `HIDDEN_APPLICATION_STATUSES` (partition the 13-value `ApplicationStatus`); DRY the duplicate guard to reuse `REAPPLY_ALLOWED_*`.
- `eligibility_service.py`: add `has_blocking_application()` — an `EXISTS` query over `HIDDEN_APPLICATION_STATUSES` using the **same (user, type, year, semester) key + semester comparison as the duplicate guard**. Deterministic, no `None` edge, multi-row-safe via `.limit(1)`.
- `scholarship_service.py` / `schemas/scholarship.py` / `scholarships.py`: surface `already_submitted: bool = False` on `EligibleScholarshipResponse`. `/eligible` no longer calls the crash-prone `get_application_status` on the hot path.

**Frontend**
- `scholarship-eligibility.ts`: add `isApplyableScholarship = isSelectableScholarship && !already_submitted`.
- Wizard dropdown + portal new-application gate now filter with `isApplyableScholarship`; catalog stays on `isSelectableScholarship`.
- `i18n.ts`: new `messages.all_eligible_already_submitted` (zh + en).
- Regenerated `lib/api/generated/schema.d.ts`.

## Test plan

- [x] Backend: `has_blocking_application` truth table over all 13 statuses (submitted-and-beyond → hidden; draft/returned/rejected/withdrawn/cancelled/deleted/none → visible).
- [x] Backend: guard refactor regression-covered by the existing `DUPLICATE_APPLICATION` endpoint test; enum-pin tripwire untouched (13 values).
- [x] Backend lint: black (line-length 120) + flake8 (B904/B014/F401/F841) clean.
- [x] Frontend: `isApplyableScholarship` unit tests; i18n zh/en parity test; `tsc --noEmit` clean.
- [ ] Manual: student with a submitted application no longer sees it in the wizard dropdown but still sees it in the catalog.

## Notes

- `manual_excluded` / `cancelled_by_challenge` are classified as hidden because the duplicate guard blocks them (showing them would only lead to a `DUPLICATE_APPLICATION` error). If the product wants these re-applyable, that requires changing the guard's exclude set (out of scope).
- `returned` stays visible per decision; the normal path is editing via "我的申請" (`editingApplication`). Creating a fresh application over a `returned` row still hits the existing guard — pre-existing behavior, documented in the spec.
- Design spec + implementation plan included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
