### PR TITLE
fix: record per-ranking allocated_count at distribution finalize

### DIFF
--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -877,6 +877,9 @@ class ManualDistributionService:
 
         approved_count = 0
         rejected_count = 0
+        # Per-ranking approved tallies — each college ranking must record its
+        # OWN winner count, not the global one (#1138).
+        approved_by_ranking: dict[int, int] = {}
 
         for item in items:
             app = item.application
@@ -927,6 +930,7 @@ class ManualDistributionService:
                         )
                     )
                 approved_count += 1
+                approved_by_ranking[item.ranking_id] = approved_by_ranking.get(item.ranking_id, 0) + 1
             elif item.is_supplementary and not item.is_allocated:
                 # Supplementary students pending a second distribution pass —
                 # leave status as 'ranked' so they appear in the next allocation.
@@ -971,7 +975,7 @@ class ManualDistributionService:
         for ranking in rankings:
             ranking.distribution_executed = True
             ranking.distribution_date = now
-            ranking.allocated_count = approved_count
+            ranking.allocated_count = approved_by_ranking.get(ranking.id, 0)
 
         await self.db.flush()
 


### PR DESCRIPTION
## 問題

`finalize()` 把**全域** `approved_count` 寫進每一個學院 ranking 的 `allocated_count`（`manual_distribution_service.py:974`），所以每個學院的學生排序頁都顯示全校正取總數（例：資訊學院「申請數 21 • 正取 136」），`remaining_quota` / `allocation_rate` 也跟著失真。

## 修法

items 迴圈以 `item.ranking_id` 累計各 ranking 的核准數，rankings 迴圈改寫入各自的數字。

## 測試

- `pytest app/tests -k "manual_distribution or finalize"` 全綠（含既有 finalize 測試）
- dev 實測：212 筆 16 學院分發後重跑 finalize，16 個 ranking 的 `allocated_count` 各自正確（總和 136）；資訊學院 UI 顯示「申請數 21 • 正取 21」

Fixes #1138