### PR TITLE
fix: verification mock reads mock SIS status instead of last digit

### DIFF
--- a/backend/app/services/student_verification_service.py
+++ b/backend/app/services/student_verification_service.py
@@ -5,7 +5,7 @@ Student verification service for checking student enrollment status
 
 import logging
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -83,9 +83,121 @@ class StudentVerificationService:
                 "api_response": {"error": str(e)},
             }
 
+    # SIS mock std_studingstatus → 驗證狀態對照（#1141）
+    # 1 在學 / 2 應畢 / 3 延畢 → 通過；4 休學；5-6 退學；11 畢業
+    _SIS_STATUS_MAP = {
+        1: StudentVerificationStatus.VERIFIED,
+        2: StudentVerificationStatus.VERIFIED,
+        3: StudentVerificationStatus.VERIFIED,
+        4: StudentVerificationStatus.SUSPENDED,
+        5: StudentVerificationStatus.WITHDRAWN,
+        6: StudentVerificationStatus.WITHDRAWN,
+        11: StudentVerificationStatus.GRADUATED,
+    }
+
+    _STATUS_MESSAGES = {
+        StudentVerificationStatus.VERIFIED: "學籍驗證通過",
+        StudentVerificationStatus.GRADUATED: "學生已畢業",
+        StudentVerificationStatus.SUSPENDED: "學生目前休學中",
+        StudentVerificationStatus.WITHDRAWN: "學生已退學",
+        StudentVerificationStatus.NOT_FOUND: "查無此學生資料",
+    }
+
     def _mock_verification(self, student_id_number: str, student_name: str) -> Dict[str, Any]:
         """
         模擬驗證 (開發測試用)
+
+        先查詢 mock student API（SIS mock）的真實學籍狀態，讓 dev 環境的
+        造冊驗證與 SIS mock 一致（#1141）；SIS mock 不可用時才退回舊的
+        「末位數字」啟發式。
+        """
+        sis_result = self._mock_sis_verification(student_id_number, student_name)
+        if sis_result is not None:
+            return sis_result
+        return self._last_digit_mock_verification(student_id_number, student_name)
+
+    def _mock_sis_verification(self, student_id_number: str, student_name: str) -> Optional[Dict[str, Any]]:
+        """以 mock student API 的 std_studingstatus / mgd_title 判定學籍。
+
+        回傳 None 表示 SIS mock 不可用（呼叫端退回末位數字啟發式）；
+        查無學生是「確定的」結果，回 NOT_FOUND 而非 None。
+        """
+        base_url = getattr(settings, "student_api_base_url", None)
+        if not base_url:
+            return None
+
+        try:
+            response = self.session.post(
+                f"{base_url}/ScholarshipStudent",
+                json={"action": "qrySoaaScholarshipStudent", "stdcode": student_id_number},
+                timeout=5,
+            )
+            payload = response.json()
+        except (requests.RequestException, ValueError):
+            logger.warning(
+                "Mock SIS unreachable for verification of %s; falling back to last-digit heuristic",
+                student_id_number,
+            )
+            return None
+
+        code = payload.get("code")
+        data = payload.get("data") or []
+        if code not in (200, "200") or not data:
+            return {
+                "status": StudentVerificationStatus.NOT_FOUND,
+                "message": self._STATUS_MESSAGES[StudentVerificationStatus.NOT_FOUND],
+                "student_info": {},
+                "verified_at": datetime.now(),
+                "api_response": {"mock": True, "source": "mock-student-api", "code": code},
+            }
+
+        record = data[0]
+        raw_status = record.get("std_studingstatus")
+        title = str(record.get("mgd_title") or "")
+
+        try:
+            status = self._SIS_STATUS_MAP.get(int(raw_status))
+        except (TypeError, ValueError):
+            status = None
+        if status is None:
+            # 數字狀態不在對照表時以中文狀態名稱推斷
+            if "休" in title:
+                status = StudentVerificationStatus.SUSPENDED
+            elif "退" in title:
+                status = StudentVerificationStatus.WITHDRAWN
+            elif "畢" in title:
+                status = StudentVerificationStatus.GRADUATED
+            else:
+                status = StudentVerificationStatus.VERIFIED
+
+        # 保留原始 std_* 欄位供規則評估（roster 的 fresh_api_data 只讀 std_/trm_ 鍵）
+        student_info = {
+            **record,
+            "student_id": student_id_number,
+            "name": record.get("std_cname") or student_name,
+            "school_name": "國立陽明交通大學",
+            "enrollment_status": title or str(raw_status),
+            "email": record.get("com_email", ""),
+            "phone": record.get("com_cellphone", ""),
+            "address": record.get("com_commadd", ""),
+        }
+
+        return {
+            "status": status,
+            "message": f"{self._STATUS_MESSAGES[status]}（SIS mock：{title or raw_status}）",
+            "student_info": student_info,
+            "verified_at": datetime.now(),
+            "api_response": {
+                "mock": True,
+                "source": "mock-student-api",
+                "std_studingstatus": raw_status,
+                "mgd_title": title,
+            },
+        }
+
+    def _last_digit_mock_verification(self, student_id_number: str, student_name: str) -> Dict[str, Any]:
+        """
+        末位數字啟發式（僅當 SIS mock 不可用時的離線退路）
         根據身分證字號末位數字決定驗證結果
         """
         logger.info(f"Mock verification for {student_id_number} ({student_name})")

--- a/backend/app/tests/test_student_verification_pure_helpers.py
+++ b/backend/app/tests/test_student_verification_pure_helpers.py
@@ -7,13 +7,16 @@ wrong label rendering, surfaces to college reviewers as 'verified'
 when the student is actually graduated / withdrawn — a real
 compliance issue (paying out scholarships to ineligible students).
 
-3 helpers covered (16 cases):
-- `_mock_verification`              : dev mode — last-digit-driven branching
+Helpers covered:
+- `_mock_verification`              : dev mode — SIS-mock-first, heuristic fallback (#1141)
+- `_mock_sis_verification`          : std_studingstatus / mgd_title → status mapping
+- `_last_digit_mock_verification`   : offline fallback — last-digit-driven branching
 - `_parse_api_response`             : 5 status strings + unknown + exception
 - `get_verification_status_label`   : zh/en label mapping for each status
 """
 
 import pytest
+import requests
 
 from app.models.payment_roster import StudentVerificationStatus
 from app.services.student_verification_service import StudentVerificationService
@@ -25,43 +28,134 @@ def service():
     return StudentVerificationService()
 
 
-# ─── _mock_verification (dev mode) ───────────────────────────────────
+# ─── _mock_verification (dev mode, SIS-mock-first — #1141) ───────────
 
 
-def test_mock_verification_last_digit_0_to_6_is_verified(service):
+def test_mock_verification_prefers_sis_result(service, monkeypatch):
+    """When the SIS mock answers, its status wins — the last-digit heuristic
+    must NOT override it (digit 3 would be VERIFIED under the heuristic)."""
+    sis_result = {
+        "status": StudentVerificationStatus.SUSPENDED,
+        "message": "學生目前休學中（SIS mock：休學）",
+        "student_info": {},
+        "verified_at": None,
+        "api_response": {"mock": True, "source": "mock-student-api"},
+    }
+    monkeypatch.setattr(service, "_mock_sis_verification", lambda *a: sis_result)
+    assert service._mock_verification("A123456783", "Test") is sis_result
+
+
+def test_mock_verification_falls_back_to_last_digit_when_sis_unavailable(service, monkeypatch):
+    """SIS mock unreachable (None) ⇒ the offline last-digit heuristic runs."""
+    monkeypatch.setattr(service, "_mock_sis_verification", lambda *a: None)
+    result = service._mock_verification("A123456787", "Test")
+    assert result["status"] == StudentVerificationStatus.GRADUATED
+
+
+# ─── _mock_sis_verification (std_studingstatus mapping) ──────────────
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def json(self):
+        return self._payload
+
+
+def _sis_payload(status, title=""):
+    return {
+        "code": 200,
+        "data": [
+            {
+                "std_stdcode": "T00",
+                "std_cname": "測試生",
+                "std_studingstatus": status,
+                "mgd_title": title,
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("sis_status", "expected"),
+    [
+        (1, StudentVerificationStatus.VERIFIED),
+        (2, StudentVerificationStatus.VERIFIED),
+        (3, StudentVerificationStatus.VERIFIED),
+        (4, StudentVerificationStatus.SUSPENDED),
+        (5, StudentVerificationStatus.WITHDRAWN),
+        (11, StudentVerificationStatus.GRADUATED),
+    ],
+)
+def test_sis_verification_status_mapping(service, monkeypatch, sis_status, expected):
+    monkeypatch.setattr(service.session, "post", lambda *a, **k: _FakeResponse(_sis_payload(sis_status)))
+    result = service._mock_sis_verification("T00", "測試生")
+    assert result["status"] == expected
+
+
+def test_sis_verification_unknown_status_uses_title(service, monkeypatch):
+    """Numeric status outside the map falls back to the Chinese title."""
+    monkeypatch.setattr(service.session, "post", lambda *a, **k: _FakeResponse(_sis_payload(99, "退學")))
+    result = service._mock_sis_verification("T00", "測試生")
+    assert result["status"] == StudentVerificationStatus.WITHDRAWN
+
+
+def test_sis_verification_missing_student_is_not_found(service, monkeypatch):
+    """SIS answering 'no such student' is definitive — NOT_FOUND, not fallback."""
+    monkeypatch.setattr(service.session, "post", lambda *a, **k: _FakeResponse({"code": 404, "data": []}))
+    result = service._mock_sis_verification("T00", "測試生")
+    assert result["status"] == StudentVerificationStatus.NOT_FOUND
+
+
+def test_sis_verification_unreachable_returns_none(service, monkeypatch):
+    """Connection error ⇒ None so the caller falls back to the heuristic."""
+
+    def _boom(*a, **k):
+        raise requests.ConnectionError("simulated outage")
+
+    monkeypatch.setattr(service.session, "post", _boom)
+    assert service._mock_sis_verification("T00", "測試生") is None
+
+
+# ─── _last_digit_mock_verification (offline fallback) ────────────────
+
+
+def test_last_digit_0_to_6_is_verified(service):
     """Last digit 0–6 ⇒ VERIFIED — most common path for happy-path tests."""
     for digit in range(7):
-        result = service._mock_verification(f"A12345678{digit}", "Test")
+        result = service._last_digit_mock_verification(f"A12345678{digit}", "Test")
         assert result["status"] == StudentVerificationStatus.VERIFIED, f"digit={digit}"
 
 
-def test_mock_verification_digit_7_is_graduated(service):
-    result = service._mock_verification("A123456787", "Test")
+def test_last_digit_7_is_graduated(service):
+    result = service._last_digit_mock_verification("A123456787", "Test")
     assert result["status"] == StudentVerificationStatus.GRADUATED
     assert "graduation_date" in result["student_info"]
 
 
-def test_mock_verification_digit_8_is_suspended(service):
-    result = service._mock_verification("A123456788", "Test")
+def test_last_digit_8_is_suspended(service):
+    result = service._last_digit_mock_verification("A123456788", "Test")
     assert result["status"] == StudentVerificationStatus.SUSPENDED
 
 
-def test_mock_verification_digit_9_is_withdrawn(service):
-    result = service._mock_verification("A123456789", "Test")
+def test_last_digit_9_is_withdrawn(service):
+    result = service._last_digit_mock_verification("A123456789", "Test")
     assert result["status"] == StudentVerificationStatus.WITHDRAWN
 
 
-def test_mock_verification_non_digit_treated_as_zero(service):
+def test_last_digit_non_digit_treated_as_zero(service):
     """If last char isn't a digit (corrupted ID), treat as 0 ⇒ VERIFIED.
     Defensive — don't crash if SIS hands us an ID ending in a letter."""
-    result = service._mock_verification("A12345678X", "Test")
+    result = service._last_digit_mock_verification("A12345678X", "Test")
     assert result["status"] == StudentVerificationStatus.VERIFIED
 
 
-def test_mock_verification_metadata_includes_last_digit(service):
+def test_last_digit_metadata_includes_last_digit(service):
     """The api_response dict carries the last_digit for debugging — pin
     the structure so future log analysis can rely on it."""
-    result = service._mock_verification("A123456783", "Test")
+    result = service._last_digit_mock_verification("A123456783", "Test")
     assert result["api_response"]["mock"] is True
     assert result["api_response"]["last_digit"] == 3
 


### PR DESCRIPTION
## 問題

`StudentVerificationService` mock 模式只看學號**末位數字**（≤6 通過、7 畢業、8 休學、9 退學），從不查 mock student API 的 `std_studingstatus`。dev 開啟造冊學籍驗證時：13 位在學生被判「畢業」、11 位被誤判休/退（共 24 位誤殺），真正的休/退學生只有在學號尾碼剛好對上時才被抓到。

## 修法

- 新增 `_mock_sis_verification`：POST mock student API `/ScholarshipStudent`，以 `std_studingstatus` 對照（1/2/3→VERIFIED、4→SUSPENDED、5/6→WITHDRAWN、11→GRADUATED），未知數字碼以 `mgd_title`（休/退/畢）推斷；查無學生回 NOT_FOUND（確定結果）
- SIS mock **不可用**（連線失敗）才退回原本的末位數字啟發式（保留離線可用性）
- 原始 `std_*` 欄位併入 `student_info`，造冊規則評估（fresh_api_data 只讀 std_/trm_ 鍵）可用新鮮資料
- 測試：原 6 個釘住末位行為的測試改測 fallback helper；新增 SIS 優先、狀態對照（6 組 parametrize）、title 推斷、NOT_FOUND、斷線 fallback 共 11 個測試

## 測試

- `pytest app/tests/test_student_verification_pure_helpers.py` 26 passed
- dev 實測：開驗證重造冊，誤殺 0（先前 24），只排除 SIS mock 真正標記休/退的 6 位學生

Fixes #1141