### PR TITLE
fix: guard migration downgrade when applications table is absent

### DIFF
--- a/backend/alembic/versions/20260714_drop_application_document.py
+++ b/backend/alembic/versions/20260714_drop_application_document.py
@@ -37,7 +37,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    existing = _existing_columns(op.get_bind())
+    bind = op.get_bind()
+    if "applications" not in sa.inspect(bind).get_table_names():
+        return
+    existing = _existing_columns(bind)
     if "application_document_url" not in existing:
         op.add_column("applications", sa.Column("application_document_url", sa.String(500), nullable=True))
     if "application_document_original_filename" not in existing:


### PR DESCRIPTION
Follow-up to #1163, adopting the Copilot review comment: `downgrade()` in `drop_app_document_001` now no-ops when the `applications` table does not exist, matching the guard in `upgrade()` and the repo's migration existence-check policy.

(The fix was intended to land in #1163 but the push didn't reach the branch before merge.)

## Test plan
- [x] black clean
- [x] `alembic downgrade add_renewal_review_flags_001 && alembic upgrade head` roundtrip verified in the dev container