### PR TITLE
feat(college-export): 學院匯出排名 support PDF format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # The college-ranking PDF export (reportlab) registers
+      # /usr/share/fonts/truetype/wqy/wqy-zenhei.ttc, installed in the backend
+      # Docker image (see backend/Dockerfile). CI runs on a bare runner, so the
+      # font must be installed here for the build_pdf / export-pdf tests to render.
+      - name: Install CJK font (reportlab PDF export tests)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fonts-wqy-zenhei
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -44,6 +44,7 @@ from app.services.review_service import ReviewService
 from app.utils.application_helpers import get_college_code_from_data
 from app.services.supplementary_import_service import SupplementaryImportService
 
+from .application_summary_export import XLSX_MEDIA_TYPE
 from ._helpers import (
     _check_academic_year_permission,
     _check_scholarship_permission,
@@ -1252,7 +1253,7 @@ async def export_ranking_excel(
         else (getattr(ranking.creator, "college_code", None) or "全校")
     )
     template_suffix = "_範本" if template else ""
-    extension = "pdf" if format == "pdf" else "xlsx"
+    extension = format  # Literal["xlsx", "pdf"] — extension IS the format
     base_filename = (
         f"{ranking.academic_year}學年度{scholarship_name}學生資料彙整表"
         f"_{college_label}{template_suffix}.{extension}"
@@ -1277,7 +1278,7 @@ async def export_ranking_excel(
             title=title,
             sheet_name=sheet_name,
         )
-        media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        media_type = XLSX_MEDIA_TYPE
 
     # 8. Audit the PII access (issue #73): business confirmed Excel must show
     # the full std_pid, so every export that includes plaintext IDs is logged.

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -10,7 +10,7 @@ Handles:
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 from urllib.parse import quote as _url_quote
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, Request, UploadFile, status
@@ -1176,14 +1176,20 @@ async def export_ranking_excel(
     ranking_id: int,
     request: Request,
     template: bool = Query(False, description="Render the rank column blank, as a fill-in import template"),
+    format: Literal["xlsx", "pdf"] = Query("xlsx", description="Output format: xlsx (default) or pdf"),
     current_user: User = Depends(require_scholarship_manager),
     db: AsyncSession = Depends(get_db),
 ):
-    """Generate the 學生資料彙整表 Excel for a ranking.
+    """Generate the 學生資料彙整表 for a ranking, as Excel (default) or PDF.
 
     Auth: admin/super_admin OR a college user whose `college_code` matches the
     ranking's own `college_code` (authoritative per-college ownership).
     """
+
+    # A PDF template makes no sense — a template is meant to be filled in and
+    # re-imported, which only the xlsx path supports.
+    if template and format == "pdf":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="範本僅支援 Excel 格式")
 
     # 1. Load ranking + items with applications
     stmt = (
@@ -1246,20 +1252,32 @@ async def export_ranking_excel(
         else (getattr(ranking.creator, "college_code", None) or "全校")
     )
     template_suffix = "_範本" if template else ""
+    extension = "pdf" if format == "pdf" else "xlsx"
     base_filename = (
-        f"{ranking.academic_year}學年度{scholarship_name}學生資料彙整表_{college_label}{template_suffix}.xlsx"
+        f"{ranking.academic_year}學年度{scholarship_name}學生資料彙整表"
+        f"_{college_label}{template_suffix}.{extension}"
     )
     encoded = _url_quote(base_filename, safe="")
 
-    # 7. Render workbook
+    # 7. Render the workbook (xlsx) or PDF — both share the same columns/rows.
     service = CollegeRankingExportService()
-    payload = service.build_workbook(
-        rows=export_rows,
-        dynamic_fields=dynamic_fields,
-        sub_type_labels=sub_type_labels,
-        title=title,
-        sheet_name=sheet_name,
-    )
+    if format == "pdf":
+        payload = service.build_pdf(
+            rows=export_rows,
+            dynamic_fields=dynamic_fields,
+            sub_type_labels=sub_type_labels,
+            title=title,
+        )
+        media_type = "application/pdf"
+    else:
+        payload = service.build_workbook(
+            rows=export_rows,
+            dynamic_fields=dynamic_fields,
+            sub_type_labels=sub_type_labels,
+            title=title,
+            sheet_name=sheet_name,
+        )
+        media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
     # 8. Audit the PII access (issue #73): business confirmed Excel must show
     # the full std_pid, so every export that includes plaintext IDs is logged.
@@ -1287,7 +1305,7 @@ async def export_ranking_excel(
                 "record_count": len(exported_app_ids),
                 "application_ids": exported_app_ids,
                 "pii_fields": ["std_pid"],
-                "export_format": "xlsx",
+                "export_format": extension,
                 "is_template": template,
             },
         )
@@ -1299,7 +1317,7 @@ async def export_ranking_excel(
 
     return StreamingResponse(
         iter([payload]),
-        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        media_type=media_type,
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{encoded}",
             "Content-Length": str(len(payload)),

--- a/backend/app/services/college_ranking_export_service.py
+++ b/backend/app/services/college_ranking_export_service.py
@@ -1,8 +1,12 @@
-"""College ranking Excel export service.
+"""College ranking export service.
 
-Pure rendering logic — receives prepared data structures, returns xlsx bytes.
-The endpoint layer is responsible for loading rows, dynamic field configs,
+Pure rendering logic — receives prepared data structures, returns xlsx or PDF
+bytes. The endpoint layer is responsible for loading rows, dynamic field configs,
 and sub-type labels from the database.
+
+``build_workbook`` and ``build_pdf`` share one source of truth for the column set
+(``_headers``) and per-row cell values (``_row_cells``), so the two formats never
+drift apart.
 """
 
 from __future__ import annotations
@@ -12,9 +16,21 @@ import math
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+# `escape` is a pure string-escaping helper (`<` → `&lt;` …) used to sanitise
+# cell values before they go into reportlab Paragraph markup. It does not parse
+# untrusted XML, so the B406 warning is a false positive here.
+from xml.sax.saxutils import escape as xml_escape  # nosec B406
+
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.units import mm
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+
+from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
 
 STATIC_HEADERS: List[str] = [
     "NO.",
@@ -76,8 +92,8 @@ class CollegeRankingExportService:
         ws = wb.active
         ws.title = sheet_name
 
-        sorted_dynamic = sorted(dynamic_fields, key=lambda f: (f.display_order, f.field_name))
-        headers = STATIC_HEADERS + [(f.export_column_label or f.field_label) for f in sorted_dynamic]
+        sorted_dynamic = self._sort_dynamic(dynamic_fields)
+        headers = self._headers(sorted_dynamic)
         total_cols = len(headers)
 
         # Row 1: title (merged across all columns)
@@ -95,11 +111,11 @@ class CollegeRankingExportService:
             cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
             cell.fill = PatternFill("solid", fgColor="DDDDDD")
 
-        # Data rows
+        # Data rows — written from the same _row_cells used by the PDF export
         for idx, row in enumerate(rows, start=1):
             excel_row = idx + 2  # +2 because rows 1-2 are title/header
-            self._write_static_cells(ws, excel_row, idx, row, sub_type_labels)
-            self._write_dynamic_cells(ws, excel_row, row, sorted_dynamic)
+            for col_idx, value in enumerate(self._row_cells(row, idx, sub_type_labels, sorted_dynamic), start=1):
+                ws.cell(row=excel_row, column=col_idx, value=value)
 
         max_row = len(rows) + 2
         self._apply_borders(ws, max_row=max_row, max_col=total_cols)
@@ -110,48 +126,171 @@ class CollegeRankingExportService:
         wb.save(buf)
         return buf.getvalue()
 
-    # -------- Static column rendering --------
-
-    def _write_static_cells(
+    def build_pdf(
         self,
-        ws,
-        excel_row: int,
-        row_index: int,
-        row: ExportRow,
+        *,
+        rows: List[ExportRow],
+        dynamic_fields: List[DynamicFieldSpec],
         sub_type_labels: Dict[str, str],
-    ) -> None:
-        sd = getattr(row.application, "student_data", None) or {}
+        title: str,
+    ) -> bytes:
+        """Render the same 學生資料彙整表 as an A4-landscape PDF.
 
-        ws.cell(row=excel_row, column=1, value=row_index)
-        ws.cell(
-            row=excel_row,
-            column=2,
-            value=(row.rank_position if row.rank_position is not None else ""),
+        Mirrors ``build_workbook`` exactly (same columns, rows and ordering via
+        ``_headers`` / ``_row_cells``). Column widths are normalised to the usable
+        page width so the wide table never overflows horizontally — long cell text
+        wraps, and rows paginate vertically with the header repeated on each page.
+        """
+        ensure_cjk_font()
+
+        sorted_dynamic = self._sort_dynamic(dynamic_fields)
+        headers = self._headers(sorted_dynamic)
+
+        page_width, _ = landscape(A4)
+        usable_width = page_width - (self._PDF_MARGIN_PT * 2)
+        col_widths = self._pdf_col_widths(headers, usable_width)
+
+        title_style = ParagraphStyle(
+            "RankingPdfTitle",
+            fontName=CJK_FONT_NAME,
+            fontSize=12,
+            leading=15,
+            alignment=1,  # center
         )
-        ws.cell(
-            row=excel_row,
-            column=3,
-            value=self._render_scholarship_type(row.application, sub_type_labels),
+        header_style = ParagraphStyle(
+            "RankingPdfHeader",
+            fontName=CJK_FONT_NAME,
+            fontSize=6.5,
+            leading=8,
+            alignment=1,
+            wordWrap="CJK",
         )
-        ws.cell(row=excel_row, column=4, value=self._safe_str(sd.get("trm_academyname")))
-        ws.cell(row=excel_row, column=5, value=self._safe_str(sd.get("trm_depname")))
-        ws.cell(row=excel_row, column=6, value=self._compute_grade(sd.get("trm_termcount")))
-        ws.cell(row=excel_row, column=7, value=self._render_direct_phd(sd.get("std_enrolltype")))
-        ws.cell(row=excel_row, column=8, value=self._safe_str(sd.get("std_cname")))
-        ws.cell(row=excel_row, column=9, value=self._safe_str(sd.get("std_ename")))
-        ws.cell(row=excel_row, column=10, value=self._safe_str(sd.get("std_nation")))
-        ws.cell(row=excel_row, column=11, value=self._render_gender(sd.get("std_sex")))
-        ws.cell(
-            row=excel_row,
-            column=12,
-            value=self._render_enrollment_date(sd.get("std_enrollyear"), sd.get("std_enrollterm")),
+        cell_style = ParagraphStyle(
+            "RankingPdfCell",
+            fontName=CJK_FONT_NAME,
+            fontSize=6,
+            leading=7.5,
+            wordWrap="CJK",  # break long CJK and unspaced ASCII (emails, IDs)
         )
-        ws.cell(row=excel_row, column=13, value=self._safe_str(sd.get("std_stdcode")))
-        ws.cell(row=excel_row, column=14, value=self._safe_str(sd.get("std_pid")))
-        ws.cell(row=excel_row, column=15, value=self._safe_str(row.bank_account))
-        ws.cell(row=excel_row, column=16, value=self._safe_str(sd.get("com_email")))
-        ws.cell(row=excel_row, column=17, value=self._safe_str(sd.get("com_commadd")))
-        ws.cell(row=excel_row, column=18, value=self._safe_str(row.advisor_names))
+
+        data: List[List[Paragraph]] = [[Paragraph(xml_escape(h), header_style) for h in headers]]
+        for idx, row in enumerate(rows, start=1):
+            values = self._row_cells(row, idx, sub_type_labels, sorted_dynamic)
+            data.append([Paragraph(xml_escape(self._safe_str(v)), cell_style) for v in values])
+
+        table = Table(data, colWidths=col_widths, repeatRows=1)
+        table.setStyle(
+            TableStyle(
+                [
+                    ("GRID", (0, 0), (-1, -1), 0.4, colors.Color(0.6, 0.6, 0.6)),
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.Color(0.87, 0.87, 0.87)),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("FONTNAME", (0, 0), (-1, -1), CJK_FONT_NAME),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 2),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 2),
+                    ("TOPPADDING", (0, 0), (-1, -1), 1),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 1),
+                ]
+            )
+        )
+
+        buf = io.BytesIO()
+        doc = SimpleDocTemplate(
+            buf,
+            pagesize=landscape(A4),
+            leftMargin=self._PDF_MARGIN_PT,
+            rightMargin=self._PDF_MARGIN_PT,
+            topMargin=self._PDF_MARGIN_PT,
+            bottomMargin=self._PDF_MARGIN_PT,
+        )
+        doc.build([Paragraph(xml_escape(title), title_style), Spacer(1, 4 * mm), table])
+        return buf.getvalue()
+
+    # -------- PDF layout helpers --------
+
+    _PDF_MARGIN_PT = 10 * mm
+
+    # Relative column weights for the wide PDF table. Narrow id/flag columns get
+    # less width; free-text columns (name, email, address, advisor, dynamic
+    # fields) get more. Headers not listed (dynamic fields) use the default.
+    _PDF_COL_WEIGHTS: Dict[str, float] = {
+        "NO.": 0.5,
+        "學院初審會議之學院排序": 0.8,
+        "申請獎學金類別": 1.4,
+        "學院": 1.0,
+        "系所": 1.2,
+        "年級": 0.5,
+        "是否為逕博學生": 0.7,
+        "學生中文姓名": 1.0,
+        "學生英文姓名": 1.4,
+        "國籍": 0.7,
+        "性別": 0.5,
+        "註冊入學日期": 0.9,
+        "學號": 1.0,
+        "學生身分證字號": 1.1,
+        "學生匯款帳號": 1.2,
+        "學生E-mail": 1.7,
+        "學生通訊地址": 2.0,
+        "指導教授姓名": 1.3,
+    }
+    _PDF_COL_WEIGHT_DEFAULT = 1.2
+
+    def _pdf_col_widths(self, headers: List[str], usable_width: float) -> List[float]:
+        weights = [self._PDF_COL_WEIGHTS.get(h, self._PDF_COL_WEIGHT_DEFAULT) for h in headers]
+        total = sum(weights) or 1.0
+        return [usable_width * w / total for w in weights]
+
+    # -------- Shared column/value model (single source of truth) --------
+
+    @staticmethod
+    def _sort_dynamic(dynamic_fields: List[DynamicFieldSpec]) -> List[DynamicFieldSpec]:
+        return sorted(dynamic_fields, key=lambda f: (f.display_order, f.field_name))
+
+    def _headers(self, sorted_dynamic: List[DynamicFieldSpec]) -> List[str]:
+        return STATIC_HEADERS + [(f.export_column_label or f.field_label) for f in sorted_dynamic]
+
+    def _row_cells(
+        self,
+        row: ExportRow,
+        row_index: int,
+        sub_type_labels: Dict[str, str],
+        sorted_dynamic: List[DynamicFieldSpec],
+    ) -> List[Any]:
+        """Ordered cell values for one row: static columns then dynamic columns.
+
+        The xlsx writer keeps the native int values (NO., rank, grade) for proper
+        Excel typing; the PDF renderer stringifies them. Both share this list so
+        the two formats render identical content.
+        """
+        return self._static_values(row, row_index, sub_type_labels) + self._dynamic_values(row, sorted_dynamic)
+
+    def _static_values(
+        self,
+        row: ExportRow,
+        row_index: int,
+        sub_type_labels: Dict[str, str],
+    ) -> List[Any]:
+        sd = getattr(row.application, "student_data", None) or {}
+        return [
+            row_index,
+            row.rank_position if row.rank_position is not None else "",
+            self._render_scholarship_type(row.application, sub_type_labels),
+            self._safe_str(sd.get("trm_academyname")),
+            self._safe_str(sd.get("trm_depname")),
+            self._compute_grade(sd.get("trm_termcount")),
+            self._render_direct_phd(sd.get("std_enrolltype")),
+            self._safe_str(sd.get("std_cname")),
+            self._safe_str(sd.get("std_ename")),
+            self._safe_str(sd.get("std_nation")),
+            self._render_gender(sd.get("std_sex")),
+            self._render_enrollment_date(sd.get("std_enrollyear"), sd.get("std_enrollterm")),
+            self._safe_str(sd.get("std_stdcode")),
+            self._safe_str(sd.get("std_pid")),
+            self._safe_str(row.bank_account),
+            self._safe_str(sd.get("com_email")),
+            self._safe_str(sd.get("com_commadd")),
+            self._safe_str(row.advisor_names),
+        ]
 
     def _safe_str(self, value: Any) -> str:
         if value is None:
@@ -206,21 +345,11 @@ class CollegeRankingExportService:
 
     # -------- Dynamic column rendering --------
 
-    def _write_dynamic_cells(
-        self,
-        ws,
-        excel_row: int,
-        row: ExportRow,
-        dynamic_fields: List[DynamicFieldSpec],
-    ) -> None:
+    def _dynamic_values(self, row: ExportRow, sorted_dynamic: List[DynamicFieldSpec]) -> List[str]:
         form_data = getattr(row.application, "submitted_form_data", None) or {}
         fields_map = form_data.get("fields") if isinstance(form_data, dict) else None
         fields_map = fields_map if isinstance(fields_map, dict) else {}
-
-        for offset, spec in enumerate(dynamic_fields):
-            col_idx = len(STATIC_HEADERS) + 1 + offset
-            value = self._extract_dynamic_value(fields_map, spec.field_name)
-            ws.cell(row=excel_row, column=col_idx, value=value)
+        return [self._extract_dynamic_value(fields_map, spec.field_name) for spec in sorted_dynamic]
 
     def _extract_dynamic_value(self, fields_map: Dict[str, Any], field_name: str) -> str:
         entry = fields_map.get(field_name)

--- a/backend/app/services/college_ranking_export_service.py
+++ b/backend/app/services/college_ranking_export_service.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import io
 import math
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # `escape` is a pure string-escaping helper (`<` → `&lt;` …) used to sanitise
 # cell values before they go into reportlab Paragraph markup. It does not parse
@@ -28,30 +28,39 @@ from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4, landscape
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import mm
-from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+from reportlab.platypus import KeepInFrame, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
 from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
 
-STATIC_HEADERS: List[str] = [
-    "NO.",
-    "學院初審會議之學院排序",
-    "申請獎學金類別",
-    "學院",
-    "系所",
-    "年級",
-    "是否為逕博學生",
-    "學生中文姓名",
-    "學生英文姓名",
-    "國籍",
-    "性別",
-    "註冊入學日期",
-    "學號",
-    "學生身分證字號",
-    "學生匯款帳號",
-    "學生E-mail",
-    "學生通訊地址",
-    "指導教授姓名",
+# Static columns shared by the xlsx and PDF exports: (header label, PDF column
+# weight). STATIC_HEADERS and the PDF weight vector are both derived from this one
+# list so they can never drift — renaming a label can't silently mis-size a column.
+# Weights are relative (narrow id/flag columns get less, free-text columns more);
+# the normalize-to-page-width math lives in _pdf_col_widths. Dynamic columns use
+# _PDF_COL_WEIGHT_DEFAULT.
+_STATIC_COLUMNS: List[Tuple[str, float]] = [
+    ("NO.", 0.5),
+    ("學院初審會議之學院排序", 0.8),
+    ("申請獎學金類別", 1.4),
+    ("學院", 1.0),
+    ("系所", 1.2),
+    ("年級", 0.5),
+    ("是否為逕博學生", 0.7),
+    ("學生中文姓名", 1.0),
+    ("學生英文姓名", 1.4),
+    ("國籍", 0.7),
+    ("性別", 0.5),
+    ("註冊入學日期", 0.9),
+    ("學號", 1.0),
+    ("學生身分證字號", 1.1),
+    ("學生匯款帳號", 1.2),
+    ("學生E-mail", 1.7),
+    ("學生通訊地址", 2.0),
+    ("指導教授姓名", 1.3),
 ]
+
+STATIC_HEADERS: List[str] = [label for label, _ in _STATIC_COLUMNS]
+_STATIC_COL_WEIGHTS: List[float] = [weight for _, weight in _STATIC_COLUMNS]
 
 
 # std_enrolltype codes that indicate 逕讀博士 (direct-track PhD)
@@ -146,9 +155,14 @@ class CollegeRankingExportService:
         sorted_dynamic = self._sort_dynamic(dynamic_fields)
         headers = self._headers(sorted_dynamic)
 
-        page_width, _ = landscape(A4)
+        page_width, page_height = landscape(A4)
         usable_width = page_width - (self._PDF_MARGIN_PT * 2)
         col_widths = self._pdf_col_widths(headers, usable_width)
+        # A reportlab Table cannot split ONE row across pages, so a single very
+        # long free-text cell (e.g. a verbose dynamic field) would raise
+        # LayoutError and fail the whole export. Cap each cell to the usable
+        # content height and let KeepInFrame shrink anything taller to fit.
+        cell_max_height = page_height - (self._PDF_MARGIN_PT * 2) - self._PDF_HEADER_RESERVE_PT
 
         title_style = ParagraphStyle(
             "RankingPdfTitle",
@@ -173,10 +187,20 @@ class CollegeRankingExportService:
             wordWrap="CJK",  # break long CJK and unspaced ASCII (emails, IDs)
         )
 
-        data: List[List[Paragraph]] = [[Paragraph(xml_escape(h), header_style) for h in headers]]
+        data: List[list] = [[Paragraph(xml_escape(h), header_style) for h in headers]]
         for idx, row in enumerate(rows, start=1):
             values = self._row_cells(row, idx, sub_type_labels, sorted_dynamic)
-            data.append([Paragraph(xml_escape(self._safe_str(v)), cell_style) for v in values])
+            data.append(
+                [
+                    KeepInFrame(
+                        col_widths[col],
+                        cell_max_height,
+                        [Paragraph(xml_escape(self._safe_str(v)), cell_style)],
+                        mode="shrink",
+                    )
+                    for col, v in enumerate(values)
+                ]
+            )
 
         table = Table(data, colWidths=col_widths, repeatRows=1)
         table.setStyle(
@@ -209,34 +233,20 @@ class CollegeRankingExportService:
     # -------- PDF layout helpers --------
 
     _PDF_MARGIN_PT = 10 * mm
-
-    # Relative column weights for the wide PDF table. Narrow id/flag columns get
-    # less width; free-text columns (name, email, address, advisor, dynamic
-    # fields) get more. Headers not listed (dynamic fields) use the default.
-    _PDF_COL_WEIGHTS: Dict[str, float] = {
-        "NO.": 0.5,
-        "學院初審會議之學院排序": 0.8,
-        "申請獎學金類別": 1.4,
-        "學院": 1.0,
-        "系所": 1.2,
-        "年級": 0.5,
-        "是否為逕博學生": 0.7,
-        "學生中文姓名": 1.0,
-        "學生英文姓名": 1.4,
-        "國籍": 0.7,
-        "性別": 0.5,
-        "註冊入學日期": 0.9,
-        "學號": 1.0,
-        "學生身分證字號": 1.1,
-        "學生匯款帳號": 1.2,
-        "學生E-mail": 1.7,
-        "學生通訊地址": 2.0,
-        "指導教授姓名": 1.3,
-    }
+    # Vertical space reserved (per page) for the title + spacer + repeated header
+    # row, subtracted from page height to bound how tall a single data cell may be.
+    _PDF_HEADER_RESERVE_PT = 60
+    # Width weight for dynamic (form-field) columns; static columns carry their own
+    # weights in _STATIC_COL_WEIGHTS (derived from _STATIC_COLUMNS).
     _PDF_COL_WEIGHT_DEFAULT = 1.2
 
     def _pdf_col_widths(self, headers: List[str], usable_width: float) -> List[float]:
-        weights = [self._PDF_COL_WEIGHTS.get(h, self._PDF_COL_WEIGHT_DEFAULT) for h in headers]
+        # headers is always STATIC_HEADERS + dynamic, so the first N columns map
+        # index-for-index onto _STATIC_COL_WEIGHTS; the rest are dynamic.
+        n_static = len(_STATIC_COL_WEIGHTS)
+        weights = [
+            _STATIC_COL_WEIGHTS[i] if i < n_static else self._PDF_COL_WEIGHT_DEFAULT for i in range(len(headers))
+        ]
         total = sum(weights) or 1.0
         return [usable_width * w / total for w in weights]
 

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -24,8 +24,6 @@ from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import mm
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,6 +33,7 @@ from app.models.application import Application
 from app.models.scholarship import ScholarshipType
 from app.services.export_summary_tables import build_embedded_summary_tables
 from app.services.minio_service import MinIOService
+from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
 
 logger = logging.getLogger(__name__)
 
@@ -128,23 +127,11 @@ async def _fetch_and_write(
         zf.writestr(error_path, f"檔案下載失敗：{error_label}\n錯誤：{str(e)}")
 
 
-CJK_FONT_PATH = "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc"
-_font_registered = False
-
-
-def _ensure_font():
-    """Register CJK font once for reportlab."""
-    global _font_registered
-    if not _font_registered:
-        pdfmetrics.registerFont(TTFont("WQY", CJK_FONT_PATH, subfontIndex=0))
-        _font_registered = True
-
-
 class ExportPackageService:
     def __init__(self, db: AsyncSession, minio_service: MinIOService):
         self.db = db
         self.minio = minio_service
-        _ensure_font()
+        ensure_cjk_font()
 
     async def generate_export_zip(
         self,
@@ -362,18 +349,18 @@ class ExportPackageService:
         export_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
 
         # Styles
-        s_normal = ParagraphStyle("CJK", fontName="WQY", fontSize=10, leading=14)
-        s_title = ParagraphStyle("CJKTitle", fontName="WQY", fontSize=16, leading=20, alignment=1)
+        s_normal = ParagraphStyle("CJK", fontName=CJK_FONT_NAME, fontSize=10, leading=14)
+        s_title = ParagraphStyle("CJKTitle", fontName=CJK_FONT_NAME, fontSize=16, leading=20, alignment=1)
         s_section = ParagraphStyle(
             "CJKSection",
-            fontName="WQY",
+            fontName=CJK_FONT_NAME,
             fontSize=12,
             leading=16,
             backColor=colors.Color(0.94, 0.94, 0.94),
         )
         s_header = ParagraphStyle(
             "CJKHeader",
-            fontName="WQY",
+            fontName=CJK_FONT_NAME,
             fontSize=9,
             leading=12,
             alignment=1,
@@ -381,7 +368,7 @@ class ExportPackageService:
         )
         s_footer = ParagraphStyle(
             "CJKFooter",
-            fontName="WQY",
+            fontName=CJK_FONT_NAME,
             fontSize=8,
             leading=10,
             alignment=1,

--- a/backend/app/services/pdf_fonts.py
+++ b/backend/app/services/pdf_fonts.py
@@ -1,0 +1,32 @@
+"""Shared CJK font registration for reportlab PDF generation.
+
+Several services render PDFs containing Traditional Chinese text (the export
+package's per-student summaries and the college ranking export). reportlab needs
+a CJK-capable TrueType font registered once per process. This leaf module owns
+that registration so every PDF producer shares one font and one constant —
+without importing each other (which would create an import cycle between
+``export_package_service`` and ``college_ranking_export_service``).
+"""
+
+from __future__ import annotations
+
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.ttfonts import TTFont
+
+# WenQuanYi Zen Hei ships in the backend image (fonts-wqy-zenhei).
+CJK_FONT_NAME = "WQY"
+CJK_FONT_PATH = "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc"
+
+_font_registered = False
+
+
+def ensure_cjk_font() -> None:
+    """Idempotently register the WQY CJK font for reportlab.
+
+    Safe to call from every PDF entry point; the first call registers the font
+    and subsequent calls are no-ops.
+    """
+    global _font_registered
+    if not _font_registered:
+        pdfmetrics.registerFont(TTFont(CJK_FONT_NAME, CJK_FONT_PATH, subfontIndex=0))
+        _font_registered = True

--- a/backend/app/tests/test_college_ranking_export_pdf.py
+++ b/backend/app/tests/test_college_ranking_export_pdf.py
@@ -85,6 +85,42 @@ def test_build_pdf_handles_xml_special_chars(service, sample_row, dynamic_fields
     assert out[:5] == b"%PDF-"
 
 
+def test_build_pdf_very_long_cell_does_not_overflow(service, dynamic_fields):
+    """A single cell taller than the page must NOT raise LayoutError / 500.
+
+    A reportlab Table cannot split one row across pages; KeepInFrame(mode='shrink')
+    must keep an extremely long free-text value within the page so the export still
+    succeeds.
+    """
+    huge = SimpleNamespace(
+        student_data={"std_cname": "長文測試", "std_stdcode": "310460900"},
+        submitted_form_data={"fields": {"essay": {"value": "長" * 4000}}},  # ~4000 CJK chars
+        sub_type_preferences=["nstc"],
+        sub_scholarship_type=None,
+    )
+    out = service.build_pdf(
+        rows=[ExportRow(rank_position=1, application=huge)],
+        dynamic_fields=dynamic_fields,
+        sub_type_labels={"nstc": "國科會"},
+        title="長文測試",
+    )
+    assert out[:5] == b"%PDF-"
+
+
+def test_build_pdf_none_student_data(service, dynamic_fields):
+    """A draft-like row (student_data is None) renders all-empty cells, not a crash."""
+    blank = SimpleNamespace(
+        student_data=None, submitted_form_data=None, sub_type_preferences=None, sub_scholarship_type=None
+    )
+    out = service.build_pdf(
+        rows=[ExportRow(rank_position=None, application=blank)],
+        dynamic_fields=dynamic_fields,
+        sub_type_labels={},
+        title="空資料",
+    )
+    assert out[:5] == b"%PDF-"
+
+
 # ─── shared column model (xlsx/pdf parity) ───────────────────────────
 
 

--- a/backend/app/tests/test_college_ranking_export_pdf.py
+++ b/backend/app/tests/test_college_ranking_export_pdf.py
@@ -1,0 +1,121 @@
+"""Tests for the PDF branch of ``CollegeRankingExportService``.
+
+The PDF export must mirror the xlsx 學生資料彙整表 exactly — same columns, same
+per-row values (via the shared ``_headers`` / ``_row_cells``) — and produce a
+valid A4-landscape PDF that never overflows horizontally (column widths normalise
+to the usable page width).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.college_ranking_export_service import (
+    STATIC_HEADERS,
+    CollegeRankingExportService,
+    DynamicFieldSpec,
+    ExportRow,
+)
+
+
+@pytest.fixture
+def service():
+    return CollegeRankingExportService()
+
+
+@pytest.fixture
+def sample_row():
+    app = SimpleNamespace(
+        student_data={
+            "std_cname": "王小明",
+            "std_ename": "Wang",
+            "std_stdcode": "310460099",
+            "std_pid": "A123456789",
+            "com_email": "wang@nycu.edu.tw",
+            "com_commadd": "新竹市大學路1001號",
+            "trm_academyname": "工學院",
+            "trm_depname": "資訊工程學系",
+            "std_sex": 1,
+            "trm_termcount": 3,
+            "std_enrolltype": 8,
+            "std_nation": "中華民國",
+            "std_enrollyear": 112,
+            "std_enrollterm": 1,
+        },
+        submitted_form_data={"fields": {"essay": {"value": "理由 <b>x</b> & y"}}},
+        sub_type_preferences=["nstc"],
+        sub_scholarship_type=None,
+    )
+    return ExportRow(rank_position=1, application=app, bank_account="0001234567", advisor_names="陳教授")
+
+
+@pytest.fixture
+def dynamic_fields():
+    return [DynamicFieldSpec(field_name="essay", field_label="得獎理由", export_column_label=None, display_order=1)]
+
+
+# ─── build_pdf ───────────────────────────────────────────────────────
+
+
+def test_build_pdf_returns_pdf_bytes(service, sample_row, dynamic_fields):
+    out = service.build_pdf(
+        rows=[sample_row],
+        dynamic_fields=dynamic_fields,
+        sub_type_labels={"nstc": "國科會"},
+        title="114學年度測試獎學金學生資料彙整表",
+    )
+    assert out[:5] == b"%PDF-", "must be a real PDF"
+    assert len(out) > 1000
+
+
+def test_build_pdf_empty_rows_still_valid(service):
+    """No applicants ⇒ a header-only PDF, not a crash."""
+    out = service.build_pdf(rows=[], dynamic_fields=[], sub_type_labels={}, title="空表")
+    assert out[:5] == b"%PDF-"
+
+
+def test_build_pdf_handles_xml_special_chars(service, sample_row, dynamic_fields):
+    """Values containing &, <, > must not break reportlab Paragraph markup."""
+    out = service.build_pdf(
+        rows=[sample_row],
+        dynamic_fields=dynamic_fields,
+        sub_type_labels={"nstc": "國科會"},
+        title="<title> & more",
+    )
+    assert out[:5] == b"%PDF-"
+
+
+# ─── shared column model (xlsx/pdf parity) ───────────────────────────
+
+
+def test_headers_static_plus_dynamic(service, dynamic_fields):
+    headers = service._headers(service._sort_dynamic(dynamic_fields))
+    assert headers[: len(STATIC_HEADERS)] == STATIC_HEADERS
+    assert headers[-1] == "得獎理由"  # dynamic label appended
+
+
+def test_row_cells_length_and_no_and_rank(service, sample_row, dynamic_fields):
+    sorted_dynamic = service._sort_dynamic(dynamic_fields)
+    cells = service._row_cells(sample_row, 7, {"nstc": "國科會"}, sorted_dynamic)
+    assert len(cells) == len(STATIC_HEADERS) + len(dynamic_fields)
+    assert cells[0] == 7  # NO. = row index
+    assert cells[1] == 1  # rank_position filled
+    assert cells[-1] == "理由 <b>x</b> & y"  # raw dynamic value (escaping happens at render)
+
+
+def test_row_cells_blank_rank_when_none(service, sample_row):
+    blank = ExportRow(rank_position=None, application=sample_row.application)
+    cells = service._row_cells(blank, 1, {"nstc": "國科會"}, [])
+    assert cells[1] == ""  # template/blank rank renders empty
+
+
+# ─── column-width normalisation (no horizontal overflow) ─────────────
+
+
+def test_pdf_col_widths_sum_to_usable_width(service, dynamic_fields):
+    headers = service._headers(service._sort_dynamic(dynamic_fields))
+    usable = 785.0
+    widths = service._pdf_col_widths(headers, usable)
+    assert len(widths) == len(headers)
+    assert sum(widths) == pytest.approx(usable)
+    assert all(w > 0 for w in widths)

--- a/backend/app/tests/test_export_package_embeds_summary.py
+++ b/backend/app/tests/test_export_package_embeds_summary.py
@@ -1,6 +1,6 @@
 """Integration test: generate_export_zip embeds the 申請總表 workbooks and the
 table rows match the student folders. Avoids DB / MinIO / reportlab font by
-monkeypatching _ensure_font, _query_applications, _get_scholarship_type,
+monkeypatching ensure_cjk_font, _query_applications, _get_scholarship_type,
 _generate_summary_pdf, and load_export_aux_data.
 """
 
@@ -42,7 +42,7 @@ def _coro_returning(value):
 
 @pytest.mark.asyncio
 async def test_export_zip_contains_summary_tables_matching_folders(monkeypatch):
-    monkeypatch.setattr("app.services.export_package_service._ensure_font", lambda: None)
+    monkeypatch.setattr("app.services.export_package_service.ensure_cjk_font", lambda: None)
 
     async def _fake_aux(db, *, scholarship_type, applications):
         return ([], {}, {}, {})
@@ -92,7 +92,7 @@ async def test_export_zip_contains_summary_tables_matching_folders(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_export_zip_degrades_when_summary_build_fails_wholesale(monkeypatch):
-    monkeypatch.setattr("app.services.export_package_service._ensure_font", lambda: None)
+    monkeypatch.setattr("app.services.export_package_service.ensure_cjk_font", lambda: None)
 
     async def _boom(*a, **k):
         raise RuntimeError("aux DB down")

--- a/backend/app/tests/test_ranking_export_pdf_endpoint.py
+++ b/backend/app/tests/test_ranking_export_pdf_endpoint.py
@@ -173,6 +173,23 @@ class TestExportPdfFormat:
 
         assert resp.status_code == 400, resp.text
 
+    async def test_invalid_format_is_422(
+        self,
+        client: AsyncClient,
+        admin_user: User,
+        ranking_with_item: CollegeRanking,
+    ):
+        app.dependency_overrides[require_scholarship_manager] = lambda: admin_user
+        try:
+            resp = await client.get(
+                f"/api/v1/college-review/rankings/{ranking_with_item.id}/export-excel",
+                params={"format": "docx"},
+            )
+        finally:
+            app.dependency_overrides.pop(require_scholarship_manager, None)
+
+        assert resp.status_code == 422, resp.text
+
     async def test_default_format_is_xlsx(
         self,
         client: AsyncClient,

--- a/backend/app/tests/test_ranking_export_pdf_endpoint.py
+++ b/backend/app/tests/test_ranking_export_pdf_endpoint.py
@@ -1,0 +1,190 @@
+"""Integration tests for the export-excel `format=pdf` branch."""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import require_scholarship_manager
+from app.main import app
+from app.models.application import Application, ApplicationStatus
+from app.models.audit_log import AuditAction, AuditLog
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.scholarship import (
+    ScholarshipConfiguration,
+    ScholarshipType,
+    SubTypeSelectionMode,
+)
+from app.models.user import AdminScholarship, User, UserRole, UserType
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession) -> User:
+    user = User(
+        nycu_id="admin901",
+        name="Admin",
+        email="admin901@nycu.edu.tw",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def scholarship(db: AsyncSession) -> ScholarshipType:
+    s = ScholarshipType(
+        code="phd_pdf_test",
+        name="Test PDF PhD",
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        status="active",
+    )
+    db.add(s)
+    await db.flush()
+    return s
+
+
+@pytest_asyncio.fixture
+async def configuration(db: AsyncSession, scholarship: ScholarshipType, admin_user: User) -> ScholarshipConfiguration:
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        academic_year=114,
+        semester=None,  # yearly
+        config_name="Test PhD 114",
+        config_code="test-pdf-114",
+        amount=40000,
+        is_active=True,
+    )
+    db.add(cfg)
+    db.add(AdminScholarship(admin_id=admin_user.id, scholarship_id=scholarship.id))
+    await db.flush()
+    return cfg
+
+
+@pytest_asyncio.fixture
+async def ranking_with_item(
+    db: AsyncSession,
+    admin_user: User,
+    scholarship: ScholarshipType,
+    configuration: ScholarshipConfiguration,
+) -> CollegeRanking:
+    student = User(
+        nycu_id="310460098",
+        name="李大華",
+        email="s98@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(student)
+    await db.flush()
+
+    r = CollegeRanking(
+        scholarship_type_id=scholarship.id,
+        sub_type_code="nstc",
+        academic_year=114,
+        ranking_name="Test",
+        created_by=admin_user.id,
+        is_finalized=False,
+    )
+    db.add(r)
+    await db.flush()
+
+    app_row = Application(
+        app_id="APP-114-0-09998",
+        user_id=student.id,
+        scholarship_type_id=scholarship.id,
+        academic_year=114,
+        semester=None,
+        status=ApplicationStatus.submitted,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        student_data={"std_stdcode": "310460098", "std_cname": "李大華", "std_pid": "A223456789"},
+        sub_type_preferences=["nstc"],
+        scholarship_subtype_list=["nstc"],
+        submitted_form_data={"fields": {}},
+    )
+    db.add(app_row)
+    await db.flush()
+
+    item = CollegeRankingItem(
+        ranking_id=r.id,
+        application_id=app_row.id,
+        rank_position=1,
+        status="ranked",
+        college_rejected=False,
+        is_allocated=False,
+    )
+    db.add(item)
+    await db.flush()
+    return r
+
+
+@pytest.mark.asyncio
+class TestExportPdfFormat:
+    async def test_format_pdf_returns_pdf(
+        self,
+        client: AsyncClient,
+        db: AsyncSession,
+        admin_user: User,
+        ranking_with_item: CollegeRanking,
+    ):
+        app.dependency_overrides[require_scholarship_manager] = lambda: admin_user
+        try:
+            resp = await client.get(
+                f"/api/v1/college-review/rankings/{ranking_with_item.id}/export-excel",
+                params={"format": "pdf"},
+            )
+        finally:
+            app.dependency_overrides.pop(require_scholarship_manager, None)
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"].startswith("application/pdf")
+        # quote() never encodes ".", so the filename* ends with a literal .pdf
+        assert resp.headers["content-disposition"].endswith(".pdf")
+        assert resp.content[:5] == b"%PDF-"
+
+        # PII audit recorded, tagged with the pdf format.
+        result = await db.execute(
+            select(AuditLog).where(
+                AuditLog.action == AuditAction.pii_access.value,
+                AuditLog.resource_type == "college_ranking",
+                AuditLog.resource_id == str(ranking_with_item.id),
+            )
+        )
+        audit = result.scalars().first()
+        assert audit is not None, "pdf export must record a pii_access audit"
+        assert audit.meta_data["export_format"] == "pdf"
+
+    async def test_format_pdf_with_template_is_rejected(
+        self,
+        client: AsyncClient,
+        admin_user: User,
+        ranking_with_item: CollegeRanking,
+    ):
+        app.dependency_overrides[require_scholarship_manager] = lambda: admin_user
+        try:
+            resp = await client.get(
+                f"/api/v1/college-review/rankings/{ranking_with_item.id}/export-excel",
+                params={"format": "pdf", "template": "true"},
+            )
+        finally:
+            app.dependency_overrides.pop(require_scholarship_manager, None)
+
+        assert resp.status_code == 400, resp.text
+
+    async def test_default_format_is_xlsx(
+        self,
+        client: AsyncClient,
+        admin_user: User,
+        ranking_with_item: CollegeRanking,
+    ):
+        app.dependency_overrides[require_scholarship_manager] = lambda: admin_user
+        try:
+            resp = await client.get(f"/api/v1/college-review/rankings/{ranking_with_item.id}/export-excel")
+        finally:
+            app.dependency_overrides.pop(require_scholarship_manager, None)
+
+        assert resp.status_code == 200, resp.text
+        assert "spreadsheetml" in resp.headers["content-type"]
+        assert resp.content[:2] == b"PK"  # xlsx is a zip

--- a/docs/superpowers/specs/2026-07-01-college-ranking-export-pdf-design.md
+++ b/docs/superpowers/specs/2026-07-01-college-ranking-export-pdf-design.md
@@ -1,0 +1,142 @@
+# 學院匯出排名 — PDF Format Support
+
+**Date:** 2026-07-01
+**Status:** Approved (design decisions locked via brainstorming)
+
+## Goal
+
+Add a PDF output option to the college ranking export ("學院匯出排名"). Today the
+`匯出` button produces only an `.xlsx` 學生資料彙整表 via openpyxl. We add a PDF
+variant that mirrors the Excel **exactly** — same columns (including PII), same
+rows, same ordering — rendered as a wide **A4-landscape** table.
+
+## Locked decisions
+
+| Decision | Choice |
+|---|---|
+| Scope | **Ranking export only** (`export-excel` endpoint / the `匯出` button). 申請總表, bulk, and the fill-in template stay Excel-only. |
+| PDF layout | **Wide landscape table, full Excel parity** — every static + dynamic column, including PII (身分證字號, 匯款帳號). |
+| Page size | **A4 landscape**, small font with cell wrapping; column widths normalized to page width. |
+| UI control | **Dropdown** on the existing `匯出` button → `匯出 Excel` / `匯出 PDF`. |
+
+## Current state (verified)
+
+- Button: `frontend/components/college-ranking-table.tsx:901` → `handleExportRanking` → `exportRankingExcel(rankingId)`.
+- API module: `frontend/lib/api/modules/college.ts` `exportRankingExcel()` → `GET /api/v1/college-review/rankings/{id}/export-excel`.
+- Endpoint: `backend/app/api/v1/endpoints/college_review/ranking_management.py` `export_ranking_excel` (line ~1174). Loads the ranking + items, builds `ExportRow`s, calls the service, writes a `pii_access` `AuditLog` (the sheet carries plaintext `std_pid`), returns a `StreamingResponse`.
+- Renderer: `backend/app/services/college_ranking_export_service.py` `CollegeRankingExportService.build_workbook()` (openpyxl). Columns = `STATIC_HEADERS` (18) + dynamic fields. Per-cell value logic lives in pure helpers (`_render_gender`, `_render_direct_phd`, `_compute_grade`, `_render_enrollment_date`, `_render_scholarship_type`, `_extract_dynamic_value`).
+- Existing PDF infra: `reportlab==4.4.10` is a dependency; `backend/app/services/export_package_service.py` already registers the WQY CJK font (`/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc`) and builds PDFs via `SimpleDocTemplate`/`Table`.
+
+## Architecture
+
+### 1. Shared CJK-font module — `backend/app/services/pdf_fonts.py` (new)
+
+The WQY font registration currently lives privately inside
+`export_package_service.py` (`CJK_FONT_PATH`, `_font_registered`, `_ensure_font`).
+Extract it into a tiny shared module:
+
+```python
+CJK_FONT_NAME = "WQY"
+CJK_FONT_PATH = "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc"
+
+def ensure_cjk_font() -> None:
+    """Idempotently register the WQY CJK font for reportlab."""
+```
+
+- **Why a new module, not import from `export_package_service`:** that would create
+  an import cycle — `export_package_service → export_summary_tables →
+  college_ranking_export_service`, and the new `build_pdf` lives in
+  `college_ranking_export_service`. A leaf module breaks the cycle and is DRY.
+- `export_package_service.py` is refactored to import `ensure_cjk_font` /
+  `CJK_FONT_NAME` from this module (its local copies removed). Its one call site
+  (`ExportPackageService.__init__`) and PDF styles (`fontName="WQY"`) keep working.
+
+### 2. `CollegeRankingExportService` — add `build_pdf()`
+
+- Refactor the column-value logic into one shared, single-sourced pair:
+  - `_headers(sorted_dynamic) -> list[str]` — `STATIC_HEADERS + dynamic labels`.
+  - `_row_cells(row, row_index, sub_type_labels, sorted_dynamic) -> list` — the
+    ordered list of cell values for one `ExportRow` (NO. + 17 static via the
+    existing pure helpers + dynamic values).
+- `build_workbook` is refactored to write cells from `_row_cells` / `_headers`
+  (same output as today — the pure helpers are unchanged, so
+  `test_college_ranking_export_pure_helpers.py` and `test_ranking_export_template.py`
+  still pass).
+- New `build_pdf(*, rows, dynamic_fields, sub_type_labels, title) -> bytes`:
+  - `ensure_cjk_font()`; `SimpleDocTemplate(buf, pagesize=landscape(A4), margins≈10mm)`.
+  - Title `Paragraph` (centered, WQY).
+  - `Table(data, colWidths=widths, repeatRows=1)` where `data[0]` = header
+    `Paragraph`s and each subsequent row = cell `Paragraph`s (WQY, ~6pt, wrap).
+  - **Column widths normalized to usable width:** per-column weights (narrow:
+    NO./排序/年級/性別/逕博; wide: 中文姓名/英文姓名/E-mail/通訊地址/指導教授/dynamic),
+    `width_i = usable_width * weight_i / Σweights`. Guarantees no horizontal
+    overflow — content wraps within cells; rows paginate vertically with the
+    header repeated each page.
+  - `TableStyle`: thin grid, light-grey header fill, `VALIGN TOP`, small padding,
+    `FONTNAME WQY` fallback.
+
+### 3. Endpoint `export_ranking_excel`
+
+- Add query param `format: Literal["xlsx", "pdf"] = "xlsx"`.
+- Branch on `format`:
+  - `xlsx` (default): unchanged — `build_workbook`, xlsx media type, `.xlsx` name.
+  - `pdf`: `build_pdf`, `media_type="application/pdf"`, `.pdf` filename.
+- Reject `template=true & format=pdf` → HTTP 400 (`範本僅支援 Excel 格式`): a PDF
+  cannot be filled in and re-imported, so the combination is meaningless.
+- **PII audit unchanged for both formats** — the PDF still contains plaintext
+  `std_pid`, so the same `pii_access` `AuditLog` is written;
+  `meta_data.export_format` reflects `"pdf"` / `"xlsx"`.
+
+### 4. Frontend — `college.ts`
+
+Generalize:
+
+```ts
+export async function exportRankingExcel(
+  rankingId: number,
+  format: "xlsx" | "pdf" = "xlsx",
+): Promise<{ blob: Blob; filename: string }>
+```
+
+Add the `format` query param and a format-appropriate fallback filename. Keep the
+exported name (callers unchanged except passing a format). `downloadRankingTemplate`
+stays xlsx.
+
+### 5. Frontend — `college-ranking-table.tsx`
+
+Replace the single `匯出` Button with the existing shadcn `DropdownMenu`
+(`@/components/ui/dropdown-menu`, already used in `payment-roster-list.tsx` etc.):
+
+- Trigger: `匯出 ▾` (outline, size sm, Download icon).
+- Items: `匯出 Excel` → `handleExportRanking("xlsx")`, `匯出 PDF` →
+  `handleExportRanking("pdf")`.
+- `handleExportRanking(format)` passes the format through to `exportRankingExcel`.
+
+### 6. OpenAPI types
+
+Regenerate `frontend/lib/api/generated/schema.d.ts` (new `format` query param),
+per CLAUDE.md §8.
+
+## Testing
+
+- **Service (pure/unit):** `build_pdf` returns bytes starting with `%PDF` and of
+  non-trivial size; header/`_row_cells` parity with the xlsx path. New file
+  `backend/app/tests/test_college_ranking_export_pdf.py`.
+- **Endpoint (integration):** mirror `test_ranking_export_template.py`:
+  - `format=pdf` → 200, `content-type: application/pdf`, `Content-Disposition`
+    filename ends `.pdf`, body starts `%PDF`.
+  - audit row present with `meta_data.export_format == "pdf"`.
+  - `template=true & format=pdf` → 400.
+  - default (no format) still returns xlsx with rank filled (regression).
+
+## Error handling
+
+- Unsupported `format` value → FastAPI 422 (via `Literal`).
+- Font file missing at render time → reportlab raises; surfaces as 500 (same as
+  the existing export-package PDF path; the font ships in the backend image).
+- PDF render must not silently fall back to xlsx — fail loudly per project policy.
+
+## Out of scope
+
+申請總表 (`department-summary-export[-bulk]`), the fill-in template, and any bulk
+ZIP export remain Excel-only.

--- a/frontend/components/college-ranking-table.tsx
+++ b/frontend/components/college-ranking-table.tsx
@@ -676,7 +676,7 @@ export function CollegeRankingTable({
     }
   };
 
-  const handleExportRanking = async (format: "xlsx" | "pdf" = "xlsx") => {
+  const handleExportRanking = async (format: "xlsx" | "pdf") => {
     if (!rankingId) {
       toast.error("缺少排名 ID，無法匯出");
       return;

--- a/frontend/components/college-ranking-table.tsx
+++ b/frontend/components/college-ranking-table.tsx
@@ -27,6 +27,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -69,6 +75,7 @@ import {
   Download,
   Upload,
   FileSpreadsheet,
+  ChevronDown,
 } from "lucide-react";
 import { getTranslation } from "@/lib/i18n";
 import { toast } from "sonner";
@@ -669,13 +676,13 @@ export function CollegeRankingTable({
     }
   };
 
-  const handleExportRanking = async () => {
+  const handleExportRanking = async (format: "xlsx" | "pdf" = "xlsx") => {
     if (!rankingId) {
       toast.error("缺少排名 ID，無法匯出");
       return;
     }
     try {
-      const result = await exportRankingExcel(rankingId);
+      const result = await exportRankingExcel(rankingId, format);
       triggerBlobDownload(result);
       toast.success(`已下載 ${result.filename}`);
     } catch (error) {
@@ -898,10 +905,25 @@ export function CollegeRankingTable({
                 </>
               )}
 
-              <Button variant="outline" size="sm" onClick={handleExportRanking}>
-                <Download className="h-4 w-4 mr-2" />
-                {locale === "zh" ? "匯出" : "Export"}
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    <Download className="h-4 w-4 mr-2" />
+                    {locale === "zh" ? "匯出" : "Export"}
+                    <ChevronDown className="h-4 w-4 ml-2" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => handleExportRanking("xlsx")}>
+                    <FileSpreadsheet className="h-4 w-4 mr-2" />
+                    {locale === "zh" ? "匯出 Excel" : "Export Excel"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handleExportRanking("pdf")}>
+                    <FileText className="h-4 w-4 mr-2" />
+                    {locale === "zh" ? "匯出 PDF" : "Export PDF"}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </div>
         </CardHeader>

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4648,7 +4648,7 @@ export interface paths {
         };
         /**
          * Export Ranking Excel
-         * @description Generate the 學生資料彙整表 Excel for a ranking.
+         * @description Generate the 學生資料彙整表 for a ranking, as Excel (default) or PDF.
          *
          *     Auth: admin/super_admin OR a college user whose `college_code` matches the
          *     ranking's own `college_code` (authoritative per-college ownership).
@@ -18752,6 +18752,8 @@ export interface operations {
             query?: {
                 /** @description Render the rank column blank, as a fill-in import template */
                 template?: boolean;
+                /** @description Output format: xlsx (default) or pdf */
+                format?: "xlsx" | "pdf";
             };
             header?: never;
             path: {

--- a/frontend/lib/api/modules/__tests__/college.test.ts
+++ b/frontend/lib/api/modules/__tests__/college.test.ts
@@ -450,6 +450,31 @@ describe("module-level export helpers", () => {
     expect(result.filename).toBe("學生資料彙整表_42.xlsx");
   });
 
+  it("exportRankingExcel(format='pdf') adds ?format=pdf and .pdf fallback", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: jest.fn().mockReturnValue("") },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    });
+    global.fetch = fetchMock as any;
+
+    const result = await exportRankingExcel(42, "pdf");
+    expect(fetchMock.mock.calls[0][0]).toContain("format=pdf");
+    expect(result.filename).toBe("學生資料彙整表_42.pdf");
+  });
+
+  it("exportRankingExcel(format='xlsx') omits the format param (URL unchanged)", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: jest.fn().mockReturnValue("") },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    });
+    global.fetch = fetchMock as any;
+
+    await exportRankingExcel(42, "xlsx");
+    expect(fetchMock.mock.calls[0][0]).not.toContain("format=");
+  });
+
   it("exportDepartmentSummary URL includes 4 params + dept_code", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -671,11 +671,13 @@ async function _fetchBinaryExport(
 /**
  * Download the 學生資料彙整表 for a college ranking, as Excel (default) or PDF.
  *
- * Endpoint: GET /api/v1/college-review/rankings/{ranking_id}/export-excel?format={xlsx|pdf}
+ * Endpoint: GET /api/v1/college-review/rankings/{ranking_id}/export-excel
+ *   `format` is an OPTIONAL query param: "pdf" appends `?format=pdf`; the
+ *   default "xlsx" is omitted entirely, so the xlsx request URL is unchanged.
  *
  * Returns the binary file as a Blob along with the filename extracted from
  * the `Content-Disposition: attachment; filename*=UTF-8''<encoded>` header.
- * Falls back to `學生資料彙整表_${rankingId}.${ext}` if the header is missing.
+ * Falls back to `學生資料彙整表_${rankingId}.${format}` if the header is missing.
  */
 export async function exportRankingExcel(
   rankingId: number,

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -502,14 +502,16 @@ export function createCollegeApi() {
     },
 
     /**
-     * Download the 學生資料彙整表 Excel for a ranking (backend-generated).
+     * Download the 學生資料彙整表 for a ranking (backend-generated), as Excel
+     * (default) or PDF.
      * Endpoint: GET /api/v1/college-review/rankings/{ranking_id}/export-excel
      * Returns the binary blob and the filename parsed from Content-Disposition.
      */
     exportRankingExcel: async (
-      rankingId: number
+      rankingId: number,
+      format: "xlsx" | "pdf" = "xlsx"
     ): Promise<{ blob: Blob; filename: string }> => {
-      return exportRankingExcel(rankingId);
+      return exportRankingExcel(rankingId, format);
     },
 
     /**

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -667,21 +667,24 @@ async function _fetchBinaryExport(
 }
 
 /**
- * Download the 學生資料彙整表 Excel for a college ranking.
+ * Download the 學生資料彙整表 for a college ranking, as Excel (default) or PDF.
  *
- * Endpoint: GET /api/v1/college-review/rankings/{ranking_id}/export-excel
+ * Endpoint: GET /api/v1/college-review/rankings/{ranking_id}/export-excel?format={xlsx|pdf}
  *
- * Returns the binary xlsx as a Blob along with the filename extracted from
+ * Returns the binary file as a Blob along with the filename extracted from
  * the `Content-Disposition: attachment; filename*=UTF-8''<encoded>` header.
- * Falls back to `學生資料彙整表_${rankingId}.xlsx` if the header is missing.
+ * Falls back to `學生資料彙整表_${rankingId}.${ext}` if the header is missing.
  */
 export async function exportRankingExcel(
-  rankingId: number
+  rankingId: number,
+  format: "xlsx" | "pdf" = "xlsx"
 ): Promise<{ blob: Blob; filename: string }> {
+  const params = new URLSearchParams();
+  if (format !== "xlsx") params.set("format", format);
   return _fetchBinaryExport(
     `/api/v1/college-review/rankings/${rankingId}/export-excel`,
-    new URLSearchParams(),
-    `學生資料彙整表_${rankingId}.xlsx`,
+    params,
+    `學生資料彙整表_${rankingId}.${format}`,
     "無法匯出排名資料"
   );
 }


### PR DESCRIPTION
## 學院匯出排名 — PDF format support

Adds a **PDF** output option to the college ranking export ("學院匯出排名"). The `匯出` button on the ranking table becomes a dropdown (`匯出 Excel` / `匯出 PDF`). The PDF mirrors the existing Excel 學生資料彙整表 exactly — same columns (incl. PII), same rows, same ordering — rendered as a wide **A4-landscape** table.

Design spec: `docs/superpowers/specs/2026-07-01-college-ranking-export-pdf-design.md`.

### Locked decisions
| Decision | Choice |
|---|---|
| Scope | Ranking export only (`export-excel`). 申請總表 / template / bulk stay Excel-only. |
| Layout | Wide landscape table, full Excel parity (every static + dynamic column, incl. 身分證/匯款帳號). |
| Page size | A4 landscape; small font + CJK wrap; column widths normalised to page width. |
| UI | Dropdown on the `匯出` button. |

### Backend
- **`backend/app/services/pdf_fonts.py` (new)** — shared WQY CJK-font registration. Extracted from `export_package_service` to break the import cycle that would otherwise form (`export_package_service → export_summary_tables → college_ranking_export_service`).
- **`college_ranking_export_service.py`** — `build_workbook` (xlsx) and new **`build_pdf`** now share one source of truth for columns/values (`_headers` / `_row_cells`). `build_pdf` uses reportlab `landscape(A4)`; **column widths normalise to the usable page width** (per-column weights → `sum == usable`) so the wide table never overflows horizontally; rows paginate vertically with the header repeated each page (`repeatRows=1`).
- **`export-excel` endpoint** — new `format: xlsx|pdf` query param. PDF reuses the same rows and writes the **same `pii_access` audit** (tagged `export_format`). `template=true & format=pdf` → HTTP 400 (a PDF can't be filled-in and re-imported).

### Frontend
- `college.ts`: `exportRankingExcel(rankingId, format="xlsx")` — adds `?format=pdf` only for PDF (xlsx URL unchanged).
- `college-ranking-table.tsx`: `匯出` button → `DropdownMenu` (`匯出 Excel` / `匯出 PDF`).
- Regenerated `frontend/lib/api/generated/schema.d.ts` (new `format` param).

### Tests
- **Backend:** `test_college_ranking_export_pdf.py` (service: valid `%PDF`, empty rows, XML-special chars, header/row parity, width-sum == usable) + `test_ranking_export_pdf_endpoint.py` (200 `application/pdf`, `.pdf` filename, audit `export_format=pdf`, `template+pdf` → 400, default still xlsx). Existing export/summary/template tests updated for the moved font symbol.
- **Frontend:** `college.test.ts` — `format=pdf` adds `?format=pdf` + `.pdf` fallback; `format=xlsx` omits the param.

### Test plan / verification
- [x] Backend: 37 targeted + 112 export-related tests pass
- [x] `build_pdf` smoke: 25-col × 60-row PDF is valid, fits page width (no h-overflow), embeds CJK font, paginates (5 pages, repeated header)
- [x] Frontend: 30 API tests pass; `tsc --noEmit` clean; eslint clean
- [x] `black` + `flake8 --select=B904,B014` clean
- [x] OpenAPI types regenerated (minimal diff)
- [ ] Localhost browser smoke (screenshots attached below)
