### PR TITLE
fix: wrap roster preview college tabs instead of overflowing the card

### DIFF
--- a/frontend/components/roster/StudentRosterPreview.tsx
+++ b/frontend/components/roster/StudentRosterPreview.tsx
@@ -418,12 +418,10 @@ export function StudentRosterPreview({
         <CardContent>
           {data.has_matrix_distribution ? (
             <Tabs value={selectedCollege} onValueChange={setSelectedCollege}>
-              <TabsList
-                className="grid w-full"
-                style={{
-                  gridTemplateColumns: `repeat(${Object.keys(data.summary.by_college).length + 1}, 1fr)`,
-                }}
-              >
+              {/* flex-wrap（多列換行）：學院多時單列 grid 會把每欄壓到比
+                  min-content 還窄而水平溢出卡片（#1145）；h-auto 蓋掉基底
+                  TabsList 的固定 h-10 讓列高隨換行長高 */}
+              <TabsList className="flex h-auto w-full flex-wrap justify-start gap-1">
                 {Object.entries(data.summary.by_college).map(
                   ([college, stats]) => (
                     <TabsTrigger


### PR DESCRIPTION
## 問題

造冊管理 →「預計分發學生名單」的學院分頁列用單列 grid（`repeat(N+1, 1fr)`）排版，12 個學院＋「已排除學生」共 13 個分頁時，每欄被壓到比 min-content 還窄，整列**水平溢出卡片**（最左分頁凸出卡片左緣）。

## 修法（採多列換行）

`TabsList` 改為 `flex h-auto w-full flex-wrap justify-start gap-1`：

- `flex-wrap`：分頁塞不下時自動換行
- `h-auto`：蓋掉基底 TabsList 的固定 `h-10`，列高隨換行長高
- 移除 inline `gridTemplateColumns`

## 測試

dev 實測（博士生獎學金 114-整學年、12 學院＋已排除學生 13 個分頁）Playwright 量測：

- `scrollWidth == clientWidth`（無水平溢出）
- 分頁列高 80px（兩列換行），左右緣皆在卡片內
- 分頁切換、各學院清單、已排除學生列表行為不變

Fixes #1145