### PR TITLE
test(api): HTTP-layer tests for roster_schedules + document_requests + professor_student (69 tests)

### DIFF
--- a/backend/app/tests/test_document_requests_endpoints.py
+++ b/backend/app/tests/test_document_requests_endpoints.py
@@ -1,0 +1,353 @@
+"""
+HTTP-layer tests for the document-request endpoints
+(app/api/v1/endpoints/document_requests.py).
+
+Focus: authorization boundaries (staff-only create/list/cancel vs student-only
+my-requests/fulfill), ownership scoping (a student may only fulfill requests on
+their own applications), input validation, not-found handling, and the
+{success, message, data} response envelope.
+
+The document-request router resolves auth via `app.core.security` role
+dependencies (require_staff / require_student), all of which depend on
+`app.core.security.get_current_user`; the login fixture overrides that.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from app.models.application import Application, ApplicationStatus
+from app.models.document_request import DocumentRequest, DocumentRequestStatus
+from app.models.scholarship import ScholarshipType, SubTypeSelectionMode
+from app.models.user import User, UserRole, UserType
+
+PREFIX = "/api/v1"
+
+
+@pytest_asyncio.fixture
+async def login():
+    """Authenticate the test client as a given User by overriding get_current_user."""
+    from app.core.security import get_current_user
+    from app.main import app
+
+    def _login(user: User) -> None:
+        async def _override():
+            return user
+
+        app.dependency_overrides[get_current_user] = _override
+
+    yield _login
+
+    from app.core.security import get_current_user as _gcu
+    from app.main import app as _app
+
+    _app.dependency_overrides.pop(_gcu, None)
+
+
+@pytest_asyncio.fixture
+async def doc_users(db):
+    users = {
+        "student": User(
+            nycu_id="dr_student",
+            name="Doc Student",
+            email="dr_student@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "other_student": User(
+            nycu_id="dr_student2",
+            name="Other Doc Student",
+            email="dr_student2@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "professor": User(
+            nycu_id="dr_prof",
+            name="Doc Professor",
+            email="dr_prof@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+        "college": User(
+            nycu_id="dr_college",
+            name="Doc College",
+            email="dr_college@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.college,
+            college_code="ENG",
+        ),
+        "admin": User(
+            nycu_id="dr_admin",
+            name="Doc Admin",
+            email="dr_admin@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.admin,
+        ),
+    }
+    for user in users.values():
+        db.add(user)
+    await db.commit()
+    for user in users.values():
+        await db.refresh(user)
+    return users
+
+
+@pytest_asyncio.fixture
+async def doc_scholarship(db) -> ScholarshipType:
+    scholarship = ScholarshipType(
+        code="dr_scholarship",
+        name="Doc Request Scholarship",
+        description="For document request endpoint tests",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+    return scholarship
+
+
+@pytest_asyncio.fixture
+async def student_application(db, doc_users, doc_scholarship) -> Application:
+    """Application owned by `student`."""
+    application = Application(
+        app_id="APP-114-1-00010",
+        user_id=doc_users["student"].id,
+        scholarship_type_id=doc_scholarship.id,
+        scholarship_name="Doc Request Scholarship",
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        status=ApplicationStatus.under_review.value,
+        academic_year=114,
+        semester="first",
+        student_data={"std_cname": "Doc Student", "email": "dr_student@test.edu"},
+        submitted_form_data={},
+        agree_terms=True,
+    )
+    db.add(application)
+    await db.commit()
+    await db.refresh(application)
+    return application
+
+
+async def _make_request(db, application, requester, status=DocumentRequestStatus.pending.value) -> DocumentRequest:
+    doc_req = DocumentRequest(
+        application_id=application.id,
+        requested_by_id=requester.id,
+        requested_at=datetime.now(timezone.utc),
+        requested_documents=["transcript"],
+        reason="Need the transcript to verify GPA",
+        status=status,
+    )
+    db.add(doc_req)
+    await db.commit()
+    await db.refresh(doc_req)
+    return doc_req
+
+
+def _create_body(**overrides) -> dict:
+    body = {
+        "requested_documents": ["transcript", "recommendation_letter"],
+        "reason": "Need supplementary documents to verify eligibility",
+    }
+    body.update(overrides)
+    return body
+
+
+def _app_dr_url(application_id: int) -> str:
+    return f"{PREFIX}/applications/{application_id}/document-requests"
+
+
+@pytest.mark.api
+class TestDocumentRequestsAuthorization:
+    """Staff-only vs student-only route gating."""
+
+    async def test_create_unauthenticated_401(self, client, student_application):
+        response = await client.post(_app_dr_url(student_application.id), json=_create_body())
+        assert response.status_code == 401
+
+    async def test_create_student_forbidden(self, client, login, doc_users, student_application):
+        # create is require_staff; a student may not request documents.
+        login(doc_users["student"])
+        response = await client.post(_app_dr_url(student_application.id), json=_create_body())
+        assert response.status_code == 403
+
+    async def test_list_unauthenticated_401(self, client, student_application):
+        response = await client.get(_app_dr_url(student_application.id))
+        assert response.status_code == 401
+
+    async def test_list_student_forbidden(self, client, login, doc_users, student_application):
+        login(doc_users["student"])
+        response = await client.get(_app_dr_url(student_application.id))
+        assert response.status_code == 403
+
+    async def test_my_requests_unauthenticated_401(self, client):
+        response = await client.get(f"{PREFIX}/document-requests/my-requests")
+        assert response.status_code == 401
+
+    async def test_my_requests_staff_forbidden(self, client, login, doc_users):
+        # my-requests is require_student; staff may not use it.
+        login(doc_users["professor"])
+        response = await client.get(f"{PREFIX}/document-requests/my-requests")
+        assert response.status_code == 403
+
+    async def test_fulfill_staff_forbidden(self, client, login, db, doc_users, student_application):
+        doc_req = await _make_request(db, student_application, doc_users["professor"])
+        # fulfill is require_student; a staff member may not fulfill.
+        login(doc_users["admin"])
+        response = await client.patch(f"{PREFIX}/document-requests/{doc_req.id}/fulfill", json={})
+        assert response.status_code == 403
+
+    async def test_cancel_student_forbidden(self, client, login, db, doc_users, student_application):
+        doc_req = await _make_request(db, student_application, doc_users["professor"])
+        # cancel is require_staff; a student may not cancel.
+        login(doc_users["student"])
+        response = await client.patch(
+            f"{PREFIX}/document-requests/{doc_req.id}/cancel",
+            json={"cancellation_reason": "no longer needed"},
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.api
+class TestDocumentRequestsOwnershipAndNotFound:
+    """Ownership scoping and not-found handling."""
+
+    async def test_fulfill_other_students_request_forbidden(self, client, login, db, doc_users, student_application):
+        # SECURITY: a student may only fulfill requests on their OWN application.
+        doc_req = await _make_request(db, student_application, doc_users["professor"])
+        login(doc_users["other_student"])
+        response = await client.patch(f"{PREFIX}/document-requests/{doc_req.id}/fulfill", json={})
+        assert response.status_code == 403
+
+    async def test_create_nonexistent_application_404(self, client, login, doc_users):
+        login(doc_users["admin"])
+        response = await client.post(_app_dr_url(999999), json=_create_body())
+        assert response.status_code == 404
+
+    async def test_list_nonexistent_application_404(self, client, login, doc_users):
+        login(doc_users["admin"])
+        response = await client.get(_app_dr_url(999999))
+        assert response.status_code == 404
+
+    async def test_fulfill_nonexistent_request_404(self, client, login, doc_users):
+        login(doc_users["student"])
+        response = await client.patch(f"{PREFIX}/document-requests/999999/fulfill", json={})
+        assert response.status_code == 404
+
+    async def test_cancel_nonexistent_request_404(self, client, login, doc_users):
+        login(doc_users["admin"])
+        response = await client.patch(
+            f"{PREFIX}/document-requests/999999/cancel",
+            json={"cancellation_reason": "not needed"},
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.api
+class TestDocumentRequestsValidation:
+    """Input validation and status-guard 400s."""
+
+    async def test_create_reason_too_short_422(self, client, login, doc_users, student_application):
+        login(doc_users["admin"])
+        response = await client.post(_app_dr_url(student_application.id), json=_create_body(reason="short"))
+        assert response.status_code == 422
+
+    async def test_create_missing_documents_422(self, client, login, doc_users, student_application):
+        login(doc_users["admin"])
+        response = await client.post(
+            _app_dr_url(student_application.id),
+            json={"reason": "Need supplementary documents to verify eligibility"},
+        )
+        assert response.status_code == 422
+
+    async def test_cancel_reason_too_short_422(self, client, login, db, doc_users, student_application):
+        doc_req = await _make_request(db, student_application, doc_users["professor"])
+        login(doc_users["admin"])
+        response = await client.patch(
+            f"{PREFIX}/document-requests/{doc_req.id}/cancel",
+            json={"cancellation_reason": "no"},
+        )
+        assert response.status_code == 422
+
+    async def test_fulfill_already_fulfilled_400(self, client, login, db, doc_users, student_application):
+        doc_req = await _make_request(
+            db, student_application, doc_users["professor"], status=DocumentRequestStatus.fulfilled.value
+        )
+        login(doc_users["student"])
+        response = await client.patch(f"{PREFIX}/document-requests/{doc_req.id}/fulfill", json={})
+        assert response.status_code == 400
+
+    async def test_cancel_non_pending_400(self, client, login, db, doc_users, student_application):
+        doc_req = await _make_request(
+            db, student_application, doc_users["professor"], status=DocumentRequestStatus.cancelled.value
+        )
+        login(doc_users["admin"])
+        response = await client.patch(
+            f"{PREFIX}/document-requests/{doc_req.id}/cancel",
+            json={"cancellation_reason": "already cancelled"},
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.api
+class TestDocumentRequestsEnvelopeAndFlow:
+    """Happy-path behavior and the {success, message, data} envelope."""
+
+    async def test_staff_create_201_envelope(self, client, login, doc_users, student_application):
+        login(doc_users["professor"])
+        response = await client.post(_app_dr_url(student_application.id), json=_create_body())
+        assert response.status_code == 201
+        body = response.json()
+        assert set(body.keys()) >= {"success", "message", "data"}
+        assert body["success"] is True
+        data = body["data"]
+        assert data["application_id"] == student_application.id
+        assert data["status"] == "pending"
+        assert data["requested_by_name"] == "Doc Professor"
+        assert data["application_app_id"] == "APP-114-1-00010"
+
+    async def test_staff_list_envelope(self, client, login, db, doc_users, student_application):
+        await _make_request(db, student_application, doc_users["professor"])
+        login(doc_users["admin"])
+        response = await client.get(_app_dr_url(student_application.id))
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert isinstance(body["data"], list)
+        assert len(body["data"]) == 1
+        assert body["data"][0]["requested_by_name"] == "Doc Professor"
+
+    async def test_student_my_requests_envelope(self, client, login, db, doc_users, student_application):
+        await _make_request(db, student_application, doc_users["professor"])
+        login(doc_users["student"])
+        response = await client.get(f"{PREFIX}/document-requests/my-requests")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert isinstance(body["data"], list)
+        assert len(body["data"]) == 1
+        assert body["data"][0]["application_app_id"] == "APP-114-1-00010"
+
+    async def test_owning_student_fulfill_200(self, client, login, db, doc_users, student_application):
+        doc_req = await _make_request(db, student_application, doc_users["professor"])
+        login(doc_users["student"])
+        response = await client.patch(
+            f"{PREFIX}/document-requests/{doc_req.id}/fulfill",
+            json={"notes": "uploaded"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["status"] == "fulfilled"
+
+    async def test_staff_cancel_200(self, client, login, db, doc_users, student_application):
+        doc_req = await _make_request(db, student_application, doc_users["professor"])
+        login(doc_users["admin"])
+        response = await client.patch(
+            f"{PREFIX}/document-requests/{doc_req.id}/cancel",
+            json={"cancellation_reason": "documents provided elsewhere"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["status"] == "cancelled"
+        assert body["data"]["cancelled_by_name"] == "Doc Admin"

--- a/backend/app/tests/test_professor_student_endpoints.py
+++ b/backend/app/tests/test_professor_student_endpoints.py
@@ -1,0 +1,273 @@
+"""
+HTTP-layer tests for the professor-student relationship endpoints
+(app/api/v1/endpoints/professor_student.py).
+
+Focus: authorization boundaries (GET = professor/admin/super_admin,
+mutations = admin-only), professor self-scoping on GET (a professor may only
+query their own relationships), input validation, not-found handling, and the
+{success, message, data} response envelope.
+
+Auth is resolved via `app.core.security` role dependencies (require_roles /
+require_admin), which depend on `app.core.security.get_current_user`; the login
+fixture overrides that.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.models.professor_student import ProfessorStudentRelationship
+from app.models.user import User, UserRole, UserType
+
+PREFIX = "/api/v1/professor-student"
+
+
+@pytest_asyncio.fixture
+async def login():
+    """Authenticate the test client as a given User by overriding get_current_user."""
+    from app.core.security import get_current_user
+    from app.main import app
+
+    def _login(user: User) -> None:
+        async def _override():
+            return user
+
+        app.dependency_overrides[get_current_user] = _override
+
+    yield _login
+
+    from app.core.security import get_current_user as _gcu
+    from app.main import app as _app
+
+    _app.dependency_overrides.pop(_gcu, None)
+
+
+@pytest_asyncio.fixture
+async def ps_users(db):
+    users = {
+        "professor": User(
+            nycu_id="ps_prof",
+            name="PS Professor",
+            email="ps_prof@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+        "other_professor": User(
+            nycu_id="ps_prof2",
+            name="PS Other Professor",
+            email="ps_prof2@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+        "student": User(
+            nycu_id="ps_student",
+            name="PS Student",
+            email="ps_student@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "admin": User(
+            nycu_id="ps_admin",
+            name="PS Admin",
+            email="ps_admin@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.admin,
+        ),
+    }
+    for user in users.values():
+        db.add(user)
+    await db.commit()
+    for user in users.values():
+        await db.refresh(user)
+    return users
+
+
+@pytest_asyncio.fixture
+async def relationship(db, ps_users) -> ProfessorStudentRelationship:
+    """An advisor relationship owned by `professor` for `student`."""
+    rel = ProfessorStudentRelationship(
+        professor_id=ps_users["professor"].id,
+        student_id=ps_users["student"].id,
+        relationship_type="advisor",
+        is_active=True,
+        created_by=ps_users["admin"].id,
+    )
+    db.add(rel)
+    await db.commit()
+    await db.refresh(rel)
+    return rel
+
+
+@pytest.mark.api
+class TestProfessorStudentAuthorization:
+    """Role gating: GET open to professor/admin, mutations admin-only."""
+
+    async def test_list_unauthenticated_401(self, client):
+        response = await client.get(PREFIX)
+        assert response.status_code == 401
+
+    async def test_list_student_forbidden(self, client, login, ps_users):
+        # require_roles(professor, admin, super_admin) excludes students.
+        login(ps_users["student"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 403
+
+    async def test_create_unauthenticated_401(self, client, ps_users):
+        response = await client.post(
+            PREFIX,
+            params={
+                "professor_id": ps_users["professor"].id,
+                "student_id": ps_users["student"].id,
+                "relationship_type": "advisor",
+            },
+        )
+        assert response.status_code == 401
+
+    async def test_create_professor_forbidden(self, client, login, ps_users):
+        # POST is require_admin; a professor may not create relationships.
+        login(ps_users["professor"])
+        response = await client.post(
+            PREFIX,
+            params={
+                "professor_id": ps_users["professor"].id,
+                "student_id": ps_users["student"].id,
+                "relationship_type": "advisor",
+            },
+        )
+        assert response.status_code == 403
+
+    async def test_update_professor_forbidden(self, client, login, ps_users, relationship):
+        login(ps_users["professor"])
+        response = await client.put(f"{PREFIX}/{relationship.id}", params={"status": "inactive"})
+        assert response.status_code == 403
+
+    async def test_delete_student_forbidden(self, client, login, ps_users, relationship):
+        login(ps_users["student"])
+        response = await client.delete(f"{PREFIX}/{relationship.id}")
+        assert response.status_code == 403
+
+
+@pytest.mark.api
+class TestProfessorStudentScoping:
+    """A professor may only query their own relationships on GET."""
+
+    async def test_professor_query_other_professor_forbidden(self, client, login, ps_users, relationship):
+        # SECURITY: a professor passing professor_id != self is rejected before
+        # the query is built (prevents reading other professors' rosters).
+        login(ps_users["professor"])
+        response = await client.get(PREFIX, params={"professor_id": ps_users["other_professor"].id})
+        assert response.status_code == 403
+
+    async def test_professor_query_own_id_allowed(self, client, login, ps_users, relationship):
+        login(ps_users["professor"])
+        response = await client.get(PREFIX, params={"professor_id": ps_users["professor"].id})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert len(body["data"]) == 1
+        assert body["data"][0]["professor_id"] == ps_users["professor"].id
+
+    async def test_professor_no_filter_sees_only_own(self, client, login, ps_users, relationship):
+        # With no professor_id filter, a professor is implicitly scoped to self.
+        login(ps_users["professor"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert all(rel["professor_id"] == ps_users["professor"].id for rel in data)
+
+    async def test_admin_query_any_professor_allowed(self, client, login, ps_users, relationship):
+        # Admins are exempt from the self-scoping restriction.
+        login(ps_users["admin"])
+        response = await client.get(PREFIX, params={"professor_id": ps_users["professor"].id})
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 1
+
+
+@pytest.mark.api
+class TestProfessorStudentValidationAndNotFound:
+    """Input validation and not-found handling (admin-authenticated)."""
+
+    async def test_create_missing_relationship_type_422(self, client, login, ps_users):
+        login(ps_users["admin"])
+        response = await client.post(
+            PREFIX,
+            params={"professor_id": ps_users["professor"].id, "student_id": ps_users["student"].id},
+        )
+        assert response.status_code == 422
+
+    async def test_create_nonexistent_professor_400(self, client, login, ps_users):
+        login(ps_users["admin"])
+        response = await client.post(
+            PREFIX,
+            params={
+                "professor_id": 999999,
+                "student_id": ps_users["student"].id,
+                "relationship_type": "advisor",
+            },
+        )
+        assert response.status_code == 400
+
+    async def test_update_nonexistent_404(self, client, login, ps_users):
+        login(ps_users["admin"])
+        response = await client.put(f"{PREFIX}/999999", params={"status": "inactive"})
+        assert response.status_code == 404
+
+    async def test_delete_nonexistent_404(self, client, login, ps_users):
+        login(ps_users["admin"])
+        response = await client.delete(f"{PREFIX}/999999")
+        assert response.status_code == 404
+
+
+@pytest.mark.api
+class TestProfessorStudentEnvelopeAndFlow:
+    """Happy-path envelope for the working paths (list / update / delete)."""
+
+    async def test_admin_list_envelope(self, client, login, ps_users, relationship):
+        login(ps_users["admin"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) >= {"success", "message", "data"}
+        assert body["success"] is True
+        assert isinstance(body["data"], list)
+        assert body["data"][0]["relationship_type"] == "advisor"
+        assert body["data"][0]["status"] == "active"
+
+    async def test_admin_update_envelope(self, client, login, ps_users, relationship):
+        login(ps_users["admin"])
+        response = await client.put(
+            f"{PREFIX}/{relationship.id}",
+            params={"status": "inactive", "notes": "ended"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["status"] == "inactive"
+        assert body["data"]["notes"] == "ended"
+
+    async def test_admin_delete_envelope(self, client, login, ps_users, relationship):
+        login(ps_users["admin"])
+        response = await client.delete(f"{PREFIX}/{relationship.id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"] is None
+
+    async def test_admin_create_valid_professor_rejected_400_bug(self, client, login, ps_users):
+        # BUG: create_professor_student_relationship validates the fetched user's
+        # role with `professor.role not in ["professor", "admin"]` and
+        # `student.role != "student"`. `User.role` is a plain enum.Enum member
+        # (UserRole.professor), never equal to the bare string "professor", so a
+        # perfectly valid professor+student pair is ALWAYS rejected with 400 —
+        # the create endpoint cannot create any relationship. Fix = compare
+        # against enum members (UserRole.professor / UserRole.student) or
+        # `.value`. Pinning current (broken) behavior.
+        login(ps_users["admin"])
+        response = await client.post(
+            PREFIX,
+            params={
+                "professor_id": ps_users["professor"].id,
+                "student_id": ps_users["student"].id,
+                "relationship_type": "advisor",
+            },
+        )
+        assert response.status_code == 400

--- a/backend/app/tests/test_roster_schedules_endpoints.py
+++ b/backend/app/tests/test_roster_schedules_endpoints.py
@@ -1,0 +1,314 @@
+"""
+HTTP-layer tests for the roster-schedule endpoints
+(app/api/v1/endpoints/roster_schedules.py).
+
+Focus: authorization boundaries (admin/super_admin only), input validation
+(cron / status / required fields), not-found handling, and the
+{success, message, data} response envelope.
+
+NOTE: several roster routes call into the APScheduler-backed
+`roster_scheduler` singleton (and, in production, Redis). Every handler runs
+`check_user_roles(...)` and its DB lookups *before* any scheduler call, so
+these tests exercise the auth / validation / 404 layer that precedes the
+scheduler and deliberately avoid asserting scheduler side-effects. The
+happy-path create test uses status=ACTIVE with no cron_expression, which the
+handler explicitly skips adding to the scheduler.
+
+Authentication is simulated by overriding the `get_current_user` dependency
+with real DB-backed User rows so all downstream role-scoping runs unmodified.
+The roster router resolves auth via `app.core.deps.get_current_user`, so the
+login fixture overrides that (and the security-module variant too, for reuse).
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+
+PREFIX = "/api/v1/roster-schedules"
+
+
+@pytest_asyncio.fixture
+async def login():
+    """Authenticate the test client as a given User by overriding get_current_user."""
+    from app.core.deps import get_current_user as deps_gcu
+    from app.core.security import get_current_user as sec_gcu
+    from app.main import app
+
+    def _login(user: User) -> None:
+        async def _override():
+            return user
+
+        app.dependency_overrides[deps_gcu] = _override
+        app.dependency_overrides[sec_gcu] = _override
+
+    yield _login
+
+    from app.core.deps import get_current_user as _deps_gcu
+    from app.core.security import get_current_user as _sec_gcu
+    from app.main import app as _app
+
+    _app.dependency_overrides.pop(_deps_gcu, None)
+    _app.dependency_overrides.pop(_sec_gcu, None)
+
+
+@pytest_asyncio.fixture
+async def roster_users(db):
+    """Real DB users spanning every role that matters for authorization."""
+    users = {
+        "student": User(
+            nycu_id="rs_student",
+            name="Roster Student",
+            email="rs_student@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "professor": User(
+            nycu_id="rs_prof",
+            name="Roster Professor",
+            email="rs_prof@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+        "college": User(
+            nycu_id="rs_college",
+            name="Roster College",
+            email="rs_college@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.college,
+            college_code="ENG",
+        ),
+        "admin": User(
+            nycu_id="rs_admin",
+            name="Roster Admin",
+            email="rs_admin@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.admin,
+        ),
+        "super_admin": User(
+            nycu_id="rs_super",
+            name="Roster Super",
+            email="rs_super@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.super_admin,
+        ),
+    }
+    for user in users.values():
+        db.add(user)
+    await db.commit()
+    for user in users.values():
+        await db.refresh(user)
+    return users
+
+
+@pytest_asyncio.fixture
+async def scholarship_config(db) -> ScholarshipConfiguration:
+    """A minimal scholarship configuration for happy-path create."""
+    scholarship = ScholarshipType(
+        code="rs_scholarship",
+        name="Roster Schedule Scholarship",
+        description="For roster schedule endpoint tests",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        academic_year=114,
+        config_name="Roster Config",
+        config_code="rs_config_114",
+        amount=10000,
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+    return config
+
+
+def _create_payload(config_id: int, **overrides) -> dict:
+    payload = {
+        "scholarship_configuration_id": config_id,
+        "roster_cycle": "monthly",
+        "schedule_name": "Test Schedule",
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.api
+class TestRosterSchedulesAuthorization:
+    """Only admin / super_admin may touch roster schedules."""
+
+    async def test_list_unauthenticated_401(self, client):
+        response = await client.get(PREFIX)
+        assert response.status_code == 401
+
+    async def test_list_student_forbidden(self, client, login, roster_users):
+        login(roster_users["student"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 403
+
+    async def test_list_professor_forbidden(self, client, login, roster_users):
+        login(roster_users["professor"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 403
+
+    async def test_list_college_forbidden(self, client, login, roster_users):
+        login(roster_users["college"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 403
+
+    async def test_create_unauthenticated_401(self, client, scholarship_config):
+        response = await client.post(PREFIX, json=_create_payload(scholarship_config.id))
+        assert response.status_code == 401
+
+    async def test_create_student_forbidden(self, client, login, roster_users, scholarship_config):
+        login(roster_users["student"])
+        response = await client.post(PREFIX, json=_create_payload(scholarship_config.id))
+        assert response.status_code == 403
+
+    async def test_get_schedule_student_forbidden(self, client, login, roster_users):
+        login(roster_users["student"])
+        response = await client.get(f"{PREFIX}/1")
+        assert response.status_code == 403
+
+    async def test_update_schedule_college_forbidden(self, client, login, roster_users):
+        login(roster_users["college"])
+        response = await client.put(f"{PREFIX}/1", json={"description": "x"})
+        assert response.status_code == 403
+
+    async def test_patch_status_professor_forbidden(self, client, login, roster_users):
+        login(roster_users["professor"])
+        response = await client.patch(f"{PREFIX}/1/status", json={"status": "paused"})
+        assert response.status_code == 403
+
+    async def test_delete_schedule_student_forbidden(self, client, login, roster_users):
+        login(roster_users["student"])
+        response = await client.delete(f"{PREFIX}/1")
+        assert response.status_code == 403
+
+    async def test_execute_schedule_student_forbidden(self, client, login, roster_users):
+        login(roster_users["student"])
+        response = await client.post(f"{PREFIX}/1/execute")
+        assert response.status_code == 403
+
+    async def test_by_config_student_forbidden(self, client, login, roster_users):
+        login(roster_users["student"])
+        response = await client.get(f"{PREFIX}/by-config/1")
+        assert response.status_code == 403
+
+    async def test_scheduler_status_student_forbidden(self, client, login, roster_users):
+        login(roster_users["student"])
+        response = await client.get(f"{PREFIX}/scheduler/status")
+        assert response.status_code == 403
+
+    async def test_scheduler_status_unauthenticated_401(self, client):
+        response = await client.get(f"{PREFIX}/scheduler/status")
+        assert response.status_code == 401
+
+
+@pytest.mark.api
+class TestRosterSchedulesValidationAndNotFound:
+    """Input validation and not-found handling (admin-authenticated)."""
+
+    async def test_create_nonexistent_config_404(self, client, login, roster_users):
+        login(roster_users["admin"])
+        response = await client.post(PREFIX, json=_create_payload(999999))
+        assert response.status_code == 404
+
+    async def test_create_missing_required_field_422(self, client, login, roster_users):
+        login(roster_users["admin"])
+        # Missing scholarship_configuration_id and roster_cycle.
+        response = await client.post(PREFIX, json={"schedule_name": "no config"})
+        assert response.status_code == 422
+
+    async def test_create_invalid_cron_422(self, client, login, roster_users, scholarship_config):
+        login(roster_users["admin"])
+        payload = _create_payload(scholarship_config.id, cron_expression="not a cron")
+        response = await client.post(PREFIX, json=payload)
+        assert response.status_code == 422
+
+    async def test_create_invalid_roster_cycle_422(self, client, login, roster_users, scholarship_config):
+        login(roster_users["admin"])
+        payload = _create_payload(scholarship_config.id, roster_cycle="fortnightly")
+        response = await client.post(PREFIX, json=payload)
+        assert response.status_code == 422
+
+    async def test_get_schedule_not_found_404(self, client, login, roster_users):
+        login(roster_users["admin"])
+        response = await client.get(f"{PREFIX}/999999")
+        assert response.status_code == 404
+
+    async def test_update_schedule_not_found_404(self, client, login, roster_users):
+        login(roster_users["admin"])
+        response = await client.put(f"{PREFIX}/999999", json={"description": "x"})
+        assert response.status_code == 404
+
+    async def test_patch_status_not_found_404(self, client, login, roster_users):
+        login(roster_users["admin"])
+        response = await client.patch(f"{PREFIX}/999999/status", json={"status": "paused"})
+        assert response.status_code == 404
+
+    async def test_patch_status_invalid_value_422(self, client, login, roster_users):
+        login(roster_users["admin"])
+        response = await client.patch(f"{PREFIX}/1/status", json={"status": "not_a_status"})
+        assert response.status_code == 422
+
+    async def test_delete_schedule_not_found_404(self, client, login, roster_users):
+        login(roster_users["admin"])
+        response = await client.delete(f"{PREFIX}/999999")
+        assert response.status_code == 404
+
+    async def test_execute_schedule_not_found_returns_500_bug(self, client, login, roster_users):
+        # BUG: execute_schedule_now() is the only handler in this module missing
+        # the `except HTTPException: raise` guard. Its own 404 ("Roster schedule
+        # not found") is caught by the bare `except Exception` and re-raised as
+        # 500, masking a legitimate not-found as a server error. Every sibling
+        # handler (get/update/patch/delete) correctly re-raises the 404.
+        # Pinning current behavior; fix = add `except HTTPException: raise`
+        # before the generic handler (see roster_schedules.py ~line 473).
+        login(roster_users["admin"])
+        response = await client.post(f"{PREFIX}/999999/execute")
+        assert response.status_code == 500
+
+
+@pytest.mark.api
+class TestRosterSchedulesEnvelope:
+    """Happy-path {success, message, data} envelope for scheduler-free paths."""
+
+    async def test_list_admin_empty_envelope(self, client, login, roster_users):
+        login(roster_users["admin"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) >= {"success", "message", "data"}
+        assert body["success"] is True
+        assert body["data"]["items"] == []
+        assert body["data"]["total"] == 0
+
+    async def test_list_super_admin_ok(self, client, login, roster_users):
+        login(roster_users["super_admin"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    async def test_create_schedule_envelope(self, client, login, roster_users, scholarship_config):
+        login(roster_users["admin"])
+        response = await client.post(PREFIX, json=_create_payload(scholarship_config.id))
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        data = body["data"]
+        assert data["schedule_name"] == "Test Schedule"
+        assert data["scholarship_configuration_id"] == scholarship_config.id
+        assert data["roster_cycle"] == "monthly"
+
+    async def test_by_config_no_schedule_returns_null(self, client, login, roster_users):
+        login(roster_users["admin"])
+        response = await client.get(f"{PREFIX}/by-config/999999")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"] is None


### PR DESCRIPTION
First endpoint-level coverage for three modules that had **zero** HTTP-layer tests. Authorization-first, per the 2026-07 test audit. **69 tests; 94 pass alongside test_admin_endpoints.py (no cross-talk).** Reuses the existing `login`/`db`/`client` harness (dependency-override of `get_current_user`).

| File | Module | Tests |
|---|---|---|
| `test_roster_schedules_endpoints.py` | roster_schedules.py (9 routes) | 28 |
| `test_document_requests_endpoints.py` | document_requests.py (5 routes) | 23 |
| `test_professor_student_endpoints.py` | professor_student.py (4 routes) | 18 |

Coverage per route is auth-weighted: unauthenticated→401, wrong-role→403, ownership/relationship scoping→403/404 (e.g. a student can only fulfill their **own** document request; a professor can only query their **own** students), not-found→404, malformed→422, happy-path envelope. Scheduler/Redis side-effects are deliberately not asserted — the tests exercise the auth/validation/404 layer that runs before any scheduler call.

## 🐛 Two real bugs found (pinned to current behavior, filed as issues — NOT fixed here)

1. **`roster_schedules.py` `execute_schedule_now` — 404 masked as 500.** It's the only handler in the module missing `except HTTPException: raise`, so its own `HTTPException(404)` is swallowed by the bare `except Exception` and re-raised as 500. Every sibling re-raises correctly. → filed as an issue; test `test_execute_schedule_not_found_returns_500_bug` pins the current 500.
2. **`professor_student.py` create endpoint is DEAD.** It checks `professor.role not in ["professor","admin"]` / `student.role != "student"`, but `User.role` is an `enum.Enum` member, never equal to the bare string — so **every** valid pair is rejected with 400 and no relationship can ever be created via the API. (Exactly the enum-vs-string class documented in CLAUDE.md.) → filed as an issue; `test_admin_create_valid_professor_rejected_400_bug` pins the current 400.

## Verification
Host venv + CI in-memory SQLite (dev Docker daemon is wedged this session). black + flake8 (B904/B014/F401) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFNCV4rmmoie3jsTFMMFth