### PR TITLE
feat: batch-imported applications enter the standard review flow like student submissions

### DIFF
--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -642,13 +642,15 @@ async def upload_file_alias(
 @router.get("/review/list")
 async def get_applications_for_review(
     status: Optional[str] = Query(None, description="Filter by status"),
-    scholarship_type_id: Optional[int] = Query(None, description="Filter by scholarship type ID"),
+    scholarship_type: Optional[str] = Query(None, description="Filter by scholarship type code"),
     current_user: User = Depends(require_staff),
     db: AsyncSession = Depends(get_db),
 ):
     """Get applications for review (staff only)"""
+    # Keyword args are load-bearing: passing these positionally once sent
+    # status into `skip` and the type filter into `limit` (issue #1131).
     service = ApplicationService(db)
-    result = await service.get_applications_for_review(current_user, status, scholarship_type_id)
+    result = await service.get_applications_for_review(current_user, status=status, scholarship_type=scholarship_type)
     return {
         "success": True,
         "message": "查詢成功",

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -1680,12 +1680,11 @@ async def download_batch_import_template(
             }
         )
 
-    # Sub-type label mapping
-    sub_type_labels = {
-        "nstc": "國科會",
-        "moe_1w": "教育部",
-        "moe_2w": "教育部配合款2萬",
-    }
+    # Sub-type label mapping — inverted from the parser's shared constant so
+    # a downloaded template is always importable (labels can never drift).
+    from app.services.batch_import_service import SUB_TYPE_CODE_BY_LABEL
+
+    sub_type_labels = {code: label for label, code in SUB_TYPE_CODE_BY_LABEL.items()}
 
     # Add sub_type columns if scholarship has sub types (Traditional Chinese)
     if scholarship.sub_type_list:

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -60,7 +60,9 @@ async def upload_batch_import_data(
     file: UploadFile = File(..., description="Excel或CSV檔案"),
     scholarship_type: str = Query(..., description="獎學金類型代碼", pattern=r"^[a-z_]{1,50}$"),
     academic_year: int = Query(..., description="學年度", ge=100, le=200),
-    semester: Optional[str] = Query(None, description="學期", pattern=r"^(first|second|yearly)$"),
+    # Empty string is accepted and normalized to None below — the frontend
+    # sends semester="" for yearly scholarships whose period has no semester.
+    semester: Optional[str] = Query(None, description="學期", pattern=r"^(first|second|yearly)?$"),
     current_user: User = Depends(require_college_role),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -1673,7 +1673,7 @@ async def download_batch_import_template(
     # Sub-type label mapping
     sub_type_labels = {
         "nstc": "國科會",
-        "moe_1w": "教育部配合款1萬",
+        "moe_1w": "教育部",
         "moe_2w": "教育部配合款2萬",
     }
 
@@ -1743,13 +1743,17 @@ async def download_batch_import_template(
             }
         )
 
-    # Add sub_type sample values if applicable
+    # Add sub_type sample values if applicable.
+    # Sub-type cells hold a 志願序 (priority) number: 1 = first choice, 2 = second
+    # choice, ... blank = not applied — this is what the importer parses (a plain
+    # "Y" is ignored). Per the current flow 教育部 (MOE) is always the first
+    # choice, so order the sample so MOE codes take the lowest numbers.
     if scholarship.sub_type_list:
-        for i, row in enumerate(sample_data):
-            for j, sub_type_code in enumerate(scholarship.sub_type_list):
+        ordered_sub_types = sorted(scholarship.sub_type_list, key=lambda c: (not str(c).startswith("moe")))
+        for row in sample_data:
+            for priority, sub_type_code in enumerate(ordered_sub_types, start=1):
                 label = sub_type_labels.get(sub_type_code, sub_type_code)
-                # First row has first sub_type as Y, second row has second sub_type as Y
-                row[label] = "Y" if i == j else ""
+                row[label] = priority
 
     # Add custom field sample values
     for field in template_custom_fields:

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -173,6 +173,14 @@ async def upload_batch_import_data(
 
         validation_warnings.extend(permission_warnings)
 
+        eligibility_warnings = await service.bulk_check_eligibility(
+            parsed_data=parsed_data,
+            scholarship_type_id=scholarship.id,
+            academic_year=academic_year,
+            semester=normalized_semester,
+        )
+        validation_warnings.extend(eligibility_warnings)
+
         for row_data in parsed_data:
             student_id = row_data["student_id"]
             row_number = row_data.get("row_number") or 0
@@ -484,6 +492,14 @@ async def revalidate_batch_import(
     )
 
     validation_warnings.extend(permission_warnings)
+
+    eligibility_warnings = await service.bulk_check_eligibility(
+        parsed_data=parsed_data,
+        scholarship_type_id=batch_import.scholarship_type_id,
+        academic_year=batch_import.academic_year,
+        semester=batch_import.semester,
+    )
+    validation_warnings.extend(eligibility_warnings)
 
     for row_data in parsed_data:
         student_id = row_data.get("student_id")

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -1694,8 +1694,21 @@ async def download_batch_import_template(
     custom_fields_result = await db.execute(custom_fields_stmt)
     custom_fields = custom_fields_result.scalars().all()
 
-    # Add custom field columns (Traditional Chinese)
+    # Add custom field columns (Traditional Chinese), skipping any that would
+    # duplicate a base/fixed column already present. postal_account and the
+    # advisor fields are also seeded as ApplicationFields, so without this the
+    # column list gets duplicate labels — which makes pandas return a DataFrame
+    # for df[label] and breaks the column-width pass with
+    # "'DataFrame' object has no attribute 'tolist'".
+    reserved_field_names = {"student_id", "student_name", "postal_account"}
+    if requires_advisor:
+        reserved_field_names.update({"advisor_name", "advisor_email", "advisor_nycu_id"})
+
+    template_custom_fields = []
     for field in custom_fields:
+        if field.field_name in reserved_field_names or field.field_label in columns:
+            continue
+        template_custom_fields.append(field)
         columns.append(field.field_label)  # Use Chinese label
         column_mapping[field.field_label] = f"custom_{field.field_name}"
 
@@ -1739,7 +1752,7 @@ async def download_batch_import_template(
                 row[label] = "Y" if i == j else ""
 
     # Add custom field sample values
-    for field in custom_fields:
+    for field in template_custom_fields:
         for i, row in enumerate(sample_data):
             # Provide sample values based on field type
             if field.field_type == "text":
@@ -1770,8 +1783,10 @@ async def download_batch_import_template(
 
         worksheet = writer.sheets["批次匯入範例"]
         for idx, col in enumerate(df.columns, 1):
-            # Calculate max length for this column
-            column_values = df[col].astype(str).tolist()
+            # Calculate max length for this column. Use positional access so a
+            # duplicate column label can never turn df[col] into a DataFrame
+            # (which has no .tolist()).
+            column_values = df.iloc[:, idx - 1].astype(str).tolist()
 
             # Collect all content in this column (header + all data)
             all_content = [str(col)] + column_values

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -46,11 +46,11 @@ logger = logging.getLogger(__name__)
 
 
 def require_college_role(current_user: User = Depends(get_current_user)) -> User:
-    """Dependency to require college role or super admin"""
-    if current_user.role not in [UserRole.college, UserRole.super_admin]:
+    """Dependency to require college, admin, or super admin role"""
+    if current_user.role not in [UserRole.college, UserRole.admin, UserRole.super_admin]:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="此功能僅限學院角色使用",
+            detail="此功能僅限學院或管理員角色使用",
         )
     return current_user
 
@@ -88,9 +88,10 @@ async def upload_batch_import_data(
             detail=f"獎學金類型 {scholarship_type} 不存在",
         )
 
-    # Get college code from user (skip for super_admin)
+    # Get college code from user (skip for admin / super_admin, who are not
+    # bound to a single college and fall back to the "admin" record value)
     college_code = current_user.college_code
-    if not college_code and current_user.role != UserRole.super_admin:
+    if not college_code and current_user.role not in (UserRole.super_admin, UserRole.admin):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="使用者未設定學院代碼",

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -15,13 +15,13 @@ import magic
 import pandas as pd
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.responses import StreamingResponse
-from sqlalchemy import desc, select, update
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.path_security import validate_object_name_minio
 from app.core.security import get_current_user
 from app.db.deps import get_db
-from app.models.application import Application, ApplicationFile, ApplicationStatus
+from app.models.application import Application, ApplicationFile
 from app.models.audit_log import AuditAction, AuditLog
 from app.models.batch_import import BatchImport
 from app.models.enums import BatchImportStatus
@@ -1141,12 +1141,6 @@ async def confirm_batch_import(
             status="completed" if len(creation_errors) == 0 else "partial",
         )
 
-        # Ensure applications created via batch import are visible for college review
-        await db.execute(
-            update(Application)
-            .where(Application.batch_import_id == batch_id)
-            .values(status=ApplicationStatus.under_review.value)
-        )
         # 每筆由批次建立的申請各留一筆稽核 (issue #964 / G2) — 沒有這些紀錄，
         # 數百筆申請的「誰建立、來自哪個檔案」將無從追溯。
         for created_id in created_ids:

--- a/backend/app/api/v1/endpoints/batch_import.py
+++ b/backend/app/api/v1/endpoints/batch_import.py
@@ -1760,16 +1760,15 @@ async def download_batch_import_template(
         )
 
     # Add sub_type sample values if applicable.
-    # Sub-type cells hold a 志願序 (priority) number: 1 = first choice, 2 = second
-    # choice, ... blank = not applied — this is what the importer parses (a plain
-    # "Y" is ignored). Per the current flow 教育部 (MOE) is always the first
-    # choice, so order the sample so MOE codes take the lowest numbers.
+    # Sub-type cells are checkmarks: 1 (or V) = applying for that category,
+    # blank = not applying. Preference order is NOT read from these cells —
+    # the system forces MOE (moe_1w) as first preference, mirroring the
+    # student wizard. Sample rows show both categories checked.
     if scholarship.sub_type_list:
-        ordered_sub_types = sorted(scholarship.sub_type_list, key=lambda c: (not str(c).startswith("moe")))
         for row in sample_data:
-            for priority, sub_type_code in enumerate(ordered_sub_types, start=1):
+            for sub_type_code in scholarship.sub_type_list:
                 label = sub_type_labels.get(sub_type_code, sub_type_code)
-                row[label] = priority
+                row[label] = 1
 
     # Add custom field sample values
     for field in template_custom_fields:

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -180,15 +180,6 @@ class User(Base):
 
         return False
 
-    def get_accessible_student_ids(self, permission: str = "view_applications") -> list[int]:
-        """Get list of student IDs this professor can access"""
-        if not self.is_professor():
-            return []
-
-        return [
-            rel.student_id for rel in self.professor_relationships if rel.is_active and rel.has_permission(permission)
-        ]
-
     def is_advisor_of(self, student_id: int) -> bool:
         """Check if this professor is an advisor of the specified student"""
         if not self.is_professor():

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -359,6 +359,9 @@ class ApplicationResponse(BaseModel):
     student_pid: Optional[str] = None  # std_pid
     student_email: Optional[str] = None  # com_email
     student_phone: Optional[str] = None  # com_cellphone
+    postal_account: Optional[str] = Field(
+        None, description="郵局帳號（來自學生 UserProfile.account_number，非 submitted_form_data）"
+    )
 
     # === Academic Organization ===
     academy_code: Optional[str] = None  # std_academyno / trm_academyno

--- a/backend/app/schemas/batch_import.py
+++ b/backend/app/schemas/batch_import.py
@@ -108,6 +108,11 @@ class ApplicationDataRow(BaseModel):
     # 郵局帳戶資訊
     postal_account: Optional[str] = Field(None, description="郵局帳號", max_length=20)
 
+    # 指導教授資訊（用於 UserProfile 回寫與教授自動指派）
+    advisor_name: Optional[str] = Field(None, description="指導教授姓名", max_length=100)
+    advisor_email: Optional[str] = Field(None, description="指導教授Email", max_length=200)
+    advisor_nycu_id: Optional[str] = Field(None, description="指導教授本校人事編號", max_length=50)
+
     # 續領
     is_renewal: bool = Field(default=False, description="是否為續領申請")
     renewal_year: Optional[int] = Field(default=None, description="續領年份，例如 113")
@@ -124,10 +129,12 @@ class ApplicationDataRow(BaseModel):
             raise ValueError("學號僅能包含英文字母和數字")
         return v
 
-    @field_validator("student_name")
+    @field_validator("student_name", "advisor_name")
     @classmethod
-    def validate_name_fields(cls, v: str) -> str:
+    def validate_name_fields(cls, v: Optional[str]) -> Optional[str]:
         """Validate name fields - no HTML/script tags for XSS prevention"""
+        if v is None:
+            return v
         v = v.strip()
         # Check for common XSS patterns
         if re.search(r"<[^>]*script|<[^>]*iframe|javascript:", v, re.IGNORECASE):

--- a/backend/app/services/application_builder.py
+++ b/backend/app/services/application_builder.py
@@ -1,0 +1,72 @@
+"""Shared application-construction helpers.
+
+Single source of truth for logic used by BOTH the student self-submission
+path (ApplicationService) and the batch import path (BatchImportService).
+Any submitted-application field rule that must stay identical across the
+two paths belongs here — that is the module's only admission criterion.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.core.exceptions import ValidationError
+from app.models.enums import ApplicationStatus, ReviewStage
+from app.utils.i18n import ScholarshipI18n
+
+logger = logging.getLogger(__name__)
+
+# Mirrors FORCED_FIRST_PREFERENCE in
+# frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx:
+# the manual preference-ordering UI is hidden; MOE (moe_1w) is always the
+# first preference when selected alongside other sub-types.
+FORCED_FIRST_PREFERENCE = "moe_1w"
+
+
+def derive_sub_scholarship_type(scholarship_subtype_list: Optional[List[str]]) -> str:
+    """Derive the denormalized scalar `sub_scholarship_type` from the selected
+    sub-type list: first entry wins, normalized to lowercase; empty → "general".
+    """
+    if scholarship_subtype_list:
+        return scholarship_subtype_list[0].lower()
+    return "general"
+
+
+def validate_sub_type_for_submission(scholarship, sub_scholarship_type: Optional[str]) -> None:
+    """Reject the synthetic "general" category on submission for scholarships
+    that define real sub-types, and arbitrary sub-types for scholarships that
+    define none. Comparison is case-insensitive.
+    """
+    if scholarship is None:
+        return
+    real_sub_types = [st.lower() for st in (scholarship.sub_type_list or []) if st and st.lower() != "general"]
+    normalized = (sub_scholarship_type or "general").lower()
+    if real_sub_types:
+        if normalized not in real_sub_types:
+            raise ValidationError("此獎學金需選擇申請類別（" + "、".join(real_sub_types) + "），不可使用通用類別")
+    elif normalized != "general":
+        raise ValidationError("此獎學金不提供申請類別選擇，不可指定子類別")
+
+
+def order_sub_type_preferences(sub_types: List[str]) -> List[str]:
+    """Order a selected sub-type list the way the student wizard does:
+    FORCED_FIRST_PREFERENCE (moe_1w) leads when present; the rest keep
+    their given order. Returns a new list.
+    """
+    if FORCED_FIRST_PREFERENCE in sub_types:
+        return [FORCED_FIRST_PREFERENCE] + [st for st in sub_types if st != FORCED_FIRST_PREFERENCE]
+    return list(sub_types)
+
+
+def build_submitted_application_values(scholarship, config) -> Dict[str, Any]:
+    """Field values every application must carry the moment it is submitted,
+    regardless of which path created it.
+    """
+    return {
+        "status": ApplicationStatus.submitted.value,
+        "status_name": ScholarshipI18n.get_application_status_text(ApplicationStatus.submitted.value),
+        "review_stage": ReviewStage.student_submitted.value,
+        "submitted_at": datetime.now(timezone.utc),
+        "amount": config.amount,
+        "scholarship_name": config.config_name or scholarship.name,
+    }

--- a/backend/app/services/application_builder.py
+++ b/backend/app/services/application_builder.py
@@ -10,8 +10,14 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.exceptions import ValidationError
+from app.models.application_sequence import ApplicationSequence
 from app.models.enums import ApplicationStatus, ReviewStage
+from app.models.user import User, UserRole
+from app.models.user_profile import UserProfile
 from app.utils.i18n import ScholarshipI18n
 
 logger = logging.getLogger(__name__)
@@ -70,3 +76,87 @@ def build_submitted_application_values(scholarship, config) -> Dict[str, Any]:
         "amount": config.amount,
         "scholarship_name": config.config_name or scholarship.name,
     }
+
+
+async def generate_app_id(
+    db: AsyncSession,
+    academic_year: int,
+    semester,
+    *,
+    suffix: str = "",
+    commit: bool = True,
+) -> str:
+    """Generate a sequential application ID with database row locking.
+
+    Format: APP-{academic_year}-{semester_code}-{sequence:05d}{suffix}
+
+    commit=True releases the sequence row lock immediately (student path).
+    commit=False keeps the lock until the caller's transaction ends — the
+    batch import path relies on this to stay atomic, at the cost of
+    blocking online submissions for the duration of the import.
+    """
+    if semester is None:
+        semester = "yearly"
+    if hasattr(semester, "value"):
+        semester = semester.value
+
+    stmt = (
+        select(ApplicationSequence)
+        .where(
+            and_(
+                ApplicationSequence.academic_year == academic_year,
+                ApplicationSequence.semester == semester,
+            )
+        )
+        .with_for_update()
+    )
+    result = await db.execute(stmt)
+    seq_record = result.scalar_one_or_none()
+
+    if not seq_record:
+        seq_record = ApplicationSequence(academic_year=academic_year, semester=semester, last_sequence=0)
+        db.add(seq_record)
+        await db.flush()
+
+    seq_record.last_sequence += 1
+    sequence_num = seq_record.last_sequence
+
+    if commit:
+        await db.commit()
+
+    app_id = ApplicationSequence.format_app_id(academic_year, semester, sequence_num)
+    return f"{app_id}{suffix}"
+
+
+async def assign_professor_from_profile(db: AsyncSession, application, user_id: int) -> Optional[User]:
+    """Auto-assign the reviewing professor from the student's UserProfile.
+
+    Looks up UserProfile.advisor_nycu_id and matches a User with
+    role=professor. Returns the professor User or None. Never overwrites
+    an already-assigned professor_id.
+    """
+    if getattr(application, "professor_id", None):
+        return None
+
+    profile_stmt = select(UserProfile).where(UserProfile.user_id == user_id)
+    profile_result = await db.execute(profile_stmt)
+    profile = profile_result.scalar_one_or_none()
+
+    if not profile or not profile.advisor_nycu_id:
+        return None
+
+    professor_stmt = select(User).where(
+        User.nycu_id == profile.advisor_nycu_id,
+        User.role == UserRole.professor,
+    )
+    professor_result = await db.execute(professor_stmt)
+    professor = professor_result.scalar_one_or_none()
+
+    if professor:
+        application.professor_id = professor.id
+        logger.info(
+            "Auto-assigned professor %s to application %s",
+            professor.id,
+            getattr(application, "app_id", "?"),
+        )
+    return professor

--- a/backend/app/services/application_builder.py
+++ b/backend/app/services/application_builder.py
@@ -128,19 +128,23 @@ async def generate_app_id(
     return f"{app_id}{suffix}"
 
 
-async def assign_professor_from_profile(db: AsyncSession, application, user_id: int) -> Optional[User]:
+async def assign_professor_from_profile(
+    db: AsyncSession, application, user_id: int, profile: Optional[UserProfile] = None
+) -> Optional[User]:
     """Auto-assign the reviewing professor from the student's UserProfile.
 
     Looks up UserProfile.advisor_nycu_id and matches a User with
     role=professor. Returns the professor User or None. Never overwrites
-    an already-assigned professor_id.
+    an already-assigned professor_id. Pass `profile` when the caller has
+    already loaded it to skip the redundant SELECT.
     """
     if getattr(application, "professor_id", None):
         return None
 
-    profile_stmt = select(UserProfile).where(UserProfile.user_id == user_id)
-    profile_result = await db.execute(profile_stmt)
-    profile = profile_result.scalar_one_or_none()
+    if profile is None:
+        profile_stmt = select(UserProfile).where(UserProfile.user_id == user_id)
+        profile_result = await db.execute(profile_stmt)
+        profile = profile_result.scalar_one_or_none()
 
     if not profile or not profile.advisor_nycu_id:
         return None

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -280,66 +280,10 @@ class ApplicationService:
         return str(semester)
 
     async def _generate_app_id(self, academic_year: int, semester: Optional[str]) -> str:
-        """
-        Generate sequential application ID with database locking
+        """Generate sequential application ID (delegates to application_builder)."""
+        from app.services.application_builder import generate_app_id
 
-        Args:
-            academic_year: Academic year (e.g., 113 for 民國113年)
-            semester: Semester enum value ('first', 'second', 'yearly' or None)
-
-        Returns:
-            str: Sequential application ID (e.g., 'APP-113-1-00001')
-
-        Format: APP-{academic_year}-{semester_code}-{sequence:05d}
-        - semester_code: '1' for first, '2' for second, '0' for yearly/None
-        """
-        from app.models.application_sequence import ApplicationSequence
-
-        # Handle None semester (for yearly scholarships)
-        if semester is None:
-            semester = "yearly"
-        # Normalise Semester enum to its string value so SQLite (String column) can bind it
-        if hasattr(semester, "value"):
-            semester = semester.value
-
-        # Use database lock to ensure thread-safe sequence generation
-        from sqlalchemy import and_, select
-
-        stmt = (
-            select(ApplicationSequence)
-            .where(
-                and_(
-                    ApplicationSequence.academic_year == academic_year,
-                    ApplicationSequence.semester == semester,
-                )
-            )
-            .with_for_update()
-        )
-
-        result = await self.db.execute(stmt)
-        seq_record = result.scalar_one_or_none()
-
-        # Create sequence record if it doesn't exist
-        if not seq_record:
-            seq_record = ApplicationSequence(academic_year=academic_year, semester=semester, last_sequence=0)
-            self.db.add(seq_record)
-            await self.db.flush()  # Flush to get the record in the session
-
-        # Increment sequence
-        seq_record.last_sequence += 1
-        sequence_num = seq_record.last_sequence
-
-        # Commit the sequence increment immediately to release the lock
-        await self.db.commit()
-
-        # Format and return app_id
-        app_id = ApplicationSequence.format_app_id(academic_year, semester, sequence_num)
-        logger.debug(
-            f"Generated app_id: {app_id} (academic_year={academic_year}, "
-            f"semester={semester}, sequence={sequence_num})"
-        )
-
-        return app_id
+        return await generate_app_id(self.db, academic_year, semester)
 
     async def _validate_student_eligibility(
         self,
@@ -451,45 +395,17 @@ class ApplicationService:
 
     @staticmethod
     def _derive_sub_scholarship_type(scholarship_subtype_list: Optional[List[str]]) -> str:
-        """Derive the denormalized scalar `sub_scholarship_type` from the selected
-        sub-type list: first entry wins, normalized to lowercase; empty → "general".
+        """Delegates to application_builder (shared with batch import)."""
+        from app.services.application_builder import derive_sub_scholarship_type
 
-        Shared by create and update so the scalar never drifts from the list
-        (a drift is what let a "general" scalar survive an edit that picked a
-        real sub-type — see _validate_sub_type_for_submission).
-        """
-        if scholarship_subtype_list:
-            return scholarship_subtype_list[0].lower()
-        return "general"
+        return derive_sub_scholarship_type(scholarship_subtype_list)
 
     @staticmethod
     def _validate_sub_type_for_submission(scholarship: ScholarshipType, sub_scholarship_type: Optional[str]) -> None:
-        """Reject the synthetic "general" category on submission for scholarships
-        that define real sub-types.
+        """Delegates to application_builder (shared with batch import)."""
+        from app.services.application_builder import validate_sub_type_for_submission
 
-        "general" is only a valid category for scholarships with no sub-types.
-        For a scholarship that defines real ones (e.g. PhD: nstc / moe_1w), a
-        "general" application matches no quota slot during distribution, so it
-        must carry a concrete sub-type before it can be submitted.
-
-        Sub-types are stored lowercase (CLAUDE.md convention), but admin-entered
-        `sub_type_list` may not be — compare case-insensitively so a correct
-        submission is never falsely rejected over casing.
-
-        When the scholarship defines no real sub-types, only the synthetic
-        "general" (or empty) is valid — an arbitrary sub-type string would be
-        stored verbatim and break downstream quota/distribution lookups, so it
-        is rejected too.
-        """
-        if scholarship is None:
-            return
-        real_sub_types = [st.lower() for st in (scholarship.sub_type_list or []) if st and st.lower() != "general"]
-        normalized = (sub_scholarship_type or "general").lower()
-        if real_sub_types:
-            if normalized not in real_sub_types:
-                raise ValidationError("此獎學金需選擇申請類別（" + "、".join(real_sub_types) + "），不可使用通用類別")
-        elif normalized != "general":
-            raise ValidationError("此獎學金不提供申請類別選擇，不可指定子類別")
+        validate_sub_type_for_submission(scholarship, sub_scholarship_type)
 
     async def _create_application_instance(
         self,
@@ -523,12 +439,18 @@ class ApplicationService:
         if not is_draft:
             self._validate_sub_type_for_submission(scholarship, sub_scholarship_type)
 
-        # Determine status based on is_draft flag
         from app.models.enums import ApplicationStatus
+        from app.services.application_builder import build_submitted_application_values
         from app.utils.i18n import ScholarshipI18n
 
-        status = ApplicationStatus.draft.value if is_draft else ApplicationStatus.submitted.value
-        status_name = ScholarshipI18n.get_application_status_text(status)
+        submitted_values = build_submitted_application_values(scholarship, config)
+
+        if is_draft:
+            status = ApplicationStatus.draft.value
+            status_name = ScholarshipI18n.get_application_status_text(status)
+        else:
+            status = submitted_values["status"]
+            status_name = submitted_values["status_name"]
 
         # Create application
         application = Application(
@@ -536,8 +458,8 @@ class ApplicationService:
             user_id=user.id,
             scholarship_type_id=scholarship.id,
             scholarship_configuration_id=config.id,
-            scholarship_name=config.config_name or scholarship.name,
-            amount=config.amount,
+            scholarship_name=submitted_values["scholarship_name"],
+            amount=submitted_values["amount"],
             scholarship_subtype_list=scholarship_subtype_list,
             # Ordered sub-type preference list (志願序). The distribution service
             # reads this first; without it, allocation falls back to selection
@@ -556,9 +478,8 @@ class ApplicationService:
         )
 
         if not is_draft:
-            application.submitted_at = datetime.now(timezone.utc)
-            # Keep review_stage consistent with the submitted status (mirrors submit_application).
-            application.review_stage = ReviewStage.student_submitted.value
+            application.submitted_at = submitted_values["submitted_at"]
+            application.review_stage = submitted_values["review_stage"]
 
         return application
 
@@ -1316,21 +1237,9 @@ class ApplicationService:
         advisor_profile = user_profile_result.scalar_one_or_none()
 
         # 自動分配指導教授：根據 UserProfile 的 advisor_nycu_id 查找教授帳號
-        if not application.professor_id and advisor_profile:
+        from app.services.application_builder import assign_professor_from_profile
 
-            if advisor_profile and advisor_profile.advisor_nycu_id:
-                professor_stmt = select(User).where(
-                    User.nycu_id == advisor_profile.advisor_nycu_id,
-                    User.role == UserRole.professor,
-                )
-                professor_result = await self.db.execute(professor_stmt)
-                professor = professor_result.scalar_one_or_none()
-                if professor:
-                    application.professor_id = professor.id
-                    logger.info(
-                        f"Auto-assigned professor {professor.id} ({professor.name}) "
-                        f"to application {application.app_id}"
-                    )
+        await assign_professor_from_profile(self.db, application, application.user_id)
 
         await self.db.commit()
         await self._invalidate_app_caches()

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1248,7 +1248,7 @@ class ApplicationService:
         # 自動分配指導教授：根據 UserProfile 的 advisor_nycu_id 查找教授帳號
         from app.services.application_builder import assign_professor_from_profile
 
-        await assign_professor_from_profile(self.db, application, application.user_id)
+        await assign_professor_from_profile(self.db, application, application.user_id, profile=advisor_profile)
 
         await self.db.commit()
         await self._invalidate_app_caches()
@@ -1357,6 +1357,22 @@ class ApplicationService:
 
         return ApplicationResponse(**response_data)
 
+    async def _get_accessible_student_ids(self, professor: User, permission: str = "view_applications") -> List[int]:
+        """Student IDs this professor may access, queried async-safely.
+
+        The former User.get_accessible_student_ids traversed the lazy
+        professor_relationships collection, which raises MissingGreenlet
+        under an AsyncSession (issue #1130) — query the rows explicitly.
+        """
+        from app.models.professor_student import ProfessorStudentRelationship
+
+        stmt = select(ProfessorStudentRelationship).where(
+            ProfessorStudentRelationship.professor_id == professor.id,
+            ProfessorStudentRelationship.is_active.is_(True),
+        )
+        result = await self.db.execute(stmt)
+        return [rel.student_id for rel in result.scalars().all() if rel.has_permission(permission)]
+
     async def get_applications_for_review(
         self,
         current_user: User,
@@ -1375,7 +1391,7 @@ class ApplicationService:
 
         if current_user.role == UserRole.professor:
             # Filter applications to only those from accessible students
-            accessible_student_ids = current_user.get_accessible_student_ids("view_applications")
+            accessible_student_ids = await self._get_accessible_student_ids(current_user)
             if accessible_student_ids:
                 query = query.where(Application.user_id.in_(accessible_student_ids))
             else:
@@ -1865,7 +1881,7 @@ class ApplicationService:
             query = query.where(Application.user_id == current_user.id)
         elif current_user.role == UserRole.professor:
             # Filter applications to only those from accessible students
-            accessible_student_ids = current_user.get_accessible_student_ids("view_applications")
+            accessible_student_ids = await self._get_accessible_student_ids(current_user)
             if accessible_student_ids:
                 query = query.where(Application.user_id.in_(accessible_student_ids))
             else:

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -907,6 +907,14 @@ class ApplicationService:
         if not student_fields.get("student_no") and application.student:
             student_fields["student_no"] = application.student.nycu_id
 
+        # 郵局帳號 lives on the student's UserProfile (student self-service and
+        # batch import both write it there — never into submitted_form_data).
+        from app.models.user_profile import UserProfile
+
+        profile_result = await self.db.execute(select(UserProfile).where(UserProfile.user_id == application.user_id))
+        student_profile = profile_result.scalar_one_or_none()
+        postal_account = student_profile.account_number if student_profile else None
+
         # Build sub_type labels from scholarship.sub_type_configs
         sub_type_labels = {}
         if application.scholarship and hasattr(application.scholarship, "sub_type_configs"):
@@ -992,6 +1000,7 @@ class ApplicationService:
             "scholarship_name": scholarship_name,
             "amount": amount,
             "currency": currency,
+            "postal_account": postal_account,
             **student_fields,  # Spread extracted student fields
             # Workflow configuration flags
             "requires_professor_recommendation": bool(

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -140,7 +140,7 @@ class BatchImportService:
         # Sub-type label mapping
         sub_type_labels = {
             "國科會": "nstc",
-            "教育部配合款1萬": "moe_1w",
+            "教育部": "moe_1w",
             "教育部配合款2萬": "moe_2w",
         }
 

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -13,13 +13,14 @@ from typing import Any, Dict, List, Optional, Tuple
 import pandas as pd
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import NotFoundError, ServiceUnavailableError
 from app.models.application import Application
 from app.models.batch_import import BatchImport
 from app.models.enums import BatchImportStatus, Semester
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.models.user_profile import UserProfile
 from app.schemas.batch_import import ApplicationDataRow, BatchImportValidationError
 from app.services.application_builder import (
@@ -29,6 +30,7 @@ from app.services.application_builder import (
     generate_app_id,
     order_sub_type_preferences,
 )
+from app.services.eligibility_service import EligibilityService
 from app.services.student_service import StudentService
 
 logger = logging.getLogger(__name__)
@@ -100,9 +102,128 @@ def _is_sub_type_marked(cell: Any) -> bool:
 class BatchImportService:
     """Service for handling batch import operations"""
 
+    # Application-period exemption: batch import exists precisely for
+    # post-deadline paper-form entry, so this reason never surfaces.
+    _PERIOD_EXEMPT_REASONS = {"不在申請期間內"}
+
     def __init__(self, db: AsyncSession, student_service: Optional[StudentService] = None):
         self.db = db
         self.student_service = student_service or StudentService()
+
+    async def bulk_check_eligibility(
+        self,
+        parsed_data: List[Dict[str, Any]],
+        scholarship_type_id: int,
+        academic_year: int,
+        semester: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        """Run the SAME eligibility check the student self-submission path
+        uses, demoted to warnings (manual review is the gate for batch
+        imports). Also warns when an advisor_nycu_id has no professor
+        account (the application would never reach a professor's queue).
+        Never raises, never blocks the import.
+        """
+        warnings: List[Dict[str, Any]] = []
+
+        # Resolve the configuration the same way create_applications_from_batch does
+        semester_enum: Optional[Semester] = None
+        if semester:
+            try:
+                semester_enum = Semester(semester)
+            except ValueError:
+                semester_enum = None
+
+        # Eager-load scholarship_type: check_student_eligibility reads
+        # config.scholarship_type.whitelist_enabled, and an async lazy-load
+        # would raise MissingGreenlet in the revalidate path (where the
+        # ScholarshipType is not already in the session identity map).
+        config_stmt = (
+            select(ScholarshipConfiguration)
+            .options(selectinload(ScholarshipConfiguration.scholarship_type))
+            .where(
+                ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
+                ScholarshipConfiguration.academic_year == academic_year,
+            )
+        )
+        if semester_enum is None or semester_enum == Semester.yearly:
+            config_stmt = config_stmt.where(ScholarshipConfiguration.semester.is_(None))
+        else:
+            config_stmt = config_stmt.where(ScholarshipConfiguration.semester == semester_enum)
+        config_result = await self.db.execute(config_stmt)
+        config = config_result.scalar_one_or_none()
+
+        if not config:
+            warnings.append(
+                {
+                    "row_number": None,
+                    "student_id": None,
+                    "field": "configuration",
+                    "warning_type": "eligibility_check_skipped",
+                    "message": "找不到對應的獎學金配置，已跳過資格預檢（確認匯入時將會失敗，請先建立配置）。",
+                }
+            )
+            return warnings
+
+        eligibility_service = EligibilityService(self.db)
+
+        # Professor-account existence: one query for all advisor ids
+        advisor_ids = {row.get("advisor_nycu_id") for row in parsed_data if row.get("advisor_nycu_id")}
+        professor_map: Dict[str, User] = {}
+        if advisor_ids:
+            prof_stmt = select(User).where(User.nycu_id.in_(list(advisor_ids)), User.role == UserRole.professor)
+            prof_result = await self.db.execute(prof_stmt)
+            professor_map = {p.nycu_id: p for p in prof_result.scalars().all()}
+
+        for row in parsed_data:
+            student_id = row.get("student_id")
+            row_number = row.get("row_number")
+
+            advisor_id = row.get("advisor_nycu_id")
+            if advisor_id and advisor_id not in professor_map:
+                warnings.append(
+                    {
+                        "row_number": row_number,
+                        "student_id": student_id,
+                        "field": "advisor_nycu_id",
+                        "warning_type": "professor_not_found",
+                        "message": f"查無人事編號 {advisor_id} 的教授帳號，該申請將無法進入教授待審清單。",
+                    }
+                )
+
+            try:
+                snapshot = await self.student_service.get_student_snapshot(
+                    student_id, academic_year=str(academic_year), semester=semester
+                )
+            except Exception:  # noqa: BLE001 — any SIS failure demotes to a skip warning
+                logger.warning("Eligibility precheck skipped for %s (SIS error)", student_id, exc_info=True)
+                warnings.append(
+                    {
+                        "row_number": row_number,
+                        "student_id": student_id,
+                        "field": "eligibility",
+                        "warning_type": "eligibility_check_skipped",
+                        "message": f"無法取得學生 {student_id} 的學籍資料，已跳過資格預檢。",
+                    }
+                )
+                continue
+
+            is_eligible, reasons = await eligibility_service.check_student_eligibility(
+                student_data=snapshot, config=config
+            )
+            effective_reasons = [r for r in reasons if r not in self._PERIOD_EXEMPT_REASONS]
+            if not is_eligible and effective_reasons:
+                warnings.append(
+                    {
+                        "row_number": row_number,
+                        "student_id": student_id,
+                        "field": "eligibility",
+                        "warning_type": "eligibility_failed",
+                        "message": f"學生 {student_id} 資格預檢未通過："
+                        f"{'；'.join(effective_reasons)}（不影響匯入，請人工審查把關）。",
+                    }
+                )
+
+        return warnings
 
     async def parse_excel_file(
         self, file_content: bytes, scholarship_type_id: int, academic_year: int, semester: Optional[str]

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -22,6 +22,8 @@ from app.models.enums import BatchImportStatus, Semester
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User, UserRole
 from app.models.user_profile import UserProfile
+from pydantic import ValidationError as PydanticValidationError
+
 from app.schemas.batch_import import ApplicationDataRow, BatchImportValidationError
 from app.services.application_builder import (
     assign_professor_from_profile,
@@ -99,6 +101,65 @@ def _is_sub_type_marked(cell: Any) -> bool:
     return False
 
 
+# Row-field → Excel column label, for human-readable validation errors.
+_ROW_FIELD_LABELS = {
+    "student_id": "學號",
+    "student_name": "學生姓名",
+    "postal_account": "郵局帳號",
+    "advisor_name": "指導教授姓名",
+    "advisor_email": "指導教授Email",
+    "advisor_nycu_id": "指導教授本校人事編號",
+    "renewal_year": "續領年份",
+    "is_renewal": "續領",
+    "sub_types": "申請類別",
+    "custom_fields": "自訂欄位",
+}
+
+
+def _format_row_validation_error(exc: PydanticValidationError) -> str:
+    """Per-field, Chinese-labelled reasons for a rejected row — staff fixing
+    their Excel need to know WHICH column failed and WHY, not a pydantic repr.
+    """
+    parts = []
+    for err in exc.errors():
+        loc = err.get("loc") or ("row",)
+        label = _ROW_FIELD_LABELS.get(str(loc[0]), str(loc[0]))
+        msg = err.get("msg", "")
+        # Pydantic v2 prefixes custom ValueError messages with "Value error, "
+        if msg.startswith("Value error, "):
+            msg = msg[len("Value error, ") :]
+        parts.append(f"{label}：{msg}")
+    return "；".join(parts) or str(exc)
+
+
+# Chinese column label → sub-type code. Shared by the parser below and the
+# template generator in api/v1/endpoints/batch_import.py — the two MUST stay
+# identical or a downloaded template stops being importable.
+SUB_TYPE_CODE_BY_LABEL = {
+    "國科會": "nstc",
+    "教育部": "moe_1w",
+    "教育部配合款2萬": "moe_2w",
+}
+
+
+def _make_warning(
+    message: str,
+    *,
+    warning_type: str,
+    row_number: Optional[int] = None,
+    student_id: Optional[str] = None,
+    field: str = "eligibility",
+) -> Dict[str, Any]:
+    """Preview-warning dict in the shape the endpoints persist and return."""
+    return {
+        "row_number": row_number,
+        "student_id": student_id,
+        "field": field,
+        "warning_type": warning_type,
+        "message": message,
+    }
+
+
 class BatchImportService:
     """Service for handling batch import operations"""
 
@@ -109,6 +170,42 @@ class BatchImportService:
     def __init__(self, db: AsyncSession, student_service: Optional[StudentService] = None):
         self.db = db
         self.student_service = student_service or StudentService()
+
+    async def _resolve_configuration(
+        self, scholarship_type_id: int, academic_year: int, semester: Optional[str]
+    ) -> Optional[ScholarshipConfiguration]:
+        """Resolve the ScholarshipConfiguration for an academic period.
+
+        Single source of the yearly-vs-semester matching rule (None or
+        "yearly" → semester IS NULL) so the preview check and the confirm
+        step can never disagree about which config applies.
+
+        Eager-loads scholarship_type: eligibility checks read
+        config.scholarship_type.whitelist_enabled, and an async lazy-load
+        would raise MissingGreenlet when the type isn't already in the
+        session identity map.
+        """
+        semester_enum: Optional[Semester] = None
+        if semester:
+            try:
+                semester_enum = Semester(semester)
+            except ValueError:
+                semester_enum = None
+
+        config_stmt = (
+            select(ScholarshipConfiguration)
+            .options(selectinload(ScholarshipConfiguration.scholarship_type))
+            .where(
+                ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
+                ScholarshipConfiguration.academic_year == academic_year,
+            )
+        )
+        if semester_enum is None or semester_enum == Semester.yearly:
+            config_stmt = config_stmt.where(ScholarshipConfiguration.semester.is_(None))
+        else:
+            config_stmt = config_stmt.where(ScholarshipConfiguration.semester == semester_enum)
+        config_result = await self.db.execute(config_stmt)
+        return config_result.scalar_one_or_none()
 
     async def bulk_check_eligibility(
         self,
@@ -125,42 +222,14 @@ class BatchImportService:
         """
         warnings: List[Dict[str, Any]] = []
 
-        # Resolve the configuration the same way create_applications_from_batch does
-        semester_enum: Optional[Semester] = None
-        if semester:
-            try:
-                semester_enum = Semester(semester)
-            except ValueError:
-                semester_enum = None
-
-        # Eager-load scholarship_type: check_student_eligibility reads
-        # config.scholarship_type.whitelist_enabled, and an async lazy-load
-        # would raise MissingGreenlet in the revalidate path (where the
-        # ScholarshipType is not already in the session identity map).
-        config_stmt = (
-            select(ScholarshipConfiguration)
-            .options(selectinload(ScholarshipConfiguration.scholarship_type))
-            .where(
-                ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
-                ScholarshipConfiguration.academic_year == academic_year,
-            )
-        )
-        if semester_enum is None or semester_enum == Semester.yearly:
-            config_stmt = config_stmt.where(ScholarshipConfiguration.semester.is_(None))
-        else:
-            config_stmt = config_stmt.where(ScholarshipConfiguration.semester == semester_enum)
-        config_result = await self.db.execute(config_stmt)
-        config = config_result.scalar_one_or_none()
-
+        config = await self._resolve_configuration(scholarship_type_id, academic_year, semester)
         if not config:
             warnings.append(
-                {
-                    "row_number": None,
-                    "student_id": None,
-                    "field": "configuration",
-                    "warning_type": "eligibility_check_skipped",
-                    "message": "找不到對應的獎學金配置，已跳過資格預檢（確認匯入時將會失敗，請先建立配置）。",
-                }
+                _make_warning(
+                    "找不到對應的獎學金配置，已跳過資格預檢（確認匯入時將會失敗，請先建立配置）。",
+                    warning_type="eligibility_check_skipped",
+                    field="configuration",
+                )
             )
             return warnings
 
@@ -181,13 +250,13 @@ class BatchImportService:
             advisor_id = row.get("advisor_nycu_id")
             if advisor_id and advisor_id not in professor_map:
                 warnings.append(
-                    {
-                        "row_number": row_number,
-                        "student_id": student_id,
-                        "field": "advisor_nycu_id",
-                        "warning_type": "professor_not_found",
-                        "message": f"查無人事編號 {advisor_id} 的教授帳號，該申請將無法進入教授待審清單。",
-                    }
+                    _make_warning(
+                        f"查無人事編號 {advisor_id} 的教授帳號，該申請將無法進入教授待審清單。",
+                        warning_type="professor_not_found",
+                        row_number=row_number,
+                        student_id=student_id,
+                        field="advisor_nycu_id",
+                    )
                 )
 
             try:
@@ -197,13 +266,12 @@ class BatchImportService:
             except Exception:  # noqa: BLE001 — any SIS failure demotes to a skip warning
                 logger.warning("Eligibility precheck skipped for %s (SIS error)", student_id, exc_info=True)
                 warnings.append(
-                    {
-                        "row_number": row_number,
-                        "student_id": student_id,
-                        "field": "eligibility",
-                        "warning_type": "eligibility_check_skipped",
-                        "message": f"無法取得學生 {student_id} 的學籍資料，已跳過資格預檢。",
-                    }
+                    _make_warning(
+                        f"無法取得學生 {student_id} 的學籍資料，已跳過資格預檢。",
+                        warning_type="eligibility_check_skipped",
+                        row_number=row_number,
+                        student_id=student_id,
+                    )
                 )
                 continue
 
@@ -215,26 +283,24 @@ class BatchImportService:
             except Exception:  # noqa: BLE001 — a bad rule config must not 500 the preview
                 logger.warning("Eligibility precheck failed for %s", student_id, exc_info=True)
                 warnings.append(
-                    {
-                        "row_number": row_number,
-                        "student_id": student_id,
-                        "field": "eligibility",
-                        "warning_type": "eligibility_check_skipped",
-                        "message": f"學生 {student_id} 資格預檢執行失敗，已跳過。",
-                    }
+                    _make_warning(
+                        f"學生 {student_id} 資格預檢執行失敗，已跳過。",
+                        warning_type="eligibility_check_skipped",
+                        row_number=row_number,
+                        student_id=student_id,
+                    )
                 )
                 continue
 
             if not is_eligible and effective_reasons:
                 warnings.append(
-                    {
-                        "row_number": row_number,
-                        "student_id": student_id,
-                        "field": "eligibility",
-                        "warning_type": "eligibility_failed",
-                        "message": f"學生 {student_id} 資格預檢未通過："
+                    _make_warning(
+                        f"學生 {student_id} 資格預檢未通過："
                         f"{'；'.join(effective_reasons)}（不影響匯入，請人工審查把關）。",
-                    }
+                        warning_type="eligibility_failed",
+                        row_number=row_number,
+                        student_id=student_id,
+                    )
                 )
 
         return warnings
@@ -254,9 +320,6 @@ class BatchImportService:
         Returns:
             Tuple of (parsed_data, validation_errors)
         """
-        from app.models.application_field import ApplicationField
-        from app.models.scholarship import ScholarshipType
-
         errors = []
         parsed_data = []
 
@@ -299,26 +362,20 @@ class BatchImportService:
         # Mirrors application_builder.validate_sub_type_for_submission.
         real_sub_types = [st for st in (scholarship.sub_type_list or []) if st and st.lower() != "general"]
 
-        # Get custom fields configuration
-        custom_fields_stmt = (
-            select(ApplicationField)
-            .where(ApplicationField.scholarship_type == scholarship.code)
-            .where(ApplicationField.is_active)
-        )
-        custom_fields_result = await self.db.execute(custom_fields_stmt)
-        custom_fields = custom_fields_result.scalars().all()
+        # Custom-field definitions (same set _build_submitted_form_data uses)
+        field_definitions = await self._fetch_field_definitions(scholarship.code)
+        custom_field_mapping = {f.field_label: f.field_name for f in field_definitions.values()}
 
-        # Sub-type label mapping
-        sub_type_labels = {
-            "國科會": "nstc",
-            "教育部": "moe_1w",
-            "教育部配合款2萬": "moe_2w",
-        }
-
-        # Add custom field mappings
-        custom_field_mapping = {}
-        for field in custom_fields:
-            custom_field_mapping[field.field_label] = field.field_name
+        # Column header → sub-type code accepted by the parser, scoped to this
+        # scholarship's real sub-types. The template writes the known Chinese
+        # label when one exists and falls back to the raw code for custom
+        # sub-types — accept BOTH so a downloaded template always round-trips
+        # through import.
+        code_to_label = {code: label for label, code in SUB_TYPE_CODE_BY_LABEL.items()}
+        sub_type_labels: Dict[str, str] = {}
+        for code in real_sub_types:
+            sub_type_labels[code_to_label.get(code, code)] = code
+            sub_type_labels.setdefault(code, code)
 
         # Pre-compute column set for O(1) membership tests
         df_columns = set(df.columns)
@@ -485,6 +542,16 @@ class BatchImportService:
 
                 parsed_data.append(normalized_row)
 
+            except PydanticValidationError as e:
+                errors.append(
+                    BatchImportValidationError(
+                        row_number=row_number,
+                        student_id=student_id,
+                        field="row_data",
+                        error_type="validation_error",
+                        message=f"資料驗證失敗：{_format_row_validation_error(e)}",
+                    )
+                )
             except Exception as e:
                 errors.append(
                     BatchImportValidationError(
@@ -492,7 +559,7 @@ class BatchImportService:
                         student_id=student_id,
                         field="row_data",
                         error_type="validation_error",
-                        message=f"資料驗證失敗: {str(e)}",
+                        message=f"資料驗證失敗：{str(e)}",
                     )
                 )
 
@@ -835,13 +902,16 @@ class BatchImportService:
 
         return user_map
 
-    async def _upsert_user_profile(self, user: User, row_data: Dict[str, Any]) -> None:
+    async def _upsert_user_profile(self, user: User, row_data: Dict[str, Any]) -> UserProfile:
         """Write postal account and advisor info to the student's UserProfile,
         the same place the student self-service flow keeps them.
 
         Overwrite policy (spec): a non-empty Excel value overwrites the
         existing profile value (paper form is authoritative); a blank Excel
         cell preserves whatever is already there.
+
+        Returns the profile so callers can reuse it (professor auto-assign
+        reads advisor_nycu_id from it) without a second SELECT.
         """
         profile_stmt = select(UserProfile).where(UserProfile.user_id == user.id)
         profile_result = await self.db.execute(profile_stmt)
@@ -861,6 +931,8 @@ class BatchImportService:
             value = row_data.get(row_key)
             if value:
                 setattr(profile, profile_attr, value)
+
+        return profile
 
     async def _fetch_field_definitions(self, scholarship_code: str) -> Dict[str, Any]:
         """Load active ApplicationField definitions for a scholarship, keyed by
@@ -943,20 +1015,9 @@ class BatchImportService:
                     batch_id=batch_import.id,
                 ) from exc
 
-        # Find scholarship configuration for this academic period
-        config_stmt = select(ScholarshipConfiguration).where(
-            ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
-            ScholarshipConfiguration.academic_year == academic_year,
-        )
-
-        # Handle semester filtering (None means yearly scholarship)
-        if semester_enum is None or semester_enum == Semester.yearly:
-            config_stmt = config_stmt.where(ScholarshipConfiguration.semester.is_(None))
-        else:
-            config_stmt = config_stmt.where(ScholarshipConfiguration.semester == semester_enum)
-
-        config_result = await self.db.execute(config_stmt)
-        scholarship_config = config_result.scalar_one_or_none()
+        # Find scholarship configuration for this academic period (same
+        # resolver the preview eligibility check uses — they must agree).
+        scholarship_config = await self._resolve_configuration(scholarship_type_id, academic_year, semester)
 
         if not scholarship_config:
             period_label = f"{academic_year}學年度"
@@ -987,6 +1048,10 @@ class BatchImportService:
             # Custom-field definitions are identical for every row in the batch;
             # fetch once here instead of once per row (avoids an N+1 query).
             field_definitions = await self._fetch_field_definitions(scholarship.code)
+
+            # Submitted-state values are loop-invariant (one shared
+            # submitted_at timestamp for the whole batch is intended).
+            submitted_values = build_submitted_application_values(scholarship, scholarship_config)
 
             # Step 2: Bulk create applications
             applications = []
@@ -1024,8 +1089,6 @@ class BatchImportService:
                     field_definitions, row_data.get("custom_fields", {})
                 )
 
-                submitted_values = build_submitted_application_values(scholarship, scholarship_config)
-
                 application = Application(
                     app_id=app_id,
                     user_id=user.id,
@@ -1058,8 +1121,8 @@ class BatchImportService:
                 # Profile upsert then professor auto-assign — same linkage the
                 # student submit path uses (professor review lists match on
                 # Application.professor_id).
-                await self._upsert_user_profile(user, row_data)
-                await assign_professor_from_profile(self.db, application, user.id)
+                profile = await self._upsert_user_profile(user, row_data)
+                await assign_professor_from_profile(self.db, application, user.id, profile=profile)
 
             # Flush all applications at once
             await self.db.flush()

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -360,7 +360,10 @@ class BatchImportService:
         # The synthetic "general" placeholder (the model default) is NOT a real
         # sub-type, so a "general"-only scholarship must not demand a mark.
         # Mirrors application_builder.validate_sub_type_for_submission.
-        real_sub_types = [st for st in (scholarship.sub_type_list or []) if st and st.lower() != "general"]
+        # Codes are normalized to lowercase (CLAUDE.md convention) — admin-
+        # entered sub_type_list isn't case-enforced, but the forced moe_1w
+        # ordering and quota/distribution lookups assume lowercase.
+        real_sub_types = [st.lower() for st in (scholarship.sub_type_list or []) if st and st.lower() != "general"]
 
         # Custom-field definitions (same set _build_submitted_form_data uses)
         field_definitions = await self._fetch_field_definitions(scholarship.code)
@@ -369,12 +372,16 @@ class BatchImportService:
         # Column header → sub-type code accepted by the parser, scoped to this
         # scholarship's real sub-types. The template writes the known Chinese
         # label when one exists and falls back to the raw code for custom
-        # sub-types — accept BOTH so a downloaded template always round-trips
-        # through import.
+        # sub-types — accept the label, the raw-case code, and the lowercase
+        # code so a downloaded template always round-trips through import.
         code_to_label = {code: label for label, code in SUB_TYPE_CODE_BY_LABEL.items()}
         sub_type_labels: Dict[str, str] = {}
-        for code in real_sub_types:
-            sub_type_labels[code_to_label.get(code, code)] = code
+        for raw_code in scholarship.sub_type_list or []:
+            if not raw_code or raw_code.lower() == "general":
+                continue
+            code = raw_code.lower()
+            sub_type_labels[code_to_label.get(code, raw_code)] = code
+            sub_type_labels.setdefault(raw_code, code)
             sub_type_labels.setdefault(code, code)
 
         # Pre-compute column set for O(1) membership tests
@@ -467,9 +474,15 @@ class BatchImportService:
                     # Parse sub_types from Chinese column names.
                     # Any positive number or checkmark = applied; ordering is
                     # forced by shared rule (moe_1w first), NOT by cell numbers.
+                    # Dedupe: a sheet may carry both the label column (國科會)
+                    # and the raw-code column (nstc) for the same sub-type.
                     selected_sub_types = []
                     for chinese_label, sub_type_code in sub_type_labels.items():
-                        if chinese_label in df_columns and _is_sub_type_marked(row.get(chinese_label)):
+                        if (
+                            chinese_label in df_columns
+                            and _is_sub_type_marked(row.get(chinese_label))
+                            and sub_type_code not in selected_sub_types
+                        ):
                             selected_sub_types.append(sub_type_code)
                     data_row["sub_types"] = order_sub_type_preferences(selected_sub_types)
 
@@ -501,11 +514,17 @@ class BatchImportService:
                         "custom_fields": {},
                     }
 
-                    # Parse sub_types from English column names (sub_type_*)
+                    # Parse sub_types from English column names (sub_type_*).
+                    # Iterate df.columns (ordered), NOT the df_columns set —
+                    # set order would make non-moe preference order random.
+                    # Codes are lowercased (sub_type_MOE_1W must still hit the
+                    # forced moe_1w rule) and deduped.
                     selected_sub_types = []
-                    for col in df_columns:
+                    for col in df.columns:
                         if col.startswith("sub_type_") and _is_sub_type_marked(row.get(col)):
-                            selected_sub_types.append(col.replace("sub_type_", ""))
+                            code = col.replace("sub_type_", "").lower()
+                            if code not in selected_sub_types:
+                                selected_sub_types.append(code)
                     data_row["sub_types"] = order_sub_type_preferences(selected_sub_types)
 
                     # Parse custom fields from English column names (custom_*)

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -207,10 +207,24 @@ class BatchImportService:
                 )
                 continue
 
-            is_eligible, reasons = await eligibility_service.check_student_eligibility(
-                student_data=snapshot, config=config
-            )
-            effective_reasons = [r for r in reasons if r not in self._PERIOD_EXEMPT_REASONS]
+            try:
+                is_eligible, reasons = await eligibility_service.check_student_eligibility(
+                    student_data=snapshot, config=config
+                )
+                effective_reasons = [r for r in reasons if r not in self._PERIOD_EXEMPT_REASONS]
+            except Exception:  # noqa: BLE001 — a bad rule config must not 500 the preview
+                logger.warning("Eligibility precheck failed for %s", student_id, exc_info=True)
+                warnings.append(
+                    {
+                        "row_number": row_number,
+                        "student_id": student_id,
+                        "field": "eligibility",
+                        "warning_type": "eligibility_check_skipped",
+                        "message": f"學生 {student_id} 資格預檢執行失敗，已跳過。",
+                    }
+                )
+                continue
+
             if not is_eligible and effective_reasons:
                 warnings.append(
                     {

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -862,11 +862,10 @@ class BatchImportService:
             if value:
                 setattr(profile, profile_attr, value)
 
-    async def _build_submitted_form_data(self, scholarship_code: str, custom_fields: Dict[str, Any]) -> Dict[str, Any]:
-        """Shape batch custom-field values into the standard student-submission
-        structure: {"fields": {name: {field_id, field_type, value, required}},
-        "documents": []}. field_type/required come from the ApplicationField
-        definitions; a value with no matching definition falls back to text.
+    async def _fetch_field_definitions(self, scholarship_code: str) -> Dict[str, Any]:
+        """Load active ApplicationField definitions for a scholarship, keyed by
+        field_name. Definitions are identical for a whole batch, so this is
+        fetched ONCE per import and reused for every row (avoids an N+1 query).
         """
         from app.models.application_field import ApplicationField
 
@@ -876,11 +875,20 @@ class BatchImportService:
             .where(ApplicationField.is_active)
         )
         defs_result = await self.db.execute(defs_stmt)
-        definitions = {f.field_name: f for f in defs_result.scalars().all()}
+        return {f.field_name: f for f in defs_result.scalars().all()}
 
+    def _build_submitted_form_data(
+        self, field_definitions: Dict[str, Any], custom_fields: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Shape batch custom-field values into the standard student-submission
+        structure: {"fields": {name: {field_id, field_type, value, required}},
+        "documents": []}. field_type/required come from the ApplicationField
+        definitions (fetched once via _fetch_field_definitions); a value with no
+        matching definition falls back to text.
+        """
         fields = {}
         for field_name, value in (custom_fields or {}).items():
-            definition = definitions.get(field_name)
+            definition = field_definitions.get(field_name)
             fields[field_name] = {
                 "field_id": field_name,
                 "field_type": definition.field_type if definition else "text",
@@ -976,6 +984,10 @@ class BatchImportService:
             # Step 1: Bulk get/create users
             user_map = await self._get_or_create_users_bulk(parsed_data)
 
+            # Custom-field definitions are identical for every row in the batch;
+            # fetch once here instead of once per row (avoids an N+1 query).
+            field_definitions = await self._fetch_field_definitions(scholarship.code)
+
             # Step 2: Bulk create applications
             applications = []
             for idx, row_data in enumerate(parsed_data):
@@ -1008,8 +1020,8 @@ class BatchImportService:
                         student_id,
                     )
 
-                submitted_form_data = await self._build_submitted_form_data(
-                    scholarship.code, row_data.get("custom_fields", {})
+                submitted_form_data = self._build_submitted_form_data(
+                    field_definitions, row_data.get("custom_fields", {})
                 )
 
                 submitted_values = build_submitted_application_values(scholarship, scholarship_config)

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -22,6 +22,7 @@ from app.models.enums import BatchImportStatus, Semester
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User
 from app.schemas.batch_import import ApplicationDataRow, BatchImportValidationError
+from app.services.application_builder import order_sub_type_preferences
 from app.services.student_service import StudentService
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,29 @@ def _parse_renewal_year(raw_value: Any) -> Tuple[bool, Optional[int]]:
         except (ValueError, TypeError):
             pass
     return False, None
+
+
+_CHECKMARK_VALUES = {"v", "✓"}
+
+
+def _is_sub_type_marked(cell: Any) -> bool:
+    """A sub-type column cell counts as "applied" when it holds a positive
+    number or a checkmark (V/v/✓). Blank, 0, NaN, or anything else means
+    not applied. Numbers no longer encode preference order — ordering is
+    derived by application_builder.order_sub_type_preferences.
+    """
+    if cell is None:
+        return False
+    if isinstance(cell, (int, float)):
+        if isinstance(cell, float) and pd.isna(cell):
+            return False
+        return cell > 0
+    if isinstance(cell, str):
+        stripped = cell.strip()
+        if stripped.isdigit():
+            return int(stripped) > 0
+        return stripped.lower() in _CHECKMARK_VALUES
+    return False
 
 
 class BatchImportService:
@@ -127,6 +151,12 @@ class BatchImportService:
                 )
             )
             return [], errors
+
+        # Real sub-types are the ones that constrain distribution quota slots.
+        # The synthetic "general" placeholder (the model default) is NOT a real
+        # sub-type, so a "general"-only scholarship must not demand a mark.
+        # Mirrors application_builder.validate_sub_type_for_submission.
+        real_sub_types = [st for st in (scholarship.sub_type_list or []) if st and st.lower() != "general"]
 
         # Get custom fields configuration
         custom_fields_stmt = (
@@ -236,19 +266,14 @@ class BatchImportService:
                         "custom_fields": {},
                     }
 
-                    # Parse sub_types from Chinese column names
-                    # Values: 1/2/3 = applied with priority order (1=first choice), blank = not applied
-                    priority_entries: list[tuple[int, str]] = []
+                    # Parse sub_types from Chinese column names.
+                    # Any positive number or checkmark = applied; ordering is
+                    # forced by shared rule (moe_1w first), NOT by cell numbers.
+                    selected_sub_types = []
                     for chinese_label, sub_type_code in sub_type_labels.items():
-                        if chinese_label in df_columns:
-                            cell = row.get(chinese_label)
-                            if isinstance(cell, (int, float)) and not pd.isna(cell) and int(cell) > 0:
-                                priority_entries.append((int(cell), sub_type_code))
-                            elif isinstance(cell, str) and cell.strip().isdigit() and int(cell.strip()) > 0:
-                                priority_entries.append((int(cell.strip()), sub_type_code))
-
-                    priority_entries.sort(key=lambda x: x[0])
-                    data_row["sub_types"] = [code for _, code in priority_entries]
+                        if chinese_label in df_columns and _is_sub_type_marked(row.get(chinese_label)):
+                            selected_sub_types.append(sub_type_code)
+                    data_row["sub_types"] = order_sub_type_preferences(selected_sub_types)
 
                     # Parse custom fields from Chinese column names
                     for chinese_label, field_name in custom_field_mapping.items():
@@ -279,18 +304,11 @@ class BatchImportService:
                     }
 
                     # Parse sub_types from English column names (sub_type_*)
-                    priority_entries = []
+                    selected_sub_types = []
                     for col in df_columns:
-                        if col.startswith("sub_type_"):
-                            sub_type_code = col.replace("sub_type_", "")
-                            cell = row.get(col)
-                            if isinstance(cell, (int, float)) and not pd.isna(cell) and int(cell) > 0:
-                                priority_entries.append((int(cell), sub_type_code))
-                            elif isinstance(cell, str) and cell.strip().isdigit() and int(cell.strip()) > 0:
-                                priority_entries.append((int(cell.strip()), sub_type_code))
-
-                    priority_entries.sort(key=lambda x: x[0])
-                    data_row["sub_types"] = [code for _, code in priority_entries]
+                        if col.startswith("sub_type_") and _is_sub_type_marked(row.get(col)):
+                            selected_sub_types.append(col.replace("sub_type_", ""))
+                    data_row["sub_types"] = order_sub_type_preferences(selected_sub_types)
 
                     # Parse custom fields from English column names (custom_*)
                     for col in df_columns:
@@ -307,6 +325,23 @@ class BatchImportService:
                 validated_row = ApplicationDataRow(**data_row)
                 normalized_row = validated_row.model_dump()
                 normalized_row["row_number"] = row_number
+
+                # Sub-type is mandatory when the scholarship defines real
+                # sub-types — a row with none marked cannot be imported
+                # (it would fall into the synthetic "general" bucket which
+                # matches no distribution quota slot).
+                if real_sub_types and not normalized_row.get("sub_types"):
+                    errors.append(
+                        BatchImportValidationError(
+                            row_number=row_number,
+                            student_id=student_id,
+                            field="sub_types",
+                            error_type="missing_sub_type",
+                            message="未勾選任何申請類別（國科會/教育部），請於 Excel 中標記後重新上傳",
+                        )
+                    )
+                    continue
+
                 parsed_data.append(normalized_row)
 
             except Exception as e:

--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -11,18 +11,24 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
-from sqlalchemy import and_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import NotFoundError, ServiceUnavailableError
-from app.models.application import Application, ApplicationStatus
-from app.models.application_sequence import ApplicationSequence
+from app.models.application import Application
 from app.models.batch_import import BatchImport
 from app.models.enums import BatchImportStatus, Semester
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User
+from app.models.user_profile import UserProfile
 from app.schemas.batch_import import ApplicationDataRow, BatchImportValidationError
-from app.services.application_builder import order_sub_type_preferences
+from app.services.application_builder import (
+    assign_professor_from_profile,
+    build_submitted_application_values,
+    derive_sub_scholarship_type,
+    generate_app_id,
+    order_sub_type_preferences,
+)
 from app.services.student_service import StudentService
 
 logger = logging.getLogger(__name__)
@@ -694,6 +700,60 @@ class BatchImportService:
 
         return user_map
 
+    async def _upsert_user_profile(self, user: User, row_data: Dict[str, Any]) -> None:
+        """Write postal account and advisor info to the student's UserProfile,
+        the same place the student self-service flow keeps them.
+
+        Overwrite policy (spec): a non-empty Excel value overwrites the
+        existing profile value (paper form is authoritative); a blank Excel
+        cell preserves whatever is already there.
+        """
+        profile_stmt = select(UserProfile).where(UserProfile.user_id == user.id)
+        profile_result = await self.db.execute(profile_stmt)
+        profile = profile_result.scalar_one_or_none()
+
+        if not profile:
+            profile = UserProfile(user_id=user.id)
+            self.db.add(profile)
+
+        field_map = {
+            "postal_account": "account_number",
+            "advisor_name": "advisor_name",
+            "advisor_email": "advisor_email",
+            "advisor_nycu_id": "advisor_nycu_id",
+        }
+        for row_key, profile_attr in field_map.items():
+            value = row_data.get(row_key)
+            if value:
+                setattr(profile, profile_attr, value)
+
+    async def _build_submitted_form_data(self, scholarship_code: str, custom_fields: Dict[str, Any]) -> Dict[str, Any]:
+        """Shape batch custom-field values into the standard student-submission
+        structure: {"fields": {name: {field_id, field_type, value, required}},
+        "documents": []}. field_type/required come from the ApplicationField
+        definitions; a value with no matching definition falls back to text.
+        """
+        from app.models.application_field import ApplicationField
+
+        defs_stmt = (
+            select(ApplicationField)
+            .where(ApplicationField.scholarship_type == scholarship_code)
+            .where(ApplicationField.is_active)
+        )
+        defs_result = await self.db.execute(defs_stmt)
+        definitions = {f.field_name: f for f in defs_result.scalars().all()}
+
+        fields = {}
+        for field_name, value in (custom_fields or {}).items():
+            definition = definitions.get(field_name)
+            fields[field_name] = {
+                "field_id": field_name,
+                "field_type": definition.field_type if definition else "text",
+                "value": value,
+                "required": bool(definition.is_required) if definition else False,
+            }
+        return {"fields": fields, "documents": []}
+
     async def create_applications_from_batch(
         self,
         batch_import: BatchImport,
@@ -789,44 +849,10 @@ class BatchImportService:
 
                 user = user_map[student_id]
 
-                # Generate app_id using the shared sequence, and append 'U' for upload/batch.
-                # This logic is adapted from ApplicationService._generate_app_id
-                temp_semester = semester
-                if temp_semester is None:
-                    temp_semester = "yearly"
-
-                # Lock the sequence record for the duration of this transaction
-                stmt = (
-                    select(ApplicationSequence)
-                    .where(
-                        and_(
-                            ApplicationSequence.academic_year == academic_year,
-                            ApplicationSequence.semester == temp_semester,
-                        )
-                    )
-                    .with_for_update()
-                )
-
-                result = await self.db.execute(stmt)
-                seq_record = result.scalar_one_or_none()
-
-                # Create sequence record if it doesn't exist
-                if not seq_record:
-                    seq_record = ApplicationSequence(
-                        academic_year=academic_year, semester=temp_semester, last_sequence=0
-                    )
-                    self.db.add(seq_record)
-                    await self.db.flush()  # Flush to get the record in the session
-
-                # Increment sequence
-                seq_record.last_sequence += 1
-                sequence_num = seq_record.last_sequence
-
-                # Format and return app_id
-                # NOTE: We do NOT commit here. The lock is held for the entire batch transaction
-                # to ensure atomicity. This will block online applications during the import.
-                base_app_id = ApplicationSequence.format_app_id(academic_year, temp_semester, sequence_num)
-                app_id = f"{base_app_id}U"
+                # Shared sequence logic; commit=False holds the row lock for
+                # the whole batch transaction (atomicity over concurrency —
+                # online submissions block during the import, intentionally).
+                app_id = await generate_app_id(self.db, academic_year, semester, suffix="U", commit=False)
 
                 # Create application
                 # Fetch student snapshot from SIS API (includes both basic info and term data)
@@ -847,25 +873,20 @@ class BatchImportService:
                         student_id,
                     )
 
-                # Construct submitted_form_data, primarily from batch import, but override dept_code if SIS has it
-                submitted_form_data = {
-                    "postal_account": row_data.get("postal_account"),
-                    "advisor_name": row_data.get("advisor_name"),
-                    "advisor_email": row_data.get("advisor_email"),
-                    "advisor_nycu_id": row_data.get("advisor_nycu_id"),
-                    "custom_fields": row_data.get("custom_fields", {}),
-                }
+                submitted_form_data = await self._build_submitted_form_data(
+                    scholarship.code, row_data.get("custom_fields", {})
+                )
+
+                submitted_values = build_submitted_application_values(scholarship, scholarship_config)
 
                 application = Application(
                     app_id=app_id,
                     user_id=user.id,
                     scholarship_type_id=scholarship_type_id,
-                    scholarship_configuration_id=scholarship_config.id,  # Link to specific configuration
-                    scholarship_name=scholarship.name,
-                    amount=None,  # Amount is now per sub-type in ScholarshipSubTypeConfig
-                    sub_scholarship_type=(
-                        row_data.get("sub_types", [None])[0].lower() if row_data.get("sub_types") else "general"
-                    ),  # Lowercase, configuration-driven
+                    scholarship_configuration_id=scholarship_config.id,
+                    scholarship_name=submitted_values["scholarship_name"],
+                    amount=submitted_values["amount"],
+                    sub_scholarship_type=derive_sub_scholarship_type(row_data.get("sub_types")),
                     scholarship_subtype_list=row_data.get("sub_types", []),
                     sub_type_preferences=row_data.get("sub_types", []) or None,
                     sub_type_selection_mode=scholarship.sub_type_selection_mode,
@@ -873,17 +894,25 @@ class BatchImportService:
                     semester=semester,
                     is_renewal=row_data.get("is_renewal", False),
                     renewal_year=row_data.get("renewal_year"),
-                    status=ApplicationStatus.under_review.value,
+                    status=submitted_values["status"],
+                    status_name=submitted_values["status_name"],
+                    review_stage=submitted_values["review_stage"],
                     imported_by_id=batch_import.importer_id,
                     batch_import_id=batch_import.id,
                     import_source="batch_import",
                     document_status="pending_documents",
-                    submitted_at=datetime.now(timezone.utc),
+                    submitted_at=submitted_values["submitted_at"],
                     student_data=student_data,
                     submitted_form_data=submitted_form_data,
                 )
                 applications.append(application)
                 self.db.add(application)
+
+                # Profile upsert then professor auto-assign — same linkage the
+                # student submit path uses (professor review lists match on
+                # Application.professor_id).
+                await self._upsert_user_profile(user, row_data)
+                await assign_professor_from_profile(self.db, application, user.id)
 
             # Flush all applications at once
             await self.db.flush()

--- a/backend/app/tests/test_application_builder.py
+++ b/backend/app/tests/test_application_builder.py
@@ -1,0 +1,107 @@
+"""Unit tests for the shared application builder helpers.
+
+These helpers are the single source of truth for logic that previously
+drifted between the student self-submission path (ApplicationService)
+and the batch import path (BatchImportService).
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.exceptions import ValidationError
+from app.services.application_builder import (
+    FORCED_FIRST_PREFERENCE,
+    build_submitted_application_values,
+    derive_sub_scholarship_type,
+    order_sub_type_preferences,
+    validate_sub_type_for_submission,
+)
+
+# --- derive_sub_scholarship_type -------------------------------------------
+
+
+def test_derive_sub_type_empty_list_returns_general():
+    assert derive_sub_scholarship_type([]) == "general"
+    assert derive_sub_scholarship_type(None) == "general"
+
+
+def test_derive_sub_type_first_entry_lowercased():
+    assert derive_sub_scholarship_type(["NSTC", "moe_1w"]) == "nstc"
+
+
+# --- validate_sub_type_for_submission ---------------------------------------
+
+
+def _scholarship_stub(sub_type_list):
+    return SimpleNamespace(sub_type_list=sub_type_list)
+
+
+def test_validate_rejects_general_when_real_sub_types_exist():
+    with pytest.raises(ValidationError):
+        validate_sub_type_for_submission(_scholarship_stub(["nstc", "moe_1w"]), "general")
+
+
+def test_validate_accepts_real_sub_type_case_insensitive():
+    validate_sub_type_for_submission(_scholarship_stub(["NSTC", "moe_1w"]), "nstc")
+
+
+def test_validate_rejects_arbitrary_sub_type_when_none_defined():
+    with pytest.raises(ValidationError):
+        validate_sub_type_for_submission(_scholarship_stub([]), "nstc")
+
+
+def test_validate_accepts_general_when_none_defined():
+    validate_sub_type_for_submission(_scholarship_stub([]), "general")
+    validate_sub_type_for_submission(_scholarship_stub(None), None)
+
+
+# --- order_sub_type_preferences ---------------------------------------------
+
+
+def test_order_forces_moe_1w_first():
+    assert order_sub_type_preferences(["nstc", "moe_1w"]) == ["moe_1w", "nstc"]
+
+
+def test_order_preserves_order_without_moe_1w():
+    assert order_sub_type_preferences(["nstc", "moe_2w"]) == ["nstc", "moe_2w"]
+
+
+def test_order_single_and_empty():
+    assert order_sub_type_preferences(["moe_1w"]) == ["moe_1w"]
+    assert order_sub_type_preferences([]) == []
+
+
+def test_forced_first_preference_constant_matches_frontend():
+    # Mirrors FORCED_FIRST_PREFERENCE in
+    # frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+    assert FORCED_FIRST_PREFERENCE == "moe_1w"
+
+
+# --- build_submitted_application_values --------------------------------------
+
+
+def test_build_submitted_values_uses_config_amount_and_name():
+    scholarship = SimpleNamespace(name="博士生獎學金")
+    config = SimpleNamespace(config_name="博士生獎學金 114學年", amount=40000)
+
+    values = build_submitted_application_values(scholarship, config)
+
+    assert values["status"] == "submitted"
+    assert values["status_name"]  # non-empty i18n text
+    assert values["review_stage"] == "student_submitted"
+    assert values["amount"] == 40000
+    assert values["scholarship_name"] == "博士生獎學金 114學年"
+    assert isinstance(values["submitted_at"], datetime)
+    assert values["submitted_at"].tzinfo == timezone.utc
+
+
+def test_build_submitted_values_falls_back_to_scholarship_name():
+    scholarship = SimpleNamespace(name="博士生獎學金")
+    config = SimpleNamespace(config_name=None, amount=None)
+
+    values = build_submitted_application_values(scholarship, config)
+
+    assert values["scholarship_name"] == "博士生獎學金"
+    assert values["amount"] is None

--- a/backend/app/tests/test_application_builder.py
+++ b/backend/app/tests/test_application_builder.py
@@ -105,3 +105,69 @@ def test_build_submitted_values_falls_back_to_scholarship_name():
 
     assert values["scholarship_name"] == "博士生獎學金"
     assert values["amount"] is None
+
+
+# --- async helpers -----------------------------------------------------------
+
+from app.models.application_sequence import ApplicationSequence  # noqa: E402,F401
+from app.models.user import User  # noqa: E402
+from app.models.user_profile import UserProfile  # noqa: E402
+from app.services.application_builder import (  # noqa: E402
+    assign_professor_from_profile,
+    generate_app_id,
+)
+
+
+async def test_generate_app_id_creates_sequence_and_formats(db):
+    app_id = await generate_app_id(db, 114, None)
+    assert app_id == "APP-114-0-00001"
+
+    app_id2 = await generate_app_id(db, 114, "yearly")
+    assert app_id2 == "APP-114-0-00002"
+
+
+async def test_generate_app_id_with_suffix_no_commit(db):
+    app_id = await generate_app_id(db, 114, "first", suffix="U", commit=False)
+    assert app_id == "APP-114-1-00001U"
+
+
+async def test_assign_professor_sets_id_when_profile_matches(db):
+    student = User(nycu_id="313554001", name="學生甲", role="student", user_type="student")
+    professor = User(nycu_id="P001234", name="張教授", role="professor", user_type="employee")
+    db.add_all([student, professor])
+    await db.flush()
+
+    db.add(UserProfile(user_id=student.id, advisor_nycu_id="P001234"))
+    await db.flush()
+
+    application = SimpleNamespace(professor_id=None)
+    result = await assign_professor_from_profile(db, application, student.id)
+
+    assert result is not None
+    assert application.professor_id == professor.id
+
+
+async def test_assign_professor_none_when_no_professor_account(db):
+    student = User(nycu_id="313554002", name="學生乙", role="student", user_type="student")
+    db.add(student)
+    await db.flush()
+    db.add(UserProfile(user_id=student.id, advisor_nycu_id="NOSUCH"))
+    await db.flush()
+
+    application = SimpleNamespace(professor_id=None)
+    result = await assign_professor_from_profile(db, application, student.id)
+
+    assert result is None
+    assert application.professor_id is None
+
+
+async def test_assign_professor_does_not_overwrite_existing(db):
+    student = User(nycu_id="313554003", name="學生丙", role="student", user_type="student")
+    db.add(student)
+    await db.flush()
+
+    application = SimpleNamespace(professor_id=999)
+    result = await assign_professor_from_profile(db, application, student.id)
+
+    assert result is None
+    assert application.professor_id == 999

--- a/backend/app/tests/test_batch_import_endpoints.py
+++ b/backend/app/tests/test_batch_import_endpoints.py
@@ -90,12 +90,15 @@ class TestBatchImportEndpoints:
     @pytest.fixture
     def valid_excel_file(self):
         """Create a valid Excel file for testing"""
+        # test_scholarship defines real sub-types (type_a, type_b), so each
+        # row MUST mark a sub-type or parse rejects it with missing_sub_type.
         df = pd.DataFrame(
             {
                 "student_id": ["111111111", "222222222"],
                 "student_name": ["王小明", "陳小華"],
                 "dept_code": ["5201", "5202"],
                 "bank_account": ["1234567890", "9876543210"],
+                "sub_type_type_a": ["V", "V"],
             }
         )
 

--- a/backend/app/tests/test_batch_import_endpoints.py
+++ b/backend/app/tests/test_batch_import_endpoints.py
@@ -15,9 +15,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import get_current_user
 from app.main import app
+from app.models.application import Application, ApplicationStatus
 from app.models.batch_import import BatchImport
-from app.models.enums import BatchImportStatus
-from app.models.scholarship import ScholarshipType
+from app.models.enums import BatchImportStatus, ReviewStage
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User, UserRole
 
 # Router is mounted under this prefix in app/api/v1/api.py
@@ -304,6 +305,85 @@ class TestBatchImportEndpoints:
         data = response.json()["data"]
         assert data["success_count"] == 2
         assert data["failed_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_confirm_batch_import_keeps_review_flow_status(
+        self, client: AsyncClient, db: AsyncSession, college_user: User
+    ):
+        """Regression (review-flow parity): the confirm endpoint must NOT
+        mutate the status the service sets. A stale
+        ``UPDATE applications SET status='under_review'`` used to run after
+        creation and stomped the submitted / student_submitted values,
+        defeating batch-import review-flow parity. This drives the REAL
+        service (not a mock) through the endpoint and reads the created
+        applications back from the DB.
+        """
+        scholarship = ScholarshipType(
+            code="phd_confirm_status",
+            name="PhD Confirm Status",
+            sub_type_list=["nstc"],
+            sub_type_selection_mode="single",
+        )
+        db.add(scholarship)
+        await db.flush()
+        db.add(
+            ScholarshipConfiguration(
+                scholarship_type_id=scholarship.id,
+                academic_year=114,
+                semester=None,
+                config_name="PhD Confirm Status 114",
+                config_code="phd_confirm_status_114",
+                amount=40000,
+            )
+        )
+
+        batch = BatchImport(
+            importer_id=college_user.id,
+            college_code="E",
+            scholarship_type_id=scholarship.id,
+            academic_year=114,
+            file_name="confirm.xlsx",
+            total_records=1,
+            import_status=BatchImportStatus.pending.value,
+            parsed_data={
+                "data": [
+                    {
+                        "student_id": "313559001",
+                        "student_name": "王小明",
+                        "sub_types": ["nstc"],
+                        "custom_fields": {},
+                        "row_number": 2,
+                    }
+                ],
+                "errors": [],
+            },
+        )
+        db.add(batch)
+        await db.commit()
+        await db.refresh(batch)
+
+        _override_user(college_user)
+        # Neutralize SIS so no network call — the endpoint builds its own
+        # BatchImportService(db) internally, so patch the StudentService it
+        # constructs rather than injecting a stub.
+        stub_sis = Mock()
+        stub_sis.get_student_snapshot = AsyncMock(return_value=None)
+        stub_sis.get_student_basic_info = AsyncMock(return_value=None)
+        with patch("app.services.batch_import_service.StudentService", return_value=stub_sis):
+            response = await client.post(
+                f"{BASE}/{batch.id}/confirm",
+                json={"batch_id": batch.id, "confirm": True},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        created_ids = response.json()["data"]["created_application_ids"]
+        assert len(created_ids) == 1
+
+        # Fresh DB re-read so enum columns come back as enum members.
+        db.expunge_all()
+        created = await db.get(Application, created_ids[0])
+        assert created.status == ApplicationStatus.submitted
+        assert created.review_stage == ReviewStage.student_submitted
 
     @pytest.mark.asyncio
     async def test_confirm_batch_import_cancel(self, client: AsyncClient, db: AsyncSession, college_user: User):

--- a/backend/app/tests/test_batch_import_endpoints.py
+++ b/backend/app/tests/test_batch_import_endpoints.py
@@ -554,6 +554,43 @@ class TestBatchImportEndpoints:
         assert "Test" in content_disposition
 
     @pytest.mark.asyncio
+    async def test_downloaded_template_round_trips_through_upload(
+        self, client: AsyncClient, college_user: User, test_scholarship: ScholarshipType
+    ):
+        """下載的範本必須「原樣可匯入」：GET /template 的檔案直接餵回
+        upload-data 不得產生任何驗證錯誤。
+
+        Covers the custom sub-type gap: test_scholarship uses raw codes
+        (type_a/type_b) with no Chinese label, so the template writes the
+        code itself as the column header — the parser must accept it, or
+        every sample row dies with missing_sub_type.
+        """
+        _override_user(college_user)
+
+        template_resp = await client.get(f"{BASE}/template", params={"scholarship_type": test_scholarship.code})
+        assert template_resp.status_code == status.HTTP_200_OK
+
+        upload_resp = await client.post(
+            f"{BASE}/upload-data",
+            params={"scholarship_type": test_scholarship.code, "academic_year": 113, "semester": "first"},
+            files={
+                "file": (
+                    "template.xlsx",
+                    template_resp.content,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
+        )
+
+        assert upload_resp.status_code == status.HTTP_200_OK
+        data = upload_resp.json()["data"]
+        assert data["validation_summary"]["errors"] == []
+        assert data["validation_summary"]["invalid_count"] == 0
+        # Both sample rows survive as importable records with sub-types parsed.
+        assert len(data["preview_data"]) == 2
+        assert all(row["sub_types"] for row in data["preview_data"])
+
+    @pytest.mark.asyncio
     async def test_upload_requires_college_role(
         self, client: AsyncClient, test_scholarship: ScholarshipType, valid_excel_file
     ):

--- a/backend/app/tests/test_batch_import_endpoints.py
+++ b/backend/app/tests/test_batch_import_endpoints.py
@@ -554,6 +554,28 @@ class TestBatchImportEndpoints:
         assert "Test" in content_disposition
 
     @pytest.mark.asyncio
+    async def test_upload_accepts_empty_semester_for_yearly(
+        self, client: AsyncClient, college_user: User, test_scholarship: ScholarshipType, valid_excel_file
+    ):
+        """Yearly scholarships have no semester part in their period, so the
+        UI sends semester="" — that must normalize to None (yearly), not die
+        in the query-pattern check with a generic 422 "Validation failed"."""
+        _override_user(college_user)
+        response = await client.post(
+            f"{BASE}/upload-data",
+            params={"scholarship_type": test_scholarship.code, "academic_year": 114, "semester": ""},
+            files={
+                "file": (
+                    "test.xlsx",
+                    valid_excel_file,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["success"] is True
+
+    @pytest.mark.asyncio
     async def test_downloaded_template_round_trips_through_upload(
         self, client: AsyncClient, college_user: User, test_scholarship: ScholarshipType
     ):

--- a/backend/app/tests/test_batch_import_endpoints.py
+++ b/backend/app/tests/test_batch_import_endpoints.py
@@ -138,6 +138,47 @@ class TestBatchImportEndpoints:
         assert len(data["preview_data"]) == 2
 
     @pytest.mark.asyncio
+    async def test_upload_batch_import_surfaces_eligibility_warnings(
+        self, client: AsyncClient, college_user: User, test_scholarship: ScholarshipType, valid_excel_file
+    ):
+        """Eligibility/professor warnings from bulk_check_eligibility must
+        surface in the upload response's validation_summary.warnings."""
+        _override_user(college_user)
+
+        fake_warning = {
+            "row_number": 2,
+            "student_id": "111111111",
+            "field": "eligibility",
+            "warning_type": "eligibility_failed",
+            "message": "學生 111111111 資格預檢未通過：GPA 未達標準（不影響匯入，請人工審查把關）。",
+        }
+
+        with patch(
+            "app.services.batch_import_service.BatchImportService.bulk_check_eligibility",
+            new_callable=AsyncMock,
+            return_value=[fake_warning],
+        ):
+            response = await client.post(
+                f"{BASE}/upload-data",
+                params={
+                    "scholarship_type": test_scholarship.code,
+                    "academic_year": 113,
+                    "semester": "first",
+                },
+                files={
+                    "file": (
+                        "test.xlsx",
+                        valid_excel_file,
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    )
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        warnings = response.json()["data"]["validation_summary"]["warnings"]
+        assert any("GPA 未達標準" in (w.get("message") or "") for w in warnings)
+
+    @pytest.mark.asyncio
     async def test_upload_batch_import_file_too_large(
         self, client: AsyncClient, college_user: User, test_scholarship: ScholarshipType
     ):

--- a/backend/app/tests/test_batch_import_pure_helpers.py
+++ b/backend/app/tests/test_batch_import_pure_helpers.py
@@ -24,6 +24,7 @@ import math
 import pandas as pd
 import pytest
 
+from app.schemas.batch_import import ApplicationDataRow
 from app.services.batch_import_service import (
     _is_sub_type_marked,
     _normalize_identifier,
@@ -158,3 +159,33 @@ def test_is_sub_type_marked_blank_zero_and_noise():
     assert _is_sub_type_marked("0") is False
     assert _is_sub_type_marked(float("nan")) is False
     assert _is_sub_type_marked("no") is False
+
+
+# ─── ApplicationDataRow advisor fields ──────────────────────────────
+# Regression: the parser populates advisor_name/advisor_email/
+# advisor_nycu_id in the raw row dict, but they are re-validated through
+# ApplicationDataRow whose model_dump() feeds the profile upsert +
+# professor auto-assign. If the schema drops these fields, advisor info
+# entered in the Excel is silently lost — UserProfile never gets the
+# advisor, and no professor is auto-assigned. Pin that they survive.
+
+
+def test_application_data_row_preserves_advisor_fields():
+    row = ApplicationDataRow(
+        student_id="csphd0001",
+        student_name="王博士",
+        advisor_name="李資訊教授",
+        advisor_email="cs_professor@nycu.edu.tw",
+        advisor_nycu_id="cs_professor",
+    )
+    dumped = row.model_dump()
+    assert dumped["advisor_name"] == "李資訊教授"
+    assert dumped["advisor_email"] == "cs_professor@nycu.edu.tw"
+    assert dumped["advisor_nycu_id"] == "cs_professor"
+
+
+def test_application_data_row_advisor_fields_default_none():
+    dumped = ApplicationDataRow(student_id="csphd0001", student_name="王博士").model_dump()
+    assert dumped["advisor_name"] is None
+    assert dumped["advisor_email"] is None
+    assert dumped["advisor_nycu_id"] is None

--- a/backend/app/tests/test_batch_import_pure_helpers.py
+++ b/backend/app/tests/test_batch_import_pure_helpers.py
@@ -25,6 +25,7 @@ import pandas as pd
 import pytest
 
 from app.services.batch_import_service import (
+    _is_sub_type_marked,
     _normalize_identifier,
     _normalize_optional,
     _parse_renewal_year,
@@ -133,3 +134,27 @@ def test_parse_renewal_year_non_numeric_returns_not_renewal():
     is_renewal, year = _parse_renewal_year("not-a-year")
     assert is_renewal is False
     assert year is None
+
+
+# ─── _is_sub_type_marked ────────────────────────────────────────────
+
+
+def test_is_sub_type_marked_positive_numbers():
+    assert _is_sub_type_marked(1) is True
+    assert _is_sub_type_marked(2.0) is True
+    assert _is_sub_type_marked("3") is True
+
+
+def test_is_sub_type_marked_checkmarks():
+    assert _is_sub_type_marked("V") is True
+    assert _is_sub_type_marked("v") is True
+    assert _is_sub_type_marked("✓") is True
+
+
+def test_is_sub_type_marked_blank_zero_and_noise():
+    assert _is_sub_type_marked(None) is False
+    assert _is_sub_type_marked("") is False
+    assert _is_sub_type_marked(0) is False
+    assert _is_sub_type_marked("0") is False
+    assert _is_sub_type_marked(float("nan")) is False
+    assert _is_sub_type_marked("no") is False

--- a/backend/app/tests/test_batch_import_pure_helpers.py
+++ b/backend/app/tests/test_batch_import_pure_helpers.py
@@ -14,9 +14,16 @@ Helpers covered:
   empty becomes None.
 - `_parse_renewal_year(value)`: renewal-year detection from
   Excel cell, returning (is_renewal, year_or_None).
+- `_is_sub_type_marked(value)`: checkmark/positive-number cell detection
+  for sub-type columns.
 
-11 cases — covers each helper across None/NaN/integer-float/string-int/
-plain-string inputs plus the renewal-year parser's failure mode.
+Plus pure-schema round-trip checks on `ApplicationDataRow`, pinning that
+the advisor_* fields survive `model_dump()` (they feed the profile upsert
++ professor auto-assign; a missing field silently dropped them).
+
+21 cases — each helper across None/NaN/integer-float/string-int/
+plain-string inputs, the renewal-year parser's failure mode, the
+sub-type-mark truth table, and the ApplicationDataRow advisor fields.
 """
 
 import math

--- a/backend/app/tests/test_batch_import_service_unit.py
+++ b/backend/app/tests/test_batch_import_service_unit.py
@@ -10,13 +10,16 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pandas as pd
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import BatchImportError
+from app.models.application import Application, ApplicationStatus
 from app.models.batch_import import BatchImport
-from app.models.enums import BatchImportStatus, Semester
+from app.models.enums import BatchImportStatus, ReviewStage, Semester
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User
+from app.models.user_profile import UserProfile
 from app.schemas.batch_import import BatchImportValidationError
 from app.services.batch_import_service import BatchImportService
 
@@ -226,6 +229,23 @@ class TestBatchImportService:
                 "get_student_snapshot",
                 new_callable=AsyncMock,
                 return_value=mock_student_snapshot,
+            ),
+            # The profile upsert, form-data shaping and professor assignment each
+            # run their own DB queries; patch them here so this stays a focused
+            # unit test of the orchestration (the DB-backed tests below exercise
+            # the real helpers). Their absence keeps db.execute to config + one
+            # sequence lookup per row.
+            patch.object(
+                service,
+                "_build_submitted_form_data",
+                new_callable=AsyncMock,
+                return_value={"fields": {}, "documents": []},
+            ),
+            patch.object(service, "_upsert_user_profile", new_callable=AsyncMock),
+            patch(
+                "app.services.batch_import_service.assign_professor_from_profile",
+                new_callable=AsyncMock,
+                return_value=None,
             ),
             patch.object(service.db, "execute") as mock_execute,
         ):
@@ -597,3 +617,208 @@ async def test_parse_general_only_scholarship_needs_no_sub_type_mark(db, scholar
     assert errors == []
     assert len(parsed) == 1
     assert parsed[0]["sub_types"] == []
+
+
+# ─── create_applications_from_batch: student-submission parity ───────
+#
+# These are DB-backed (unlike the mocked TestBatchImportService cases
+# above): they persist real rows and read them back so the spec
+# behaviour — batch-created applications entering the standard review
+# flow — is verified against real DB state, not mocks.
+
+
+def _no_sis_student_service():
+    """A StudentService stub that reports no SIS data, so the batch
+    path falls back to Excel values without any network call (the test
+    env's default settings have the SIS API 'enabled')."""
+    stub = MagicMock()
+    stub.get_student_basic_info = AsyncMock(return_value=None)
+    stub.get_student_snapshot = AsyncMock(return_value=None)
+    return stub
+
+
+@pytest_asyncio.fixture
+async def scholarship_with_config(db: AsyncSession):
+    """A ScholarshipType plus a matching 114-year ScholarshipConfiguration
+    (period/amount/config_name live on the configuration)."""
+    scholarship = ScholarshipType(
+        code="phd_batch",
+        name="PhD Batch Scholarship",
+        sub_type_list=["nstc", "moe_1w"],
+        sub_type_selection_mode="multiple",
+    )
+    db.add(scholarship)
+    await db.flush()
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        academic_year=114,
+        semester=None,
+        config_name="PhD Batch Scholarship 114",
+        config_code="phd_batch_114",
+        amount=10000,
+    )
+    db.add(config)
+    await db.commit()
+    await db.refresh(scholarship)
+    return scholarship
+
+
+@pytest_asyncio.fixture
+async def batch_import_fixture(db: AsyncSession):
+    """A persisted BatchImport record and its importer user."""
+    importer = User(nycu_id="importer_admin", name="Importer", role="admin", user_type="employee")
+    db.add(importer)
+    await db.flush()
+
+    batch = BatchImport(
+        importer_id=importer.id,
+        college_code="E",
+        academic_year=114,
+        file_name="test.xlsx",
+        total_records=1,
+    )
+    db.add(batch)
+    await db.commit()
+    await db.refresh(batch)
+    return batch
+
+
+@pytest.mark.asyncio
+async def test_batch_created_application_matches_student_submission_shape(
+    db, batch_import_fixture, scholarship_with_config
+):
+    """Core spec assertion: a batch-created application looks like a
+    student-submitted one (status/review_stage/amount/name/form_data)."""
+    parsed_data = [
+        {
+            "student_id": "313554001",
+            "student_name": "王小明",
+            "postal_account": "1234567890123",
+            "advisor_name": "張教授",
+            "advisor_email": "chang@nycu.edu.tw",
+            "advisor_nycu_id": "P001234",
+            "is_renewal": False,
+            "renewal_year": None,
+            "sub_types": ["moe_1w", "nstc"],
+            "custom_fields": {"contact_phone": "0912345678"},
+            "row_number": 2,
+        }
+    ]
+
+    service = BatchImportService(db, student_service=_no_sis_student_service())
+    created_ids, errors = await service.create_applications_from_batch(
+        batch_import=batch_import_fixture,
+        parsed_data=parsed_data,
+        scholarship_type_id=scholarship_with_config.id,
+        academic_year=114,
+        semester=None,
+    )
+
+    assert errors == []
+    # Commit + expunge so the re-read is a fresh DB load (enum columns come
+    # back as enum members, not the strings set in-session).
+    await db.commit()
+    db.expunge_all()
+    app = await db.get(Application, created_ids[0])
+
+    # Review flow parity
+    assert app.status == ApplicationStatus.submitted
+    assert app.review_stage == ReviewStage.student_submitted
+    assert app.submitted_at is not None
+    # Value parity (config-sourced)
+    assert app.amount is not None
+    assert "114" in app.scholarship_name  # config_name carries the year
+    # app_id keeps the batch marker
+    assert app.app_id.endswith("U")
+    # Standard form-data structure; postal/advisor NOT inside
+    assert set(app.submitted_form_data.keys()) == {"fields", "documents"}
+    assert app.submitted_form_data["documents"] == []
+    assert app.submitted_form_data["fields"]["contact_phone"]["value"] == "0912345678"
+    assert "postal_account" not in app.submitted_form_data["fields"]
+    # Sub-type scalar via shared derivation
+    assert app.sub_scholarship_type == "moe_1w"
+    assert app.sub_type_preferences == ["moe_1w", "nstc"]
+    # Unchanged batch markers
+    assert app.import_source == "batch_import"
+    assert app.batch_import_id == batch_import_fixture.id
+    assert app.document_status == "pending_documents"
+
+
+@pytest.mark.asyncio
+async def test_batch_upserts_user_profile_with_overwrite(db, batch_import_fixture, scholarship_with_config):
+    # Pre-existing profile: advisor set by the student, postal blank
+    user = User(nycu_id="313554002", name="陳小華", role="student", user_type="student")
+    db.add(user)
+    await db.flush()
+    db.add(UserProfile(user_id=user.id, account_number=None, advisor_name="舊教授", advisor_nycu_id="P000001"))
+    await db.flush()
+
+    parsed_data = [
+        {
+            "student_id": "313554002",
+            "student_name": "陳小華",
+            "postal_account": "9876543210987",
+            "advisor_name": "李教授",
+            "advisor_email": None,  # blank in Excel — must preserve existing (None here)
+            "advisor_nycu_id": "P005678",
+            "is_renewal": False,
+            "renewal_year": None,
+            "sub_types": ["nstc"],
+            "custom_fields": {},
+            "row_number": 2,
+        }
+    ]
+
+    service = BatchImportService(db, student_service=_no_sis_student_service())
+    await service.create_applications_from_batch(
+        batch_import=batch_import_fixture,
+        parsed_data=parsed_data,
+        scholarship_type_id=scholarship_with_config.id,
+        academic_year=114,
+        semester=None,
+    )
+    await db.commit()
+
+    profile_result = await db.execute(select(UserProfile).where(UserProfile.user_id == user.id))
+    profile = profile_result.scalar_one()
+    assert profile.account_number == "9876543210987"  # filled from Excel
+    assert profile.advisor_name == "李教授"  # Excel value overwrites
+    assert profile.advisor_email is None  # blank Excel cell preserves existing
+    assert profile.advisor_nycu_id == "P005678"  # Excel value overwrites
+
+
+@pytest.mark.asyncio
+async def test_batch_assigns_professor_when_account_exists(db, batch_import_fixture, scholarship_with_config):
+    professor = User(nycu_id="P001234", name="張教授", role="professor", user_type="employee")
+    db.add(professor)
+    await db.flush()
+
+    parsed_data = [
+        {
+            "student_id": "313554003",
+            "student_name": "林小強",
+            "postal_account": None,
+            "advisor_name": "張教授",
+            "advisor_email": "chang@nycu.edu.tw",
+            "advisor_nycu_id": "P001234",
+            "is_renewal": False,
+            "renewal_year": None,
+            "sub_types": ["nstc"],
+            "custom_fields": {},
+            "row_number": 2,
+        }
+    ]
+
+    service = BatchImportService(db, student_service=_no_sis_student_service())
+    created_ids, _ = await service.create_applications_from_batch(
+        batch_import=batch_import_fixture,
+        parsed_data=parsed_data,
+        scholarship_type_id=scholarship_with_config.id,
+        academic_year=114,
+        semester=None,
+    )
+    await db.commit()
+
+    app = await db.get(Application, created_ids[0])
+    assert app.professor_id == professor.id

--- a/backend/app/tests/test_batch_import_service_unit.py
+++ b/backend/app/tests/test_batch_import_service_unit.py
@@ -956,7 +956,7 @@ async def test_bulk_check_eligibility_real_check_no_missing_greenlet(db, scholar
     the session identity map (revalidate path). check_student_eligibility reads
     config.scholarship_type.whitelist_enabled, so without eager-loading this
     would raise MissingGreenlet on an async lazy-load."""
-    config_id = scholarship_with_config.id
+    scholarship_type_id = scholarship_with_config.id
     # Drop everything from the identity map so config.scholarship_type must be
     # resolved from the query, not the identity map.
     db.expunge_all()
@@ -970,7 +970,7 @@ async def test_bulk_check_eligibility_real_check_no_missing_greenlet(db, scholar
 
     parsed_data = [{"student_id": "313554001", "sub_types": ["nstc"], "advisor_nycu_id": None, "row_number": 2}]
     # Must not raise (regression guard for MissingGreenlet).
-    warnings = await service.bulk_check_eligibility(parsed_data, config_id, 114, None)
+    warnings = await service.bulk_check_eligibility(parsed_data, scholarship_type_id, 114, None)
 
     # No skip warning about missing config (the config was found).
     assert not any(w["warning_type"] == "eligibility_check_skipped" and w["field"] == "configuration" for w in warnings)
@@ -1008,3 +1008,34 @@ async def test_bulk_check_eligibility_skips_row_when_check_raises(db, scholarshi
     assert skip_warnings[0]["student_id"] == "313554001"
     # A raised check must NOT produce an eligibility_failed warning.
     assert not any(w["warning_type"] == "eligibility_failed" for w in warnings)
+
+
+@pytest.mark.asyncio
+async def test_parse_dedupes_label_and_raw_code_columns(db, scholarship_with_sub_types):
+    """A sheet carrying BOTH the Chinese label column (國科會) and the
+    raw-code column (nstc), both marked, must yield the code once — not a
+    duplicated preference list (Copilot review, PR #1129)."""
+    df = pd.DataFrame([{"學號": "313554001", "學生姓名": "王小明", "國科會": 1, "nstc": "V"}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(buf.getvalue(), scholarship_with_sub_types.id, 114, None)
+
+    assert errors == []
+    assert parsed[0]["sub_types"] == ["nstc"]
+
+
+@pytest.mark.asyncio
+async def test_parse_english_sub_type_columns_lowercased(db, scholarship_with_sub_types):
+    """sub_type_MOE_1W must normalize to moe_1w so the forced-first rule and
+    downstream lowercase quota lookups still match (Copilot review, PR #1129)."""
+    df = pd.DataFrame([{"student_id": "313554001", "student_name": "王小明", "sub_type_NSTC": 1, "sub_type_MOE_1W": 1}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(buf.getvalue(), scholarship_with_sub_types.id, 114, None)
+
+    assert errors == []
+    assert parsed[0]["sub_types"] == ["moe_1w", "nstc"]

--- a/backend/app/tests/test_batch_import_service_unit.py
+++ b/backend/app/tests/test_batch_import_service_unit.py
@@ -822,3 +822,78 @@ async def test_batch_assigns_professor_when_account_exists(db, batch_import_fixt
 
     app = await db.get(Application, created_ids[0])
     assert app.professor_id == professor.id
+
+
+# ─── bulk_check_eligibility: preview-stage warnings ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_bulk_check_eligibility_flags_failures_but_filters_period(db, scholarship_with_config, monkeypatch):
+    service = BatchImportService(db)
+
+    async def fake_snapshot(student_id, academic_year=None, semester=None):
+        return {"std_stdcode": student_id, "trm_ascore_gpa": 2.0}
+
+    monkeypatch.setattr(service.student_service, "get_student_snapshot", fake_snapshot)
+
+    async def fake_check(student_data, config, user_id=None):
+        # Simulates: outside application period AND a real rule failure
+        return False, ["不在申請期間內", "GPA 未達標準"]
+
+    from app.services import batch_import_service as bis_module
+
+    monkeypatch.setattr(
+        bis_module.EligibilityService, "check_student_eligibility", staticmethod(fake_check), raising=False
+    )
+
+    parsed_data = [{"student_id": "313554001", "sub_types": ["nstc"], "advisor_nycu_id": None, "row_number": 2}]
+    warnings = await service.bulk_check_eligibility(parsed_data, scholarship_with_config.id, 114, None)
+
+    eligibility_warnings = [w for w in warnings if w["warning_type"] == "eligibility_failed"]
+    assert len(eligibility_warnings) == 1
+    assert "GPA 未達標準" in eligibility_warnings[0]["message"]
+    # Application-period reason is exempted for batch import (late entry)
+    assert "不在申請期間內" not in eligibility_warnings[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_bulk_check_eligibility_warns_missing_professor_account(db, scholarship_with_config, monkeypatch):
+    service = BatchImportService(db)
+
+    async def fake_snapshot(student_id, academic_year=None, semester=None):
+        return {"std_stdcode": student_id}
+
+    monkeypatch.setattr(service.student_service, "get_student_snapshot", fake_snapshot)
+
+    parsed_data = [{"student_id": "313554001", "sub_types": ["nstc"], "advisor_nycu_id": "NOSUCH", "row_number": 2}]
+    warnings = await service.bulk_check_eligibility(parsed_data, scholarship_with_config.id, 114, None)
+
+    professor_warnings = [w for w in warnings if w["warning_type"] == "professor_not_found"]
+    assert len(professor_warnings) == 1
+    assert "NOSUCH" in professor_warnings[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_bulk_check_eligibility_real_check_no_missing_greenlet(db, scholarship_with_config, monkeypatch):
+    """Runs the REAL check_student_eligibility with the ScholarshipType NOT in
+    the session identity map (revalidate path). check_student_eligibility reads
+    config.scholarship_type.whitelist_enabled, so without eager-loading this
+    would raise MissingGreenlet on an async lazy-load."""
+    config_id = scholarship_with_config.id
+    # Drop everything from the identity map so config.scholarship_type must be
+    # resolved from the query, not the identity map.
+    db.expunge_all()
+
+    service = BatchImportService(db)
+
+    async def fake_snapshot(student_id, academic_year=None, semester=None):
+        return {"std_stdcode": student_id}
+
+    monkeypatch.setattr(service.student_service, "get_student_snapshot", fake_snapshot)
+
+    parsed_data = [{"student_id": "313554001", "sub_types": ["nstc"], "advisor_nycu_id": None, "row_number": 2}]
+    # Must not raise (regression guard for MissingGreenlet).
+    warnings = await service.bulk_check_eligibility(parsed_data, config_id, 114, None)
+
+    # No skip warning about missing config (the config was found).
+    assert not any(w["warning_type"] == "eligibility_check_skipped" and w["field"] == "configuration" for w in warnings)

--- a/backend/app/tests/test_batch_import_service_unit.py
+++ b/backend/app/tests/test_batch_import_service_unit.py
@@ -237,8 +237,13 @@ class TestBatchImportService:
             # sequence lookup per row.
             patch.object(
                 service,
-                "_build_submitted_form_data",
+                "_fetch_field_definitions",
                 new_callable=AsyncMock,
+                return_value={},
+            ),
+            patch.object(
+                service,
+                "_build_submitted_form_data",
                 return_value={"fields": {}, "documents": []},
             ),
             patch.object(service, "_upsert_user_profile", new_callable=AsyncMock),

--- a/backend/app/tests/test_batch_import_service_unit.py
+++ b/backend/app/tests/test_batch_import_service_unit.py
@@ -824,6 +824,78 @@ async def test_batch_assigns_professor_when_account_exists(db, batch_import_fixt
     assert app.professor_id == professor.id
 
 
+@pytest.mark.asyncio
+async def test_advisor_columns_survive_parse_to_profile_and_professor(
+    db, batch_import_fixture, scholarship_with_config
+):
+    """Regression: advisor columns from the Excel must survive the FULL
+    chain — parse_excel_file → ApplicationDataRow round-trip →
+    create_applications_from_batch → UserProfile + professor auto-assign.
+
+    The earlier tests fed hand-built parsed_data dicts that already carried
+    advisor_* keys, so they never exercised the schema layer. The defect
+    lived exactly there: ApplicationDataRow had no advisor fields, so
+    model_dump() silently dropped advisor info parsed from the sheet — the
+    profile never got the advisor and no professor was auto-assigned.
+    """
+    professor = User(nycu_id="P009999", name="趙教授", role="professor", user_type="employee")
+    db.add(professor)
+    await db.flush()
+
+    # Chinese-column Excel with advisor + postal columns.
+    df = pd.DataFrame(
+        {
+            "學號": ["313557001"],
+            "學生姓名": ["黃小美"],
+            "國科會": [1],
+            "指導教授姓名": ["趙教授"],
+            "指導教授Email": ["zhao@nycu.edu.tw"],
+            "指導教授本校人事編號": ["P009999"],
+            "郵局帳號": ["1234567890"],
+        }
+    )
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False)
+    file_content = buffer.getvalue()
+
+    service = BatchImportService(db, student_service=_no_sis_student_service())
+
+    parsed_data, parse_errors = await service.parse_excel_file(
+        file_content=file_content,
+        scholarship_type_id=scholarship_with_config.id,
+        academic_year=114,
+        semester=None,
+    )
+    assert parse_errors == []
+    assert len(parsed_data) == 1
+    # Advisor fields survived parse → schema round-trip (the defect site).
+    assert parsed_data[0]["advisor_nycu_id"] == "P009999"
+    assert parsed_data[0]["advisor_name"] == "趙教授"
+    assert parsed_data[0]["advisor_email"] == "zhao@nycu.edu.tw"
+
+    created_ids, create_errors = await service.create_applications_from_batch(
+        batch_import=batch_import_fixture,
+        parsed_data=parsed_data,
+        scholarship_type_id=scholarship_with_config.id,
+        academic_year=114,
+        semester=None,
+    )
+    assert create_errors == []
+    await db.commit()
+
+    student = (await db.execute(select(User).where(User.nycu_id == "313557001"))).scalar_one()
+    profile = (await db.execute(select(UserProfile).where(UserProfile.user_id == student.id))).scalar_one()
+    assert profile.advisor_nycu_id == "P009999"
+    assert profile.advisor_name == "趙教授"
+    assert profile.advisor_email == "zhao@nycu.edu.tw"
+    assert profile.account_number == "1234567890"
+
+    # Professor auto-assigned from the advisor_nycu_id that survived the chain.
+    app = await db.get(Application, created_ids[0])
+    assert app.professor_id == professor.id
+
+
 # ─── bulk_check_eligibility: preview-stage warnings ──────────────────
 
 

--- a/backend/app/tests/test_batch_import_service_unit.py
+++ b/backend/app/tests/test_batch_import_service_unit.py
@@ -4,9 +4,12 @@ Unit tests for BatchImportService
 Tests file parsing, validation, bulk operations, and transaction rollback.
 """
 
+import io
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import pandas as pd
 import pytest
+import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import BatchImportError
@@ -36,6 +39,8 @@ class TestBatchImportService:
         scholarship.amount = 10000
         scholarship.main_type = "general"
         scholarship.sub_type_selection_mode = "single"
+        # No real sub-types → parse_excel_file must not require sub-type marks.
+        scholarship.sub_type_list = []
         return scholarship
 
     @pytest.fixture
@@ -495,3 +500,100 @@ class TestBatchImportService:
             assert batch_import.failed_count == 5
             assert batch_import.import_status == "partial"
             assert batch_import.error_summary["total_errors"] == 1
+
+
+# ─── parse_excel_file sub-type parsing (checkmark semantics) ─────────
+
+
+@pytest_asyncio.fixture
+async def scholarship_with_sub_types(db: AsyncSession):
+    """A ScholarshipType that defines real sub-types (nstc, moe_1w).
+
+    Mirrors the ScholarshipType construction style in
+    test_batch_import_endpoints.py: only columns that exist on
+    ScholarshipType are set (period/amount live on ScholarshipConfiguration).
+    """
+    scholarship = ScholarshipType(
+        code="phd_sub_types",
+        name="PhD Scholarship With Sub Types",
+        sub_type_list=["nstc", "moe_1w"],
+        sub_type_selection_mode="multiple",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+    return scholarship
+
+
+@pytest.mark.asyncio
+async def test_parse_orders_preferences_moe_first_regardless_of_numbers(db, scholarship_with_sub_types):
+    # 國科會=1, 教育部=2 in the Excel — moe_1w must STILL come first
+    df = pd.DataFrame([{"學號": "313554001", "學生姓名": "王小明", "國科會": 1, "教育部": 2}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(buf.getvalue(), scholarship_with_sub_types.id, 114, None)
+
+    assert errors == []
+    assert parsed[0]["sub_types"] == ["moe_1w", "nstc"]
+
+
+@pytest.mark.asyncio
+async def test_parse_accepts_checkmark_v(db, scholarship_with_sub_types):
+    df = pd.DataFrame([{"學號": "313554001", "學生姓名": "王小明", "國科會": "V", "教育部": ""}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(buf.getvalue(), scholarship_with_sub_types.id, 114, None)
+
+    assert errors == []
+    assert parsed[0]["sub_types"] == ["nstc"]
+
+
+@pytest.mark.asyncio
+async def test_parse_missing_sub_type_is_hard_error(db, scholarship_with_sub_types):
+    df = pd.DataFrame([{"學號": "313554001", "學生姓名": "王小明", "國科會": "", "教育部": ""}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(buf.getvalue(), scholarship_with_sub_types.id, 114, None)
+
+    assert parsed == []
+    assert len(errors) == 1
+    assert errors[0].error_type == "missing_sub_type"
+    assert errors[0].student_id == "313554001"
+
+
+@pytest_asyncio.fixture
+async def scholarship_general_only(db: AsyncSession):
+    """A ScholarshipType carrying only the synthetic "general" placeholder
+    (the model default). It defines NO real sub-types, so rows must NOT be
+    required to mark one."""
+    scholarship = ScholarshipType(
+        code="general_only",
+        name="General Scholarship",
+        sub_type_list=["general"],
+        sub_type_selection_mode="single",
+    )
+    db.add(scholarship)
+    await db.commit()
+    await db.refresh(scholarship)
+    return scholarship
+
+
+@pytest.mark.asyncio
+async def test_parse_general_only_scholarship_needs_no_sub_type_mark(db, scholarship_general_only):
+    # No sub-type columns at all; a "general"-only scholarship must parse cleanly.
+    df = pd.DataFrame([{"學號": "313554001", "學生姓名": "王小明"}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(buf.getvalue(), scholarship_general_only.id, 114, None)
+
+    assert errors == []
+    assert len(parsed) == 1
+    assert parsed[0]["sub_types"] == []

--- a/backend/app/tests/test_batch_import_service_unit.py
+++ b/backend/app/tests/test_batch_import_service_unit.py
@@ -897,3 +897,37 @@ async def test_bulk_check_eligibility_real_check_no_missing_greenlet(db, scholar
 
     # No skip warning about missing config (the config was found).
     assert not any(w["warning_type"] == "eligibility_check_skipped" and w["field"] == "configuration" for w in warnings)
+
+
+@pytest.mark.asyncio
+async def test_bulk_check_eligibility_skips_row_when_check_raises(db, scholarship_with_config, monkeypatch):
+    """A failing eligibility check (e.g. malformed rule config) must be demoted
+    to a per-row skip warning, never propagated to 500 the preview endpoints."""
+    service = BatchImportService(db)
+
+    async def fake_snapshot(student_id, academic_year=None, semester=None):
+        return {"std_stdcode": student_id}
+
+    monkeypatch.setattr(service.student_service, "get_student_snapshot", fake_snapshot)
+
+    async def boom_check(student_data, config, user_id=None):
+        raise RuntimeError("malformed rule config")
+
+    from app.services import batch_import_service as bis_module
+
+    monkeypatch.setattr(
+        bis_module.EligibilityService, "check_student_eligibility", staticmethod(boom_check), raising=False
+    )
+
+    parsed_data = [{"student_id": "313554001", "sub_types": ["nstc"], "advisor_nycu_id": None, "row_number": 2}]
+    # Must not raise.
+    warnings = await service.bulk_check_eligibility(parsed_data, scholarship_with_config.id, 114, None)
+
+    skip_warnings = [
+        w for w in warnings if w["warning_type"] == "eligibility_check_skipped" and w["field"] == "eligibility"
+    ]
+    assert len(skip_warnings) == 1
+    assert skip_warnings[0]["row_number"] == 2
+    assert skip_warnings[0]["student_id"] == "313554001"
+    # A raised check must NOT produce an eligibility_failed warning.
+    assert not any(w["warning_type"] == "eligibility_failed" for w in warnings)

--- a/backend/app/tests/test_get_applications_for_review_deep.py
+++ b/backend/app/tests/test_get_applications_for_review_deep.py
@@ -158,3 +158,62 @@ async def test_scholarship_type_filter_by_code(db: AsyncSession):
     # Filter to scholarship_type code matching cfg_a's type code.
     result = await service.get_applications_for_review(current_user=admin, scholarship_type="forrev_type_a")
     assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_professor_path_scopes_without_lazy_load(db: AsyncSession):
+    """Issue #1130 regression: the professor branch used to traverse the lazy
+    professor_relationships collection, which raises MissingGreenlet under an
+    AsyncSession. The access list must be queried explicitly AND scope the
+    results to students with view permission."""
+    from app.models.professor_student import ProfessorStudentRelationship
+
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id="forrev_prof_scope")
+    accessible = await _seed_user(db, role=UserRole.student, nycu_id="forrev_stu_acc")
+    hidden = await _seed_user(db, role=UserRole.student, nycu_id="forrev_stu_hid")
+    cfg = await _seed_config(db, suffix="prof_scope")
+    app_acc = await _seed_app(
+        db, student=accessible, config=cfg, status=ApplicationStatus.submitted.value, suffix="acc1"
+    )
+    await _seed_app(db, student=hidden, config=cfg, status=ApplicationStatus.submitted.value, suffix="hid1")
+
+    db.add(
+        ProfessorStudentRelationship(
+            professor_id=professor.id,
+            student_id=accessible.id,
+            relationship_type="advisor",
+            is_active=True,
+            can_view_applications=True,
+        )
+    )
+    await db.commit()
+
+    service = ApplicationService(db)
+    result = await service.get_applications_for_review(current_user=professor)
+    assert [r.id for r in result] == [app_acc.id]
+
+
+@pytest.mark.asyncio
+async def test_review_list_endpoint_wires_filters_as_keywords(client, db: AsyncSession):
+    """Issue #1131 regression: /review/list once passed its query params
+    positionally, sending status into `skip` (offset("submitted") → 500) and
+    the type filter into `limit`. Both filters must reach the service."""
+    from app.core.security import get_current_user
+    from app.main import app as fastapi_app
+
+    admin = await _seed_user(db, role=UserRole.admin, nycu_id="forrev_admin_http")
+    student = await _seed_user(db, role=UserRole.student, nycu_id="forrev_stu_http")
+    cfg_a = await _seed_config(db, suffix="http_a")
+    cfg_b = await _seed_config(db, suffix="http_b")
+    await _seed_app(db, student=student, config=cfg_a, status=ApplicationStatus.submitted.value, suffix="ha1")
+    await _seed_app(db, student=student, config=cfg_a, status=ApplicationStatus.approved.value, suffix="ha2")
+    await _seed_app(db, student=student, config=cfg_b, status=ApplicationStatus.submitted.value, suffix="hb1")
+
+    fastapi_app.dependency_overrides[get_current_user] = lambda: admin
+    resp = await client.get(
+        "/api/v1/applications/review/list",
+        params={"status": "submitted", "scholarship_type": "forrev_http_a"},
+    )
+    assert resp.status_code == 200
+    rows = resp.json()["data"]
+    assert len(rows) == 1

--- a/docs/superpowers/plans/2026-07-09-batch-import-like-student-submission.md
+++ b/docs/superpowers/plans/2026-07-09-batch-import-like-student-submission.md
@@ -1,0 +1,1410 @@
+# Batch Import Aligned with Student Self-Submission — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Batch-imported applications behave like student self-submitted ones: same review flow (`submitted` → professor → college), same `submitted_form_data` structure, same field values (`config.amount`, `config.config_name`), postal/advisor data in `UserProfile`, and eligibility warnings at preview.
+
+**Architecture:** Extract the drift-prone application-construction core into a new shared module `backend/app/services/application_builder.py` (app_id generation, sub-type derivation/validation/ordering, submitted-state field values, professor auto-assign). Both `ApplicationService` (student path — pure refactor, behavior unchanged) and `BatchImportService` (batch path — behavior changes per spec) call it.
+
+**Tech Stack:** FastAPI, SQLAlchemy async, pandas/openpyxl, pytest (`asyncio_mode=auto`), Next.js frontend (no code change expected).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-batch-import-like-student-submission-design.md`
+
+## Global Constraints
+
+- Run backend tests inside the dev container: `docker exec scholarship_backend_dev python -m pytest <path> -v --no-cov -p no:cacheprovider`
+- `async def` tests run in the **integration** CI lane automatically (`asyncio_mode=auto`); sync tests run in **unit**. Do not convert existing sync tests to async.
+- Lint gates (hard): `uvx --from "black==26.3.1" black --check --line-length=120 backend/app`; `flake8 app --select=B904,B014 --max-line-length=120` (run inside `backend/`); `raise` inside `except` must use `from exc`; `logger.warning/error` interpolating the exception inside `except` must pass `exc_info=True`.
+- Enum convention: Python enum members lowercase matching DB values; pass enum **members** (not `.value`) when constructing in-memory test objects.
+- Never build test models via `Model.__new__`; use `Model(**kwargs)` or `m = Model(); m.__dict__.update(...)` for duck-typed stubs.
+- API responses stay in `{success, message, data}` format.
+- Commit messages in English, conventional-commit style.
+- Keep `app_id` suffix `"U"` for batch imports. No email automation, no fixed-document cloning, no DB migration, no data backfill.
+- Sub-types are configuration-driven strings, lowercase (`nstc`, `moe_1w`, …) — never enum-constrained.
+
+---
+
+### Task 1: `application_builder.py` — pure helpers (sub-type derivation, validation, ordering, submitted values)
+
+**Files:**
+- Create: `backend/app/services/application_builder.py`
+- Test: `backend/app/tests/test_application_builder.py`
+
+**Interfaces:**
+- Produces (later tasks import these from `app.services.application_builder`):
+  - `FORCED_FIRST_PREFERENCE: str = "moe_1w"`
+  - `derive_sub_scholarship_type(scholarship_subtype_list: Optional[List[str]]) -> str`
+  - `validate_sub_type_for_submission(scholarship, sub_scholarship_type: Optional[str]) -> None` (raises `app.core.exceptions.ValidationError`)
+  - `order_sub_type_preferences(sub_types: List[str]) -> List[str]`
+  - `build_submitted_application_values(scholarship, config) -> Dict[str, Any]` with keys `status`, `status_name`, `review_stage`, `submitted_at`, `amount`, `scholarship_name`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/app/tests/test_application_builder.py`. These are **sync** tests (unit lane) — the helpers under test are pure.
+
+```python
+"""Unit tests for the shared application builder helpers.
+
+These helpers are the single source of truth for logic that previously
+drifted between the student self-submission path (ApplicationService)
+and the batch import path (BatchImportService).
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.exceptions import ValidationError
+from app.services.application_builder import (
+    FORCED_FIRST_PREFERENCE,
+    build_submitted_application_values,
+    derive_sub_scholarship_type,
+    order_sub_type_preferences,
+    validate_sub_type_for_submission,
+)
+
+
+# --- derive_sub_scholarship_type -------------------------------------------
+
+
+def test_derive_sub_type_empty_list_returns_general():
+    assert derive_sub_scholarship_type([]) == "general"
+    assert derive_sub_scholarship_type(None) == "general"
+
+
+def test_derive_sub_type_first_entry_lowercased():
+    assert derive_sub_scholarship_type(["NSTC", "moe_1w"]) == "nstc"
+
+
+# --- validate_sub_type_for_submission ---------------------------------------
+
+
+def _scholarship_stub(sub_type_list):
+    return SimpleNamespace(sub_type_list=sub_type_list)
+
+
+def test_validate_rejects_general_when_real_sub_types_exist():
+    with pytest.raises(ValidationError):
+        validate_sub_type_for_submission(_scholarship_stub(["nstc", "moe_1w"]), "general")
+
+
+def test_validate_accepts_real_sub_type_case_insensitive():
+    validate_sub_type_for_submission(_scholarship_stub(["NSTC", "moe_1w"]), "nstc")
+
+
+def test_validate_rejects_arbitrary_sub_type_when_none_defined():
+    with pytest.raises(ValidationError):
+        validate_sub_type_for_submission(_scholarship_stub([]), "nstc")
+
+
+def test_validate_accepts_general_when_none_defined():
+    validate_sub_type_for_submission(_scholarship_stub([]), "general")
+    validate_sub_type_for_submission(_scholarship_stub(None), None)
+
+
+# --- order_sub_type_preferences ---------------------------------------------
+
+
+def test_order_forces_moe_1w_first():
+    assert order_sub_type_preferences(["nstc", "moe_1w"]) == ["moe_1w", "nstc"]
+
+
+def test_order_preserves_order_without_moe_1w():
+    assert order_sub_type_preferences(["nstc", "moe_2w"]) == ["nstc", "moe_2w"]
+
+
+def test_order_single_and_empty():
+    assert order_sub_type_preferences(["moe_1w"]) == ["moe_1w"]
+    assert order_sub_type_preferences([]) == []
+
+
+def test_forced_first_preference_constant_matches_frontend():
+    # Mirrors FORCED_FIRST_PREFERENCE in
+    # frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx
+    assert FORCED_FIRST_PREFERENCE == "moe_1w"
+
+
+# --- build_submitted_application_values --------------------------------------
+
+
+def test_build_submitted_values_uses_config_amount_and_name():
+    scholarship = SimpleNamespace(name="博士生獎學金")
+    config = SimpleNamespace(config_name="博士生獎學金 114學年", amount=40000)
+
+    values = build_submitted_application_values(scholarship, config)
+
+    assert values["status"] == "submitted"
+    assert values["status_name"]  # non-empty i18n text
+    assert values["review_stage"] == "student_submitted"
+    assert values["amount"] == 40000
+    assert values["scholarship_name"] == "博士生獎學金 114學年"
+    assert isinstance(values["submitted_at"], datetime)
+    assert values["submitted_at"].tzinfo == timezone.utc
+
+
+def test_build_submitted_values_falls_back_to_scholarship_name():
+    scholarship = SimpleNamespace(name="博士生獎學金")
+    config = SimpleNamespace(config_name=None, amount=None)
+
+    values = build_submitted_application_values(scholarship, config)
+
+    assert values["scholarship_name"] == "博士生獎學金"
+    assert values["amount"] is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_application_builder.py -v --no-cov -p no:cacheprovider`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.application_builder'`
+
+- [ ] **Step 3: Write the module (pure helpers only)**
+
+Create `backend/app/services/application_builder.py`. The derivation/validation bodies are **moved verbatim** from `ApplicationService._derive_sub_scholarship_type` / `_validate_sub_type_for_submission` (`backend/app/services/application_service.py:452-492`) so behavior is identical:
+
+```python
+"""Shared application-construction helpers.
+
+Single source of truth for logic used by BOTH the student self-submission
+path (ApplicationService) and the batch import path (BatchImportService).
+Any submitted-application field rule that must stay identical across the
+two paths belongs here — that is the module's only admission criterion.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.core.exceptions import ValidationError
+from app.models.enums import ApplicationStatus, ReviewStage
+from app.utils.i18n import ScholarshipI18n
+
+logger = logging.getLogger(__name__)
+
+# Mirrors FORCED_FIRST_PREFERENCE in
+# frontend/components/student-wizard/steps/ScholarshipApplicationStep.tsx:
+# the manual preference-ordering UI is hidden; MOE (moe_1w) is always the
+# first preference when selected alongside other sub-types.
+FORCED_FIRST_PREFERENCE = "moe_1w"
+
+
+def derive_sub_scholarship_type(scholarship_subtype_list: Optional[List[str]]) -> str:
+    """Derive the denormalized scalar `sub_scholarship_type` from the selected
+    sub-type list: first entry wins, normalized to lowercase; empty → "general".
+    """
+    if scholarship_subtype_list:
+        return scholarship_subtype_list[0].lower()
+    return "general"
+
+
+def validate_sub_type_for_submission(scholarship, sub_scholarship_type: Optional[str]) -> None:
+    """Reject the synthetic "general" category on submission for scholarships
+    that define real sub-types, and arbitrary sub-types for scholarships that
+    define none. Comparison is case-insensitive.
+    """
+    if scholarship is None:
+        return
+    real_sub_types = [st.lower() for st in (scholarship.sub_type_list or []) if st and st.lower() != "general"]
+    normalized = (sub_scholarship_type or "general").lower()
+    if real_sub_types:
+        if normalized not in real_sub_types:
+            raise ValidationError("此獎學金需選擇申請類別（" + "、".join(real_sub_types) + "），不可使用通用類別")
+    elif normalized != "general":
+        raise ValidationError("此獎學金不提供申請類別選擇，不可指定子類別")
+
+
+def order_sub_type_preferences(sub_types: List[str]) -> List[str]:
+    """Order a selected sub-type list the way the student wizard does:
+    FORCED_FIRST_PREFERENCE (moe_1w) leads when present; the rest keep
+    their given order. Returns a new list.
+    """
+    if FORCED_FIRST_PREFERENCE in sub_types:
+        return [FORCED_FIRST_PREFERENCE] + [st for st in sub_types if st != FORCED_FIRST_PREFERENCE]
+    return list(sub_types)
+
+
+def build_submitted_application_values(scholarship, config) -> Dict[str, Any]:
+    """Field values every application must carry the moment it is submitted,
+    regardless of which path created it.
+    """
+    return {
+        "status": ApplicationStatus.submitted.value,
+        "status_name": ScholarshipI18n.get_application_status_text(ApplicationStatus.submitted.value),
+        "review_stage": ReviewStage.student_submitted.value,
+        "submitted_at": datetime.now(timezone.utc),
+        "amount": config.amount,
+        "scholarship_name": config.config_name or scholarship.name,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_application_builder.py -v --no-cov -p no:cacheprovider`
+Expected: all PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uvx --from "black==26.3.1" black --line-length=120 backend/app/services/application_builder.py backend/app/tests/test_application_builder.py
+cd backend && flake8 app/services/application_builder.py app/tests/test_application_builder.py --select=B904,B014 --max-line-length=120 && cd ..
+git add backend/app/services/application_builder.py backend/app/tests/test_application_builder.py
+git commit -m "feat: add shared application builder helpers (sub-type + submitted values)"
+```
+
+---
+
+### Task 2: `application_builder.py` — async helpers (`generate_app_id`, `assign_professor_from_profile`)
+
+**Files:**
+- Modify: `backend/app/services/application_builder.py`
+- Test: `backend/app/tests/test_application_builder.py` (append async tests)
+
+**Interfaces:**
+- Produces:
+  - `async generate_app_id(db, academic_year: int, semester, *, suffix: str = "", commit: bool = True) -> str`
+    — `semester` accepts `None`, a `Semester` enum member, or a string. `commit=True` commits immediately to release the row lock (student path). `commit=False` holds the lock for the caller's enclosing transaction (batch path — blocks online applications during import, intentionally).
+  - `async assign_professor_from_profile(db, application, user_id: int) -> Optional[User]`
+    — looks up `UserProfile.advisor_nycu_id` for `user_id`; if a `User` with `role == UserRole.professor` matches, sets `application.professor_id` and returns the professor, else returns `None`. Does NOT overwrite an already-set `application.professor_id`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/app/tests/test_application_builder.py`. These are **async** tests (integration lane) using the existing async `db` fixture (see `backend/app/tests/conftest.py` — same fixture `test_batch_import_service_unit.py` uses):
+
+```python
+# --- async helpers -----------------------------------------------------------
+
+from app.models.application_sequence import ApplicationSequence  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.models.user_profile import UserProfile  # noqa: E402
+from app.services.application_builder import (  # noqa: E402
+    assign_professor_from_profile,
+    generate_app_id,
+)
+
+
+async def test_generate_app_id_creates_sequence_and_formats(db):
+    app_id = await generate_app_id(db, 114, None)
+    assert app_id == "APP-114-0-00001"
+
+    app_id2 = await generate_app_id(db, 114, "yearly")
+    assert app_id2 == "APP-114-0-00002"
+
+
+async def test_generate_app_id_with_suffix_no_commit(db):
+    app_id = await generate_app_id(db, 114, "first", suffix="U", commit=False)
+    assert app_id == "APP-114-1-00001U"
+
+
+async def test_assign_professor_sets_id_when_profile_matches(db):
+    student = User(nycu_id="313554001", name="學生甲", role="student", user_type="student")
+    professor = User(nycu_id="P001234", name="張教授", role="professor", user_type="employee")
+    db.add_all([student, professor])
+    await db.flush()
+
+    db.add(UserProfile(user_id=student.id, advisor_nycu_id="P001234"))
+    await db.flush()
+
+    application = SimpleNamespace(professor_id=None)
+    result = await assign_professor_from_profile(db, application, student.id)
+
+    assert result is not None
+    assert application.professor_id == professor.id
+
+
+async def test_assign_professor_none_when_no_professor_account(db):
+    student = User(nycu_id="313554002", name="學生乙", role="student", user_type="student")
+    db.add(student)
+    await db.flush()
+    db.add(UserProfile(user_id=student.id, advisor_nycu_id="NOSUCH"))
+    await db.flush()
+
+    application = SimpleNamespace(professor_id=None)
+    result = await assign_professor_from_profile(db, application, student.id)
+
+    assert result is None
+    assert application.professor_id is None
+
+
+async def test_assign_professor_does_not_overwrite_existing(db):
+    student = User(nycu_id="313554003", name="學生丙", role="student", user_type="student")
+    db.add(student)
+    await db.flush()
+
+    application = SimpleNamespace(professor_id=999)
+    result = await assign_professor_from_profile(db, application, student.id)
+
+    assert result is None
+    assert application.professor_id == 999
+```
+
+Note: if the `User` constructor requires different kwargs in conftest fixtures, copy the construction style from existing tests in `test_batch_import_service_unit.py` — never invent column names (`nycu_id`/`name`/`status`, NOT `username`/`full_name`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_application_builder.py -v --no-cov -p no:cacheprovider`
+Expected: new tests FAIL with `ImportError: cannot import name 'generate_app_id'`
+
+- [ ] **Step 3: Implement the async helpers**
+
+Append to `backend/app/services/application_builder.py`:
+
+```python
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application_sequence import ApplicationSequence
+from app.models.user import User, UserRole
+from app.models.user_profile import UserProfile
+
+
+async def generate_app_id(
+    db: AsyncSession,
+    academic_year: int,
+    semester,
+    *,
+    suffix: str = "",
+    commit: bool = True,
+) -> str:
+    """Generate a sequential application ID with database row locking.
+
+    Format: APP-{academic_year}-{semester_code}-{sequence:05d}{suffix}
+
+    commit=True releases the sequence row lock immediately (student path).
+    commit=False keeps the lock until the caller's transaction ends — the
+    batch import path relies on this to stay atomic, at the cost of
+    blocking online submissions for the duration of the import.
+    """
+    if semester is None:
+        semester = "yearly"
+    if hasattr(semester, "value"):
+        semester = semester.value
+
+    stmt = (
+        select(ApplicationSequence)
+        .where(
+            and_(
+                ApplicationSequence.academic_year == academic_year,
+                ApplicationSequence.semester == semester,
+            )
+        )
+        .with_for_update()
+    )
+    result = await db.execute(stmt)
+    seq_record = result.scalar_one_or_none()
+
+    if not seq_record:
+        seq_record = ApplicationSequence(academic_year=academic_year, semester=semester, last_sequence=0)
+        db.add(seq_record)
+        await db.flush()
+
+    seq_record.last_sequence += 1
+    sequence_num = seq_record.last_sequence
+
+    if commit:
+        await db.commit()
+
+    app_id = ApplicationSequence.format_app_id(academic_year, semester, sequence_num)
+    return f"{app_id}{suffix}"
+
+
+async def assign_professor_from_profile(db: AsyncSession, application, user_id: int):
+    """Auto-assign the reviewing professor from the student's UserProfile.
+
+    Looks up UserProfile.advisor_nycu_id and matches a User with
+    role=professor. Returns the professor User or None. Never overwrites
+    an already-assigned professor_id.
+    """
+    if getattr(application, "professor_id", None):
+        return None
+
+    profile_stmt = select(UserProfile).where(UserProfile.user_id == user_id)
+    profile_result = await db.execute(profile_stmt)
+    profile = profile_result.scalar_one_or_none()
+
+    if not profile or not profile.advisor_nycu_id:
+        return None
+
+    professor_stmt = select(User).where(
+        User.nycu_id == profile.advisor_nycu_id,
+        User.role == UserRole.professor,
+    )
+    professor_result = await db.execute(professor_stmt)
+    professor = professor_result.scalar_one_or_none()
+
+    if professor:
+        application.professor_id = professor.id
+        logger.info("Auto-assigned professor %s to application %s", professor.id, getattr(application, "app_id", "?"))
+    return professor
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_application_builder.py -v --no-cov -p no:cacheprovider`
+Expected: all PASS
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uvx --from "black==26.3.1" black --line-length=120 backend/app/services/application_builder.py backend/app/tests/test_application_builder.py
+cd backend && flake8 app/services/application_builder.py app/tests/test_application_builder.py --select=B904,B014 --max-line-length=120 && cd ..
+git add backend/app/services/application_builder.py backend/app/tests/test_application_builder.py
+git commit -m "feat: add generate_app_id and professor auto-assign to application builder"
+```
+
+---
+
+### Task 3: `ApplicationService` delegates to the builder (pure refactor, zero behavior change)
+
+**Files:**
+- Modify: `backend/app/services/application_service.py`
+
+**Interfaces:**
+- Consumes: everything Task 1–2 produced.
+- Produces: no new interface. `ApplicationService._generate_app_id`, `_derive_sub_scholarship_type`, `_validate_sub_type_for_submission` keep their signatures (thin delegates) so all existing call sites and tests stay valid.
+
+- [ ] **Step 1: Replace `_generate_app_id` body with a delegate**
+
+At `backend/app/services/application_service.py:282-342`, replace the entire method body (keep the signature and docstring first line):
+
+```python
+    async def _generate_app_id(self, academic_year: int, semester: Optional[str]) -> str:
+        """Generate sequential application ID (delegates to application_builder)."""
+        from app.services.application_builder import generate_app_id
+
+        return await generate_app_id(self.db, academic_year, semester)
+```
+
+- [ ] **Step 2: Replace the two sub-type staticmethods with delegates**
+
+At `backend/app/services/application_service.py:452-492`, replace both staticmethod bodies (keep signatures — tests and call sites reference them via `self.`/class):
+
+```python
+    @staticmethod
+    def _derive_sub_scholarship_type(scholarship_subtype_list: Optional[List[str]]) -> str:
+        """Delegates to application_builder (shared with batch import)."""
+        from app.services.application_builder import derive_sub_scholarship_type
+
+        return derive_sub_scholarship_type(scholarship_subtype_list)
+
+    @staticmethod
+    def _validate_sub_type_for_submission(scholarship: ScholarshipType, sub_scholarship_type: Optional[str]) -> None:
+        """Delegates to application_builder (shared with batch import)."""
+        from app.services.application_builder import validate_sub_type_for_submission
+
+        validate_sub_type_for_submission(scholarship, sub_scholarship_type)
+```
+
+- [ ] **Step 3: Use `build_submitted_application_values` in `_create_application_instance`**
+
+At `backend/app/services/application_service.py:526-561`, the current code sets `status`/`status_name` inline, then sets `submitted_at`/`review_stage` in the `if not is_draft` block, and the `Application(...)` uses `amount=config.amount`, `scholarship_name=config.config_name or scholarship.name`. Replace with builder values so the submitted-state fields come from one place:
+
+```python
+        from app.models.enums import ApplicationStatus
+        from app.services.application_builder import build_submitted_application_values
+        from app.utils.i18n import ScholarshipI18n
+
+        submitted_values = build_submitted_application_values(scholarship, config)
+
+        if is_draft:
+            status = ApplicationStatus.draft.value
+            status_name = ScholarshipI18n.get_application_status_text(status)
+        else:
+            status = submitted_values["status"]
+            status_name = submitted_values["status_name"]
+
+        # Create application
+        application = Application(
+            app_id=app_id,
+            user_id=user.id,
+            scholarship_type_id=scholarship.id,
+            scholarship_configuration_id=config.id,
+            scholarship_name=submitted_values["scholarship_name"],
+            amount=submitted_values["amount"],
+            scholarship_subtype_list=scholarship_subtype_list,
+            # Ordered sub-type preference list (志願序). The distribution service
+            # reads this first; without it, allocation falls back to selection
+            # order. The frontend computes the order (MOE/moe_1w forced first).
+            sub_type_preferences=application_data.sub_type_preferences,
+            sub_type_selection_mode=sub_type_selection_mode,
+            sub_scholarship_type=sub_scholarship_type,
+            is_renewal=False,  # New applications are never renewals
+            academic_year=academic_year,
+            semester=semester,
+            student_data=student_snapshot,
+            submitted_form_data=application_data.form_data.dict() if application_data.form_data else {},
+            agree_terms=application_data.agree_terms or False,
+            status=status,
+            status_name=status_name,
+        )
+
+        if not is_draft:
+            application.submitted_at = submitted_values["submitted_at"]
+            application.review_stage = submitted_values["review_stage"]
+
+        return application
+```
+
+- [ ] **Step 4: Use `assign_professor_from_profile` in `submit_application`**
+
+At `backend/app/services/application_service.py:1313-1333`, the submit path loads `advisor_profile` and then auto-assigns the professor inline. The profile load is reused later for email automation — keep it. Replace ONLY the auto-assign block (`# 自動分配指導教授...` through the `logger.info(...)` inside `if professor:`) with:
+
+```python
+        # 自動分配指導教授：根據 UserProfile 的 advisor_nycu_id 查找教授帳號
+        from app.services.application_builder import assign_professor_from_profile
+
+        await assign_professor_from_profile(self.db, application, application.user_id)
+```
+
+- [ ] **Step 5: Run the full application service + submit test suites (regression gate)**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/ -k "application_service or submit" -v --no-cov -p no:cacheprovider`
+Expected: all PASS with **no assertion changes**. If a test fails, the refactor changed behavior — fix the refactor, not the test.
+
+Also run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_application_builder.py -v --no-cov -p no:cacheprovider`
+Expected: PASS
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uvx --from "black==26.3.1" black --line-length=120 backend/app/services/application_service.py
+cd backend && flake8 app/services/application_service.py --select=B904,B014 --max-line-length=120 && cd ..
+git add backend/app/services/application_service.py
+git commit -m "refactor: ApplicationService delegates shared logic to application_builder"
+```
+
+---
+
+### Task 4: Batch parse — checkmark semantics, forced preference order, missing-sub-type hard error
+
+**Files:**
+- Modify: `backend/app/services/batch_import_service.py` (`parse_excel_file`, new module-level helper)
+- Test: `backend/app/tests/test_batch_import_pure_helpers.py`, `backend/app/tests/test_batch_import_service_unit.py`
+
+**Interfaces:**
+- Produces: module-level `_is_sub_type_marked(cell) -> bool` in `batch_import_service.py` (positive int/float, digit string, or `V`/`v`/`✓` → True; blank/0/NaN/other → False).
+- Changes: `parse_excel_file` row output — `sub_types` is now ordered by `order_sub_type_preferences` (moe_1w first), no longer by Excel numbers. Rows with zero marked sub-types (when `scholarship.sub_type_list` is non-empty) produce a `missing_sub_type` error and are excluded from `parsed_data` (same treatment as the existing blank-student-id parse error — they are not stored, not editable inline, must be fixed in the Excel and re-uploaded).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/app/tests/test_batch_import_pure_helpers.py`:
+
+```python
+from app.services.batch_import_service import _is_sub_type_marked
+
+
+def test_is_sub_type_marked_positive_numbers():
+    assert _is_sub_type_marked(1) is True
+    assert _is_sub_type_marked(2.0) is True
+    assert _is_sub_type_marked("3") is True
+
+
+def test_is_sub_type_marked_checkmarks():
+    assert _is_sub_type_marked("V") is True
+    assert _is_sub_type_marked("v") is True
+    assert _is_sub_type_marked("✓") is True
+
+
+def test_is_sub_type_marked_blank_zero_and_noise():
+    assert _is_sub_type_marked(None) is False
+    assert _is_sub_type_marked("") is False
+    assert _is_sub_type_marked(0) is False
+    assert _is_sub_type_marked("0") is False
+    assert _is_sub_type_marked(float("nan")) is False
+    assert _is_sub_type_marked("no") is False
+```
+
+Append to `backend/app/tests/test_batch_import_service_unit.py` (async, follow the file's existing fixture style for building the Excel bytes and the scholarship fixture — reuse its helpers for creating a `ScholarshipType` with `sub_type_list=["nstc", "moe_1w"]`):
+
+```python
+async def test_parse_orders_preferences_moe_first_regardless_of_numbers(db, scholarship_with_sub_types):
+    # 國科會=1, 教育部=2 in the Excel — moe_1w must STILL come first
+    df = pd.DataFrame([{"學號": "313554001", "學生姓名": "王小明", "國科會": 1, "教育部": 2}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(
+        buf.getvalue(), scholarship_with_sub_types.id, 114, None
+    )
+
+    assert errors == []
+    assert parsed[0]["sub_types"] == ["moe_1w", "nstc"]
+
+
+async def test_parse_accepts_checkmark_v(db, scholarship_with_sub_types):
+    df = pd.DataFrame([{"學號": "313554001", "學生姓名": "王小明", "國科會": "V", "教育部": ""}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(
+        buf.getvalue(), scholarship_with_sub_types.id, 114, None
+    )
+
+    assert errors == []
+    assert parsed[0]["sub_types"] == ["nstc"]
+
+
+async def test_parse_missing_sub_type_is_hard_error(db, scholarship_with_sub_types):
+    df = pd.DataFrame([{"學號": "313554001", "學生姓名": "王小明", "國科會": "", "教育部": ""}])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+
+    service = BatchImportService(db)
+    parsed, errors = await service.parse_excel_file(
+        buf.getvalue(), scholarship_with_sub_types.id, 114, None
+    )
+
+    assert parsed == []
+    assert len(errors) == 1
+    assert errors[0].error_type == "missing_sub_type"
+    assert errors[0].student_id == "313554001"
+```
+
+If `scholarship_with_sub_types` does not exist as a fixture, create it in the same test file mirroring how existing tests in that file build their `ScholarshipType` (check the file's imports/fixtures first — do not invent).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_batch_import_pure_helpers.py app/tests/test_batch_import_service_unit.py -v --no-cov -p no:cacheprovider`
+Expected: new tests FAIL (`ImportError: cannot import name '_is_sub_type_marked'`; ordering/error assertions fail)
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/services/batch_import_service.py`:
+
+3a. Add module-level helper after `_parse_renewal_year` (~line 68):
+
+```python
+_CHECKMARK_VALUES = {"v", "✓"}
+
+
+def _is_sub_type_marked(cell: Any) -> bool:
+    """A sub-type column cell counts as "applied" when it holds a positive
+    number or a checkmark (V/v/✓). Blank, 0, NaN, or anything else means
+    not applied. Numbers no longer encode preference order — ordering is
+    derived by application_builder.order_sub_type_preferences.
+    """
+    if cell is None:
+        return False
+    if isinstance(cell, (int, float)):
+        if isinstance(cell, float) and pd.isna(cell):
+            return False
+        return cell > 0
+    if isinstance(cell, str):
+        stripped = cell.strip()
+        if stripped.isdigit():
+            return int(stripped) > 0
+        return stripped.lower() in _CHECKMARK_VALUES
+    return False
+```
+
+3b. In `parse_excel_file`, replace BOTH sub-type parsing blocks (Chinese branch ~lines 239-251 and English branch ~lines 281-293). The `priority_entries` sort machinery goes away. Chinese branch:
+
+```python
+                    # Parse sub_types from Chinese column names.
+                    # Any positive number or checkmark = applied; ordering is
+                    # forced by shared rule (moe_1w first), NOT by cell numbers.
+                    selected_sub_types = []
+                    for chinese_label, sub_type_code in sub_type_labels.items():
+                        if chinese_label in df_columns and _is_sub_type_marked(row.get(chinese_label)):
+                            selected_sub_types.append(sub_type_code)
+                    data_row["sub_types"] = order_sub_type_preferences(selected_sub_types)
+```
+
+English branch:
+
+```python
+                    # Parse sub_types from English column names (sub_type_*)
+                    selected_sub_types = []
+                    for col in df_columns:
+                        if col.startswith("sub_type_") and _is_sub_type_marked(row.get(col)):
+                            selected_sub_types.append(col.replace("sub_type_", ""))
+                    data_row["sub_types"] = order_sub_type_preferences(selected_sub_types)
+```
+
+Add the import at the top of the file:
+
+```python
+from app.services.application_builder import order_sub_type_preferences
+```
+
+3c. After the Pydantic validation block (after `normalized_row = validated_row.model_dump()`, before `parsed_data.append(...)` ~line 310), add the hard error:
+
+```python
+                # Sub-type is mandatory when the scholarship defines real
+                # sub-types — a row with none marked cannot be imported
+                # (it would fall into the synthetic "general" bucket which
+                # matches no distribution quota slot).
+                if scholarship.sub_type_list and not normalized_row.get("sub_types"):
+                    errors.append(
+                        BatchImportValidationError(
+                            row_number=row_number,
+                            student_id=student_id,
+                            field="sub_types",
+                            error_type="missing_sub_type",
+                            message="未勾選任何申請類別（國科會/教育部），請於 Excel 中標記後重新上傳",
+                        )
+                    )
+                    continue
+```
+
+- [ ] **Step 4: Run tests to verify they pass, plus the full batch test files**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_batch_import_pure_helpers.py app/tests/test_batch_import_service_unit.py app/tests/test_batch_import_defaults_and_postal.py -v --no-cov -p no:cacheprovider`
+Expected: PASS. Pre-existing tests that asserted number-based ordering (e.g. anything asserting `sub_types == ["nstc", "moe_1w"]` because 國科會=1) must be UPDATED to the forced-moe-first expectation — that behavior change is the point of this task; update the assertion and note it in the commit body.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uvx --from "black==26.3.1" black --line-length=120 backend/app/services/batch_import_service.py backend/app/tests/test_batch_import_pure_helpers.py backend/app/tests/test_batch_import_service_unit.py
+cd backend && flake8 app/services/batch_import_service.py --select=B904,B014 --max-line-length=120 && cd ..
+git add backend/app/services/batch_import_service.py backend/app/tests/test_batch_import_pure_helpers.py backend/app/tests/test_batch_import_service_unit.py
+git commit -m "feat: batch import sub-type columns use checkmark semantics with forced moe_1w-first ordering"
+```
+
+---
+
+### Task 5: Batch creation aligned with student submission (status, form_data structure, profile upsert, professor assign)
+
+**Files:**
+- Modify: `backend/app/services/batch_import_service.py` (`create_applications_from_batch`, new `_upsert_user_profile`, new `_build_submitted_form_data`)
+- Test: `backend/app/tests/test_batch_import_service_unit.py`, `backend/app/tests/test_batch_import_defaults_and_postal.py`
+
+**Interfaces:**
+- Consumes: `generate_app_id(db, year, sem, suffix="U", commit=False)`, `derive_sub_scholarship_type`, `build_submitted_application_values`, `assign_professor_from_profile` from `app.services.application_builder`.
+- Changes to created `Application` rows:
+  - `status="submitted"`, `status_name` set, `review_stage="student_submitted"`, `submitted_at` set (all from `build_submitted_application_values`)
+  - `amount=config.amount`, `scholarship_name=config.config_name or scholarship.name`
+  - `submitted_form_data={"fields": {...standard entries from custom_fields...}, "documents": []}` — postal/advisor NOT included
+  - unchanged: `imported_by_id`, `batch_import_id`, `import_source="batch_import"`, `document_status="pending_documents"`, `is_renewal`, `renewal_year`, `sub_type_preferences`
+- New side effects per row: `UserProfile` upsert (Excel non-empty values overwrite; blanks preserve; missing profile created), then professor auto-assign.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `backend/app/tests/test_batch_import_service_unit.py` (reuse that file's existing fixtures for `batch_import` record / scholarship / config — `test_create_applications_from_batch_success` at line 182 shows the setup pattern; mirror it):
+
+```python
+async def test_batch_created_application_matches_student_submission_shape(
+    db, batch_import_fixture, scholarship_with_config
+):
+    """Core spec assertion: a batch-created application looks like a
+    student-submitted one (status/review_stage/amount/name/form_data)."""
+    parsed_data = [
+        {
+            "student_id": "313554001",
+            "student_name": "王小明",
+            "postal_account": "1234567890123",
+            "advisor_name": "張教授",
+            "advisor_email": "chang@nycu.edu.tw",
+            "advisor_nycu_id": "P001234",
+            "is_renewal": False,
+            "renewal_year": None,
+            "sub_types": ["moe_1w", "nstc"],
+            "custom_fields": {"contact_phone": "0912345678"},
+            "row_number": 2,
+        }
+    ]
+
+    service = BatchImportService(db)
+    created_ids, errors = await service.create_applications_from_batch(
+        batch_import=batch_import_fixture,
+        parsed_data=parsed_data,
+        scholarship_type_id=scholarship_with_config.id,
+        academic_year=114,
+        semester=None,
+    )
+
+    assert errors == []
+    app = await db.get(Application, created_ids[0])
+
+    # Review flow parity
+    assert app.status == ApplicationStatus.submitted
+    assert app.review_stage == "student_submitted"
+    assert app.submitted_at is not None
+    # Value parity (config-sourced)
+    assert app.amount is not None
+    assert "114" in app.scholarship_name  # config_name carries the year
+    # app_id keeps the batch marker
+    assert app.app_id.endswith("U")
+    # Standard form-data structure; postal/advisor NOT inside
+    assert set(app.submitted_form_data.keys()) == {"fields", "documents"}
+    assert app.submitted_form_data["documents"] == []
+    assert app.submitted_form_data["fields"]["contact_phone"]["value"] == "0912345678"
+    assert "postal_account" not in app.submitted_form_data["fields"]
+    # Sub-type scalar via shared derivation
+    assert app.sub_scholarship_type == "moe_1w"
+    assert app.sub_type_preferences == ["moe_1w", "nstc"]
+
+
+async def test_batch_upserts_user_profile_with_overwrite(db, batch_import_fixture, scholarship_with_config):
+    # Pre-existing profile: advisor set by the student, postal blank
+    user = User(nycu_id="313554002", name="陳小華", role="student", user_type="student")
+    db.add(user)
+    await db.flush()
+    db.add(UserProfile(user_id=user.id, account_number=None, advisor_name="舊教授", advisor_nycu_id="P000001"))
+    await db.flush()
+
+    parsed_data = [
+        {
+            "student_id": "313554002",
+            "student_name": "陳小華",
+            "postal_account": "9876543210987",
+            "advisor_name": "李教授",
+            "advisor_email": None,  # blank in Excel — must preserve existing (None here)
+            "advisor_nycu_id": "P005678",
+            "is_renewal": False,
+            "renewal_year": None,
+            "sub_types": ["nstc"],
+            "custom_fields": {},
+            "row_number": 2,
+        }
+    ]
+
+    service = BatchImportService(db)
+    await service.create_applications_from_batch(
+        batch_import=batch_import_fixture,
+        parsed_data=parsed_data,
+        scholarship_type_id=scholarship_with_config.id,
+        academic_year=114,
+        semester=None,
+    )
+
+    profile_result = await db.execute(select(UserProfile).where(UserProfile.user_id == user.id))
+    profile = profile_result.scalar_one()
+    assert profile.account_number == "9876543210987"  # filled from Excel
+    assert profile.advisor_name == "李教授"  # Excel value overwrites
+    assert profile.advisor_nycu_id == "P005678"  # Excel value overwrites
+
+
+async def test_batch_assigns_professor_when_account_exists(db, batch_import_fixture, scholarship_with_config):
+    professor = User(nycu_id="P001234", name="張教授", role="professor", user_type="employee")
+    db.add(professor)
+    await db.flush()
+
+    parsed_data = [
+        {
+            "student_id": "313554003",
+            "student_name": "林小強",
+            "postal_account": None,
+            "advisor_name": "張教授",
+            "advisor_email": "chang@nycu.edu.tw",
+            "advisor_nycu_id": "P001234",
+            "is_renewal": False,
+            "renewal_year": None,
+            "sub_types": ["nstc"],
+            "custom_fields": {},
+            "row_number": 2,
+        }
+    ]
+
+    service = BatchImportService(db)
+    created_ids, _ = await service.create_applications_from_batch(
+        batch_import=batch_import_fixture,
+        parsed_data=parsed_data,
+        scholarship_type_id=scholarship_with_config.id,
+        academic_year=114,
+        semester=None,
+    )
+
+    app = await db.get(Application, created_ids[0])
+    assert app.professor_id == professor.id
+```
+
+Adjust fixture names (`batch_import_fixture`, `scholarship_with_config`) to whatever the file actually defines — read the file's existing `test_create_applications_from_batch_success` setup first and reuse its fixtures verbatim. `ApplicationStatus.submitted` comparison: DB-loaded model returns the enum member (per repo gotchas); if the existing tests in this file compare `.status` against strings, match their convention.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_batch_import_service_unit.py -v --no-cov -p no:cacheprovider`
+Expected: new tests FAIL (status is `under_review`, form_data flat, no profile rows)
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/services/batch_import_service.py`:
+
+3a. Add imports at top:
+
+```python
+from app.models.user_profile import UserProfile
+from app.services.application_builder import (
+    assign_professor_from_profile,
+    build_submitted_application_values,
+    derive_sub_scholarship_type,
+    generate_app_id,
+)
+```
+
+3b. Add two private methods to `BatchImportService`:
+
+```python
+    async def _upsert_user_profile(self, user: User, row_data: Dict[str, Any]) -> None:
+        """Write postal account and advisor info to the student's UserProfile,
+        the same place the student self-service flow keeps them.
+
+        Overwrite policy (spec): a non-empty Excel value overwrites the
+        existing profile value (paper form is authoritative); a blank Excel
+        cell preserves whatever is already there.
+        """
+        profile_stmt = select(UserProfile).where(UserProfile.user_id == user.id)
+        profile_result = await self.db.execute(profile_stmt)
+        profile = profile_result.scalar_one_or_none()
+
+        if not profile:
+            profile = UserProfile(user_id=user.id)
+            self.db.add(profile)
+
+        field_map = {
+            "postal_account": "account_number",
+            "advisor_name": "advisor_name",
+            "advisor_email": "advisor_email",
+            "advisor_nycu_id": "advisor_nycu_id",
+        }
+        for row_key, profile_attr in field_map.items():
+            value = row_data.get(row_key)
+            if value:
+                setattr(profile, profile_attr, value)
+
+    async def _build_submitted_form_data(self, scholarship_code: str, custom_fields: Dict[str, Any]) -> Dict[str, Any]:
+        """Shape batch custom-field values into the standard student-submission
+        structure: {"fields": {name: {field_id, field_type, value, required}},
+        "documents": []}. field_type/required come from the ApplicationField
+        definitions; a value with no matching definition falls back to text.
+        """
+        from app.models.application_field import ApplicationField
+
+        defs_stmt = (
+            select(ApplicationField)
+            .where(ApplicationField.scholarship_type == scholarship_code)
+            .where(ApplicationField.is_active)
+        )
+        defs_result = await self.db.execute(defs_stmt)
+        definitions = {f.field_name: f for f in defs_result.scalars().all()}
+
+        fields = {}
+        for field_name, value in (custom_fields or {}).items():
+            definition = definitions.get(field_name)
+            fields[field_name] = {
+                "field_id": field_name,
+                "field_type": definition.field_type if definition else "text",
+                "value": value,
+                "required": bool(definition.is_required) if definition else False,
+            }
+        return {"fields": fields, "documents": []}
+```
+
+3c. In `create_applications_from_batch` (lines 744-857), inside the per-row loop, replace the inline app_id sequence block (lines 757-794) with:
+
+```python
+                # Shared sequence logic; commit=False holds the row lock for
+                # the whole batch transaction (atomicity over concurrency —
+                # online submissions block during the import, intentionally).
+                app_id = await generate_app_id(
+                    self.db, academic_year, semester, suffix="U", commit=False
+                )
+```
+
+(`ApplicationSequence` import and the `and_` import become unused in this file — remove them.)
+
+3d. Still in the loop, after the `student_data` snapshot fetch, replace the `submitted_form_data` construction and the `Application(...)` call (lines 816-851) with:
+
+```python
+                submitted_form_data = await self._build_submitted_form_data(
+                    scholarship.code, row_data.get("custom_fields", {})
+                )
+
+                submitted_values = build_submitted_application_values(scholarship, scholarship_config)
+
+                application = Application(
+                    app_id=app_id,
+                    user_id=user.id,
+                    scholarship_type_id=scholarship_type_id,
+                    scholarship_configuration_id=scholarship_config.id,
+                    scholarship_name=submitted_values["scholarship_name"],
+                    amount=submitted_values["amount"],
+                    sub_scholarship_type=derive_sub_scholarship_type(row_data.get("sub_types")),
+                    scholarship_subtype_list=row_data.get("sub_types", []),
+                    sub_type_preferences=row_data.get("sub_types", []) or None,
+                    sub_type_selection_mode=scholarship.sub_type_selection_mode,
+                    academic_year=academic_year,
+                    semester=semester,
+                    is_renewal=row_data.get("is_renewal", False),
+                    renewal_year=row_data.get("renewal_year"),
+                    status=submitted_values["status"],
+                    status_name=submitted_values["status_name"],
+                    review_stage=submitted_values["review_stage"],
+                    imported_by_id=batch_import.importer_id,
+                    batch_import_id=batch_import.id,
+                    import_source="batch_import",
+                    document_status="pending_documents",
+                    submitted_at=submitted_values["submitted_at"],
+                    student_data=student_data,
+                    submitted_form_data=submitted_form_data,
+                )
+                applications.append(application)
+                self.db.add(application)
+
+                # Profile upsert then professor auto-assign — same linkage the
+                # student submit path uses (professor review lists match on
+                # Application.professor_id).
+                await self._upsert_user_profile(user, row_data)
+                await assign_professor_from_profile(self.db, application, user.id)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_batch_import_service_unit.py app/tests/test_batch_import_defaults_and_postal.py -v --no-cov -p no:cacheprovider`
+Expected: new tests PASS. Existing tests asserting `status == under_review` / flat `submitted_form_data` keys (e.g. `postal_account` at top level) must be UPDATED to the new shape — intended behavior change; update assertions to match the spec (status `submitted`, `{"fields", "documents"}` keys).
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uvx --from "black==26.3.1" black --line-length=120 backend/app/services/batch_import_service.py backend/app/tests/test_batch_import_service_unit.py backend/app/tests/test_batch_import_defaults_and_postal.py
+cd backend && flake8 app/services/batch_import_service.py --select=B904,B014 --max-line-length=120 && cd ..
+git add backend/app/services/batch_import_service.py backend/app/tests/test_batch_import_service_unit.py backend/app/tests/test_batch_import_defaults_and_postal.py
+git commit -m "feat: batch-imported applications enter the standard review flow like student submissions"
+```
+
+---
+
+### Task 6: Eligibility + professor-account warnings in preview (upload-data & revalidate)
+
+**Files:**
+- Modify: `backend/app/services/batch_import_service.py` (new `bulk_check_eligibility`)
+- Modify: `backend/app/api/v1/endpoints/batch_import.py` (`upload_batch_import_data` ~line 174, `revalidate_batch_import` ~line 486)
+- Test: `backend/app/tests/test_batch_import_service_unit.py`, `backend/app/tests/test_batch_import_endpoints.py`
+
+**Interfaces:**
+- Produces: `async BatchImportService.bulk_check_eligibility(parsed_data: List[Dict], scholarship_type_id: int, academic_year: int, semester: Optional[str]) -> List[Dict[str, Any]]` — returns warning dicts in the exact shape the endpoints already store: `{"row_number", "student_id", "field", "warning_type", "message"}`. Warning types: `eligibility_failed`, `eligibility_check_skipped`, `professor_not_found`. Never raises; never blocks.
+
+- [ ] **Step 1: Write the failing service tests**
+
+Append to `backend/app/tests/test_batch_import_service_unit.py`:
+
+```python
+async def test_bulk_check_eligibility_flags_failures_but_filters_period(
+    db, scholarship_with_config, monkeypatch
+):
+    service = BatchImportService(db)
+
+    async def fake_snapshot(student_id, academic_year=None, semester=None):
+        return {"std_stdcode": student_id, "trm_ascore_gpa": 2.0}
+
+    monkeypatch.setattr(service.student_service, "get_student_snapshot", fake_snapshot)
+
+    async def fake_check(student_data, config, user_id=None):
+        # Simulates: outside application period AND a real rule failure
+        return False, ["不在申請期間內", "GPA 未達標準"]
+
+    from app.services import batch_import_service as bis_module
+
+    monkeypatch.setattr(
+        bis_module.EligibilityService, "check_student_eligibility", staticmethod(fake_check), raising=False
+    )
+
+    parsed_data = [{"student_id": "313554001", "sub_types": ["nstc"], "advisor_nycu_id": None, "row_number": 2}]
+    warnings = await service.bulk_check_eligibility(
+        parsed_data, scholarship_with_config.id, 114, None
+    )
+
+    eligibility_warnings = [w for w in warnings if w["warning_type"] == "eligibility_failed"]
+    assert len(eligibility_warnings) == 1
+    assert "GPA 未達標準" in eligibility_warnings[0]["message"]
+    # Application-period reason is exempted for batch import (late entry)
+    assert "不在申請期間內" not in eligibility_warnings[0]["message"]
+
+
+async def test_bulk_check_eligibility_warns_missing_professor_account(db, scholarship_with_config, monkeypatch):
+    service = BatchImportService(db)
+
+    async def fake_snapshot(student_id, academic_year=None, semester=None):
+        return {"std_stdcode": student_id}
+
+    monkeypatch.setattr(service.student_service, "get_student_snapshot", fake_snapshot)
+
+    parsed_data = [
+        {"student_id": "313554001", "sub_types": ["nstc"], "advisor_nycu_id": "NOSUCH", "row_number": 2}
+    ]
+    warnings = await service.bulk_check_eligibility(parsed_data, scholarship_with_config.id, 114, None)
+
+    professor_warnings = [w for w in warnings if w["warning_type"] == "professor_not_found"]
+    assert len(professor_warnings) == 1
+    assert "NOSUCH" in professor_warnings[0]["message"]
+```
+
+Note on the monkeypatch style: if patching the class method proves awkward, patch where it is looked up (`bis_module.EligibilityService`) or restructure the fake as an instance-level attribute — follow whatever pattern `test_batch_import_service_unit.py` already uses for `student_service` fakes.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_batch_import_service_unit.py -k eligibility -v --no-cov -p no:cacheprovider`
+Expected: FAIL — `AttributeError: 'BatchImportService' object has no attribute 'bulk_check_eligibility'`
+
+- [ ] **Step 3: Implement `bulk_check_eligibility`**
+
+Add to `BatchImportService` (import `EligibilityService` at module top: `from app.services.eligibility_service import EligibilityService`):
+
+```python
+    # Application-period exemption: batch import exists precisely for
+    # post-deadline paper-form entry, so this reason never surfaces.
+    _PERIOD_EXEMPT_REASONS = {"不在申請期間內"}
+
+    async def bulk_check_eligibility(
+        self,
+        parsed_data: List[Dict[str, Any]],
+        scholarship_type_id: int,
+        academic_year: int,
+        semester: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        """Run the SAME eligibility check the student self-submission path
+        uses, demoted to warnings (manual review is the gate for batch
+        imports). Also warns when an advisor_nycu_id has no professor
+        account (the application would never reach a professor's queue).
+        Never raises, never blocks the import.
+        """
+        warnings: List[Dict[str, Any]] = []
+
+        # Resolve the configuration the same way create_applications_from_batch does
+        semester_enum: Optional[Semester] = None
+        if semester:
+            try:
+                semester_enum = Semester(semester)
+            except ValueError:
+                semester_enum = None
+
+        config_stmt = select(ScholarshipConfiguration).where(
+            ScholarshipConfiguration.scholarship_type_id == scholarship_type_id,
+            ScholarshipConfiguration.academic_year == academic_year,
+        )
+        if semester_enum is None or semester_enum == Semester.yearly:
+            config_stmt = config_stmt.where(ScholarshipConfiguration.semester.is_(None))
+        else:
+            config_stmt = config_stmt.where(ScholarshipConfiguration.semester == semester_enum)
+        config_result = await self.db.execute(config_stmt)
+        config = config_result.scalar_one_or_none()
+
+        if not config:
+            warnings.append(
+                {
+                    "row_number": None,
+                    "student_id": None,
+                    "field": "configuration",
+                    "warning_type": "eligibility_check_skipped",
+                    "message": "找不到對應的獎學金配置，已跳過資格預檢（確認匯入時將會失敗，請先建立配置）。",
+                }
+            )
+            return warnings
+
+        eligibility_service = EligibilityService(self.db)
+
+        # Professor-account existence: one query for all advisor ids
+        advisor_ids = {row.get("advisor_nycu_id") for row in parsed_data if row.get("advisor_nycu_id")}
+        professor_map: Dict[str, User] = {}
+        if advisor_ids:
+            prof_stmt = select(User).where(User.nycu_id.in_(list(advisor_ids)), User.role == UserRole.professor)
+            prof_result = await self.db.execute(prof_stmt)
+            professor_map = {p.nycu_id: p for p in prof_result.scalars().all()}
+
+        for row in parsed_data:
+            student_id = row.get("student_id")
+            row_number = row.get("row_number")
+
+            advisor_id = row.get("advisor_nycu_id")
+            if advisor_id and advisor_id not in professor_map:
+                warnings.append(
+                    {
+                        "row_number": row_number,
+                        "student_id": student_id,
+                        "field": "advisor_nycu_id",
+                        "warning_type": "professor_not_found",
+                        "message": f"查無人事編號 {advisor_id} 的教授帳號，該申請將無法進入教授待審清單。",
+                    }
+                )
+
+            try:
+                snapshot = await self.student_service.get_student_snapshot(
+                    student_id, academic_year=str(academic_year), semester=semester
+                )
+            except Exception:  # noqa: BLE001 — any SIS failure demotes to a skip warning
+                logger.warning("Eligibility precheck skipped for %s (SIS error)", student_id, exc_info=True)
+                warnings.append(
+                    {
+                        "row_number": row_number,
+                        "student_id": student_id,
+                        "field": "eligibility",
+                        "warning_type": "eligibility_check_skipped",
+                        "message": f"無法取得學生 {student_id} 的學籍資料，已跳過資格預檢。",
+                    }
+                )
+                continue
+
+            is_eligible, reasons = await eligibility_service.check_student_eligibility(
+                student_data=snapshot, config=config
+            )
+            effective_reasons = [r for r in reasons if r not in self._PERIOD_EXEMPT_REASONS]
+            if not is_eligible and effective_reasons:
+                warnings.append(
+                    {
+                        "row_number": row_number,
+                        "student_id": student_id,
+                        "field": "eligibility",
+                        "warning_type": "eligibility_failed",
+                        "message": f"學生 {student_id} 資格預檢未通過：{'；'.join(effective_reasons)}（不影響匯入，請人工審查把關）。",
+                    }
+                )
+
+        return warnings
+```
+
+`UserRole` import: `from app.models.user import User, UserRole` (User already imported — extend it).
+
+- [ ] **Step 4: Wire into both preview endpoints**
+
+In `backend/app/api/v1/endpoints/batch_import.py`:
+
+4a. `upload_batch_import_data` — after `validation_warnings.extend(permission_warnings)` (line 174), inside the `if parsed_data:` block:
+
+```python
+        eligibility_warnings = await service.bulk_check_eligibility(
+            parsed_data=parsed_data,
+            scholarship_type_id=scholarship.id,
+            academic_year=academic_year,
+            semester=normalized_semester,
+        )
+        validation_warnings.extend(eligibility_warnings)
+```
+
+4b. `revalidate_batch_import` — after `validation_warnings.extend(permission_warnings)` (line 486):
+
+```python
+    eligibility_warnings = await service.bulk_check_eligibility(
+        parsed_data=parsed_data,
+        scholarship_type_id=batch_import.scholarship_type_id,
+        academic_year=batch_import.academic_year,
+        semester=batch_import.semester,
+    )
+    validation_warnings.extend(eligibility_warnings)
+```
+
+- [ ] **Step 5: Add endpoint test + run**
+
+Append to `backend/app/tests/test_batch_import_endpoints.py` a test asserting the upload response surfaces eligibility warnings — mirror that file's existing upload-endpoint test setup (client fixture, auth override, multipart upload), stub `BatchImportService.bulk_check_eligibility` to return one warning dict, and assert it appears in `data["validation_summary"]["warnings"]` with its `message`.
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_batch_import_service_unit.py app/tests/test_batch_import_endpoints.py -v --no-cov -p no:cacheprovider`
+Expected: PASS
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uvx --from "black==26.3.1" black --line-length=120 backend/app/services/batch_import_service.py backend/app/api/v1/endpoints/batch_import.py backend/app/tests/test_batch_import_service_unit.py backend/app/tests/test_batch_import_endpoints.py
+cd backend && flake8 app/services/batch_import_service.py app/api/v1/endpoints/batch_import.py --select=B904,B014 --max-line-length=120 && cd ..
+git add backend/app/services/batch_import_service.py backend/app/api/v1/endpoints/batch_import.py backend/app/tests/test_batch_import_service_unit.py backend/app/tests/test_batch_import_endpoints.py
+git commit -m "feat: eligibility and professor-account warnings in batch import preview"
+```
+
+---
+
+### Task 7: Template — checkmark semantics in sample rows
+
+**Files:**
+- Modify: `backend/app/api/v1/endpoints/batch_import.py:1746-1756` (sample sub-type values)
+- Test: `backend/app/tests/test_batch_import_endpoints.py` (template test, if one asserts sample values)
+
+- [ ] **Step 1: Replace the 志願序-number sample block**
+
+At `backend/app/api/v1/endpoints/batch_import.py:1746-1756`, replace:
+
+```python
+    # Add sub_type sample values if applicable.
+    # Sub-type cells are checkmarks: 1 (or V) = applying for that category,
+    # blank = not applying. Preference order is NOT read from these cells —
+    # the system forces MOE (moe_1w) as first preference, mirroring the
+    # student wizard. Sample rows show both categories checked.
+    if scholarship.sub_type_list:
+        for row in sample_data:
+            for sub_type_code in scholarship.sub_type_list:
+                label = sub_type_labels.get(sub_type_code, sub_type_code)
+                row[label] = 1
+```
+
+- [ ] **Step 2: Run template endpoint tests**
+
+Run: `docker exec scholarship_backend_dev python -m pytest app/tests/test_batch_import_endpoints.py -k template -v --no-cov -p no:cacheprovider`
+Expected: PASS (update any assertion that expected priority numbers 1/2 in sample cells to expect `1` in every sub-type cell)
+
+- [ ] **Step 3: Lint and commit**
+
+```bash
+uvx --from "black==26.3.1" black --line-length=120 backend/app/api/v1/endpoints/batch_import.py
+git add backend/app/api/v1/endpoints/batch_import.py backend/app/tests/test_batch_import_endpoints.py
+git commit -m "feat: batch import template samples use checkmark semantics for sub-type columns"
+```
+
+---
+
+### Task 8: Full verification — backend lanes, frontend, OpenAPI, e2e
+
+**Files:**
+- Possibly modify: `frontend/lib/api/generated/schema.d.ts` (regen), `frontend/components/__tests__/batch-import-panel.test.tsx`, `frontend/e2e/specs/batch-import-upload.spec.ts`
+
+- [ ] **Step 1: Full backend batch + application test sweep**
+
+```bash
+docker exec scholarship_backend_dev python -m pytest app/tests/test_batch_import_endpoints.py app/tests/test_batch_import_pure_helpers.py app/tests/test_batch_import_service_unit.py app/tests/test_batch_import_defaults_and_postal.py app/tests/test_application_builder.py -v --no-cov -p no:cacheprovider
+docker exec scholarship_backend_dev python -m pytest app/tests/ -k "application_service or critical_workflows" --no-cov -p no:cacheprovider -q
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Repo-wide lint gates**
+
+```bash
+uvx --from "black==26.3.1" black --check --line-length=120 backend/app
+cd backend && flake8 app --select=B904,B014 --max-line-length=120 && cd ..
+docker exec scholarship_backend_dev python -m pytest app/tests/test_no_logger_warning_traceback_loss.py app/tests/test_no_logger_error_traceback_loss.py --no-cov -p no:cacheprovider -q
+```
+Expected: clean.
+
+- [ ] **Step 3: Frontend checks**
+
+No response-schema shape changed (warnings reuse the existing `{row, field, message}` structure), so `schema.d.ts` regen is likely a no-op — verify:
+
+```bash
+cd frontend && npm run api:generate && git diff --stat lib/api/generated/schema.d.ts
+```
+If the diff is non-empty, commit it. Then run the frontend tests:
+
+```bash
+cd frontend && npx vitest run components/__tests__/batch-import-panel.test.tsx lib/api/modules/__tests__/batch-import.test.ts
+```
+Expected: PASS (the panel renders warnings generically; no code change anticipated).
+
+- [ ] **Step 4: E2E smoke (only if dev stack is up)**
+
+```bash
+cd frontend && npx playwright test e2e/specs/batch-import-upload.spec.ts
+```
+If the spec asserts old behavior (e.g. imported status shown as 審核中), update the assertion to 已提交.
+
+- [ ] **Step 5: End-to-end verification of the real flow**
+
+Use the `playwright-test-and-debug` skill flow: log in as a college user, download the template for the PhD scholarship, upload a filled file (one row with 國科會=1/教育部=1, one row with both blank → expect a missing_sub_type error and an eligibility warning section), confirm the import, then verify in the DB:
+
+```bash
+docker exec scholarship_postgres_dev psql -U scholarship_user -d scholarship_db -c \
+  "SELECT app_id, status, review_stage, amount, scholarship_name, professor_id, submitted_form_data FROM applications WHERE import_source='batch_import' ORDER BY id DESC LIMIT 3;"
+docker exec scholarship_postgres_dev psql -U scholarship_user -d scholarship_db -c \
+  "SELECT user_id, account_number, advisor_name, advisor_nycu_id FROM user_profiles ORDER BY id DESC LIMIT 3;"
+```
+Expected: `status=submitted`, `review_stage=student_submitted`, amount/name from config, `app_id` ends with `U`, form_data has `fields`/`documents` keys, profile rows upserted. Then log in as the professor account and confirm the imported application appears in the 待審 list.
+
+- [ ] **Step 6: Final commit if anything changed in steps 3–4**
+
+```bash
+git add -A && git commit -m "test: update frontend/e2e assertions for batch import review-flow parity"
+```
+
+---
+
+## Self-Review Notes (already applied)
+
+- Spec coverage: review-flow parity (Task 5), data-structure parity (Task 5), UserProfile overwrite (Task 5), eligibility/whitelist warnings + period exemption + professor warning (Task 6), sub-type hard error + checkmark parsing + forced ordering (Task 4), amount/config_name (Tasks 1+5), U suffix kept (Tasks 2+5), template samples (Task 7), no email/no clone/no migration (nothing added anywhere).
+- Period exemption is implemented by filtering the exact reason string `"不在申請期間內"` from `EligibilityService` output — fragile if that copy changes, but the alternative (a bypass flag threaded through EligibilityService) touches the student path for a batch-only concern. The string is pinned by `_PERIOD_EXEMPT_REASONS` next to a comment; `test_bulk_check_eligibility_flags_failures_but_filters_period` breaks loudly if the copy drifts.
+- `missing_sub_type` rows are excluded at parse (like blank-student-id rows): not inline-editable, must fix Excel and re-upload. Matches "預覽擋下" semantics agreed in brainstorming.
+- Type consistency: `order_sub_type_preferences` (Tasks 1/4), `generate_app_id(db, year, semester, suffix=, commit=)` (Tasks 2/3/5), `bulk_check_eligibility(parsed_data, scholarship_type_id, academic_year, semester)` (Task 6 service + endpoints) — names and signatures match across tasks.

--- a/docs/superpowers/specs/2026-07-09-batch-import-like-student-submission-design.md
+++ b/docs/superpowers/specs/2026-07-09-batch-import-like-student-submission-design.md
@@ -1,0 +1,128 @@
+# 批次匯入對齊學生自送申請流程 — 設計文件
+
+日期：2026-07-09
+分支：`claude/admin-batch-import-workflow-dig3m3`
+
+## 背景與問題
+
+批次匯入（`BatchImportService`）與學生自送（`ApplicationService.create_application` / `submit_application`）是兩條獨立實作的申請建立路徑，長期漂移導致匯入的申請與學生自送的申請行為不一致：
+
+| 面向 | 學生自送 | 批次匯入（現況） |
+|---|---|---|
+| 初始狀態 | `submitted` + `review_stage=student_submitted` | 直接 `under_review`，無 `review_stage`、無 `status_name` |
+| 教授指派 | 依 `UserProfile.advisor_nycu_id` 自動設 `professor_id` | 無 → 永遠進不了教授待審清單 |
+| 資格驗證 | `EligibilityService`（含白名單）、子類別必填 | 幾乎沒有（只查重複） |
+| `submitted_form_data` | 標準 `{fields, documents}` 結構 | 扁平 dict（postal_account、advisor_name…） |
+| 郵局帳號/指導教授 | 存 `UserProfile` | 塞在 `submitted_form_data` |
+| 金額/名稱 | `config.amount`、`config.config_name` | `amount=None`、`scholarship.name` |
+| app_id | `APP-114-0-00001` | 加 `U` 後綴（保留此差異） |
+
+目標：**批次匯入建立的申請要像學生自己送出一樣**——同一條審查流程、同一種資料結構、同一套欄位值。
+
+## 已確認的需求決策
+
+1. **審查流程一致**：匯入後 `status=submitted`、`review_stage=student_submitted`，走教授 → 學院完整審查流程。
+2. **資料結構一致**：`submitted_form_data` 用標準 `{fields, documents}` 結構；郵局帳號、指導教授資訊寫入 `UserProfile`（**覆蓋**既有值；Excel 空白欄位保留原值）。
+3. **驗證**：套用 eligibility/白名單/子類別檢查；**豁免申請期間**（補登情境）。eligibility/白名單不過**只列警告不擋**；子類別必填**硬擋**。
+4. **金額/名稱對齊**：帶入 `config.amount`、`config.config_name or scholarship.name`。
+5. **保留 app_id 的 `U` 後綴**（承辦人可一眼辨識來源）。
+6. **子類別志願序改為系統推導**：Excel 子類別欄位任何正值標記＝有申請；順序比照學生端規則——`moe_1w` 有選就強制第一志願（`FORCED_FIRST_PREFERENCE`，見 `ScholarshipApplicationStep.tsx:120`），Excel 數字不再有排序意義。nstc/moe_1w 至少一個有標記，否則該列為硬錯誤。
+7. **排除範圍**：不觸發 email 自動通知、不 clone 固定文件（存摺封面）、不遷移既有已匯入資料。
+
+## 實作方案：抽出共用申請建構邏輯（方案 B）
+
+不直接重用 `create_application`（與學生情境耦合過深：逐筆 commit、email、eligibility 硬擋），也不只在批次服務內改值（漂移會再發生）。改為把**會漂移的核心**抽成共用模組，兩條路徑共同呼叫。
+
+### 新模組 `backend/app/services/application_builder.py`
+
+只收「已證實漂移」的邏輯，不做投機性抽象：
+
+1. **`generate_app_id(db, academic_year, semester, suffix="") -> str`**
+   現有序號邏輯（`ApplicationSequence` + `FOR UPDATE` 鎖 + 格式化）搬入。學生路徑 `suffix=""`、批次路徑 `suffix="U"`。取代 `ApplicationService._generate_app_id` 與批次服務內整段複製的序號碼。
+2. **`derive_sub_scholarship_type(subtype_list) -> str`** 與 **`validate_sub_type_for_submission(scholarship, sub_type)`**
+   自 `ApplicationService` 的 staticmethod 搬入，call site 直接改引用。
+3. **`build_submitted_application_values(scholarship, config) -> dict`**
+   回傳提交狀態的共用欄位組：`status=submitted`、`status_name`（i18n）、`review_stage=student_submitted`、`submitted_at`、`amount=config.amount`、`scholarship_name=config.config_name or scholarship.name`。
+4. **`assign_professor_from_profile(db, application, user) -> None`**
+   自 `submit_application` 抽出：依 `UserProfile.advisor_nycu_id` 查 `role=professor` 的 User，設 `application.professor_id`；查無則留空。
+
+`ApplicationService`（`_create_application_instance`、`submit_application`）與 `BatchImportService` 均改為呼叫上述 helpers。學生路徑屬純重構，行為不變。
+
+### `BatchImportService.create_applications_from_batch` 變更
+
+**Application 欄位**：
+- `status`: `under_review` → `submitted`，補 `status_name`、`review_stage=student_submitted`（用 helper 3）
+- `amount`、`scholarship_name`：改由 helper 3 帶入
+- `app_id`：改用 helper 1（`suffix="U"`，行為不變）
+- 子類別 scalar：改用 helper 2
+- 不變：`imported_by_id`、`batch_import_id`、`import_source="batch_import"`、`document_status="pending_documents"`、`is_renewal`/`renewal_year`
+
+**`submitted_form_data`**：扁平 dict → 標準結構，只裝 Excel 自訂欄位（對應 `application_fields` 定義，`field_type`/`required` 從定義帶入）：
+
+```json
+{
+  "fields": {
+    "contact_phone": {"field_id": "contact_phone", "field_type": "text", "value": "0912...", "required": true}
+  },
+  "documents": []
+}
+```
+
+**UserProfile upsert**（每列，建申請前）：
+- 郵局帳號 → `account_number`；指導教授三欄 → `advisor_name` / `advisor_email` / `advisor_nycu_id`
+- Excel 有值 → 覆蓋既有 profile 值；Excel 空白 → 保留原值；無 profile → 新建
+- 之後呼叫 helper 4 自動指派教授
+
+**志願序解析**（`parse_excel_file`）：
+- 子類別欄位（國科會/教育部…）標記判定：正整數（1、2…）或勾選字樣（V/v/✓）＝有申請；空白或 0 ＝未申請（數字不再解讀為排序）
+- `sub_types` / `sub_type_preferences` 順序＝`moe_1w` 強制第一，其餘依欄位順序
+- nstc/moe_1w 皆空白 → 該列硬錯誤（`missing_sub_type`）
+
+### 預覽階段驗證（`upload-data` 與 `{batch_id}/validate` 兩入口）
+
+在現有重複申請/學院歸屬檢查外新增：
+
+1. **Eligibility（含白名單）→ 警告**：逐列抓 SIS snapshot，呼叫 `EligibilityService.check_student_eligibility`（與學生自送同一服務）。不過的列入 `validation_warnings`（`warning_type: "eligibility_failed"`，訊息帶原因），不擋匯入。
+2. **子類別必填 → 硬錯誤**：見上；confirm 時有 error 的列被排除（沿用既有 `error_student_ids` 機制），全部有錯則整批擋下。
+3. **教授帳號 → 警告**：有填指導教授人事編號但查無 `role=professor` 帳號 → 警告「查無教授帳號，該申請將無法進入教授待審清單」。
+4. **申請期間：不檢查**。
+
+### Confirm 階段
+
+維持現狀：單一交易、意外錯誤全回滾（all-or-nothing）；警告純資訊性；eligibility 不重跑。
+
+### 範本下載（`/template`）
+
+說明與範例列改為「打勾（填 1 或 V）表示申請該類別」，移除 `8bc041d9` 引入的志願序數字示範。
+
+## 前端變更（小）
+
+- `batch-import-panel.tsx`：新警告型別沿用既有警告列表渲染，確認文案正常；志願序數字相關說明文字改為打勾語意
+- 申請列表顯示「已提交」為既有 status 渲染，無需改碼
+- 若 OpenAPI schema 有變 → `npm run api:generate` 並提交 `schema.d.ts`
+
+## 測試計畫
+
+**新增**：
+- `application_builder` 單元測試：app_id suffix、`moe_1w` 強制第一志願推導、submitted 欄位組、教授自動指派（有/無教授帳號）
+- UserProfile 覆蓋語意：有值覆蓋、空白保留、無 profile 新建
+- 預覽 eligibility 警告、查無教授警告、子類別缺漏硬錯誤
+
+**更新**：
+- `test_batch_import_service_unit.py`、`test_batch_import_endpoints.py`、`test_batch_import_pure_helpers.py`、`test_batch_import_defaults_and_postal.py`：status 改 `submitted`、form_data 新結構、志願序推導
+- 前端 `batch-import-panel.test.tsx`、e2e `batch-import-upload.spec.ts`
+
+**回歸**：學生自送路徑抽 helper 屬純重構，既有 `application_service` 測試需全數通過且不改斷言。
+
+依 repo 標準：async 測試進 integration lane；black + flake8（B904/B014）+ logger traceback AST invariant 全過。
+
+## 錯誤處理
+
+- SIS API 不可用：預覽照現行機制降級為警告（`student_api_unavailable`），eligibility 檢查跳過並註記
+- UserProfile upsert 失敗：屬同一交易，隨批次回滾
+- 教授查無帳號：不是錯誤，警告 + `professor_id=NULL`；學院/管理端仍可審（既有回退路徑）
+
+## 不做的事
+
+- 不發 `application_submitted` 自動信、不 clone 存摺封面
+- 不做 DB migration（欄位皆既存）；舊匯入申請的扁平 `submitted_form_data` 不回填，讀取端 `_normalize_submitted_form_data` 已相容舊格式

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -542,7 +542,7 @@ export default function ScholarshipManagementSystem() {
             </TabsContent>
           )}
 
-          {/* 批次匯入 - college 和 super_admin 角色可見 */}
+          {/* 批次匯入 - college、admin 和 super_admin 角色可見 */}
           {(user.role === "college" || user.role === "admin" || user.role === "super_admin") && (
             <TabsContent value="batch-import" className="space-y-4">
               <BatchImportPanel locale={locale} />

--- a/frontend/components/batch-application-file-upload.tsx
+++ b/frontend/components/batch-application-file-upload.tsx
@@ -176,10 +176,11 @@ export function BatchApplicationFileUpload({
 
     if (!firstApp) return [];
 
-    // For batch import: use submitted_form_data.custom_fields (show all fields)
-    const customFields = firstApp.submitted_form_data?.custom_fields;
-    if (customFields && typeof customFields === 'object' && Object.keys(customFields).length > 0) {
-      return Object.keys(customFields); // Show all custom fields
+    // For batch import: use submitted_form_data.fields (standard shape) — the
+    // custom-field values live under fields[name].value
+    const fields = firstApp.submitted_form_data?.fields;
+    if (fields && typeof fields === 'object' && Object.keys(fields).length > 0) {
+      return Object.keys(fields); // Show all custom fields
     }
 
     // For regular applications: use form_data (show all fields)
@@ -374,9 +375,9 @@ export function BatchApplicationFileUpload({
                    state.application?.scholarship_type || "-"}
                 </TableCell>
 
-                {/* Postal Account */}
+                {/* Postal Account (郵局帳號 lives on the student's UserProfile) */}
                 <TableCell className="text-sm font-mono">
-                    {state.application?.submitted_form_data?.fields?.postal_account?.value || "-"}
+                    {state.application?.postal_account || "-"}
                 </TableCell>
 
                 {/* Sub Scholarship Types */}
@@ -398,7 +399,7 @@ export function BatchApplicationFileUpload({
                 {/* Dynamic Form Data Fields */}
                 {displayFields.map((field) => (
                   <TableCell key={field} className="text-sm">
-                    {state.application?.submitted_form_data?.custom_fields?.[field] ||
+                    {state.application?.submitted_form_data?.fields?.[field]?.value ||
                      state.application?.form_data?.[field] || "-"}
                   </TableCell>
                 ))}

--- a/frontend/components/batch-application-file-upload.tsx
+++ b/frontend/components/batch-application-file-upload.tsx
@@ -396,11 +396,14 @@ export function BatchApplicationFileUpload({
                   </div>
                 </TableCell>
 
-                {/* Dynamic Form Data Fields */}
+                {/* Dynamic Form Data Fields — ?? not ||: 0 and false are
+                    legitimate custom-field values and must still display */}
                 {displayFields.map((field) => (
                   <TableCell key={field} className="text-sm">
-                    {state.application?.submitted_form_data?.fields?.[field]?.value ||
-                     state.application?.form_data?.[field] || "-"}
+                    {String(
+                      state.application?.submitted_form_data?.fields?.[field]?.value ??
+                      state.application?.form_data?.[field] ?? "-"
+                    )}
                   </TableCell>
                 ))}
 

--- a/frontend/components/batch-import-panel.tsx
+++ b/frontend/components/batch-import-panel.tsx
@@ -62,10 +62,10 @@ interface PeriodOption {
 
 type ValidationWarning =
   | {
-      row?: number;
-      field?: string;
-      message?: string;
-      warning_type?: string;
+      row?: number | null;
+      field?: string | null;
+      message?: string | null;
+      warning_type?: string | null;
     }
   | string;
 

--- a/frontend/components/batch-import-panel.tsx
+++ b/frontend/components/batch-import-panel.tsx
@@ -280,7 +280,7 @@ export function BatchImportPanel({ locale = "zh" }: BatchImportPanelProps) {
         selectedFile,
         selectedScholarship.code,
         academicYear,
-        semester || ""
+        semester
       );
 
       if (response.success && response.data) {

--- a/frontend/e2e/specs/batch-import-upload.spec.ts
+++ b/frontend/e2e/specs/batch-import-upload.spec.ts
@@ -57,7 +57,10 @@ test.describe("College batch-import upload parses CSV into a preview batch", () 
     pushTrace(runState, collegeLogin.traceId);
 
     // 1. Valid CSV with the required columns (Chinese header variant).
-    const csv = `學號,學生姓名\n${CSV_STUDENT_ID},${CSV_STUDENT_NAME}\n`;
+    //    phd defines real sub-types (nstc/moe_1w), so a row with NO sub-type
+    //    marked is now excluded at parse as missing_sub_type — the valid row
+    //    must carry a sub-type mark (教育部 = moe_1w) to be counted.
+    const csv = `學號,學生姓名,教育部\n${CSV_STUDENT_ID},${CSV_STUDENT_NAME},1\n`;
     const form = new FormData();
     form.append("file", new Blob([csv], { type: "text/csv" }), "e2e-batch.csv");
 

--- a/frontend/lib/api/compat.ts
+++ b/frontend/lib/api/compat.ts
@@ -103,6 +103,13 @@ export function toApiResponse<T>(
     } else if (response.error.message) {
       // Handle message field - ensure it's a string
       errorMessage = safeStringify(response.error.message);
+      // The backend's validation handler puts the generic text in `message`
+      // ("Validation failed") and the actual per-field reasons in `errors` —
+      // without them the user sees no reason at all.
+      const errorList = (response.error as { errors?: unknown }).errors;
+      if (Array.isArray(errorList) && errorList.length > 0) {
+        errorMessage += `: ${errorList.map((e) => safeStringify(e)).join('; ')}`;
+      }
     } else {
       errorMessage = `Request failed with status ${response.response.status}`;
     }

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -12130,8 +12130,8 @@ export interface operations {
             query?: {
                 /** @description Filter by status */
                 status?: string | null;
-                /** @description Filter by scholarship type ID */
-                scholarship_type_id?: number | null;
+                /** @description Filter by scholarship type code */
+                scholarship_type?: string | null;
             };
             header?: never;
             path?: never;

--- a/frontend/lib/api/modules/batch-import.ts
+++ b/frontend/lib/api/modules/batch-import.ts
@@ -38,6 +38,56 @@ function resolveAuthToken(): string | null {
   );
 }
 
+/**
+ * Fetch an authenticated file endpoint and trigger a browser download.
+ * Shared by template/file downloads: error-body extraction and RFC 5987
+ * filename handling live in one place.
+ */
+async function downloadAuthedFile(path: string, label: string, fallbackFilename: string): Promise<void> {
+  const token = resolveAuthToken();
+  const baseURL = typeof window !== "undefined" ? "" : process.env.INTERNAL_API_URL || "http://localhost:8000";
+
+  const response = await fetch(`${baseURL}${path}`, {
+    method: "GET",
+    headers: {
+      ...(token && { Authorization: `Bearer ${token}` }),
+    },
+  });
+
+  if (!response.ok) {
+    let detail = "";
+    try {
+      const body = await response.clone().json();
+      detail = body?.message || body?.detail || "";
+    } catch {
+      // Non-JSON error body — surface the status alone.
+    }
+    throw new Error(`Failed to download ${label} (${response.status}${detail ? `: ${detail}` : ""})`);
+  }
+
+  const blob = await response.blob();
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+
+  // Extract filename from Content-Disposition header
+  const contentDisposition = response.headers.get("content-disposition");
+  let filename = fallbackFilename;
+  if (contentDisposition) {
+    // Match filename*=UTF-8''encoded_name (RFC 5987)
+    const filenameMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/);
+    if (filenameMatch) {
+      filename = decodeURIComponent(filenameMatch[1].trim());
+    }
+  }
+
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+}
+
 type BatchUploadResult = {
   batch_id: number;
   file_name: string;
@@ -291,53 +341,11 @@ export function createBatchImportApi() {
      * Type-safe: Returns blob for file download
      */
     downloadTemplate: async (scholarshipType: string): Promise<void> => {
-      const token = resolveAuthToken();
-      const baseURL = typeof window !== "undefined" ? "" : process.env.INTERNAL_API_URL || "http://localhost:8000";
-
-      const response = await fetch(
-        `${baseURL}/api/v1/college-review/batch-import/template?scholarship_type=${encodeURIComponent(scholarshipType)}`,
-        {
-          method: "GET",
-          headers: {
-            ...(token && { Authorization: `Bearer ${token}` }),
-          },
-        }
+      await downloadAuthedFile(
+        `/api/v1/college-review/batch-import/template?scholarship_type=${encodeURIComponent(scholarshipType)}`,
+        "template",
+        `batch_import_template_${scholarshipType}.xlsx`
       );
-
-      if (!response.ok) {
-        let detail = "";
-        try {
-          const body = await response.clone().json();
-          detail = body?.message || body?.detail || "";
-        } catch {
-          // Non-JSON error body — surface the status alone.
-        }
-        throw new Error(
-          `Failed to download template (${response.status}${detail ? `: ${detail}` : ""})`
-        );
-      }
-
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-
-      // Extract filename from Content-Disposition header
-      const contentDisposition = response.headers.get("content-disposition");
-      let filename = `batch_import_template_${scholarshipType}.xlsx`;
-      if (contentDisposition) {
-        // Match filename*=UTF-8''encoded_name (RFC 5987)
-        const filenameMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/);
-        if (filenameMatch) {
-          filename = decodeURIComponent(filenameMatch[1].trim());
-        }
-      }
-
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
     },
 
     /**
@@ -356,58 +364,11 @@ export function createBatchImportApi() {
      * Type-safe: Returns blob for file download
      */
     downloadFile: async (batchId: number): Promise<void> => {
-      const token = resolveAuthToken();
-      const baseURL =
-        typeof window !== "undefined"
-          ? ""
-          : process.env.INTERNAL_API_URL || "http://localhost:8000";
-
-      const response = await fetch(
-        `${baseURL}/api/v1/college-review/batch-import/${batchId}/download`,
-        {
-          method: "GET",
-          headers: {
-            ...(token && { Authorization: `Bearer ${token}` }),
-          },
-        }
+      await downloadAuthedFile(
+        `/api/v1/college-review/batch-import/${batchId}/download`,
+        "file",
+        `batch_import_${batchId}.xlsx`
       );
-
-      if (!response.ok) {
-        let detail = "";
-        try {
-          const body = await response.clone().json();
-          detail = body?.message || body?.detail || "";
-        } catch {
-          // Non-JSON error body — surface the status alone.
-        }
-        throw new Error(
-          `Failed to download file (${response.status}${detail ? `: ${detail}` : ""})`
-        );
-      }
-
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-
-      // Extract filename from Content-Disposition header
-      const contentDisposition = response.headers.get("content-disposition");
-      let filename = `batch_import_${batchId}.xlsx`;
-      if (contentDisposition) {
-        // Match filename*=UTF-8''encoded_name (RFC 5987)
-        const filenameMatch = contentDisposition.match(
-          /filename\*=UTF-8''([^;]+)/
-        );
-        if (filenameMatch) {
-          filename = decodeURIComponent(filenameMatch[1].trim());
-        }
-      }
-
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
     },
   };
 }

--- a/frontend/lib/api/modules/batch-import.ts
+++ b/frontend/lib/api/modules/batch-import.ts
@@ -210,7 +210,7 @@ export function createBatchImportApi() {
       file: File,
       scholarshipType: string,
       academicYear: number,
-      semester: string
+      semester?: string
     ): Promise<ApiResponse<BatchUploadResult>> => {
       const formData = createFileUploadFormData({ file });
 
@@ -219,7 +219,9 @@ export function createBatchImportApi() {
           query: {
             scholarship_type: scholarshipType,
             academic_year: academicYear,
-            semester: semester,
+            // Yearly scholarships have no semester — omit the param entirely
+            // (an empty string would fail the endpoint's pattern check).
+            ...(semester ? { semester } : {}),
           },
         },
         body: formData as MultipartFormData<{ file: string }>,

--- a/frontend/lib/api/modules/batch-import.ts
+++ b/frontend/lib/api/modules/batch-import.ts
@@ -15,6 +15,7 @@ import { typedClient } from '../typed-client';
 import { toApiResponse } from '../compat';
 import { createFileUploadFormData, type MultipartFormData } from '../form-data-helpers';
 import type { ApiResponse } from '../types';
+import { getAuthToken } from '../../utils/url-validation';
 
 /**
  * Resolve the auth token for direct `fetch()` downloads.
@@ -30,12 +31,9 @@ function resolveAuthToken(): string | null {
   const inMemory = typedClient.getToken();
   if (inMemory) return inMemory;
   if (typeof window === 'undefined') return null;
-  return (
-    localStorage.getItem('auth_token') ||
-    localStorage.getItem('token') ||
-    sessionStorage.getItem('auth_token') ||
-    null
-  );
+  // Delegate to the app-wide fallback chain (localStorage/sessionStorage,
+  // auth_token + legacy token keys) instead of re-implementing a subset.
+  return getAuthToken() || null;
 }
 
 /**
@@ -88,6 +86,16 @@ async function downloadAuthedFile(path: string, label: string, fallbackFilename:
   window.URL.revokeObjectURL(url);
 }
 
+/** Upload/details warnings come back as structured objects from the backend
+ *  (`{row, field, message}`); plain strings are tolerated for older records. */
+type BatchValidationWarning =
+  | string
+  | {
+      row?: number | null;
+      field?: string | null;
+      message?: string | null;
+    };
+
 type BatchUploadResult = {
   batch_id: number;
   file_name: string;
@@ -96,7 +104,7 @@ type BatchUploadResult = {
   validation_summary: {
     valid_count: number;
     invalid_count: number;
-    warnings: string[];
+    warnings: BatchValidationWarning[];
     errors: Array<{
       row: number;
       field?: string;
@@ -185,7 +193,7 @@ type BatchDetails = BatchHistoryItem & {
   validation_summary: {
     valid_count: number;
     invalid_count: number;
-    warnings: string[];
+    warnings: BatchValidationWarning[];
     errors: Array<{
       row: number;
       field?: string;

--- a/frontend/lib/api/modules/batch-import.ts
+++ b/frontend/lib/api/modules/batch-import.ts
@@ -16,6 +16,28 @@ import { toApiResponse } from '../compat';
 import { createFileUploadFormData, type MultipartFormData } from '../form-data-helpers';
 import type { ApiResponse } from '../types';
 
+/**
+ * Resolve the auth token for direct `fetch()` downloads.
+ *
+ * The typed client keeps an in-memory copy, but that can be empty on a fresh
+ * page load / session restore where the token only lives in localStorage. The
+ * rest of the app reads the token straight from storage at call time, so fall
+ * back to the same keys here — otherwise these downloads go out without an
+ * Authorization header and the backend rejects them with 401
+ * ("Authorization header missing").
+ */
+function resolveAuthToken(): string | null {
+  const inMemory = typedClient.getToken();
+  if (inMemory) return inMemory;
+  if (typeof window === 'undefined') return null;
+  return (
+    localStorage.getItem('auth_token') ||
+    localStorage.getItem('token') ||
+    sessionStorage.getItem('auth_token') ||
+    null
+  );
+}
+
 type BatchUploadResult = {
   batch_id: number;
   file_name: string;
@@ -269,7 +291,7 @@ export function createBatchImportApi() {
      * Type-safe: Returns blob for file download
      */
     downloadTemplate: async (scholarshipType: string): Promise<void> => {
-      const token = typedClient.getToken();
+      const token = resolveAuthToken();
       const baseURL = typeof window !== "undefined" ? "" : process.env.INTERNAL_API_URL || "http://localhost:8000";
 
       const response = await fetch(
@@ -283,7 +305,16 @@ export function createBatchImportApi() {
       );
 
       if (!response.ok) {
-        throw new Error("Failed to download template");
+        let detail = "";
+        try {
+          const body = await response.clone().json();
+          detail = body?.message || body?.detail || "";
+        } catch {
+          // Non-JSON error body — surface the status alone.
+        }
+        throw new Error(
+          `Failed to download template (${response.status}${detail ? `: ${detail}` : ""})`
+        );
       }
 
       const blob = await response.blob();
@@ -325,7 +356,7 @@ export function createBatchImportApi() {
      * Type-safe: Returns blob for file download
      */
     downloadFile: async (batchId: number): Promise<void> => {
-      const token = typedClient.getToken();
+      const token = resolveAuthToken();
       const baseURL =
         typeof window !== "undefined"
           ? ""
@@ -342,7 +373,16 @@ export function createBatchImportApi() {
       );
 
       if (!response.ok) {
-        throw new Error("Failed to download file");
+        let detail = "";
+        try {
+          const body = await response.clone().json();
+          detail = body?.message || body?.detail || "";
+        } catch {
+          // Non-JSON error body — surface the status alone.
+        }
+        throw new Error(
+          `Failed to download file (${response.status}${detail ? `: ${detail}` : ""})`
+        );
       }
 
       const blob = await response.blob();

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -157,6 +157,8 @@ export interface Application {
   status_zh?: string;
   student_name?: string;
   student_no?: string;
+  /** 郵局帳號 (from the student's UserProfile.account_number, not submitted_form_data) */
+  postal_account?: string | null;
   student_termcount?: number;
   gpa?: number;
   department?: string;


### PR DESCRIPTION
## Summary

批次匯入建立的申請現在與學生自行送出的申請走完全相同的審查流程與資料結構（spec: `docs/superpowers/specs/2026-07-09-batch-import-like-student-submission-design.md`）。

### Review-flow parity
- Imported applications are created with `status=submitted` + `review_stage=student_submitted` (previously jumped straight to `under_review`), entering the professor → college review flow like student submissions. Removed the confirm-endpoint block that force-overrode status back to `under_review`.
- Postal account (郵局帳號) and advisor info (指導教授) now land in `UserProfile` — the same place the student flow keeps them. Non-empty Excel values overwrite; blanks preserve. Professor auto-assign (`Application.professor_id`) runs from the upserted profile, so imported applications appear in the professor's 待審 queue.
- `amount` / `scholarship_name` now sourced from `ScholarshipConfiguration` (`config.amount`, `config.config_name`) like the student path. The `U` app_id suffix is kept as the batch marker.

### Shared builder (anti-drift)
- New `backend/app/services/application_builder.py`: app_id sequence generation (with suffix + lock-holding `commit=False` for batch atomicity), sub-type derivation/validation/ordering, submitted-state field values, professor auto-assign. Both `ApplicationService` (pure refactor, zero behavior change) and `BatchImportService` delegate to it.

### Sub-type semantics
- Excel sub-type columns are now checkmarks (positive number or V/v/✓ = applying) — the numbers no longer encode 志願序. Preference order is system-derived with `moe_1w` forced first, mirroring the student wizard's `FORCED_FIRST_PREFERENCE`. Rows marking no sub-type (when the scholarship defines real ones) are hard-rejected with `missing_sub_type`. Template samples updated accordingly.
- `submitted_form_data` uses the standard `{fields, documents}` structure (custom fields only, typed from `ApplicationField` definitions).

### Preview warnings (non-blocking)
- Upload/revalidate now run the same `EligibilityService.check_student_eligibility` as the student path per row, demoted to warnings (`eligibility_failed`) — manual review remains the gate. The application-period reason is exempted (batch import exists for post-deadline paper entry). Never-raises: SIS or rule-eval failures degrade to `eligibility_check_skipped`.
- `professor_not_found` warning when an advisor 人事編號 has no professor account.

### Defects found & fixed during end-to-end verification
- Confirm endpoint force-overrode status to `under_review` (endpoint regression test added).
- `ApplicationDataRow` silently dropped advisor fields, breaking profile upsert + professor assign (full-chain parse→create→profile→professor test added).
- Post-import document-upload table read postal/custom fields from the old flat form_data shape (`postal_account` now exposed on the application detail response from `UserProfile`).

Also includes 3 earlier commits on this branch: template download auth fix + admin role access, template 500 fix on duplicate fixed fields, and the 教育部 label rename.

## Test plan
- [x] Backend: 94 passed across `test_application_builder.py` + 4 batch-import test files; application-service regression suite passed with no assertion changes
- [x] Lint: black 26.3.1 clean, flake8 B904/B014 clean, logger-traceback AST invariants pass
- [x] Frontend: jest batch-import-panel 16 passed; `tsc --noEmit` clean; `npm run api:generate` no-op
- [x] E2E spec updated for mandatory sub-type marking; real-flow verification via API + DB: imported app has `status=submitted`, `review_stage=student_submitted`, amount/name from config, `app_id` ends with `U`, `{fields,documents}` form_data, profile upserted, professor auto-assigned
- [ ] Manual: professor 待審清單 UI check (blocked by a pre-existing `MissingGreenlet` 500 in `GET /applications/review/list`, unrelated to this branch)

## Notes for reviewers
- Known pre-existing issues observed but intentionally NOT touched: `GET /applications/review/list` MissingGreenlet lazy-load 500 (`user.py:189`); `applications.py:651` positional-arg misalignment.
- No DB migration needed; old imported applications keep flat form_data (readers normalize via `_normalize_submitted_form_data`).