### PR TITLE
fix: flag 休學/退學 students at import precheck and roster eligibility

### DIFF
--- a/backend/alembic/versions/harden_enrollment_rule_001.py
+++ b/backend/alembic/versions/harden_enrollment_rule_001.py
@@ -1,0 +1,40 @@
+"""Make the 在學生身分 (trm_studystatus) rules hard (#1139)
+
+The PhD / direct-PhD "active student status" rule (trm_studystatus in 1,2,3)
+was seeded as a soft rule. Soft non-warning failures are silently swallowed
+by both the batch-import eligibility precheck and the roster eligibility
+gate, so 休學/退學 students flowed to payment rosters with no flag anywhere.
+Seed data is fixed alongside this migration; this backfills existing DBs.
+
+Revision ID: harden_enrollment_rule_001
+Revises: align_academy_names_001
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "harden_enrollment_rule_001"
+down_revision = "align_academy_names_001"
+branch_labels = None
+depends_on = None
+
+TABLE = "scholarship_rules"
+
+_WHERE = "condition_field = 'trm_studystatus' AND rule_name LIKE '%在學生身分%'"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if TABLE not in inspector.get_table_names():
+        return
+    bind.execute(sa.text(f"UPDATE {TABLE} SET is_hard_rule = true WHERE {_WHERE}"))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if TABLE not in inspector.get_table_names():
+        return
+    bind.execute(sa.text(f"UPDATE {TABLE} SET is_hard_rule = false WHERE {_WHERE}"))

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -364,7 +364,9 @@ async def seed_scholarship_rules(session: AsyncSession) -> None:
             "expected_value": "1,2,3",
             "message": "博士生獎學金需要在學生身分 1: 在學 2: 應畢 3: 延畢",
             "message_en": "PhD scholarship requires active student status",
-            "is_hard_rule": False,
+            # 硬性規則（#1139）：休學/退學（4/5）必須在匯入預檢與造冊資格
+            # 檢查中被標記，不可静默通過
+            "is_hard_rule": True,
             "is_warning": False,
             "priority": 2,
             "is_active": True,
@@ -558,7 +560,9 @@ async def seed_scholarship_rules(session: AsyncSession) -> None:
             "expected_value": "1,2,3",
             "message": "逕讀博士獎學金需要在學生身分 1: 在學 2: 應畢 3: 延畢",
             "message_en": "Direct PhD scholarship requires active student status",
-            "is_hard_rule": False,
+            # 硬性規則（#1139）：休學/退學（4/5）必須在匯入預檢與造冊資格
+            # 檢查中被標記，不可静默通過
+            "is_hard_rule": True,
             "is_warning": False,
             "priority": 2,
             "is_active": True,

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -1105,7 +1105,9 @@ class RosterService:
                 if not rule_result["passed"]:
                     if rule.is_hard_rule:
                         failed_rules.append(rule_result["message"])
-                    elif rule.is_warning:
+                    else:
+                        # 軟性規則失敗不影響 is_eligible，但必須留下紀錄，
+                        # 讓造冊 Excel 的資格欄位看得到（#1139）
                         warning_rules.append(rule_result["message"])
 
                 details[f"rule_{rule.id}"] = rule_result


### PR DESCRIPTION
## 問題

博士生/逕博的「在學生身分」規則（`trm_studystatus in 1,2,3`）種子設為**軟規則**（`is_hard_rule=False, is_warning=False`），而批次匯入資格預檢與造冊資格檢查**都只把硬規則計入失敗**——軟規則失敗被靜默吞掉。結果：休學/退學學生匯入時 0 警告，一路通過教授審核、學院排名、分發，最後以 `is_included=true` 列進付款造冊（dev 實測 2 休學＋4 退學拿到國科會名額且無任何 UI 標記）。

## 修法

- **seed + `harden_enrollment_rule_001` migration**：把兩條在學生身分規則改為硬規則（migration 補既有 DB；依 #1139 定調「修資料不修過濾器」）。匯入預覽因此出現「資格預檢未通過」警告（不影響匯入，人工把關），造冊資格檢查即使未開學籍驗證也會排除
- **roster `_validate_student_eligibility`**：軟規則失敗記入 `warning_rules`（不影響 is_eligible），讓造冊 Excel 資格欄位看得到

migration 接在 `align_academy_names_001`（#1149）之後。

## 測試

- `pytest app/tests -k "eligibility or batch_import or roster"` 全綠
- dev 實測（212 筆、5 休＋5 退＋3 延畢）：
  - 匯入預覽出現**剛好 10 個**警告（延畢 3 位正確不警告）
  - 造冊（預設、未開驗證）：6 位已分發的休/退學生被排除，原因「不符合獎學金規則: …在學生身分…」；126 合格 / 10 排除
  - 開啟學籍驗證（配合 #1147 的 SIS mock 修正）結果一致

Fixes #1139