### PR TITLE
feat(manual-distribution): export 申請總表 by 學院 instead of 系所

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -284,7 +284,7 @@ async def export_department_summary_bulk(
         if not college_code:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="未指定學院，無法使用本學院範圍",
+                detail="未設定學院，無法使用本學院範圍",
             )
         dept_rows = (
             (await db.execute(select(Department).where(Department.academy_code == college_code))).scalars().all()

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -225,6 +225,10 @@ async def export_department_summary_bulk(
     academic_year: int = Query(...),
     semester: Optional[str] = Query(None),
     scope: Literal["college", "all"] = Query(...),
+    academy_code: Optional[str] = Query(
+        None,
+        description="Academy (學院) code to export when scope='college'; admins may pick any college",
+    ),
     current_user: User = Depends(require_scholarship_manager),
     db: AsyncSession = Depends(get_db),
 ):
@@ -261,18 +265,35 @@ async def export_department_summary_bulk(
         )
 
     if scope == "college":
-        college_code = (current_user.college_code or "").strip()
+        # Admins may target any academy via academy_code; a college user is
+        # always pinned to their own college_code and cannot cross-export.
+        requested_academy = (academy_code or "").strip()
+        if is_admin:
+            college_code = requested_academy or (current_user.college_code or "").strip()
+        else:
+            college_code = (current_user.college_code or "").strip()
+            if requested_academy and requested_academy != college_code:
+                logger.warning(
+                    "department-summary-export-bulk denied: cross-college academy_code",
+                    extra={**log_extra, "requested_academy": requested_academy, "user_college": college_code},
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="無權限匯出此學院之資料",
+                )
         if not college_code:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="未設定學院，無法使用本學院範圍",
+                detail="未指定學院，無法使用本學院範圍",
             )
         dept_rows = (
             (await db.execute(select(Department).where(Department.academy_code == college_code))).scalars().all()
         )
         target_dept_codes = [d.code for d in dept_rows if d.code]
+        resolved_college_code = college_code
     else:  # scope == "all"
         target_dept_codes = None  # no dept filter
+        resolved_college_code = None
 
     # Load scholarship type
     stype = (
@@ -373,7 +394,7 @@ async def export_department_summary_bulk(
 
     payload = buf.getvalue()
 
-    scope_label = current_user.college_code if scope == "college" else "全部"
+    scope_label = resolved_college_code if scope == "college" else "全部"
     base_filename = (
         f"{academic_year}學年度{scholarship_name}學生資料彙整表"
         f"_{_sanitise_filename_part(scope_label or '全部')}.zip"

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -5,10 +5,7 @@ import { logger } from "@/lib/utils/logger";
 import { useCollegeManagement } from "@/contexts/college-management-context";
 import { useReferenceData } from "@/hooks/use-reference-data";
 import { apiClient } from "@/lib/api";
-import {
-  exportDepartmentSummary,
-  exportDepartmentSummaryBulk,
-} from "@/lib/api/modules/college";
+import { exportDepartmentSummaryBulk } from "@/lib/api/modules/college";
 import type {
   DistributionStudent,
   LocalAlloc,
@@ -78,8 +75,7 @@ interface ManualDistributionPanelProps {
   scholarshipType: { id: number; code: string; name: string };
 }
 
-const ALL_DEPTS_OWN = "__college_all__";
-const ALL_DEPTS_SYSTEM = "__all__";
+const ALL_ACADEMIES_SYSTEM = "__all__";
 
 /** Seed local allocation state from the server snapshot (null = unallocated). */
 function seedAllocations(
@@ -128,17 +124,18 @@ export function ManualDistributionPanel({
   // Use the ID directly from the prop (provided by the admin available-combinations endpoint)
   const scholarshipTypeId = scholarshipType.id;
 
-  const { departments, academies } = useReferenceData();
+  const { academies } = useReferenceData();
   const [summaryDept, setSummaryDept] = useState<string>("");
 
-  const visibleDepartments = useMemo(() => {
-    if (!departments) return [];
-    if (user.role === "admin" || user.role === "super_admin") return departments;
-    return departments.filter(
-      (d: { code: string; name: string; academy_code?: string | null }) =>
-        d.academy_code === user.college_code
+  // The 匯出總表 dropdown lists 學院 (academies), not individual 系所.
+  // Admins see every academy; a college user sees only their own.
+  const visibleAcademies = useMemo(() => {
+    if (!academies) return [];
+    if (user.role === "admin" || user.role === "super_admin") return academies;
+    return academies.filter(
+      (a: { code: string; name: string }) => a.code === user.college_code
     );
-  }, [departments, user]);
+  }, [academies, user]);
 
   const handleDownloadSummary = useCallback(async () => {
     if (!summaryDept || !scholarshipType.id || !selectedAcademicYear) {
@@ -152,12 +149,15 @@ export function ManualDistributionPanel({
         semester: selectedSemester ?? null,
       };
       let result: { blob: Blob; filename: string };
-      if (summaryDept === ALL_DEPTS_OWN) {
-        result = await exportDepartmentSummaryBulk({ ...common, scope: "college" });
-      } else if (summaryDept === ALL_DEPTS_SYSTEM) {
+      if (summaryDept === ALL_ACADEMIES_SYSTEM) {
         result = await exportDepartmentSummaryBulk({ ...common, scope: "all" });
       } else {
-        result = await exportDepartmentSummary({ ...common, department_code: summaryDept });
+        // summaryDept holds an academy code — export that college's departments.
+        result = await exportDepartmentSummaryBulk({
+          ...common,
+          scope: "college",
+          academy_code: summaryDept,
+        });
       }
       const url = URL.createObjectURL(result.blob);
       const a = document.createElement("a");
@@ -782,22 +782,17 @@ export function ManualDistributionPanel({
             <div className="flex gap-2 flex-wrap">
               <Select value={summaryDept} onValueChange={setSummaryDept}>
                 <SelectTrigger className="w-[200px] h-9">
-                  <SelectValue placeholder="選擇系所匯出總表" />
+                  <SelectValue placeholder="選擇學院匯出總表" />
                 </SelectTrigger>
                 <SelectContent>
-                  {visibleDepartments.map((d: { code: string; name: string }) => (
-                    <SelectItem key={d.code} value={d.code}>
-                      {d.name}
+                  {visibleAcademies.map((a: { code: string; name: string }) => (
+                    <SelectItem key={a.code} value={a.code}>
+                      {a.name}
                     </SelectItem>
                   ))}
-                  {user.college_code && (
-                    <SelectItem value={ALL_DEPTS_OWN}>
-                      本學院全部 (ZIP)
-                    </SelectItem>
-                  )}
                   {(user.role === "admin" || user.role === "super_admin") && (
-                    <SelectItem value={ALL_DEPTS_SYSTEM}>
-                      全部系所 (ZIP)
+                    <SelectItem value={ALL_ACADEMIES_SYSTEM}>
+                      全部學院 (ZIP)
                     </SelectItem>
                   )}
                 </SelectContent>

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -18515,6 +18515,8 @@ export interface operations {
                 academic_year: number;
                 semester?: string | null;
                 scope: "college" | "all";
+                /** @description Academy (學院) code to export when scope='college'; admins may pick any college */
+                academy_code?: string | null;
             };
             header?: never;
             path?: never;

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -820,13 +820,19 @@ export async function exportDepartmentSummary(
  * Endpoint: GET /api/v1/college-review/applications/department-summary-export-bulk
  */
 export async function exportDepartmentSummaryBulk(
-  args: DepartmentSummaryExportArgs & { scope: "college" | "all" }
+  args: DepartmentSummaryExportArgs & {
+    scope: "college" | "all";
+    // When scope is "college", an explicit academy code to export. Admins use
+    // this to pick any college; omitted for a college user's own academy.
+    academy_code?: string;
+  }
 ): Promise<{ blob: Blob; filename: string }> {
   const params = new URLSearchParams();
   params.set("scholarship_type_id", String(args.scholarship_type_id));
   params.set("academic_year", String(args.academic_year));
   if (args.semester) params.set("semester", args.semester);
   params.set("scope", args.scope);
+  if (args.academy_code) params.set("academy_code", args.academy_code);
 
   return _fetchBinaryExport(
     "/api/v1/college-review/applications/department-summary-export-bulk",


### PR DESCRIPTION
## Summary
The 手動分發 page's 「選擇系所匯出總表」 dropdown listed **all 768 departments** from the `departments` table — including non-department units (圖書館, 體育室, 教學小組…) and duplicate/legacy academy codes — making it unusable.

This changes it to list **學院 (academies)** instead:
- **Admin / super_admin**: see every 學院 + a `全部學院 (ZIP)` option.
- **College user**: see only their own 學院.
- Selecting a 學院 exports a ZIP of that college's per-department 申請總表.

## Changes
- **Frontend** (`ManualDistributionPanel.tsx`): dropdown now maps `academies` (role-filtered); placeholder → `選擇學院匯出總表`; removed the redundant single-department export path and `本學院全部` item.
- **API module** (`college.ts`): `exportDepartmentSummaryBulk` gains optional `academy_code`.
- **Backend** (`application_summary_export.py`): `department-summary-export-bulk` accepts `academy_code` so an admin can target any college; non-admins are pinned to their own `college_code` (cross-college → 403). ZIP filename uses the resolved college code.
- Regenerated OpenAPI TS types.

## Verification
- Confirmed `academy_code` present in live OpenAPI schema.
- Logged in as admin and called the endpoint:
  - `academy_code=C`, scholarship_type 2 / year 114 → **200 `application/zip`, 13KB** ✅
  - academy with no matching applications → 404 (expected).
- `tsc --noEmit` clean for touched files; backend file syntax-checked.