### PR TITLE
fix(auth): refresh user from /auth/me so SSO logins get college_code (staging 學院匯出總表 dropdown empty)

### DIFF
--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -751,6 +751,14 @@ export function ApplicationReviewPanel({
               <SelectValue placeholder="選擇系所匯出總表" />
             </SelectTrigger>
             <SelectContent>
+              {departmentGroups.length === 0 &&
+                !user.college_code &&
+                user.role !== "admin" &&
+                user.role !== "super_admin" && (
+                  <div className="px-2 py-1.5 text-sm text-muted-foreground">
+                    無可選系所（帳號未設定所屬學院，請聯絡管理員）
+                  </div>
+                )}
               {departmentGroups.map(group => {
                 const value = group.codes.join(",");
                 const label = ambiguousGroupNames.has(group.name)

--- a/frontend/hooks/__tests__/use-auth.test.tsx
+++ b/frontend/hooks/__tests__/use-auth.test.tsx
@@ -1,9 +1,40 @@
 import React from "react";
-import { renderHook, render } from "@testing-library/react";
+import { renderHook, render, act, waitFor } from "@testing-library/react";
 import { ReactNode, Component, ErrorInfo } from "react";
 import { AuthProvider, useAuth } from "../use-auth";
+import { apiClient, User, ApiResponse } from "@/lib/api";
 
-// API client is automatically mocked by __mocks__ directory
+// jest.mock("@/lib/api") is NOT hoisted above ESM imports in this setup, so the
+// hook captures the real apiClient — spy on its methods instead of mocking the module.
+
+// SSO callbacks build the user from token claims only — no college_code.
+const makeStubUser = (): User => ({
+  id: "5",
+  nycu_id: "collegeuser",
+  role: "college",
+  name: "collegeuser",
+  email: "collegeuser@nycu.edu.tw",
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+});
+
+// /auth/me payload: the backend serializes id as a NUMBER and includes the
+// college fields the JWT stub lacks.
+const makeServerUserResponse = (): ApiResponse<User> => ({
+  success: true,
+  message: "ok",
+  data: {
+    id: 5 as unknown as string,
+    nycu_id: "collegeuser",
+    name: "資訊學院承辦人",
+    email: "collegeuser@nycu.edu.tw",
+    role: "college",
+    college_code: "C",
+    college_name: "資訊學院",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  },
+});
 
 // Test wrapper with AuthProvider
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -46,6 +77,14 @@ function TestComponent() {
 }
 
 describe("useAuth Hook", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("should provide auth context", () => {
     const { result } = renderHook(() => useAuth(), { wrapper });
 
@@ -90,5 +129,71 @@ describe("useAuth Hook", () => {
 
     // Restore console.error
     consoleSpy.mockRestore();
+  });
+
+  it("refreshes the JWT-derived stub user from /auth/me after login", async () => {
+    jest
+      .spyOn(apiClient.auth, "getCurrentUser")
+      .mockResolvedValue(makeServerUserResponse());
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    act(() => {
+      result.current.login("mock-token", makeStubUser());
+    });
+
+    await waitFor(() => {
+      expect(result.current.user?.college_code).toBe("C");
+    });
+    expect(result.current.user?.name).toBe("資訊學院承辦人");
+    // The backend sends a numeric id; normalizeUser must coerce it to string.
+    expect(result.current.user?.id).toBe("5");
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it("keeps the stored user when /auth/me refresh fails", async () => {
+    jest
+      .spyOn(apiClient.auth, "getCurrentUser")
+      .mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    act(() => {
+      result.current.login("mock-token", makeStubUser());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+    expect(result.current.user?.nycu_id).toBe("collegeuser");
+    expect(result.current.error).toBe(null);
+  });
+
+  it("does not resurrect the session when /auth/me resolves after logout", async () => {
+    let resolveMe: (value: ApiResponse<User>) => void = () => {};
+    jest.spyOn(apiClient.auth, "getCurrentUser").mockReturnValue(
+      new Promise<ApiResponse<User>>(resolve => {
+        resolveMe = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    act(() => {
+      result.current.login("mock-token", makeStubUser());
+    });
+    act(() => {
+      result.current.logout();
+    });
+
+    await act(async () => {
+      resolveMe(makeServerUserResponse());
+      await Promise.resolve();
+    });
+
+    expect(result.current.user).toBe(null);
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(localStorage.getItem("user")).toBe(null);
+    expect(localStorage.getItem("dev_user")).toBe(null);
   });
 });

--- a/frontend/hooks/use-auth.tsx
+++ b/frontend/hooks/use-auth.tsx
@@ -25,11 +25,58 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
+// Single source of truth for shaping a user object, wherever it came from
+// (JWT stub, /auth/me, stored JSON): backend sends numeric id and may leave
+// name null; the app contract is string id and non-empty name.
+function normalizeUser(raw: User): User {
+  return {
+    ...raw,
+    id: String(raw.id),
+    name: raw.full_name || raw.name || raw.nycu_id,
+    role: raw.role?.toLowerCase() as User["role"],
+  };
+}
+
+function persistUser(normalizedUser: User): void {
+  const json = JSON.stringify(normalizedUser);
+  localStorage.setItem("user", json);
+  localStorage.setItem("dev_user", json);
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter();
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // SSO logins only carry JWT claims (nycu_id/role) — server-only fields like
+  // college_code stay undefined until this /auth/me refresh lands, and the
+  // college UI (e.g. 系所匯出總表 dropdown) filters on college_code.
+  const refreshUserFromServer = useCallback(async () => {
+    try {
+      const response = await apiClient.auth.getCurrentUser();
+      // The user may have logged out while /me was in flight — applying the
+      // response would resurrect the session.
+      if (!localStorage.getItem("auth_token")) return;
+      if (response?.success && response.data) {
+        const normalizedUser = normalizeUser(response.data as User);
+        // Skip the state write when nothing changed — setUser here re-renders
+        // the whole provider tree on every page load otherwise.
+        if (JSON.stringify(normalizedUser) === localStorage.getItem("user")) {
+          return;
+        }
+        persistUser(normalizedUser);
+        setUser(normalizedUser);
+        logger.debug("User profile refreshed from server", {
+          role: normalizedUser.role,
+          hasCollegeCode: !!normalizedUser.college_code,
+        });
+      }
+    } catch (err) {
+      // Keep the locally stored user — a transient /me failure must not log the user out.
+      logger.warn("Failed to refresh user profile from server", { err });
+    }
+  }, []);
 
   // Check for existing authentication on mount
   useEffect(() => {
@@ -48,16 +95,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         try {
           const userData = JSON.parse(userJson);
           apiClient.setToken(token);
-          // Convert role to lowercase for frontend consistency
-          const normalizedUser = {
-            ...userData,
-            name: userData.full_name || userData.name,
-            role: userData.role?.toLowerCase(),
-          };
+          const normalizedUser = normalizeUser(userData);
           setUser(normalizedUser);
           logger.debug("Authentication restored from localStorage", {
             role: normalizedUser.role,
           });
+          // Stored user may be a stale JWT-derived stub — re-sync from the server.
+          void refreshUserFromServer();
         } catch (err) {
           logger.error("Failed to parse stored user data", { err });
           localStorage.removeItem("auth_token");
@@ -71,7 +115,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
 
     checkExistingAuth();
-  }, []);
+  }, [refreshUserFromServer]);
 
   const login = useCallback((token: string, userData: User) => {
     logger.debug("useAuth.login() called", {
@@ -82,35 +126,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       apiClient.setToken(token);
       localStorage.setItem("auth_token", token);
-      localStorage.setItem("user", JSON.stringify(userData));
-
-      // Also store as dev_user for backwards compatibility
-      const devUser = {
-        ...userData,
-        name: userData.full_name || userData.name,
-        role: userData.role?.toLowerCase(),
-      };
-      localStorage.setItem("dev_user", JSON.stringify(devUser));
-      const finalUser = {
-        ...userData,
-        name: userData.full_name || userData.name,
-        role: userData.role?.toLowerCase() as
-          | "student"
-          | "professor"
-          | "college"
-          | "admin"
-          | "super_admin",
-      };
+      const finalUser = normalizeUser(userData);
+      persistUser(finalUser);
       setUser(finalUser);
       setError(null);
       logger.debug("useAuth.login() completed", {
         role: finalUser.role,
       });
+      // SSO callbacks pass a JWT-derived stub; replace it with the full server profile.
+      void refreshUserFromServer();
     } catch (err) {
       logger.error("Error in login", { err });
       setError(err instanceof Error ? err.message : "Login failed");
     }
-  }, []);
+  }, [refreshUserFromServer]);
 
   const logout = useCallback(() => {
     logger.debug("Logging out");
@@ -153,11 +182,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const response = await apiClient.users.updateProfile(userData);
 
       if (response.success && response.data) {
-        // Map full_name to name for component compatibility
-        const updatedUser = {
-          ...response.data,
-          name: response.data.full_name ?? response.data.name,
-        };
+        const updatedUser = normalizeUser(response.data);
+        persistUser(updatedUser);
         setUser(updatedUser);
       } else {
         throw new Error(response.message || "Update failed");

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -43,6 +43,8 @@ export interface User {
   status?: "在學" | "畢業" | "在職" | "退休";
   dept_code?: string;
   dept_name?: string;
+  college_code?: string;
+  college_name?: string;
   comment?: string;
   last_login_at?: string;
   created_at: string;


### PR DESCRIPTION
## Problem

On **staging**, a college-role user clicking 選擇系所匯出總表 saw nothing pop up.

Root cause: staging users log in via NYCU Portal SSO, and both SSO callbacks build the user object **from JWT claims only** (`nycu_id`, `role`, placeholder name/email — a code comment said *"will be updated from backend later"*, which was never implemented). `use-auth` persisted that stub in localStorage forever, so `user.college_code` stayed `undefined`:

- `visibleDepartments` filters on `d.academy_code === user.college_code` → no department items
- the 本學院全部 (ZIP) item requires `user.college_code` → absent
- non-admin → no 全部系所 (ZIP)

→ the Radix Select popover rendered with **zero items**, which looks like the click does nothing. Dev never reproduces this because password login returns the full user object.

## Fix

- **`use-auth.tsx`**: `refreshUserFromServer()` — GET `/auth/me`, called after `login()` and on mount-restore, so already-logged-in staging users heal on next page load without re-login. Guards: skip applying the response if the user logged out while it was in flight (session-resurrection race), and skip the `setUser` when the profile is unchanged (avoids an app-wide provider re-render on every load). A failed refresh keeps the stored user (transient `/me` errors can't log anyone out).
- **`use-auth.tsx`**: extracted `normalizeUser()` / `persistUser()` — the normalization was copy-pasted in 4 places and had drifted (`updateUser` missed role lowercasing). Also coerces the backend's numeric `id` to string (the `User.id: string` contract) and falls back to `nycu_id` when the server `name` is null.
- **`lib/api/types.ts`**: add `college_code`/`college_name` to `User` (backend returns them; `types/user.ts` already had them).
- **`ApplicationReviewPanel.tsx`**: if an account genuinely has no `college_code`, the dropdown now shows 無可選系所（帳號未設定所屬學院，請聯絡管理員） instead of an invisible empty popover.

## Review notes (xhigh self-review ran before this PR)

Confirmed-and-fixed in this PR: logout/refresh race, id string→number flip, null-name blanking, 4× duplicated normalization, unconditional `setUser` re-render.

Known follow-ups (out of scope): `lib/api/types.ts` `User` vs `types/user.ts` `User` are now field-identical duplicates that should be unified into one canonical type; the SSO callbacks still construct the JWT stub (placeholder name/email visible until `/me` lands) and the `handleSSOCallbackInMainPage` copy in `app/page.tsx` appears to be dead code; a college account without `college_code` still renders other college views blank — a shell-level misconfiguration banner would cover them all.

## Test plan

- [x] `hooks/__tests__/use-auth.test.tsx`: stub→`/auth/me` refresh populates `college_code`/real name/string id; refresh failure keeps stored user; `/auth/me` resolving **after logout** does not resurrect the session
- [x] 17 suites / 213 tests covering every `AuthProvider`-mounting component pass
- [x] `tsc --noEmit` and ESLint clean
- [x] Against the running dev backend: `/auth/me` for `cs_college` returns `college_code: "C"`; `/reference-data/all` has 47 departments with `academy_code: "C"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)