### PR TITLE
fix: run batch-import SIS lookups concurrently to stay inside proxy window

### DIFF
--- a/backend/app/services/batch_import_service.py
+++ b/backend/app/services/batch_import_service.py
@@ -5,10 +5,11 @@ Handles Excel/CSV parsing, validation, and application creation
 for college staff importing offline collected student data.
 """
 
+import asyncio
 import io
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 from sqlalchemy import select
@@ -161,6 +162,36 @@ SUB_TYPE_CODE_BY_LABEL = {
 }
 
 
+# Cap on concurrent SIS calls per batch — parallel enough to keep a ~200-row
+# sheet inside the frontend proxy window (issue #1172: sequential per-row
+# lookups took 20-45s and the proxied socket was reset) without flooding SIS.
+SIS_LOOKUP_CONCURRENCY = 10
+
+
+async def _fetch_per_student(
+    student_ids: List[str],
+    fetch: Callable[[str], Awaitable[Any]],
+) -> Dict[str, Any]:
+    """Run one SIS lookup per student concurrently (bounded) and return
+    student_id → result, storing a raised exception as the value so callers
+    keep their per-row error handling.
+
+    SIS lookups are pure HTTP (StudentService holds no AsyncSession), so they
+    are safe to parallelize; DB-bound work must stay sequential in callers.
+    """
+    semaphore = asyncio.Semaphore(SIS_LOOKUP_CONCURRENCY)
+
+    async def bounded_fetch(student_id: str) -> Any:
+        async with semaphore:
+            return await fetch(student_id)
+
+    results = await asyncio.gather(
+        *(bounded_fetch(student_id) for student_id in student_ids),
+        return_exceptions=True,
+    )
+    return dict(zip(student_ids, results))
+
+
 def _make_warning(
     message: str,
     *,
@@ -262,6 +293,15 @@ class BatchImportService:
             prof_result = await self.db.execute(prof_stmt)
             professor_map = {p.nycu_id: p for p in prof_result.scalars().all()}
 
+        # Concurrent snapshot prefetch — the sequential per-row SIS fetch was
+        # the preview-request bottleneck (issue #1172).
+        snapshot_map = await _fetch_per_student(
+            [row.get("student_id") for row in parsed_data],
+            lambda student_id: self.student_service.get_student_snapshot(
+                student_id, academic_year=str(academic_year), semester=semester
+            ),
+        )
+
         for row in parsed_data:
             student_id = row.get("student_id")
             row_number = row.get("row_number")
@@ -278,12 +318,10 @@ class BatchImportService:
                     )
                 )
 
-            try:
-                snapshot = await self.student_service.get_student_snapshot(
-                    student_id, academic_year=str(academic_year), semester=semester
-                )
-            except Exception:  # noqa: BLE001 — any SIS failure demotes to a skip warning
-                logger.warning("Eligibility precheck skipped for %s (SIS error)", student_id, exc_info=True)
+            snapshot = snapshot_map.get(student_id)
+            if isinstance(snapshot, BaseException):
+                # Any SIS failure demotes to a skip warning
+                logger.warning("Eligibility precheck skipped for %s (SIS error)", student_id, exc_info=snapshot)
                 warnings.append(
                     _make_warning(
                         f"無法取得學生 {student_id} 的學籍資料，已跳過資格預檢。",
@@ -716,15 +754,18 @@ class BatchImportService:
         student_map = {s.nycu_id: s for s in students}
 
         # Query SIS API first for ALL students (both existing and new)
-        # This allows us to validate new students using current SIS data
+        # This allows us to validate new students using current SIS data.
+        # Lookups run concurrently (issue #1172) — the sequential per-student
+        # loop was the other half of the preview-request bottleneck.
         sis_data_map: Dict[str, Optional[Dict[str, Any]]] = {}
         api_codes: Dict[str, str] = {}
         if getattr(self.student_service, "api_enabled", False):
+            basic_info_map = await _fetch_per_student(student_ids, self.student_service.get_student_basic_info)
             api_failed = False
             for student_id in student_ids:
-                try:
-                    api_data = await self.student_service.get_student_basic_info(student_id)
-                except ServiceUnavailableError:
+                api_data = basic_info_map.get(student_id)
+                if isinstance(api_data, ServiceUnavailableError):
+                    # One global warning no matter how many lookups failed
                     if not api_failed:
                         add_warning(
                             None,
@@ -732,12 +773,13 @@ class BatchImportService:
                             "學籍系統目前不可用，已跳過即時系所驗證。",
                         )
                         api_failed = True
-                    break
-                except Exception:  # pylint: disable=broad-except
+                    sis_data_map[student_id] = None
+                    continue
+                if isinstance(api_data, BaseException):
                     logger.warning(
                         "Student API unexpected error for %s",
                         student_id,
-                        exc_info=True,
+                        exc_info=api_data,
                     )
                     add_warning(
                         student_id,
@@ -896,23 +938,29 @@ class BatchImportService:
 
         # Bulk create missing users
         if missing_student_ids:
+            # Concurrent SIS prefetch for the new users (issue #1172)
+            basic_info_map = await _fetch_per_student(
+                [row["student_id"] for row in parsed_data if row["student_id"] in missing_student_ids],
+                self.student_service.get_student_basic_info,
+            )
+
             new_users = []
             for row in parsed_data:
                 student_id = row["student_id"]
                 if student_id in missing_student_ids:
-                    # Attempt to fetch SIS data for new users
-                    sis_data = None
-                    try:
-                        sis_data = await self.student_service.get_student_basic_info(student_id)
-                    except ServiceUnavailableError:
+                    sis_data = basic_info_map.get(student_id)
+                    if isinstance(sis_data, ServiceUnavailableError):
                         logger.warning(
                             f"SIS API unavailable for student {student_id}. Creating user with batch import data."
                         )
-                    except Exception:
-                        logger.exception(
+                        sis_data = None
+                    elif isinstance(sis_data, BaseException):
+                        logger.error(
                             "Error fetching SIS data for student %s. Creating user with batch import data.",
                             student_id,
+                            exc_info=sis_data,
                         )
+                        sis_data = None
 
                     new_user = User(
                         nycu_id=student_id,
@@ -1090,6 +1138,15 @@ class BatchImportService:
             # submitted_at timestamp for the whole batch is intended).
             submitted_values = build_submitted_application_values(scholarship, scholarship_config)
 
+            # Concurrent SIS snapshot prefetch — the sequential per-row fetch
+            # made confirm as slow as the upload preview was (issue #1172).
+            snapshot_map = await _fetch_per_student(
+                [row["student_id"] for row in parsed_data],
+                lambda sid: self.student_service.get_student_snapshot(
+                    sid, academic_year=str(academic_year), semester=semester
+                ),
+            )
+
             # Step 2: Bulk create applications
             applications = []
             for idx, row_data in enumerate(parsed_data):
@@ -1103,24 +1160,23 @@ class BatchImportService:
                 # online submissions block during the import, intentionally).
                 app_id = await generate_app_id(self.db, academic_year, semester, suffix="U", commit=False)
 
-                # Create application
-                # Fetch student snapshot from SIS API (includes both basic info and term data)
+                # Prefetched SIS snapshot (includes both basic info and term data)
                 student_data = None
-                try:
-                    student_data = await self.student_service.get_student_snapshot(
-                        student_id, academic_year=str(academic_year), semester=semester
-                    )
-                except (NotFoundError, ServiceUnavailableError):
+                snapshot = snapshot_map.get(student_id)
+                if isinstance(snapshot, (NotFoundError, ServiceUnavailableError)):
                     logger.warning(
                         "SIS API unavailable or student not found for %s. Creating application without student snapshot.",
                         student_id,
-                        exc_info=True,
+                        exc_info=snapshot,
                     )
-                except Exception:
-                    logger.exception(
+                elif isinstance(snapshot, BaseException):
+                    logger.error(
                         "Error fetching student snapshot for %s. Creating application without student snapshot.",
                         student_id,
+                        exc_info=snapshot,
                     )
+                else:
+                    student_data = snapshot
 
                 submitted_form_data = self._build_submitted_form_data(
                     field_definitions, row_data.get("custom_fields", {})

--- a/backend/app/tests/test_batch_import_service_unit.py
+++ b/backend/app/tests/test_batch_import_service_unit.py
@@ -4,6 +4,7 @@ Unit tests for BatchImportService
 Tests file parsing, validation, bulk operations, and transaction rollback.
 """
 
+import asyncio
 import io
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -13,7 +14,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.exceptions import BatchImportError
+from app.core.exceptions import BatchImportError, ServiceUnavailableError
 from app.models.application import Application, ApplicationStatus
 from app.models.batch_import import BatchImport
 from app.models.enums import BatchImportStatus, ReviewStage, Semester
@@ -1008,6 +1009,106 @@ async def test_bulk_check_eligibility_skips_row_when_check_raises(db, scholarshi
     assert skip_warnings[0]["student_id"] == "313554001"
     # A raised check must NOT produce an eligibility_failed warning.
     assert not any(w["warning_type"] == "eligibility_failed" for w in warnings)
+
+
+# ─── concurrent SIS lookups (issue #1172) ────────────────────────────
+#
+# Sequential per-row SIS lookups made a ~200-row upload take 20-45s and
+# blow past the frontend proxy window (ECONNRESET → user-facing 500).
+# Lookups now run concurrently via _fetch_per_student.
+
+
+@pytest.mark.asyncio
+async def test_fetch_per_student_runs_lookups_concurrently():
+    """All lookups must be in flight at once: each fake fetch blocks until
+    every other fetch has started, so a sequential implementation would
+    dead-end in the wait_for timeout (surfacing as an exception value)."""
+    from app.services.batch_import_service import _fetch_per_student
+
+    started: set = set()
+    all_started = asyncio.Event()
+
+    async def fetch(student_id):
+        started.add(student_id)
+        if len(started) == 3:
+            all_started.set()
+        await asyncio.wait_for(all_started.wait(), timeout=5)
+        return {"std_stdcode": student_id}
+
+    result = await _fetch_per_student(["s1", "s2", "s3"], fetch)
+
+    assert result == {
+        "s1": {"std_stdcode": "s1"},
+        "s2": {"std_stdcode": "s2"},
+        "s3": {"std_stdcode": "s3"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_per_student_maps_exceptions_per_student():
+    """A failed lookup must surface as that student's value (not abort the
+    batch), so callers keep their per-row demote-to-warning handling."""
+    from app.services.batch_import_service import _fetch_per_student
+
+    async def fetch(student_id):
+        if student_id == "bad":
+            raise ServiceUnavailableError("SIS down")
+        return {"std_stdcode": student_id}
+
+    result = await _fetch_per_student(["good", "bad"], fetch)
+
+    assert result["good"] == {"std_stdcode": "good"}
+    assert isinstance(result["bad"], ServiceUnavailableError)
+
+
+@pytest.mark.asyncio
+async def test_bulk_validate_sis_unavailable_warns_once_and_validates_all(db):
+    """SIS being down must produce ONE global warning while every student
+    still gets permission/duplicate results (previously the loop broke and
+    skipped the remaining students silently)."""
+    stub = MagicMock()
+    stub.api_enabled = True
+    stub.get_student_basic_info = AsyncMock(side_effect=ServiceUnavailableError("SIS down"))
+    service = BatchImportService(db, student_service=stub)
+
+    permission_results, duplicate_results, warnings = await service.bulk_validate_permissions_and_duplicates(
+        student_ids=["s1", "s2", "s3"],
+        college_code="E",
+        scholarship_type_id=1,
+        academic_year=114,
+        semester=None,
+    )
+
+    unavailable = [w for w in warnings if w["warning_type"] == "student_api_unavailable"]
+    assert len(unavailable) == 1
+    for student_id in ["s1", "s2", "s3"]:
+        assert permission_results[student_id] == (True, None)
+        assert duplicate_results[student_id] == (False, None)
+
+
+@pytest.mark.asyncio
+async def test_bulk_check_eligibility_snapshot_failure_only_skips_that_row(db, scholarship_with_config, monkeypatch):
+    """A snapshot fetch failing for one student demotes to a per-row skip
+    warning; the other rows still get their eligibility precheck."""
+    service = BatchImportService(db)
+
+    async def fake_snapshot(student_id, academic_year=None, semester=None):
+        if student_id == "313554002":
+            raise ServiceUnavailableError("SIS down")
+        return {"std_stdcode": student_id}
+
+    monkeypatch.setattr(service.student_service, "get_student_snapshot", fake_snapshot)
+
+    parsed_data = [
+        {"student_id": "313554001", "sub_types": ["nstc"], "advisor_nycu_id": None, "row_number": 2},
+        {"student_id": "313554002", "sub_types": ["nstc"], "advisor_nycu_id": None, "row_number": 3},
+    ]
+    warnings = await service.bulk_check_eligibility(parsed_data, scholarship_with_config.id, 114, None)
+
+    skip_warnings = [w for w in warnings if w["warning_type"] == "eligibility_check_skipped"]
+    assert len(skip_warnings) == 1
+    assert skip_warnings[0]["student_id"] == "313554002"
+    assert skip_warnings[0]["row_number"] == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #1172 — 批次匯入 upload-data of a ~200-row Excel exceeded the frontend proxy window: the endpoint did **2+ sequential SIS lookups per row** (~20-45s total), the Next.js `/api/:path*` rewrite proxy reset the socket (`ECONNRESET`), and the operator saw **上傳失敗 (HTTP 500)** while the backend silently finished parsing and persisted an orphaned `pending` batch (retry ⇒ duplicate).

This takes the issue's "batch the SIS lookups concurrently" direction:

- New `_fetch_per_student` helper: bounded-concurrency (10) fan-out of one SIS lookup per student, returning `student_id → result-or-exception` so callers keep their per-row error handling.
- Applied to all four per-row SIS loops:
  - `bulk_check_eligibility` (snapshot per row — upload preview)
  - `bulk_validate_permissions_and_duplicates` (basic info per row — upload preview)
  - `_get_or_create_users_bulk` (basic info per missing user — confirm step)
  - `create_applications_from_batch` (snapshot per row — confirm step had the same bottleneck)
- SIS calls are pure HTTP (`StudentService` holds no `AsyncSession`), so they parallelize safely; **all DB-bound work stays sequential** on the shared session.
- Semantics preserved: failures still demote to the same per-row warnings/log lines. One deliberate improvement: when SIS is unavailable, every student is still permission/duplicate-validated (previously the loop `break`-ed and silently skipped the rest of the sheet) while keeping the single global 學籍系統目前不可用 warning.

With concurrency 10, a 212-row sheet drops from ~600+ serial SIS round-trips to ~60 batched rounds — comfortably inside the dev proxy and production nginx `proxy_read_timeout` windows.

## Test plan

- [x] `pytest app/tests/test_batch_import_service_unit.py app/tests/test_batch_import_endpoints.py app/tests/test_batch_import_defaults_and_postal.py` — 67 passed (61 existing + 6 new)
- [x] New tests: parallelism proof (each fake lookup blocks until all are in flight — deadlocks if sequential), exception-as-value mapping, single global SIS-unavailable warning with all students still validated, per-row snapshot-failure skip
- [x] Dependent suites: `test_batch_import_pure_helpers.py`, `test_application_builder.py`, `test_renewal_import*.py` — 53 passed
- [x] `black --check` + `flake8 --select=B904,B014,F401,F841` clean; logger traceback-loss AST invariant suites pass