### PR TITLE
fix(frontend): remove empty Contact Information section from footer

### DIFF
--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -64,22 +64,9 @@ export function Footer({ locale = "zh" }: FooterProps) {
             </div>
           </div>
 
-          {/* Contact Information — collapsible on mobile via native <details>
+          {/* Related Links — collapsible on mobile via native <details>
               (closed by default below md). Above md it renders flat without
               a disclosure widget so desktop layout is unchanged. */}
-          <details className="group [&_summary::-webkit-details-marker]:hidden" open>
-            <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
-              <h4 className="font-bold text-nycu-navy-800 text-lg">
-                {locale === "zh" ? "聯絡資訊" : "Contact Information"}
-              </h4>
-              <ChevronDown
-                className="h-5 w-5 text-nycu-navy-600 transition-transform group-open:rotate-180 md:hidden"
-                aria-hidden="true"
-              />
-            </summary>
-          </details>
-
-          {/* Related Links — same collapsible pattern as Contact Information. */}
           <details className="group [&_summary::-webkit-details-marker]:hidden" open>
             <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
               <h4 className="font-bold text-nycu-navy-800 text-lg">

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -64,10 +64,11 @@ export function Footer({ locale = "zh" }: FooterProps) {
             </div>
           </div>
 
-          {/* Related Links — collapsible on mobile via native <details>
-              (closed by default below md). Above md it renders flat without
-              a disclosure widget so desktop layout is unchanged. */}
-          <details className="group [&_summary::-webkit-details-marker]:hidden" open>
+          {/* Related Links — expanded by default (native <details open>) on
+              every breakpoint. Below md the summary stays interactive so
+              users can collapse it; the disclosure chevron is hidden at
+              md+ where the toggle affordance isn't needed. */}
+          <details className="group [&_summary::-webkit-details-marker]:hidden md:col-span-2" open>
             <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
               <h4 className="font-bold text-nycu-navy-800 text-lg">
                 {locale === "zh" ? "相關連結" : "Related Links"}


### PR DESCRIPTION
## Summary
- Follow-up to the previous 簽核 → 審核 rename PR (#1098): the footer's 聯絡資訊 (Contact Information) section had already had its body content cleared, leaving just an empty collapsible panel with a header and chevron.
- This removes the section entirely (including the 聯絡資訊 header text), since there's nothing left inside it to justify keeping the panel.

## Changes
- `frontend/components/footer.tsx`: deleted the empty Contact Information `<details>` block; the Related Links section now takes its place in the footer grid.

## Test plan
- [x] `npx esbuild` syntax-check on the edited file
- [x] Verified no tests reference the removed 聯絡資訊/"Contact Information" footer text


---
_Generated by [Claude Code](https://claude.ai/code/session_01J4f21kHRMv2zU2eUwSiPM8)_