### PR TITLE
fix(frontend): user permission list pagination + role filter

### DIFF
--- a/frontend/components/user-permission-management.tsx
+++ b/frontend/components/user-permission-management.tsx
@@ -169,7 +169,7 @@ export function UserPermissionManagement() {
         setUsers(sortedUsers);
         setUserPagination((prev) => ({
           ...prev,
-          total: sortedUsers.length,
+          total: response.data?.total ?? sortedUsers.length,
         }));
       } else {
         const errorMsg = response.message || "獲取使用者失敗";

--- a/frontend/components/user-permission-management.tsx
+++ b/frontend/components/user-permission-management.tsx
@@ -126,12 +126,10 @@ export function UserPermissionManagement() {
     setUsersError(null);
 
     try {
-      const baseRoles = user?.role === "admin"
-        ? "college,admin,professor"
-        : "college,admin,super_admin,professor";
-      const allowedRoles = baseRoles
-        .split(",")
-        .map((role) => role.trim());
+      const allowedRoles =
+        user?.role === "admin"
+          ? ["college", "admin", "professor"]
+          : ["college", "admin", "super_admin", "professor"];
 
       // The backend prefers `roles` over `role` (`if roles: ... elif role:`),
       // and we always send `roles`, so the role filter must narrow the `roles`

--- a/frontend/components/user-permission-management.tsx
+++ b/frontend/components/user-permission-management.tsx
@@ -126,21 +126,26 @@ export function UserPermissionManagement() {
     setUsersError(null);
 
     try {
-      let rolesParam = "college,admin,super_admin,professor";
-      if (user?.role === "admin") {
-        rolesParam = "college,admin,professor";
-      }
-      rolesParam = rolesParam
+      const baseRoles = user?.role === "admin"
+        ? "college,admin,professor"
+        : "college,admin,super_admin,professor";
+      const allowedRoles = baseRoles
         .split(",")
-        .map((role) => role.trim())
-        .join(",");
+        .map((role) => role.trim());
+
+      // The backend prefers `roles` over `role` (`if roles: ... elif role:`),
+      // and we always send `roles`, so the role filter must narrow the `roles`
+      // scope itself — sending a separate `role` param would be ignored.
+      const rolesParam =
+        userRoleFilter && allowedRoles.includes(userRoleFilter)
+          ? userRoleFilter
+          : allowedRoles.join(",");
 
       const params: {
         page: number;
         size: number;
         roles: string;
         search?: string;
-        role?: string;
       } = {
         page: userPagination.page,
         size: userPagination.size,
@@ -148,7 +153,6 @@ export function UserPermissionManagement() {
       };
 
       if (userSearch) params.search = userSearch;
-      if (userRoleFilter) params.role = userRoleFilter;
 
       const response = await apiClient.users.getAll(params);
 
@@ -242,7 +246,13 @@ export function UserPermissionManagement() {
   }, [user, userPagination.page]);
 
   useEffect(() => {
-    if (user?.role === "super_admin") {
+    if (user?.role !== "super_admin") return;
+    // Reset to the first page when search/filter changes so we never land on an
+    // out-of-range page. If already on page 1, fetch directly; otherwise the
+    // page-change effect above handles the fetch.
+    if (userPagination.page !== 1) {
+      setUserPagination((prev) => ({ ...prev, page: 1 }));
+    } else {
       fetchUsers();
     }
   }, [userSearch, userRoleFilter]);


### PR DESCRIPTION
Fixes two functional bugs on 系統管理 → 使用者權限.

## 1. 只顯示 10 筆，無法翻頁

`fetchUsers` 以 `size: 10` 分頁請求，但把分頁 `total` 設成**當前頁的筆數**（≤10）而非後端回傳的真實總數：

```ts
setUserPagination((prev) => ({ ...prev, total: sortedUsers.length }));
```

→「共 X 筆」永遠 ≤10，「下一頁」的 `page * size >= total` 永遠成立而被 disable，卡在第一頁。

**Fix:** `total: response.data?.total ?? sortedUsers.length`。後端 `/api/v1/users` 已回傳套用篩選後的正確 `total`。

## 2. 角色篩選 (角色篩選下拉) 完全無效

後端 `get_all_users` 用 `if roles: ... elif role:`，而前端**永遠**送非空的 `roles`，所以另外送的 `role` 參數永遠被忽略 — 選任何角色結果都不變。

**Fix:** 把選到的角色收斂進 `roles` scope 本身（在允許範圍內），不再送無效的 `role`。同時在 search/filter 變更時 reset 回第 1 頁，避免停在超出範圍的空白頁。

## 已檢查但未動 / 未在此 PR 修

- **批次匯入** 按鈕目前無 `onClick`（未實作的 stub），非本次 regression；批次匯入屬獨立功能，未納入此 bugfix。
- 新增/編輯使用者、搜尋、清除篩選、統計卡片 — 邏輯正確。

## Test plan

- [ ] super_admin 登入 → 系統管理 → 使用者權限
- [ ] 「共 N 筆」顯示真實總數，「下一頁」可用並正確翻頁
- [ ] 角色篩選選「管理員 / 學院 / 教授 / 超級管理員」→ 列表確實只剩該角色
- [ ] 在第 2 頁時變更搜尋 / 篩選 → 自動回到第 1 頁，無空白頁
- [ ] 清除篩選 → 回到完整清單

🤖 Generated with [Claude Code](https://claude.com/claude-code)