### PR TITLE
fix(ui): update moe_1w scholarship label to 每月 $5000 元 wording

### DIFF
--- a/backend/alembic/versions/update_moe_1w_subtype_label.py
+++ b/backend/alembic/versions/update_moe_1w_subtype_label.py
@@ -1,0 +1,49 @@
+"""update moe_1w sub-type label to 每月 $5000 元 wording
+
+Revision ID: update_moe_1w_label_001
+Revises: college_view_distribution_001
+Create Date: 2026-07-08 00:00:00.000000
+
+The student wizard renders sub-type cards straight from
+scholarship_sub_type_configs.name, and deployed databases still carry the
+original "教育部博士生獎學金 (指導教授配合款一萬)" row (the seed only inserts
+when the row is missing, so seed-side renames never reach existing DBs).
+
+Updates the phd moe_1w sub-type config:
+- name:        教育部博士生獎學金 (指導教授配合款每月 $5000 元)
+- description: 教育部博士生獎學金，指導教授配合款每月 $5000 元
+- name_en / description_en aligned to the NT$5,000/month wording
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "update_moe_1w_label_001"
+down_revision: Union[str, Sequence[str], None] = "college_view_distribution_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE scholarship_sub_type_configs
+        SET
+            name = '教育部博士生獎學金 (指導教授配合款每月 $5000 元)',
+            name_en = 'MOE PHD Scholarship (Professor Match NT$5,000/month)',
+            description = '教育部博士生獎學金，指導教授配合款每月 $5000 元',
+            description_en = 'MOE PHD Scholarship with professor match of NT$5,000/month'
+        WHERE sub_type_code = 'moe_1w'
+        """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        UPDATE scholarship_sub_type_configs
+        SET
+            name = '教育部博士生獎學金 (指導教授配合款每月五千)',
+            name_en = 'MOE PHD Scholarship (Professor Match NT$5,000/month)',
+            description = '教育部博士生獎學金，指導教授配合款每月五千元',
+            description_en = 'MOE PHD Scholarship with professor match of NT$5,000/month'
+        WHERE sub_type_code = 'moe_1w'
+        """)

--- a/backend/alembic/versions/update_moe_1w_subtype_label.py
+++ b/backend/alembic/versions/update_moe_1w_subtype_label.py
@@ -5,14 +5,23 @@ Revises: college_view_distribution_001
 Create Date: 2026-07-08 00:00:00.000000
 
 The student wizard renders sub-type cards straight from
-scholarship_sub_type_configs.name, and deployed databases still carry the
-original "教育部博士生獎學金 (指導教授配合款一萬)" row (the seed only inserts
-when the row is missing, so seed-side renames never reach existing DBs).
+scholarship_sub_type_configs.name. The seed only inserts when the row is
+missing, so seed-side renames never reach existing DBs — depending on when a
+deployment was seeded, its phd moe_1w row may carry either the original
+"教育部博士生獎學金 (指導教授配合款一萬)" wording or the interim
+"教育部博士生獎學金 (指導教授配合款每月五千)" wording. This migration rewrites
+whichever variant is present. downgrade() restores the interim wording (the
+label the codebase seed shipped immediately before this revision), NOT the
+original 一萬 wording.
 
 Updates the phd moe_1w sub-type config:
 - name:        教育部博士生獎學金 (指導教授配合款每月 $5000 元)
 - description: 教育部博士生獎學金，指導教授配合款每月 $5000 元
 - name_en / description_en aligned to the NT$5,000/month wording
+
+The UPDATE is scoped to the phd scholarship type: sub_type_code values are
+configuration-driven strings, not globally unique, so another scholarship
+type could legitimately define its own 'moe_1w' with a different label.
 """
 
 from typing import Sequence, Union
@@ -34,6 +43,9 @@ def upgrade() -> None:
             description = '教育部博士生獎學金，指導教授配合款每月 $5000 元',
             description_en = 'MOE PHD Scholarship with professor match of NT$5,000/month'
         WHERE sub_type_code = 'moe_1w'
+          AND scholarship_type_id IN (
+              SELECT id FROM scholarship_types WHERE code = 'phd'
+          )
         """)
 
 
@@ -46,4 +58,7 @@ def downgrade() -> None:
             description = '教育部博士生獎學金，指導教授配合款每月五千元',
             description_en = 'MOE PHD Scholarship with professor match of NT$5,000/month'
         WHERE sub_type_code = 'moe_1w'
+          AND scholarship_type_id IN (
+              SELECT id FROM scholarship_types WHERE code = 'phd'
+          )
         """)

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -421,7 +421,7 @@ async def seed_scholarship_rules(session: AsyncSession) -> None:
             "created_by": admin_id,
             "updated_by": admin_id,
         },
-        # 博士生獎學金 教育部獎學金 (每月五千) 5. 中華民國國籍 6. 一至三年級
+        # 博士生獎學金 教育部獎學金 (每月 $5000 元) 5. 中華民國國籍 6. 一至三年級
         {
             "scholarship_type_id": 2,
             "sub_type": "moe_1w",
@@ -809,9 +809,9 @@ async def seed_scholarship_sub_type_configs(session: AsyncSession) -> None:
                     {
                         "scholarship_type_id": scholarship.id,
                         "sub_type_code": "moe_1w",
-                        "name": "教育部博士生獎學金 (指導教授配合款每月五千)",
+                        "name": "教育部博士生獎學金 (指導教授配合款每月 $5000 元)",
                         "name_en": "MOE PHD Scholarship (Professor Match NT$5,000/month)",
-                        "description": "教育部博士生獎學金，指導教授配合款每月五千元",
+                        "description": "教育部博士生獎學金，指導教授配合款每月 $5000 元",
                         "description_en": "MOE PHD Scholarship with professor match of NT$5,000/month",
                         "amount": None,  # 使用主獎學金金額
                         "display_order": 2,

--- a/frontend/e2e/specs/student-subtype-label.spec.ts
+++ b/frontend/e2e/specs/student-subtype-label.spec.ts
@@ -97,6 +97,14 @@ test.describe("phd moe_1w sub-type label wording", () => {
         eligibleRes.body,
       )}`,
     ).toBe(true);
+    expect(
+      eligibleRes.body?.success,
+      `ApiResponse.success must be true: body=${JSON.stringify(eligibleRes.body)}`,
+    ).toBe(true);
+    expect(
+      Array.isArray(eligibleRes.body.data),
+      `ApiResponse.data must be a scholarship array: body=${JSON.stringify(eligibleRes.body)}`,
+    ).toBe(true);
 
     const phd = eligibleRes.body.data.find((s) => s.code === SCHOLARSHIP_CODE);
     expect(phd, `phd scholarship missing from /scholarships/eligible for ${STUDENT_ID}`).toBeTruthy();

--- a/frontend/e2e/specs/student-subtype-label.spec.ts
+++ b/frontend/e2e/specs/student-subtype-label.spec.ts
@@ -62,18 +62,20 @@ test.describe("phd moe_1w sub-type label wording", () => {
     browser,
   }) => {
     // (a) DB layer — the source of truth the wizard label is built from.
-    const { rows } = await pool.query<{ name: string; is_active: boolean }>(
-      `SELECT sstc.name, sstc.is_active
+    // (scholarship_type_id, sub_type_code) has no unique constraint, so pin
+    // exactly ONE active row — a duplicate would make the backend's
+    // translation lookup (last-write-wins) nondeterministic.
+    const { rows } = await pool.query<{ name: string }>(
+      `SELECT sstc.name
          FROM scholarship_sub_type_configs sstc
          JOIN scholarship_types st ON st.id = sstc.scholarship_type_id
-        WHERE st.code = $1 AND sstc.sub_type_code = $2`,
+        WHERE st.code = $1 AND sstc.sub_type_code = $2 AND sstc.is_active = TRUE`,
       [SCHOLARSHIP_CODE, SUB_TYPE],
     );
     expect(
       rows.length,
-      `no scholarship_sub_type_configs row for (${SCHOLARSHIP_CODE}, ${SUB_TYPE}) — seed/migration missing`,
-    ).toBeGreaterThan(0);
-    expect(rows[0].is_active, "moe_1w sub-type config must be active").toBe(true);
+      `expected exactly one ACTIVE scholarship_sub_type_configs row for (${SCHOLARSHIP_CODE}, ${SUB_TYPE}), got ${rows.length} — seed/migration missing or duplicated`,
+    ).toBe(1);
     expect(
       rows[0].name,
       "scholarship_sub_type_configs.name must carry the 每月 $5000 元 wording (migration update_moe_1w_label_001)",

--- a/frontend/e2e/specs/student-subtype-label.spec.ts
+++ b/frontend/e2e/specs/student-subtype-label.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * E2E spec: the phd moe_1w sub-type card label reads
+ * 「教育部博士生獎學金 (指導教授配合款每月 $5000 元)」.
+ *
+ * Why this exists: the student wizard (ScholarshipApplicationStep) renders
+ * the 選擇申請項目 cards verbatim from `eligible_sub_types[].label`, which the
+ * backend reads from scholarship_sub_type_configs.name. The label was renamed
+ * from the stale 「指導教授配合款一萬」 wording, and because the seed only
+ * INSERTs when the row is missing, deployed DBs kept the old name until
+ * migration update_moe_1w_label_001 rewrote it in place. This spec pins both
+ * layers so the wording can't silently regress:
+ *
+ *   (a) DB   — scholarship_sub_type_configs.name for (phd, moe_1w) is the
+ *              new wording (the migration/seed actually landed), and
+ *   (b) API  — GET /api/v1/scholarships/eligible as stuphd001 (本國籍,
+ *              三年級 → eligible for moe_1w) returns that exact label in
+ *              eligible_sub_types, which is the string the wizard card shows.
+ *
+ * Pinned invariants:
+ * - The zh label is exactly 教育部博士生獎學金 (指導教授配合款每月 $5000 元).
+ * - Neither the stale 「一萬」 nor the interim 「每月五千」 wording survives
+ *   anywhere in the phd sub-type labels served to students.
+ */
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../helpers/auth";
+import { apiAs } from "../helpers/api";
+import { pool } from "../helpers/db";
+import { attachRunState, newRunState, pushTrace, type RunState } from "../helpers/runState";
+import { captureDiagnostics } from "../helpers/diagnose";
+
+const STUDENT_ID = "stuphd001";
+const SCHOLARSHIP_CODE = "phd";
+const SUB_TYPE = "moe_1w";
+const EXPECTED_LABEL = "教育部博士生獎學金 (指導教授配合款每月 $5000 元)";
+const STALE_WORDINGS = ["指導教授配合款一萬", "指導教授配合款每月五千"];
+
+interface EligibleSubType {
+  value: string | null;
+  label: string;
+  label_en: string;
+  is_default?: boolean;
+}
+
+interface EligibleScholarship {
+  code: string;
+  eligible_sub_types: EligibleSubType[];
+}
+
+test.describe("phd moe_1w sub-type label wording", () => {
+  let runState: RunState;
+
+  test.beforeEach(() => {
+    runState = newRunState();
+  });
+
+  test.afterEach(async ({}, testInfo) => {
+    await captureDiagnostics(testInfo, runState);
+    await attachRunState(testInfo, runState);
+  });
+
+  test("@nightly DB + /scholarships/eligible serve 每月 $5000 元 label for moe_1w", async ({
+    browser,
+  }) => {
+    // (a) DB layer — the source of truth the wizard label is built from.
+    const { rows } = await pool.query<{ name: string; is_active: boolean }>(
+      `SELECT sstc.name, sstc.is_active
+         FROM scholarship_sub_type_configs sstc
+         JOIN scholarship_types st ON st.id = sstc.scholarship_type_id
+        WHERE st.code = $1 AND sstc.sub_type_code = $2`,
+      [SCHOLARSHIP_CODE, SUB_TYPE],
+    );
+    expect(
+      rows.length,
+      `no scholarship_sub_type_configs row for (${SCHOLARSHIP_CODE}, ${SUB_TYPE}) — seed/migration missing`,
+    ).toBeGreaterThan(0);
+    expect(rows[0].is_active, "moe_1w sub-type config must be active").toBe(true);
+    expect(
+      rows[0].name,
+      "scholarship_sub_type_configs.name must carry the 每月 $5000 元 wording (migration update_moe_1w_label_001)",
+    ).toBe(EXPECTED_LABEL);
+
+    // (b) API layer — the exact payload ScholarshipApplicationStep renders as
+    // the 選擇申請項目 card text (subType.label, verbatim).
+    const studentLogin = await loginAs(browser, STUDENT_ID);
+    pushTrace(runState, studentLogin.traceId);
+
+    const eligibleRes = await apiAs<{
+      success: boolean;
+      data: EligibleScholarship[];
+    }>(studentLogin.token, "GET", "/scholarships/eligible");
+    pushTrace(runState, eligibleRes.traceId);
+    expect(
+      eligibleRes.ok,
+      `GET /scholarships/eligible failed: HTTP ${eligibleRes.status} body=${JSON.stringify(
+        eligibleRes.body,
+      )}`,
+    ).toBe(true);
+
+    const phd = eligibleRes.body.data.find((s) => s.code === SCHOLARSHIP_CODE);
+    expect(phd, `phd scholarship missing from /scholarships/eligible for ${STUDENT_ID}`).toBeTruthy();
+
+    const moe1w = phd!.eligible_sub_types.find((st) => st.value === SUB_TYPE);
+    expect(
+      moe1w,
+      `moe_1w missing from eligible_sub_types — ${STUDENT_ID} (本國籍/三年級) should qualify; got ${JSON.stringify(
+        phd!.eligible_sub_types,
+      )}`,
+    ).toBeTruthy();
+    expect(moe1w!.label, "the wizard card text (subType.label)").toBe(EXPECTED_LABEL);
+
+    // No phd sub-type label may still carry the stale wordings.
+    for (const subType of phd!.eligible_sub_types) {
+      for (const stale of STALE_WORDINGS) {
+        expect(
+          subType.label.includes(stale),
+          `stale wording 「${stale}」 leaked back into sub-type ${subType.value}: ${subType.label}`,
+        ).toBe(false);
+      }
+    }
+
+    await studentLogin.context.close();
+  });
+});

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -260,7 +260,7 @@ export const translations = {
     },
     rule_types: {
       nstc: "國科會博士生獎學金",
-      moe_1w: "教育部博士生獎學金 (指導教授配合款每月五千)",
+      moe_1w: "教育部博士生獎學金 (指導教授配合款每月 $5000 元)",
       moe_2w: "教育部博士生獎學金 (指導教授配合款兩萬)",
     },
     scholarship_sections: {


### PR DESCRIPTION
## Summary
Updates the PhD MOE scholarship (moe_1w) sub-type label across the database, backend seed, and frontend to use the standardized "每月 $5000 元" (NT$5,000/month) wording instead of the previous "每月五千" variant. Includes a database migration to update existing deployments and an E2E test to prevent future regressions.

## Changes

### Backend
- **Migration** (`update_moe_1w_subtype_label.py`): Alembic migration that updates `scholarship_sub_type_configs` for the moe_1w sub-type to the new label wording in both Chinese and English
- **Seed** (`seed_scholarship_configs.py`): Updated the seed data to use the new "教育部博士生獎學金 (指導教授配合款每月 $5000 元)" label for new database instances

### Frontend
- **i18n** (`i18n.ts`): Updated the `moe_1w` rule type translation to match the new label wording
- **E2E Test** (`student-subtype-label.spec.ts`): Added comprehensive nightly test that verifies:
  - The database row carries the correct label (migration applied)
  - The `/scholarships/eligible` API returns the exact label for eligible students
  - No stale wordings ("指導教授配合款一萬" or "指導教授配合款每月五千") leak into any PhD sub-type labels

## Implementation Details
The E2E test pins both the database layer (source of truth) and API layer (what the student wizard renders) to prevent silent regressions of the label wording. The migration uses an UPDATE statement to rewrite existing database rows in place, since the seed-only-on-missing approach means deployed databases retain the original label until explicitly migrated.

https://claude.ai/code/session_01PsUWsPWifoGZnktEmUwcnM