### PR TITLE
fix(reviews): enforce authorization scoping on review endpoints (#1081 A/B)

### DIFF
--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import joinedload
 
 from app.core.security import get_current_user
 from app.db.deps import get_db
-from app.models.application import Application
+from app.models.application import Application, ApplicationStatus
 from app.models.audit_log import AuditAction
 from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.user import User
@@ -28,6 +28,37 @@ from app.services.review_service import ReviewService
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _assert_review_submission_allowed(current_user: User, application: Application) -> None:
+    """Role-scoped review-submission guard (#1081).
+
+    - Students are never reviewers.
+    - A professor may only review an application where they are the assigned
+      professor (``application.professor_id``).
+    - A professor full-reject is terminal for the professor (Review-Flow
+      Policy): once the application is rejected, only college/admin may
+      revert it (回發) — the professor cannot re-review here.
+    - College/admin/super_admin behavior is unchanged (sub-type filtering
+      still applies downstream via get_reviewable_subtypes).
+    """
+    if current_user.is_student():
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="學生無權提交審查")
+
+    if current_user.is_professor():
+        if application.professor_id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="您不是此申請的指導教授，無權審查此申請",
+            )
+        # Compare against enum AND its .value: a SQLite-loaded status can come
+        # back as the raw string, so the bare `== enum` check silently missed
+        # the terminal-reject state (matches can_professor_submit_review).
+        if application.status in (ApplicationStatus.rejected, ApplicationStatus.rejected.value):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="申請已被拒絕，教授無法再次審查（僅學院或管理員可回發）",
+            )
 
 
 @router.post("/reviews", status_code=status.HTTP_201_CREATED)
@@ -51,6 +82,9 @@ async def create_review(
     application = await db.get(Application, review_data.application_id)
     if not application:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="申請不存在")
+
+    # 授權範圍 (#1081)：學生不得審查；教授僅限其指導的申請，且教授全部拒絕後不得再審。
+    _assert_review_submission_allowed(current_user, application)
 
     # 取得可審查的子項目
     reviewable_subtypes = await review_service.get_reviewable_subtypes(review_data.application_id, current_user.role)
@@ -181,6 +215,15 @@ async def get_review(
     if not review:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="審查記錄不存在")
 
+    # 授權範圍 (#1081)：admin/super_admin/college 可讀；教授僅限自己提交的審查或其
+    # 指導的申請；學生不得讀取。
+    if current_user.is_student():
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="學生無權讀取審查記錄")
+    if current_user.is_professor() and review.reviewer_id != current_user.id:
+        application = await db.get(Application, review.application_id)
+        if not application or application.professor_id != current_user.id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="您無權讀取此審查記錄")
+
     return {
         "success": True,
         "message": "審查記錄取得成功",
@@ -221,6 +264,13 @@ async def get_application_reviews(
     application = await db.get(Application, application_id)
     if not application:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="申請不存在")
+
+    # 授權範圍 (#1081)：admin/super_admin/college 可讀；教授僅限其指導的申請；
+    # 學生不得讀取完整審查記錄（學生使用 review-status 查詢自身進度）。
+    if current_user.is_student():
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="學生無權讀取審查記錄")
+    if current_user.is_professor() and application.professor_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="您不是此申請的指導教授，無權讀取審查記錄")
 
     # 查詢所有審查記錄
     stmt = (
@@ -283,6 +333,10 @@ async def get_application_review_status(
     application = await db.get(Application, application_id)
     if not application:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="申請不存在")
+
+    # 授權範圍 (#1081)：學生僅能查詢自己的申請；教授/學院/管理員維持原行為。
+    if current_user.is_student() and application.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="您無權查詢此申請的審查狀態")
 
     # 取得子項目累積狀態
     subtype_statuses = await review_service.get_subtype_cumulative_status(application_id)
@@ -436,6 +490,27 @@ async def submit_application_review(
     # Validate application_id
     if application_id <= 0:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid application ID")
+
+    # Authorization scoping (#1081): a professor may only review an application
+    # where they are the assigned professor, and a professor full-reject is
+    # terminal (they cannot re-review a rejected application here). College/
+    # admin/super_admin behavior is unchanged. A missing application yields 403
+    # for professors (consistent with the sub-type filter that returns []).
+    if current_user.is_professor():
+        application = await db.get(Application, application_id)
+        if not application or application.professor_id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="您不是此申請的指導教授，無權審查此申請",
+            )
+        # Compare against enum AND its .value: a SQLite-loaded status can come
+        # back as the raw string, so the bare `== enum` check silently missed
+        # the terminal-reject state (matches can_professor_submit_review).
+        if application.status in (ApplicationStatus.rejected, ApplicationStatus.rejected.value):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="申請已被拒絕，教授無法再次審查（僅學院或管理員可回發）",
+            )
 
     try:
         # Use unified ReviewService for creating/updating reviews

--- a/backend/app/tests/test_reviews_endpoints.py
+++ b/backend/app/tests/test_reviews_endpoints.py
@@ -122,6 +122,7 @@ async def review_application(db, review_users, review_scholarship) -> Applicatio
     application = Application(
         app_id="APP-114-1-00001",
         user_id=review_users["student"].id,
+        professor_id=review_users["professor"].id,
         scholarship_type_id=review_scholarship.id,
         sub_type_selection_mode=SubTypeSelectionMode.multiple,
         status=ApplicationStatus.under_review.value,
@@ -176,31 +177,67 @@ class TestReviewsAuthorization:
         response = await client.post(f"{REVIEWS_PREFIX}/reviews", json=payload)
         assert response.status_code == 403
 
-    async def test_security_gap_student_can_read_any_application_reviews(
-        self, client, login, review_users, review_application
-    ):
-        # SECURITY GAP (#1081): GET /applications/{id}/reviews only requires
-        # authentication. Any student (including one unrelated to the
-        # application) can read every reviewer's name, role, recommendation and
-        # comments for any application by enumerating IDs. Expected: students
-        # should be denied (or scoped to their own applications).
+    async def test_student_cannot_read_application_reviews(self, client, login, review_users, review_application):
+        # Enforced rule (#1081): students may not read the full reviews list for
+        # any application (they use review-status for their own progress).
         login(review_users["other_student"])
         response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviews")
-        assert response.status_code == 200  # pins current (vulnerable) behavior
+        assert response.status_code == 403
+
+    async def test_owning_student_cannot_read_application_reviews(
+        self, client, login, review_users, review_application
+    ):
+        # Enforced rule (#1081): even the owning student is denied the full
+        # reviews list — students only get review-status.
+        login(review_users["student"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviews")
+        assert response.status_code == 403
+
+    async def test_assigned_professor_can_read_application_reviews(
+        self, client, login, review_users, review_application
+    ):
+        # Enforced rule (#1081): the application's assigned professor may read
+        # its reviews.
+        login(review_users["professor"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviews")
+        assert response.status_code == 200
         assert response.json()["success"] is True
 
-    async def test_security_gap_student_can_read_review_status(self, client, login, review_users, review_application):
-        # SECURITY GAP (#1081): review-status leaks decision_reason and
-        # per-sub-type rejection details to any authenticated user.
+    async def test_unrelated_professor_cannot_read_application_reviews(
+        self, client, login, review_users, review_application
+    ):
+        # Enforced rule (#1081): a professor who is not the assigned advisor may
+        # not read another application's reviews.
+        login(review_users["unrelated_professor"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviews")
+        assert response.status_code == 403
+
+    async def test_college_can_read_application_reviews(self, client, login, review_users, review_application):
+        login(review_users["college"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/reviews")
+        assert response.status_code == 200
+
+    async def test_student_cannot_read_other_application_review_status(
+        self, client, login, review_users, review_application
+    ):
+        # Enforced rule (#1081): a student may query review-status ONLY for their
+        # own application; another student's application is denied.
         login(review_users["other_student"])
         response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/review-status")
-        assert response.status_code == 200  # pins current (vulnerable) behavior
+        assert response.status_code == 403
+
+    async def test_owning_student_can_read_own_review_status(self, client, login, review_users, review_application):
+        # Enforced rule (#1081): the owning student CAN read their own
+        # review-status (progress display).
+        login(review_users["student"])
+        response = await client.get(f"{REVIEWS_PREFIX}/applications/{review_application.id}/review-status")
+        assert response.status_code == 200
         body = response.json()
         assert body["success"] is True
         assert "decision_reason" in body["data"]
 
-    async def test_security_gap_student_can_read_single_review(self, client, login, review_users, review_application):
-        # First create a review as professor.
+    async def test_student_cannot_read_single_review(self, client, login, review_users, review_application):
+        # First create a review as the assigned professor.
         login(review_users["professor"])
         created = await client.post(
             f"{REVIEWS_PREFIX}/reviews",
@@ -209,24 +246,64 @@ class TestReviewsAuthorization:
         assert created.status_code == 201
         review_id = created.json()["data"]["id"]
 
-        # SECURITY GAP (#1081): GET /reviews/{id} has no role/ownership check —
-        # an unrelated student can read the full review record.
+        # Enforced rule (#1081): GET /reviews/{id} denies students.
         login(review_users["other_student"])
         response = await client.get(f"{REVIEWS_PREFIX}/reviews/{review_id}")
-        assert response.status_code == 200  # pins current (vulnerable) behavior
+        assert response.status_code == 403
+
+    async def test_unrelated_professor_cannot_read_single_review(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        created = await client.post(
+            f"{REVIEWS_PREFIX}/reviews",
+            json={"application_id": review_application.id, **_approve_items("nstc", "moe_1w")},
+        )
+        assert created.status_code == 201
+        review_id = created.json()["data"]["id"]
+
+        # Enforced rule (#1081): a professor who neither authored the review nor
+        # advises the application is denied.
+        login(review_users["unrelated_professor"])
+        response = await client.get(f"{REVIEWS_PREFIX}/reviews/{review_id}")
+        assert response.status_code == 403
+
+    async def test_admin_can_read_single_review(self, client, login, review_users, review_application):
+        login(review_users["professor"])
+        created = await client.post(
+            f"{REVIEWS_PREFIX}/reviews",
+            json={"application_id": review_application.id, **_approve_items("nstc", "moe_1w")},
+        )
+        assert created.status_code == 201
+        review_id = created.json()["data"]["id"]
+
+        login(review_users["admin"])
+        response = await client.get(f"{REVIEWS_PREFIX}/reviews/{review_id}")
+        assert response.status_code == 200
         assert response.json()["data"]["reviewer_name"] == "Review Professor"
 
-    async def test_security_gap_unrelated_professor_can_submit_review(
-        self, client, login, review_users, review_application
-    ):
-        # SECURITY GAP (#1081): the multi-role route POST /applications/{id}/review
-        # does not verify the professor-student advisor relationship (the
-        # /professor/... route does, via can_professor_submit_review). ANY
-        # professor can review ANY application here.
+    async def test_unrelated_professor_cannot_submit_review(self, client, login, review_users, review_application):
+        # Enforced rule (#1081): the multi-role route POST /applications/{id}/review
+        # verifies the professor is the application's assigned advisor. An
+        # unrelated professor is denied.
         login(review_users["unrelated_professor"])
         response = await client.post(_submit_url(review_application.id), json=_approve_items("nstc"))
-        assert response.status_code == 200  # pins current (vulnerable) behavior
+        assert response.status_code == 403
+
+    async def test_assigned_professor_can_submit_review(self, client, login, review_users, review_application):
+        # Enforced rule (#1081): the assigned professor CAN still submit.
+        login(review_users["professor"])
+        response = await client.post(_submit_url(review_application.id), json=_approve_items("nstc"))
+        assert response.status_code == 200
         assert response.json()["success"] is True
+
+    async def test_unrelated_professor_cannot_create_review_via_reviews_endpoint(
+        self, client, login, review_users, review_application
+    ):
+        # Enforced rule (#1081): POST /reviews also verifies the advisor
+        # relationship for professors.
+        login(review_users["unrelated_professor"])
+        payload = {"application_id": review_application.id, **_approve_items("nstc")}
+        response = await client.post(f"{REVIEWS_PREFIX}/reviews", json=payload)
+        assert response.status_code == 403
 
     async def test_professor_submit_nonexistent_application_403(self, client, login, review_users):
         # Current behavior: the submit route never 404s on a missing
@@ -275,23 +352,19 @@ class TestReviewsPolicy:
         await db.refresh(review_application)
         assert review_application.status == ApplicationStatus.rejected
 
-    async def test_security_gap_professor_can_rereview_after_full_reject(
-        self, client, login, review_users, review_application
-    ):
-        # SECURITY GAP (#1081) / policy divergence: project policy says a
-        # professor full-reject is terminal — a second professor review must
-        # return 403. The /professor/applications/{id}/review route enforces
-        # this, but this unified multi-role route does not:
-        # get_reviewable_subtypes returns ALL sub-types for professors, so the
-        # professor can silently overwrite their terminal reject with an
-        # approve.
+    async def test_professor_cannot_rereview_after_full_reject(self, client, login, review_users, review_application):
+        # Review-Flow Policy (#1081): a professor full-reject is terminal — the
+        # second professor review on this unified multi-role route must now be
+        # rejected with 403 (mirrors the /professor/applications/{id}/review
+        # route). Previously get_reviewable_subtypes returned ALL sub-types for
+        # professors, letting them silently overwrite a terminal reject.
         login(review_users["professor"])
         first = await client.post(_submit_url(review_application.id), json=_reject_items("nstc", "moe_1w"))
         assert first.status_code == 200
 
         second = await client.post(_submit_url(review_application.id), json=_approve_items("nstc", "moe_1w"))
-        assert second.status_code == 200  # pins current behavior; policy says 403
-        assert second.json()["data"]["recommendation"] == "approve"
+        assert second.status_code == 403
+        assert second.json()["success"] is False
 
     async def test_review_status_overall_rejected_after_full_reject(
         self, client, login, review_users, review_application


### PR DESCRIPTION
Closes the 5 `test_security_gap_*` pins from PR #1103 — the reviews.py findings (A + B) of the #1081 security audit. Each is a parallel review endpoint that reached evaluative data / mutation with only a role check while a sibling route (professor.py) scoped correctly.

## Fixes

| Endpoint | Before | After |
|---|---|---|
| `GET /applications/{id}/reviews` | any authenticated user (incl. students) reads any application's full review trail | students 403; professor only if assigned; college/admin unchanged |
| `GET /applications/{id}/review-status` | leaks `decision_reason` + rejector identity to any student | student may query only their own application |
| `GET /reviews/{id}` | no role/ownership check at all | students 403; professor only if `reviewer_id` theirs or assigned professor |
| `POST /reviews` and `POST /applications/{id}/review` | an **unrelated professor** could approve/reject any application | professor only where `professor_id == current_user.id` |
| terminal-reject | professor could re-review (approve-over-reject) after full reject via these multi-role routes | 403 — mirrors the `/professor/...` route |

The terminal-reject check compares status against the enum **and** its `.value` — a SQLite-loaded status comes back as the raw string, which the bare `== enum` check silently missed (this was the one test that initially still returned 200).

## Tests

The 5 pinned `test_security_gap_*` tests are flipped to assert the enforced 403 and renamed; positive-path tests confirm the assigned professor / owning student / college / admin still succeed.

## Frontend impact: none

No non-generated frontend code calls `review-status`, `GET /reviews/{id}`, or the list-reviews endpoint (grep-verified); only admin/college call `/review` and `/sub-types`, which are unaffected.

## Verification

- 40/40 `test_reviews_endpoints.py` pass
- 44 passed across `can_professor_*` / `college_review` / audit-invariant regression files
- black + flake8 (B904/B014/F401) clean
- Verified on the host venv with CI's in-memory SQLite (the local Docker daemon was wedged this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFNCV4rmmoie3jsTFMMFth