### PR TITLE
feat(quota): show Chinese college names instead of codes in quota Excel import

### DIFF
--- a/frontend/components/admin/quota-import/QuotaImportDialog.tsx
+++ b/frontend/components/admin/quota-import/QuotaImportDialog.tsx
@@ -53,7 +53,7 @@ export function QuotaImportDialog({
               <tr>
                 <th className="border p-1 text-left">子類型＼學院</th>
                 {knownColleges.map(c => (
-                  <th key={c.code} className="border p-1">{c.code}</th>
+                  <th key={c.code} className="border p-1">{c.name || c.code}</th>
                 ))}
               </tr>
             </thead>

--- a/frontend/components/admin/quota-import/QuotaImportDialog.tsx
+++ b/frontend/components/admin/quota-import/QuotaImportDialog.tsx
@@ -51,9 +51,9 @@ export function QuotaImportDialog({
           <table className="w-full border-collapse text-sm">
             <thead>
               <tr>
-                <th className="border p-1 text-left">子類型＼學院</th>
+                <th scope="col" className="border p-1 text-left">子類型＼學院</th>
                 {knownColleges.map(c => (
-                  <th key={c.code} className="border p-1">{c.name || c.code}</th>
+                  <th key={c.code} scope="col" className="border p-1">{c.name || c.code}</th>
                 ))}
               </tr>
             </thead>

--- a/frontend/lib/quota/__tests__/build-quota-template.test.ts
+++ b/frontend/lib/quota/__tests__/build-quota-template.test.ts
@@ -17,9 +17,9 @@ describe("buildQuotaMatrixRows", () => {
     expect(parsed).toEqual(quotas);
   });
 
-  it("emits a header row of college codes and pre-fills 0 for missing cells", () => {
+  it("emits a header row of college names and pre-fills 0 for missing cells", () => {
     const rows = buildQuotaMatrixRows({ nstc: { C: 9 } }, COLLEGES, SUBTYPES);
-    expect(rows[0].slice(1)).toEqual(["C", "E"]);
+    expect(rows[0].slice(1)).toEqual(["資訊", "電機"]);
     expect(rows[1]).toEqual(["nstc", 9, 0]);
     expect(rows[2]).toEqual(["moe_1w", 0, 0]);
   });

--- a/frontend/lib/quota/build-quota-template.ts
+++ b/frontend/lib/quota/build-quota-template.ts
@@ -8,7 +8,9 @@ export function buildQuotaMatrixRows(
   knownColleges: KnownCollege[],
   knownSubTypes: KnownSubType[],
 ): (string | number)[][] {
-  const header: (string | number)[] = [CORNER_LABEL, ...knownColleges.map(c => c.code)];
+  // Header shows the Chinese college name (falling back to code). parseQuotaSheet
+  // resolves a header by code OR name OR nameEn, so this stays round-trip safe.
+  const header: (string | number)[] = [CORNER_LABEL, ...knownColleges.map(c => c.name || c.code)];
   const body = knownSubTypes.map(s => [
     s.code,
     ...knownColleges.map(c => quotas?.[s.code]?.[c.code] ?? 0),

--- a/frontend/lib/quota/parse-quota-sheet.ts
+++ b/frontend/lib/quota/parse-quota-sheet.ts
@@ -135,7 +135,7 @@ export function parseQuotaSheet(
     for (const c of knownColleges) {
       const before = currentQuotas?.[s.code]?.[c.code] ?? 0;
       if (before > 0 && quotas[s.code][c.code] === 0) {
-        warnings.push({ kind: "zeroed", severity: "warning", message: `此匯入會將 ${s.code}/${c.code} 由 ${before} 歸零` });
+        warnings.push({ kind: "zeroed", severity: "warning", message: `此匯入會將 ${s.label || s.code}/${c.name || c.code} 由 ${before} 歸零` });
       }
     }
   }


### PR DESCRIPTION
## What & Why

In **系統管理 → 獎學金配置 → 配額設定 → 匯入 Excel**, the college columns showed raw college **codes** (`C`, `E`, …). This PR replaces them with the **Chinese college names** (e.g. 資訊學院, 電機學院) so administrators read meaningful labels instead of internal codes.

## Changes

| Where | File | Change |
|-------|------|--------|
| Downloaded Excel template header | `frontend/lib/quota/build-quota-template.ts` | Header cells use `c.name` (falls back to `c.code`) |
| Import preview dialog header | `frontend/components/admin/quota-import/QuotaImportDialog.tsx` | Column headers use `c.name` (falls back to `c.code`) |
| Zeroed-cell warning message | `frontend/lib/quota/parse-quota-sheet.ts` | Uses sub-type label + college name for consistency with the preview |

## Round-trip safety

`parseQuotaSheet`'s `resolveCollege` already matches a header column by **code, name, or nameEn**, so a template downloaded with Chinese-name headers still re-imports correctly. The existing round-trip test now exercises this name-matching path, and `build-quota-template.test.ts` was updated to expect Chinese-name headers.

## Testing

- Updated unit tests in `frontend/lib/quota/__tests__/build-quota-template.test.ts`.
- Existing round-trip and parser tests cover the code/name/nameEn resolution.

> Note: the full frontend `jest` suite could not be run in the CI-less dev sandbox because the `xlsx` dependency is served from an external CDN that is blocked there; the touched pure-function tests do not depend on `xlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MK9AmeQNwRMcMcEmw1Quuy

---
_Generated by [Claude Code](https://claude.ai/code/session_01MK9AmeQNwRMcMcEmw1Quuy)_