### PR TITLE
fix(api): 4 endpoint bugs surfaced by endpoint-coverage tests (#1112 #1113 #1115 #1117)

### DIFF
--- a/backend/app/api/v1/endpoints/admin/scholarships.py
+++ b/backend/app/api/v1/endpoints/admin/scholarships.py
@@ -447,10 +447,15 @@ async def get_scholarship_sub_type_configs(
                 "description": "一般獎學金",
                 "description_en": "General Scholarship",
                 "amount": None,
-                "currency": scholarship.currency,
+                # #1117: ScholarshipType has NO currency/amount columns (they live
+                # on ScholarshipConfiguration — the documented split). Reading them
+                # here raised AttributeError → 500 for the DEFAULT sub_type_list
+                # ["general"]. A general sub-type with no explicit config has no
+                # configured amount, so default currency + a null effective amount.
+                "currency": "TWD",
                 "display_order": 0,
                 "is_active": True,
-                "effective_amount": scholarship.amount,
+                "effective_amount": None,
                 "created_at": now,
                 "updated_at": now,
             }

--- a/backend/app/api/v1/endpoints/professor_student.py
+++ b/backend/app/api/v1/endpoints/professor_student.py
@@ -128,7 +128,10 @@ async def create_professor_student_relationship(
         # Verify users exist
         prof_query = await db.execute(select(User).where(User.id == professor_id))
         professor = prof_query.scalar_one_or_none()
-        if not professor or professor.role not in ["professor", "admin"]:
+        # #1112: User.role is a UserRole enum member, never equal to a bare
+        # string — comparing against ["professor", "admin"] rejected EVERY valid
+        # pair (the endpoint could never create a relationship). Compare enums.
+        if not professor or professor.role not in (UserRole.professor, UserRole.admin):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid professor ID or user is not a professor",
@@ -136,7 +139,7 @@ async def create_professor_student_relationship(
 
         student_query = await db.execute(select(User).where(User.id == student_id))
         student = student_query.scalar_one_or_none()
-        if not student or student.role != "student":
+        if not student or student.role != UserRole.student:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid student ID or user is not a student",

--- a/backend/app/api/v1/endpoints/roster_schedules.py
+++ b/backend/app/api/v1/endpoints/roster_schedules.py
@@ -470,6 +470,11 @@ async def execute_schedule_now(
             data={"schedule_id": schedule_id, "force_regenerate": force_regenerate},
         )
 
+    except HTTPException:
+        # #1113: without this, the 404 "Roster schedule not found" raised above
+        # was swallowed by the bare `except Exception` and re-raised as 500.
+        # Every sibling handler already re-raises HTTPException first.
+        raise
     except Exception as e:
         logger.exception("Error executing schedule %s", schedule_id)
         raise HTTPException(

--- a/backend/app/api/v1/endpoints/scholarships.py
+++ b/backend/app/api/v1/endpoints/scholarships.py
@@ -298,7 +298,7 @@ async def get_scholarship_detail(id: int, db: AsyncSession = Depends(get_db)):
         "description_en": scholarship.description_en,
         "application_cycle": scholarship.application_cycle.value if scholarship.application_cycle else "semester",
         "sub_type_list": scholarship.sub_type_list or [],
-        "amount": active_config.amount if active_config else 0,  # Get amount from active configuration
+        "amount": active_config.amount if active_config else None,  # None when no active config (#1115)
         "currency": active_config.currency if active_config else "TWD",  # Get currency from active configuration
         "whitelist_enabled": scholarship.whitelist_enabled if hasattr(scholarship, "whitelist_enabled") else False,
         "whitelist_student_ids": [
@@ -735,7 +735,7 @@ async def toggle_scholarship_whitelist(
         "description_en": scholarship.description_en,
         "application_cycle": scholarship.application_cycle.value if scholarship.application_cycle else "semester",
         "sub_type_list": scholarship.sub_type_list or [],
-        "amount": active_config.amount if active_config else 0,
+        "amount": active_config.amount if active_config else None,  # None when no active config (#1115)
         "currency": active_config.currency if active_config else "TWD",
         "whitelist_enabled": scholarship.whitelist_enabled,
         "whitelist_student_ids": [

--- a/backend/app/schemas/scholarship.py
+++ b/backend/app/schemas/scholarship.py
@@ -70,7 +70,10 @@ class ScholarshipTypeBase(BaseModel):
     @field_validator("amount")
     @classmethod
     def validate_amount(cls, v):
-        if v <= 0:
+        # None is allowed so ScholarshipTypeResponse can represent a type with no
+        # active configuration yet (#1115); inputs (ScholarshipTypeCreate) keep
+        # `amount: Decimal` required, so a positive amount is still enforced there.
+        if v is not None and v <= 0:
             raise ValueError("Amount must be greater than 0")
         return v
 
@@ -124,6 +127,10 @@ class ScholarshipTypeUpdate(BaseModel):
 
 class ScholarshipTypeResponse(ScholarshipTypeBase):
     id: int
+    # A scholarship type whose active ScholarshipConfiguration does not exist yet
+    # has no configured amount — represent it as null rather than 500ing on the
+    # base's `amount > 0` rule (#1115).
+    amount: Optional[Decimal] = None
     created_at: datetime
     updated_at: datetime
     created_by: Optional[int] = None

--- a/backend/app/tests/test_admin_scholarships_endpoints.py
+++ b/backend/app/tests/test_admin_scholarships_endpoints.py
@@ -285,19 +285,23 @@ class TestAdminScholarshipsEndpoints:
         assert "nstc" in codes
 
     @pytest.mark.asyncio
-    async def test_get_sub_type_configs_general_crashes_500(self, login, admin, scholarship):
-        """BUG: GET sub-type-configs 500s when sub_type_list contains 'general'
-        but no explicit general config exists.
+    async def test_get_sub_type_configs_general_default_succeeds(self, login, admin, scholarship):
+        """#1117 (fixed): GET sub-type-configs no longer 500s when sub_type_list
+        contains 'general' with no explicit general config.
 
-        The synthetic-general default (admin/scholarships.py ~L449-453) reads
-        ``scholarship.currency`` and ``scholarship.amount``, but ScholarshipType
-        has NEITHER column (per CLAUDE.md these live on ScholarshipConfiguration).
-        The unhandled AttributeError becomes an HTTP 500 in production; the test
-        ASGI transport re-raises it. Pinning current (broken) behavior.
+        The synthetic-general default used to read ``scholarship.currency`` /
+        ``scholarship.amount`` — columns ScholarshipType does not have (they live
+        on ScholarshipConfiguration) → AttributeError → 500. It now emits a
+        default-currency, null-amount synthetic config.
         """
         c = login(admin)
-        with pytest.raises(AttributeError, match="currency"):
-            await c.get(f"/api/v1/admin/scholarships/{scholarship.id}/sub-type-configs")
+        resp = await c.get(f"/api/v1/admin/scholarships/{scholarship.id}/sub-type-configs")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        general = next((x for x in data if x["sub_type_code"] == "general"), None)
+        assert general is not None
+        assert general["currency"] == "TWD"
+        assert general["effective_amount"] is None
 
     # ------------------------------------------------------------------
     # POST /scholarships/{scholarship_id}/sub-type-configs

--- a/backend/app/tests/test_professor_student_endpoints.py
+++ b/backend/app/tests/test_professor_student_endpoints.py
@@ -252,15 +252,11 @@ class TestProfessorStudentEnvelopeAndFlow:
         assert body["success"] is True
         assert body["data"] is None
 
-    async def test_admin_create_valid_professor_rejected_400_bug(self, client, login, ps_users):
-        # BUG: create_professor_student_relationship validates the fetched user's
-        # role with `professor.role not in ["professor", "admin"]` and
-        # `student.role != "student"`. `User.role` is a plain enum.Enum member
-        # (UserRole.professor), never equal to the bare string "professor", so a
-        # perfectly valid professor+student pair is ALWAYS rejected with 400 —
-        # the create endpoint cannot create any relationship. Fix = compare
-        # against enum members (UserRole.professor / UserRole.student) or
-        # `.value`. Pinning current (broken) behavior.
+    async def test_admin_create_valid_professor_succeeds(self, client, login, ps_users):
+        # #1112 (fixed): the role check now compares UserRole enum members, so a
+        # valid professor+student pair is accepted. Previously `professor.role
+        # not in ["professor","admin"]` (enum vs bare string) rejected EVERY pair
+        # with 400 — the create endpoint could never create a relationship.
         login(ps_users["admin"])
         response = await client.post(
             PREFIX,
@@ -270,4 +266,6 @@ class TestProfessorStudentEnvelopeAndFlow:
                 "relationship_type": "advisor",
             },
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True

--- a/backend/app/tests/test_roster_schedules_endpoints.py
+++ b/backend/app/tests/test_roster_schedules_endpoints.py
@@ -261,17 +261,14 @@ class TestRosterSchedulesValidationAndNotFound:
         response = await client.delete(f"{PREFIX}/999999")
         assert response.status_code == 404
 
-    async def test_execute_schedule_not_found_returns_500_bug(self, client, login, roster_users):
-        # BUG: execute_schedule_now() is the only handler in this module missing
-        # the `except HTTPException: raise` guard. Its own 404 ("Roster schedule
-        # not found") is caught by the bare `except Exception` and re-raised as
-        # 500, masking a legitimate not-found as a server error. Every sibling
-        # handler (get/update/patch/delete) correctly re-raises the 404.
-        # Pinning current behavior; fix = add `except HTTPException: raise`
-        # before the generic handler (see roster_schedules.py ~line 473).
+    async def test_execute_schedule_not_found_returns_404(self, client, login, roster_users):
+        # #1113 (fixed): execute_schedule_now() now re-raises HTTPException before
+        # the generic handler, so a missing schedule surfaces as 404 (was masked
+        # as 500 because it was the only handler lacking `except HTTPException:
+        # raise`).
         login(roster_users["admin"])
         response = await client.post(f"{PREFIX}/999999/execute")
-        assert response.status_code == 500
+        assert response.status_code == 404
 
 
 @pytest.mark.api

--- a/backend/app/tests/test_scholarships_endpoints.py
+++ b/backend/app/tests/test_scholarships_endpoints.py
@@ -97,11 +97,11 @@ async def scholarship(db) -> ScholarshipType:
 
 @pytest_asyncio.fixture
 async def active_config(db, scholarship) -> ScholarshipConfiguration:
-    """An active configuration (amount > 0) so ScholarshipTypeResponse validates.
+    """An active configuration so the detail response carries a real amount.
 
-    Without an active config the detail / whitelist responses build
-    ScholarshipTypeResponse(amount=0), which fails the ``amount > 0`` schema
-    validator and 500s (see TestScholarshipResponseBuildBug).
+    Without an active config the detail / whitelist responses now build
+    ScholarshipTypeResponse with a null amount (see
+    TestScholarshipResponseBuildNoConfig) — that path used to 500 before #1115.
     """
     config = ScholarshipConfiguration(
         scholarship_type_id=scholarship.id,
@@ -348,8 +348,6 @@ class TestScholarshipResponseBuildNoConfig:
 
     async def test_whitelist_toggle_without_config_succeeds(self, client, login, sch_users, scholarship):
         login(sch_users["admin"])
-        response = await client.patch(
-            f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True}
-        )
+        response = await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True})
         assert response.status_code == 200
         assert response.json()["success"] is True

--- a/backend/app/tests/test_scholarships_endpoints.py
+++ b/backend/app/tests/test_scholarships_endpoints.py
@@ -331,32 +331,25 @@ class TestDevEndpointsDebugGate:
 
 
 @pytest.mark.api
-class TestScholarshipResponseBuildBug:
-    """BUG (pinned current behavior): GET /{id} and PATCH /{id}/whitelist crash
-    for any scholarship type that has NO active ScholarshipConfiguration.
+class TestScholarshipResponseBuildNoConfig:
+    """#1115 (fixed): GET /{id} and PATCH /{id}/whitelist for a scholarship type
+    with NO active ScholarshipConfiguration now succeed with a null amount.
 
-    scholarships.py builds ScholarshipTypeResponse(amount=0) when active_config is
-    None (lines ~299 and ~736), but ScholarshipTypeResponse's field validator
-    rejects ``amount <= 0`` ("Amount must be greater than 0"), so the response
-    construction raises a pydantic ValidationError. In production the error
-    middleware turns this into an HTTP 500; under the ASGI test transport the
-    exception propagates to the caller (pinned with pytest.raises below). A
-    brand-new scholarship type (created before its configuration) is therefore
-    un-viewable via these routes.
+    Previously scholarships.py passed amount=0 when active_config was None, which
+    tripped ScholarshipTypeResponse's `amount > 0` validator → pydantic
+    ValidationError → HTTP 500. The endpoints now pass None and the response
+    schema allows a null amount (input schemas still require a positive amount).
     """
 
-    async def test_get_detail_without_config_raises(self, client, scholarship):
-        # BUG: should be 200 with amount=0; instead the amount>0 validator raises.
-        from pydantic import ValidationError
+    async def test_get_detail_without_config_returns_null_amount(self, client, scholarship):
+        response = await client.get(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}")
+        assert response.status_code == 200
+        assert response.json()["data"]["amount"] is None
 
-        with pytest.raises(ValidationError):
-            await client.get(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}")
-
-    async def test_whitelist_toggle_without_config_raises(self, client, login, sch_users, scholarship):
-        # BUG: the whitelist flag IS persisted (commit precedes response building),
-        # but the response construction raises because there is no active config.
-        from pydantic import ValidationError
-
+    async def test_whitelist_toggle_without_config_succeeds(self, client, login, sch_users, scholarship):
         login(sch_users["admin"])
-        with pytest.raises(ValidationError):
-            await client.patch(f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True})
+        response = await client.patch(
+            f"{SCHOLARSHIPS_PREFIX}/{scholarship.id}/whitelist", json={"enabled": True}
+        )
+        assert response.status_code == 200
+        assert response.json()["success"] is True


### PR DESCRIPTION
Fixes the four production bugs that the endpoint-coverage test wave (PRs #1111/#1114/#1116) pinned. Each is a CLAUDE.md-documented bug class; the pinning tests are **flipped here** to assert the corrected behavior.

| # | Endpoint | Bug | Fix |
|---|---|---|---|
| **#1112** | `POST /professor-student` | **create endpoint was 100% DEAD** — compared `User.role` (enum member) to bare strings `"professor"`/`"student"`, so every valid pair → 400 | compare `UserRole` enum members |
| **#1113** | `POST /roster-schedules/{id}/execute` | own 404 masked as 500 — only handler missing `except HTTPException: raise` | add the re-raise guard |
| **#1115** | `GET /scholarships/{id}`, `PATCH /scholarships/{id}/whitelist` | 500 when the type has no active `ScholarshipConfiguration` (passed `amount=0` → tripped the `amount > 0` validator) | endpoints pass `None`; validator + response allow null amount; **inputs still require amount > 0** |
| **#1117** | `GET /admin/scholarships/{id}/sub-type-configs` | 500 on the **default** `sub_type_list=["general"]` — synthetic default read `scholarship.currency`/`.amount`, columns `ScholarshipType` lacks | emit default currency + null effective amount |

## Notes on #1115 (schema change kept safe)
`ScholarshipTypeResponse.amount` becomes `Optional`, and the shared base validator now allows `None`. Input schema `ScholarshipTypeCreate` keeps `amount: Decimal` (required) so a positive amount is still enforced on create/update — verified:
```
OK create rejects amount=0 / -5 / missing;  OK response allows amount=None
```
`ScholarshipTypeResponse` is not used as a `response_model` (API-standardization returns dicts), so the **OpenAPI surface is unchanged** — `schema.d.ts` regenerates byte-identical, no frontend type change needed (verified by diffing an offline-generated spec).

## Verification
Host venv + CI in-memory SQLite (dev Docker wedged this session): **402 passed** across scholarship + touched-module suites, including the 4 flipped pin-tests now asserting 200/404/null-amount. black + flake8 (B904/B014/F401) clean.

Closes #1112, closes #1113, closes #1115, closes #1117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFNCV4rmmoie3jsTFMMFth