### PR TITLE
fix(frontend): FileUpload drops selected files + leaks blob URLs (#1096)

### DIFF
--- a/frontend/components/__tests__/dev-login-page.test.tsx
+++ b/frontend/components/__tests__/dev-login-page.test.tsx
@@ -252,6 +252,48 @@ describe("DevLoginPage Component", () => {
     });
   });
 
+  it("should show 'Logging in...' and disable buttons while login is in flight, clearing on failure (issue #1096)", async () => {
+    // Hold the login promise open so the in-flight state is observable.
+    let rejectLogin!: (err: Error) => void;
+    mockSSOLoginSpy.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectLogin = reject;
+        })
+    );
+    render(<DevLoginPage />);
+
+    const studentButton = await screen.findByRole("button", {
+      name: "Login as Student",
+    });
+    fireEvent.click(studentButton);
+
+    // The clicked card's button flips to the in-flight label and every
+    // login button disables while isLoggingIn is set.
+    const inFlightButton = await screen.findByRole("button", {
+      name: "Logging in...",
+    });
+    expect(inFlightButton).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Login as Professor" })
+    ).toBeDisabled();
+
+    // Fail the login: isLoggingIn/selectedUser clear and buttons re-enable.
+    rejectLogin(new Error("Failed to fetch"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Backend server is not running or not accessible/)
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: "Login as Student" })
+    ).not.toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Logging in..." })
+    ).not.toBeInTheDocument();
+  });
+
   it("should reload the user list via Refresh Users button", async () => {
     render(<DevLoginPage />);
 

--- a/frontend/components/__tests__/file-upload.test.tsx
+++ b/frontend/components/__tests__/file-upload.test.tsx
@@ -49,14 +49,13 @@ function getRowButtons() {
   return { previewButton: buttons[0], removeButton: buttons[1] };
 }
 
-// NOTE: every real caller passes `initialFiles` (controlled usage, echoing
-// onFilesChange back into the prop). When the prop is OMITTED, the default
-// `initialFiles = []` parameter creates a fresh array per render, so the
-// sync-useEffect re-runs after an internal setFiles and WIPES the freshly
-// selected files from the list (component bug for uncontrolled usage —
-// see final report). Tests that assert the rendered list after selection
-// therefore pass a stable empty array, mirroring real usage.
-const STABLE_EMPTY_FILES: File[] = [];
+// NOTE (issue #1096 bug 1, FIXED): the default `initialFiles = []` parameter
+// used to create a fresh array identity per render, so the sync-useEffect
+// re-ran after any internal setFiles and WIPED freshly selected files in
+// uncontrolled usage (prop omitted). The component now defaults to a stable
+// module-scope EMPTY_FILES constant, so tests no longer need to pass a
+// stable empty array as a workaround — uncontrolled usage is covered by a
+// dedicated regression test below.
 
 describe("FileUpload Component", () => {
   let mockOnFilesChange: jest.Mock;
@@ -87,10 +86,7 @@ describe("FileUpload Component", () => {
 
   it("should handle file selection via input", () => {
     const { container } = render(
-      <FileUpload
-        onFilesChange={mockOnFilesChange}
-        initialFiles={STABLE_EMPTY_FILES}
-      />
+      <FileUpload onFilesChange={mockOnFilesChange} />
     );
 
     const file = new File(["content"], "test.pdf", {
@@ -100,6 +96,23 @@ describe("FileUpload Component", () => {
 
     expect(mockOnFilesChange).toHaveBeenCalledWith([file]);
     expect(screen.getByText("test.pdf")).toBeInTheDocument();
+  });
+
+  it("should keep a selected file listed in uncontrolled usage (issue #1096 bug 1 regression)", () => {
+    // No initialFiles prop at all: before the fix, the fresh-[] default
+    // re-triggered the sync effect after selection and wiped the list.
+    const { container } = render(
+      <FileUpload onFilesChange={mockOnFilesChange} />
+    );
+
+    const file = new File(["content"], "keep-me.pdf", {
+      type: "application/pdf",
+    });
+    selectFiles(getFileInput(container), [file]);
+
+    expect(mockOnFilesChange).toHaveBeenCalledWith([file]);
+    expect(screen.getByText("keep-me.pdf")).toBeInTheDocument();
+    expect(screen.getByText(/\(1\/5\)/)).toBeInTheDocument();
   });
 
   it("should handle drag and drop", () => {
@@ -153,11 +166,7 @@ describe("FileUpload Component", () => {
 
   it("should enforce the max files limit", () => {
     const { container } = render(
-      <FileUpload
-        onFilesChange={mockOnFilesChange}
-        maxFiles={2}
-        initialFiles={STABLE_EMPTY_FILES}
-      />
+      <FileUpload onFilesChange={mockOnFilesChange} maxFiles={2} />
     );
 
     const files = [
@@ -243,10 +252,7 @@ describe("FileUpload Component", () => {
 
     try {
       const { container } = render(
-        <FileUpload
-          onFilesChange={mockOnFilesChange}
-          initialFiles={STABLE_EMPTY_FILES}
-        />
+        <FileUpload onFilesChange={mockOnFilesChange} />
       );
 
       const file = new File(["content"], "test.pdf", {
@@ -311,6 +317,34 @@ describe("FileUpload Component", () => {
     expect(screen.getByText("Preview: test.pdf")).toBeInTheDocument();
     expect(screen.getByText("Type: application/pdf")).toBeInTheDocument();
     expect(screen.getByText("URL: blob:mock-object-url")).toBeInTheDocument();
+  });
+
+  it("should revoke preview object URLs on unmount (issue #1096 bug 2 regression)", () => {
+    // The old code used a useState lazy initializer as if it were useEffect;
+    // React never runs a returned "cleanup" from an initializer, so blob
+    // URLs created for previews leaked. Now a real useEffect revokes them.
+    const initialFiles = [
+      new File(["content"], "test.pdf", { type: "application/pdf" }),
+    ];
+
+    const { unmount } = render(
+      <FileUpload
+        onFilesChange={mockOnFilesChange}
+        initialFiles={initialFiles}
+      />
+    );
+
+    const { previewButton } = getRowButtons();
+    fireEvent.click(previewButton);
+
+    expect(global.URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(global.URL.revokeObjectURL).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith(
+      "blob:mock-object-url"
+    );
   });
 
   it("should prefer the server url for previously-uploaded files in preview", () => {

--- a/frontend/components/dev-login-page.tsx
+++ b/frontend/components/dev-login-page.tsx
@@ -161,6 +161,11 @@ export function DevLoginPage() {
   const handleUserLogin = async (user: MockUser) => {
     logger.debug("Calling mock SSO login API", { nycu_id: user.nycu_id });
 
+    // Issue #1096 bonus: these setters were never called, so the
+    // "Logging in..." label and button-disable below could never trigger.
+    setSelectedUser(user.id);
+    setIsLoggingIn(true);
+
     try {
       const response = await api.auth.mockSSOLogin(user.nycu_id);
       logger.debug("Mock SSO login response received", {

--- a/frontend/components/file-upload.tsx
+++ b/frontend/components/file-upload.tsx
@@ -34,12 +34,20 @@ interface FileUploadProps {
   locale?: Locale; // 添加語言支持
 }
 
+// UNCONTROLLED-USAGE FIX (issue #1096):
+// The default must be a stable module-scope constant. A literal `[]` default
+// parameter creates a fresh array identity every render, so the sync-effect
+// below (keyed on `initialFiles`) re-fires after every internal `setFiles`
+// and wipes a just-selected file back to []. With a stable identity the
+// effect only runs on mount for uncontrolled usage.
+const EMPTY_FILES: File[] = [];
+
 export function FileUpload({
   onFilesChange,
   acceptedTypes = [".pdf", ".jpg", ".jpeg", ".png"],
   maxSize = 10 * 1024 * 1024, // 10MB
   maxFiles = 5,
-  initialFiles = [],
+  initialFiles = EMPTY_FILES,
   fileType = "",
   locale = "zh",
 }: FileUploadProps) {
@@ -77,12 +85,13 @@ export function FileUpload({
   // 初始化和同步外部文件
   //
   // INFINITE-LOOP FIX (PR #509):
-  // The default `initialFiles = []` parameter creates a fresh array
-  // reference on every render. With a naive `setFiles([...initialFiles])`,
-  // this useEffect would fire every render, schedule a state update,
-  // trigger another render, and loop indefinitely. Compare contents
-  // before setting state — if they match, return the previous reference
-  // so React's bailout breaks the cycle.
+  // If a controlled parent recreates the `initialFiles` array every render,
+  // a naive `setFiles([...initialFiles])` here would fire every render,
+  // schedule a state update, trigger another render, and loop indefinitely.
+  // Compare contents before setting state — if they match, return the
+  // previous reference so React's bailout breaks the cycle. (Uncontrolled
+  // usage is covered by the stable EMPTY_FILES default above, which keeps
+  // this effect from re-firing at all.)
   useEffect(() => {
     setFiles((prev) => {
       if (
@@ -224,6 +233,9 @@ export function FileUpload({
     return "other";
   };
 
+  // Blob object URLs created for previews — revoked on unmount (issue #1096).
+  const createdObjectUrlsRef = useRef<string[]>([]);
+
   // 處理文件預覽
   const handleFilePreview = (file: File) => {
     const previewUrl = getFilePreviewUrl(file);
@@ -231,6 +243,11 @@ export function FileUpload({
       // No previewable URL (e.g. a restored file lacking a same-origin path);
       // nothing to show, and opening the dialog with an empty src renders blank.
       return;
+    }
+    if (previewUrl.startsWith("blob:")) {
+      // Object URL freshly created by resolveFilePreviewUrl — remember it so
+      // the unmount effect below can revoke it.
+      createdObjectUrlsRef.current.push(previewUrl);
     }
     const fileType = getFileType(file);
 
@@ -249,16 +266,15 @@ export function FileUpload({
     }
   }, []);
 
-  // 組件卸載時清理臨時URL
-  useState(() => {
+  // 組件卸載時清理臨時URL (issue #1096: this was previously a `useState`
+  // lazy initializer whose returned "cleanup" React never invoked — the
+  // object URLs created for previews leaked for the lifetime of the page).
+  useEffect(() => {
     return () => {
-      files.forEach(file => {
-        if (!isUploadedFile(file)) {
-          cleanupTempUrl(URL.createObjectURL(file));
-        }
-      });
+      createdObjectUrlsRef.current.forEach(cleanupTempUrl);
+      createdObjectUrlsRef.current = [];
     };
-  });
+  }, [cleanupTempUrl]);
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
Closes #1096.

## Bug 1 — uncontrolled usage wipes just-selected files
`initialFiles = []` default parameter → fresh array identity every render → the PR #509 sync-effect (keyed on `initialFiles`) re-fires after every internal `setFiles` and resets state to `[]`. A user-selected file vanishes from the list immediately (parent still received `onFilesChange`, so form state and UI disagree).
**Fix:** stable module-scope `EMPTY_FILES` default. The effect now only runs on mount for uncontrolled usage. All 5 production call sites pass `initialFiles` (controlled) — unaffected.

## Bug 2 — blob object-URL leak (`useState` used as `useEffect`)
The unmount cleanup lived in a `useState(() => { ... return cleanup })` lazy initializer — React never invokes that returned function. Worse, the "cleanup" called `URL.createObjectURL(file)` **again**, revoking brand-new URLs and never the real preview ones.
**Fix:** proper `useEffect`; track the actually-created object URLs in a ref and revoke exactly those on unmount.

## Bonus — dev-login-page vestigial state
`isLoggingIn` / `selectedUser` setters were never called → the "Logging in..." label + button-disable were dead code. Wired into the login click handler.

## Verification
- `file-upload.test.tsx` adds a no-`initialFiles` "selection persists" test (proves bug 1 fixed)
- 36 tests across the two suites pass; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFNCV4rmmoie3jsTFMMFth