### PR TITLE
fix: show professor-centric 待審核/已審核 status in professor review list

### DIFF
--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -650,6 +650,10 @@ class ApplicationListResponse(BaseModel):
     # Admin toggle (ScholarshipConfiguration.allow_college_view_distribution):
     # the student timeline's final step is only checked once this is opened
     allow_college_view_distribution: bool = False
+    # Professor-centric review status for the professor queue: True once the
+    # viewing professor has an ApplicationReview row for this application.
+    # None for endpoints/roles where "the professor" is not defined.
+    has_professor_reviewed: Optional[bool] = None
 
     @property
     def is_editable(self) -> bool:

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2406,6 +2406,7 @@ class ApplicationService:
                         ScholarshipConfiguration.scholarship_type
                     ),
                     selectinload(Application.student),
+                    selectinload(Application.reviews),
                 )
                 .join(Application.scholarship_configuration)
                 .where(
@@ -2530,6 +2531,9 @@ class ApplicationService:
                             if app.scholarship_configuration
                             else None
                         ),
+                        # Professor-centric review status: has THIS professor
+                        # recorded a review? Mirrors the pending/completed split.
+                        has_professor_reviewed=any(review.reviewer_id == professor_id for review in app.reviews),
                     )
                 )
 

--- a/backend/app/tests/test_get_professor_applications_paginated_deep.py
+++ b/backend/app/tests/test_get_professor_applications_paginated_deep.py
@@ -267,6 +267,30 @@ async def test_status_filter_completed_is_apps_with_professor_review(db: AsyncSe
 
 
 @pytest.mark.asyncio
+async def test_has_professor_reviewed_flag_reflects_review_existence(db: AsyncSession):
+    """The response's has_professor_reviewed flag drives the 待審核/已審核 status
+    badge, so it must be True exactly for apps this professor has reviewed —
+    including a reviewed app still sitting at under_review (issue #182)."""
+    student = await _seed_user(db, role=UserRole.student, nycu_id="profpag_stu_flag")
+    prof = await _seed_user(db, role=UserRole.professor, nycu_id="profpag_prof_flag")
+    cfg = await _seed_config(db, requires_prof=True, suffix="flag")
+
+    unreviewed = await _seed_app(
+        db, student=student, config=cfg, status=ApplicationStatus.under_review.value, professor_id=prof.id, suffix="f1"
+    )
+    reviewed = await _seed_app(
+        db, student=student, config=cfg, status=ApplicationStatus.under_review.value, professor_id=prof.id, suffix="f2"
+    )
+    await _seed_review(db, application=reviewed, reviewer_id=prof.id)
+
+    service = ApplicationService(db)
+    apps, _ = await service.get_professor_applications_paginated(professor_id=prof.id, status_filter="all")
+    flag_by_id = {a.id: a.has_professor_reviewed for a in apps}
+    assert flag_by_id[reviewed.id] is True
+    assert flag_by_id[unreviewed.id] is False
+
+
+@pytest.mark.asyncio
 async def test_pagination_returns_correct_slice_and_total(db: AsyncSession):
     """page=2, size=2 returns rows 3-4. total_count reflects the full filtered set."""
     student = await _seed_user(db, role=UserRole.student, nycu_id="profpag_stu_page")

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -249,26 +249,18 @@ function ProfessorReviewComponentInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reviewModalOpen, subTypes, reviewData.items.length]);
 
-  // Render the professor-centric 狀態 badges for a queue row.
+  // Render the professor-centric 狀態 badge for a queue row.
   //
   // The queue is bucketed by whether THIS professor has reviewed (待審核 vs
-  // 已完成), so the status column shows that same signal — 待審核 / 已審核 —
-  // rather than the global application status (which stays 審批中 while a
-  // reviewed app waits for the college, and would look unfinished here).
-  // A secondary badge surfaces the downstream stage (學院/管理員/造冊…) so the
-  // professor can still see where the application went after them.
-  const renderReviewStatusBadges = (app: Application) => {
+  // 已完成), so the status column shows only that same signal — 待審核 / 已審核.
+  // Downstream stages (學院/管理員/配額分發…) are intentionally NOT shown here:
+  // the professor only cares about their own step.
+  const renderReviewStatusBadge = (app: Application) => {
     const reviewed = app.has_professor_reviewed === true;
-    const downstreamLabel = app.review_stage
-      ? STAGE_LABEL_ZH[app.review_stage]
-      : undefined;
     return (
-      <>
-        <Badge variant={reviewed ? "default" : "secondary"}>
-          {reviewed ? "已審核" : "待審核"}
-        </Badge>
-        {downstreamLabel && <Badge variant="outline">{downstreamLabel}</Badge>}
-      </>
+      <Badge variant={reviewed ? "default" : "secondary"}>
+        {reviewed ? "已審核" : "待審核"}
+      </Badge>
     );
   };
 
@@ -661,7 +653,7 @@ function ProfessorReviewComponentInner({
                             </TableCell>
                             <TableCell>
                               <div className="flex gap-2">
-                                {renderReviewStatusBadges(app)}
+                                {renderReviewStatusBadge(app)}
                               </div>
                             </TableCell>
                             <TableCell>
@@ -700,7 +692,7 @@ function ProfessorReviewComponentInner({
                               </p>
                             </div>
                             <div className="flex flex-wrap items-start gap-1 justify-end">
-                              {renderReviewStatusBadges(app)}
+                              {renderReviewStatusBadge(app)}
                             </div>
                           </div>
 

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -38,8 +38,6 @@ import { Search, Eye, CheckCircle, AlertCircle, Clock, X, FileText } from "lucid
 import apiClient, { Application, ApiResponse } from "@/lib/api";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { User } from "@/types/user";
-import { getDisplayStatusInfo } from "@/lib/utils/application-helpers";
-import { Locale } from "@/lib/validators";
 
 interface ProfessorReviewComponentProps {
   user: User;
@@ -251,28 +249,27 @@ function ProfessorReviewComponentInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reviewModalOpen, subTypes, reviewData.items.length]);
 
-  // Get status badge variant
-  const getStatusVariant = (status: string) => {
-    switch (status) {
-      case "under_review":
-        return "default";
-      case "submitted":
-        return "secondary";
-      default:
-        return "outline";
-    }
-  };
-
-  // Get status display text
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case "under_review":
-        return "審核中";
-      case "submitted":
-        return "已提交";
-      default:
-        return status;
-    }
+  // Render the professor-centric 狀態 badges for a queue row.
+  //
+  // The queue is bucketed by whether THIS professor has reviewed (待審核 vs
+  // 已完成), so the status column shows that same signal — 待審核 / 已審核 —
+  // rather than the global application status (which stays 審批中 while a
+  // reviewed app waits for the college, and would look unfinished here).
+  // A secondary badge surfaces the downstream stage (學院/管理員/造冊…) so the
+  // professor can still see where the application went after them.
+  const renderReviewStatusBadges = (app: Application) => {
+    const reviewed = app.has_professor_reviewed === true;
+    const downstreamLabel = app.review_stage
+      ? STAGE_LABEL_ZH[app.review_stage]
+      : undefined;
+    return (
+      <>
+        <Badge variant={reviewed ? "default" : "secondary"}>
+          {reviewed ? "已審核" : "待審核"}
+        </Badge>
+        {downstreamLabel && <Badge variant="outline">{downstreamLabel}</Badge>}
+      </>
+    );
   };
 
   // Open review modal
@@ -664,21 +661,7 @@ function ProfessorReviewComponentInner({
                             </TableCell>
                             <TableCell>
                               <div className="flex gap-2">
-                                {(() => {
-                                  const statusInfo = getDisplayStatusInfo(app, "zh");
-                                  return (
-                                    <>
-                                      <Badge variant={statusInfo.statusVariant}>
-                                        {statusInfo.statusLabel}
-                                      </Badge>
-                                      {statusInfo.showStage && statusInfo.stageLabel && (
-                                        <Badge variant={statusInfo.stageVariant}>
-                                          {statusInfo.stageLabel}
-                                        </Badge>
-                                      )}
-                                    </>
-                                  );
-                                })()}
+                                {renderReviewStatusBadges(app)}
                               </div>
                             </TableCell>
                             <TableCell>
@@ -704,7 +687,6 @@ function ProfessorReviewComponentInner({
                       offscreen as it was in the table layout (P1 audit). */}
                   <div className="md:hidden divide-y">
                     {filteredApplications.map(app => {
-                      const statusInfo = getDisplayStatusInfo(app, "zh");
                       return (
                         <div key={app.id} className="p-4 space-y-3">
                           {/* Header: name + status */}
@@ -718,14 +700,7 @@ function ProfessorReviewComponentInner({
                               </p>
                             </div>
                             <div className="flex flex-wrap items-start gap-1 justify-end">
-                              <Badge variant={statusInfo.statusVariant}>
-                                {statusInfo.statusLabel}
-                              </Badge>
-                              {statusInfo.showStage && statusInfo.stageLabel && (
-                                <Badge variant={statusInfo.stageVariant}>
-                                  {statusInfo.stageLabel}
-                                </Badge>
-                              )}
+                              {renderReviewStatusBadges(app)}
                             </div>
                           </div>
 

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -151,8 +151,6 @@ export interface Application {
   allow_college_view_distribution?: boolean;
   professor_review_completed?: boolean;
   college_review_completed?: boolean;
-  /** 審核階段（用於前端進度顯示），如 professor_reviewed / college_review。 */
-  review_stage?: string;
   /** 教授端佇列專用：檢視的教授是否已對本申請留下審核紀錄。
    *  非教授端點回傳 undefined。 */
   has_professor_reviewed?: boolean;

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -151,6 +151,11 @@ export interface Application {
   allow_college_view_distribution?: boolean;
   professor_review_completed?: boolean;
   college_review_completed?: boolean;
+  /** 審核階段（用於前端進度顯示），如 professor_reviewed / college_review。 */
+  review_stage?: string;
+  /** 教授端佇列專用：檢視的教授是否已對本申請留下審核紀錄。
+   *  非教授端點回傳 undefined。 */
+  has_professor_reviewed?: boolean;
   form_data?: Record<string, any>;
   submitted_form_data?: Record<string, any>;
   meta_data?: Record<string, any>;


### PR DESCRIPTION
Follow-up to #1158.

## Problem

The professor **獎學金申請列表** 狀態 column showed the **global** application status (審批中 / 已核准 / 已駁回…). After #1158 bucketed the list by *review existence*, a professor-reviewed app that still awaits college review stays at `under_review` — so it sits in the **已完成** tab yet its 狀態 badge said **審批中**, looking unfinished.

## Fix

Make the 狀態 column professor-centric, matching the 待審核/已完成 buckets:

| Badge | Meaning |
|-------|---------|
| 待審核 | this professor has **not** reviewed yet |
| 已審核 | this professor **has** reviewed |

Plus a secondary badge for the **downstream stage** (學院審核中 / 配額已分發 / …) so the professor still sees where the application went after them.

- Backend adds an authoritative `has_professor_reviewed` flag to the professor list response (computed from `ApplicationReview` existence, reviews eager-loaded) so the badge can't drift from the server-side bucketing.
- Removed dead `getStatusText`/`getStatusVariant` helpers and the now-unused `getDisplayStatusInfo` / `Locale` imports.

## Test plan

- [x] `test_has_professor_reviewed_flag_reflects_review_existence` — flag True/False per review existence, incl. a reviewed `under_review` app.
- [x] Existing professor list/stats/routing tests green (22 passed).
- [x] `black` + `flake8` (B904/B014/F401) clean; frontend `tsc` + `eslint` clean.
- [x] **Verified E2E in the running app**: logged in as professor A00005, the 狀態 column renders `已審核` + `配額已分發` (downstream), the old `審批中` badge is gone; API returns `has_professor_reviewed` across pending/completed/all.

## Note

Dict-wrapped API (no `response_model`), so `ApplicationListResponse` isn't in OpenAPI — the frontend uses the hand-written `types.ts` (updated here); no generated-schema change.