### PR TITLE
test(api): HTTP-layer tests for scholarships + quota_dashboard (56 tests)

### DIFF
--- a/backend/app/tests/test_quota_dashboard_endpoints.py
+++ b/backend/app/tests/test_quota_dashboard_endpoints.py
@@ -1,0 +1,269 @@
+"""
+HTTP-layer tests for the quota dashboard endpoints
+(app/api/v1/endpoints/quota_dashboard.py).
+
+Focus: authorization boundaries (require_staff vs require_admin), required-query
+validation, the {success, message, data} response envelope, and the CSV export
+branch. The export route is the sharpest boundary: it is admin-only while the
+other three routes admit any staff member (admin / college / professor), so a
+staff-but-not-admin user is accepted everywhere except export.
+
+Authentication is simulated by overriding `get_current_user` with real
+DB-backed User rows so the actual require_staff / require_admin gates run.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.models.scholarship import ScholarshipType
+from app.models.user import User, UserRole, UserType
+
+QUOTA_PREFIX = "/api/v1/quota-dashboard"
+
+
+@pytest_asyncio.fixture
+async def login():
+    """Authenticate the test client as a given User via dependency override."""
+    from app.core.security import get_current_user
+    from app.main import app
+
+    def _login(user: User) -> None:
+        async def _override():
+            return user
+
+        app.dependency_overrides[get_current_user] = _override
+
+    yield _login
+    from app.core.security import get_current_user as _gcu
+    from app.main import app as _app
+
+    _app.dependency_overrides.pop(_gcu, None)
+
+
+@pytest_asyncio.fixture
+async def quota_users(db):
+    """Real DB users covering the roles the quota routes distinguish."""
+    users = {
+        "student": User(
+            nycu_id="quota_student",
+            name="Quota Student",
+            email="quota_student@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "professor": User(
+            nycu_id="quota_prof",
+            name="Quota Professor",
+            email="quota_prof@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+        "college": User(
+            nycu_id="quota_college",
+            name="Quota College",
+            email="quota_college@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.college,
+            college_code="ENG",
+        ),
+        "admin": User(
+            nycu_id="quota_admin",
+            name="Quota Admin",
+            email="quota_admin@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.admin,
+        ),
+    }
+    for user in users.values():
+        db.add(user)
+    await db.commit()
+    for user in users.values():
+        await db.refresh(user)
+    return users
+
+
+@pytest_asyncio.fixture
+async def quota_scholarship(db) -> ScholarshipType:
+    scholarship = ScholarshipType(
+        code="quota_scholarship",
+        name="Quota Test Scholarship",
+        description="Scholarship used by quota dashboard endpoint tests",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+    return scholarship
+
+
+@pytest.mark.api
+class TestQuotaOverview:
+    """GET /overview - require_staff, academic_year required."""
+
+    async def test_overview_unauthenticated_401(self, client):
+        response = await client.get(f"{QUOTA_PREFIX}/overview", params={"academic_year": 114})
+        assert response.status_code == 401
+        assert response.json()["success"] is False
+
+    async def test_overview_student_forbidden_403(self, client, login, quota_users):
+        login(quota_users["student"])
+        response = await client.get(f"{QUOTA_PREFIX}/overview", params={"academic_year": 114})
+        assert response.status_code == 403
+
+    async def test_overview_missing_academic_year_422(self, client, login, quota_users):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/overview")
+        assert response.status_code == 422
+
+    async def test_overview_admin_200_envelope(self, client, login, quota_users, quota_scholarship):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/overview", params={"academic_year": 114})
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) >= {"success", "message", "data"}
+        assert body["success"] is True
+        data = body["data"]
+        assert data["academic_year"] == 114
+        assert "overview" in data
+        assert "global_stats" in data
+        assert data["global_stats"]["total_applications"] == 0
+
+    async def test_overview_professor_staff_allowed_200(self, client, login, quota_users):
+        # require_staff admits professors.
+        login(quota_users["professor"])
+        response = await client.get(f"{QUOTA_PREFIX}/overview", params={"academic_year": 114})
+        assert response.status_code == 200
+
+    async def test_overview_college_staff_allowed_200(self, client, login, quota_users):
+        login(quota_users["college"])
+        response = await client.get(f"{QUOTA_PREFIX}/overview", params={"academic_year": 114})
+        assert response.status_code == 200
+
+
+@pytest.mark.api
+class TestDetailedQuotaStatus:
+    """GET /detailed/{scholarship_type_id}/{sub_type} - require_staff."""
+
+    async def test_detailed_unauthenticated_401(self, client, quota_scholarship):
+        response = await client.get(
+            f"{QUOTA_PREFIX}/detailed/{quota_scholarship.id}/general", params={"academic_year": 114}
+        )
+        assert response.status_code == 401
+
+    async def test_detailed_student_forbidden_403(self, client, login, quota_users, quota_scholarship):
+        login(quota_users["student"])
+        response = await client.get(
+            f"{QUOTA_PREFIX}/detailed/{quota_scholarship.id}/general", params={"academic_year": 114}
+        )
+        assert response.status_code == 403
+
+    async def test_detailed_missing_academic_year_422(self, client, login, quota_users, quota_scholarship):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/detailed/{quota_scholarship.id}/general")
+        assert response.status_code == 422
+
+    async def test_detailed_scholarship_not_found_404(self, client, login, quota_users):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/detailed/999999/general", params={"academic_year": 114})
+        assert response.status_code == 404
+
+    async def test_detailed_non_int_id_422(self, client, login, quota_users):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/detailed/not-an-int/general", params={"academic_year": 114})
+        assert response.status_code == 422
+
+    async def test_detailed_admin_200_envelope(self, client, login, quota_users, quota_scholarship):
+        login(quota_users["admin"])
+        response = await client.get(
+            f"{QUOTA_PREFIX}/detailed/{quota_scholarship.id}/general", params={"academic_year": 114}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        data = body["data"]
+        assert data["scholarship_type"]["id"] == quota_scholarship.id
+        assert data["scholarship_type"]["code"] == "quota_scholarship"
+        assert "quota_status" in data
+        assert data["recent_applications"] == []
+
+
+@pytest.mark.api
+class TestQuotaAlerts:
+    """GET /alerts - require_staff."""
+
+    async def test_alerts_unauthenticated_401(self, client):
+        response = await client.get(f"{QUOTA_PREFIX}/alerts", params={"academic_year": 114})
+        assert response.status_code == 401
+
+    async def test_alerts_student_forbidden_403(self, client, login, quota_users):
+        login(quota_users["student"])
+        response = await client.get(f"{QUOTA_PREFIX}/alerts", params={"academic_year": 114})
+        assert response.status_code == 403
+
+    async def test_alerts_missing_academic_year_422(self, client, login, quota_users):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/alerts")
+        assert response.status_code == 422
+
+    async def test_alerts_college_200_envelope(self, client, login, quota_users, quota_scholarship):
+        login(quota_users["college"])
+        response = await client.get(f"{QUOTA_PREFIX}/alerts", params={"academic_year": 114})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        # No approved applications -> no alerts.
+        assert body["data"]["alerts"] == []
+        assert body["data"]["academic_year"] == 114
+
+
+@pytest.mark.api
+class TestQuotaExport:
+    """GET /export - require_admin (stricter than the sibling routes)."""
+
+    async def test_export_unauthenticated_401(self, client):
+        response = await client.get(f"{QUOTA_PREFIX}/export", params={"academic_year": 114})
+        assert response.status_code == 401
+
+    async def test_export_student_forbidden_403(self, client, login, quota_users):
+        login(quota_users["student"])
+        response = await client.get(f"{QUOTA_PREFIX}/export", params={"academic_year": 114})
+        assert response.status_code == 403
+
+    async def test_export_professor_forbidden_403(self, client, login, quota_users):
+        # Professor is staff (can hit /overview) but NOT admin -> export denied.
+        login(quota_users["professor"])
+        response = await client.get(f"{QUOTA_PREFIX}/export", params={"academic_year": 114})
+        assert response.status_code == 403
+
+    async def test_export_college_forbidden_403(self, client, login, quota_users):
+        # College is staff but NOT admin -> export denied. Pins the require_admin
+        # boundary that separates export from the other three quota routes.
+        login(quota_users["college"])
+        response = await client.get(f"{QUOTA_PREFIX}/export", params={"academic_year": 114})
+        assert response.status_code == 403
+
+    async def test_export_missing_academic_year_422(self, client, login, quota_users):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/export")
+        assert response.status_code == 422
+
+    async def test_export_invalid_format_422(self, client, login, quota_users):
+        # format query is pattern-gated to ^(json|csv)$.
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/export", params={"academic_year": 114, "format": "xml"})
+        assert response.status_code == 422
+
+    async def test_export_admin_json_200_envelope(self, client, login, quota_users, quota_scholarship):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/export", params={"academic_year": 114, "format": "json"})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert "records" in body["data"]
+        assert body["data"]["count"] == 0
+
+    async def test_export_admin_csv_200_content_type(self, client, login, quota_users, quota_scholarship):
+        login(quota_users["admin"])
+        response = await client.get(f"{QUOTA_PREFIX}/export", params={"academic_year": 114, "format": "csv"})
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert "attachment" in response.headers.get("content-disposition", "")

--- a/backend/app/tests/test_scholarships_endpoints.py
+++ b/backend/app/tests/test_scholarships_endpoints.py
@@ -1,0 +1,362 @@
+"""
+HTTP-layer tests for the scholarship endpoints (app/api/v1/endpoints/scholarships.py).
+
+Focus: authorization boundaries (public vs authenticated vs admin-only),
+input validation (path-pattern + request body), the {success, message, data}
+response envelope, and the dev-only debug gate.
+
+These exercise the real FastAPI app over ASGI with the in-memory SQLite database
+from conftest. Authentication is simulated by overriding the `get_current_user`
+dependency with real DB-backed User rows so that every downstream role gate
+(require_admin, etc.) runs unmodified.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.models.enums import Semester
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+
+SCHOLARSHIPS_PREFIX = "/api/v1/scholarships"
+
+
+@pytest_asyncio.fixture
+async def login():
+    """Authenticate the test client as a given User via dependency override."""
+    from app.core.security import get_current_user
+    from app.main import app
+
+    def _login(user: User) -> None:
+        async def _override():
+            return user
+
+        app.dependency_overrides[get_current_user] = _override
+
+    yield _login
+    from app.core.security import get_current_user as _gcu
+    from app.main import app as _app
+
+    _app.dependency_overrides.pop(_gcu, None)
+
+
+@pytest_asyncio.fixture
+async def sch_users(db):
+    """Real DB users covering every role the scholarship routes distinguish."""
+    users = {
+        "student": User(
+            nycu_id="sch_student",
+            name="Scholarship Student",
+            email="sch_student@test.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        ),
+        "professor": User(
+            nycu_id="sch_prof",
+            name="Scholarship Professor",
+            email="sch_prof@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.professor,
+        ),
+        "college": User(
+            nycu_id="sch_college",
+            name="Scholarship College",
+            email="sch_college@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.college,
+            college_code="ENG",
+        ),
+        "admin": User(
+            nycu_id="sch_admin",
+            name="Scholarship Admin",
+            email="sch_admin@test.edu",
+            user_type=UserType.employee,
+            role=UserRole.admin,
+        ),
+    }
+    for user in users.values():
+        db.add(user)
+    await db.commit()
+    for user in users.values():
+        await db.refresh(user)
+    return users
+
+
+@pytest_asyncio.fixture
+async def scholarship(db) -> ScholarshipType:
+    scholarship = ScholarshipType(
+        code="phd_scholarship",
+        name="PhD Test Scholarship",
+        description="Scholarship used by scholarships endpoint tests",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+    return scholarship
+
+
+@pytest_asyncio.fixture
+async def active_config(db, scholarship) -> ScholarshipConfiguration:
+    """An active configuration (amount > 0) so ScholarshipTypeResponse validates.
+
+    Without an active config the detail / whitelist responses build
+    ScholarshipTypeResponse(amount=0), which fails the ``amount > 0`` schema
+    validator and 500s (see TestScholarshipResponseBuildBug).
+    """
+    config = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        academic_year=114,
+        semester=Semester.first,
+        config_name="phd test config",
+        config_code="phd_test_cfg_114_1",
+        amount=10000,
+        is_active=True,
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(config)
+    return config
+
+
+@pytest.mark.api
+class TestPublicListingAndDetail:
+    """GET "" and GET /{id} are unauthenticated / public routes."""
+
+    async def test_list_scholarships_public_200_envelope(self, client, scholarship):
+        response = await client.get(SCHOLARSHIPS_PREFIX)
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) >= {"success", "message", "data"}
+        assert body["success"] is True
+        assert isinstance(body["data"], list)
+        codes = [s["code"] for s in body["data"]]
+        assert "phd_scholarship" in codes
+
+    async def test_list_scholarships_empty_ok(self, client):
+        response = await client.get(SCHOLARSHIPS_PREFIX)
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    async def test_list_scholarships_with_filters(self, client, scholarship):
+        response = await client.get(SCHOLARSHIPS_PREFIX, params={"academic_year": 114, "semester": "first"})
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert all(s["academic_year"] == 114 for s in data)
+        assert all(s["semester"] == "first" for s in data)
+
+    async def test_list_invalid_academic_year_422(self, client):
+        response = await client.get(SCHOLARSHIPS_PREFIX, params={"academic_year": "not-a-number"})
+        assert response.status_code == 422
+
+    async def test_get_detail_public_200_envelope(self, client, scholarship, active_config):
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"]["id"] == scholarship.id
+        assert body["data"]["code"] == "phd_scholarship"
+
+    async def test_get_detail_not_found_404(self, client):
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/999999")
+        assert response.status_code == 404
+
+    async def test_get_detail_non_int_id_422(self, client):
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/not-an-int")
+        assert response.status_code == 422
+
+
+@pytest.mark.api
+class TestEligibleScholarships:
+    """GET /eligible requires authentication (any role); resolves student data."""
+
+    async def test_eligible_unauthenticated_401(self, client):
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/eligible")
+        assert response.status_code == 401
+        assert response.json()["success"] is False
+
+    async def test_eligible_non_student_returns_404(self, client, login, sch_users):
+        # get_student_data_from_user returns None for a non-student role, so the
+        # endpoint raises STUDENT_DATA_NOT_FOUND (404) deterministically without
+        # touching the external SIS API.
+        login(sch_users["professor"])
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/eligible")
+        assert response.status_code == 404
+
+
+@pytest.mark.api
+class TestWhitelistToggle:
+    """PATCH /{id}/whitelist is admin-only (require_admin)."""
+
+    async def test_whitelist_unauthenticated_401(self, client, scholarship):
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True})
+        assert response.status_code == 401
+
+    async def test_whitelist_student_forbidden_403(self, client, login, sch_users, scholarship):
+        login(sch_users["student"])
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True})
+        assert response.status_code == 403
+
+    async def test_whitelist_professor_forbidden_403(self, client, login, sch_users, scholarship):
+        login(sch_users["professor"])
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True})
+        assert response.status_code == 403
+
+    async def test_whitelist_college_forbidden_403(self, client, login, sch_users, scholarship):
+        # require_admin excludes college; only admin/super_admin may toggle.
+        login(sch_users["college"])
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True})
+        assert response.status_code == 403
+
+    async def test_whitelist_admin_not_found_404(self, client, login, sch_users):
+        login(sch_users["admin"])
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/999999/whitelist", json={"enabled": True})
+        assert response.status_code == 404
+
+    async def test_whitelist_missing_body_422(self, client, login, sch_users, scholarship):
+        login(sch_users["admin"])
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={})
+        assert response.status_code == 422
+
+    async def test_whitelist_admin_enable_200_envelope(self, client, login, db, sch_users, scholarship, active_config):
+        login(sch_users["admin"])
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True})
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) >= {"success", "message", "data"}
+        assert body["success"] is True
+        assert body["data"]["id"] == scholarship.id
+        assert body["data"]["whitelist_enabled"] is True
+
+        await db.refresh(scholarship)
+        assert scholarship.whitelist_enabled is True
+
+    async def test_whitelist_admin_disable_200(self, client, login, sch_users, scholarship, active_config):
+        login(sch_users["admin"])
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": False})
+        assert response.status_code == 200
+        assert response.json()["data"]["whitelist_enabled"] is False
+
+
+@pytest.mark.api
+class TestTermsDocument:
+    """GET /{scholarship_type}/terms requires authentication; path is pattern-gated."""
+
+    async def test_get_terms_unauthenticated_401(self, client, scholarship):
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/phd_scholarship/terms")
+        assert response.status_code == 401
+
+    async def test_get_terms_missing_document_404(self, client, login, sch_users, scholarship):
+        # Scholarship exists but has no terms_document_url uploaded.
+        login(sch_users["student"])
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/phd_scholarship/terms")
+        assert response.status_code == 404
+
+    async def test_get_terms_unknown_type_404(self, client, login, sch_users):
+        login(sch_users["student"])
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/no_such_type/terms")
+        assert response.status_code == 404
+
+    async def test_get_terms_invalid_path_pattern_422(self, client, login, sch_users):
+        # Path pattern is ^[a-z_]{1,50}$ - uppercase/digits are rejected.
+        login(sch_users["student"])
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/BadType123/terms")
+        assert response.status_code == 422
+
+
+@pytest.mark.api
+class TestUploadTerms:
+    """POST /{scholarship_type}/upload-terms is admin-only (require_admin)."""
+
+    def _file(self):
+        return {"file": ("terms.pdf", b"%PDF-1.4 dummy terms content", "application/pdf")}
+
+    async def test_upload_terms_unauthenticated_401(self, client):
+        response = await client.post(f"{SCHOLARSHIPS_PREFIX}/phd_scholarship/upload-terms", files=self._file())
+        assert response.status_code == 401
+
+    async def test_upload_terms_student_forbidden_403(self, client, login, sch_users):
+        login(sch_users["student"])
+        response = await client.post(f"{SCHOLARSHIPS_PREFIX}/phd_scholarship/upload-terms", files=self._file())
+        assert response.status_code == 403
+
+    async def test_upload_terms_admin_unknown_type_404(self, client, login, sch_users):
+        # Admin passes the role gate + file validation, but the scholarship type
+        # does not exist -> 404 (raised before any MinIO interaction).
+        login(sch_users["admin"])
+        response = await client.post(f"{SCHOLARSHIPS_PREFIX}/no_such_type/upload-terms", files=self._file())
+        assert response.status_code == 404
+
+
+@pytest.mark.api
+class TestDevEndpointsDebugGate:
+    """The /dev/* routes are admin-only AND gated behind settings.debug.
+
+    In the test environment settings.debug is False, so an authenticated admin
+    is still rejected with 403 ("Only available in development mode"). This pins
+    the double gate: role first, then the debug flag.
+    """
+
+    async def test_reset_periods_unauthenticated_401(self, client):
+        response = await client.post(f"{SCHOLARSHIPS_PREFIX}/dev/reset-application-periods")
+        assert response.status_code == 401
+
+    async def test_reset_periods_student_forbidden_403(self, client, login, sch_users):
+        login(sch_users["student"])
+        response = await client.post(f"{SCHOLARSHIPS_PREFIX}/dev/reset-application-periods")
+        assert response.status_code == 403
+
+    async def test_reset_periods_admin_blocked_by_debug_gate_403(self, client, login, sch_users):
+        login(sch_users["admin"])
+        response = await client.post(f"{SCHOLARSHIPS_PREFIX}/dev/reset-application-periods")
+        assert response.status_code == 403
+
+    async def test_toggle_whitelist_admin_blocked_by_debug_gate_403(self, client, login, sch_users, scholarship):
+        login(sch_users["admin"])
+        response = await client.post(f"{SCHOLARSHIPS_PREFIX}/dev/toggle-whitelist/{scholarship.id}")
+        assert response.status_code == 403
+
+    async def test_add_to_whitelist_student_forbidden_403(self, client, login, sch_users, scholarship):
+        login(sch_users["student"])
+        response = await client.post(
+            f"{SCHOLARSHIPS_PREFIX}/dev/add-to-whitelist/{scholarship.id}", params={"student_id": 5}
+        )
+        assert response.status_code == 403
+
+    async def test_add_to_whitelist_admin_blocked_by_debug_gate_403(self, client, login, sch_users, scholarship):
+        login(sch_users["admin"])
+        response = await client.post(
+            f"{SCHOLARSHIPS_PREFIX}/dev/add-to-whitelist/{scholarship.id}", params={"student_id": 5}
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.api
+class TestScholarshipResponseBuildBug:
+    """BUG (pinned current behavior): GET /{id} and PATCH /{id}/whitelist crash
+    for any scholarship type that has NO active ScholarshipConfiguration.
+
+    scholarships.py builds ScholarshipTypeResponse(amount=0) when active_config is
+    None (lines ~299 and ~736), but ScholarshipTypeResponse's field validator
+    rejects ``amount <= 0`` ("Amount must be greater than 0"), so the response
+    construction raises a pydantic ValidationError. In production the error
+    middleware turns this into an HTTP 500; under the ASGI test transport the
+    exception propagates to the caller (pinned with pytest.raises below). A
+    brand-new scholarship type (created before its configuration) is therefore
+    un-viewable via these routes.
+    """
+
+    async def test_get_detail_without_config_raises(self, client, scholarship):
+        # BUG: should be 200 with amount=0; instead the amount>0 validator raises.
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            await client.get(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}")
+
+    async def test_whitelist_toggle_without_config_raises(self, client, login, sch_users, scholarship):
+        # BUG: the whitelist flag IS persisted (commit precedes response building),
+        # but the response construction raises because there is no active config.
+        from pydantic import ValidationError
+
+        login(sch_users["admin"])
+        with pytest.raises(ValidationError):
+            await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True})


### PR DESCRIPTION
First endpoint-level coverage for `scholarships.py` (9 routes) and `quota_dashboard.py` (4 routes), authorization-first. **56 tests; 81 pass alongside test_admin_endpoints.py.** Reuses the `login`/`db`/`client` harness.

- `test_scholarships_endpoints.py` — 32 tests (public list/detail, eligible, whitelist PATCH admin-gated, terms upload/preview, dev-only debug-gated routes)
- `test_quota_dashboard_endpoints.py` — 24 tests (overview/detailed/alerts = `require_staff`; export = `require_admin`)

Key boundary pinned: `/quota-dashboard/export` is `require_admin` while its three siblings are `require_staff`, so a staff-but-not-admin professor/college user passes overview/detailed/alerts but is denied export.

## 🐛 Bug found (pinned, filed as issue — NOT fixed here)
`scholarships.py` — `GET /{id}` and `PATCH /{id}/whitelist` build `ScholarshipTypeResponse(amount = active_config.amount if active_config else 0)`. When a scholarship type has **no active ScholarshipConfiguration**, `amount=0` trips `ScholarshipTypeResponse`'s `@field_validator("amount")` ("must be > 0") → pydantic ValidationError → **HTTP 500**. A brand-new scholarship type (created before its config) is un-viewable, and its whitelist toggle 500s *after* persisting the flag. Pinned in `TestScholarshipResponseBuildBug`.

## Verification
Host venv + CI in-memory SQLite (dev Docker wedged this session). black + flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFNCV4rmmoie3jsTFMMFth