### PR TITLE
docs: address Copilot review comments from #1184

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -255,7 +255,7 @@ Examples:
 - **Concurrency Safety**: Uses database-level row locking (`FOR UPDATE`) to prevent duplicate numbers
 - **Auto-Creation**: Sequence records are created automatically when first application is made
 
-Implementation: `app/models/application_sequence.py` + `_generate_app_id` in `app/services/application_service.py`.
+Implementation: `backend/app/models/application_sequence.py` + `_generate_app_id` in `backend/app/services/application_service.py`.
 
 #### Migration
 Migration `6b5cb44d2fe3` creates the `application_sequences` table and initializes sequences from existing applications.

--- a/.claude/skills/regex-security/SKILL.md
+++ b/.claude/skills/regex-security/SKILL.md
@@ -35,21 +35,23 @@ match = safe_regex_match(user_pattern, value, timeout_seconds=1)
 
 ## Validation Layers
 
-1. **Length Check**: Maximum 200 characters
+Listed in execution order (`validate_regex_pattern` in `regex_validator.py`):
+
+1. **Empty & Length Checks**: rejects empty patterns; maximum 200 characters (`MAX_PATTERN_LENGTH`)
 2. **ReDoS Detection**: 6 dangerous patterns checked:
    - Multiple unbounded wildcards: `.*.*`
    - Multiple unbounded plus: `.+.+`
+   - Adjacent quantified groups: `(a*)*(b*)*`, `(a+)+(b+)+`
    - Nested quantified groups: `(a*)*`, `(a+)+`
-   - Quantifiers on quantified groups
-3. **Timeout Protection**: SIGALRM-based (1 second max) — only active on platforms with `signal.SIGALRM` (Unix-like); on Windows the `hasattr(signal, "SIGALRM")` guard skips it, so ReDoS detection and length limits are the only protection there
-4. **Syntax Validation**: Compilation test
-5. **JSON Sanitization**: Round-trip to break taint flow
+3. **JSON Sanitization**: Round-trip to break taint flow (runs BEFORE compilation — the sanitized pattern is what gets compiled)
+4. **Syntax Validation**: Compilation test of the sanitized pattern
+5. **Timeout Protection**: SIGALRM-based (1 second max) — Unix-only; on Windows the `hasattr(signal, "SIGALRM")` guard skips the timeout (all other layers above still run there). The alarm guards compilation here and matching inside `safe_regex_match`/`safe_regex_search`; a bare `validate_regex_pattern(pattern)` call does NOT timeout-guard later matching, so always match through the safe wrappers.
 
 ## CodeQL Suppression
 
-**IMPORTANT**: CodeQL does NOT support inline comment suppressions (e.g., `# lgtm[...]`). The correct way to suppress false positives is using the `filter-sarif` GitHub Action.
+**IMPORTANT**: CodeQL does NOT support inline comment suppressions (e.g., `# lgtm[...]`, `# codeql[...]`). The correct way to suppress false positives is using the `filter-sarif` GitHub Action.
 
-**Implementation**: see `.github/workflows/codeql.yml` — the authoritative source. The flow is: analyze with `upload: false` → map the matrix language to CodeQL's SARIF filename (`javascript-typescript` → `javascript.sarif`, via the `sarif-lang` step) → run `advanced-security/filter-sarif@v1` per language → upload the filtered `sarif-results/${{ steps.sarif-lang.outputs.name }}.sarif`. When adding a suppression, edit the `patterns` block of the matching filter step in that workflow rather than copying a snippet from here, e.g.:
+**Implementation**: see `.github/workflows/codeql.yml` — the authoritative source. The flow is: analyze with `upload: false` → map the matrix language to CodeQL's SARIF filename (`javascript-typescript` → `javascript.sarif`, via the `sarif-lang` step) → run `advanced-security/filter-sarif@v1` for the languages that have a conditional filter step (currently `python` and `javascript-typescript`; the `actions` language has no filter step, so its SARIF uploads unfiltered) → upload `sarif-results/${{ steps.sarif-lang.outputs.name }}.sarif`. To suppress a false positive in a language with no filter step yet, add a new conditional filter-sarif step for it. When adding a suppression, edit the `patterns` block of the matching filter step in that workflow rather than copying a snippet from here, e.g.:
 
 ```yaml
 patterns: |
@@ -95,9 +97,9 @@ if validation_regex:
         # Pattern is now safe to use
         match = safe_regex_match(validation_regex, string_value, timeout_seconds=1)
         if not match:
-            raise ValueError(f"Value does not match pattern: {validation_regex}")
+            raise ValueError(f"Value does not match validation pattern: {validation_regex}")
     except RegexValidationError as e:
-        raise ValueError(f"Invalid validation pattern: {str(e)}")
+        raise ValueError(f"Invalid validation pattern: {str(e)}") from e
 ```
 
 ## Security Checklist

--- a/.claude/skills/regex-security/SKILL.md
+++ b/.claude/skills/regex-security/SKILL.md
@@ -41,7 +41,7 @@ match = safe_regex_match(user_pattern, value, timeout_seconds=1)
    - Multiple unbounded plus: `.+.+`
    - Nested quantified groups: `(a*)*`, `(a+)+`
    - Quantifiers on quantified groups
-3. **Timeout Protection**: Signal-based (1 second max)
+3. **Timeout Protection**: SIGALRM-based (1 second max) — only active on platforms with `signal.SIGALRM` (Unix-like); on Windows the `hasattr(signal, "SIGALRM")` guard skips it, so ReDoS detection and length limits are the only protection there
 4. **Syntax Validation**: Compilation test
 5. **JSON Sanitization**: Round-trip to break taint flow
 
@@ -49,28 +49,11 @@ match = safe_regex_match(user_pattern, value, timeout_seconds=1)
 
 **IMPORTANT**: CodeQL does NOT support inline comment suppressions (e.g., `# lgtm[...]`). The correct way to suppress false positives is using the `filter-sarif` GitHub Action.
 
-**Implementation** (`.github/workflows/codeql.yml`):
+**Implementation**: see `.github/workflows/codeql.yml` — the authoritative source. The flow is: analyze with `upload: false` → map the matrix language to CodeQL's SARIF filename (`javascript-typescript` → `javascript.sarif`, via the `sarif-lang` step) → run `advanced-security/filter-sarif@v1` per language → upload the filtered `sarif-results/${{ steps.sarif-lang.outputs.name }}.sarif`. When adding a suppression, edit the `patterns` block of the matching filter step in that workflow rather than copying a snippet from here, e.g.:
 
 ```yaml
-- name: Perform CodeQL Analysis
-  uses: github/codeql-action/analyze@v4
-  with:
-    output: sarif-results
-    upload: false  # Filter before upload
-
-- name: Filter Python SARIF (Remove False Positives)
-  if: matrix.language == 'python'
-  uses: advanced-security/filter-sarif@v1
-  with:
-    patterns: |
-      -backend/app/core/regex_validator.py:py/regex-injection
-    input: sarif-results/python.sarif
-    output: sarif-results/python.sarif
-
-- name: Upload SARIF to Code Scanning
-  uses: github/codeql-action/upload-sarif@v4
-  with:
-    sarif_file: sarif-results/${{ matrix.language }}.sarif
+patterns: |
+  -backend/app/core/regex_validator.py:py/regex-injection
 ```
 
 **Pattern Syntax**:
@@ -83,8 +66,7 @@ match = safe_regex_match(user_pattern, value, timeout_seconds=1)
 
 ## Test Coverage
 
-See `backend/app/tests/test_regex_validator.py` for comprehensive test suite:
-- 22 test cases covering all security scenarios
+See `backend/app/tests/test_regex_validator.py` for the comprehensive test suite covering:
 - Dangerous pattern rejection tests
 - ReDoS attack prevention tests
 - Edge case coverage (unicode, empty strings, long inputs)

--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -70,9 +70,9 @@ Even if attacker manipulates `localStorage.setItem('auth_token', 'http://evil.co
 - Pattern length check (max 200 chars)
 - Dangerous ReDoS pattern detection (6 patterns checked)
 - Regex syntax compilation test with timeout
-- Signal-based timeout protection (1 second max)
+- SIGALRM-based timeout protection (1 second max; Unix-only — skipped on platforms without `signal.SIGALRM`)
 - JSON round-trip sanitization to break taint flow
-- Comprehensive test coverage (22 test cases)
+- Comprehensive test coverage in `backend/app/tests/test_regex_validator.py`
 
 This is a legitimate use case where administrators define regex patterns for configuration validation (emails, API keys, etc.). Using `re.escape()` would break functionality by converting patterns to literal strings.
 
@@ -94,7 +94,7 @@ No stack trace information can reach the API response due to these comprehensive
 
 To suppress a new false positive alert:
 
-1. **Add pattern to workflow:** Edit `.github/workflows/codeql.yml` line 116
+1. **Add pattern to workflow:** Edit the `patterns:` block of the matching language's "Filter ... SARIF" step in `.github/workflows/codeql.yml` (add a new conditional filter-sarif step if that language has none)
 2. **Document justification:** Add explanation to `codeql-config.yml`
 3. **Test thoroughly:** Verify the alert is truly a false positive
 4. **Commit changes:** Push to trigger new CodeQL scan
@@ -115,26 +115,26 @@ These suppressions were reviewed and approved based on:
 
 - ✅ Comprehensive input validation
 - ✅ Multiple sanitization layers
-- ✅ Extensive test coverage (61 tests total: 27 URL + 22 regex + 12 sanitization)
+- ✅ Extensive test coverage (see Test Coverage below)
 - ✅ Industry-standard security practices
 - ✅ Defense-in-depth architecture
 
 ## Test Coverage
 
-- **URL Validation:** 27 tests in `frontend/lib/utils/url-validation.test.ts`
+- **URL Validation:** `frontend/lib/utils/url-validation.test.ts`
   - Same-origin validation tests
   - External URL rejection tests
   - Endpoint allowlist enforcement
   - Parameter encoding and injection prevention
   - Integration tests (storage → builder → validation)
 
-- **Regex Validator:** 22 tests in `test_regex_validator.py`
+- **Regex Validator:** `backend/app/tests/test_regex_validator.py`
   - Valid pattern tests
   - ReDoS pattern rejection
   - Timeout protection
   - Security scenarios
 
-- **Sanitization:** 12 tests in `test_bank_verification_sanitization.py`
+- **Sanitization:** `backend/app/tests/test_bank_verification_stack_trace_scrub.py`
   - Stack trace detection
   - Pattern removal
   - Nested structure handling

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -13,9 +13,10 @@ packs:
 
 # SUPPRESSED ALERTS
 #
-# CodeQL does NOT support inline comment suppressions (e.g., `# codeql[...]`).
-# File-specific query exclusions are handled via the filter-sarif GitHub Action
-# in .github/workflows/codeql.yml (lines 111-119).
+# CodeQL does NOT support inline comment suppressions (e.g., `# lgtm[...]`,
+# `# codeql[...]`). File-specific query exclusions are handled via the
+# filter-sarif GitHub Action steps ("Filter ... SARIF") in
+# .github/workflows/codeql.yml.
 #
 # Current suppressions (via filter-sarif):
 #
@@ -29,9 +30,9 @@ packs:
 #   - Pattern length check (max 200 chars)
 #   - Dangerous ReDoS pattern detection (6 patterns checked)
 #   - Regex syntax compilation test with timeout
-#   - Signal-based timeout protection (1 second max)
+#   - SIGALRM-based timeout protection (1 second max; Unix-only)
 #   - JSON round-trip sanitization to break taint flow
-#   - Comprehensive test coverage (22 test cases)
+#   - Comprehensive test coverage in backend/app/tests/test_regex_validator.py
 #
 # This is a legitimate use case where administrators define regex patterns
 # for configuration validation (emails, API keys, etc.). Using re.escape()

--- a/docs/superpowers/plans/2026-05-06-monitoring-stack-audit-phase1.md
+++ b/docs/superpowers/plans/2026-05-06-monitoring-stack-audit-phase1.md
@@ -670,9 +670,9 @@ For the live /metrics check, use:
 
 - [ ] **Step 1: Dispatch Branch D**
 
-`Agent(subagent_type=backend-engineer-postgres-minio, description="Audit backend metrics interface", prompt=<filled template>)`
+`Agent(subagent_type=general-purpose, description="Audit backend metrics interface", prompt=<filled template>)`
 
-(Use backend specialist here; this branch reads backend Python code in depth.)
+(This branch reads backend Python code in depth. The former `backend-engineer-postgres-minio` specialist agent was removed in #1184.)
 
 - [ ] **Step 2: Verify deliverable**
 


### PR DESCRIPTION
## Summary

Follow-up to #1184 (merged before its Copilot review comments were addressed). All 6 inline comments verified against the repo and fixed:

- **`.claude/CLAUDE.md`**: Application-ID implementation pointers now use `backend/app/...` paths (the repo has no top-level `app/`)
- **`.claude/skills/regex-security/SKILL.md`**:
  - Timeout protection is now described as SIGALRM-based and **Unix-only** — the implementation guards every use with `hasattr(signal, "SIGALRM")`, so Windows falls back to ReDoS detection + length limits only
  - The CodeQL suppression section no longer embeds a drifted workflow snippet (it hard-coded `python.sarif` / `${{ matrix.language }}.sarif`); it now points at `.github/workflows/codeql.yml` as the source of truth and explains the `sarif-lang` filename mapping the real workflow uses
  - Dropped the hard-coded "22 test cases" count (already stale — the module has 27) in favor of describing covered behaviors
- **`docs/superpowers/plans/2026-05-06-monitoring-stack-audit-phase1.md`**: the dispatch example referencing the removed `backend-engineer-postgres-minio` agent now uses `general-purpose` with a note about the removal

## Test plan
- [x] Verified `backend/app/models/application_sequence.py` / `application_service.py` paths exist
- [x] Verified `hasattr(signal, "SIGALRM")` guards in `backend/app/core/regex_validator.py`
- [x] Verified the workflow's `sarif-lang` mapping in `.github/workflows/codeql.yml`
- [x] `grep -c "def test_"` confirms 27 tests in `test_regex_validator.py`