### PR TITLE
fix: remove pagination cap on professor application list

### DIFF
--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -26,12 +26,16 @@ async def get_professor_applications(
     request: Request,
     status_filter: Optional[str] = Query(None, description="Filter by review status: pending, completed, all"),
     page: int = Query(1, ge=1, description="Page number"),
-    size: int = Query(20, ge=1, le=100, description="Items per page"),
+    size: Optional[int] = Query(None, ge=1, description="Items per page; omit to return all applications"),
     current_user: User = Depends(require_professor),
     db: AsyncSession = Depends(get_db),
 ):
-    """Get applications requiring professor review with pagination"""
-    logger.info("Professor {current_user.id} requesting applications for review (page {page}, size {size})")
+    """Get applications requiring professor review.
+
+    Returns ALL assigned applications by default; pass ``page``/``size``
+    for explicit pagination.
+    """
+    logger.info(f"Professor {current_user.id} requesting applications for review (page {page}, size {size})")
 
     try:
         service = ApplicationService(db)
@@ -42,8 +46,13 @@ async def get_professor_applications(
             size=size,
         )
 
-        # Calculate pagination metadata
-        total_pages = (total_count + size - 1) // size  # Ceiling division
+        # Calculate pagination metadata; size=None means the full set in one page
+        if size is None:
+            response_size = total_count
+            total_pages = 1 if total_count else 0
+        else:
+            response_size = size
+            total_pages = (total_count + size - 1) // size  # Ceiling division
 
         logger.info(
             f"Found {len(applications)} applications (page {page}/{total_pages}, total: {total_count}) for professor {current_user.id}"
@@ -53,7 +62,7 @@ async def get_professor_applications(
             items=applications,
             total=total_count,
             page=page,
-            size=size,
+            size=response_size,
             pages=total_pages,
         )
         return {

--- a/backend/app/api/v1/endpoints/professor.py
+++ b/backend/app/api/v1/endpoints/professor.py
@@ -48,6 +48,7 @@ async def get_professor_applications(
 
         # Calculate pagination metadata; size=None means the full set in one page
         if size is None:
+            page = 1  # keep metadata consistent — the full set is always page 1
             response_size = total_count
             total_pages = 1 if total_count else 0
         else:

--- a/backend/app/api/v1/endpoints/professor_student.py
+++ b/backend/app/api/v1/endpoints/professor_student.py
@@ -68,6 +68,9 @@ async def get_professor_student_relationships(
             is_active = active_status.lower() == "active"
             query = query.where(ProfessorStudentRelationship.is_active == is_active)
 
+        # Stable ordering so explicit pagination is deterministic across requests
+        query = query.order_by(ProfessorStudentRelationship.id)
+
         # Apply pagination only when explicitly requested (size=None → return all)
         if size is not None:
             query = query.offset((page - 1) * size).limit(size)

--- a/backend/app/api/v1/endpoints/professor_student.py
+++ b/backend/app/api/v1/endpoints/professor_student.py
@@ -28,7 +28,7 @@ async def get_professor_student_relationships(
     relationship_type: Optional[str] = Query(None, description="Filter by relationship type"),
     active_status: Optional[str] = Query(None, alias="status", description="Filter by active status (active/inactive)"),
     page: int = Query(1, ge=1, description="Page number"),
-    size: int = Query(20, ge=1, le=100, description="Items per page"),
+    size: Optional[int] = Query(None, ge=1, description="Items per page; omit to return all relationships"),
     current_user: User = Depends(require_roles(UserRole.professor, UserRole.admin, UserRole.super_admin)),
     db: AsyncSession = Depends(get_db),
 ):
@@ -68,8 +68,9 @@ async def get_professor_student_relationships(
             is_active = active_status.lower() == "active"
             query = query.where(ProfessorStudentRelationship.is_active == is_active)
 
-        # Apply pagination
-        query = query.offset((page - 1) * size).limit(size)
+        # Apply pagination only when explicitly requested (size=None → return all)
+        if size is not None:
+            query = query.offset((page - 1) * size).limit(size)
 
         # Execute query
         result = await db.execute(query)

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2371,9 +2371,13 @@ class ApplicationService:
         professor_id: int,
         status_filter: Optional[str] = None,
         page: int = 1,
-        size: int = 20,
+        size: Optional[int] = None,
     ) -> tuple[List[ApplicationListResponse], int]:
-        """Get paginated applications assigned to professor with total count"""
+        """Get applications assigned to professor with total count.
+
+        ``size=None`` (default) returns ALL matching applications;
+        pass ``page``/``size`` for explicit pagination.
+        """
         try:
             # Build base query with ALL required filters (consistent with what will be returned)
             base_query = (
@@ -2429,9 +2433,10 @@ class ApplicationService:
             count_result = await self.db.execute(count_query)
             total_count = count_result.scalar()
 
-            # Apply pagination and get results
-            offset = (page - 1) * size
-            paginated_query = base_query.offset(offset).limit(size).order_by(desc(Application.created_at))
+            # Apply ordering, then pagination only when explicitly requested
+            paginated_query = base_query.order_by(desc(Application.created_at))
+            if size is not None:
+                paginated_query = paginated_query.offset((page - 1) * size).limit(size)
 
             result = await self.db.execute(paginated_query)
             applications = result.unique().scalars().all()

--- a/backend/app/tests/test_get_professor_applications_paginated_deep.py
+++ b/backend/app/tests/test_get_professor_applications_paginated_deep.py
@@ -14,6 +14,9 @@ Contract pinned (6 cases):
 - status_filter='completed' narrows to {approved, partial_approved, rejected}.
 - Pagination: page=2, size=2 returns rows 3-4 of an ordered set; total
   count reflects the full filtered set, not the page.
+- No implicit cap: the default call (size omitted) returns EVERY assigned
+  application — professors must see all of them (the old default silently
+  truncated the list to 20).
 """
 
 from datetime import datetime, timedelta, timezone
@@ -256,3 +259,27 @@ async def test_pagination_returns_correct_slice_and_total(db: AsyncSession):
     assert total == 5
     # The page has 2 rows.
     assert len(page2) == 2
+
+
+@pytest.mark.asyncio
+async def test_default_call_returns_all_applications_without_cap(db: AsyncSession):
+    """size omitted → every assigned application is returned (no implicit 20-row cap)."""
+    student = await _seed_user(db, role=UserRole.student, nycu_id="profpag_stu_nocap")
+    prof = await _seed_user(db, role=UserRole.professor, nycu_id="profpag_prof_nocap")
+    cfg = await _seed_config(db, requires_prof=True, suffix="nocap")
+
+    # 25 apps > the old default page size of 20.
+    for i in range(25):
+        await _seed_app(
+            db,
+            student=student,
+            config=cfg,
+            status=ApplicationStatus.submitted.value,
+            professor_id=prof.id,
+            suffix=f"nocap_{i}",
+        )
+
+    service = ApplicationService(db)
+    apps, total = await service.get_professor_applications_paginated(professor_id=prof.id)
+    assert total == 25
+    assert len(apps) == 25

--- a/backend/app/tests/test_professor_endpoints.py
+++ b/backend/app/tests/test_professor_endpoints.py
@@ -140,6 +140,36 @@ class TestProfessorApplicationsEndpoint:
             )
 
     @pytest.mark.asyncio
+    async def test_get_professor_applications_default_returns_all(
+        self, mock_professor, mock_db_session, mock_request, sample_applications
+    ):
+        """size omitted (None) → no pagination cap; response size reflects the full set"""
+        with patch("app.api.v1.endpoints.professor.ApplicationService") as mock_service_class:
+            mock_service = mock_service_class.return_value
+            mock_service.get_professor_applications_paginated = AsyncMock(return_value=(sample_applications * 25, 25))
+
+            result = await get_professor_applications(
+                request=mock_request,
+                status_filter=None,
+                page=1,
+                size=None,
+                current_user=mock_professor,
+                db=mock_db_session,
+            )
+
+            assert result["success"] is True
+            data = result["data"]
+            assert data["total"] == 25
+            assert data["size"] == 25
+            assert data["pages"] == 1
+            assert len(data["items"]) == 25
+
+            # size=None must be forwarded so the service skips LIMIT/OFFSET
+            mock_service.get_professor_applications_paginated.assert_called_once_with(
+                professor_id=mock_professor.id, status_filter=None, page=1, size=None
+            )
+
+    @pytest.mark.asyncio
     async def test_get_professor_applications_with_filters(
         self, mock_professor, mock_db_session, mock_request, sample_applications
     ):

--- a/backend/app/tests/test_professor_student_endpoints.py
+++ b/backend/app/tests/test_professor_student_endpoints.py
@@ -269,3 +269,50 @@ class TestProfessorStudentEnvelopeAndFlow:
         assert response.status_code == 200
         body = response.json()
         assert body["success"] is True
+
+
+@pytest.mark.api
+class TestProfessorStudentNoPaginationCap:
+    """size omitted → ALL relationships returned (no implicit 20-row cap);
+    explicit page/size still paginates deterministically."""
+
+    async def _seed_many(self, db, ps_users, count=25):
+        # Distinct relationship_type per row to sidestep the
+        # (professor, student, type) uniqueness rule.
+        for i in range(count):
+            db.add(
+                ProfessorStudentRelationship(
+                    professor_id=ps_users["professor"].id,
+                    student_id=ps_users["student"].id,
+                    relationship_type=f"nocap_t{i:02d}",
+                    is_active=True,
+                    created_by=ps_users["admin"].id,
+                )
+            )
+        await db.commit()
+
+    async def test_default_returns_all_rows_beyond_old_cap(self, client, login, db, ps_users):
+        # 25 rows > the old default page size of 20.
+        await self._seed_many(db, ps_users, count=25)
+        login(ps_users["professor"])
+        response = await client.get(PREFIX)
+        assert response.status_code == 200
+        assert len(response.json()["data"]) == 25
+
+    async def test_explicit_size_still_paginates(self, client, login, db, ps_users):
+        await self._seed_many(db, ps_users, count=25)
+        login(ps_users["professor"])
+
+        page1 = await client.get(PREFIX, params={"page": 1, "size": 10})
+        assert page1.status_code == 200
+        page1_ids = [rel["id"] for rel in page1.json()["data"]]
+        assert len(page1_ids) == 10
+
+        page3 = await client.get(PREFIX, params={"page": 3, "size": 10})
+        assert page3.status_code == 200
+        page3_ids = [rel["id"] for rel in page3.json()["data"]]
+        assert len(page3_ids) == 5
+
+        # Ordered by id → pages are disjoint and deterministic.
+        assert not set(page1_ids) & set(page3_ids)
+        assert max(page1_ids) < min(page3_ids)

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -4282,7 +4282,10 @@ export interface paths {
         };
         /**
          * Get Professor Applications
-         * @description Get applications requiring professor review with pagination
+         * @description Get applications requiring professor review.
+         *
+         *     Returns ALL assigned applications by default; pass ``page``/``size``
+         *     for explicit pagination.
          */
         get: operations["get_professor_applications_api_v1_professor_applications_get"];
         put?: never;
@@ -18138,8 +18141,8 @@ export interface operations {
                 status_filter?: string | null;
                 /** @description Page number */
                 page?: number;
-                /** @description Items per page */
-                size?: number;
+                /** @description Items per page; omit to return all applications */
+                size?: number | null;
             };
             header?: never;
             path?: never;
@@ -18338,8 +18341,8 @@ export interface operations {
                 status?: string | null;
                 /** @description Page number */
                 page?: number;
-                /** @description Items per page */
-                size?: number;
+                /** @description Items per page; omit to return all relationships */
+                size?: number | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Problem

Professors could only ever see the first 20 assigned student applications. The professor review page fetches the list once without `page`/`size`, the backend defaulted to `size=20` (max 100), and the frontend flattens the paginated response with no pagination UI — silently hiding everything past the first page.

## Changes

- **`GET /api/v1/professor/applications`**: `size` is now optional; when omitted the endpoint returns **all** assigned applications (`pages=1`, `size=total`). Explicit `page`/`size` still paginates, with the `le=100` cap removed.
- **`ApplicationService.get_professor_applications_paginated`**: `size=None` skips `LIMIT`/`OFFSET` entirely.
- **`GET /api/v1/professor-student`**: same fix — the relationship management page also fetched with no params and was capped at 20 rows.
- Regenerated frontend OpenAPI types (`schema.d.ts`) for the changed query params. No frontend code changes needed since the UI never sent `size`.

## Tests

- New service-level regression test: 25 seeded applications (above the old 20 default) are all returned by the default call.
- New endpoint-level test: `size=None` is forwarded to the service and the response reports the full set.
- All touched suites pass: 15 service/routing tests, 14 endpoint tests, black + flake8 (B904/B014) clean, frontend typecheck and 24 professor API module tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152sxNk8fc4PfBhuwAxy9Hp

---
_Generated by [Claude Code](https://claude.ai/code/session_0152sxNk8fc4PfBhuwAxy9Hp)_