### PR TITLE
docs: clarify enum locations and update documentation notes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,6 +19,8 @@ docker compose -f docker-compose.dev.yml restart backend
 
 This spins up the full stack (backend, frontend, database, RustFS object storage (S3 API, service name `minio`), mock student API) with hot-reload enabled.
 
+> For a full from-scratch setup (permissions, migrations, seeding), use the `/init-dev-env` skill rather than re-deriving the steps here.
+
 ## Core Development Principles
 
 ### 1. Error Handling Standards
@@ -155,7 +157,7 @@ If you see `LookupError: 'value' is not among the defined enum values`:
 
 ### 5. API Response Standardization
 
-**CRITICAL**: All API endpoints MUST return a consistent ApiResponse format for frontend compatibility.
+**IMPORTANT**: All API endpoints MUST return a consistent ApiResponse format for frontend compatibility.
 
 #### Standard Format
 ```python
@@ -334,7 +336,7 @@ Migration `6b5cb44d2fe3` creates the `application_sequences` table and initializ
 
 ### 7. Application Data Structure Principles
 
-**CRITICAL**: Clear separation between API data snapshot and student-submitted data.
+**IMPORTANT**: Clear separation between API data snapshot and student-submitted data.
 
 #### student_data (JSON Field)
 **Purpose**: Pure SIS API data snapshot at time of application submission.
@@ -447,7 +449,7 @@ CI validates type sync automatically. Backend must be running on `localhost:8000
 ```
 
 ### Alembic Migration Development Rules
-**CRITICAL**: Always include existence checks in migrations:
+**IMPORTANT**: Always include existence checks in migrations:
 
 ```python
 # ✅ CORRECT - Check before creating
@@ -589,7 +591,7 @@ match = safe_regex_match(user_pattern, value, timeout_seconds=1)
 
 ### Test Coverage
 
-See `backend/tests/test_regex_validator.py` for comprehensive test suite:
+See `backend/app/tests/test_regex_validator.py` for comprehensive test suite:
 - 22 test cases covering all security scenarios
 - Dangerous pattern rejection tests
 - ReDoS attack prevention tests
@@ -667,7 +669,7 @@ return new NextResponse(fileBuffer, {
 });
 ```
 
-**CRITICAL**: Missing `Content-Length` or incomplete `Content-Disposition` can cause PDF viewer errors (including false "password protected" errors).
+**Note**: Missing `Content-Length` or incomplete `Content-Disposition` can cause PDF viewer errors (including false "password protected" errors).
 
 ### Environment Variables
 ```bash

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -143,7 +143,7 @@ CREATE TYPE semester AS ENUM ('first', 'second', 'yearly');
 - ✅ Normalize to lowercase in application layer: `sub_type.lower().strip()`
 
 #### Enum Synchronization Checklist
-1. Update Python enum in `backend/app/models/enums.py`
+1. Update the Python enum where it lives — most are in `backend/app/models/enums.py`, but `UserRole`/`UserType`/`EmployeeStatus` are defined in `backend/app/models/user.py`
 2. Update TypeScript enum in `frontend/lib/enums.ts`
 3. Create Alembic migration for database enum changes
 4. Update all code references using find/replace


### PR DESCRIPTION
## Summary
Updated CLAUDE.md documentation to improve clarity on enum definitions, fix incorrect file paths, and adjust emphasis levels for various guidelines.

## Key Changes
- **Enum definition locations**: Clarified that `UserRole`, `UserType`, and `EmployeeStatus` are defined in `backend/app/models/user.py` rather than `backend/app/models/enums.py`
- **File path corrections**: Fixed incorrect test file path from `backend/tests/test_regex_validator.py` to `backend/app/tests/test_regex_validator.py`
- **Emphasis adjustments**: Changed several "CRITICAL" labels to "IMPORTANT" for API response standardization, migration rules, and data structure principles to better reflect actual severity levels
- **Development guidance**: Added note about using `/init-dev-env` skill for full from-scratch setup instead of manually deriving steps
- **PDF handling note**: Changed "CRITICAL" to "Note" for Content-Length/Content-Disposition guidance as it's more of a helpful tip than a critical requirement

## Implementation Details
These are documentation-only changes that improve developer experience by:
- Reducing confusion when developers need to locate and update enum definitions
- Providing accurate file paths for test references
- Better calibrating the importance levels of different guidelines to help developers prioritize
- Directing developers to appropriate tools for environment setup

https://claude.ai/code/session_012ZnHpt7dibqf4b95nzWJWp