### PR TITLE
feat: default new employee users to professor role

### DIFF
--- a/frontend/components/user-permission-management.tsx
+++ b/frontend/components/user-permission-management.tsx
@@ -94,7 +94,7 @@ export function UserPermissionManagement() {
     nycu_id: "",
     email: "",
     name: "",
-    role: "college",
+    role: "professor",
     student_no: "",
   });
   const [userPagination, setUserPagination] = useState({
@@ -434,7 +434,7 @@ export function UserPermissionManagement() {
       nycu_id: "",
       email: "",
       name: "",
-      role: "college",
+      role: "professor",
       user_type: "student",
       status: "在學",
       dept_code: "",


### PR DESCRIPTION
## Summary

New users created through the admin **user-permission form** (新增使用者權限) previously defaulted to the **college (學院)** role. This changes that default to **professor (教授)** for new employee users.

This aligns the admin UI with the backend SSO auto-provisioning, which **already** defaults `userType=employee` users to `professor`:
- `portal_sso_service.py` (`_map_user_type_to_role` and the inline classification)
- `pre_authorization_service.py` (`_get_default_role_from_portal`)

## Changes

`frontend/components/user-permission-management.tsx` (the live user-management component, rendered via `admin-management-interface` and `UserManagementPanel`):

- Initial `userForm` state: `role: "college"` → `role: "professor"`
- `resetUserForm()` (applied after each create/update): `role: "college"` → `role: "professor"`

The `UserEditModal` role dropdown already lists 教授/professor as an option, and a professor default correctly starts a new user with no scholarship-management permissions.

## Not touched

- `admin-management-interface.tsx` has its own `userForm` block with a `college` default, but it is **dead code** — that component imports `UserEditModal` and declares `showUserForm` but never renders the modal (user management is delegated to `<UserPermissionManagement/>`). No behavior change there.

## Test plan

- [ ] Open admin → 使用者權限管理 → click 「新增使用者權限」; confirm the role dropdown defaults to **教授 (professor)**.
- [ ] Create a user, then open the form again; confirm the reset default is still **教授**.
- [ ] Editing an existing user still shows that user's actual role (unchanged).

No e2e/unit test asserts this UI default (the related `role-permissions.spec.ts` only pins API authorization via pre-seeded users), so no test changes are required.