### PR TITLE
fix: preserve text-cell formatting in batch import (leading zeros)

### DIFF
--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -78,6 +78,25 @@ def _parse_renewal_year(raw_value: Any) -> Tuple[bool, Optional[int]]:
     return False, None
 
 
+_NUMERIC_FIELD_TYPES = {"number", "integer", "float", "decimal"}
+
+
+def _normalize_custom_field_value(value: Any, field_type: Optional[str]) -> Any:
+    """Normalize a custom-field cell by its ApplicationField type.
+
+    Numeric field types keep their numeric value; everything else becomes a
+    trimmed string (int-safe, so a numeric cell 3.0 renders "3" while text
+    cells keep leading zeros — #1140).
+    """
+    if isinstance(value, bool):
+        return value
+    if (field_type or "").lower() in _NUMERIC_FIELD_TYPES:
+        return value
+    if isinstance(value, float) and value.is_integer():
+        value = int(value)
+    return str(value).strip()
+
+
 _CHECKMARK_VALUES = {"v", "✓"}
 
 
@@ -324,12 +343,15 @@ class BatchImportService:
         parsed_data = []
 
         try:
-            # Try reading as Excel first
-            df = pd.read_excel(io.BytesIO(file_content))
+            # Try reading as Excel first. dtype=object keeps each cell's own
+            # type (text cells stay text) instead of coercing whole columns —
+            # column-level int64 inference ate leading zeros in text cells
+            # like 聯絡電話 "09xxxxxxxxx" (#1140).
+            df = pd.read_excel(io.BytesIO(file_content), dtype=object)
         except Exception:
             try:
                 # Fallback to CSV
-                df = pd.read_csv(io.BytesIO(file_content))
+                df = pd.read_csv(io.BytesIO(file_content), dtype=object)
             except Exception as e:
                 errors.append(
                     BatchImportValidationError(
@@ -368,6 +390,7 @@ class BatchImportService:
         # Custom-field definitions (same set _build_submitted_form_data uses)
         field_definitions = await self._fetch_field_definitions(scholarship.code)
         custom_field_mapping = {f.field_label: f.field_name for f in field_definitions.values()}
+        custom_field_types = {f.field_name: f.field_type for f in field_definitions.values()}
 
         # Column header → sub-type code accepted by the parser, scoped to this
         # scholarship's real sub-types. The template writes the known Chinese
@@ -489,12 +512,9 @@ class BatchImportService:
                     # Parse custom fields from Chinese column names
                     for chinese_label, field_name in custom_field_mapping.items():
                         if chinese_label in df_columns and pd.notna(row.get(chinese_label)):
-                            value = row.get(chinese_label)
-                            # Convert to appropriate type
-                            if isinstance(value, (int, float, bool)):
-                                data_row["custom_fields"][field_name] = value
-                            else:
-                                data_row["custom_fields"][field_name] = str(value).strip()
+                            data_row["custom_fields"][field_name] = _normalize_custom_field_value(
+                                row.get(chinese_label), custom_field_types.get(field_name)
+                            )
                 else:
                     # English column format (backward compatibility)
                     is_renewal, renewal_year = _parse_renewal_year(
@@ -532,11 +552,9 @@ class BatchImportService:
                         if col.startswith("custom_"):
                             field_name = col.replace("custom_", "")
                             if pd.notna(row.get(col)):
-                                value = row.get(col)
-                                if isinstance(value, (int, float, bool)):
-                                    data_row["custom_fields"][field_name] = value
-                                else:
-                                    data_row["custom_fields"][field_name] = str(value).strip()
+                                data_row["custom_fields"][field_name] = _normalize_custom_field_value(
+                                    row.get(col), custom_field_types.get(field_name)
+                                )
 
                 # Validate using Pydantic schema and capture normalized values
                 validated_row = ApplicationDataRow(**data_row)


### PR DESCRIPTION
## 問題

`pd.read_excel` 的欄級 dtype 推斷會把「整欄都像數字」的文字欄轉成 int64，批次匯入的 聯絡電話 "09xxxxxxxxx" 因此變成整數、**前導零遺失**（存進 `submitted_form_data.fields.contact_phone.value` 的是 9123123123）。openpyxl 本身讀出的是正確字串——零是在 pandas 欄級推斷丟的。

## 修法

- `pd.read_excel(..., dtype=object)`（CSV 同步 `dtype=object`）：保留每個儲存格自己的型別，不做欄級強制轉型
- 新增 `_normalize_custom_field_value(value, field_type)`：數值型欄位保留數字；其他（含 text）轉為修剪過的字串（int-safe，數字格 3.0 → "3"）
- 兩個欄位解析分支（中文欄名 / custom_* 英文欄名）共用此 normalizer

既有 helpers（`_normalize_identifier` / `_parse_renewal_year` / `_is_sub_type_marked`）本就處理混合型別，行為不變。

## 測試

- `pytest app/tests -k batch_import` 全綠
- dev 實測：212 筆檔案重新上傳預覽，`contact_phone` 解析為 `'09123123123'`（字串、含前導零）

Fixes #1140