### PR TITLE
feat: make scholarship application notices admin-editable

### DIFF
--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -9,6 +9,11 @@ from app.core.security import get_current_user, require_admin
 from app.db.deps import get_db
 from app.models.system_setting import ConfigCategory, ConfigDataType
 from app.models.user import User
+from app.schemas.application_notices import (
+    APPLICATION_NOTICES_KEY,
+    DEFAULT_APPLICATION_NOTICES,
+    ApplicationNotices,
+)
 from app.schemas.supplementary_doc import (
     ReorderRequest,
     SupplementaryDocResponse,
@@ -124,6 +129,80 @@ async def get_public_docs(
     rows = result.scalars().all()
     data = {row.key: row.value for row in rows}
     return {"success": True, "message": "OK", "data": data}
+
+
+@router.get("/application-notices")
+async def get_application_notices(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    取得學生申請精靈的「獎學金申請注意事項」內容（zh/en）。
+    所有登入使用者皆可讀取；尚未設定時回傳系統預設內容。
+    """
+    from pydantic import ValidationError
+
+    config_service = ConfigurationService(db)
+    setting = await config_service.get_configuration(APPLICATION_NOTICES_KEY)
+
+    if setting is None:
+        notices = DEFAULT_APPLICATION_NOTICES
+    else:
+        try:
+            raw_value = await config_service.get_decrypted_value(setting)
+            notices = ApplicationNotices.model_validate(raw_value)
+        except (ValidationError, ValueError) as e:
+            logger.exception("Stored application_notices setting is not valid JSON content")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="注意事項設定資料格式錯誤，請聯絡系統管理員",
+            ) from e
+
+    return {"success": True, "message": "OK", "data": notices.model_dump()}
+
+
+@router.put("/application-notices")
+async def update_application_notices(
+    payload: ApplicationNotices,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    更新「獎學金申請注意事項」內容。僅限管理員。
+    整份 zh/en 內容一次覆寫，變更會寫入設定稽核日誌。
+    """
+    config_service = ConfigurationService(db)
+
+    try:
+        await config_service.set_configuration(
+            key=APPLICATION_NOTICES_KEY,
+            value=payload.model_dump(),
+            user_id=current_user.id,
+            category=ConfigCategory.features,
+            data_type=ConfigDataType.json,
+            description="學生申請精靈「獎學金申請注意事項」內容（zh/en）",
+            change_reason="Update application notices",
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    logger.info(
+        "application-notices updated by user_id=%s",
+        current_user.id,
+        extra={
+            "actor_user_id": current_user.id,
+            "actor_role": (current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role)),
+            "config_key": APPLICATION_NOTICES_KEY,
+            "zh_item_count": len(payload.zh.items),
+            "en_item_count": len(payload.en.items),
+        },
+    )
+
+    return {
+        "success": True,
+        "message": "Application notices updated successfully",
+        "data": payload.model_dump(),
+    }
 
 
 @router.post("/upload/{doc_key}")

--- a/backend/app/api/v1/endpoints/system_settings.py
+++ b/backend/app/api/v1/endpoints/system_settings.py
@@ -152,7 +152,7 @@ async def get_application_notices(
             raw_value = await config_service.get_decrypted_value(setting)
             notices = ApplicationNotices.model_validate(raw_value)
         except (ValidationError, ValueError) as e:
-            logger.exception("Stored application_notices setting is not valid JSON content")
+            logger.exception("Stored application_notices setting is invalid (malformed JSON or schema mismatch)")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="注意事項設定資料格式錯誤，請聯絡系統管理員",

--- a/backend/app/schemas/application_notices.py
+++ b/backend/app/schemas/application_notices.py
@@ -1,0 +1,178 @@
+"""Schemas and default content for the student wizard 獎學金申請注意事項.
+
+The content is stored in ``system_settings`` under key ``application_notices``
+(``data_type=json``) so administrators can edit every notice item (and the
+important-notice banner) without a code deploy. When the setting has not been
+configured yet, the API serves ``DEFAULT_APPLICATION_NOTICES`` — the original
+copy that used to be hardcoded in the frontend wizard.
+"""
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+# system_settings.key that stores the admin-edited content.
+APPLICATION_NOTICES_KEY = "application_notices"
+
+
+class ApplicationNoticeItem(BaseModel):
+    """One numbered notice item (e.g. 申請資格, 申請期限)."""
+
+    title: str = Field(..., min_length=1, max_length=100)
+    content: str = Field(..., min_length=1, max_length=2000)
+
+
+class LocalizedApplicationNotices(BaseModel):
+    """Notice content for a single locale."""
+
+    items: List[ApplicationNoticeItem] = Field(..., min_length=1, max_length=30)
+    important_notice: str = Field(..., min_length=1, max_length=2000)
+
+
+class ApplicationNotices(BaseModel):
+    """Full bilingual notice content shown in the application wizard."""
+
+    zh: LocalizedApplicationNotices
+    en: LocalizedApplicationNotices
+
+
+DEFAULT_APPLICATION_NOTICES = ApplicationNotices(
+    zh=LocalizedApplicationNotices(
+        items=[
+            ApplicationNoticeItem(
+                title="申請資格",
+                content=(
+                    "申請人必須為本校在學【全職學生】，【不得於公私立機構從事專職全時之有給職工作】，"
+                    "且符合各獎學金規定的申請條件。請確認您的學籍狀態與申請資格。"
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="申請限制",
+                content=(
+                    "每位獲獎學生至多可領獎3年共計6學期，國科會與教育部獎學金兩獎項合併計算，申請次數不限。\n"
+                    "每次申請為一學年期程，並可申請續領至滿三學年為止。如遇休學、退學、畢業，"
+                    "或有違反本校獎學金要點相關規定之情事，將喪失領獎資格，將由備取學生遞補。"
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="申請期限",
+                content="各獎學金有不同的申請期限，逾期申請恕不受理。請注意各獎學金的開放申請日期與截止日期。",
+            ),
+            ApplicationNoticeItem(
+                title="文件準備",
+                content=(
+                    "請備妥所需文件，包括但不限於成績單、郵局存摺封面、勞保投保紀錄、指導教授推薦函等。"
+                    "所有文件必須為清晰可辨識的電子檔案（PDF、JPG、JPEG 或 PNG 格式）。"
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="資料正確性",
+                content="申請人應確保所填寫資料及上傳文件之正確性與真實性。如有虛偽不實，將取消申請資格並依校規處理。",
+            ),
+            ApplicationNoticeItem(
+                title="個人資料使用",
+                content="您的個人資料將僅用於獎學金申請審核及後續相關作業，本校將依個人資料保護法規定妥善保管。",
+            ),
+            ApplicationNoticeItem(
+                title="審核流程",
+                content=(
+                    "申請送出後，須經指導教授審核，並依序辦理系所初審、學院複審及教務處校級複核會議審查等程序。"
+                    "審核期間，請隨時留意系統通知，以掌握最新審查進度。"
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="獎金撥款",
+                content="獲獎學生請確認郵局帳戶資料正確無誤，獎學金將於核定後撥款至指定帳戶",
+            ),
+            ApplicationNoticeItem(
+                title="申請撤回",
+                content="申請送出後如需撤回，請於審核開始前聯繫承辦單位。審核程序啟動後將無法撤回申請。",
+            ),
+        ],
+        important_notice=(
+            "請務必詳細閱讀各項獎學金要點與相關規定。\n"
+            "每位學生每次申請國科會或教育部博士生獎學金為一學年期程，僅可擇一獲獎，請謹慎選擇。"
+        ),
+    ),
+    en=LocalizedApplicationNotices(
+        items=[
+            ApplicationNoticeItem(
+                title="Eligibility",
+                content=(
+                    "Applicants must be currently enrolled students and meet the specific requirements of "
+                    "each scholarship. Please verify your enrollment status and eligibility."
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="Application Restrictions",
+                content=(
+                    "Each awarded student may receive the scholarship for up to 3 years (6 semesters total); "
+                    "the NSTC and MOE scholarships are counted together, with no limit on the number of "
+                    "applications.\nEach application covers one academic year, and may be renewed up to a "
+                    "total of three academic years. Recipients who take a leave of absence, withdraw, "
+                    "graduate, or violate the university's scholarship regulations will forfeit their "
+                    "eligibility, and a waitlisted student will be selected instead."
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="Application Deadline",
+                content=(
+                    "Each scholarship has different application deadlines. Late applications will not be "
+                    "accepted. Please note the opening and closing dates for each scholarship."
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="Document Preparation",
+                content=(
+                    "Please prepare all required documents, including but not limited to transcripts, "
+                    "enrollment certificates, and advisor recommendation letters. All documents must be "
+                    "clear electronic files (PDF, JPG, JPEG, or PNG format)."
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="Data Accuracy",
+                content=(
+                    "Applicants must ensure the accuracy and authenticity of all information and uploaded "
+                    "documents. False information will result in disqualification and disciplinary action "
+                    "according to university regulations."
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="Personal Data Usage",
+                content=(
+                    "Your personal data will be used solely for scholarship application review and related "
+                    "procedures. The university will safeguard your data according to Personal Data "
+                    "Protection Act."
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="Review Process",
+                content=(
+                    "After submission, applications will go through department preliminary review, college "
+                    "review, and administrative approval. Please monitor system notifications during the "
+                    "review period."
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="Award Distribution",
+                content=(
+                    "Award recipients should ensure their bank account information is correct. Scholarships "
+                    "will be disbursed to the designated account after approval."
+                ),
+            ),
+            ApplicationNoticeItem(
+                title="Application Withdrawal",
+                content=(
+                    "If you need to withdraw your application after submission, please contact the "
+                    "administrative office before the review begins. Withdrawal is not possible once the "
+                    "review process has started."
+                ),
+            ),
+        ],
+        important_notice=(
+            "Please read the regulations and related rules for each scholarship carefully.\n"
+            "Each student may apply for either the NSTC or MOE PhD Scholarship for one academic year per "
+            "application, and may only receive one of the two. Please choose carefully."
+        ),
+    ),
+)

--- a/backend/app/tests/test_application_notices_endpoints.py
+++ b/backend/app/tests/test_application_notices_endpoints.py
@@ -1,0 +1,146 @@
+"""Tests for the admin-editable 獎學金申請注意事項 endpoints.
+
+GET  /api/v1/system-settings/application-notices — any authenticated user
+PUT  /api/v1/system-settings/application-notices — admin only
+"""
+
+import pytest
+from httpx import AsyncClient
+from pydantic import ValidationError
+
+from app.core.security import get_current_user
+from app.main import app
+from app.models.user import User
+from app.schemas.application_notices import (
+    APPLICATION_NOTICES_KEY,
+    DEFAULT_APPLICATION_NOTICES,
+    ApplicationNotices,
+)
+
+
+def _valid_payload() -> dict:
+    return {
+        "zh": {
+            "items": [
+                {"title": "申請資格", "content": "自訂資格說明"},
+                {"title": "申請期限", "content": "自訂期限說明"},
+            ],
+            "important_notice": "自訂重要提醒",
+        },
+        "en": {
+            "items": [
+                {"title": "Eligibility", "content": "Custom eligibility"},
+                {"title": "Deadline", "content": "Custom deadline"},
+            ],
+            "important_notice": "Custom important notice",
+        },
+    }
+
+
+class TestApplicationNoticesSchema:
+    def test_default_notices_are_valid_and_bilingual(self):
+        assert len(DEFAULT_APPLICATION_NOTICES.zh.items) == 9
+        assert len(DEFAULT_APPLICATION_NOTICES.en.items) == 9
+        assert DEFAULT_APPLICATION_NOTICES.zh.items[0].title == "申請資格"
+        assert DEFAULT_APPLICATION_NOTICES.zh.important_notice
+        assert DEFAULT_APPLICATION_NOTICES.en.important_notice
+
+    def test_rejects_empty_items_list(self):
+        payload = _valid_payload()
+        payload["zh"]["items"] = []
+        with pytest.raises(ValidationError):
+            ApplicationNotices.model_validate(payload)
+
+    def test_rejects_blank_item_title(self):
+        payload = _valid_payload()
+        payload["zh"]["items"][0]["title"] = ""
+        with pytest.raises(ValidationError):
+            ApplicationNotices.model_validate(payload)
+
+    def test_rejects_missing_locale(self):
+        payload = _valid_payload()
+        del payload["en"]
+        with pytest.raises(ValidationError):
+            ApplicationNotices.model_validate(payload)
+
+    def test_rejects_overlong_content(self):
+        payload = _valid_payload()
+        payload["zh"]["items"][0]["content"] = "x" * 2001
+        with pytest.raises(ValidationError):
+            ApplicationNotices.model_validate(payload)
+
+
+class TestApplicationNoticesEndpoints:
+    @pytest.fixture(autouse=True)
+    def _cleanup_overrides(self):
+        yield
+        app.dependency_overrides.pop(get_current_user, None)
+
+    def _login(self, user: User):
+        app.dependency_overrides[get_current_user] = lambda: user
+
+    @pytest.mark.asyncio
+    async def test_get_returns_defaults_when_unconfigured(self, client: AsyncClient, test_user: User):
+        self._login(test_user)
+        response = await client.get("/api/v1/system-settings/application-notices")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["data"] == DEFAULT_APPLICATION_NOTICES.model_dump()
+
+    @pytest.mark.asyncio
+    async def test_put_requires_admin(self, client: AsyncClient, test_user: User):
+        self._login(test_user)
+        response = await client.put(
+            "/api/v1/system-settings/application-notices",
+            json=_valid_payload(),
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_admin_update_roundtrip(self, client: AsyncClient, test_admin: User):
+        self._login(test_admin)
+        payload = _valid_payload()
+
+        put_response = await client.put(
+            "/api/v1/system-settings/application-notices",
+            json=payload,
+        )
+        assert put_response.status_code == 200
+        assert put_response.json()["success"] is True
+
+        get_response = await client.get("/api/v1/system-settings/application-notices")
+        assert get_response.status_code == 200
+        assert get_response.json()["data"] == payload
+
+    @pytest.mark.asyncio
+    async def test_put_rejects_invalid_payload(self, client: AsyncClient, test_admin: User):
+        self._login(test_admin)
+        payload = _valid_payload()
+        payload["zh"]["items"] = []
+        response = await client.put(
+            "/api/v1/system-settings/application-notices",
+            json=payload,
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_update_writes_audit_log(self, client: AsyncClient, test_admin: User, db):
+        from sqlalchemy import select
+
+        from app.models.system_setting import ConfigurationAuditLog
+
+        self._login(test_admin)
+        response = await client.put(
+            "/api/v1/system-settings/application-notices",
+            json=_valid_payload(),
+        )
+        assert response.status_code == 200
+
+        result = await db.execute(
+            select(ConfigurationAuditLog).where(ConfigurationAuditLog.setting_key == APPLICATION_NOTICES_KEY)
+        )
+        logs = result.scalars().all()
+        assert len(logs) == 1
+        assert logs[0].action == "CREATE"
+        assert logs[0].changed_by == test_admin.id

--- a/frontend/components/__tests__/notice-agreement-step.test.tsx
+++ b/frontend/components/__tests__/notice-agreement-step.test.tsx
@@ -5,13 +5,22 @@ import { NoticeAgreementStep } from "../student-wizard/steps/NoticeAgreementStep
 jest.mock("../../lib/api", () => {
   const getPublicDocs = jest.fn();
   const list = jest.fn();
+  const noticesGet = jest.fn();
   return {
     __esModule: true,
     default: {
-      systemSettings: { getPublicDocs, supplementaryDocs: { list } },
+      systemSettings: {
+        getPublicDocs,
+        supplementaryDocs: { list },
+        applicationNotices: { get: noticesGet },
+      },
     },
     api: {
-      systemSettings: { getPublicDocs, supplementaryDocs: { list } },
+      systemSettings: {
+        getPublicDocs,
+        supplementaryDocs: { list },
+        applicationNotices: { get: noticesGet },
+      },
     },
   };
 });
@@ -21,12 +30,33 @@ const apiMock = jest.requireMock("../../lib/api") as {
     systemSettings: {
       getPublicDocs: jest.Mock;
       supplementaryDocs: { list: jest.Mock };
+      applicationNotices: { get: jest.Mock };
     };
   };
 };
 
 const mockGetPublicDocs = apiMock.api.systemSettings.getPublicDocs;
 const mockSuppList = apiMock.api.systemSettings.supplementaryDocs.list;
+const mockNoticesGet = apiMock.api.systemSettings.applicationNotices.get;
+
+const SAMPLE_NOTICES = {
+  zh: {
+    items: [
+      { title: "申請資格", content: "申請資格說明內容" },
+      { title: "申請期限", content: "申請期限說明內容" },
+      { title: "獎金撥款", content: "獎金撥款說明內容" },
+    ],
+    important_notice: "請務必詳細閱讀各項獎學金要點與相關規定。",
+  },
+  en: {
+    items: [
+      { title: "Eligibility", content: "Eligibility details" },
+      { title: "Deadline", content: "Deadline details" },
+      { title: "Distribution", content: "Distribution details" },
+    ],
+    important_notice: "Please read the regulations carefully.",
+  },
+};
 
 jest.mock("../inline-pdf-viewer", () => ({
   InlinePdfViewer: (props: {
@@ -55,6 +85,11 @@ describe("NoticeAgreementStep", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSuppList.mockResolvedValue({ success: true, message: "OK", data: [] });
+    mockNoticesGet.mockResolvedValue({
+      success: true,
+      message: "OK",
+      data: SAMPLE_NOTICES,
+    });
     Object.defineProperty(window, "localStorage", {
       value: {
         getItem: jest.fn(() => "test-token"),
@@ -187,7 +222,7 @@ describe("NoticeAgreementStep", () => {
     expect(agreeCheckbox).not.toBeDisabled();
   });
 
-  it("keeps the 8 hardcoded notice items visible as a static summary", async () => {
+  it("renders the admin-managed notice items fetched from the API", async () => {
     mockGetPublicDocs.mockResolvedValue({
       success: true,
       data: { regulations_url: "system-docs/x.pdf" },
@@ -204,9 +239,35 @@ describe("NoticeAgreementStep", () => {
     await waitFor(() =>
       expect(screen.getByText("申請資格")).toBeInTheDocument(),
     );
-    expect(mockGetPublicDocs).toHaveBeenCalled();
+    expect(mockNoticesGet).toHaveBeenCalled();
     expect(screen.getByText("申請期限")).toBeInTheDocument();
     expect(screen.getByText("獎金撥款")).toBeInTheDocument();
+    expect(screen.getByText("申請資格說明內容")).toBeInTheDocument();
+    expect(
+      screen.getByText(/請務必詳細閱讀各項獎學金要點/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error message (not stale content) when notices fail to load", async () => {
+    mockGetPublicDocs.mockResolvedValue({
+      success: true,
+      data: { regulations_url: "system-docs/x.pdf" },
+    });
+    mockNoticesGet.mockRejectedValue(new Error("network down"));
+
+    render(
+      <NoticeAgreementStep
+        agreedToTerms={false}
+        onAgree={noop}
+        onNext={noop}
+        locale="zh"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/無法載入注意事項/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("申請資格")).not.toBeInTheDocument();
   });
 });
 
@@ -214,6 +275,11 @@ describe("NoticeAgreementStep — 參考文件 list", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSuppList.mockResolvedValue({ success: true, message: "OK", data: [] });
+    mockNoticesGet.mockResolvedValue({
+      success: true,
+      message: "OK",
+      data: SAMPLE_NOTICES,
+    });
     Object.defineProperty(window, "localStorage", {
       value: { getItem: jest.fn(() => "test-token") },
       configurable: true,

--- a/frontend/components/admin/system-docs/ApplicationNoticesPanel.tsx
+++ b/frontend/components/admin/system-docs/ApplicationNoticesPanel.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  ArrowDown,
+  ArrowUp,
+  ListChecks,
+  Loader2,
+  Plus,
+  Save,
+  Trash2,
+} from "lucide-react";
+import apiClient from "@/lib/api";
+import type {
+  ApplicationNotices,
+  LocalizedApplicationNotices,
+} from "@/lib/api/modules/system-settings";
+import { toast } from "sonner";
+
+const LOCALES: Array<{ key: "zh" | "en"; label: string }> = [
+  { key: "zh", label: "中文" },
+  { key: "en", label: "English" },
+];
+
+const MAX_ITEMS = 30;
+
+export function ApplicationNoticesPanel() {
+  const [notices, setNotices] = useState<ApplicationNotices | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    setLoadFailed(false);
+    try {
+      const res = await apiClient.systemSettings.applicationNotices.get();
+      if (res.success && res.data) {
+        setNotices(res.data);
+        setDirty(false);
+      } else {
+        setLoadFailed(true);
+        toast.error(res.message || "載入注意事項失敗");
+      }
+    } catch {
+      setLoadFailed(true);
+      toast.error("載入注意事項失敗");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const mutateLocale = (
+    locale: "zh" | "en",
+    mutate: (draft: LocalizedApplicationNotices) => LocalizedApplicationNotices
+  ) => {
+    setNotices((prev) => {
+      if (!prev) return prev;
+      return { ...prev, [locale]: mutate(prev[locale]) };
+    });
+    setDirty(true);
+  };
+
+  const updateItem = (
+    locale: "zh" | "en",
+    index: number,
+    patch: Partial<{ title: string; content: string }>
+  ) =>
+    mutateLocale(locale, (draft) => ({
+      ...draft,
+      items: draft.items.map((item, i) =>
+        i === index ? { ...item, ...patch } : item
+      ),
+    }));
+
+  const addItem = (locale: "zh" | "en") =>
+    mutateLocale(locale, (draft) => ({
+      ...draft,
+      items: [...draft.items, { title: "", content: "" }],
+    }));
+
+  const removeItem = (locale: "zh" | "en", index: number) =>
+    mutateLocale(locale, (draft) => ({
+      ...draft,
+      items: draft.items.filter((_, i) => i !== index),
+    }));
+
+  const moveItem = (locale: "zh" | "en", index: number, direction: -1 | 1) =>
+    mutateLocale(locale, (draft) => {
+      const target = index + direction;
+      if (target < 0 || target >= draft.items.length) return draft;
+      const items = [...draft.items];
+      [items[index], items[target]] = [items[target], items[index]];
+      return { ...draft, items };
+    });
+
+  const validate = (data: ApplicationNotices): string | null => {
+    for (const { key, label } of LOCALES) {
+      const localized = data[key];
+      if (localized.items.length === 0) {
+        return `${label}至少需要一項注意事項`;
+      }
+      if (!localized.important_notice.trim()) {
+        return `${label}的重要提醒不可為空`;
+      }
+      for (let i = 0; i < localized.items.length; i++) {
+        if (!localized.items[i].title.trim()) {
+          return `${label}第 ${i + 1} 項的標題不可為空`;
+        }
+        if (!localized.items[i].content.trim()) {
+          return `${label}第 ${i + 1} 項的內容不可為空`;
+        }
+      }
+    }
+    return null;
+  };
+
+  const save = async () => {
+    if (!notices) return;
+    const error = validate(notices);
+    if (error) {
+      toast.error(error);
+      return;
+    }
+    setSaving(true);
+    try {
+      const res =
+        await apiClient.systemSettings.applicationNotices.update(notices);
+      if (res.success) {
+        toast.success("注意事項已更新，學生端將立即看到新內容");
+        setDirty(false);
+        if (res.data) setNotices(res.data);
+      } else {
+        toast.error(res.message || "儲存失敗");
+      }
+    } catch {
+      toast.error("儲存失敗");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card className="overflow-hidden border-gray-200/80 shadow-sm">
+      <CardHeader className="bg-gradient-to-br from-gray-50 to-white border-b">
+        <div className="flex items-start gap-4">
+          <div className="rounded-xl bg-nycu-navy-900 p-3 shadow-sm">
+            <ListChecks className="h-6 w-6 text-white" />
+          </div>
+          <div className="flex-1">
+            <CardTitle className="text-xl text-nycu-navy-900">
+              獎學金申請注意事項
+            </CardTitle>
+            <CardDescription className="mt-1">
+              編輯學生申請流程第一步顯示的注意事項與重要提醒（中英文）。儲存後學生端即套用新內容。
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="p-6">
+        {loading ? (
+          <div className="flex items-center justify-center py-10 text-gray-500">
+            <Loader2 className="h-5 w-5 mr-2 animate-spin" />
+            載入中...
+          </div>
+        ) : loadFailed || !notices ? (
+          <div className="flex flex-col items-center gap-3 py-10 text-sm text-gray-500">
+            <p>無法載入注意事項內容</p>
+            <Button variant="outline" size="sm" onClick={load}>
+              重新載入
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <Tabs defaultValue="zh">
+              <TabsList className="grid w-full max-w-xs grid-cols-2">
+                {LOCALES.map(({ key, label }) => (
+                  <TabsTrigger key={key} value={key}>
+                    {label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+
+              {LOCALES.map(({ key }) => {
+                const localized = notices[key];
+                return (
+                  <TabsContent key={key} value={key} className="space-y-6 mt-4">
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor={`important-notice-${key}`}
+                        className="font-semibold text-nycu-navy-900"
+                      >
+                        重要提醒
+                      </Label>
+                      <Textarea
+                        id={`important-notice-${key}`}
+                        value={localized.important_notice}
+                        onChange={(e) =>
+                          mutateLocale(key, (draft) => ({
+                            ...draft,
+                            important_notice: e.target.value,
+                          }))
+                        }
+                        maxLength={2000}
+                        rows={3}
+                        placeholder="顯示於注意事項頂部的醒目提醒"
+                      />
+                    </div>
+
+                    <div className="space-y-4">
+                      <Label className="font-semibold text-nycu-navy-900">
+                        注意事項條目
+                      </Label>
+                      {localized.items.map((item, index) => (
+                        <div
+                          key={index}
+                          className="rounded-lg border border-gray-200 p-4 space-y-3 bg-white"
+                        >
+                          <div className="flex items-center gap-2">
+                            <div className="flex-shrink-0 w-7 h-7 rounded-full bg-nycu-blue-100 text-nycu-blue-700 flex items-center justify-center font-semibold text-sm">
+                              {index + 1}
+                            </div>
+                            <Input
+                              value={item.title}
+                              onChange={(e) =>
+                                updateItem(key, index, {
+                                  title: e.target.value,
+                                })
+                              }
+                              maxLength={100}
+                              placeholder="標題（例：申請資格）"
+                              className="flex-1"
+                            />
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => moveItem(key, index, -1)}
+                              disabled={index === 0}
+                              title="上移"
+                            >
+                              <ArrowUp className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => moveItem(key, index, 1)}
+                              disabled={index === localized.items.length - 1}
+                              title="下移"
+                            >
+                              <ArrowDown className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => removeItem(key, index)}
+                              disabled={localized.items.length <= 1}
+                              className="text-red-500 hover:text-red-600 hover:bg-red-50"
+                              title="刪除"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                          <Textarea
+                            value={item.content}
+                            onChange={(e) =>
+                              updateItem(key, index, {
+                                content: e.target.value,
+                              })
+                            }
+                            maxLength={2000}
+                            rows={3}
+                            placeholder="內容說明（支援換行）"
+                          />
+                        </div>
+                      ))}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => addItem(key)}
+                        disabled={localized.items.length >= MAX_ITEMS}
+                      >
+                        <Plus className="h-4 w-4 mr-1.5" />
+                        新增條目
+                      </Button>
+                    </div>
+                  </TabsContent>
+                );
+              })}
+            </Tabs>
+
+            <div className="flex items-center justify-end gap-3 pt-4 border-t">
+              {dirty && (
+                <span className="text-sm text-amber-600">尚有未儲存的變更</span>
+              )}
+              <Button
+                onClick={save}
+                disabled={saving || !dirty}
+                className="nycu-gradient text-white"
+              >
+                {saving ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+                    儲存中...
+                  </>
+                ) : (
+                  <>
+                    <Save className="h-4 w-4 mr-1.5" />
+                    儲存變更
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/admin/system-docs/ApplicationNoticesPanel.tsx
+++ b/frontend/components/admin/system-docs/ApplicationNoticesPanel.tsx
@@ -36,8 +36,36 @@ const LOCALES: Array<{ key: "zh" | "en"; label: string }> = [
 
 const MAX_ITEMS = 30;
 
+// Items get a stable client-side key so React tracks identity across
+// reordering — index keys would make inputs reuse the wrong DOM state.
+type EditableItem = { key: string; title: string; content: string };
+type EditableLocalized = {
+  items: EditableItem[];
+  important_notice: string;
+};
+type EditableNotices = { zh: EditableLocalized; en: EditableLocalized };
+
+let itemKeyCounter = 0;
+const nextItemKey = () => `notice-item-${++itemKeyCounter}`;
+
+function toEditable(notices: ApplicationNotices): EditableNotices {
+  const localize = (l: LocalizedApplicationNotices): EditableLocalized => ({
+    important_notice: l.important_notice,
+    items: l.items.map((item) => ({ ...item, key: nextItemKey() })),
+  });
+  return { zh: localize(notices.zh), en: localize(notices.en) };
+}
+
+function toPayload(notices: EditableNotices): ApplicationNotices {
+  const strip = (l: EditableLocalized): LocalizedApplicationNotices => ({
+    important_notice: l.important_notice,
+    items: l.items.map(({ title, content }) => ({ title, content })),
+  });
+  return { zh: strip(notices.zh), en: strip(notices.en) };
+}
+
 export function ApplicationNoticesPanel() {
-  const [notices, setNotices] = useState<ApplicationNotices | null>(null);
+  const [notices, setNotices] = useState<EditableNotices | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -49,7 +77,7 @@ export function ApplicationNoticesPanel() {
     try {
       const res = await apiClient.systemSettings.applicationNotices.get();
       if (res.success && res.data) {
-        setNotices(res.data);
+        setNotices(toEditable(res.data));
         setDirty(false);
       } else {
         setLoadFailed(true);
@@ -70,7 +98,7 @@ export function ApplicationNoticesPanel() {
 
   const mutateLocale = (
     locale: "zh" | "en",
-    mutate: (draft: LocalizedApplicationNotices) => LocalizedApplicationNotices
+    mutate: (draft: EditableLocalized) => EditableLocalized
   ) => {
     setNotices((prev) => {
       if (!prev) return prev;
@@ -94,7 +122,7 @@ export function ApplicationNoticesPanel() {
   const addItem = (locale: "zh" | "en") =>
     mutateLocale(locale, (draft) => ({
       ...draft,
-      items: [...draft.items, { title: "", content: "" }],
+      items: [...draft.items, { key: nextItemKey(), title: "", content: "" }],
     }));
 
   const removeItem = (locale: "zh" | "en", index: number) =>
@@ -112,7 +140,7 @@ export function ApplicationNoticesPanel() {
       return { ...draft, items };
     });
 
-  const validate = (data: ApplicationNotices): string | null => {
+  const validate = (data: EditableNotices): string | null => {
     for (const { key, label } of LOCALES) {
       const localized = data[key];
       if (localized.items.length === 0) {
@@ -142,12 +170,12 @@ export function ApplicationNoticesPanel() {
     }
     setSaving(true);
     try {
-      const res =
-        await apiClient.systemSettings.applicationNotices.update(notices);
+      const res = await apiClient.systemSettings.applicationNotices.update(
+        toPayload(notices)
+      );
       if (res.success) {
         toast.success("注意事項已更新，學生端將立即看到新內容");
         setDirty(false);
-        if (res.data) setNotices(res.data);
       } else {
         toast.error(res.message || "儲存失敗");
       }
@@ -232,7 +260,7 @@ export function ApplicationNoticesPanel() {
                       </Label>
                       {localized.items.map((item, index) => (
                         <div
-                          key={index}
+                          key={item.key}
                           className="rounded-lg border border-gray-200 p-4 space-y-3 bg-white"
                         >
                           <div className="flex items-center gap-2">

--- a/frontend/components/admin/system-docs/SystemDocsPanel.tsx
+++ b/frontend/components/admin/system-docs/SystemDocsPanel.tsx
@@ -28,6 +28,7 @@ import { previewMimeType } from "@/lib/utils";
 import { toast } from "sonner";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { SupplementaryDocsList } from "./SupplementaryDocsList";
+import { ApplicationNoticesPanel } from "./ApplicationNoticesPanel";
 
 interface DocSlot {
   key: DocKey;
@@ -450,6 +451,8 @@ export function SystemDocsPanel() {
       </Card>
 
       <SupplementaryDocsList />
+
+      <ApplicationNoticesPanel />
 
       <FilePreviewDialog
         isOpen={preview !== null}

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -31,6 +31,7 @@ import { api } from "@/lib/api";
 import {
   buildFileProxyUrl,
   buildSuppDocFileProxyUrl,
+  type ApplicationNotices,
   type SupplementaryDoc,
 } from "@/lib/api/modules/system-settings";
 import { previewMimeType } from "@/lib/utils";
@@ -44,63 +45,18 @@ interface NoticeAgreementStepProps {
   locale: "zh" | "en";
 }
 
-// Static locale copy hoisted to module scope so the ~140-line object isn't
-// reallocated on every render.
+// Static locale copy hoisted to module scope so the object isn't reallocated
+// on every render. The notice items and important-notice content are NOT here:
+// they are admin-editable and fetched from
+// GET /api/v1/system-settings/application-notices.
 const NOTICES = {
   zh: {
     title: "獎學金申請注意事項",
     subtitle:
       "請詳細閱讀以下內容，點擊「閱讀獎學金要點」並滑至底部後方可勾選同意繼續申請",
-    items: [
-      {
-        title: "申請資格",
-        content:
-          "申請人必須為本校在學【全職學生】，【不得於公私立機構從事專職全時之有給職工作】，且符合各獎學金規定的申請條件。請確認您的學籍狀態與申請資格。",
-      },
-      {
-        title: "申請限制",
-        content:
-          "每位獲獎學生至多可領獎3年共計6學期，國科會與教育部獎學金兩獎項合併計算，申請次數不限。\n每次申請為一學年期程，並可申請續領至滿三學年為止。如遇休學、退學、畢業，或有違反本校獎學金要點相關規定之情事，將喪失領獎資格，將由備取學生遞補。",
-      },
-      {
-        title: "申請期限",
-        content:
-          "各獎學金有不同的申請期限，逾期申請恕不受理。請注意各獎學金的開放申請日期與截止日期。",
-      },
-      {
-        title: "文件準備",
-        content:
-          "請備妥所需文件，包括但不限於成績單、郵局存摺封面、勞保投保紀錄、指導教授推薦函等。所有文件必須為清晰可辨識的電子檔案（PDF、JPG、JPEG 或 PNG 格式）。",
-      },
-      {
-        title: "資料正確性",
-        content:
-          "申請人應確保所填寫資料及上傳文件之正確性與真實性。如有虛偽不實，將取消申請資格並依校規處理。",
-      },
-      {
-        title: "個人資料使用",
-        content:
-          "您的個人資料將僅用於獎學金申請審核及後續相關作業，本校將依個人資料保護法規定妥善保管。",
-      },
-      {
-        title: "審核流程",
-        content:
-          "申請送出後，須經指導教授審核，並依序辦理系所初審、學院複審及教務處校級複核會議審查等程序。審核期間，請隨時留意系統通知，以掌握最新審查進度。",
-      },
-      {
-        title: "獎金撥款",
-        content:
-          "獲獎學生請確認郵局帳戶資料正確無誤，獎學金將於核定後撥款至指定帳戶",
-      },
-      {
-        title: "申請撤回",
-        content:
-          "申請送出後如需撤回，請於審核開始前聯繫承辦單位。審核程序啟動後將無法撤回申請。",
-      },
-    ],
     importantNotice: "重要提醒",
-    importantContent:
-      "請務必詳細閱讀各項獎學金要點與相關規定。\n每位學生每次申請國科會或教育部博士生獎學金為一學年期程，僅可擇一獲獎，請謹慎選擇。",
+    noticesLoading: "正在載入注意事項…",
+    noticesLoadError: "無法載入注意事項，請重新整理頁面或聯絡承辦單位。",
     agreementText: "我已詳細閱讀並了解獎學金要點，同意遵守相關規定",
     readNoticeText: "尚未閱讀獎學金要點",
     readNoticeHint: "請點擊上方按鈕開啟獎學金要點並滑至底端",
@@ -124,56 +80,10 @@ const NOTICES = {
     title: "Scholarship Application Notice",
     subtitle:
       "Read the following carefully. Scroll the Scholarship Regulations below to the bottom before agreeing to continue.",
-    items: [
-      {
-        title: "Eligibility",
-        content:
-          "Applicants must be currently enrolled students and meet the specific requirements of each scholarship. Please verify your enrollment status and eligibility.",
-      },
-      {
-        title: "Application Restrictions",
-        content:
-          "Each awarded student may receive the scholarship for up to 3 years (6 semesters total); the NSTC and MOE scholarships are counted together, with no limit on the number of applications.\nEach application covers one academic year, and may be renewed up to a total of three academic years. Recipients who take a leave of absence, withdraw, graduate, or violate the university's scholarship regulations will forfeit their eligibility, and a waitlisted student will be selected instead.",
-      },
-      {
-        title: "Application Deadline",
-        content:
-          "Each scholarship has different application deadlines. Late applications will not be accepted. Please note the opening and closing dates for each scholarship.",
-      },
-      {
-        title: "Document Preparation",
-        content:
-          "Please prepare all required documents, including but not limited to transcripts, enrollment certificates, and advisor recommendation letters. All documents must be clear electronic files (PDF, JPG, JPEG, or PNG format).",
-      },
-      {
-        title: "Data Accuracy",
-        content:
-          "Applicants must ensure the accuracy and authenticity of all information and uploaded documents. False information will result in disqualification and disciplinary action according to university regulations.",
-      },
-      {
-        title: "Personal Data Usage",
-        content:
-          "Your personal data will be used solely for scholarship application review and related procedures. The university will safeguard your data according to Personal Data Protection Act.",
-      },
-      {
-        title: "Review Process",
-        content:
-          "After submission, applications will go through department preliminary review, college review, and administrative approval. Please monitor system notifications during the review period.",
-      },
-      {
-        title: "Award Distribution",
-        content:
-          "Award recipients should ensure their bank account information is correct. Scholarships will be disbursed to the designated account after approval.",
-      },
-      {
-        title: "Application Withdrawal",
-        content:
-          "If you need to withdraw your application after submission, please contact the administrative office before the review begins. Withdrawal is not possible once the review process has started.",
-      },
-    ],
     importantNotice: "Important Notice",
-    importantContent:
-      "Please read the regulations and related rules for each scholarship carefully.\nEach student may apply for either the NSTC or MOE PhD Scholarship for one academic year per application, and may only receive one of the two. Please choose carefully.",
+    noticesLoading: "Loading application notices…",
+    noticesLoadError:
+      "Failed to load the application notices. Please refresh the page or contact the administrative office.",
     agreementText:
       "I have read and understand the scholarship regulations and agree to comply",
     readNoticeText: "Regulations not yet read",
@@ -217,6 +127,8 @@ export function NoticeAgreementStep({
   const [supplementaryDocs, setSupplementaryDocs] = useState<SupplementaryDoc[]>(
     []
   );
+  const [notices, setNotices] = useState<ApplicationNotices | null>(null);
+  const [noticesError, setNoticesError] = useState(false);
   const [previewFile, setPreviewFile] = useState<{
     url: string;
     filename: string;
@@ -224,13 +136,14 @@ export function NoticeAgreementStep({
   } | null>(null);
 
   useEffect(() => {
-    // allSettled (not all): a supplementary-docs fetch failure must not drop
-    // publicDocs, which gates the regulations scroll-and-agree flow.
+    // allSettled (not all): a supplementary-docs or notices fetch failure must
+    // not drop publicDocs, which gates the regulations scroll-and-agree flow.
     Promise.allSettled([
       api.systemSettings.getPublicDocs(),
       api.systemSettings.supplementaryDocs.list(),
+      api.systemSettings.applicationNotices.get(),
     ])
-      .then(([docsResult, suppResult]) => {
+      .then(([docsResult, suppResult, noticesResult]) => {
         if (docsResult.status === "fulfilled") {
           const docsRes = docsResult.value;
           if (docsRes.success && docsRes.data) setPublicDocs(docsRes.data);
@@ -251,6 +164,22 @@ export function NoticeAgreementStep({
           console.error(
             "[NoticeAgreementStep] supplementaryDocs.list failed",
             suppResult.reason
+          );
+        }
+        if (
+          noticesResult.status === "fulfilled" &&
+          noticesResult.value.success &&
+          noticesResult.value.data
+        ) {
+          setNotices(noticesResult.value.data);
+        } else {
+          setNoticesError(true);
+          // eslint-disable-next-line no-console
+          console.error(
+            "[NoticeAgreementStep] applicationNotices.get failed",
+            noticesResult.status === "rejected"
+              ? noticesResult.reason
+              : noticesResult.value
           );
         }
       })
@@ -283,6 +212,7 @@ export function NoticeAgreementStep({
 
   const hasRegulationsUploaded = Boolean(publicDocs.regulations_url);
   const t = NOTICES[locale];
+  const localizedNotices = notices ? notices[locale] : null;
 
   return (
     <div className="space-y-6">
@@ -299,44 +229,59 @@ export function NoticeAgreementStep({
           </div>
         </CardHeader>
         <CardContent className="space-y-6">
-          <Alert className="border-amber-200 bg-amber-50">
-            <AlertTriangle className="h-5 w-5 text-amber-600" />
-            <AlertDescription>
-              <div className="font-semibold text-amber-900 mb-1">
-                {t.importantNotice}
-              </div>
-              <div className="text-sm text-amber-800 whitespace-pre-line">
-                {t.importantContent}
-              </div>
-            </AlertDescription>
-          </Alert>
-
-          <Card className="border-2">
-            <div className="p-6">
-              <div className="space-y-4">
-                {t.items.map((item, index) => (
-                  <div
-                    key={index}
-                    className="pb-4 border-b last:border-b-0 last:pb-0"
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="flex-shrink-0 w-8 h-8 rounded-full bg-nycu-blue-100 text-nycu-blue-700 flex items-center justify-center font-semibold text-sm">
-                        {index + 1}
-                      </div>
-                      <div className="flex-1">
-                        <h4 className="font-semibold text-nycu-navy-800 mb-2">
-                          {item.title}
-                        </h4>
-                        <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-line">
-                          {item.content}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
+          {noticesError ? (
+            <Alert className="border-red-300 bg-red-50">
+              <AlertCircle className="h-5 w-5 text-red-600" />
+              <AlertDescription className="text-red-900">
+                {t.noticesLoadError}
+              </AlertDescription>
+            </Alert>
+          ) : !localizedNotices ? (
+            <div className="p-4 bg-gray-50 rounded-lg border border-gray-200 text-sm text-gray-500">
+              {t.noticesLoading}
             </div>
-          </Card>
+          ) : (
+            <>
+              <Alert className="border-amber-200 bg-amber-50">
+                <AlertTriangle className="h-5 w-5 text-amber-600" />
+                <AlertDescription>
+                  <div className="font-semibold text-amber-900 mb-1">
+                    {t.importantNotice}
+                  </div>
+                  <div className="text-sm text-amber-800 whitespace-pre-line">
+                    {localizedNotices.important_notice}
+                  </div>
+                </AlertDescription>
+              </Alert>
+
+              <Card className="border-2">
+                <div className="p-6">
+                  <div className="space-y-4">
+                    {localizedNotices.items.map((item, index) => (
+                      <div
+                        key={index}
+                        className="pb-4 border-b last:border-b-0 last:pb-0"
+                      >
+                        <div className="flex items-start gap-3">
+                          <div className="flex-shrink-0 w-8 h-8 rounded-full bg-nycu-blue-100 text-nycu-blue-700 flex items-center justify-center font-semibold text-sm">
+                            {index + 1}
+                          </div>
+                          <div className="flex-1">
+                            <h4 className="font-semibold text-nycu-navy-800 mb-2">
+                              {item.title}
+                            </h4>
+                            <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-line">
+                              {item.content}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </Card>
+            </>
+          )}
 
           {(() => {
             const sampleAvailable = Boolean(publicDocs.sample_document_url);

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -6727,6 +6727,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/system-settings/application-notices": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Application Notices
+         * @description 取得學生申請精靈的「獎學金申請注意事項」內容（zh/en）。
+         *     所有登入使用者皆可讀取；尚未設定時回傳系統預設內容。
+         */
+        get: operations["get_application_notices_api_v1_system_settings_application_notices_get"];
+        /**
+         * Update Application Notices
+         * @description 更新「獎學金申請注意事項」內容。僅限管理員。
+         *     整份 zh/en 內容一次覆寫，變更會寫入設定稽核日誌。
+         */
+        put: operations["update_application_notices_api_v1_system_settings_application_notices_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/system-settings/upload/{doc_key}": {
         parameters: {
             query?: never;
@@ -8013,6 +8039,24 @@ export interface components {
             documents: components["schemas"]["DocumentData"][];
         };
         /**
+         * ApplicationNoticeItem
+         * @description One numbered notice item (e.g. 申請資格, 申請期限).
+         */
+        ApplicationNoticeItem: {
+            /** Title */
+            title: string;
+            /** Content */
+            content: string;
+        };
+        /**
+         * ApplicationNotices
+         * @description Full bilingual notice content shown in the application wizard.
+         */
+        ApplicationNotices: {
+            zh: components["schemas"]["LocalizedApplicationNotices"];
+            en: components["schemas"]["LocalizedApplicationNotices"];
+        };
+        /**
          * ApplicationReviewResponse
          * @description Application review response schema (unified review system)
          */
@@ -9206,6 +9250,16 @@ export interface components {
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
+        };
+        /**
+         * LocalizedApplicationNotices
+         * @description Notice content for a single locale.
+         */
+        LocalizedApplicationNotices: {
+            /** Items */
+            items: components["schemas"]["ApplicationNoticeItem"][];
+            /** Important Notice */
+            important_notice: string;
         };
         /**
          * ManualBankReviewRequestSchema
@@ -21809,6 +21863,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_application_notices_api_v1_system_settings_application_notices_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    update_application_notices_api_v1_system_settings_application_notices_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ApplicationNotices"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/lib/api/modules/__tests__/system-settings.test.ts
+++ b/frontend/lib/api/modules/__tests__/system-settings.test.ts
@@ -255,6 +255,61 @@ describe("createSystemSettingsApi", () => {
     );
   });
 
+  // ─── applicationNotices (raw fetch) ────────────────────────────────
+
+  it("applicationNotices.get GETs /application-notices with Bearer token", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest
+        .fn()
+        .mockResolvedValue({ success: true, message: "OK", data: {} }),
+    });
+    global.fetch = fetchMock as any;
+    Object.defineProperty(global, "localStorage", {
+      value: { getItem: () => "test-token" },
+      writable: true,
+    });
+
+    const api = createSystemSettingsApi();
+    await api.applicationNotices.get();
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/system-settings/application-notices");
+    expect(opts.headers.Authorization).toBe("Bearer test-token");
+  });
+
+  it("applicationNotices.update PUTs the full zh/en payload as JSON", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest
+        .fn()
+        .mockResolvedValue({ success: true, message: "OK", data: {} }),
+    });
+    global.fetch = fetchMock as any;
+    Object.defineProperty(global, "localStorage", {
+      value: { getItem: () => "test-token" },
+      writable: true,
+    });
+
+    const notices = {
+      zh: {
+        items: [{ title: "申請資格", content: "內容" }],
+        important_notice: "提醒",
+      },
+      en: {
+        items: [{ title: "Eligibility", content: "Content" }],
+        important_notice: "Notice",
+      },
+    };
+
+    const api = createSystemSettingsApi();
+    await api.applicationNotices.update(notices);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/v1/system-settings/application-notices");
+    expect(opts.method).toBe("PUT");
+    expect(opts.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(opts.body)).toEqual(notices);
+  });
+
   it("uploadRegulations sends empty Bearer when no token", async () => {
     // Pin: fallback to empty string (not undefined). Backend
     // sees "Bearer " and rejects — pin so refactor doesn't

--- a/frontend/lib/api/modules/system-settings.ts
+++ b/frontend/lib/api/modules/system-settings.ts
@@ -74,6 +74,24 @@ export function buildSuppDocFileProxyUrl(
   )}&v=${cacheBuster}`;
 }
 
+/** One numbered notice item on the application wizard's notice step. */
+export type ApplicationNoticeItem = {
+  title: string;
+  content: string;
+};
+
+/** Notice content for a single locale. */
+export type LocalizedApplicationNotices = {
+  items: ApplicationNoticeItem[];
+  important_notice: string;
+};
+
+/** Admin-editable 獎學金申請注意事項 content (bilingual). */
+export type ApplicationNotices = {
+  zh: LocalizedApplicationNotices;
+  en: LocalizedApplicationNotices;
+};
+
 // System configuration types
 type SystemConfiguration = {
   key: string;
@@ -316,6 +334,46 @@ export function createSystemSettingsApi() {
       );
       const json = await res.json();
       return json;
+    },
+
+    applicationNotices: {
+      /**
+       * Get the 獎學金申請注意事項 content (any authenticated user).
+       * Returns backend defaults when the admin hasn't customized it yet.
+       */
+      get: async (): Promise<ApiResponse<ApplicationNotices>> => {
+        const token =
+          typeof window !== "undefined"
+            ? localStorage.getItem("auth_token") || ""
+            : "";
+        const res = await fetch(
+          "/api/v1/system-settings/application-notices",
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        return (await res.json()) as ApiResponse<ApplicationNotices>;
+      },
+
+      /** Replace the full zh/en notice content (admin only). */
+      update: async (
+        notices: ApplicationNotices
+      ): Promise<ApiResponse<ApplicationNotices>> => {
+        const token =
+          typeof window !== "undefined"
+            ? localStorage.getItem("auth_token") || ""
+            : "";
+        const res = await fetch(
+          "/api/v1/system-settings/application-notices",
+          {
+            method: "PUT",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(notices),
+          }
+        );
+        return (await res.json()) as ApiResponse<ApplicationNotices>;
+      },
     },
 
     supplementaryDocs: {


### PR DESCRIPTION
## Summary
Moves the hardcoded scholarship application notices from the frontend wizard component into an admin-editable system setting, allowing administrators to update notice content without code deployment. The notices are now fetched from the backend API and displayed dynamically in both Chinese and English.

## Key Changes

### Backend
- **New schema** (`backend/app/schemas/application_notices.py`): Defines `ApplicationNotices`, `LocalizedApplicationNotices`, and `ApplicationNoticeItem` Pydantic models with validation (min/max lengths, required fields). Includes `DEFAULT_APPLICATION_NOTICES` containing the original hardcoded content.
- **New API endpoints** (`backend/app/api/v1/endpoints/system_settings.py`):
  - `GET /api/v1/system-settings/application-notices`: Returns admin-edited notices or defaults if unconfigured (any authenticated user)
  - `PUT /api/v1/system-settings/application-notices`: Updates full zh/en notice content (admin only), writes audit log
- **New tests** (`backend/app/tests/test_application_notices_endpoints.py`): Comprehensive test coverage for schema validation, endpoint access control, and roundtrip updates

### Frontend
- **New admin panel** (`frontend/components/admin/system-docs/ApplicationNoticesPanel.tsx`): Full CRUD UI for managing notices with:
  - Bilingual tabs (Chinese/English)
  - Important notice textarea
  - Numbered notice items with title/content fields
  - Reorder (up/down), add, and delete operations
  - Validation and dirty state tracking
  - Save with audit logging
- **Updated student wizard** (`frontend/components/student-wizard/steps/NoticeAgreementStep.tsx`):
  - Fetches notices from API instead of using hardcoded content
  - Displays admin-managed items dynamically
  - Graceful error handling with fallback messaging
  - Maintains existing scroll-and-agree flow
- **API client** (`frontend/lib/api/modules/system-settings.ts`): New `applicationNotices` module with `get()` and `update()` methods
- **Generated types** (`frontend/lib/api/generated/schema.d.ts`): OpenAPI schema updates for new endpoints and types
- **Updated tests** (`frontend/components/__tests__/notice-agreement-step.test.tsx`): Mock API calls and verify dynamic notice rendering

## Implementation Details

- Notices are stored in `system_settings` table under key `application_notices` with `data_type=json`
- When unconfigured, the API serves `DEFAULT_APPLICATION_NOTICES` (preserving original content)
- Admin panel enforces validation: at least 1 item per locale, non-empty titles/content, max 30 items
- Changes are immediately visible to students (no caching)
- Configuration changes are logged in `ConfigurationAuditLog` for compliance
- Frontend uses `Promise.allSettled()` to prevent notices fetch failure from blocking the wizard

https://claude.ai/code/session_017SFC13VJFLzKk22Bz3KNHw