### PR TITLE
feat: simplify student application progress timeline to 4 steps

### DIFF
--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -394,6 +394,9 @@ class ApplicationResponse(BaseModel):
     # Workflow configuration flags
     requires_professor_recommendation: bool = False
     requires_college_review: bool = False
+    # Admin toggle (ScholarshipConfiguration.allow_college_view_distribution):
+    # the student timeline's final step is only checked once this is opened
+    allow_college_view_distribution: bool = False
 
     @property
     def is_editable(self) -> bool:
@@ -644,6 +647,9 @@ class ApplicationListResponse(BaseModel):
     # Workflow configuration flags
     requires_professor_recommendation: bool = False
     requires_college_review: bool = False
+    # Admin toggle (ScholarshipConfiguration.allow_college_view_distribution):
+    # the student timeline's final step is only checked once this is opened
+    allow_college_view_distribution: bool = False
 
     @property
     def is_editable(self) -> bool:

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -700,6 +700,10 @@ class ApplicationService:
             requires_college_review=bool(
                 application.scholarship_configuration and application.scholarship_configuration.requires_college_review
             ),
+            allow_college_view_distribution=bool(
+                application.scholarship_configuration
+                and application.scholarship_configuration.allow_college_view_distribution
+            ),
         )
 
     async def get_user_applications(self, user: User, status: Optional[str] = None) -> List[ApplicationListResponse]:
@@ -1009,6 +1013,10 @@ class ApplicationService:
             ),
             "requires_college_review": bool(
                 application.scholarship_configuration and application.scholarship_configuration.requires_college_review
+            ),
+            "allow_college_view_distribution": bool(
+                application.scholarship_configuration
+                and application.scholarship_configuration.allow_college_view_distribution
             ),
         }
 

--- a/backend/app/tests/test_application_list_response_props.py
+++ b/backend/app/tests/test_application_list_response_props.py
@@ -162,12 +162,14 @@ def test_agree_terms_defaults_false():
 
 def test_workflow_flags_default_false():
     # Pin: requires_professor_recommendation +
-    # requires_college_review default False. These are set on
-    # the underlying scholarship config — the response surfaces
-    # them for the frontend, but default is "no extra workflow".
+    # requires_college_review + allow_college_view_distribution
+    # default False. These are set on the underlying scholarship
+    # config — the response surfaces them for the frontend, but
+    # default is "no extra workflow / distribution not opened".
     r = ApplicationListResponse(**_kwargs())
     assert r.requires_professor_recommendation is False
     assert r.requires_college_review is False
+    assert r.allow_college_view_distribution is False
 
 
 def test_scholarship_subtype_list_defaults_empty():

--- a/frontend/components/__tests__/enhanced-student-portal.test.tsx
+++ b/frontend/components/__tests__/enhanced-student-portal.test.tsx
@@ -352,8 +352,9 @@ describe("EnhancedStudentPortal", () => {
       expect(screen.getByText("Review Progress")).toBeInTheDocument();
     });
     expect(screen.getByText("Submit Application")).toBeInTheDocument();
+    expect(screen.getByText("Professor Review")).toBeInTheDocument();
     expect(
-      screen.getByText("Waiting for Professor Review")
+      screen.getByText("Finalized (Contact College Office)")
     ).toBeInTheDocument();
   });
 

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -143,6 +143,12 @@ export interface Application {
    *  (top-level flag from the college review listing; distinct from the
    *  nested scholarship_configuration.requires_professor_recommendation). */
   requires_professor_recommendation?: boolean;
+  /** Whether this scholarship requires a college review step (top-level flag
+   *  surfaced on application list/detail responses). */
+  requires_college_review?: boolean;
+  /** Admin toggle「開放學院查看分發結果」— the student timeline's final
+   *  已核定(請洽院辦) step is only checked once this is opened. */
+  allow_college_view_distribution?: boolean;
   professor_review_completed?: boolean;
   college_review_completed?: boolean;
   form_data?: Record<string, any>;

--- a/frontend/lib/utils/__tests__/application-helpers.test.ts
+++ b/frontend/lib/utils/__tests__/application-helpers.test.ts
@@ -206,6 +206,18 @@ describe("Application Helpers", () => {
       expect(timeline[3].status).toBe("pending");
     });
 
+    it("marks the final step rejected for cancelled_by_challenge", () => {
+      const app = {
+        ...mockApplication,
+        status: "cancelled_by_challenge",
+        review_stage: "college_review",
+        allow_college_view_distribution: true,
+      };
+      const timeline = getApplicationTimeline(app, "zh");
+
+      expect(timeline[3].status).toBe("rejected");
+    });
+
     it("should return correct timeline for rejected status", () => {
       const rejectedApp = { ...mockApplication, status: "rejected", review_stage: "college_reviewed" };
       const timeline = getApplicationTimeline(rejectedApp, "zh");

--- a/frontend/lib/utils/__tests__/application-helpers.test.ts
+++ b/frontend/lib/utils/__tests__/application-helpers.test.ts
@@ -123,8 +123,9 @@ describe("Application Helpers", () => {
       submitted_at: "2025-01-02T10:00:00Z",
       reviewed_at: "2025-01-03T10:00:00Z",
       approved_at: "2025-01-04T10:00:00Z",
-      // getApplicationTimeline now conditionalizes professor/college review steps
-      // on these flags. Tests below expect the full 8-step timeline.
+      // getApplicationTimeline conditionalizes professor/college review steps
+      // on these flags. Tests below expect the full 4-step timeline:
+      // 提交申請 → 教授審核 → 學院審核 → 已核定(請洽院辦)
       requires_professor_recommendation: true,
       requires_college_review: true,
     };
@@ -133,37 +134,76 @@ describe("Application Helpers", () => {
       const draftApp = { ...mockApplication, status: "draft", review_stage: "student_draft" };
       const timeline = getApplicationTimeline(draftApp, "zh");
 
-      expect(timeline).toHaveLength(8);
+      expect(timeline).toHaveLength(4);
       expect(timeline[0].title).toBe("提交申請");
       expect(timeline[0].status).toBe("current");
+      expect(timeline[1].title).toBe("教授審核");
       expect(timeline[1].status).toBe("pending");
+      expect(timeline[2].title).toBe("學院審核");
       expect(timeline[2].status).toBe("pending");
+      expect(timeline[3].title).toBe("已核定(請洽院辦)");
       expect(timeline[3].status).toBe("pending");
-      expect(timeline[4].status).toBe("pending");
-      expect(timeline[5].status).toBe("pending");
-      expect(timeline[6].status).toBe("pending");
-      expect(timeline[7].status).toBe("pending");
     });
 
     it("should return correct timeline for submitted status in English", () => {
       const submittedApp = { ...mockApplication, status: "submitted", review_stage: "student_submitted" };
       const timeline = getApplicationTimeline(submittedApp, "en");
 
-      expect(timeline).toHaveLength(8);
+      expect(timeline).toHaveLength(4);
       expect(timeline[0].title).toBe("Submit Application");
       expect(timeline[0].status).toBe("completed");
-      expect(timeline[1].title).toContain("Waiting for Professor Review");
+      expect(timeline[1].title).toContain("Professor Review");
       expect(timeline[1].status).toBe("current");
-      expect(timeline[2].title).toBe("Professor Reviewing");
+      expect(timeline[2].title).toBe("College Review");
       expect(timeline[2].status).toBe("pending");
+      expect(timeline[3].title).toBe("Finalized (Contact College Office)");
+      expect(timeline[3].status).toBe("pending");
     });
 
-    it("should return correct timeline for approved status", () => {
+    it("marks college review current once the professor review is submitted", () => {
+      const app = { ...mockApplication, review_stage: "college_review" };
+      const timeline = getApplicationTimeline(app, "zh");
+
+      expect(timeline[1].status).toBe("completed");
+      expect(timeline[2].status).toBe("current");
+      expect(timeline[3].status).toBe("pending");
+    });
+
+    it("does NOT check 已核定 for approved status while distribution is not opened to colleges", () => {
       const approvedApp = { ...mockApplication, status: "approved", review_stage: "completed" };
       const timeline = getApplicationTimeline(approvedApp, "zh");
 
       expect(timeline[0].status).toBe("completed");
-      expect(timeline[7].status).toBe("completed");
+      expect(timeline[1].status).toBe("completed");
+      expect(timeline[2].status).toBe("completed");
+      // Admin toggle allow_college_view_distribution is off → not completed yet
+      expect(timeline[3].status).toBe("current");
+      expect(timeline[3].date).toBe("");
+    });
+
+    it("checks 已核定 only when admin opened distribution results to colleges", () => {
+      const approvedApp = {
+        ...mockApplication,
+        status: "approved",
+        review_stage: "completed",
+        allow_college_view_distribution: true,
+      };
+      const timeline = getApplicationTimeline(approvedApp, "zh");
+
+      expect(timeline[3].status).toBe("completed");
+      expect(timeline[3].date).not.toBe("");
+    });
+
+    it("does not check 已核定 for non-approved status even when the toggle is on", () => {
+      const app = {
+        ...mockApplication,
+        status: "under_review",
+        review_stage: "college_review",
+        allow_college_view_distribution: true,
+      };
+      const timeline = getApplicationTimeline(app, "zh");
+
+      expect(timeline[3].status).toBe("pending");
     });
 
     it("should return correct timeline for rejected status", () => {
@@ -171,7 +211,20 @@ describe("Application Helpers", () => {
       const timeline = getApplicationTimeline(rejectedApp, "zh");
 
       expect(timeline[0].status).toBe("completed");
-      expect(timeline[7].status).toBe("rejected");
+      expect(timeline[3].status).toBe("rejected");
+    });
+
+    it("skips professor/college steps when the scholarship does not require them", () => {
+      const app = {
+        ...mockApplication,
+        requires_professor_recommendation: false,
+        requires_college_review: false,
+      };
+      const timeline = getApplicationTimeline(app, "zh");
+
+      expect(timeline).toHaveLength(2);
+      expect(timeline[0].title).toBe("提交申請");
+      expect(timeline[1].title).toBe("已核定(請洽院辦)");
     });
   });
 

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -91,6 +91,7 @@ type ApplicationTimelineInput = {
   professor?: { name?: string; nycu_id?: string };
   requires_professor_recommendation?: boolean;
   requires_college_review?: boolean;
+  allow_college_view_distribution?: boolean;
   submitted_at?: string;
   created_at?: string;
   approved_at?: string;
@@ -119,29 +120,25 @@ export const getApplicationTimeline = (
   // 教授姓名
   const professorName = application.professor?.name || application.professor?.nycu_id;
 
-  // 判斷步驟狀態的輔助函數
+  // 判斷合併步驟狀態的輔助函數:
+  // entryStage 為進入此步驟的階段,exitStage 為完成後進入的階段
   const getStepStatus = (
-    targetStage: string,
-    nextStage: string,
+    entryStage: string,
+    exitStage: string,
     hasCompletedEvidence?: boolean
   ): "completed" | "current" | "pending" | "rejected" => {
     // 如果被拒絕,且已達到該階段,標記為 rejected
-    if (status === "rejected" && hasReachedStage(reviewStage, targetStage)) {
+    if (status === "rejected" && hasReachedStage(reviewStage, entryStage)) {
       return "rejected";
     }
 
-    // 如果有明確的完成證據 (如審核記錄)
-    if (hasCompletedEvidence) {
+    // 如果有明確的完成證據 (如審核記錄),或已進入後續階段
+    if (hasCompletedEvidence || hasReachedStage(reviewStage, exitStage)) {
       return "completed";
     }
 
-    // 如果已達到下一階段,則此階段已完成
-    if (hasReachedStage(reviewStage, nextStage)) {
-      return "completed";
-    }
-
-    // 如果正好在此階段
-    if (reviewStage === targetStage) {
+    // 已進入此步驟但尚未完成
+    if (hasReachedStage(reviewStage, entryStage)) {
       return "current";
     }
 
@@ -152,9 +149,11 @@ export const getApplicationTimeline = (
   // Workflow configuration flags
   const requiresProfessor = application.requires_professor_recommendation ?? false;
   const requiresCollege = application.requires_college_review ?? false;
+  // 管理員「開放學院查看分發結果」開關:開啟後最終步驟才會打勾
+  const allowCollegeViewDistribution = application.allow_college_view_distribution ?? false;
 
-  // Determine the stage after professor review (skip college if not required)
-  const afterProfessorStage = requiresCollege ? "college_review" : "admin_review";
+  const isTerminated =
+    status === "rejected" || status === "returned" || status === "withdrawn" || status === "cancelled";
 
   const steps: TimelineStep[] = [
     // 1. 提交申請
@@ -168,72 +167,48 @@ export const getApplicationTimeline = (
     },
   ];
 
-  // Professor review steps (only if required)
+  // 2. 教授審核 (only if required)
   if (requiresProfessor) {
-    steps.push(
-      {
-        id: "wait_professor",
-        title: locale === "zh"
-          ? `等待教授審核${professorName ? ` (${professorName})` : ""}`
-          : `Waiting for Professor Review${professorName ? ` (${professorName})` : ""}`,
-        status: getStepStatus("student_submitted", "professor_review"),
-        date: "",
-      },
-      {
-        id: "professor_reviewing",
-        title: locale === "zh" ? "教授審核中" : "Professor Reviewing",
-        status: getStepStatus("professor_review", "professor_reviewed", hasProfessorReview),
-        date: "",
-      },
-      {
-        id: "professor_submitted",
-        title: locale === "zh" ? "教授已送出審核" : "Professor Review Submitted",
-        status: getStepStatus("professor_reviewed", afterProfessorStage, hasProfessorReview),
-        date: hasProfessorReview ? formatDate(professorReview?.reviewed_at, locale) : "",
-      },
-    );
+    steps.push({
+      id: "professor_review",
+      title: locale === "zh"
+        ? `教授審核${professorName ? ` (${professorName})` : ""}`
+        : `Professor Review${professorName ? ` (${professorName})` : ""}`,
+      status: getStepStatus("student_submitted", "professor_reviewed", hasProfessorReview),
+      date: hasProfessorReview ? formatDate(professorReview?.reviewed_at, locale) : "",
+    });
   }
 
-  // College review steps (only if required)
+  // 3. 學院審核 (only if required)
   if (requiresCollege) {
-    steps.push(
-      {
-        id: "wait_college",
-        title: locale === "zh" ? "等待學院審核" : "Waiting for College Review",
-        status: getStepStatus("professor_reviewed", "college_review"),
-        date: "",
-      },
-      {
-        id: "college_reviewing",
-        title: locale === "zh" ? "學院審核中" : "College Reviewing",
-        status: getStepStatus("college_review", "college_reviewed", hasCollegeReview),
-        date: "",
-      },
-      {
-        id: "college_submitted",
-        title: locale === "zh" ? "學院已送出審核" : "College Review Submitted",
-        status: getStepStatus("college_reviewed", "admin_review", hasCollegeReview),
-        date: hasCollegeReview ? formatDate(collegeReview?.reviewed_at, locale) : "",
-      },
-    );
+    steps.push({
+      id: "college_review",
+      title: locale === "zh" ? "學院審核" : "College Review",
+      status: getStepStatus(
+        requiresProfessor ? "professor_reviewed" : "student_submitted",
+        "college_reviewed",
+        hasCollegeReview
+      ),
+      date: hasCollegeReview ? formatDate(collegeReview?.reviewed_at, locale) : "",
+    });
   }
 
-  // Final decision
+  // 4. 已核定(請洽院辦) — 僅在管理員開放學院查看分發結果後才打勾
   steps.push({
     id: "final_decision",
-    title: locale === "zh" ? "最終核定" : "Final Decision",
-    status:
-      status === "approved"
-        ? "completed"
-        : status === "rejected" || status === "returned" || status === "withdrawn" || status === "cancelled"
-          ? "rejected"
-          : "pending",
-    date:
-      status === "approved"
+    title: locale === "zh" ? "已核定(請洽院辦)" : "Finalized (Contact College Office)",
+    status: isTerminated
+      ? "rejected"
+      : status === "approved"
+        ? allowCollegeViewDistribution
+          ? "completed"
+          : "current"
+        : "pending",
+    date: isTerminated
+      ? formatDate(application.reviewed_at, locale)
+      : status === "approved" && allowCollegeViewDistribution
         ? formatDate(application.approved_at, locale)
-        : status === "rejected" || status === "returned" || status === "withdrawn" || status === "cancelled"
-          ? formatDate(application.reviewed_at, locale)
-          : "",
+        : "",
   });
 
   return steps;

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -154,7 +154,11 @@ export const getApplicationTimeline = (
   const allowCollegeViewDistribution = application.allow_college_view_distribution ?? false;
 
   const isTerminated =
-    status === "rejected" || status === "returned" || status === "withdrawn" || status === "cancelled";
+    status === "rejected" ||
+    status === "returned" ||
+    status === "withdrawn" ||
+    status === "cancelled" ||
+    status === "cancelled_by_challenge";
 
   const steps: TimelineStep[] = [
     // 1. 提交申請

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -121,7 +121,8 @@ export const getApplicationTimeline = (
   const professorName = application.professor?.name || application.professor?.nycu_id;
 
   // 判斷合併步驟狀態的輔助函數:
-  // entryStage 為進入此步驟的階段,exitStage 為完成後進入的階段
+  // entryStage 為進入此步驟的階段,exitStage 為此步驟完成時所到達的階段
+  // (review_stage 達到 exitStage 即視為此步驟已完成)
   const getStepStatus = (
     entryStage: string,
     exitStage: string,


### PR DESCRIPTION
## Summary

Collapses the student「我的申請」review progress display from 8 steps to 4:

**提交申請 → 教授審核 → 學院審核 → 已核定(請洽院辦)**

The final「已核定(請洽院辦)」step is only checked once the admin has opened the「開放學院查看分發結果」toggle (`ScholarshipConfiguration.allow_college_view_distribution`):

- Approved + toggle **on** → step completed (checked, shows approval date)
- Approved + toggle **off** → step shown as *current* (in progress), not checked
- Not approved (even with toggle on) → pending
- Rejected / returned / withdrawn / cancelled → red rejected marker (unchanged)

## Changes

### Frontend
- `lib/utils/application-helpers.ts` — `getApplicationTimeline()` merges the three professor sub-steps (等待審核／審核中／已送出) into a single 教授審核 step and likewise for 學院審核; each step is checked once the corresponding review is submitted and shows the review date. Professor/college steps remain config-driven (omitted when the scholarship doesn't require them).
- `lib/api/types.ts` — `Application` gains top-level `requires_college_review` and `allow_college_view_distribution` fields.

### Backend
- `app/schemas/application.py` — `ApplicationListResponse` / `ApplicationResponse` gain `allow_college_view_distribution: bool = False`.
- `app/services/application_service.py` — both canonical response builders populate the flag from `application.scholarship_configuration`.

No OpenAPI regeneration needed: these responses are manually wrapped dicts, not schema components.

## Testing
- `frontend`: `jest application-helpers` — 61 tests pass, including new toggle-on/off timeline cases; `tsc --noEmit` clean.
- `backend`: `pytest app/tests/test_application_list_response_props.py` — 15 tests pass (extended default-flag pin); black + flake8 (B904/B014) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XhWVpL1fueKaHTWpdcKqp6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhWVpL1fueKaHTWpdcKqp6)_