### PR TITLE
feat: show applied scholarships in admin student list with filters

### DIFF
--- a/backend/alembic/versions/20260712_add_applications_user_id_index.py
+++ b/backend/alembic/versions/20260712_add_applications_user_id_index.py
@@ -1,0 +1,61 @@
+"""add index on applications.user_id FK
+
+Revision ID: 20260712_app_user_idx
+Revises: harden_enrollment_rule_001
+Create Date: 2026-07-12
+
+applications.user_id is a foreign key with no plain index. PostgreSQL does not
+auto-index FKs, and the partial unique indexes leading with user_id
+(uq_user_renewal_app / uq_user_challenge_app / uq_user_pure_new_app) cannot
+serve arbitrary user_id lookups because of their WHERE predicates. Hot paths
+probing applications by user_id include the student application list and the
+admin student list's applied-scholarships aggregation / EXISTS filters.
+
+The index is created idempotently (skipped if already present) so the
+migration is safe to re-run on databases that already have it.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260712_app_user_idx"
+down_revision: Union[str, Sequence[str], None] = "harden_enrollment_rule_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+APP_USER_INDEX = "ix_applications_user_id"
+
+
+def upgrade() -> None:
+    """Create the applications.user_id index if it does not already exist."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if "applications" in existing_tables:
+        app_indexes = {i["name"] for i in inspector.get_indexes("applications")}
+        if APP_USER_INDEX not in app_indexes:
+            op.create_index(
+                APP_USER_INDEX,
+                "applications",
+                ["user_id"],
+                unique=False,
+            )
+
+
+def downgrade() -> None:
+    """Drop the applications.user_id index if present."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if "applications" in existing_tables:
+        app_indexes = {i["name"] for i in inspector.get_indexes("applications")}
+        if APP_USER_INDEX in app_indexes:
+            op.drop_index(APP_USER_INDEX, table_name="applications")

--- a/backend/app/api/v1/endpoints/admin/students.py
+++ b/backend/app/api/v1/endpoints/admin/students.py
@@ -88,7 +88,7 @@ def convert_student_to_dict(user: User, applied_scholarships: Optional[list[dict
         "college_code": user.college_code,
         "role": user.role.value if hasattr(user.role, "value") else str(user.role),
         "comment": user.comment,
-        "applied_scholarships": applied_scholarships or [],
+        "applied_scholarships": applied_scholarships if applied_scholarships is not None else [],
         "created_at": user.created_at.isoformat() if user.created_at else None,
         "updated_at": user.updated_at.isoformat() if user.updated_at else None,
         "last_login_at": user.last_login_at.isoformat() if user.last_login_at else None,

--- a/backend/app/api/v1/endpoints/admin/students.py
+++ b/backend/app/api/v1/endpoints/admin/students.py
@@ -11,6 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import require_admin
 from app.db.deps import get_db
+from app.models.application import Application
+from app.models.enums import ApplicationStatus
+from app.models.scholarship import ScholarshipType
 from app.models.user import EmployeeStatus, User, UserRole
 from app.services.student_service import StudentService
 
@@ -19,7 +22,59 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def convert_student_to_dict(user: User) -> dict:
+def applied_application_filters() -> list:
+    """Filter clauses for applications that count as "the student applied".
+
+    An application counts once the student has submitted it (draft = not yet
+    applied); soft-deleted rows and rows without a scholarship type link are
+    excluded. Shared by the list annotation and the scholarship filters so the
+    badges shown always match what the filters return.
+    """
+    return [
+        Application.deleted_at.is_(None),
+        Application.status.notin_([ApplicationStatus.draft, ApplicationStatus.deleted]),
+        Application.scholarship_type_id.isnot(None),
+    ]
+
+
+async def get_applied_scholarships_map(db: AsyncSession, user_ids: list[int]) -> dict[int, list[dict]]:
+    """Aggregate which scholarship types each user has applied for.
+
+    Returns {user_id: [{scholarship_type_id, code, name, application_count}]},
+    one entry per distinct scholarship type with the number of qualifying
+    applications (see applied_application_filters for what qualifies).
+    """
+    applied_map: dict[int, list[dict]] = {user_id: [] for user_id in user_ids}
+    if not user_ids:
+        return applied_map
+
+    stmt = (
+        select(
+            Application.user_id,
+            ScholarshipType.id,
+            ScholarshipType.code,
+            ScholarshipType.name,
+            func.count(Application.id),
+        )
+        .join(ScholarshipType, Application.scholarship_type_id == ScholarshipType.id)
+        .where(Application.user_id.in_(user_ids), *applied_application_filters())
+        .group_by(Application.user_id, ScholarshipType.id, ScholarshipType.code, ScholarshipType.name)
+        .order_by(ScholarshipType.id)
+    )
+    result = await db.execute(stmt)
+    for user_id, type_id, type_code, type_name, application_count in result.all():
+        applied_map[user_id].append(
+            {
+                "scholarship_type_id": type_id,
+                "code": type_code,
+                "name": type_name,
+                "application_count": application_count,
+            }
+        )
+    return applied_map
+
+
+def convert_student_to_dict(user: User, applied_scholarships: Optional[list[dict]] = None) -> dict:
     """Convert User model (student role) to dictionary"""
     return {
         "id": user.id,
@@ -33,6 +88,7 @@ def convert_student_to_dict(user: User) -> dict:
         "college_code": user.college_code,
         "role": user.role.value if hasattr(user.role, "value") else str(user.role),
         "comment": user.comment,
+        "applied_scholarships": applied_scholarships or [],
         "created_at": user.created_at.isoformat() if user.created_at else None,
         "updated_at": user.updated_at.isoformat() if user.updated_at else None,
         "last_login_at": user.last_login_at.isoformat() if user.last_login_at else None,
@@ -46,11 +102,21 @@ async def get_all_students(
     search: Optional[str] = Query(None, description="Search by name, email, or NYCU ID"),
     dept_code: Optional[str] = Query(None, description="Filter by department code"),
     status: Optional[str] = Query(None, description="Filter by status (在學/畢業)"),
+    scholarship_type_id: Optional[int] = Query(
+        None, description="Filter by scholarship type the student has applied for"
+    ),
+    has_application: Optional[bool] = Query(
+        None, description="Filter by whether the student has applied for any scholarship"
+    ),
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Get all students with pagination, search, and filters
+
+    Each student item includes applied_scholarships: the scholarship types the
+    student has submitted applications for (drafts and deleted applications
+    excluded), with per-type application counts.
 
     Requires admin or super_admin role.
     """
@@ -79,6 +145,24 @@ async def get_all_students(
         if status in valid_statuses:
             stmt = stmt.where(User.status == status)
 
+    # Apply scholarship application filters (EXISTS correlated on User.id)
+    if scholarship_type_id is not None:
+        stmt = stmt.where(
+            select(Application.id)
+            .where(
+                Application.user_id == User.id,
+                Application.scholarship_type_id == scholarship_type_id,
+                *applied_application_filters(),
+            )
+            .exists()
+        )
+
+    if has_application is not None:
+        any_application = (
+            select(Application.id).where(Application.user_id == User.id, *applied_application_filters()).exists()
+        )
+        stmt = stmt.where(any_application if has_application else ~any_application)
+
     # Get total count
     count_stmt = select(func.count()).select_from(stmt.subquery())
     result = await db.execute(count_stmt)
@@ -91,8 +175,11 @@ async def get_all_students(
     result = await db.execute(stmt)
     students = result.scalars().all()
 
+    # Annotate each student with the scholarships they have applied for
+    applied_map = await get_applied_scholarships_map(db, [student.id for student in students])
+
     # Convert to dict
-    student_list = [convert_student_to_dict(student) for student in students]
+    student_list = [convert_student_to_dict(student, applied_map.get(student.id, [])) for student in students]
 
     # Calculate total pages
     pages = (total + size - 1) // size if total > 0 else 0
@@ -205,10 +292,12 @@ async def get_student_detail(
         },
     )
 
+    applied_map = await get_applied_scholarships_map(db, [student.id])
+
     return {
         "success": True,
         "message": "Student detail retrieved successfully",
-        "data": convert_student_to_dict(student),
+        "data": convert_student_to_dict(student, applied_map.get(student.id, [])),
     }
 
 

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -257,6 +257,14 @@ class Application(Base):
             "ix_applications_scholarship_configuration_id",
             "scholarship_configuration_id",
         ),
+        # Plain index on the user FK — the partial unique indexes above lead
+        # with user_id but their WHERE predicates make them unusable for
+        # arbitrary per-user lookups (student application list, admin student
+        # list applied-scholarships aggregation).
+        Index(
+            "ix_applications_user_id",
+            "user_id",
+        ),
     )
 
     def __repr__(self):

--- a/backend/app/tests/test_admin_pure_helpers.py
+++ b/backend/app/tests/test_admin_pure_helpers.py
@@ -18,7 +18,7 @@ Two helpers tested here:
     cross-college data when it should be scoped, or (b) hide all
     data from super_admin when filter falsely fires.
 
-12 cases.
+14 cases.
 """
 
 from datetime import datetime
@@ -57,7 +57,7 @@ def _user(**overrides):
 
 
 def test_convert_returns_all_documented_keys():
-    # Pin: 13 keys in the response dict. If a column gets added
+    # Pin: 15 keys in the response dict. If a column gets added
     # to User the admin endpoint needs to add it here AND update
     # this test — the explicit count catches silent omissions.
     out = convert_student_to_dict(_user())
@@ -73,11 +73,26 @@ def test_convert_returns_all_documented_keys():
         "college_code",
         "role",
         "comment",
+        "applied_scholarships",
         "created_at",
         "updated_at",
         "last_login_at",
     }
     assert set(out.keys()) == expected_keys
+
+
+def test_convert_applied_scholarships_defaults_to_empty_list():
+    # Pin: omitted applied_scholarships → [] (not None). The admin
+    # student list frontend maps over this field unconditionally.
+    out = convert_student_to_dict(_user())
+    assert out["applied_scholarships"] == []
+
+
+def test_convert_applied_scholarships_passes_through():
+    # Pin: provided aggregation list is embedded verbatim.
+    applied = [{"scholarship_type_id": 1, "code": "phd", "name": "博士生獎學金", "application_count": 2}]
+    out = convert_student_to_dict(_user(), applied_scholarships=applied)
+    assert out["applied_scholarships"] == applied
 
 
 def test_convert_enums_emit_value_not_name():

--- a/backend/app/tests/test_admin_students_endpoint.py
+++ b/backend/app/tests/test_admin_students_endpoint.py
@@ -1,0 +1,247 @@
+"""Integration tests for GET /api/v1/admin/students applied-scholarships data + filters.
+
+Covers the admin student list additions:
+  - each item carries applied_scholarships (distinct scholarship types with
+    per-type application counts, drafts / deleted excluded)
+  - scholarship_type_id query filter (students who applied for that type)
+  - has_application query filter (true = applied for anything, false = nothing)
+
+Auth pattern follows test_admin_student_history_endpoint.py — overrides
+require_admin, uses the conftest `client` whose get_db override shares the
+in-memory SQLite session.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from app.models.application import Application, ApplicationStatus
+from app.models.scholarship import ScholarshipType
+from app.models.user import User, UserRole, UserType
+
+
+@pytest_asyncio.fixture
+async def authed_admin_client(client, admin_user):
+    """AsyncClient with require_admin overridden to return the mock admin_user."""
+    from app.core.security import require_admin
+    from app.main import app
+
+    async def override_require_admin():
+        return admin_user
+
+    app.dependency_overrides[require_admin] = override_require_admin
+    yield client
+    del app.dependency_overrides[require_admin]
+
+
+@pytest_asyncio.fixture
+async def seeded_students(client):
+    """Three students + two scholarship types + applications in every relevant state.
+
+    - applicant_multi: 2 qualifying applications for PHD (submitted + approved)
+      plus a draft for NSTC (must NOT count) and a soft-deleted PHD row
+      (must NOT count).
+    - applicant_single: 1 qualifying application for NSTC.
+    - non_applicant: no applications at all.
+    """
+    from app.db.deps import get_db
+    from app.main import app
+
+    db_gen = app.dependency_overrides[get_db]()
+    db = await db_gen.__anext__()
+
+    students = {}
+    for key, nycu_id, name in [
+        ("applicant_multi", "stu001", "多申請學生"),
+        ("applicant_single", "stu002", "單申請學生"),
+        ("non_applicant", "stu003", "未申請學生"),
+    ]:
+        user = User(
+            nycu_id=nycu_id,
+            name=name,
+            email=f"{nycu_id}@nycu.edu.tw",
+            user_type=UserType.student,
+            role=UserRole.student,
+        )
+        db.add(user)
+        students[key] = user
+    await db.commit()
+    for user in students.values():
+        await db.refresh(user)
+
+    phd = ScholarshipType(code="phd_test", name="博士生獎學金", description="Test")
+    nstc = ScholarshipType(code="nstc_test", name="國科會獎學金", description="Test")
+    db.add_all([phd, nstc])
+    await db.commit()
+    await db.refresh(phd)
+    await db.refresh(nstc)
+
+    now = datetime.now(timezone.utc)
+    applications = [
+        # applicant_multi: two qualifying PHD applications (different semesters
+        # to satisfy the per-(user, type, year, semester) unique indexes)
+        Application(
+            app_id="APP-113-1-00001",
+            user_id=students["applicant_multi"].id,
+            scholarship_type_id=phd.id,
+            status=ApplicationStatus.submitted.value,
+            academic_year=113,
+            semester="first",
+            sub_type_selection_mode="single",
+        ),
+        Application(
+            app_id="APP-113-2-00001",
+            user_id=students["applicant_multi"].id,
+            scholarship_type_id=phd.id,
+            status=ApplicationStatus.approved.value,
+            academic_year=113,
+            semester="second",
+            sub_type_selection_mode="single",
+        ),
+        # draft: must NOT count as applied
+        Application(
+            app_id="APP-113-1-00002",
+            user_id=students["applicant_multi"].id,
+            scholarship_type_id=nstc.id,
+            status=ApplicationStatus.draft.value,
+            academic_year=113,
+            semester="first",
+            sub_type_selection_mode="single",
+        ),
+        # soft-deleted: must NOT count as applied
+        Application(
+            app_id="APP-112-1-00001",
+            user_id=students["applicant_multi"].id,
+            scholarship_type_id=phd.id,
+            status=ApplicationStatus.rejected.value,
+            academic_year=112,
+            semester="first",
+            sub_type_selection_mode="single",
+            deleted_at=now,
+        ),
+        # applicant_single: one qualifying NSTC application
+        Application(
+            app_id="APP-113-1-00003",
+            user_id=students["applicant_single"].id,
+            scholarship_type_id=nstc.id,
+            status=ApplicationStatus.under_review.value,
+            academic_year=113,
+            semester="first",
+            sub_type_selection_mode="single",
+        ),
+    ]
+    db.add_all(applications)
+    await db.commit()
+
+    return {"students": students, "phd": phd, "nstc": nstc}
+
+
+def _items_by_nycu_id(body: dict) -> dict:
+    return {item["nycu_id"]: item for item in body["data"]["items"]}
+
+
+@pytest.mark.asyncio
+async def test_list_includes_applied_scholarships_aggregation(authed_admin_client, seeded_students):
+    """Every item has applied_scholarships; counts aggregate per type and
+    exclude drafts and soft-deleted applications."""
+    response = await authed_admin_client.get("/api/v1/admin/students")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    items = _items_by_nycu_id(body)
+    assert set(items.keys()) == {"stu001", "stu002", "stu003"}
+
+    phd = seeded_students["phd"]
+    nstc = seeded_students["nstc"]
+
+    # applicant_multi: only PHD counts (draft NSTC + soft-deleted PHD excluded);
+    # both qualifying PHD applications aggregate into one entry with count 2
+    multi = items["stu001"]["applied_scholarships"]
+    assert multi == [
+        {
+            "scholarship_type_id": phd.id,
+            "code": "phd_test",
+            "name": "博士生獎學金",
+            "application_count": 2,
+        }
+    ]
+
+    single = items["stu002"]["applied_scholarships"]
+    assert single == [
+        {
+            "scholarship_type_id": nstc.id,
+            "code": "nstc_test",
+            "name": "國科會獎學金",
+            "application_count": 1,
+        }
+    ]
+
+    assert items["stu003"]["applied_scholarships"] == []
+
+
+@pytest.mark.asyncio
+async def test_filter_by_scholarship_type_id(authed_admin_client, seeded_students):
+    """scholarship_type_id returns only students with a qualifying application
+    for that type — a draft does not qualify."""
+    phd = seeded_students["phd"]
+    nstc = seeded_students["nstc"]
+
+    response = await authed_admin_client.get("/api/v1/admin/students", params={"scholarship_type_id": phd.id})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["total"] == 1
+    assert set(_items_by_nycu_id(body).keys()) == {"stu001"}
+
+    # stu001's NSTC application is a draft → only stu002 matches NSTC
+    response = await authed_admin_client.get("/api/v1/admin/students", params={"scholarship_type_id": nstc.id})
+    body = response.json()
+    assert body["data"]["total"] == 1
+    assert set(_items_by_nycu_id(body).keys()) == {"stu002"}
+
+
+@pytest.mark.asyncio
+async def test_filter_has_application_true(authed_admin_client, seeded_students):
+    response = await authed_admin_client.get("/api/v1/admin/students", params={"has_application": "true"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["total"] == 2
+    assert set(_items_by_nycu_id(body).keys()) == {"stu001", "stu002"}
+
+
+@pytest.mark.asyncio
+async def test_filter_has_application_false(authed_admin_client, seeded_students):
+    """A student whose only applications are drafts/soft-deleted has not applied."""
+    response = await authed_admin_client.get("/api/v1/admin/students", params={"has_application": "false"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["total"] == 1
+    assert set(_items_by_nycu_id(body).keys()) == {"stu003"}
+
+
+@pytest.mark.asyncio
+async def test_scholarship_filter_combines_with_status_filter(authed_admin_client, seeded_students):
+    """Scholarship filters AND with the existing filters (nonexistent type → empty)."""
+    response = await authed_admin_client.get("/api/v1/admin/students", params={"scholarship_type_id": 999999})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]["total"] == 0
+    assert body["data"]["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_student_detail_includes_applied_scholarships(authed_admin_client, seeded_students):
+    """GET /{user_id} carries the same applied_scholarships shape."""
+    user_id = seeded_students["students"]["applicant_multi"].id
+    response = await authed_admin_client.get(f"/api/v1/admin/students/{user_id}")
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data["applied_scholarships"]) == 1
+    assert data["applied_scholarships"][0]["code"] == "phd_test"
+    assert data["applied_scholarships"][0]["application_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_returns_401_or_403(client):
+    response = await client.get("/api/v1/admin/students")
+    assert response.status_code in (401, 403)

--- a/backend/app/tests/test_admin_students_endpoint.py
+++ b/backend/app/tests/test_admin_students_endpoint.py
@@ -32,7 +32,7 @@ async def authed_admin_client(client, admin_user):
 
     app.dependency_overrides[require_admin] = override_require_admin
     yield client
-    del app.dependency_overrides[require_admin]
+    app.dependency_overrides.pop(require_admin, None)
 
 
 @pytest_asyncio.fixture

--- a/frontend/components/admin/students/StudentListManagement.tsx
+++ b/frontend/components/admin/students/StudentListManagement.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { logger } from "@/lib/utils/logger";
 import { apiClient } from "@/lib/api";
-import type { Student, StudentStats } from "@/lib/api";
+import type { ScholarshipType, Student, StudentStats } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -50,9 +50,17 @@ export function StudentListManagement() {
   const [search, setSearch] = useState("");
   const [deptFilter, setDeptFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
+  // "" = all, "any" = has some application, "none" = no application,
+  // numeric string = applied for that scholarship type id
+  const [scholarshipFilter, setScholarshipFilter] = useState("");
+  const [scholarshipTypes, setScholarshipTypes] = useState<ScholarshipType[]>([]);
 
   const [selectedStudent, setSelectedStudent] = useState<Student | null>(null);
   const [showDetailModal, setShowDetailModal] = useState(false);
+
+  // Bumped by 搜尋/清除 so the fetch effect reruns with the committed
+  // filter state (a direct fetchStudents() call would close over stale state)
+  const [refreshKey, setRefreshKey] = useState(0);
 
   // Fetch students
   const fetchStudents = async () => {
@@ -66,6 +74,8 @@ export function StudentListManagement() {
         search?: string;
         dept_code?: string;
         status?: string;
+        scholarship_type_id?: number;
+        has_application?: boolean;
       } = {
         page: pagination.page,
         size: pagination.size,
@@ -74,6 +84,13 @@ export function StudentListManagement() {
       if (search) params.search = search;
       if (deptFilter) params.dept_code = deptFilter;
       if (statusFilter) params.status = statusFilter;
+      if (scholarshipFilter === "any") {
+        params.has_application = true;
+      } else if (scholarshipFilter === "none") {
+        params.has_application = false;
+      } else if (scholarshipFilter) {
+        params.scholarship_type_id = Number(scholarshipFilter);
+      }
 
       // Use apiClient instead of direct fetch
       const response = await apiClient.students.getAll(params);
@@ -112,24 +129,43 @@ export function StudentListManagement() {
     }
   };
 
-  // Initial load
+  // Fetch scholarship types for the filter dropdown
+  const fetchScholarshipTypes = async () => {
+    try {
+      const response = await apiClient.scholarships.getAll();
+
+      if (response.success && response.data) {
+        setScholarshipTypes(response.data);
+      }
+    } catch (error) {
+      logger.error("獲取獎學金類型失敗", { error: error });
+    }
+  };
+
+  // Refetch on pagination change and on explicit search/clear
   useEffect(() => {
     fetchStudents();
+  }, [pagination.page, pagination.size, refreshKey]);
+
+  // Initial load
+  useEffect(() => {
     fetchStats();
-  }, [pagination.page, pagination.size]);
+    fetchScholarshipTypes();
+  }, []);
 
   // Search and filter handler
   const handleSearch = () => {
     setPagination((prev) => ({ ...prev, page: 1 }));
-    fetchStudents();
+    setRefreshKey((key) => key + 1);
   };
 
   const handleClearFilters = () => {
     setSearch("");
     setDeptFilter("");
     setStatusFilter("");
+    setScholarshipFilter("");
     setPagination((prev) => ({ ...prev, page: 1 }));
-    setTimeout(() => fetchStudents(), 0);
+    setRefreshKey((key) => key + 1);
   };
 
   const handleViewDetails = (student: Student) => {
@@ -251,6 +287,30 @@ export function StudentListManagement() {
               </Select>
             </div>
 
+            <div className="w-full md:w-56">
+              <Label htmlFor="scholarship">獎學金篩選</Label>
+              <Select
+                value={scholarshipFilter || "all"}
+                onValueChange={(value) =>
+                  setScholarshipFilter(value === "all" ? "" : value)
+                }
+              >
+                <SelectTrigger id="scholarship">
+                  <SelectValue placeholder="全部學生" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">全部學生</SelectItem>
+                  <SelectItem value="any">有申請獎學金</SelectItem>
+                  <SelectItem value="none">未申請獎學金</SelectItem>
+                  {scholarshipTypes.map((scholarship) => (
+                    <SelectItem key={scholarship.id} value={String(scholarship.id)}>
+                      {scholarship.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
             <div className="flex items-end gap-2">
               <Button onClick={handleSearch}>
                 <Search className="mr-2 h-4 w-4" />
@@ -289,6 +349,7 @@ export function StudentListManagement() {
                   <TableHead className="w-[200px]">信箱</TableHead>
                   <TableHead className="w-[150px]">系所</TableHead>
                   <TableHead className="w-[80px]">狀態</TableHead>
+                  <TableHead className="w-[200px]">申請獎學金</TableHead>
                   <TableHead className="w-[120px]">註冊時間</TableHead>
                   <TableHead className="w-[120px]">最後登入</TableHead>
                   <TableHead className="w-[100px]">操作</TableHead>
@@ -297,13 +358,13 @@ export function StudentListManagement() {
               <TableBody>
                 {loading ? (
                   <TableRow>
-                    <TableCell colSpan={8} className="text-center py-8">
+                    <TableCell colSpan={9} className="text-center py-8">
                       載入中...
                     </TableCell>
                   </TableRow>
                 ) : students.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={8} className="text-center py-8">
+                    <TableCell colSpan={9} className="text-center py-8">
                       沒有找到學生
                     </TableCell>
                   </TableRow>
@@ -317,6 +378,28 @@ export function StudentListManagement() {
                       <TableCell className="text-sm">{student.email}</TableCell>
                       <TableCell>{getDepartmentName(student.dept_code, departments)}</TableCell>
                       <TableCell>{getStatusBadge(student.status)}</TableCell>
+                      <TableCell>
+                        {student.applied_scholarships &&
+                        student.applied_scholarships.length > 0 ? (
+                          <div className="flex flex-wrap gap-1">
+                            {student.applied_scholarships.map((scholarship) => (
+                              <Badge
+                                key={scholarship.scholarship_type_id}
+                                variant="outline"
+                                className="text-xs"
+                              >
+                                {scholarship.name}
+                                {scholarship.application_count > 1 &&
+                                  ` ×${scholarship.application_count}`}
+                              </Badge>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-sm text-muted-foreground">
+                            未申請
+                          </span>
+                        )}
+                      </TableCell>
                       <TableCell className="text-sm">
                         {formatDate(student.created_at)}
                       </TableCell>

--- a/frontend/components/admin/students/StudentListManagement.tsx
+++ b/frontend/components/admin/students/StudentListManagement.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { logger } from "@/lib/utils/logger";
 import { apiClient } from "@/lib/api";
-import type { ScholarshipType, Student, StudentStats } from "@/lib/api";
+import type { Student, StudentStats } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -27,9 +27,12 @@ import { Label } from "@/components/ui/label";
 import { GraduationCap, Users, UserCheck, X, Search, Eye } from "lucide-react";
 import { StudentDetailModal } from "./StudentDetailModal";
 import { useReferenceData, getDepartmentName } from "@/hooks/use-reference-data";
+import { useScholarshipData } from "@/hooks/use-scholarship-data";
 
 export function StudentListManagement() {
   const { departments, isLoading: refDataLoading } = useReferenceData();
+  // Shared SWR-cached scholarship list, reused for the 獎學金篩選 dropdown
+  const { scholarships: scholarshipTypes } = useScholarshipData();
   const [students, setStudents] = useState<Student[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -53,7 +56,6 @@ export function StudentListManagement() {
   // "" = all, "any" = has some application, "none" = no application,
   // numeric string = applied for that scholarship type id
   const [scholarshipFilter, setScholarshipFilter] = useState("");
-  const [scholarshipTypes, setScholarshipTypes] = useState<ScholarshipType[]>([]);
 
   const [selectedStudent, setSelectedStudent] = useState<Student | null>(null);
   const [showDetailModal, setShowDetailModal] = useState(false);
@@ -129,19 +131,6 @@ export function StudentListManagement() {
     }
   };
 
-  // Fetch scholarship types for the filter dropdown
-  const fetchScholarshipTypes = async () => {
-    try {
-      const response = await apiClient.scholarships.getAll();
-
-      if (response.success && response.data) {
-        setScholarshipTypes(response.data);
-      }
-    } catch (error) {
-      logger.error("獲取獎學金類型失敗", { error: error });
-    }
-  };
-
   // Refetch on pagination change and on explicit search/clear
   useEffect(() => {
     fetchStudents();
@@ -150,7 +139,6 @@ export function StudentListManagement() {
   // Initial load
   useEffect(() => {
     fetchStats();
-    fetchScholarshipTypes();
   }, []);
 
   // Search and filter handler

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -2314,6 +2314,10 @@ export interface paths {
          * Get All Students
          * @description Get all students with pagination, search, and filters
          *
+         *     Each student item includes applied_scholarships: the scholarship types the
+         *     student has submitted applications for (drafts and deleted applications
+         *     excluded), with per-type application counts.
+         *
          *     Requires admin or super_admin role.
          */
         get: operations["get_all_students_api_v1_admin_students_get"];
@@ -15138,6 +15142,10 @@ export interface operations {
                 dept_code?: string | null;
                 /** @description Filter by status (在學/畢業) */
                 status?: string | null;
+                /** @description Filter by scholarship type the student has applied for */
+                scholarship_type_id?: number | null;
+                /** @description Filter by whether the student has applied for any scholarship */
+                has_application?: boolean | null;
             };
             header?: never;
             path?: never;

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -120,6 +120,7 @@ export type {
 
 // Re-export Students module types
 export type {
+  AppliedScholarship,
   Student,
   StudentStats,
   StudentSISBasicInfo,

--- a/frontend/lib/api/modules/__tests__/students.test.ts
+++ b/frontend/lib/api/modules/__tests__/students.test.ts
@@ -9,7 +9,7 @@
  * scope), query-filter shapes, and the SIS data sub-route
  * which fetches fresh upstream data.
  *
- * 9 cases.
+ * 10 cases.
  */
 
 import { createStudentsApi } from "../students";
@@ -37,8 +37,9 @@ describe("createStudentsApi", () => {
   // ─── getAll list with filters ──────────────────────────────────────
 
   it("getAll GETs /admin/students with all filters", async () => {
-    // Pin: 5 optional filters per docstring (page/size/search/
-    // dept_code/status). SNAKE_CASE preserved.
+    // Pin: 7 optional filters per docstring (page/size/search/
+    // dept_code/status/scholarship_type_id/has_application).
+    // SNAKE_CASE preserved.
     mockedRaw.GET.mockResolvedValueOnce(
       _ok({ items: [], total: 0, page: 1, size: 20, pages: 0 })
     );
@@ -49,6 +50,8 @@ describe("createStudentsApi", () => {
       search: "wang",
       dept_code: "4460",
       status: "在學",
+      scholarship_type_id: 3,
+      has_application: true,
     });
     expect(mockedRaw.GET).toHaveBeenCalledWith("/api/v1/admin/students", {
       params: {
@@ -58,9 +61,25 @@ describe("createStudentsApi", () => {
           search: "wang",
           dept_code: "4460",
           status: "在學",
+          scholarship_type_id: 3,
+          has_application: true,
         },
       },
     });
+  });
+
+  it("getAll passes has_application=false through (not dropped as falsy)", async () => {
+    // Pin: `false` filters students who applied for NOTHING —
+    // a falsy-check refactor dropping it would silently turn
+    // the 未申請 filter into no filter at all.
+    mockedRaw.GET.mockResolvedValueOnce(
+      _ok({ items: [], total: 0, page: 1, size: 20, pages: 0 })
+    );
+    const api = createStudentsApi();
+    await api.getAll({ has_application: false });
+    expect(mockedRaw.GET.mock.calls[0][1].params.query.has_application).toBe(
+      false
+    );
   });
 
   it("getAll forwards undefined query when no params", async () => {

--- a/frontend/lib/api/modules/students.ts
+++ b/frontend/lib/api/modules/students.ts
@@ -23,6 +23,13 @@ type PaginatedResponse<T> = {
   pages: number;
 };
 
+export type AppliedScholarship = {
+  scholarship_type_id: number;
+  code: string;
+  name: string;
+  application_count: number;
+};
+
 export type Student = {
   id: number;
   nycu_id: string;
@@ -34,6 +41,7 @@ export type Student = {
   dept_name?: string;
   college_code?: string;
   comment?: string;
+  applied_scholarships?: AppliedScholarship[];
   created_at: string;
   updated_at?: string;
   last_login_at?: string;
@@ -92,6 +100,8 @@ export function createStudentsApi() {
      * @param params.search - Search by name, email, or NYCU ID
      * @param params.dept_code - Filter by department code
      * @param params.status - Filter by status (在學/畢業)
+     * @param params.scholarship_type_id - Filter by scholarship type the student has applied for
+     * @param params.has_application - Filter by whether the student has applied for any scholarship
      */
     getAll: async (params?: {
       page?: number;
@@ -99,6 +109,8 @@ export function createStudentsApi() {
       search?: string;
       dept_code?: string;
       status?: string;
+      scholarship_type_id?: number;
+      has_application?: boolean;
     }): Promise<ApiResponse<PaginatedResponse<Student>>> => {
       const response = await typedClient.raw.GET('/api/v1/admin/students', {
         params: { query: params },


### PR DESCRIPTION
## 概要 (Summary)

管理員的學生列表新增「申請獎學金」欄位與篩選功能：每位學生會顯示其已申請的獎學金類型（含各類型申請次數），並可依獎學金篩選學生。

Admin student list (`GET /api/v1/admin/students`) now annotates each student with the scholarship types they've submitted applications for, and adds two filters so admins can slice the list by scholarship.

## 變更內容 (What changed)

### Backend
- **`applied_scholarships` per student** — each list item (and the `/{user_id}` detail) carries the distinct scholarship types the student has submitted applications for, each with `scholarship_type_id`, `code`, `name`, and `application_count`. Drafts, `deleted`-status and soft-deleted (`deleted_at`) applications are excluded via a shared filter helper (`applied_application_filters`) so the badges always match what the filters return. The aggregation is a single `GROUP BY` query over the page's user IDs — no N+1.
- **Two new query filters**, implemented as correlated `EXISTS` subqueries:
  - `scholarship_type_id` (int) — students who applied for that scholarship type
  - `has_application` (bool) — students who applied for any (`true`) / no (`false`) scholarship
- **`ix_applications_user_id`** — the `applications.user_id` FK had no plain index (the partial unique indexes' `WHERE` predicates make them unusable for arbitrary per-user lookups). Added to the model `__table_args__` plus an idempotent migration, following the repo's existing FK-index convention.

### Frontend
- New **申請獎學金** badge column in `StudentListManagement` (shows `×N` when a student has multiple applications for the same type, 未申請 otherwise).
- New **獎學金篩選** dropdown (全部學生 / 有申請獎學金 / 未申請獎學金 / each scholarship type), sourced from the shared SWR-cached `useScholarshipData()` hook.
- Fixed a pre-existing stale-closure bug: 清除 previously refetched via `setTimeout` closing over pre-clear filter state, so it didn't actually clear results. Both 搜尋 and 清除 now trigger the fetch through a `refreshKey` effect that always sees committed state.
- Regenerated `schema.d.ts` (verified the pipeline reproduces the committed file byte-for-byte before the change, so the diff is exactly the two new query params).

## 測試 (Test plan)

- [x] 7 backend integration tests (`test_admin_students_endpoint.py`): aggregation, both filters, draft/soft-deleted exclusion, detail endpoint — pass locally
- [x] Updated `test_admin_pure_helpers.py` pins for the new `applied_scholarships` key
- [x] 10 frontend jest tests (`students.test.ts`), including a pin that `has_application: false` isn't dropped as falsy
- [x] `tsc`, `eslint`, backend `black` + `flake8 B904/B014` clean; Alembic single head
- [ ] Manual smoke on localhost admin student list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
