### PR TITLE
fix(renewal-import): restrict 匯入續領生 to admin/super_admin only

### DIFF
--- a/backend/app/api/v1/endpoints/renewal_import.py
+++ b/backend/app/api/v1/endpoints/renewal_import.py
@@ -17,7 +17,7 @@ from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import BatchImportError
-from app.core.security import get_current_user
+from app.core.security import require_admin
 from app.db.deps import get_db
 from app.models.audit_log import AuditAction, AuditLog
 from app.models.batch_import import BatchImport, BatchImportStatus
@@ -63,16 +63,6 @@ ALLOWED_UPLOAD_MIME_TYPES = {
 }
 
 
-def require_college_role(current_user: User = Depends(get_current_user)) -> User:
-    """Dependency to require college, admin, or super admin role."""
-    if current_user.role not in [UserRole.college, UserRole.admin, UserRole.super_admin]:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="此功能僅限學院或管理員角色使用",
-        )
-    return current_user
-
-
 async def _load_config_in_renewal_period(
     db: AsyncSession,
     scholarship_type_id: int,
@@ -110,7 +100,7 @@ async def upload_renewal_import(
     scholarship_type: str = Query(..., description="獎學金類型代碼", pattern=r"^[a-z_]{1,50}$"),
     academic_year: int = Query(..., description="學年度", ge=100, le=200),
     semester: Optional[str] = Query(None, description="學期", pattern=r"^(first|second|yearly)$"),
-    current_user: User = Depends(require_college_role),
+    current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
     """上傳續領生名單，解析並回傳預覽（僅保留「是 + 通過」的續領生）。"""
@@ -217,7 +207,7 @@ async def upload_renewal_import(
 async def confirm_renewal_import(
     batch_id: int,
     request: RenewalImportConfirmRequest | None = Body(None),
-    current_user: User = Depends(require_college_role),
+    current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
     """確認匯入續領生，建立已核准的續領申請（供造冊使用）。"""
@@ -325,7 +315,7 @@ async def confirm_renewal_import(
 async def get_renewal_import_history(
     skip: int = Query(0, ge=0, description="跳過筆數"),
     limit: int = Query(20, ge=1, le=100, description="每頁筆數"),
-    current_user: User = Depends(require_college_role),
+    current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
     """查詢續領匯入歷史記錄（僅顯示已確認的批次）。"""
@@ -384,7 +374,7 @@ async def get_renewal_import_history(
 @router.get("/{batch_id}/details")
 async def get_renewal_import_details(
     batch_id: int,
-    current_user: User = Depends(require_college_role),
+    current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
     """查詢續領匯入詳細資訊。"""
@@ -437,7 +427,7 @@ async def get_renewal_import_details(
 @router.get("/template")
 async def download_renewal_import_template(
     scholarship_type: str = Query(..., description="獎學金類型代碼", pattern=r"^[a-z_]{1,50}$"),
-    current_user: User = Depends(require_college_role),
+    current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
     """下載續領匯入範例 Excel 檔案。
@@ -448,7 +438,7 @@ async def download_renewal_import_template(
     **注意**: 「獎學金類別」欄位可填 `國科會` 或 `教育部`；僅「學生是否申請續領=是」
     且「續領審核結果=通過」的列會被匯入。
 
-    **權限**: 僅限 college 角色。
+    **權限**: 僅限 admin / super_admin 角色。
     """
     stmt = select(ScholarshipType).where(ScholarshipType.code == scholarship_type)
     scholarship = (await db.execute(stmt)).scalar_one_or_none()

--- a/backend/app/tests/test_renewal_import_endpoints.py
+++ b/backend/app/tests/test_renewal_import_endpoints.py
@@ -31,7 +31,7 @@ BASE = "/api/v1/college-review/renewal-import"
 def _override_user(user: User):
     """Override the get_current_user dependency to return the given user.
 
-    require_college_role still executes (role gating preserved); only the
+    require_admin still executes (role gating preserved); only the
     underlying get_current_user dependency is replaced. The conftest `client`
     fixture clears all overrides at teardown.
     """
@@ -102,13 +102,12 @@ class TestRenewalImportEndpoints:
     """Test cases for renewal import API endpoints."""
 
     @pytest.fixture
-    async def college_user(self, db: AsyncSession) -> User:
+    async def admin_user(self, db: AsyncSession) -> User:
         user = User(
-            nycu_id="college_renewal",
-            name="College Renewal User",
-            email="college.renewal@test.com",
-            role=UserRole.college,
-            college_code="E",
+            nycu_id="admin_renewal",
+            name="Admin Renewal User",
+            email="admin.renewal@test.com",
+            role=UserRole.admin,
             user_type="employee",
         )
         db.add(user)
@@ -131,13 +130,13 @@ class TestRenewalImportEndpoints:
 
     @pytest.mark.asyncio
     async def test_upload_rejects_outside_renewal_period(
-        self, client: AsyncClient, db: AsyncSession, college_user: User, phd_scholarship: ScholarshipType
+        self, client: AsyncClient, db: AsyncSession, admin_user: User, phd_scholarship: ScholarshipType
     ):
         """Uploading against a config whose renewal window is CLOSED -> 400."""
         db.add(_make_config(phd_scholarship.id, renewal_open=False))
         await db.commit()
 
-        _override_user(college_user)
+        _override_user(admin_user)
         response = await client.post(
             f"{BASE}/upload",
             params={"scholarship_type": "phd", "academic_year": 114, "semester": "first"},
@@ -156,10 +155,10 @@ class TestRenewalImportEndpoints:
 
     @pytest.mark.asyncio
     async def test_upload_missing_config_returns_404(
-        self, client: AsyncClient, db: AsyncSession, college_user: User, phd_scholarship: ScholarshipType
+        self, client: AsyncClient, db: AsyncSession, admin_user: User, phd_scholarship: ScholarshipType
     ):
         """No config for the (year, semester) -> 404 before any file read."""
-        _override_user(college_user)
+        _override_user(admin_user)
         response = await client.post(
             f"{BASE}/upload",
             params={"scholarship_type": "phd", "academic_year": 114, "semester": "first"},
@@ -176,7 +175,7 @@ class TestRenewalImportEndpoints:
 
     @pytest.mark.asyncio
     async def test_upload_happy_path_filters_non_passing_rows(
-        self, client: AsyncClient, db: AsyncSession, college_user: User, phd_scholarship: ScholarshipType, monkeypatch
+        self, client: AsyncClient, db: AsyncSession, admin_user: User, phd_scholarship: ScholarshipType, monkeypatch
     ):
         """Open renewal window + a 2-row sheet -> 200, 1 imported, 1 skipped."""
         db.add(_make_config(phd_scholarship.id, renewal_open=True))
@@ -185,7 +184,7 @@ class TestRenewalImportEndpoints:
         # Disable the external SIS lookup so validate_and_preview is deterministic.
         monkeypatch.setattr(settings, "student_api_enabled", False, raising=False)
 
-        _override_user(college_user)
+        _override_user(admin_user)
         response = await client.post(
             f"{BASE}/upload",
             params={"scholarship_type": "phd", "academic_year": 114, "semester": "first"},
@@ -207,17 +206,24 @@ class TestRenewalImportEndpoints:
         assert data["preview_data"][0]["sub_type"] == "nstc"
 
     @pytest.mark.asyncio
-    async def test_upload_requires_college_role(self, client: AsyncClient, phd_scholarship: ScholarshipType):
-        """Upload endpoint requires college / admin / super_admin role."""
-        student_user = User(
+    @pytest.mark.parametrize(
+        "role,user_type",
+        [(UserRole.student, "student"), (UserRole.college, "employee")],
+    )
+    async def test_upload_requires_admin_role(
+        self, client: AsyncClient, phd_scholarship: ScholarshipType, role: UserRole, user_type: str
+    ):
+        """Upload endpoint is admin / super_admin only — students AND college users get 403."""
+        non_admin_user = User(
             id=999,
-            nycu_id="student_renewal",
-            name="Student User",
-            email="student.renewal@test.com",
-            role=UserRole.student,
-            user_type="student",
+            nycu_id="non_admin_renewal",
+            name="Non Admin User",
+            email="non.admin.renewal@test.com",
+            role=role,
+            college_code="E" if role == UserRole.college else None,
+            user_type=user_type,
         )
-        _override_user(student_user)
+        _override_user(non_admin_user)
         response = await client.post(
             f"{BASE}/upload",
             params={"scholarship_type": "phd", "academic_year": 114, "semester": "first"},
@@ -232,9 +238,9 @@ class TestRenewalImportEndpoints:
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.asyncio
-    async def test_download_template(self, client: AsyncClient, college_user: User, phd_scholarship: ScholarshipType):
+    async def test_download_template(self, client: AsyncClient, admin_user: User, phd_scholarship: ScholarshipType):
         """Template download returns an .xlsx attachment."""
-        _override_user(college_user)
+        _override_user(admin_user)
         response = await client.get(f"{BASE}/template", params={"scholarship_type": "phd"})
 
         assert response.status_code == status.HTTP_200_OK
@@ -244,10 +250,10 @@ class TestRenewalImportEndpoints:
         assert ".xlsx" in content_disposition
 
     @pytest.mark.asyncio
-    async def test_confirm_rejects_non_renewal_batch(self, client: AsyncClient, db: AsyncSession, college_user: User):
+    async def test_confirm_rejects_non_renewal_batch(self, client: AsyncClient, db: AsyncSession, admin_user: User):
         """The renewal confirm endpoint must reject a non-renewal batch (import_type='application') -> 404."""
         batch = BatchImport(
-            importer_id=college_user.id,
+            importer_id=admin_user.id,
             college_code="E",
             scholarship_type_id=1,
             academic_year=114,
@@ -262,7 +268,7 @@ class TestRenewalImportEndpoints:
         await db.commit()
         await db.refresh(batch)
 
-        _override_user(college_user)
+        _override_user(admin_user)
         response = await client.post(
             f"{BASE}/{batch.id}/confirm",
             json={"batch_id": batch.id, "confirm": True},
@@ -271,10 +277,10 @@ class TestRenewalImportEndpoints:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.asyncio
-    async def test_confirm_rejects_non_owner(self, client: AsyncClient, db: AsyncSession, college_user: User):
-        """A different non-super-admin user cannot confirm someone else's renewal batch -> 403."""
+    async def test_confirm_rejects_non_owner(self, client: AsyncClient, db: AsyncSession, admin_user: User):
+        """A different non-super-admin admin cannot confirm someone else's renewal batch -> 403."""
         batch = BatchImport(
-            importer_id=college_user.id,
+            importer_id=admin_user.id,
             college_code="E",
             scholarship_type_id=1,
             academic_year=114,
@@ -289,14 +295,14 @@ class TestRenewalImportEndpoints:
         await db.commit()
         await db.refresh(batch)
 
-        # A DIFFERENT college user (not the importer, not super_admin).
+        # A DIFFERENT admin user (not the importer, not super_admin) — passes
+        # require_admin, so the 403 comes from the ownership check.
         other_user = User(
             id=999,
-            nycu_id="other_college",
-            name="Other College User",
-            email="other.college@test.com",
-            role=UserRole.college,
-            college_code="H",
+            nycu_id="other_admin",
+            name="Other Admin User",
+            email="other.admin@test.com",
+            role=UserRole.admin,
             user_type="employee",
         )
         _override_user(other_user)
@@ -309,7 +315,7 @@ class TestRenewalImportEndpoints:
 
     @pytest.mark.asyncio
     async def test_confirm_happy_path_creates_approved_renewals(
-        self, client: AsyncClient, db: AsyncSession, college_user: User, phd_scholarship: ScholarshipType, monkeypatch
+        self, client: AsyncClient, db: AsyncSession, admin_user: User, phd_scholarship: ScholarshipType, monkeypatch
     ):
         """Confirming a pending renewal batch creates an approved is_renewal Application."""
         # Config for the (year, semester) is required by create_renewals_from_batch.
@@ -325,7 +331,7 @@ class TestRenewalImportEndpoints:
             )
         )
         batch = BatchImport(
-            importer_id=college_user.id,
+            importer_id=admin_user.id,
             college_code="E",
             scholarship_type_id=phd_scholarship.id,
             academic_year=114,
@@ -368,7 +374,7 @@ class TestRenewalImportEndpoints:
         # Keep the user-bulk path off the network; the student User is pre-created.
         monkeypatch.setattr(settings, "student_api_enabled", False, raising=False)
 
-        _override_user(college_user)
+        _override_user(admin_user)
         response = await client.post(
             f"{BASE}/{batch.id}/confirm",
             json={"batch_id": batch.id, "confirm": True},

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -272,7 +272,7 @@ export default function ScholarshipManagementSystem() {
 
     if (user.role === "college") {
       return (
-        <TabsList className="grid w-full grid-cols-3 bg-nycu-blue-50 border border-nycu-blue-200">
+        <TabsList className="grid w-full grid-cols-2 bg-nycu-blue-50 border border-nycu-blue-200">
           <TabsTrigger
             value="main"
             className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
@@ -286,13 +286,6 @@ export default function ScholarshipManagementSystem() {
           >
             <Upload className="h-4 w-4" />
             批次匯入
-          </TabsTrigger>
-          <TabsTrigger
-            value="renewal-import"
-            className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
-          >
-            <UserCheck className="h-4 w-4" />
-            {locale === "zh" ? "匯入續領生" : "Import Renewals"}
           </TabsTrigger>
         </TabsList>
       );
@@ -572,8 +565,8 @@ export default function ScholarshipManagementSystem() {
             </TabsContent>
           )}
 
-          {/* 匯入續領生 - college、admin 和 super_admin 角色可見 */}
-          {(user.role === "college" || user.role === "admin" || user.role === "super_admin") && (
+          {/* 匯入續領生 - 只有 admin 和 super_admin 可見 */}
+          {(user.role === "admin" || user.role === "super_admin") && (
             <TabsContent value="renewal-import" className="space-y-4">
               <RenewalImportPanel locale={locale} />
             </TabsContent>

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -5520,7 +5520,7 @@ export interface paths {
          *     **注意**: 「獎學金類別」欄位可填 `國科會` 或 `教育部`；僅「學生是否申請續領=是」
          *     且「續領審核結果=通過」的列會被匯入。
          *
-         *     **權限**: 僅限 college 角色。
+         *     **權限**: 僅限 admin / super_admin 角色。
          */
         get: operations["download_renewal_import_template_api_v1_college_review_renewal_import_template_get"];
         put?: never;


### PR DESCRIPTION
## Summary
- Backend: replace the file-local `require_college_role` dependency in `renewal_import.py` with the shared `require_admin` — all five renewal-import endpoints (upload / confirm / history / details / template) now return 403 for college users.
- Frontend: remove the 匯入續領生 tab from the college role's tab list (grid 3→2 cols) and narrow the `TabsContent` gate to admin/super_admin.
- Tests: endpoint tests now run as an admin user; parametrized 403 test covers both student and college roles; the non-owner confirm test uses a second admin so it still exercises the ownership check instead of being short-circuited by the role gate.
- Docs: template endpoint docstring updated (was still claiming 僅限 college 角色).

批次匯入 (batch import) is deliberately unchanged and keeps college access.

## Test plan
- [x] `app/tests/test_renewal_import_endpoints.py` — 9 passed (host, in-memory SQLite)
- [x] black + flake8 (B904/B014/F401) clean
- [x] frontend `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)