### PR TITLE
test(api): first HTTP-layer coverage for reviews + ranking_management — fixes 2 production 500s

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -667,11 +667,15 @@ async def update_ranking_order(
         # G8 (#970): capture the prior order — rank overwrites previously left
         # no trace, so 「核配當時的名次」 could not be reconstructed.
         prior_rows = await db.execute(
-            select(CollegeRankingItem.application_id, CollegeRankingItem.rank_position).where(
-                CollegeRankingItem.ranking_id == ranking_id
-            )
+            select(
+                CollegeRankingItem.id,
+                CollegeRankingItem.application_id,
+                CollegeRankingItem.rank_position,
+            ).where(CollegeRankingItem.ranking_id == ranking_id)
         )
-        old_order = {str(app_id): pos for app_id, pos in prior_rows.all()}
+        prior = prior_rows.all()
+        old_order = {str(app_id): pos for _item_id, app_id, pos in prior}
+        item_to_app = {item_id: app_id for item_id, app_id, _pos in prior}
 
         ranking = await service.update_ranking_order(
             ranking_id=ranking_id, new_order=[item.model_dump() for item in new_order]
@@ -685,9 +689,13 @@ async def update_ranking_order(
                 resource_id=str(ranking_id),
                 description=f"ranking order updated ({len(new_order)} item(s))",
                 old_values={"rank_positions": old_order},
+                # RankingOrderUpdate carries item_id/position (NOT application_id/
+                # rank_position) — reading the wrong keys here 500'd EVERY valid
+                # reorder request since the G8 audit block landed. Key new_values by
+                # application_id (via the prior-rows mapping) so old/new stay comparable.
                 new_values={
                     "rank_positions": {
-                        str(i["application_id"]): i.get("rank_position")
+                        str(item_to_app.get(i["item_id"], f"item:{i['item_id']}")): i.get("position")
                         for i in (item.model_dump() for item in new_order)
                     }
                 },

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -129,7 +129,10 @@ async def create_review(
         .options(joinedload(ApplicationReview.reviewer), joinedload(ApplicationReview.items))
     )
     result = await db.execute(stmt)
-    review_with_relations = result.scalar_one()
+    # .unique() is REQUIRED: joinedload(ApplicationReview.items) is a collection
+    # eager load — without it any review with 2+ items raises InvalidRequestError
+    # (500 AFTER the commit, so the review was created but the client saw an error).
+    review_with_relations = result.unique().scalar_one()
 
     return {
         "success": True,
@@ -173,7 +176,7 @@ async def get_review(
         .options(joinedload(ApplicationReview.reviewer), joinedload(ApplicationReview.items))
     )
     result = await db.execute(stmt)
-    review = result.scalar_one_or_none()
+    review = result.unique().scalar_one_or_none()
 
     if not review:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="審查記錄不存在")
@@ -227,7 +230,7 @@ async def get_application_reviews(
         .order_by(ApplicationReview.reviewed_at.desc())
     )
     result = await db.execute(stmt)
-    reviews = result.scalars().all()
+    reviews = result.unique().scalars().all()
 
     return {
         "success": True,
@@ -306,7 +309,7 @@ async def get_application_review_status(
         .order_by(ApplicationReview.reviewed_at.desc())
     )
     result = await db.execute(stmt)
-    reviews = result.scalars().all()
+    reviews = result.unique().scalars().all()
 
     return {
         "success": True,

--- a/backend/app/tests/test_ranking_management_endpoints.py
+++ b/backend/app/tests/test_ranking_management_endpoints.py
@@ -1,0 +1,576 @@
+"""
+HTTP-layer tests for the college ranking endpoints
+(app/api/v1/endpoints/college_review/ranking_management.py).
+
+Focus (issue #1081 follow-up): cross-college authorization scoping,
+finalized-state guards, input validation, and the {success, message, data}
+response envelope.
+
+Authentication is simulated by overriding `get_current_user` with real
+DB-backed User rows so the actual require_college / require_scholarship_manager
+role gates and assert_can_manage_ranking scoping run unmodified.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.application import Application, ApplicationStatus
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import Semester
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+
+RANKINGS_URL = "/api/v1/college-review/rankings"
+
+XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+@pytest_asyncio.fixture
+async def login():
+    """Authenticate the test client as a given User via dependency override."""
+    from app.core.security import get_current_user
+    from app.main import app
+
+    def _login(user: User) -> None:
+        async def _override():
+            return user
+
+        app.dependency_overrides[get_current_user] = _override
+
+    yield _login
+    from app.core.security import get_current_user as _gcu
+    from app.main import app as _app
+
+    _app.dependency_overrides.pop(_gcu, None)
+
+
+@pytest_asyncio.fixture
+async def rank_users(db):
+    users = {
+        "college_eng": User(
+            nycu_id="rank_eng1",
+            name="ENG Reviewer",
+            email="rank_eng1@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.college,
+            college_code="ENG",
+        ),
+        "college_eng2": User(
+            nycu_id="rank_eng2",
+            name="ENG Reviewer Two",
+            email="rank_eng2@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.college,
+            college_code="ENG",
+        ),
+        "college_sci": User(
+            nycu_id="rank_sci1",
+            name="SCI Reviewer",
+            email="rank_sci1@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.college,
+            college_code="SCI",
+        ),
+        "admin": User(
+            nycu_id="rank_admin",
+            name="Rank Admin",
+            email="rank_admin@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.admin,
+        ),
+        "student": User(
+            nycu_id="rank_student",
+            name="Rank Student",
+            email="rank_student@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "professor": User(
+            nycu_id="rank_prof",
+            name="Rank Professor",
+            email="rank_prof@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+    }
+    for user in users.values():
+        db.add(user)
+    await db.commit()
+    for user in users.values():
+        await db.refresh(user)
+    return users
+
+
+@pytest_asyncio.fixture
+async def rank_scholarship(db) -> ScholarshipType:
+    scholarship = ScholarshipType(
+        code="rank_test_scholarship",
+        name="Ranking Test Scholarship",
+        description="Scholarship used by ranking endpoint tests",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+    return scholarship
+
+
+@pytest_asyncio.fixture
+async def ranking_eng(db, rank_users, rank_scholarship) -> CollegeRanking:
+    ranking = CollegeRanking(
+        scholarship_type_id=rank_scholarship.id,
+        sub_type_code="nstc",
+        academic_year=114,
+        semester="first",
+        college_code="ENG",
+        ranking_name="ENG nstc ranking",
+        total_applications=0,
+        created_by=rank_users["college_eng"].id,
+    )
+    db.add(ranking)
+    await db.commit()
+    await db.refresh(ranking)
+    return ranking
+
+
+@pytest_asyncio.fixture
+async def ranking_sci(db, rank_users, rank_scholarship) -> CollegeRanking:
+    ranking = CollegeRanking(
+        scholarship_type_id=rank_scholarship.id,
+        sub_type_code="nstc",
+        academic_year=114,
+        semester="first",
+        college_code="SCI",
+        ranking_name="SCI nstc ranking",
+        total_applications=0,
+        created_by=rank_users["college_sci"].id,
+    )
+    db.add(ranking)
+    await db.commit()
+    await db.refresh(ranking)
+    return ranking
+
+
+@pytest_asyncio.fixture
+async def ranking_eng_items(db, rank_users, rank_scholarship, ranking_eng):
+    """Two ranked applications (student IDs S001/S002) inside the ENG ranking."""
+    students = []
+    for idx in (1, 2):
+        student = User(
+            nycu_id=f"rank_stu{idx}",
+            name=f"Ranked Student {idx}",
+            email=f"rank_stu{idx}@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        )
+        db.add(student)
+        students.append(student)
+    await db.commit()
+
+    items = []
+    for idx, student in enumerate(students, start=1):
+        await db.refresh(student)
+        application = Application(
+            app_id=f"APP-114-1-0100{idx}",
+            user_id=student.id,
+            scholarship_type_id=rank_scholarship.id,
+            sub_type_selection_mode=SubTypeSelectionMode.single,
+            status=ApplicationStatus.approved.value,
+            academic_year=114,
+            semester="first",
+            scholarship_subtype_list=["nstc"],
+            student_data={"std_stdcode": f"S00{idx}", "std_cname": f"Ranked Student {idx}", "std_academyno": "ENG"},
+            submitted_form_data={},
+            agree_terms=True,
+        )
+        db.add(application)
+        await db.commit()
+        await db.refresh(application)
+
+        item = CollegeRankingItem(
+            ranking_id=ranking_eng.id,
+            application_id=application.id,
+            rank_position=idx,
+            status="ranked",
+        )
+        db.add(item)
+        await db.commit()
+        await db.refresh(item)
+        items.append(item)
+
+    ranking_eng.total_applications = len(items)
+    await db.commit()
+    return items
+
+
+@pytest.mark.api
+class TestRankingAuthorization:
+    """Role gates and cross-college scoping."""
+
+    async def test_list_rankings_unauthenticated_401(self, client):
+        response = await client.get(RANKINGS_URL)
+        assert response.status_code == 401
+        assert response.json()["success"] is False
+
+    async def test_create_ranking_unauthenticated_401(self, client):
+        response = await client.post(RANKINGS_URL, json={})
+        assert response.status_code == 401
+
+    async def test_student_list_rankings_403(self, client, login, rank_users):
+        login(rank_users["student"])
+        response = await client.get(RANKINGS_URL)
+        assert response.status_code == 403
+
+    async def test_professor_list_rankings_403(self, client, login, rank_users):
+        login(rank_users["professor"])
+        response = await client.get(RANKINGS_URL)
+        assert response.status_code == 403
+
+    async def test_admin_list_rankings_403(self, client, login, rank_users):
+        # Pins a behavior quirk: require_college accepts ONLY role=college, so
+        # admins are rejected here even though the handler contains an
+        # admin-sees-all branch (that branch is unreachable via HTTP).
+        login(rank_users["admin"])
+        response = await client.get(RANKINGS_URL)
+        assert response.status_code == 403
+
+    async def test_student_create_ranking_403(self, client, login, rank_users, rank_scholarship):
+        login(rank_users["student"])
+        payload = {
+            "scholarship_type_id": rank_scholarship.id,
+            "sub_type_code": "nstc",
+            "academic_year": 114,
+            "semester": "first",
+        }
+        response = await client.post(RANKINGS_URL, json=payload)
+        assert response.status_code == 403
+
+    async def test_college_list_scoped_to_own_college(self, client, login, rank_users, ranking_eng, ranking_sci):
+        login(rank_users["college_eng"])
+        response = await client.get(RANKINGS_URL)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        ids = [r["id"] for r in body["data"]]
+        assert ranking_eng.id in ids
+        assert ranking_sci.id not in ids
+
+    async def test_same_college_second_reviewer_sees_ranking(self, client, login, rank_users, ranking_eng):
+        # Rankings are college-owned (issue #1034): every reviewer of the
+        # owning college shares the ranking, not only the creator.
+        login(rank_users["college_eng2"])
+        response = await client.get(RANKINGS_URL)
+        assert response.status_code == 200
+        assert ranking_eng.id in [r["id"] for r in response.json()["data"]]
+
+    async def test_cross_college_get_detail_403(self, client, login, rank_users, ranking_sci):
+        login(rank_users["college_eng"])
+        response = await client.get(f"{RANKINGS_URL}/{ranking_sci.id}")
+        assert response.status_code == 403
+
+    async def test_cross_college_update_403(self, client, login, rank_users, ranking_sci):
+        login(rank_users["college_eng"])
+        response = await client.put(f"{RANKINGS_URL}/{ranking_sci.id}", json={"ranking_name": "hijacked"})
+        assert response.status_code == 403
+
+    async def test_cross_college_order_update_403(self, client, login, rank_users, ranking_sci):
+        login(rank_users["college_eng"])
+        response = await client.put(f"{RANKINGS_URL}/{ranking_sci.id}/order", json=[{"item_id": 1, "position": 1}])
+        assert response.status_code == 403
+
+    async def test_cross_college_finalize_403(self, client, login, rank_users, ranking_sci):
+        login(rank_users["college_eng"])
+        response = await client.post(f"{RANKINGS_URL}/{ranking_sci.id}/finalize")
+        assert response.status_code == 403
+
+    async def test_cross_college_unfinalize_403(self, client, login, db, rank_users, ranking_sci):
+        ranking_sci.is_finalized = True
+        ranking_sci.ranking_status = "finalized"
+        await db.commit()
+
+        login(rank_users["college_eng"])
+        response = await client.post(f"{RANKINGS_URL}/{ranking_sci.id}/unfinalize")
+        assert response.status_code == 403
+
+    async def test_cross_college_delete_403(self, client, login, db, rank_users, ranking_sci):
+        login(rank_users["college_eng"])
+        response = await client.delete(f"{RANKINGS_URL}/{ranking_sci.id}")
+        assert response.status_code == 403
+
+        # Row must still exist
+        row = (await db.execute(select(CollegeRanking).where(CollegeRanking.id == ranking_sci.id))).scalar_one()
+        assert row is not None
+
+    async def test_cross_college_import_excel_403(self, client, login, rank_users, ranking_sci):
+        login(rank_users["college_eng"])
+        payload = [{"student_id": "S001", "student_name": "X", "rank_position": 1}]
+        response = await client.post(f"{RANKINGS_URL}/{ranking_sci.id}/import-excel", json=payload)
+        assert response.status_code == 403
+
+    async def test_cross_college_supplementary_import_403(self, client, login, rank_users, ranking_sci):
+        login(rank_users["college_eng"])
+        response = await client.post(
+            f"{RANKINGS_URL}/{ranking_sci.id}/supplementary-import",
+            files={"file": ("dummy.xlsx", b"PK\x03\x04dummy", XLSX_MIME)},
+        )
+        assert response.status_code == 403
+
+    async def test_supplementary_import_flag_closed_403(self, client, login, rank_users, ranking_eng):
+        # Own college, but no ScholarshipConfiguration opened the feature.
+        login(rank_users["college_eng"])
+        response = await client.post(
+            f"{RANKINGS_URL}/{ranking_eng.id}/supplementary-import",
+            files={"file": ("dummy.xlsx", b"PK\x03\x04dummy", XLSX_MIME)},
+        )
+        assert response.status_code == 403
+        assert "補充匯入" in response.json()["message"]
+
+    async def test_student_export_excel_403(self, client, login, rank_users, ranking_eng):
+        login(rank_users["student"])
+        response = await client.get(f"{RANKINGS_URL}/{ranking_eng.id}/export-excel")
+        assert response.status_code == 403
+
+    async def test_cross_college_export_excel_403(self, client, login, rank_users, ranking_sci):
+        login(rank_users["college_eng"])
+        response = await client.get(f"{RANKINGS_URL}/{ranking_sci.id}/export-excel")
+        assert response.status_code == 403
+
+    async def test_export_excel_requires_scholarship_permission(self, client, login, rank_users, ranking_eng):
+        # Own-college reviewer WITHOUT an AdminScholarship grant for this
+        # scholarship type is rejected by the explicit permission check.
+        login(rank_users["college_eng"])
+        response = await client.get(f"{RANKINGS_URL}/{ranking_eng.id}/export-excel")
+        assert response.status_code == 403
+
+    async def test_create_ranking_blocked_after_deadline(self, client, login, db, rank_users, rank_scholarship):
+        # College-review deadline in the past blocks ranking creation for
+        # college users (#63); admins bypass (not exercised here).
+        from datetime import datetime, timedelta, timezone
+
+        config = ScholarshipConfiguration(
+            scholarship_type_id=rank_scholarship.id,
+            academic_year=114,
+            semester=Semester.first,
+            config_name="rank test config",
+            config_code="rank_test_cfg_114_1",
+            amount=10000,
+            college_review_end=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        db.add(config)
+        await db.commit()
+
+        login(rank_users["college_eng"])
+        payload = {
+            "scholarship_type_id": rank_scholarship.id,
+            "sub_type_code": "nstc",
+            "academic_year": 114,
+            "semester": "first",
+        }
+        response = await client.post(RANKINGS_URL, json=payload)
+        assert response.status_code == 403
+
+
+@pytest.mark.api
+class TestRankingValidationAndGuards:
+    """404s, 409 finalized-state guards and payload validation."""
+
+    async def test_get_detail_not_found_404(self, client, login, rank_users):
+        login(rank_users["college_eng"])
+        response = await client.get(f"{RANKINGS_URL}/999999")
+        assert response.status_code == 404
+
+    async def test_update_not_found_404(self, client, login, rank_users):
+        login(rank_users["college_eng"])
+        response = await client.put(f"{RANKINGS_URL}/999999", json={"ranking_name": "x"})
+        assert response.status_code == 404
+
+    async def test_delete_not_found_404(self, client, login, rank_users):
+        login(rank_users["college_eng"])
+        response = await client.delete(f"{RANKINGS_URL}/999999")
+        assert response.status_code == 404
+
+    async def test_order_update_not_found_404(self, client, login, rank_users):
+        login(rank_users["college_eng"])
+        response = await client.put(f"{RANKINGS_URL}/999999/order", json=[{"item_id": 1, "position": 1}])
+        assert response.status_code == 404
+
+    async def test_update_empty_name_422(self, client, login, rank_users, ranking_eng):
+        login(rank_users["college_eng"])
+        response = await client.put(f"{RANKINGS_URL}/{ranking_eng.id}", json={"ranking_name": ""})
+        assert response.status_code == 422
+
+    async def test_create_ranking_missing_fields_422(self, client, login, rank_users):
+        login(rank_users["college_eng"])
+        response = await client.post(RANKINGS_URL, json={"sub_type_code": "nstc"})
+        assert response.status_code == 422
+
+    async def test_update_finalized_ranking_409(self, client, login, db, rank_users, ranking_eng):
+        ranking_eng.is_finalized = True
+        ranking_eng.ranking_status = "finalized"
+        await db.commit()
+
+        login(rank_users["college_eng"])
+        response = await client.put(f"{RANKINGS_URL}/{ranking_eng.id}", json={"ranking_name": "new name"})
+        assert response.status_code == 409
+
+    async def test_delete_finalized_ranking_409(self, client, login, db, rank_users, ranking_eng):
+        ranking_eng.is_finalized = True
+        ranking_eng.ranking_status = "finalized"
+        await db.commit()
+
+        login(rank_users["college_eng"])
+        response = await client.delete(f"{RANKINGS_URL}/{ranking_eng.id}")
+        assert response.status_code == 409
+
+    async def test_order_update_finalized_409(self, client, login, db, rank_users, ranking_eng, ranking_eng_items):
+        ranking_eng.is_finalized = True
+        ranking_eng.ranking_status = "finalized"
+        await db.commit()
+
+        login(rank_users["college_eng"])
+        payload = [{"item_id": ranking_eng_items[0].id, "position": 1}]
+        response = await client.put(f"{RANKINGS_URL}/{ranking_eng.id}/order", json=payload)
+        assert response.status_code == 409
+
+    async def test_order_update_duplicate_positions_400(
+        self, client, login, rank_users, ranking_eng, ranking_eng_items
+    ):
+        login(rank_users["college_eng"])
+        payload = [
+            {"item_id": ranking_eng_items[0].id, "position": 1},
+            {"item_id": ranking_eng_items[1].id, "position": 1},
+        ]
+        response = await client.put(f"{RANKINGS_URL}/{ranking_eng.id}/order", json=payload)
+        assert response.status_code == 400
+
+    async def test_finalize_already_finalized_409(self, client, login, db, rank_users, ranking_eng):
+        ranking_eng.is_finalized = True
+        ranking_eng.ranking_status = "finalized"
+        await db.commit()
+
+        login(rank_users["college_eng"])
+        response = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/finalize")
+        assert response.status_code == 409
+
+    async def test_unfinalize_not_finalized_409(self, client, login, rank_users, ranking_eng):
+        login(rank_users["college_eng"])
+        response = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/unfinalize")
+        assert response.status_code == 409
+
+    async def test_import_excel_invalid_rank_422(self, client, login, rank_users, ranking_eng):
+        login(rank_users["college_eng"])
+        payload = [{"student_id": "S001", "student_name": "X", "rank_position": "X"}]
+        response = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/import-excel", json=payload)
+        assert response.status_code == 422
+
+    async def test_import_excel_duplicate_student_ids_422(
+        self, client, login, rank_users, ranking_eng, ranking_eng_items
+    ):
+        login(rank_users["college_eng"])
+        payload = [
+            {"student_id": "S001", "student_name": "A", "rank_position": 1},
+            {"student_id": "S001", "student_name": "A", "rank_position": 2},
+        ]
+        response = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/import-excel", json=payload)
+        assert response.status_code == 422
+
+    async def test_import_excel_unknown_student_422(self, client, login, rank_users, ranking_eng, ranking_eng_items):
+        login(rank_users["college_eng"])
+        payload = [
+            {"student_id": "S001", "student_name": "A", "rank_position": 1},
+            {"student_id": "S002", "student_name": "B", "rank_position": 2},
+            {"student_id": "S999", "student_name": "Ghost", "rank_position": 3},
+        ]
+        response = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/import-excel", json=payload)
+        assert response.status_code == 422
+
+
+@pytest.mark.api
+class TestRankingFlowAndEnvelope:
+    """Happy paths and the {success, message, data} envelope."""
+
+    async def test_get_detail_owner_200_envelope(self, client, login, rank_users, ranking_eng):
+        login(rank_users["college_eng"])
+        response = await client.get(f"{RANKINGS_URL}/{ranking_eng.id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) >= {"success", "message", "data"}
+        assert body["success"] is True
+        assert body["data"]["id"] == ranking_eng.id
+        assert body["data"]["ranking_name"] == "ENG nstc ranking"
+        assert body["data"]["items"] == []
+
+    async def test_update_ranking_name_200(self, client, login, rank_users, ranking_eng):
+        login(rank_users["college_eng"])
+        response = await client.put(f"{RANKINGS_URL}/{ranking_eng.id}", json={"ranking_name": "Renamed"})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["ranking_name"] == "Renamed"
+
+    async def test_finalize_then_unfinalize_flow(self, client, login, rank_users, ranking_eng):
+        login(rank_users["college_eng"])
+
+        finalized = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/finalize")
+        assert finalized.status_code == 200
+        body = finalized.json()
+        assert body["success"] is True
+        assert body["data"]["is_finalized"] is True
+        assert body["data"]["ranking_status"] == "finalized"
+
+        unfinalized = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/unfinalize")
+        assert unfinalized.status_code == 200
+        body = unfinalized.json()
+        assert body["data"]["is_finalized"] is False
+        assert body["data"]["ranking_status"] == "draft"
+
+    async def test_same_college_second_reviewer_can_finalize(self, client, login, rank_users, ranking_eng):
+        # College-owned rankings: any reviewer of the owning college may act.
+        login(rank_users["college_eng2"])
+        response = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/finalize")
+        assert response.status_code == 200
+
+    async def test_delete_ranking_200_and_gone(self, client, login, db, rank_users, ranking_eng):
+        login(rank_users["college_eng"])
+        response = await client.delete(f"{RANKINGS_URL}/{ranking_eng.id}")
+        assert response.status_code == 200
+        assert response.json()["data"]["ranking_id"] == ranking_eng.id
+
+        row = (await db.execute(select(CollegeRanking).where(CollegeRanking.id == ranking_eng.id))).scalar_one_or_none()
+        assert row is None
+
+    async def test_import_excel_happy_path(self, client, login, db, rank_users, ranking_eng, ranking_eng_items):
+        login(rank_users["college_eng"])
+        payload = [
+            {"student_id": "S002", "student_name": "Ranked Student 2", "rank_position": 1},
+            {"student_id": "S001", "student_name": "Ranked Student 1", "rank_position": "N"},
+        ]
+        response = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/import-excel", json=payload)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["updated_count"] == 2
+        assert body["data"]["rejected_count"] == 1
+
+        # S001 was marked "N": pushed after ranked students + college_rejected flag
+        await db.refresh(ranking_eng_items[0])
+        await db.refresh(ranking_eng_items[1])
+        assert ranking_eng_items[1].rank_position == 1  # S002 ranked first
+        assert ranking_eng_items[0].college_rejected is True
+        assert ranking_eng_items[0].rank_position == 2
+
+    async def test_order_update_happy_path(self, client, login, rank_users, ranking_eng, ranking_eng_items):
+        login(rank_users["college_eng"])
+        payload = [
+            {"item_id": ranking_eng_items[0].id, "position": 2},
+            {"item_id": ranking_eng_items[1].id, "position": 1},
+        ]
+        response = await client.put(f"{RANKINGS_URL}/{ranking_eng.id}/order", json=payload)
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    async def test_admin_export_excel_200(self, client, login, rank_users, ranking_sci):
+        login(rank_users["admin"])
+        response = await client.get(f"{RANKINGS_URL}/{ranking_sci.id}/export-excel")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith(XLSX_MIME)

--- a/backend/app/tests/test_reviews_endpoints.py
+++ b/backend/app/tests/test_reviews_endpoints.py
@@ -1,0 +1,442 @@
+"""
+HTTP-layer tests for the unified review endpoints (app/api/v1/endpoints/reviews.py).
+
+Focus (issue #1081 follow-up): authorization scoping, review-flow policy,
+input validation, and the {success, message, data} response envelope.
+
+These tests exercise the real FastAPI app over ASGI with the in-memory SQLite
+database from conftest. Authentication is simulated by overriding the
+`get_current_user` dependency with real DB-backed User rows so that all
+role-scoping logic downstream of authentication runs unmodified.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.models.application import Application, ApplicationStatus
+from app.models.scholarship import ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+
+REVIEWS_PREFIX = "/api/v1/reviews"
+
+
+def _submit_url(application_id: int) -> str:
+    return f"{REVIEWS_PREFIX}/applications/{application_id}/review"
+
+
+@pytest_asyncio.fixture
+async def login():
+    """Return a function that authenticates the test client as a given User.
+
+    Overrides the get_current_user dependency (auth layer) while leaving every
+    downstream role/permission check intact.
+    """
+    from app.core.security import get_current_user
+    from app.main import app
+
+    def _login(user: User) -> None:
+        async def _override():
+            return user
+
+        app.dependency_overrides[get_current_user] = _override
+
+    yield _login
+    from app.core.security import get_current_user as _gcu
+    from app.main import app as _app
+
+    _app.dependency_overrides.pop(_gcu, None)
+
+
+@pytest_asyncio.fixture
+async def review_users(db):
+    """Real DB users covering every role involved in the review flow."""
+    users = {
+        "student": User(
+            nycu_id="rev_student",
+            name="Review Student",
+            email="rev_student@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "other_student": User(
+            nycu_id="rev_student2",
+            name="Other Student",
+            email="rev_student2@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "professor": User(
+            nycu_id="rev_prof",
+            name="Review Professor",
+            email="rev_prof@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+        "unrelated_professor": User(
+            nycu_id="rev_prof2",
+            name="Unrelated Professor",
+            email="rev_prof2@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+        "college": User(
+            nycu_id="rev_college",
+            name="College Reviewer",
+            email="rev_college@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.college,
+            college_code="ENG",
+        ),
+        "admin": User(
+            nycu_id="rev_admin",
+            name="Review Admin",
+            email="rev_admin@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.admin,
+        ),
+    }
+    for user in users.values():
+        db.add(user)
+    await db.commit()
+    for user in users.values():
+        await db.refresh(user)
+    return users
+
+
+@pytest_asyncio.fixture
+async def review_scholarship(db) -> ScholarshipType:
+    scholarship = ScholarshipType(
+        code="rev_phd_scholarship",
+        name="Review Test Scholarship",
+        description="Scholarship used by review endpoint tests",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+    return scholarship
+
+
+@pytest_asyncio.fixture
+async def review_application(db, review_users, review_scholarship) -> Application:
+    """Application owned by `student` with two reviewable sub-types."""
+    application = Application(
+        app_id="APP-114-1-00001",
+        user_id=review_users["student"].id,
+        scholarship_type_id=review_scholarship.id,
+        sub_type_selection_mode=SubTypeSelectionMode.multiple,
+        status=ApplicationStatus.under_review.value,
+        academic_year=114,
+        semester="first",
+        scholarship_subtype_list=["nstc", "moe_1w"],
+        student_data={"std_stdcode": "310460031", "std_cname": "Review Student"},
+        submitted_form_data={},
+        agree_terms=True,
+    )
+    db.add(application)
+    await db.commit()
+    await db.refresh(application)
+    return application
+
+
+def _approve_items(*codes):
+    return {"items": [{"sub_type_code": code, "recommendation": "approve", "comments": None} for code in codes]}
+
+
+def _reject_items(*codes):
+    return {
+        "items": [{"sub_type_code": code, "recommendation": "reject", "comments": f"rejected {code}"} for code in codes]
+    }
+
+
+@pytest.mark.api
+class TestReviewsAuthorization:
+    """Authorization scoping for the unified review endpoints."""
+
+    async def test_submit_review_unauthenticated_401(self, client, review_application):
+        response = await client.post(_submit_url(review_application.id), json=_approve_items("nstc"))
+        assert response.status_code == 401
+        assert response.json()["success"] is False
+
+    async def test_get_application_reviews_unauthenticated_401(self, client, review_application):
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviews")
+        assert response.status_code == 401
+
+    async def test_student_cannot_submit_review(self, client, login, review_users, review_application):
+        login(review_users["student"])
+        response = await client.post(_submit_url(review_application.id), json=_approve_items("nstc"))
+        assert response.status_code == 403
+
+    async def test_student_cannot_create_review_via_reviews_endpoint(
+        self, client, login, review_users, review_application
+    ):
+        """POST /reviews has no explicit role gate; the student is stopped by the
+        reviewable-subtypes filter (unknown role -> empty list -> 403)."""
+        login(review_users["student"])
+        payload = {"application_id": review_application.id, **_approve_items("nstc")}
+        response = await client.post(f"{REVIEWS_PREFIX}/reviews", json=payload)
+        assert response.status_code == 403
+
+    async def test_security_gap_student_can_read_any_application_reviews(
+        self, client, login, review_users, review_application
+    ):
+        # SECURITY GAP (#1081): GET /applications/{id}/reviews only requires
+        # authentication. Any student (including one unrelated to the
+        # application) can read every reviewer's name, role, recommendation and
+        # comments for any application by enumerating IDs. Expected: students
+        # should be denied (or scoped to their own applications).
+        login(review_users["other_student"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviews")
+        assert response.status_code == 200  # pins current (vulnerable) behavior
+        assert response.json()["success"] is True
+
+    async def test_security_gap_student_can_read_review_status(self, client, login, review_users, review_application):
+        # SECURITY GAP (#1081): review-status leaks decision_reason and
+        # per-sub-type rejection details to any authenticated user.
+        login(review_users["other_student"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/review-status")
+        assert response.status_code == 200  # pins current (vulnerable) behavior
+        body = response.json()
+        assert body["success"] is True
+        assert "decision_reason" in body["data"]
+
+    async def test_security_gap_student_can_read_single_review(self, client, login, review_users, review_application):
+        # First create a review as professor.
+        login(review_users["professor"])
+        created = await client.post(
+            f"{REVIEWS_PREFIX}/reviews",
+            json={"application_id": review_application.id, **_approve_items("nstc", "moe_1w")},
+        )
+        assert created.status_code == 201
+        review_id = created.json()["data"]["id"]
+
+        # SECURITY GAP (#1081): GET /reviews/{id} has no role/ownership check —
+        # an unrelated student can read the full review record.
+        login(review_users["other_student"])
+        response = await client.get(f"{REVIEWS_PREFIX}/reviews/{review_id}")
+        assert response.status_code == 200  # pins current (vulnerable) behavior
+        assert response.json()["data"]["reviewer_name"] == "Review Professor"
+
+    async def test_security_gap_unrelated_professor_can_submit_review(
+        self, client, login, review_users, review_application
+    ):
+        # SECURITY GAP (#1081): the multi-role route POST /applications/{id}/review
+        # does not verify the professor-student advisor relationship (the
+        # /professor/... route does, via can_professor_submit_review). ANY
+        # professor can review ANY application here.
+        login(review_users["unrelated_professor"])
+        response = await client.post(_submit_url(review_application.id), json=_approve_items("nstc"))
+        assert response.status_code == 200  # pins current (vulnerable) behavior
+        assert response.json()["success"] is True
+
+    async def test_professor_submit_nonexistent_application_403(self, client, login, review_users):
+        # Current behavior: the submit route never 404s on a missing
+        # application — get_reviewable_subtypes returns [] and the sub-type
+        # check yields 403 instead.
+        login(review_users["professor"])
+        response = await client.post(_submit_url(999999), json=_approve_items("nstc"))
+        assert response.status_code == 403
+
+    async def test_college_cannot_review_professor_rejected_subtype(
+        self, client, login, review_users, review_application
+    ):
+        login(review_users["professor"])
+        rejected = await client.post(_submit_url(review_application.id), json=_reject_items("nstc", "moe_1w"))
+        assert rejected.status_code == 200
+
+        login(review_users["college"])
+        response = await client.post(_submit_url(review_application.id), json=_approve_items("nstc"))
+        assert response.status_code == 403
+
+    async def test_admin_reviewable_subtypes_empty_after_professor_reject(
+        self, client, login, review_users, review_application
+    ):
+        login(review_users["professor"])
+        rejected = await client.post(_submit_url(review_application.id), json=_reject_items("nstc", "moe_1w"))
+        assert rejected.status_code == 200
+
+        login(review_users["admin"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviewable-subtypes")
+        assert response.status_code == 200
+        assert response.json()["data"]["reviewable_subtypes"] == []
+
+
+@pytest.mark.api
+class TestReviewsPolicy:
+    """Review-flow policy: professor full-reject is terminal for the professor."""
+
+    async def test_professor_full_reject_sets_application_rejected(
+        self, client, login, db, review_users, review_application
+    ):
+        login(review_users["professor"])
+        response = await client.post(_submit_url(review_application.id), json=_reject_items("nstc", "moe_1w"))
+        assert response.status_code == 200
+        assert response.json()["data"]["recommendation"] == "reject"
+
+        await db.refresh(review_application)
+        assert review_application.status == ApplicationStatus.rejected
+
+    async def test_security_gap_professor_can_rereview_after_full_reject(
+        self, client, login, review_users, review_application
+    ):
+        # SECURITY GAP (#1081) / policy divergence: project policy says a
+        # professor full-reject is terminal — a second professor review must
+        # return 403. The /professor/applications/{id}/review route enforces
+        # this, but this unified multi-role route does not:
+        # get_reviewable_subtypes returns ALL sub-types for professors, so the
+        # professor can silently overwrite their terminal reject with an
+        # approve.
+        login(review_users["professor"])
+        first = await client.post(_submit_url(review_application.id), json=_reject_items("nstc", "moe_1w"))
+        assert first.status_code == 200
+
+        second = await client.post(_submit_url(review_application.id), json=_approve_items("nstc", "moe_1w"))
+        assert second.status_code == 200  # pins current behavior; policy says 403
+        assert second.json()["data"]["recommendation"] == "approve"
+
+    async def test_review_status_overall_rejected_after_full_reject(
+        self, client, login, review_users, review_application
+    ):
+        login(review_users["professor"])
+        rejected = await client.post(_submit_url(review_application.id), json=_reject_items("nstc", "moe_1w"))
+        assert rejected.status_code == 200
+
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/review-status")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["overall_status"] == "rejected"
+        assert set(data["subtype_statuses"].keys()) == {"nstc", "moe_1w"}
+
+
+@pytest.mark.api
+class TestReviewsValidation:
+    """Input validation and not-found handling."""
+
+    async def test_submit_review_empty_items_422(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        response = await client.post(_submit_url(review_application.id), json={"items": []})
+        assert response.status_code == 422
+        assert response.json()["success"] is False
+
+    async def test_submit_review_invalid_recommendation_422(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        payload = {"items": [{"sub_type_code": "nstc", "recommendation": "maybe"}]}
+        response = await client.post(_submit_url(review_application.id), json=payload)
+        assert response.status_code == 422
+
+    async def test_submit_review_missing_body_422(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        response = await client.post(_submit_url(review_application.id), json={})
+        assert response.status_code == 422
+
+    async def test_reject_without_comments_400(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        payload = {"items": [{"sub_type_code": "nstc", "recommendation": "reject", "comments": None}]}
+        response = await client.post(_submit_url(review_application.id), json=payload)
+        assert response.status_code == 400
+
+    async def test_submit_review_unknown_subtype_403(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        response = await client.post(_submit_url(review_application.id), json=_approve_items("not_a_subtype"))
+        assert response.status_code == 403
+
+    async def test_submit_review_invalid_application_id_400(self, client, login, review_users):
+        login(review_users["professor"])
+        response = await client.post(_submit_url(0), json=_approve_items("nstc"))
+        assert response.status_code == 400
+
+    async def test_create_review_nonexistent_application_404(self, client, login, review_users):
+        login(review_users["professor"])
+        payload = {"application_id": 999999, **_approve_items("nstc")}
+        response = await client.post(f"{REVIEWS_PREFIX}/reviews", json=payload)
+        assert response.status_code == 404
+
+    async def test_get_review_not_found_404(self, client, login, review_users):
+        login(review_users["admin"])
+        response = await client.get(f"{REVIEWS_PREFIX}/reviews/999999")
+        assert response.status_code == 404
+
+    async def test_get_application_reviews_not_found_404(self, client, login, review_users):
+        login(review_users["admin"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/999999/reviews")
+        assert response.status_code == 404
+
+    async def test_reviewable_subtypes_not_found_404(self, client, login, review_users):
+        login(review_users["professor"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/999999/reviewable-subtypes")
+        assert response.status_code == 404
+
+
+@pytest.mark.api
+class TestReviewsEnvelopeAndFlow:
+    """Happy-path behavior and the {success, message, data} envelope."""
+
+    async def test_professor_submit_review_envelope(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        response = await client.post(_submit_url(review_application.id), json=_approve_items("nstc", "moe_1w"))
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) >= {"success", "message", "data"}
+        assert body["success"] is True
+        data = body["data"]
+        assert data["application_id"] == review_application.id
+        assert data["reviewer_id"] == review_users["professor"].id
+        assert data["recommendation"] == "approve"
+        assert {item["sub_type_code"] for item in data["items"]} == {"nstc", "moe_1w"}
+
+    async def test_create_review_endpoint_201_envelope(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        payload = {"application_id": review_application.id, **_approve_items("nstc", "moe_1w")}
+        response = await client.post(f"{REVIEWS_PREFIX}/reviews", json=payload)
+        assert response.status_code == 201
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["reviewer_role"] in ("professor", "UserRole.professor")
+        assert len(body["data"]["items"]) == 2
+
+    async def test_subtype_code_is_normalized(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        payload = {"items": [{"sub_type_code": " NSTC ", "recommendation": "approve"}]}
+        response = await client.post(_submit_url(review_application.id), json=payload)
+        assert response.status_code == 200
+        items = response.json()["data"]["items"]
+        assert items[0]["sub_type_code"] == "nstc"
+
+    async def test_get_own_review_returns_null_when_absent(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        response = await client.get(_submit_url(review_application.id))
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"] is None
+
+    async def test_get_own_review_after_submit(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        submitted = await client.post(_submit_url(review_application.id), json=_approve_items("nstc"))
+        assert submitted.status_code == 200
+
+        response = await client.get(_submit_url(review_application.id))
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["reviewer_id"] == review_users["professor"].id
+        assert data["items"][0]["sub_type_code"] == "nstc"
+
+    async def test_reviewable_subtypes_professor_sees_all(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviewable-subtypes")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert sorted(data["reviewable_subtypes"]) == ["moe_1w", "nstc"]
+        assert sorted(data["all_subtypes"]) == ["moe_1w", "nstc"]
+
+    async def test_application_reviews_list_after_submit(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        submitted = await client.post(_submit_url(review_application.id), json=_approve_items("nstc", "moe_1w"))
+        assert submitted.status_code == 200
+
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviews")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert isinstance(body["data"], list)
+        assert len(body["data"]) == 1
+        assert body["data"][0]["reviewer_name"] == "Review Professor"


### PR DESCRIPTION
Adds endpoint-level tests (75) for the two largest untested endpoint modules — `reviews.py` (659L) and `college_review/ranking_management.py` (1503L) — with authorization boundaries first, per the #1081 audit. The new tests immediately exposed **two production bugs**, fixed in this PR.

## 🐛 Bug 1: multi-item reviews 500 everywhere (`reviews.py`, 4 sites)

All four `ApplicationReview` queries eager-load the `items` **collection** via `joinedload` but never call `.unique()`:
- `create_review` → 500 **after** `db.commit()` — the review IS created but the client gets an error (retry ⇒ duplicate-review confusion)
- both list/read endpoints → 500 on any review with 2+ sub-type items

Single-item reviews mask the bug, which is why it survived. Fix: `result.unique()` at all 4 sites.

## 🐛 Bug 2: ranking reorder 100% broken since the G8 audit block (`update_ranking_order`)

The #970 audit block reads `i["application_id"]` / `i.get("rank_position")` from `RankingOrderUpdate` — whose fields are `item_id` / `position`. **Every valid reorder request has 500'd (KeyError) since that block landed.** Fix: map `item_id → application_id` via the prior-rows query so `old_values`/`new_values` stay keyed consistently.

## 🔒 SECURITY GAP pins (current behavior documented, NOT changed — feeds #1081)

1. `GET /applications/{id}/reviews` — any authenticated **student** can read any application's reviews
2. `GET /applications/{id}/review-status` — leaks `decision_reason` etc. to students
3. `GET /reviews/{id}` — no role/ownership check at all
4. `POST /applications/{id}/review` — an **unrelated professor** (not the assigned one) can submit a review
5. Same route allows professor **re-review after full reject**, diverging from the documented terminal-reject policy (403 expected)

Each is a test named `test_security_gap_*` with a `# SECURITY GAP (#1081)` comment — when the gap is fixed, the test flips and tells you exactly what changed.

## Coverage map

- `test_reviews_endpoints.py` — create/read/list/status routes: student 403/401 walls, professor cross-application access, envelope shape, 422/404 validation
- `test_ranking_management_endpoints.py` — ranking CRUD/order/finalize: college_code scoping (cross-college 403 incl. delete), deadline guard, already-finalized 409, order-update happy path (the test that caught bug 2), envelope shape

## Verification

- 75/75 new tests pass in the dev container
- 303 passed across related existing review/college/ranking/audit-invariant files (no regression from the 2 source fixes)
- black + flake8 (B904/B014/F401) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFNCV4rmmoie3jsTFMMFth