### PR TITLE
fix(frontend): clarify student wizard notice and advisor copy

### DIFF
--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -58,14 +58,14 @@ const NOTICES = {
           "申請人必須為本校在學【全職學生】，【不得於公私立機構從事專職全時之有給職工作】，且符合各獎學金規定的申請條件。請確認您的學籍狀態與申請資格。",
       },
       {
-        title: "申請期限",
-        content:
-          "各獎學金有不同的申請期限，逾期申請恕不受理。請注意各獎學金的開放申請日期與截止日期。",
-      },
-      {
         title: "申請限制",
         content:
           "每位獲獎學生至多可領獎3年共計6學期，國科會與教育部獎學金兩獎項合併計算，申請次數不限。\n每次申請為一學年期程，並可申請續領至滿三學年為止。如遇休學、退學、畢業，或有違反本校獎學金要點相關規定之情事，將喪失領獎資格，將由備取學生遞補。",
+      },
+      {
+        title: "申請期限",
+        content:
+          "各獎學金有不同的申請期限，逾期申請恕不受理。請注意各獎學金的開放申請日期與截止日期。",
       },
       {
         title: "文件準備",
@@ -131,14 +131,14 @@ const NOTICES = {
           "Applicants must be currently enrolled students and meet the specific requirements of each scholarship. Please verify your enrollment status and eligibility.",
       },
       {
-        title: "Application Deadline",
-        content:
-          "Each scholarship has different application deadlines. Late applications will not be accepted. Please note the opening and closing dates for each scholarship.",
-      },
-      {
         title: "Application Restrictions",
         content:
           "Each awarded student may receive the scholarship for up to 3 years (6 semesters total); the NSTC and MOE scholarships are counted together, with no limit on the number of applications.\nEach application covers one academic year, and may be renewed up to a total of three academic years. Recipients who take a leave of absence, withdraw, graduate, or violate the university's scholarship regulations will forfeit their eligibility, and a waitlisted student will be selected instead.",
+      },
+      {
+        title: "Application Deadline",
+        content:
+          "Each scholarship has different application deadlines. Late applications will not be accepted. Please note the opening and closing dates for each scholarship.",
       },
       {
         title: "Document Preparation",

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -63,6 +63,11 @@ const NOTICES = {
           "各獎學金有不同的申請期限，逾期申請恕不受理。請注意各獎學金的開放申請日期與截止日期。",
       },
       {
+        title: "申請限制",
+        content:
+          "每位獲獎學生至多可領獎3年共計6學期，國科會與教育部獎學金兩獎項合併計算，申請次數不限。\n每次申請為一學年期程，並可申請續領至滿三學年為止。如遇休學、退學、畢業，或有違反本校獎學金要點相關規定之情事，將喪失領獎資格，將由備取學生遞補。",
+      },
+      {
         title: "文件準備",
         content:
           "請備妥所需文件，包括但不限於成績單、郵局存摺封面、勞保投保紀錄、指導教授推薦函等。所有文件必須為清晰可辨識的電子檔案（PDF、JPG、JPEG 或 PNG 格式）。",
@@ -95,7 +100,7 @@ const NOTICES = {
     ],
     importantNotice: "重要提醒",
     importantContent:
-      "請務必詳細閱讀各獎學金的申請條款與相關規定。每位學生每學期限申請一項獎學金，請謹慎選擇。",
+      "請務必詳細閱讀各項獎學金要點與相關規定。\n每位學生每次申請國科會或教育部博士生獎學金為一學年期程，僅可擇一獲獎，請謹慎選擇。",
     agreementText: "我已詳細閱讀並了解獎學金要點，同意遵守相關規定",
     readNoticeText: "尚未閱讀獎學金要點",
     readNoticeHint: "請點擊上方按鈕開啟獎學金要點並滑至底端",
@@ -131,6 +136,11 @@ const NOTICES = {
           "Each scholarship has different application deadlines. Late applications will not be accepted. Please note the opening and closing dates for each scholarship.",
       },
       {
+        title: "Application Restrictions",
+        content:
+          "Each awarded student may receive the scholarship for up to 3 years (6 semesters total); the NSTC and MOE scholarships are counted together, with no limit on the number of applications.\nEach application covers one academic year, and may be renewed up to a total of three academic years. Recipients who take a leave of absence, withdraw, graduate, or violate the university's scholarship regulations will forfeit their eligibility, and a waitlisted student will be selected instead.",
+      },
+      {
         title: "Document Preparation",
         content:
           "Please prepare all required documents, including but not limited to transcripts, enrollment certificates, and advisor recommendation letters. All documents must be clear electronic files (PDF, JPG, JPEG, or PNG format).",
@@ -163,7 +173,7 @@ const NOTICES = {
     ],
     importantNotice: "Important Notice",
     importantContent:
-      "Please read the terms and conditions of each scholarship carefully. Each student may only apply for one scholarship per semester. Choose wisely.",
+      "Please read the regulations and related rules for each scholarship carefully.\nEach student may apply for either the NSTC or MOE PhD Scholarship for one academic year per application, and may only receive one of the two. Please choose carefully.",
     agreementText:
       "I have read and understand the scholarship regulations and agree to comply",
     readNoticeText: "Regulations not yet read",
@@ -295,7 +305,9 @@ export function NoticeAgreementStep({
               <div className="font-semibold text-amber-900 mb-1">
                 {t.importantNotice}
               </div>
-              <div className="text-sm text-amber-800">{t.importantContent}</div>
+              <div className="text-sm text-amber-800 whitespace-pre-line">
+                {t.importantContent}
+              </div>
             </AlertDescription>
           </Alert>
 
@@ -315,7 +327,7 @@ export function NoticeAgreementStep({
                         <h4 className="font-semibold text-nycu-navy-800 mb-2">
                           {item.title}
                         </h4>
-                        <p className="text-sm text-gray-700 leading-relaxed">
+                        <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-line">
                           {item.content}
                         </p>
                       </div>

--- a/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+++ b/frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
@@ -222,11 +222,16 @@ export function ScholarshipApplicationStep({
       subtitle: "填寫個人資料、選擇獎學金類型並完成申請",
       personalInfoTitle: "個人資料",
       advisorInfo: "指導教授資訊",
+      advisorInfoNotes: [
+        "如有超過一位指導教授或共同指導，請填寫一位主要指導教授。",
+        "申請教育部博士生獎學金之學生，請填寫可提供每月$5000元配合款的指導教授。（每年配合款經費金額將配合教育部相關規定，採滾動式調整。）",
+        "如無指導教授或指導教授為兼任老師無單一入口網權限須請系主任或所長代為簽核。",
+      ],
       advisorName: "教授姓名",
       advisorNamePlaceholder: "請輸入指導教授姓名",
       advisorEmail: "教授 Email",
       advisorEmailPlaceholder: "professor@nycu.edu.tw",
-      advisorId: "指導教授本校人事編號",
+      advisorId: "指導教授本校人事編號（請向指導教授確認）",
       advisorIdPlaceholder: "請輸入指導教授本校人事編號",
       bankInfo: "郵局帳號資訊",
       accountNumber: "郵局局號加帳號共 14 碼(限本人)",
@@ -326,6 +331,11 @@ export function ScholarshipApplicationStep({
       subtitle: "Fill personal information, select scholarship type and apply",
       personalInfoTitle: "Personal Information",
       advisorInfo: "Advisor Information",
+      advisorInfoNotes: [
+        "If you have more than one advisor or co-advisors, please list one primary advisor.",
+        "Applicants for the MOE PhD Scholarship should list an advisor who can provide a monthly matching fund of $5,000 (the annual matching amount will be adjusted according to MOE regulations).",
+        "If you have no advisor, or your advisor is an adjunct instructor without single sign-on access, please ask your department chair or institute director to sign on your behalf.",
+      ],
       advisorName: "Advisor Name",
       advisorNamePlaceholder: "Enter advisor's name",
       advisorEmail: "Advisor Email",
@@ -1258,6 +1268,13 @@ export function ScholarshipApplicationStep({
               <User className="h-4 w-4 text-violet-600" />
               {text.advisorInfo}
             </h3>
+            {text.advisorInfoNotes && text.advisorInfoNotes.length > 0 && (
+              <ul className="mb-3 list-decimal list-inside space-y-1 text-sm text-gray-600">
+                {text.advisorInfoNotes.map((note, i) => (
+                  <li key={i}>{note}</li>
+                ))}
+              </ul>
+            )}
             {advisorErrors.length > 0 && (
               <Alert variant="destructive" className="mb-3">
                 <AlertCircle className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Advisor NYCU ID label now reads 指導教授本校人事編號（請向指導教授確認）
- Added 3-point guidance list under 指導教授資訊 (co-advisor, MOE PhD matching-fund advisor, adjunct/no-advisor sign-off note)
- Inserted a new 申請限制 item (#2) into the scholarship notice list, describing the 3-year/6-semester cap and NSTC+MOE combined counting
- Revised the important-notice banner text to 請務必詳細閱讀各項獎學金要點與相關規定 plus the one-scholarship-per-application-year rule
- Added `whitespace-pre-line` so multi-line notice content renders with line breaks

## Test plan
- [x] `tsc --noEmit` passes for both touched files
- [x] `notice-agreement-step.test.tsx` suite passes (7/7)
- [ ] Manual check in dev: student wizard notice step and advisor info step render the new copy correctly