### PR TITLE
fix(frontend): rename admin history tab and config actions column labels

### DIFF
--- a/frontend/components/admin-configuration-management.tsx
+++ b/frontend/components/admin-configuration-management.tsx
@@ -759,7 +759,9 @@ export function AdminConfigurationManagement({
                         </th>
                         <th className="text-left p-4 font-semibold">狀態</th>
                         <th className="text-left p-4 font-semibold">學院功能</th>
-                        <th className="text-right p-4 font-semibold">操作</th>
+                        <th className="text-right p-4 font-semibold">
+                          設定申請/審查期間
+                        </th>
                       </tr>
                     </thead>
                     <tbody>

--- a/frontend/components/admin/AdminManagementShell.tsx
+++ b/frontend/components/admin/AdminManagementShell.tsx
@@ -109,7 +109,7 @@ function AdminManagementContent({ user }: AdminManagementShellProps) {
           <TabsTrigger value="dashboard">系統概覽</TabsTrigger>
           <TabsTrigger value="users">使用者權限</TabsTrigger>
           <TabsTrigger value="students">學生列表</TabsTrigger>
-          <TabsTrigger value="student-history">學生領取歷史</TabsTrigger>
+          <TabsTrigger value="student-history">學生領獎紀錄查詢</TabsTrigger>
           {hasQuotaPermission && (
             <TabsTrigger value="quota">名額管理</TabsTrigger>
           )}

--- a/frontend/components/admin/student-history/StudentHistoryPanel.tsx
+++ b/frontend/components/admin/student-history/StudentHistoryPanel.tsx
@@ -89,7 +89,7 @@ export function StudentHistoryPanel() {
     <div className="space-y-4">
       <Card>
         <CardHeader>
-          <CardTitle>學生領取歷史查詢</CardTitle>
+          <CardTitle>學生領獎紀錄查詢</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex items-end gap-3">

--- a/frontend/e2e/specs/admin-revoke-suspend.spec.ts
+++ b/frontend/e2e/specs/admin-revoke-suspend.spec.ts
@@ -945,7 +945,7 @@ test.describe("locked roster dialog — revoked student panel + item removal", (
     },
   );
   test(
-    "@nightly suspend is queryable via /admin/audit-logs and visible in 學生領取歷史 (G29 #991)",
+    "@nightly suspend is queryable via /admin/audit-logs and visible in 學生領獎紀錄查詢 (G29 #991)",
     async ({ browser }) => {
       // The fixture suspended csphd0002 AFTER the roster locked (its item is
       // untouched by earlier tests — the revoked student's item gets removed
@@ -953,7 +953,7 @@ test.describe("locked roster dialog — revoked student panel + item removal", (
       // Two compliance read paths must surface it:
       //   1. the system-wide audit-log endpoint (#1007) carries the typed
       //      suspend event with the reason;
-      //   2. 學生領取歷史 (#1005) shows the paid row WITH the suspension
+      //   2. 學生領獎紀錄查詢 (#1005) shows the paid row WITH the suspension
       //      context instead of an unqualified 已領取.
       const adminLogin = await loginAs(browser, "admin");
       pushTrace(runState, adminLogin.traceId);
@@ -987,7 +987,7 @@ test.describe("locked roster dialog — revoked student panel + item removal", (
       expect(suspendEvents[0].new_values?.reason).toContain("E2E locked-roster fixture");
       expect(suspendEvents[0].actor_nycu_id).toBe("admin");
 
-      // 2. 學生領取歷史 suspension context.
+      // 2. 學生領獎紀錄查詢 suspension context.
       const historyRes = await apiAs<{
         success: boolean;
         data: {
@@ -1008,7 +1008,7 @@ test.describe("locked roster dialog — revoked student panel + item removal", (
       );
       expect(
         suspendedRecords.length,
-        "suspended-after-lock payment must carry suspension context in 學生領取歷史 (G25)",
+        "suspended-after-lock payment must carry suspension context in 學生領獎紀錄查詢 (G25)",
       ).toBeGreaterThan(0);
       expect(suspendedRecords[0].suspend_reason).toContain("E2E locked-roster fixture");
       expect(suspendedRecords[0].suspended_at).toBeTruthy();

--- a/frontend/e2e/specs/admin-student-history.spec.ts
+++ b/frontend/e2e/specs/admin-student-history.spec.ts
@@ -1,7 +1,7 @@
 /**
  * E2E: Admin student scholarship history lookup.
  *
- * Tab: AdminManagementShell → "學生領取歷史"
+ * Tab: AdminManagementShell → "學生領獎紀錄查詢"
  * Endpoint: GET /api/v1/admin/student-history/{student_number}
  *
  * Mirrors the auth pattern from admin-manual-distribution.spec.ts: log in as
@@ -19,7 +19,7 @@ test.describe("Admin student scholarship history", () => {
     await page.goto("/");
     // AdminManagementShell renders inside the top-level "系統管理" (value="admin") tab.
     await page.getByRole("tab", { name: "系統管理" }).click();
-    await page.getByRole("tab", { name: "學生領取歷史" }).click();
+    await page.getByRole("tab", { name: "學生領獎紀錄查詢" }).click();
     await page.getByLabel("學號").fill("@@");
     await page.getByRole("button", { name: "查詢" }).click();
     await expect(page.getByText(/請輸入有效的學號/)).toBeVisible();
@@ -31,7 +31,7 @@ test.describe("Admin student scholarship history", () => {
     const page = await context.newPage();
     await page.goto("/");
     await page.getByRole("tab", { name: "系統管理" }).click();
-    await page.getByRole("tab", { name: "學生領取歷史" }).click();
+    await page.getByRole("tab", { name: "學生領獎紀錄查詢" }).click();
     await page.getByLabel("學號").fill("GHOST00000");
     await page.getByRole("button", { name: "查詢" }).click();
     await expect(page.getByText("查無此學生資料")).toBeVisible({
@@ -52,7 +52,7 @@ test.describe("Admin student scholarship history", () => {
     const page = await context.newPage();
     await page.goto("/");
     await page.getByRole("tab", { name: "系統管理" }).click();
-    await page.getByRole("tab", { name: "學生領取歷史" }).click();
+    await page.getByRole("tab", { name: "學生領獎紀錄查詢" }).click();
     await page.getByLabel("學號").fill("stuphd001");
     await page.getByRole("button", { name: "查詢" }).click();
     await expect(

--- a/frontend/e2e/specs/showcase-replay.spec.ts
+++ b/frontend/e2e/specs/showcase-replay.spec.ts
@@ -15,7 +15,7 @@
  * records trace but never video. We inject auth onto the fixture context via
  * `authContext` instead.
  *
- * Flow: admin → 系統管理 → 學生領取歷史 → query seeded stuphd001 → result renders.
+ * Flow: admin → 系統管理 → 學生領獎紀錄查詢 → query seeded stuphd001 → result renders.
  * Kept assertion-light on purpose: the value is the recording, and it must stay
  * green every night.
  */
@@ -34,7 +34,7 @@ test("showcase: admin looks up a student's scholarship history", async ({
 
   // AdminManagementShell renders inside the top-level "系統管理" tab.
   await page.getByRole("tab", { name: "系統管理" }).click();
-  await page.getByRole("tab", { name: "學生領取歷史" }).click();
+  await page.getByRole("tab", { name: "學生領獎紀錄查詢" }).click();
 
   await page.getByLabel("學號").fill("stuphd001");
   await page.getByRole("button", { name: "查詢" }).click();


### PR DESCRIPTION
## Summary
- Admin 系統管理 tab "學生領取歷史" renamed to "學生領獎紀錄查詢" (and the matching `StudentHistoryPanel` card title updated for consistency)
- 獎學金配置 table's "操作" column header renamed to "設定申請/審查期間"
- Updated Playwright e2e specs (`admin-student-history.spec.ts`, `showcase-replay.spec.ts`, `admin-revoke-suspend.spec.ts`) that located the tab by its old accessible name

## Test plan
- [x] `npx jest --testPathPattern="admin-configuration-management|admin-management-interface|PaymentHistoryTable"` — 33 tests pass
- [ ] Manually verify the two renamed labels render correctly in 系統管理 → 獎學金配置 / 學生領獎紀錄查詢

🤖 Generated with [Claude Code](https://claude.com/claude-code)