### PR TITLE
chore(mock): load git-ignored local student datasets when present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ frontend/junit.xml
 .claude/worktrees/
 # codegraph
 .codegraph/
+
+# Local-only mock student datasets (contain real-looking student IDs)
+mock-student-api/students_local.py

--- a/mock-student-api/main.py
+++ b/mock-student-api/main.py
@@ -5066,6 +5066,18 @@ SAMPLE_STUDENTS.update({c: _mk_summary_demo_student(c, e) for c, e in _SUMMARY_E
 SAMPLE_TERMS.update({c: _mk_summary_demo_terms(c, e) for c, e in _SUMMARY_EXPORT_DEMO.items()})
 # --- end demo students ------------------------------------------------------
 
+# --- optional local dataset (git-ignored) ------------------------------------
+# Merges extra students/terms from students_local.py when present, so datasets
+# with real-looking student IDs stay out of version control (see .gitignore).
+try:
+    from students_local import STUDENTS_LOCAL, TERMS_LOCAL
+
+    SAMPLE_STUDENTS.update(STUDENTS_LOCAL)
+    SAMPLE_TERMS.update(TERMS_LOCAL)
+except ImportError:
+    pass
+# --- end local dataset --------------------------------------------------------
+
 
 @app.get("/")
 async def root():


### PR DESCRIPTION
## 內容

mock-student-api 啟動時嘗試載入 `students_local.py`（已加入 .gitignore）的 `STUDENTS_LOCAL` / `TERMS_LOCAL` 併入 `SAMPLE_STUDENTS` / `SAMPLE_TERMS`。

讓 dev 可以掛大量「真實長相學號」的測試資料集（例：212 筆跨 16 學院的批次匯入測資）而不會把學號 commit 進版控；檔案不存在時無任何行為改變。dev compose 對 mock-student-api 是 bind mount + `--reload`，放入檔案即生效。