### PR TITLE
feat(roster-excel): 造冊 Excel 加上資格驗證資訊，不符合的儲存格紅底

### DIFF
--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -6,9 +6,10 @@ Excel export service for payment roster generation
 import hashlib
 import logging
 import os
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 from openpyxl import Workbook, load_workbook
@@ -21,6 +22,34 @@ from app.models.payment_roster import PaymentRoster, PaymentRosterItem
 from app.services.minio_service import MinIOService
 
 logger = logging.getLogger(__name__)
+
+# --- Eligibility-verification enrichment (review-document columns) ----------
+# Appended after the STD_UP_MIXLISTA base columns. The per-rule columns sit
+# BETWEEN 學籍驗證 and 納入造冊 and are computed per roster (see
+# _collect_rule_columns), so they are not listed here.
+COL_VERIFICATION = "學籍驗證"  # verification_status label
+COL_INCLUDED = "納入造冊"  # is_included → 是/否
+COL_EXCLUSION = "排除原因"  # exclusion_reason
+COL_BANK_ACCOUNT = "帳號"  # existing base column 3 — reddened when blank
+
+# Per-rule cell labels (the value itself drives the fill, see _resolve_cell_fill)
+RULE_PASS_LABEL = "通過"
+RULE_FAIL_LABEL = "未通過"  # hard fail → red
+RULE_WARN_LABEL = "警告"  # warning fail → amber
+NOT_APPLICABLE = "—"  # rule has no detail for this student
+
+# verification_status labels (must match _get_verification_status_label) that
+# mean "not currently enrolled" → red. 已驗證 / unknown ("—") never red.
+BAD_VERIFICATION_LABELS = {"已畢業", "休學中", "已退學", "驗證錯誤", "查無此人"}
+
+# Manual-removal exclusion_reason prefixes — these items were intentionally
+# taken off a locked roster and must NOT reappear in the review export.
+MANUAL_REMOVAL_PREFIXES = ("鎖定後移除", "比對分發移除")
+
+# Excel standard "bad" red and "neutral" amber conditional-format fills.
+RED_FILL = PatternFill(start_color="FFC7CE", end_color="FFC7CE", fill_type="solid")
+AMBER_FILL = PatternFill(start_color="FFEB9C", end_color="FFEB9C", fill_type="solid")
+FILL_BY_KIND = {"red": RED_FILL, "amber": AMBER_FILL}
 
 
 class ExcelExportService:
@@ -41,6 +70,14 @@ class ExcelExportService:
         self.default_template_name = default_template
         self.ensure_export_directory()
         self._load_template_structure()
+        # Immutable base column list (STD_UP_MIXLISTA). The verification +
+        # per-rule columns are rebuilt onto this in _prepare_excel_data, so the
+        # column list never accumulates across calls.
+        self._base_columns: List[str] = list(self.template_columns)
+        # Per-rule column headers for the current export (set in
+        # _prepare_excel_data) — used by _resolve_cell_fill to scope the
+        # 未通過/警告 value-based fills to rule cells only.
+        self._rule_column_headers: set = set()
 
     def _get_template_paths(self) -> Dict[str, str]:
         """Get hardcoded template path mapping (CodeQL requirement)"""
@@ -345,13 +382,101 @@ class ExcelExportService:
             raise FileStorageError(f"Failed to export Excel file: {e}", file_name=file_name) from e
 
     def _get_roster_items(self, roster: PaymentRoster, include_excluded: bool) -> List[PaymentRosterItem]:
-        """取得造冊明細"""
-        items = roster.items
+        """取得造冊明細 (review scope).
+
+        Default (include_excluded=False): show included students PLUS students
+        auto-excluded for ineligibility (failed 學籍/規則/缺銀行) — so they can
+        be shown in red — but HIDE students manually removed after locking
+        (鎖定後移除 / 比對分發移除), which were intentionally taken off the list.
+
+        include_excluded=True returns everything, including manual removals.
+        """
+        items = list(roster.items)
 
         if not include_excluded:
-            items = [item for item in items if item.is_included]
+            items = [item for item in items if item.is_included or not self._is_manual_removal(item)]
 
-        return sorted(items, key=lambda x: x.student_name)
+        return sorted(items, key=lambda x: x.student_name or "")
+
+    @staticmethod
+    def _is_manual_removal(item: PaymentRosterItem) -> bool:
+        """True if the item was manually removed (vs auto-excluded for ineligibility)."""
+        reason = getattr(item, "exclusion_reason", None) or ""
+        return reason.startswith(MANUAL_REMOVAL_PREFIXES)
+
+    def _collect_rule_columns(self, items: List[PaymentRosterItem]) -> List[Tuple[str, str]]:
+        """Build the dynamic per-rule column set from the frozen eligibility
+        snapshot (``item.rule_validation_result["details"]``).
+
+        Returns an ordered list of ``(rule_key, header)`` where rule_key is
+        ``"rule_<id>"`` and header is the rule's ``rule_name``. Ordered by
+        numeric rule id; on duplicate rule_name, the id is appended to keep
+        headers unique. Non-rule detail keys (no_rules_found / error) are
+        ignored. The Excel layer never re-evaluates rules — it only reads.
+        """
+        seen: Dict[str, str] = {}  # rule_key -> rule_name (first seen)
+        for item in items:
+            rvr = getattr(item, "rule_validation_result", None)
+            if not isinstance(rvr, dict):
+                continue
+            details = rvr.get("details")
+            if not isinstance(details, dict):
+                continue
+            for key, detail in details.items():
+                if not isinstance(key, str) or not key.startswith("rule_") or not isinstance(detail, dict):
+                    continue
+                seen.setdefault(key, detail.get("rule_name") or key)
+
+        def _rule_sort_key(key: str) -> Tuple[int, Any]:
+            try:
+                return (0, int(key.split("_", 1)[1]))
+            except (IndexError, ValueError):
+                return (1, key)
+
+        ordered_keys = sorted(seen, key=_rule_sort_key)
+        name_freq = Counter(seen[k] for k in ordered_keys)
+
+        columns: List[Tuple[str, str]] = []
+        for key in ordered_keys:
+            name = seen[key]
+            if name_freq[name] > 1:
+                rule_id = key.split("_", 1)[1] if "_" in key else key
+                header = f"{name} ({rule_id})"
+            else:
+                header = name
+            columns.append((key, header))
+        return columns
+
+    @staticmethod
+    def _rule_cell_value(detail: Optional[Dict[str, Any]]) -> str:
+        """Render one rule cell from its frozen detail dict."""
+        if not isinstance(detail, dict):
+            return NOT_APPLICABLE
+        if detail.get("passed"):
+            return RULE_PASS_LABEL
+        # A failure that is explicitly a warning (and not a hard rule) → amber;
+        # anything else (hard rule, error result with no severity) → red.
+        if detail.get("is_warning") and not detail.get("is_hard_rule"):
+            return RULE_WARN_LABEL
+        return RULE_FAIL_LABEL
+
+    def _resolve_cell_fill(self, column_name: str, value: Any, row: Dict[str, Any], rule_headers: set) -> Optional[str]:
+        """Pure red/amber/none decision for one cell, driven by the rendered
+        value + column identity (no separate fill map needed)."""
+        if column_name == COL_BANK_ACCOUNT:
+            return "red" if not value else None
+        if column_name == COL_VERIFICATION:
+            return "red" if value in BAD_VERIFICATION_LABELS else None
+        if column_name == COL_INCLUDED:
+            return "red" if value == "否" else None
+        if column_name == COL_EXCLUSION:
+            return "red" if row.get(COL_INCLUDED) == "否" else None
+        if column_name in rule_headers:
+            if value == RULE_FAIL_LABEL:
+                return "red"
+            if value == RULE_WARN_LABEL:
+                return "amber"
+        return None
 
     def _resolve_template_path(self, template_name: Optional[str]) -> str:
         """
@@ -399,8 +524,23 @@ class ExcelExportService:
         return self._get_roster_items(roster, include_excluded)
 
     def _prepare_excel_data(self, roster: PaymentRoster, roster_items: List[PaymentRosterItem]) -> List[Dict]:
-        """準備Excel資料 - STD_UP_MIXLISTA 30欄位格式"""
+        """準備Excel資料 - STD_UP_MIXLISTA 30欄位 + 資格驗證欄位
+
+        Appends, after the base columns: 學籍驗證, one column per scholarship
+        rule (read from the frozen eligibility snapshot), then 納入造冊 + 排除原因.
+        Rebuilt from the immutable base each call, so the column list is stable
+        regardless of how many times this runs.
+        """
         excel_data = []
+
+        rule_columns = self._collect_rule_columns(roster_items)
+        self._rule_column_headers = {header for _, header in rule_columns}
+        self.template_columns = (
+            list(self._base_columns)
+            + [COL_VERIFICATION]
+            + [header for _, header in rule_columns]
+            + [COL_INCLUDED, COL_EXCLUSION]
+        )
 
         for idx, item in enumerate(roster_items, start=1):
             # 取得學生相關資訊
@@ -491,13 +631,31 @@ class ExcelExportService:
                 "分發獎學金": self._format_allocation_display(item),
             }
 
+            # --- 資格驗證欄位 (review document) ---
+            verification_status = getattr(item, "verification_status", None)
+            row_data[COL_VERIFICATION] = (
+                self._get_verification_status_label(verification_status)
+                if verification_status is not None
+                else NOT_APPLICABLE
+            )
+
+            # 每條規則一欄，值取自凍結的資格快照（不重新評估）
+            rvr = getattr(item, "rule_validation_result", None)
+            details = rvr.get("details") if isinstance(rvr, dict) else None
+            details = details if isinstance(details, dict) else {}
+            for rule_key, header in rule_columns:
+                row_data[header] = self._rule_cell_value(details.get(rule_key))
+
+            row_data[COL_INCLUDED] = "是" if getattr(item, "is_included", True) else "否"
+            row_data[COL_EXCLUSION] = getattr(item, "exclusion_reason", None) or ""
+
             # 儲存Excel行資料到資料庫
             item.excel_row_data = row_data
             item.excel_remarks = remarks
 
             excel_data.append(row_data)
 
-        logger.info(f"Prepared {len(excel_data)} rows for 30-column format export")
+        logger.info(f"Prepared {len(excel_data)} rows for export ({len(self.template_columns)} columns)")
         return excel_data
 
     def _validate_export_data(self, excel_data: List[Dict]) -> Dict[str, Any]:
@@ -613,6 +771,15 @@ class ExcelExportService:
                 wb = load_workbook(template_path)
                 ws = wb.active
                 logger.info("Using template file for Excel generation: %s", template_path)
+                # The template only defines the base columns; write headers for
+                # any appended verification/rule columns whose header cell is blank.
+                for col_idx, column_name in enumerate(self.template_columns, start=1):
+                    header_cell = ws.cell(row=1, column=col_idx)
+                    if header_cell.value in (None, ""):
+                        header_cell.value = column_name
+                        header_cell.font = Font(bold=True)
+                        header_cell.alignment = Alignment(horizontal="center", vertical="center")
+                        header_cell.fill = PatternFill(start_color="D3D3D3", end_color="D3D3D3", fill_type="solid")
             else:
                 wb = Workbook()
                 ws = wb.active
@@ -648,6 +815,11 @@ class ExcelExportService:
                         cell.alignment = Alignment(horizontal="center")
                     elif column_name in ["申請日期", "核准日期", "造冊日期"] and isinstance(value, str) and value:
                         cell.alignment = Alignment(horizontal="center")
+
+                    # 不符合資格的儲存格使用紅底（警告使用琥珀色）
+                    fill_kind = self._resolve_cell_fill(column_name, value, row_data, self._rule_column_headers)
+                    if fill_kind:
+                        cell.fill = FILL_BY_KIND[fill_kind]
 
             total_rows = max(len(excel_data) + (1 if include_header else 0), 1)
             self._apply_excel_styling(ws, total_rows, include_header)
@@ -712,6 +884,9 @@ class ExcelExportService:
             "驗證狀態": 10,
             "申請身分": 14,
             "分發獎學金": 18,
+            COL_VERIFICATION: 10,
+            COL_INCLUDED: 8,
+            COL_EXCLUSION: 28,
         }
 
         for col_idx, column_name in enumerate(self.template_columns, start=1):

--- a/backend/app/tests/test_excel_export_eligibility.py
+++ b/backend/app/tests/test_excel_export_eligibility.py
@@ -1,0 +1,361 @@
+"""
+Eligibility-verification enrichment of the roster (造冊) Excel.
+
+Covers the feature added on 2026-06-30: the STD_UP_MIXLISTA payment sheet now
+carries verification columns (學籍驗證 / 納入造冊 / 排除原因) plus ONE COLUMN PER
+SCHOLARSHIP RULE, and paints the specific failing cells red (hard fail) or amber
+(warning fail). See docs/superpowers/specs/2026-06-30-roster-excel-eligibility-
+verification-design.md.
+
+Design invariants pinned here:
+
+- The per-rule pass/fail is NOT re-evaluated in the Excel layer. It is read from
+  the frozen `item.rule_validation_result["details"]["rule_<id>"]` snapshot that
+  RosterService writes at generation time. So these tests feed that snapshot
+  shape directly (no DB, SimpleNamespace stubs like the sibling row-mapping test).
+- Fill is a pure function of (column_name, rendered value, row) — a rule cell
+  reading "未通過" is red, "警告" is amber, regardless of how it was produced.
+- The review export shows ineligibility-excluded students (so they can be shown
+  in red) but HIDES students manually removed after locking.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+from openpyxl import load_workbook
+
+from app.models.payment_roster import StudentVerificationStatus
+from app.services.excel_export_service import ExcelExportService
+
+RED = "FFC7CE"
+AMBER = "FFEB9C"
+
+
+@pytest.fixture
+def service() -> ExcelExportService:
+    return ExcelExportService()
+
+
+def _rule_detail(rule_name: str, passed: bool, *, hard: bool = True, warning: bool = False) -> Dict[str, Any]:
+    return {
+        "passed": passed,
+        "rule_name": rule_name,
+        "rule_type": "gpa",
+        "is_hard_rule": hard,
+        "is_warning": warning,
+        "message": f"{rule_name} 訊息",
+    }
+
+
+def _make_item(
+    *,
+    student_id_number: str = "A123456789",
+    student_name: str = "王小明",
+    bank_account: Optional[str] = "00012345678",
+    is_included: bool = True,
+    exclusion_reason: Optional[str] = None,
+    verification_status: StudentVerificationStatus = StudentVerificationStatus.VERIFIED,
+    rule_details: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> SimpleNamespace:
+    rvr: Optional[Dict[str, Any]] = None
+    if rule_details is not None:
+        rvr = {"is_eligible": is_included, "failed_rules": [], "warning_rules": [], "details": rule_details}
+    return SimpleNamespace(
+        student_id_number=student_id_number,
+        student_name=student_name,
+        student_email="x@nycu.edu.tw",
+        bank_account=bank_account,
+        scholarship_name="博士班獎學金",
+        scholarship_amount=50000,
+        permanent_address=None,
+        application_identity="114新申請",
+        allocated_sub_type=None,
+        allocation_year=None,
+        is_included=is_included,
+        exclusion_reason=exclusion_reason,
+        verification_status=verification_status,
+        rule_validation_result=rvr,
+        excel_row_data=None,
+        excel_remarks=None,
+    )
+
+
+def _make_roster(**kw: Any) -> SimpleNamespace:
+    return SimpleNamespace(
+        period_label=kw.get("period_label", "2025-H1"),
+        roster_code=kw.get("roster_code", "ROSTER-114-2025-H1-PHD001"),
+        academic_year=kw.get("academic_year", 114),
+        items=kw.get("items", []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_manual_removal — distinguishes intentional removals from ineligibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reason,expected",
+    [
+        ("鎖定後移除[補充]：重複", True),
+        ("比對分發移除：不在分發名單", True),
+        ("缺少銀行帳戶資訊", False),
+        ("學籍驗證未通過: graduated", False),
+        ("不符合獎學金規則: GPA 不足", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_manual_removal(service: ExcelExportService, reason: Optional[str], expected: bool) -> None:
+    item = _make_item(is_included=False, exclusion_reason=reason)
+    assert service._is_manual_removal(item) is expected
+
+
+# ---------------------------------------------------------------------------
+# _get_roster_items — review scope
+# ---------------------------------------------------------------------------
+
+
+def test_get_roster_items_shows_ineligible_hides_manual_removal(service: ExcelExportService) -> None:
+    included = _make_item(student_name="A_included")
+    ineligible = _make_item(student_name="B_ineligible", is_included=False, exclusion_reason="缺少銀行帳戶資訊")
+    manual = _make_item(student_name="C_manual", is_included=False, exclusion_reason="鎖定後移除：手動")
+    roster = _make_roster(items=[included, ineligible, manual])
+
+    names = [it.student_name for it in service._get_roster_items(roster, include_excluded=False)]
+
+    assert "A_included" in names
+    assert "B_ineligible" in names  # auto-excluded → shown (will be red)
+    assert "C_manual" not in names  # manual removal → hidden
+
+
+def test_get_roster_items_include_excluded_returns_everything(service: ExcelExportService) -> None:
+    included = _make_item(student_name="A_included")
+    manual = _make_item(student_name="C_manual", is_included=False, exclusion_reason="鎖定後移除：手動")
+    roster = _make_roster(items=[included, manual])
+
+    names = [it.student_name for it in service._get_roster_items(roster, include_excluded=True)]
+
+    assert names == ["A_included", "C_manual"]  # sorted by name, manual removal included
+
+
+# ---------------------------------------------------------------------------
+# _collect_rule_columns — dynamic per-rule column set
+# ---------------------------------------------------------------------------
+
+
+def test_collect_rule_columns_orders_by_rule_id(service: ExcelExportService) -> None:
+    item1 = _make_item(rule_details={"rule_5": _rule_detail("GPA門檻", True), "rule_2": _rule_detail("國籍", True)})
+    item2 = _make_item(rule_details={"rule_2": _rule_detail("國籍", True), "rule_9": _rule_detail("年級", False)})
+
+    cols = service._collect_rule_columns([item1, item2])
+
+    assert [key for key, _ in cols] == ["rule_2", "rule_5", "rule_9"]
+    assert [header for _, header in cols] == ["國籍", "GPA門檻", "年級"]
+
+
+def test_collect_rule_columns_disambiguates_duplicate_names(service: ExcelExportService) -> None:
+    item = _make_item(
+        rule_details={"rule_2": _rule_detail("學業成績", True), "rule_7": _rule_detail("學業成績", False)}
+    )
+
+    cols = service._collect_rule_columns([item])
+
+    headers = [header for _, header in cols]
+    assert headers == ["學業成績 (2)", "學業成績 (7)"]
+
+
+def test_collect_rule_columns_ignores_non_rule_detail_keys(service: ExcelExportService) -> None:
+    no_rules = _make_item(rule_details={"no_rules_found": True})
+    errored = _make_item(rule_details={"error": "boom"})
+    none_item = _make_item(rule_details=None)
+
+    assert service._collect_rule_columns([no_rules, errored, none_item]) == []
+
+
+# ---------------------------------------------------------------------------
+# _prepare_excel_data — verification + per-rule cell values
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_adds_verification_columns_for_qualified(service: ExcelExportService) -> None:
+    roster = _make_roster()
+    item = _make_item(verification_status=StudentVerificationStatus.VERIFIED, is_included=True)
+
+    row = service._prepare_excel_data(roster, [item])[0]
+
+    assert row["學籍驗證"] == "已驗證"
+    assert row["納入造冊"] == "是"
+    assert row["排除原因"] == ""
+
+
+def test_prepare_verification_columns_for_excluded(service: ExcelExportService) -> None:
+    roster = _make_roster()
+    item = _make_item(
+        verification_status=StudentVerificationStatus.GRADUATED,
+        is_included=False,
+        exclusion_reason="學籍驗證未通過: graduated",
+    )
+
+    row = service._prepare_excel_data(roster, [item])[0]
+
+    assert row["學籍驗證"] == "已畢業"
+    assert row["納入造冊"] == "否"
+    assert row["排除原因"] == "學籍驗證未通過: graduated"
+
+
+def test_prepare_per_rule_cell_values(service: ExcelExportService) -> None:
+    roster = _make_roster()
+    item = _make_item(
+        rule_details={
+            "rule_2": _rule_detail("國籍", True),  # 通過
+            "rule_5": _rule_detail("GPA門檻", False, hard=True),  # 未通過 (red)
+            "rule_9": _rule_detail("年級", False, hard=False, warning=True),  # 警告 (amber)
+        }
+    )
+
+    row = service._prepare_excel_data(roster, [item])[0]
+
+    assert row["國籍"] == "通過"
+    assert row["GPA門檻"] == "未通過"
+    assert row["年級"] == "警告"
+
+
+def test_prepare_per_rule_cell_dash_when_no_detail(service: ExcelExportService) -> None:
+    """A rule column present on the sheet but with no detail for this item
+    (rule not applicable to this student) renders '—', not blank/crash."""
+    roster = _make_roster()
+    has_rule = _make_item(student_name="A", rule_details={"rule_5": _rule_detail("GPA門檻", True)})
+    no_rule = _make_item(student_name="B", rule_details={})
+
+    rows = service._prepare_excel_data(roster, [has_rule, no_rule])
+
+    # both rows expose the column; the one lacking detail shows —
+    assert rows[0]["GPA門檻"] == "通過"
+    assert rows[1]["GPA門檻"] == "—"
+
+
+def test_prepare_sets_template_columns_dynamically(service: ExcelExportService) -> None:
+    roster = _make_roster()
+    item = _make_item(rule_details={"rule_5": _rule_detail("GPA門檻", True)})
+
+    service._prepare_excel_data(roster, [item])
+
+    cols = service.template_columns
+    # base STD_UP_MIXLISTA columns survive, verification + rule columns appended
+    assert "身分證字號" in cols and "分發獎學金" in cols
+    assert cols.index("學籍驗證") < cols.index("GPA門檻") < cols.index("納入造冊") < cols.index("排除原因")
+
+
+def test_prepare_is_idempotent_no_duplicate_columns(service: ExcelExportService) -> None:
+    """Calling _prepare_excel_data twice must not append the verification
+    columns twice (column list is rebuilt from the immutable base)."""
+    roster = _make_roster()
+    item = _make_item(rule_details={"rule_5": _rule_detail("GPA門檻", True)})
+
+    service._prepare_excel_data(roster, [item])
+    service._prepare_excel_data(roster, [item])
+
+    cols = service.template_columns
+    assert cols.count("學籍驗證") == 1
+    assert cols.count("GPA門檻") == 1
+    assert cols.count("納入造冊") == 1
+
+
+# ---------------------------------------------------------------------------
+# _resolve_cell_fill — pure red/amber/none decision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "column,value,row,rule_headers,expected",
+    [
+        ("帳號", "", {}, set(), "red"),  # missing bank account
+        ("帳號", "00012345678", {}, set(), None),
+        ("學籍驗證", "已畢業", {}, set(), "red"),
+        ("學籍驗證", "休學中", {}, set(), "red"),
+        ("學籍驗證", "已驗證", {}, set(), None),
+        ("學籍驗證", "—", {}, set(), None),  # unknown status never reds
+        ("納入造冊", "否", {}, set(), "red"),
+        ("納入造冊", "是", {}, set(), None),
+        ("排除原因", "缺銀行", {"納入造冊": "否"}, set(), "red"),
+        ("排除原因", "", {"納入造冊": "是"}, set(), None),
+        ("GPA門檻", "未通過", {}, {"GPA門檻"}, "red"),
+        ("GPA門檻", "警告", {}, {"GPA門檻"}, "amber"),
+        ("GPA門檻", "通過", {}, {"GPA門檻"}, None),
+        ("GPA門檻", "—", {}, {"GPA門檻"}, None),
+        # a base column whose value happens to be "未通過" is NOT a rule col → no fill
+        ("說明", "未通過", {}, {"GPA門檻"}, None),
+    ],
+)
+def test_resolve_cell_fill(
+    service: ExcelExportService,
+    column: str,
+    value: str,
+    row: Dict[str, Any],
+    rule_headers: set,
+    expected: Optional[str],
+) -> None:
+    assert service._resolve_cell_fill(column, value, row, rule_headers) == expected
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real workbook carries the red/amber fills on the right cells
+# ---------------------------------------------------------------------------
+
+
+def _cell_rgb(ws, header_row: List[str], row_idx: int, column_name: str):
+    col_idx = header_row.index(column_name) + 1
+    return ws.cell(row=row_idx, column=col_idx).fill
+
+
+def test_create_excel_file_paints_failing_cells(service: ExcelExportService, tmp_path) -> None:
+    roster = _make_roster()
+    item = _make_item(
+        student_name="陳大文",
+        bank_account=None,  # missing bank → 帳號 red
+        is_included=False,
+        exclusion_reason="不符合獎學金規則: GPA 不足",
+        verification_status=StudentVerificationStatus.GRADUATED,  # 學籍驗證 red
+        rule_details={
+            "rule_2": _rule_detail("國籍", True),  # 通過 → no fill
+            "rule_5": _rule_detail("GPA門檻", False, hard=True),  # 未通過 → red
+            "rule_9": _rule_detail("年級", False, hard=False, warning=True),  # 警告 → amber
+        },
+    )
+
+    excel_data = service._prepare_excel_data(roster, [item])
+    out = os.path.join(str(tmp_path), "roster.xlsx")
+    service._create_excel_file(
+        excel_data,
+        out,
+        roster,
+        template_path="/nonexistent/template.xlsx",
+        include_header=True,
+        include_statistics=False,
+    )
+
+    wb = load_workbook(out)
+    ws = wb.active
+    headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+    data_row = 2
+
+    def fill_of(col: str) -> str:
+        return _cell_rgb(ws, headers, data_row, col).start_color.rgb or ""
+
+    def has(col: str, rgb: str) -> bool:
+        f = _cell_rgb(ws, headers, data_row, col)
+        return f.fill_type == "solid" and (f.start_color.rgb or "").endswith(rgb)
+
+    assert has("帳號", RED)
+    assert has("學籍驗證", RED)
+    assert has("GPA門檻", RED)
+    assert has("年級", AMBER)
+    assert has("納入造冊", RED)
+    assert has("排除原因", RED)
+    # the passing rule cell carries NO solid fill
+    assert _cell_rgb(ws, headers, data_row, "國籍").fill_type != "solid"

--- a/docs/superpowers/specs/2026-06-30-roster-excel-eligibility-verification-design.md
+++ b/docs/superpowers/specs/2026-06-30-roster-excel-eligibility-verification-design.md
@@ -1,0 +1,136 @@
+# 造冊名單 Excel：資格驗證資訊 + 不符合儲存格紅底
+
+**Date:** 2026-06-30
+**Status:** Approved (design)
+**Scope:** `backend/app/services/excel_export_service.py` (+ tests)
+
+## Goal
+
+The roster (造冊) Excel — the STD_UP_MIXLISTA payment-format sheet produced by
+`ExcelExportService.export_roster_to_excel` — should carry **eligibility
+verification information**, including **one column per scholarship rule**, and
+**highlight the specific failing cells with a red background** (warning-rule
+failures use amber). This turns the roster Excel into a review document that
+lets an admin see, at a glance, exactly why any student is non-compliant.
+
+## Key facts (verified)
+
+- **No `.xlsx` template file exists in the repo.** `_load_template_structure`
+  always falls back to `_set_default_columns`, and `_create_excel_file` always
+  builds a fresh `Workbook` (the `use_template` branch is dead in practice).
+  So extending the column set is purely a matter of extending the default list
+  and the data-writing loop.
+- `self.field_mapping` in the export service is **dead** (never read elsewhere).
+- `item.excel_row_data` is **write-only** (no consumers) — safe to extend.
+- **Per-rule results are already frozen on each item.**
+  `RosterService._validate_student_eligibility()` loops
+  `_evaluate_scholarship_rule()` over `_get_scholarship_rules()` and stores the
+  outcome in `item.rule_validation_result["details"]`, keyed `"rule_<id>"`:
+
+  ```python
+  {"passed": bool, "rule_name": str, "rule_type": str,
+   "is_hard_rule": bool, "is_warning": bool, "message": str, ...}
+  ```
+
+  This is populated in **both** `generate_roster` and
+  `generate_rosters_from_distribution`. The Excel layer therefore **reads the
+  frozen snapshot** — no DB access, no re-evaluation, and guaranteed consistent
+  with the recorded `is_eligible` / `failed_rules`. Rule-evaluation logic stays
+  in `RosterService` as the single source of truth.
+
+## Reuse decision
+
+Instead of re-querying or re-running rules in the Excel layer, reuse the
+**already-stored** `rule_validation_result["details"]`. The only new logic is a
+**pure presentation helper** that turns those per-item details into a stable,
+ordered set of columns.
+
+## Columns
+
+### Static base (unchanged)
+The existing 30 STD_UP_MIXLISTA columns (`身分證字號` … `分發獎學金`).
+
+### Appended verification columns
+| Order | 欄位 | Source | Red/Amber condition |
+|------|------|--------|---------------------|
+| after 30 | 學籍驗證 | `verification_status` → label | **red** if `!= VERIFIED` |
+| dynamic | *(one per rule)* header = `rule_name` | `details["rule_<id>"]` | hard-rule fail → **red**; warning-rule fail → **amber** |
+| end | 納入造冊 | `is_included` → 是/否 | **red** if `False` |
+| end | 排除原因 | `exclusion_reason or ""` | **red** if `is_included == False` |
+
+Additionally: the **existing 帳號 (col 3)** cell turns **red** when
+`bank_account` is missing.
+
+### Per-rule cell values
+- `通過` — `passed == True` (no fill)
+- `未通過` — `passed == False` and rule is hard (or severity unknown) → **red**
+- `警告` — `passed == False` and rule is warning → **amber**
+- `—` — that rule has no detail entry for this item (rule not applicable)
+
+The per-rule **column set is dynamic per roster** (the union of rule ids seen
+across the roster's items, ordered by rule id; on duplicate `rule_name`,
+disambiguate by appending the id).
+
+## Item scope (which students appear)
+
+Show **included** students **plus students auto-excluded for ineligibility**
+(failed 學籍 / rules / missing bank at generation). **Hide students manually
+removed after locking** (`exclusion_reason` starting with `鎖定後移除` or
+`比對分發移除`) — those were intentionally removed and must not reappear on a
+re-download.
+
+Implemented via a pure helper `_is_manual_removal(item)`. The default export
+item set becomes: `included ∪ (excluded ∧ ¬manual_removal)`.
+`include_excluded=True` still returns absolutely everything (incl. manual
+removals) for callers that explicitly want it.
+
+## Mechanics / data flow
+
+The final column list is no longer fully static (per-rule columns depend on the
+roster), so thread it through explicitly:
+
+1. `_collect_rule_columns(items) -> List[RuleColumn]` — pure; scans
+   `details`, returns ordered de-duplicated rule columns
+   `(key="rule_<id>", header, ...)`.
+2. Build `columns = STATIC_BASE + ["學籍驗證"] + [rc.header …] + ["納入造冊", "排除原因"]`.
+3. `_prepare_excel_data(roster, items, rule_columns)` — returns
+   `(rows, fill_map)` where `rows` is the list of column→value dicts and
+   `fill_map` is a parallel list of `{column_name: "red" | "amber"}` per row.
+4. `_create_excel_file(rows, columns, fill_map, …)` — writes using the passed
+   `columns` and applies per-cell fills.
+5. Column widths: per-rule and verification columns get a sensible default
+   width; borders already span `len(columns)`.
+
+Red fill: `PatternFill(start_color="FFC7CE", end_color="FFC7CE", fill_type="solid")`
+(Excel's standard "bad" red). Amber: `PatternFill("FFEB9C", …)` ("neutral" amber).
+
+## Error handling
+
+- Items with `rule_validation_result is None` or empty `details` → all per-rule
+  cells `—`, no rule-based red (still red on 學籍/帳號/納入 as applicable).
+- A `details` value that is not a `rule_<id>` entry (e.g. `no_rules_found`,
+  `error`) is ignored by `_collect_rule_columns`.
+- Per-rule error results (no `is_hard_rule`) default to **red** (treated as a
+  hard fail), since an un-evaluated rule must not silently look compliant.
+
+## Testing (TDD)
+
+Extend `backend/app/tests/test_excel_export_service_rows.py` (or a sibling
+pure-helper test) using the existing `SimpleNamespace` stub pattern:
+
+- `_is_manual_removal` true/false matrix.
+- `_collect_rule_columns`: ordering, de-dup, ignores non-rule detail keys,
+  handles missing/empty details.
+- `_prepare_excel_data`: per-rule cell values (通過/未通過/警告/—), verification
+  column values, and the parallel `fill_map` (red vs amber vs none, incl. the
+  missing-bank red on 帳號).
+- A real temp-file `export_roster_to_excel` (or `_create_excel_file`) round-trip
+  asserting the appended headers exist and the expected cells carry the red/amber
+  `PatternFill` — and that a manually-removed item is absent while an
+  ineligibility-excluded item is present (red).
+
+## Risk (accepted)
+
+This enriches the official STD_UP_MIXLISTA payment sheet and now includes
+ineligible students (red). It functions as a **review document**; red rows are
+removed before any payment-system upload.


### PR DESCRIPTION
## 摘要
造冊名單生成的 Excel（STD_UP_MIXLISTA 付款格式）現在兼作**資格驗證審查文件**：在原 30 欄之後附加驗證欄位，並在**不符合的儲存格**標上紅底（硬性不符）/ 琥珀色（警告）。

### 新增欄位（附加於「分發獎學金」之後）
- `學籍驗證` — 學籍驗證狀態（已驗證 / 已畢業 / 休學中 / 已退學 / 驗證錯誤 / 查無此人）
- **每條獎學金規則一欄** — `通過` / `未通過` / `警告` / `—`(不適用)
- `納入造冊` — 是 / 否
- `排除原因`

### 紅底規則（只標示出問題的儲存格）
| 條件 | 標色的儲存格 |
|------|------|
| 學籍非「已驗證」 | 學籍驗證 → 紅 |
| 規則硬性不符 | 該規則欄 `未通過` → 紅 |
| 規則警告不符 | 該規則欄 `警告` → 琥珀 |
| 缺郵局帳號 | 帳號(既有第3欄) → 紅 |
| `is_included=False` | 納入造冊 `否` + 排除原因 → 紅 |

完全符合的學生不會有任何標色。

## 重用既有邏輯（不重新評估）
每條規則的通過/未通過在造冊產生時就已凍結於 `PaymentRosterItem.rule_validation_result["details"]["rule_<id>"]`（由 `RosterService._validate_student_eligibility` 於 `generate_roster` 與 `generate_rosters_from_distribution` 兩條路徑寫入）。Excel 層**只讀取**此快照（`_collect_rule_columns` 動態組欄 + `_rule_cell_value`），不重跑規則引擎，保證與 `is_eligible`/`failed_rules` 一致。規則評估的唯一真相仍在 `RosterService`。

填色採**值驅動**（`_resolve_cell_fill`），因此 `_prepare_excel_data` 維持原本的 `List[Dict]` 回傳契約，既有測試不受影響。

## 納入範圍變更
預設匯出（`include_excluded=False`）現在顯示「已納入 + 因資格不符自動排除」的學生（讓不符合者以紅底呈現），但**隱藏鎖定後手動移除**者（`鎖定後移除` / `比對分發移除`），避免重新下載時復活。

> ⚠️ 取捨：官方付款表單現在會多出欄位並包含紅底的不合格列 → 作為審查文件使用；上傳付款系統前需移除紅底列。

## 實作
- 全部變更集中於 `backend/app/services/excel_export_service.py`（+ 測試 + spec）。
- 倉庫內無 `.xlsx` 範本檔 → 一律走預設欄位、全新 Workbook 路徑。

## 測試
- 新增 `app/tests/test_excel_export_eligibility.py`（34 例，含真實 workbook 紅/琥珀填色斷言、`_is_manual_removal`、`_collect_rule_columns` 排序/去重、納入範圍過濾）。
- 既有 roster/excel/payment 測試 **609 passed**，無回歸；聚焦消費端（generation / scheduler / API）**97 passed**。
- Lint：`black --check` 通過；`flake8 --select=B904,B014` 通過。
- 無需重產 OpenAPI 型別（未改 endpoint/schema）；前端 preview 因讀 `template_columns` 會自動帶出新欄位。

## Test plan
- [ ] 產生一份含不合格學生的造冊，下載 Excel，確認附加欄位與紅/琥珀底色正確
- [ ] 確認完全合格的造冊無任何標色
- [ ] 確認鎖定後手動移除的學生不出現在預設匯出