### PR TITLE
fix: bucket professor review queue by review existence, not status

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -37,7 +37,6 @@ from app.services.eligibility_service import EligibilityService
 from app.services.email_automation_service import email_automation_service
 from app.services.email_service import EmailService
 from app.services.minio_service import minio_service
-from app.services.review_phase_filter import apply_renewal_phase_filter
 from app.services.student_service import StudentService
 from app.utils.phone_validation import (
     TAIWAN_MOBILE_MESSAGE,
@@ -2376,6 +2375,16 @@ class ApplicationService:
         return document_type_names.get(file_type, file_type)
 
     # Professor Review Methods
+    @staticmethod
+    def _professor_reviewed(professor_id: int):
+        """Correlated predicate: this professor authored an ApplicationReview for the row.
+
+        Shared by the professor queue (:meth:`get_professor_applications_paginated`)
+        and the dashboard badge (:meth:`get_professor_review_stats`) so the
+        "has this professor reviewed?" split cannot drift between the two.
+        """
+        return Application.reviews.any(ApplicationReview.reviewer_id == professor_id)
+
     async def get_professor_applications_paginated(
         self,
         professor_id: int,
@@ -2422,32 +2431,24 @@ class ApplicationService:
                 )
             )
 
-            # Apply status filter to base query
+            # Discriminate pending vs completed by whether THIS professor has
+            # already recorded a review, NOT by Application.status.
+            #
+            # Status is unreliable here: a professor "approve" on a scholarship
+            # that requires college review deliberately keeps status at
+            # under_review (issue #182), so a status-based "pending" filter kept
+            # showing applications the professor had already reviewed. The only
+            # sound signal that the professor is done is the existence of an
+            # ApplicationReview row authored by them.
+            reviewed_by_me = self._professor_reviewed(professor_id)
+
             if status_filter == "pending":
-                base_query = base_query.where(
-                    Application.status.in_(
-                        [
-                            ApplicationStatus.submitted.value,
-                            ApplicationStatus.under_review.value,  # Include under_review in pending
-                        ]
-                    )
-                )
-                # Phase 4 (renewal routing): pending professor lists must only
-                # include applications matching the *current* review phase —
-                # renewal apps during the renewal_professor_review window,
-                # non-renewal apps during the general professor_review window.
-                base_query = apply_renewal_phase_filter(base_query, role="professor", alias_name="prof_phase_cfg")
+                # 待審核 — assigned to me but I have not reviewed yet.
+                base_query = base_query.where(~reviewed_by_me)
             elif status_filter == "completed":
-                base_query = base_query.where(
-                    Application.status.in_(
-                        [
-                            ApplicationStatus.approved.value,
-                            ApplicationStatus.partial_approved.value,
-                            ApplicationStatus.rejected.value,
-                        ]
-                    )
-                )
-            # "all" or None shows all applications (no additional status filter)
+                # 已完成 — assigned to me and I have already reviewed.
+                base_query = base_query.where(reviewed_by_me)
+            # "all" or None → 全部 = 待審核 + 已完成 (no review-existence filter)
 
             # Get total count with same filters
             count_query = select(func.count()).select_from(base_query.subquery())
@@ -2684,8 +2685,6 @@ class ApplicationService:
           surfacing it here would require a join on
           ScholarshipConfiguration.professor_review_end_date)
         """
-        already_reviewed = select(ApplicationReview.application_id).where(ApplicationReview.reviewer_id == professor_id)
-
         pending_query = select(sa_func.count(Application.id)).where(
             Application.professor_id == professor_id,
             Application.status.in_(
@@ -2694,7 +2693,7 @@ class ApplicationService:
                     ApplicationStatus.under_review.value,
                 ]
             ),
-            Application.id.not_in(already_reviewed),
+            ~self._professor_reviewed(professor_id),
         )
 
         completed_query = select(sa_func.count(ApplicationReview.id)).where(

--- a/backend/app/services/college_review_service.py
+++ b/backend/app/services/college_review_service.py
@@ -306,8 +306,8 @@ class CollegeReviewService:
         # application was invisible to the college. We intentionally drop that
         # gate here: pending (submitted / under_review) and historical (approved /
         # partial_approved / rejected) rows are all shown, scoped to the college
-        # by the ``college_code`` filter below. The professor listing keeps its
-        # own renewal-phase filter — only college visibility is broadened.
+        # by the ``college_code`` filter below. The professor listing likewise no
+        # longer phase-gates; it buckets by whether the professor has reviewed.
         stmt = (
             select(Application)
             .options(

--- a/backend/app/tests/test_get_professor_applications_paginated_deep.py
+++ b/backend/app/tests/test_get_professor_applications_paginated_deep.py
@@ -10,8 +10,9 @@ Contract pinned (6 cases):
 - Base filter: only applications assigned to the calling professor.
 - Base filter: only statuses in {submitted, under_review, approved,
   partial_approved, rejected}; drafts are excluded.
-- status_filter='pending' narrows to {submitted, under_review}.
-- status_filter='completed' narrows to {approved, partial_approved, rejected}.
+- status_filter='pending' → applications this professor has NOT reviewed yet
+  (no ApplicationReview row authored by them), regardless of Application.status.
+- status_filter='completed' → applications this professor HAS reviewed.
 - Pagination: page=2, size=2 returns rows 3-4 of an ordered set; total
   count reflects the full filtered set, not the page.
 - No implicit cap: the default call (size omitted) returns EVERY assigned
@@ -25,9 +26,24 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.application import Application, ApplicationStatus
+from app.models.review import ApplicationReview
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User, UserRole, UserType
 from app.services.application_service import ApplicationService
+
+
+async def _seed_review(db: AsyncSession, *, application: Application, reviewer_id: int) -> ApplicationReview:
+    """Record a professor review for ``application`` — the signal that moves it
+    from 待審核 (pending) to 已完成 (completed)."""
+    review = ApplicationReview(
+        application_id=application.id,
+        reviewer_id=reviewer_id,
+        recommendation="approve",
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    db.add(review)
+    await db.commit()
+    return review
 
 
 async def _seed_user(db: AsyncSession, *, role: UserRole, nycu_id: str) -> User:
@@ -56,9 +72,8 @@ async def _seed_config(db: AsyncSession, *, requires_prof: bool, suffix: str) ->
         academic_year=114,
         application_start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         application_end_date=datetime(2030, 1, 1, tzinfo=timezone.utc),
-        # The "pending" professor queue overlays a review-phase filter that
-        # requires an open professor-review window; without these the renewal
-        # phase filter excludes every row (total=0).
+        # Review windows are retained for realism, but the professor queue no
+        # longer phase-gates — it buckets by whether the professor has reviewed.
         professor_review_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
         professor_review_end=datetime(2030, 1, 1, tzinfo=timezone.utc),
         requires_professor_recommendation=requires_prof,
@@ -181,42 +196,57 @@ async def test_excludes_drafts(db: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_status_filter_pending_narrows_to_submitted_and_under_review(db: AsyncSession):
+async def test_status_filter_pending_is_apps_without_professor_review(db: AsyncSession):
+    """pending = assigned apps this professor has NOT reviewed yet — independent
+    of Application.status. A professor-approved app whose scholarship requires
+    college review stays at under_review (issue #182) but must NOT appear in
+    pending once the review row exists."""
     student = await _seed_user(db, role=UserRole.student, nycu_id="profpag_stu_pending")
     prof = await _seed_user(db, role=UserRole.professor, nycu_id="profpag_prof_pending")
     cfg = await _seed_config(db, requires_prof=True, suffix="pending")
 
+    # Two apps left un-reviewed → pending.
     await _seed_app(
         db, student=student, config=cfg, status=ApplicationStatus.submitted.value, professor_id=prof.id, suffix="p1"
     )
     await _seed_app(
         db, student=student, config=cfg, status=ApplicationStatus.under_review.value, professor_id=prof.id, suffix="p2"
     )
-    await _seed_app(
-        db, student=student, config=cfg, status=ApplicationStatus.approved.value, professor_id=prof.id, suffix="p3"
+    # Two apps the professor already reviewed (still under_review) → NOT pending.
+    reviewed_a = await _seed_app(
+        db, student=student, config=cfg, status=ApplicationStatus.under_review.value, professor_id=prof.id, suffix="p3"
     )
-    await _seed_app(
-        db, student=student, config=cfg, status=ApplicationStatus.rejected.value, professor_id=prof.id, suffix="p4"
+    reviewed_b = await _seed_app(
+        db, student=student, config=cfg, status=ApplicationStatus.approved.value, professor_id=prof.id, suffix="p4"
     )
+    await _seed_review(db, application=reviewed_a, reviewer_id=prof.id)
+    await _seed_review(db, application=reviewed_b, reviewer_id=prof.id)
 
     service = ApplicationService(db)
     apps, total = await service.get_professor_applications_paginated(professor_id=prof.id, status_filter="pending")
     assert total == 2
+    returned = {a.id for a in apps}
+    assert reviewed_a.id not in returned
+    assert reviewed_b.id not in returned
 
 
 @pytest.mark.asyncio
-async def test_status_filter_completed_narrows_to_approved_partial_rejected(db: AsyncSession):
+async def test_status_filter_completed_is_apps_with_professor_review(db: AsyncSession):
+    """completed = assigned apps this professor HAS reviewed — independent of
+    Application.status."""
     student = await _seed_user(db, role=UserRole.student, nycu_id="profpag_stu_done")
     prof = await _seed_user(db, role=UserRole.professor, nycu_id="profpag_prof_done")
     cfg = await _seed_config(db, requires_prof=True, suffix="done")
 
+    # Un-reviewed → NOT completed.
     await _seed_app(
         db, student=student, config=cfg, status=ApplicationStatus.submitted.value, professor_id=prof.id, suffix="d1"
     )
-    await _seed_app(
-        db, student=student, config=cfg, status=ApplicationStatus.approved.value, professor_id=prof.id, suffix="d2"
+    # Three reviewed apps spanning different statuses → all completed.
+    r1 = await _seed_app(
+        db, student=student, config=cfg, status=ApplicationStatus.under_review.value, professor_id=prof.id, suffix="d2"
     )
-    await _seed_app(
+    r2 = await _seed_app(
         db,
         student=student,
         config=cfg,
@@ -224,13 +254,16 @@ async def test_status_filter_completed_narrows_to_approved_partial_rejected(db: 
         professor_id=prof.id,
         suffix="d3",
     )
-    await _seed_app(
+    r3 = await _seed_app(
         db, student=student, config=cfg, status=ApplicationStatus.rejected.value, professor_id=prof.id, suffix="d4"
     )
+    for app in (r1, r2, r3):
+        await _seed_review(db, application=app, reviewer_id=prof.id)
 
     service = ApplicationService(db)
     apps, total = await service.get_professor_applications_paginated(professor_id=prof.id, status_filter="completed")
     assert total == 3
+    assert {a.id for a in apps} == {r1.id, r2.id, r3.id}
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_review_routing_renewal.py
+++ b/backend/app/tests/test_review_routing_renewal.py
@@ -383,29 +383,40 @@ async def test_college_sees_only_general_during_general_period(
 
 
 @pytest.mark.asyncio
-async def test_application_service_pending_list_filters_by_renewal_phase(
+async def test_application_service_pending_list_splits_by_professor_review_existence(
     db: AsyncSession,
     test_user: User,
     test_scholarship: ScholarshipType,
     test_professor: User,
 ):
     """End-to-end check that ApplicationService.get_professor_applications_paginated
-    with status_filter='pending' applies the renewal-phase filter.
+    buckets applications by whether THIS professor has already reviewed them,
+    not by Application.status or the renewal review phase.
 
-    Setup: config currently in its renewal_professor_review window.
-    Expectation: the renewal app is returned; the general app is hidden.
+    The professor listing no longer applies apply_renewal_phase_filter: a
+    professor "approve" on a requires-college scholarship keeps status at
+    under_review (issue #182), so status-based bucketing kept already-reviewed
+    apps in 待審核. The sound signal is the existence of an ApplicationReview
+    row authored by the professor.
+
+    Expectation:
+      - pending   → only apps with NO review by this professor
+      - completed → only apps the professor has already reviewed
+      - all/None  → 全部 = pending + completed (every assigned app)
     """
+    from app.models.review import ApplicationReview
     from app.services.application_service import ApplicationService
 
+    # Config sits in its renewal window (general window in the future). Under the
+    # old phase gate the general app would have been hidden from pending — it must
+    # now surface because phase gating is gone.
     config = _make_config_in_renewal_phase(test_scholarship.id, role="professor", config_code="SVC-PROF-RENEW")
-    # Mark the configuration as requiring professor recommendation so the
-    # existing service filter doesn't drop these rows for an unrelated reason.
     config.requires_professor_recommendation = True
     db.add(config)
     await db.commit()
     await db.refresh(config)
 
-    renewal_app = await _make_pending_application(
+    reviewed_app = await _make_pending_application(
         db,
         user=test_user,
         scholarship_type=test_scholarship,
@@ -413,7 +424,7 @@ async def test_application_service_pending_list_filters_by_renewal_phase(
         is_renewal=True,
         app_id_suffix="00051",
     )
-    general_app = await _make_pending_application(
+    unreviewed_app = await _make_pending_application(
         db,
         user=test_user,
         scholarship_type=test_scholarship,
@@ -421,24 +432,45 @@ async def test_application_service_pending_list_filters_by_renewal_phase(
         is_renewal=False,
         app_id_suffix="00052",
     )
-    # Both applications must be assigned to the professor so they pass the
-    # existing professor_id filter.
-    renewal_app.professor_id = test_professor.id
-    general_app.professor_id = test_professor.id
+    reviewed_app.professor_id = test_professor.id
+    unreviewed_app.professor_id = test_professor.id
+
+    # Record a professor review for one app only. Its status stays under_review
+    # (mirrors the issue #182 behaviour) yet it must count as 已完成.
+    db.add(
+        ApplicationReview(
+            application_id=reviewed_app.id,
+            reviewer_id=test_professor.id,
+            recommendation="approve",
+            reviewed_at=datetime.now(timezone.utc),
+        )
+    )
     await db.commit()
 
     service = ApplicationService(db)
-    applications, total_count = await service.get_professor_applications_paginated(
-        professor_id=test_professor.id,
-        status_filter="pending",
-        page=1,
-        size=20,
-    )
 
-    returned_ids = {a.id for a in applications}
-    assert renewal_app.id in returned_ids, "renewal app should be visible during renewal phase"
-    assert general_app.id not in returned_ids, "general app should be filtered out during renewal phase"
-    assert total_count == 1
+    pending, pending_total = await service.get_professor_applications_paginated(
+        professor_id=test_professor.id, status_filter="pending", page=1, size=20
+    )
+    pending_ids = {a.id for a in pending}
+    assert unreviewed_app.id in pending_ids, "un-reviewed app must be in 待審核"
+    assert reviewed_app.id not in pending_ids, "reviewed app must NOT be in 待審核 despite under_review status"
+    assert pending_total == 1
+
+    completed, completed_total = await service.get_professor_applications_paginated(
+        professor_id=test_professor.id, status_filter="completed", page=1, size=20
+    )
+    completed_ids = {a.id for a in completed}
+    assert reviewed_app.id in completed_ids, "reviewed app must be in 已完成"
+    assert unreviewed_app.id not in completed_ids, "un-reviewed app must NOT be in 已完成"
+    assert completed_total == 1
+
+    all_apps, all_total = await service.get_professor_applications_paginated(
+        professor_id=test_professor.id, status_filter="all", page=1, size=20
+    )
+    all_ids = {a.id for a in all_apps}
+    assert all_ids == {reviewed_app.id, unreviewed_app.id}, "全部 must equal 待審核 + 已完成"
+    assert all_total == pending_total + completed_total
 
 
 @pytest.mark.asyncio
@@ -455,8 +487,8 @@ async def test_college_service_pending_list_shows_all_regardless_of_phase(
     「學院端應該要可以看到隸屬於該學院的所有申請，即使還卡在教授審核的階段」.
     The college listing is no longer time-gated, so both the renewal and the
     general pending apps surface even while only the renewal_college_review
-    window is open. The professor listing keeps its own phase filter (see the
-    professor test above), which is unchanged.
+    window is open. The professor listing likewise no longer phase-gates — it
+    buckets by professor-review existence (see the service test above).
     """
     from app.services.college_review_service import CollegeReviewService
 


### PR DESCRIPTION
## Problem

On the professor **獎學金申請審查** page, the 待審核 / 已完成 / 全部 filter bucketed applications by `Application.status`. But a professor's review does **not** reliably change the status — an "approve" on a scholarship that `requires_college_review` deliberately keeps the app at `under_review` (issue #182). Consequences:

- An application the professor **already reviewed** stayed stuck in **待審核**.
- **已完成** missed those same applications.
- **全部** was not the union 待審核 + 已完成 (only the pending branch also ran `apply_renewal_phase_filter`).

## Fix

Bucket by whether **this professor has an `ApplicationReview` row**, not by status:

| Filter | Meaning |
|--------|---------|
| 待審核 (pending) | assigned to me & I have **not** reviewed yet |
| 已完成 (completed) | assigned to me & I **have** reviewed |
| 全部 (all) | 待審核 + 已完成 (no review-existence filter) |

- Dropped the renewal-phase gate from the professor queue (matching the college listing, which dropped it earlier) so `全部 = 待審核 + 已完成` holds and review history isn't hidden once a window closes.
- Extracted the "has this professor reviewed?" predicate into one shared `_professor_reviewed()` helper (relationship-based `Application.reviews.any(...)`), used by both the queue and the dashboard badge (`get_professor_review_stats`) so they can't drift on that predicate.

## Test plan

- [x] `test_review_routing_renewal.py` — rewritten to pin: reviewed-but-`under_review` app → 已完成 not 待審核; `全部 = 待審核 + 已完成`.
- [x] `test_get_professor_applications_paginated_deep.py` — pending = un-reviewed, completed = reviewed, independent of status.
- [x] `test_professor_review_stats.py` — unchanged, still green (stats SQL swap is behavior-preserving).
- [x] `black` + `flake8` (B904/B014/F401) clean.

## Follow-ups (not in this PR)

- `get_professor_review_stats` guards pending to `{submitted, under_review}` while the list spans `REVIEWABLE_APPLICATION_STATUSES`; an un-reviewed *terminal-status* app shows in the queue but not the badge. Reconciling shifts a visible count — deliberate decision needed.
- `review_phase_filter.py` now has zero production callers (test-only); candidate for deletion.