### PR TITLE
fix(ui): show MOE sub-types as 教育部 instead of 教育部+N

### DIFF
--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -95,13 +95,12 @@ function seedAllocations(
 /**
  * Derive abbreviated display name from sub_type code and full display_name.
  * nstc           → "國科會"
- * moe_1w/moe_2w  → "教育部+1" / "教育部+2"
+ * moe_1w/moe_2w  → "教育部"
  * other          → truncated display_name
  */
 function getSubTypeShortName(sub_type: string, display_name: string): string {
   if (sub_type === "nstc") return "國科會";
-  const moeMatch = sub_type.match(/^moe_(\d+)w$/);
-  if (moeMatch) return `教育部+${moeMatch[1]}`;
+  if (/^moe_\d+w$/.test(sub_type)) return "教育部";
   return display_name.length > 7
     ? display_name.slice(0, 6) + "…"
     : display_name;
@@ -239,7 +238,7 @@ export function ManualDistributionPanel({
       for (const cData of configs) {
         if (cData.total <= 0) continue;
         // Multi-config sub-types (e.g. nstc borrowing): label with config code → "國科會 · phd_114"
-        // Single-config sub-types (e.g. moe_1w): just the short name → "教育部+1"
+        // Single-config sub-types (e.g. moe_1w): just the short name → "教育部"
         const display_name = isMulti ? `${shortName} · ${cData.config_code}` : shortName;
         cols.push({
           sub_type,

--- a/frontend/components/admin/renewal/RenewalDistributionResult.tsx
+++ b/frontend/components/admin/renewal/RenewalDistributionResult.tsx
@@ -41,14 +41,13 @@ interface RenewalDistributionResultProps {
 /**
  * 將 sub_type 代碼轉為簡短中文顯示名稱。
  *   nstc          → "國科會"
- *   moe_1w/moe_2w → "教育部+1" / "教育部+2"
+ *   moe_1w/moe_2w → "教育部"
  *   其他          → 原值
  */
 function getSubTypeShortName(subType: string | null): string {
   if (!subType) return "未分類";
   if (subType === "nstc") return "國科會";
-  const moeMatch = subType.match(/^moe_(\d+)w$/);
-  if (moeMatch) return `教育部+${moeMatch[1]}`;
+  if (/^moe_\d+w$/.test(subType)) return "教育部";
   return subType;
 }
 

--- a/frontend/components/student/ChallengeApplicationCard.tsx
+++ b/frontend/components/student/ChallengeApplicationCard.tsx
@@ -57,13 +57,12 @@ interface ChallengeApplicationCardProps {
 /**
  * 將 sub_type 代碼轉為簡短中文顯示名稱。
  *   nstc          → "國科會"
- *   moe_1w/moe_2w → "教育部+1" / "教育部+2"
+ *   moe_1w/moe_2w → "教育部"
  *   其他          → 原值
  */
 function getSubTypeShortName(subType: string): string {
   if (subType === "nstc") return "國科會";
-  const moeMatch = subType.match(/^moe_(\d+)w$/);
-  if (moeMatch) return `教育部+${moeMatch[1]}`;
+  if (/^moe_\d+w$/.test(subType)) return "教育部";
   return subType;
 }
 


### PR DESCRIPTION
## Summary
- The `moe_1w`/`moe_2w` sub-type short-name helper displayed "教育部+1"/"教育部+2", which reads like a tag-overflow "+N more" badge instead of the intended MOE renewal-year label.
- Updated the three components that share this display logic to render plain "教育部" for any `moe_XXw` sub-type.

## Files changed
- `frontend/components/student/ChallengeApplicationCard.tsx`
- `frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx`
- `frontend/components/admin/renewal/RenewalDistributionResult.tsx`

## Test plan
- [x] `tsc --noEmit` passes with no errors in touched files
- [x] Verified no other components contain the old `教育部+N` pattern