### PR TITLE
fix(auth): close unauthenticated register+login -> super_admin takeover

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -54,7 +54,17 @@ async def populate_college_info(user_data: UserResponse, db: AsyncSession, user:
 @router.post("/register", status_code=status.HTTP_201_CREATED)
 @rate_limit(requests=10, window_seconds=600)  # 10 registrations / 10 min per IP
 async def register(request: Request, user_data: UserCreate, db: AsyncSession = Depends(get_db)):
-    """Register a new user"""
+    """Register a new user.
+
+    SECURITY: dev/test only. Real identities come from Portal SSO
+    (which creates users directly, not via this endpoint) or from
+    admin-authenticated POST /users. This endpoint accepts a
+    client-supplied `role` with no credential check, so it must never
+    be reachable when mock SSO is disabled (staging/production).
+    """
+    if not settings.enable_mock_sso:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
     client_ip = _client_ip(request)
     try:
         auth_service = AuthService(db)
@@ -103,7 +113,17 @@ async def register(request: Request, user_data: UserCreate, db: AsyncSession = D
 @router.post("/login")
 @rate_limit(requests=20, window_seconds=300)  # 20 attempts / 5 min per IP — slows brute force
 async def login(request: Request, login_data: UserLogin, db: AsyncSession = Depends(get_db)):
-    """Login user and return access token"""
+    """Login user and return access token.
+
+    SECURITY: dev/test only. `UserLogin` carries no password/credential —
+    `AuthService.authenticate_user` mints a token for any existing
+    `nycu_id`/email with no verification. Real logins go through Portal
+    SSO (`/auth/portal-sso/*`), so this must never be reachable when
+    mock SSO is disabled (staging/production).
+    """
+    if not settings.enable_mock_sso:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
     client_ip = _client_ip(request)
     try:
         auth_service = AuthService(db)

--- a/backend/app/tests/test_auth_login_register_gated.py
+++ b/backend/app/tests/test_auth_login_register_gated.py
@@ -1,0 +1,62 @@
+"""
+Regression tests for the CRITICAL unauthenticated privilege-escalation chain:
+
+    POST /auth/register (no auth, client-supplied `role`, incl. super_admin)
+    + POST /auth/login (no password field at all — UserLogin has only `username`)
+    = unauthenticated account creation + password-less token minting for any user.
+
+Fix: both endpoints now 404 unless `settings.enable_mock_sso` is True, matching
+the existing gate on /auth/mock-sso/* and /auth/dev-profiles/*. Real identities
+come from Portal SSO (creates users directly, not via /auth/register) or from
+the admin-gated POST /users (which reuses AuthService.register_user directly,
+bypassing this HTTP endpoint) — so gating here does not affect any real flow.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from app.core.config import settings
+
+
+@pytest.mark.asyncio
+async def test_register_is_404_when_mock_sso_disabled(client: AsyncClient, monkeypatch):
+    monkeypatch.setattr(settings, "enable_mock_sso", False)
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={"nycu_id": "attacker_created", "role": "super_admin"},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_login_is_404_when_mock_sso_disabled(client: AsyncClient, monkeypatch):
+    monkeypatch.setattr(settings, "enable_mock_sso", False)
+
+    response = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "admin@nycu.edu.tw"},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_register_and_login_still_work_when_mock_sso_enabled(client: AsyncClient, monkeypatch):
+    """Dev/test convenience is preserved — only reachable deployments (staging/prod,
+    which set ENABLE_MOCK_SSO=false) are closed off."""
+    monkeypatch.setattr(settings, "enable_mock_sso", True)
+
+    register_response = await client.post(
+        "/api/v1/auth/register",
+        json={"nycu_id": "dev_only_user", "role": "student"},
+    )
+    assert register_response.status_code == 201
+
+    login_response = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "dev_only_user"},
+    )
+    assert login_response.status_code == 200
+    assert "access_token" in login_response.json()["data"]


### PR DESCRIPTION
## Summary

Fixes #1079 — a **CRITICAL unauthenticated privilege-escalation chain**: `POST /auth/register` accepted a client-supplied `role` (including `super_admin`) with no auth, and `POST /auth/login` had no password field at all, so `authenticate_user` minted a valid JWT for any existing (or just-registered) username with zero credential verification. Together: two unauthenticated requests → full `super_admin` access.

Found via an internal audit run using the [Cloudflare security-audit-skill](https://github.com/cloudflare/security-audit-skill) methodology — independently confirmed by two separate hunting passes plus my own direct code read. Full writeup and lower-priority hardening notes are in #1079.

## Fix

- Gate `POST /auth/register` and `POST /auth/login` behind `settings.enable_mock_sso` (404 when disabled) — the same pattern already used for `/auth/mock-sso/*` and `/auth/dev-profiles/*`.
- `ENABLE_MOCK_SSO=false` in both `docker-compose.staging.yml` and `docker-compose.prod.yml` closes this off on every reachable deployment. Local dev/test (`ENABLE_MOCK_SSO=true` default) are unaffected.
- No real flow depends on these endpoints: confirmed Portal SSO creates users directly via the ORM (not through `/auth/register`), the admin-gated `POST /users` reuses `AuthService.register_user()` directly, and no live frontend page calls either endpoint (grepped — only referenced in test files).

## Test plan

- [x] New regression tests (`backend/app/tests/test_auth_login_register_gated.py`): both endpoints return 404 when `enable_mock_sso=False`; both still work (201/200) when `enable_mock_sso=True`, preserving local dev/test behavior.
- [x] `python -m pytest app/tests/test_auth_login_register_gated.py app/tests/test_auth_service.py app/tests/test_auth_rate_limit_invariants.py --no-cov -v` — 26/26 passed (host env, worktree code).
- [x] `black --check --line-length=120` on touched files — clean.
- [x] `flake8 --select=B904,B014` on touched files — clean.
- [ ] Deploy to staging and confirm `POST /auth/register` / `POST /auth/login` now return 404 there (not verified live — only reproduced locally, see #1079 for why).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
