### PR TITLE
fix: zoom/download controls for the 閱讀獎學金要點 PDF viewer with a hardened reading gate

### DIFF
--- a/frontend/components/__tests__/inline-pdf-viewer.test.tsx
+++ b/frontend/components/__tests__/inline-pdf-viewer.test.tsx
@@ -72,6 +72,12 @@ jest.mock("react-pdf", () => {
 // Mock the worker side-effect import so it doesn't blow up jsdom.
 jest.mock("@/lib/pdf-worker", () => ({}));
 
+// Spy on the download helper so tests can assert without real anchor clicks.
+jest.mock("@/lib/utils/download", () => ({
+  ...jest.requireActual("@/lib/utils/download"),
+  triggerFileDownload: jest.fn(),
+}));
+
 // react-pdf bundles CSS we don't need under jsdom.
 jest.mock("react-pdf/dist/Page/AnnotationLayer.css", () => ({}), { virtual: true });
 jest.mock("react-pdf/dist/Page/TextLayer.css", () => ({}), { virtual: true });
@@ -90,9 +96,11 @@ function setScrollMetrics(
     scrollTop,
   }: { scrollHeight: number; clientHeight: number; scrollTop: number },
 ) {
-  Object.defineProperty(el, "scrollHeight", { configurable: true, value: scrollHeight });
-  Object.defineProperty(el, "clientHeight", { configurable: true, value: clientHeight });
-  Object.defineProperty(el, "scrollTop", { configurable: true, value: scrollTop });
+  // writable: the viewer restores scroll position after zoom by assigning
+  // scrollTop; a non-writable property would throw under strict mode.
+  Object.defineProperty(el, "scrollHeight", { configurable: true, writable: true, value: scrollHeight });
+  Object.defineProperty(el, "clientHeight", { configurable: true, writable: true, value: clientHeight });
+  Object.defineProperty(el, "scrollTop", { configurable: true, writable: true, value: scrollTop });
 }
 
 function flushRaf() {
@@ -198,6 +206,93 @@ describe("InlinePdfViewer", () => {
     });
 
     expect(onReached).not.toHaveBeenCalled();
+  });
+
+  it("zoom controls change the zoom level within [50%, 300%] and reset restores 100%", () => {
+    render(<InlinePdfViewer url="/fake.pdf" />);
+
+    // Disabled until the document loads.
+    expect(screen.getByTestId("pdf-zoom-in")).toBeDisabled();
+    expect(screen.getByTestId("pdf-zoom-out")).toBeDisabled();
+
+    act(() => reactPdf.__setSuccess(1));
+    expect(screen.getByTestId("pdf-zoom-level")).toHaveTextContent("100%");
+
+    fireEvent.click(screen.getByTestId("pdf-zoom-in"));
+    expect(screen.getByTestId("pdf-zoom-level")).toHaveTextContent("125%");
+
+    // Clamp at MIN_SCALE (50%): 125 → 100 → 75 → 50, then the button disables.
+    const zoomOut = screen.getByTestId("pdf-zoom-out");
+    fireEvent.click(zoomOut);
+    fireEvent.click(zoomOut);
+    fireEvent.click(zoomOut);
+    expect(screen.getByTestId("pdf-zoom-level")).toHaveTextContent("50%");
+    expect(zoomOut).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("pdf-zoom-reset"));
+    expect(screen.getByTestId("pdf-zoom-level")).toHaveTextContent("100%");
+    expect(screen.getByTestId("pdf-zoom-reset")).toBeDisabled();
+  });
+
+  it("does NOT auto-latch a fitting document while zoomed out (gate-bypass guard), but scrolling to the bottom still latches", async () => {
+    const onReached = jest.fn();
+    const { container } = render(
+      <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
+    );
+    const scroller = container.querySelector(
+      "[data-testid='pdf-scroll-container']",
+    ) as HTMLElement;
+    // Overflows at 100%.
+    setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 0 });
+
+    await act(async () => {
+      reactPdf.__setSuccess(2);
+      await flushRaf();
+    });
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(onReached).not.toHaveBeenCalled();
+
+    // Zoom out to 50%; now the whole document "fits" — must NOT auto-latch.
+    fireEvent.click(screen.getByTestId("pdf-zoom-out"));
+    fireEvent.click(screen.getByTestId("pdf-zoom-out"));
+    setScrollMetrics(scroller, { scrollHeight: 480, clientHeight: 500, scrollTop: 0 });
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(onReached).not.toHaveBeenCalled();
+
+    // Back at 100% the document overflows again; reaching the bottom by
+    // scrolling latches as usual.
+    fireEvent.click(screen.getByTestId("pdf-zoom-reset"));
+    setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 1098 });
+    fireEvent.scroll(scroller);
+    expect(onReached).toHaveBeenCalledTimes(1);
+  });
+
+  it("download button delegates to triggerFileDownload with the proxy URL and filename", () => {
+    const { triggerFileDownload } = jest.requireMock("@/lib/utils/download") as {
+      triggerFileDownload: jest.Mock;
+    };
+    triggerFileDownload.mockClear();
+
+    render(
+      <InlinePdfViewer url="/api/v1/preview/system-docs?key=regulations_url" downloadFilename="要點.pdf" />,
+    );
+    act(() => reactPdf.__setSuccess(1));
+
+    fireEvent.click(screen.getByTestId("pdf-download"));
+    expect(triggerFileDownload).toHaveBeenCalledWith(
+      "/api/v1/preview/system-docs?key=regulations_url",
+      "要點.pdf",
+    );
   });
 
   it("fires onLoadError and never fires onReachedBottom when load fails", () => {

--- a/frontend/components/__tests__/inline-pdf-viewer.test.tsx
+++ b/frontend/components/__tests__/inline-pdf-viewer.test.tsx
@@ -365,6 +365,60 @@ describe("InlinePdfViewer", () => {
     expect(scroller.scrollTop).toBe(1125);
   });
 
+  it("resets viewer state when the url changes and never latches against the old document", async () => {
+    const onReached = jest.fn();
+    const { container, rerender } = render(
+      <InlinePdfViewer url="/a.pdf" onReachedBottom={onReached} />,
+    );
+    const scroller = getScroller(container);
+    setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 0 });
+
+    await act(async () => {
+      reactPdf.__setSuccess(2);
+      await flushRaf();
+    });
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+    // Zoom in so the settle effect re-runs on the url-change commit with the
+    // (stale) fully-rendered counters — the exact hazard being guarded.
+    fireEvent.click(screen.getByTestId("pdf-zoom-in"));
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(onReached).not.toHaveBeenCalled();
+
+    // Swap the document. The old pages unmount, so the container collapses
+    // and would "fit" — the gate must NOT latch for the not-yet-loaded doc.
+    rerender(<InlinePdfViewer url="/b.pdf" onReachedBottom={onReached} />);
+    setScrollMetrics(scroller, { scrollHeight: 0, clientHeight: 500, scrollTop: 0 });
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(onReached).not.toHaveBeenCalled();
+    // Zoom resets for the new document.
+    expect(screen.getByTestId("pdf-zoom-level")).toHaveTextContent("100%");
+
+    // The new document loads and genuinely fits → latches once, on its own merits.
+    await act(async () => {
+      reactPdf.__setSuccess(1);
+      await flushRaf();
+    });
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(onReached).toHaveBeenCalledTimes(1);
+  });
+
   it("download button delegates to triggerFileDownload with the proxy URL and filename", () => {
     const { triggerFileDownload } = jest.requireMock("@/lib/utils/download") as {
       triggerFileDownload: jest.Mock;

--- a/frontend/components/__tests__/inline-pdf-viewer.test.tsx
+++ b/frontend/components/__tests__/inline-pdf-viewer.test.tsx
@@ -88,6 +88,14 @@ const reactPdf = jest.requireMock("react-pdf") as {
   __renderAllPages: () => void;
 };
 
+/**
+ * Define scroll metrics with a browser-like scrollTop: writes are clamped to
+ * [0, scrollHeight - clientHeight] and any change dispatches a real scroll
+ * event. This mirrors the mechanism behind the zoom-clamp gate-bypass this
+ * suite regression-tests: in a browser, a programmatic scrollTop write (or a
+ * content resize) that lands past the max is clamped to the bottom and fires
+ * a scroll event.
+ */
 function setScrollMetrics(
   el: HTMLElement,
   {
@@ -96,17 +104,43 @@ function setScrollMetrics(
     scrollTop,
   }: { scrollHeight: number; clientHeight: number; scrollTop: number },
 ) {
-  // writable: the viewer restores scroll position after zoom by assigning
-  // scrollTop; a non-writable property would throw under strict mode.
-  Object.defineProperty(el, "scrollHeight", { configurable: true, writable: true, value: scrollHeight });
-  Object.defineProperty(el, "clientHeight", { configurable: true, writable: true, value: clientHeight });
-  Object.defineProperty(el, "scrollTop", { configurable: true, writable: true, value: scrollTop });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    writable: true,
+    value: scrollHeight,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    configurable: true,
+    writable: true,
+    value: clientHeight,
+  });
+  let current = scrollTop;
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => current,
+    set: (v: number) => {
+      const max = Math.max(0, (el.scrollHeight as number) - (el.clientHeight as number));
+      const next = Math.max(0, Math.min(v, max));
+      if (next !== current) {
+        current = next;
+        el.dispatchEvent(new Event("scroll"));
+      }
+    },
+  });
 }
 
 function flushRaf() {
   return new Promise<void>((resolve) =>
     requestAnimationFrame(() => resolve()),
   );
+}
+
+function getScroller(container: HTMLElement): HTMLElement {
+  const scroller = container.querySelector(
+    "[data-testid='pdf-scroll-container']",
+  ) as HTMLElement;
+  expect(scroller).not.toBeNull();
+  return scroller;
 }
 
 describe("InlinePdfViewer", () => {
@@ -124,11 +158,7 @@ describe("InlinePdfViewer", () => {
       <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
     );
     act(() => reactPdf.__setSuccess(2));
-
-    const scroller = container.querySelector(
-      "[data-testid='pdf-scroll-container']",
-    ) as HTMLElement;
-    expect(scroller).not.toBeNull();
+    const scroller = getScroller(container);
 
     // Initial scroll, not yet at bottom.
     setScrollMetrics(scroller, { scrollHeight: 2000, clientHeight: 500, scrollTop: 100 });
@@ -151,10 +181,7 @@ describe("InlinePdfViewer", () => {
     const { container } = render(
       <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
     );
-
-    const scroller = container.querySelector(
-      "[data-testid='pdf-scroll-container']",
-    ) as HTMLElement;
+    const scroller = getScroller(container);
     setScrollMetrics(scroller, { scrollHeight: 400, clientHeight: 500, scrollTop: 0 });
 
     // onLoadSuccess alone (without page render) must NOT auto-latch. This is
@@ -187,10 +214,7 @@ describe("InlinePdfViewer", () => {
     const { container } = render(
       <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
     );
-
-    const scroller = container.querySelector(
-      "[data-testid='pdf-scroll-container']",
-    ) as HTMLElement;
+    const scroller = getScroller(container);
     // After all pages render, scrollHeight (1600) >> clientHeight (500)
     setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 0 });
 
@@ -234,15 +258,12 @@ describe("InlinePdfViewer", () => {
     expect(screen.getByTestId("pdf-zoom-reset")).toBeDisabled();
   });
 
-  it("does NOT auto-latch a fitting document while zoomed out (gate-bypass guard), but scrolling to the bottom still latches", async () => {
+  it("regression: the scroll-restore clamp during a zoom transition must NOT latch the reading gate", async () => {
     const onReached = jest.fn();
     const { container } = render(
       <InlinePdfViewer url="/fake.pdf" onReachedBottom={onReached} />,
     );
-    const scroller = container.querySelector(
-      "[data-testid='pdf-scroll-container']",
-    ) as HTMLElement;
-    // Overflows at 100%.
+    const scroller = getScroller(container);
     setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 0 });
 
     await act(async () => {
@@ -257,10 +278,25 @@ describe("InlinePdfViewer", () => {
     });
     expect(onReached).not.toHaveBeenCalled();
 
-    // Zoom out to 50%; now the whole document "fits" — must NOT auto-latch.
+    // User scrolls partway down (not latched).
+    act(() => {
+      scroller.scrollTop = 1000;
+    });
+    expect(onReached).not.toHaveBeenCalled();
+
+    // Zoom out to 75%. The component's restore writes scrollTop = 750; in the
+    // browser the later canvas shrink clamps scrollTop to the new bottom and
+    // fires a scroll event — the settling window must swallow all of it.
     fireEvent.click(screen.getByTestId("pdf-zoom-out"));
-    fireEvent.click(screen.getByTestId("pdf-zoom-out"));
-    setScrollMetrics(scroller, { scrollHeight: 480, clientHeight: 500, scrollTop: 0 });
+    // Simulate the passive canvas resize: content shrinks, browser clamps the
+    // 750 restore to the new max (1200 - 500 = 700 = bottom) and fires scroll.
+    setScrollMetrics(scroller, { scrollHeight: 1200, clientHeight: 500, scrollTop: 750 });
+    act(() => {
+      scroller.scrollTop = 9999; // clamped to 700 → dispatches scroll at bottom
+    });
+    expect(onReached).not.toHaveBeenCalled();
+
+    // Pages finish rendering at 75%; the settle window closes.
     await act(async () => {
       reactPdf.__renderAllPages();
     });
@@ -269,12 +305,64 @@ describe("InlinePdfViewer", () => {
     });
     expect(onReached).not.toHaveBeenCalled();
 
-    // Back at 100% the document overflows again; reaching the bottom by
-    // scrolling latches as usual.
-    fireEvent.click(screen.getByTestId("pdf-zoom-reset"));
-    setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 1098 });
+    // Even a genuine scroll to the bottom at 75% must not latch (content
+    // below 100% is not legible reading), and the hint says so.
     fireEvent.scroll(scroller);
+    expect(onReached).not.toHaveBeenCalled();
+    expect(screen.getByTestId("pdf-zoom-hint")).toBeInTheDocument();
+
+    // Back at 100%: restore targets 700 / 0.75 ≈ 933 in the regrown layout.
+    fireEvent.click(screen.getByTestId("pdf-zoom-reset"));
+    setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 700 });
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+    // Not at the bottom (1600 - 933 - 500 = 167 > 8) → still not latched.
+    expect(onReached).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("pdf-zoom-hint")).not.toBeInTheDocument();
+
+    // Now genuinely reach the bottom at 100% → latches exactly once.
+    act(() => {
+      scroller.scrollTop = 1600 - 500;
+    });
     expect(onReached).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-applies the zoom scroll restore after the new-scale layout settles (position kept)", async () => {
+    const { container } = render(<InlinePdfViewer url="/fake.pdf" />);
+    const scroller = getScroller(container);
+    setScrollMetrics(scroller, { scrollHeight: 1600, clientHeight: 500, scrollTop: 0 });
+
+    await act(async () => {
+      reactPdf.__setSuccess(2);
+      await flushRaf();
+    });
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+
+    act(() => {
+      scroller.scrollTop = 900;
+    });
+
+    // Zoom in to 125%: the immediate restore targets 1125, but the old layout
+    // caps scrollTop at 1100 — the browser clamps. Once the canvases grow
+    // (scrollHeight 2000), the settle pass must re-apply the true target.
+    fireEvent.click(screen.getByTestId("pdf-zoom-in"));
+    setScrollMetrics(scroller, { scrollHeight: 2000, clientHeight: 500, scrollTop: scroller.scrollTop });
+    await act(async () => {
+      reactPdf.__renderAllPages();
+    });
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(scroller.scrollTop).toBe(1125);
   });
 
   it("download button delegates to triggerFileDownload with the proxy URL and filename", () => {
@@ -295,7 +383,7 @@ describe("InlinePdfViewer", () => {
     );
   });
 
-  it("fires onLoadError and never fires onReachedBottom when load fails", () => {
+  it("fires onLoadError and never fires onReachedBottom when load fails — and keeps download/open-in-new-tab available", () => {
     const onReached = jest.fn();
     const onErr = jest.fn();
     render(
@@ -312,5 +400,10 @@ describe("InlinePdfViewer", () => {
     expect(onErr).toHaveBeenCalledWith(err);
     expect(onReached).not.toHaveBeenCalled();
     expect(screen.getByText(/重新載入|Reload/)).toBeInTheDocument();
+    // The file may still be downloadable even when pdf.js can't render it, so
+    // the toolbar's escape hatches must survive the error state.
+    expect(screen.getByTestId("pdf-download")).toBeEnabled();
+    expect(screen.getByTestId("pdf-open-new-tab")).toBeEnabled();
+    expect(screen.getByTestId("pdf-zoom-in")).toBeDisabled();
   });
 });

--- a/frontend/components/file-preview-dialog.tsx
+++ b/frontend/components/file-preview-dialog.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Eye, FileText } from "lucide-react";
 import { Locale } from "@/lib/validators";
 import { getTranslation } from "@/lib/i18n";
+import { triggerFileDownload } from "@/lib/utils/download";
 
 interface FilePreviewDialogProps {
   isOpen: boolean;
@@ -67,16 +68,7 @@ export function FilePreviewDialog({
     if (!file) return;
 
     // 如果有專門的下載URL，使用它；否則使用預覽URL
-    const downloadUrl = file.downloadUrl || file.url;
-
-    // 創建一個隱藏的 a 標籤來下載文件
-    const link = document.createElement("a");
-    link.href = downloadUrl;
-    link.download = file.filename;
-    link.target = "_blank";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    triggerFileDownload(file.downloadUrl || file.url, file.filename);
   };
 
   if (!file) return null;

--- a/frontend/components/inline-pdf-viewer.tsx
+++ b/frontend/components/inline-pdf-viewer.tsx
@@ -1,10 +1,24 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { Document, Page } from "react-pdf";
-import { AlertCircle, RotateCcw } from "lucide-react";
+import {
+  AlertCircle,
+  Download,
+  ExternalLink,
+  RotateCcw,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { triggerFileDownload } from "@/lib/utils/download";
 
 // Side-effect import: configures pdfjs.GlobalWorkerOptions.workerSrc.
 import "@/lib/pdf-worker";
@@ -16,18 +30,43 @@ interface InlinePdfViewerProps {
   url: string;
   // Tailwind classes for sizing the scroll container, e.g.
   // `h-[min(700px,calc(90vh-200px))]`. Required in practice — the
-  // container has no intrinsic height without one.
+  // container has no intrinsic height without one. The zoom/download
+  // toolbar adds its own height on top of this.
   className?: string;
   onReachedBottom?: () => void;
   onLoadError?: (err: Error) => void;
+  // Filename used by the toolbar's download button.
+  downloadFilename?: string;
   locale?: "zh" | "en";
 }
 
 const SLACK_PX = 8;
+const MIN_SCALE = 0.5;
+const MAX_SCALE = 3;
+const SCALE_STEP = 0.25;
+const DEFAULT_SCALE = 1;
 
 const LABELS = {
-  zh: { loading: "載入中…", error: "無法載入文件", reload: "重新載入" },
-  en: { loading: "Loading…", error: "Failed to load document", reload: "Reload" },
+  zh: {
+    loading: "載入中…",
+    error: "無法載入文件",
+    reload: "重新載入",
+    zoomIn: "放大",
+    zoomOut: "縮小",
+    resetZoom: "重設縮放",
+    download: "下載",
+    openInNewTab: "另開新視窗",
+  },
+  en: {
+    loading: "Loading…",
+    error: "Failed to load document",
+    reload: "Reload",
+    zoomIn: "Zoom in",
+    zoomOut: "Zoom out",
+    resetZoom: "Reset zoom",
+    download: "Download",
+    openInNewTab: "Open in new tab",
+  },
 } as const;
 
 export function InlinePdfViewer({
@@ -35,6 +74,7 @@ export function InlinePdfViewer({
   className,
   onReachedBottom,
   onLoadError,
+  downloadFilename,
   locale = "zh",
 }: InlinePdfViewerProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -42,6 +82,7 @@ export function InlinePdfViewer({
   const [renderedCount, setRenderedCount] = useState(0);
   const [loadError, setLoadError] = useState<Error | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [scale, setScale] = useState(DEFAULT_SCALE);
 
   const latched = useRef(false);
   useEffect(() => {
@@ -63,6 +104,26 @@ export function InlinePdfViewer({
     }
   }, [fireReached]);
 
+  // Keep the reading position stable across zoom changes: page height scales
+  // linearly with `scale`, so the equivalent scroll offset is prev * ratio.
+  const pendingScrollTop = useRef<number | null>(null);
+  const zoomTo = useCallback((compute: (prev: number) => number) => {
+    setScale((prev) => {
+      const next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, compute(prev)));
+      if (next !== prev && scrollRef.current) {
+        pendingScrollTop.current = (scrollRef.current.scrollTop * next) / prev;
+      }
+      return next;
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (pendingScrollTop.current === null) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = pendingScrollTop.current;
+    pendingScrollTop.current = null;
+  }, [scale]);
+
   const handleLoadSuccess = useCallback(
     ({ numPages: n }: { numPages: number }) => {
       setNumPages(n);
@@ -81,7 +142,12 @@ export function InlinePdfViewer({
   // race against canvas painting and could auto-latch on an empty container.
   // Wait until every page has reported render success, then check on the
   // next frame so layout has settled.
+  //
+  // Only auto-latch at the default scale: a zoomed-out document that "fits"
+  // would otherwise unlock the reading gate without the content ever being
+  // legible.
   useEffect(() => {
+    if (scale !== DEFAULT_SCALE) return;
     if (numPages === null || renderedCount < numPages) return;
     const el = scrollRef.current;
     if (!el) return;
@@ -93,7 +159,7 @@ export function InlinePdfViewer({
       }
     });
     return () => cancelAnimationFrame(id);
-  }, [numPages, renderedCount, fireReached]);
+  }, [numPages, renderedCount, fireReached, scale]);
 
   const handleLoadError = useCallback(
     (err: Error) => {
@@ -103,64 +169,148 @@ export function InlinePdfViewer({
     [onLoadError],
   );
 
+  const handleDownload = useCallback(() => {
+    triggerFileDownload(url, downloadFilename || "document.pdf");
+  }, [url, downloadFilename]);
+
+  const handleOpenInNewTab = useCallback(() => {
+    window.open(url, "_blank", "noopener");
+  }, [url]);
+
   const labels = LABELS[locale];
+  const isDocumentReady = numPages !== null;
 
   return (
-    <div
-      ref={scrollRef}
-      data-testid="pdf-scroll-container"
-      onScroll={handleScroll}
-      className={`overflow-y-auto rounded-lg border bg-white ${className ?? ""}`}
-    >
-      {loadError ? (
-        <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
-          <AlertCircle className="h-8 w-8 text-red-500" />
-          <p className="text-sm font-medium text-red-700">{labels.error}</p>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              setLoadError(null);
-              setNumPages(null);
-              setReloadToken((t) => t + 1);
-            }}
-          >
-            <RotateCcw className="mr-1.5 h-4 w-4" />
-            {labels.reload}
-          </Button>
+    <div className="flex flex-col overflow-hidden rounded-lg border bg-white">
+      {!loadError && (
+        <div className="flex items-center justify-between gap-2 border-b bg-gray-50 px-2 py-1.5">
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              data-testid="pdf-zoom-out"
+              title={labels.zoomOut}
+              aria-label={labels.zoomOut}
+              disabled={!isDocumentReady || scale <= MIN_SCALE}
+              onClick={() => zoomTo((prev) => prev - SCALE_STEP)}
+            >
+              <ZoomOut className="h-4 w-4" />
+            </Button>
+            <span
+              data-testid="pdf-zoom-level"
+              className="w-12 text-center text-xs font-medium tabular-nums text-gray-600"
+            >
+              {Math.round(scale * 100)}%
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              data-testid="pdf-zoom-in"
+              title={labels.zoomIn}
+              aria-label={labels.zoomIn}
+              disabled={!isDocumentReady || scale >= MAX_SCALE}
+              onClick={() => zoomTo((prev) => prev + SCALE_STEP)}
+            >
+              <ZoomIn className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              data-testid="pdf-zoom-reset"
+              title={labels.resetZoom}
+              aria-label={labels.resetZoom}
+              disabled={!isDocumentReady || scale === DEFAULT_SCALE}
+              onClick={() => zoomTo(() => DEFAULT_SCALE)}
+            >
+              <RotateCcw className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              data-testid="pdf-open-new-tab"
+              title={labels.openInNewTab}
+              aria-label={labels.openInNewTab}
+              onClick={handleOpenInNewTab}
+            >
+              <ExternalLink className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              data-testid="pdf-download"
+              title={labels.download}
+              aria-label={labels.download}
+              onClick={handleDownload}
+            >
+              <Download className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
-      ) : (
-        <Document
-          key={`${url}#${reloadToken}`}
-          file={url}
-          loading={
-            <div className="space-y-3 p-6">
-              <Skeleton className="h-6 w-full" />
-              <Skeleton className="h-6 w-[90%]" />
-              <Skeleton className="h-6 w-[85%]" />
-              <Skeleton className="h-6 w-[95%]" />
-              <p className="pt-2 text-center text-xs text-muted-foreground">
-                {labels.loading}
-              </p>
-            </div>
-          }
-          onLoadSuccess={handleLoadSuccess}
-          onLoadError={handleLoadError}
-        >
-          {numPages !== null
-            ? Array.from({ length: numPages }, (_, i) => (
-                <Page
-                  key={i + 1}
-                  pageNumber={i + 1}
-                  renderAnnotationLayer
-                  renderTextLayer
-                  onRenderSuccess={handlePageRenderSuccess}
-                  className="mx-auto mb-2"
-                />
-              ))
-            : null}
-        </Document>
       )}
+      <div
+        ref={scrollRef}
+        data-testid="pdf-scroll-container"
+        onScroll={handleScroll}
+        className={`overflow-auto bg-white ${className ?? ""}`}
+      >
+        {loadError ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
+            <AlertCircle className="h-8 w-8 text-red-500" />
+            <p className="text-sm font-medium text-red-700">{labels.error}</p>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setLoadError(null);
+                setNumPages(null);
+                setReloadToken((t) => t + 1);
+              }}
+            >
+              <RotateCcw className="mr-1.5 h-4 w-4" />
+              {labels.reload}
+            </Button>
+          </div>
+        ) : (
+          <Document
+            key={`${url}#${reloadToken}`}
+            file={url}
+            loading={
+              <div className="space-y-3 p-6">
+                <Skeleton className="h-6 w-full" />
+                <Skeleton className="h-6 w-[90%]" />
+                <Skeleton className="h-6 w-[85%]" />
+                <Skeleton className="h-6 w-[95%]" />
+                <p className="pt-2 text-center text-xs text-muted-foreground">
+                  {labels.loading}
+                </p>
+              </div>
+            }
+            onLoadSuccess={handleLoadSuccess}
+            onLoadError={handleLoadError}
+          >
+            {numPages !== null
+              ? Array.from({ length: numPages }, (_, i) => (
+                  <Page
+                    key={i + 1}
+                    pageNumber={i + 1}
+                    scale={scale}
+                    renderAnnotationLayer
+                    renderTextLayer
+                    onRenderSuccess={handlePageRenderSuccess}
+                    className="mx-auto mb-2 w-fit"
+                  />
+                ))
+              : null}
+          </Document>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/components/inline-pdf-viewer.tsx
+++ b/frontend/components/inline-pdf-viewer.tsx
@@ -133,6 +133,13 @@ export function InlinePdfViewer({
   // that would otherwise satisfy the bottom check without any real reading.
   const settling = useRef(false);
   const pendingScrollTop = useRef<number | null>(null);
+  // Identity of the document instance currently loaded. The settle effect
+  // only acts when this matches the docKey being rendered — otherwise, on a
+  // url change, it could run with stale numPages/renderedCount in the same
+  // commit that unmounts the old pages and latch against the collapsed
+  // container before the new document loads.
+  const docKey = `${url}#${reloadToken}`;
+  const loadedDocKey = useRef<string | null>(null);
 
   useEffect(() => {
     latched.current = false;
@@ -140,6 +147,9 @@ export function InlinePdfViewer({
     pendingScrollTop.current = null;
     setScale(DEFAULT_SCALE);
     setReachedBottom(false);
+    setNumPages(null);
+    setRenderedCount(0);
+    setLoadError(null);
   }, [url, reloadToken]);
 
   const fireReached = useCallback(() => {
@@ -196,6 +206,7 @@ export function InlinePdfViewer({
   // re-check the bottom/fits condition on the next frame — which also covers
   // the initial "short document fits without scrolling" auto-latch.
   useEffect(() => {
+    if (loadedDocKey.current !== docKey) return;
     if (numPages === null || renderedCount < numPages) return;
     const el = scrollRef.current;
     if (el && pendingScrollTop.current !== null) {
@@ -207,15 +218,16 @@ export function InlinePdfViewer({
       tryLatchAtBottom();
     });
     return () => cancelAnimationFrame(id);
-  }, [numPages, renderedCount, tryLatchAtBottom]);
+  }, [numPages, renderedCount, tryLatchAtBottom, docKey]);
 
   const handleLoadSuccess = useCallback(
     ({ numPages: n }: { numPages: number }) => {
+      loadedDocKey.current = docKey;
       setNumPages(n);
       setRenderedCount(0);
       setLoadError(null);
     },
-    [],
+    [docKey],
   );
 
   const handlePageRenderSuccess = useCallback(() => {

--- a/frontend/components/inline-pdf-viewer.tsx
+++ b/frontend/components/inline-pdf-viewer.tsx
@@ -15,6 +15,7 @@ import {
   RotateCcw,
   ZoomIn,
   ZoomOut,
+  type LucideIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -28,10 +29,10 @@ import "react-pdf/dist/Page/TextLayer.css";
 
 interface InlinePdfViewerProps {
   url: string;
-  // Tailwind classes for sizing the scroll container, e.g.
-  // `h-[min(700px,calc(90vh-200px))]`. Required in practice — the
-  // container has no intrinsic height without one. The zoom/download
-  // toolbar adds its own height on top of this.
+  // Tailwind classes sizing the WHOLE viewer (toolbar + scroll area), e.g.
+  // `h-[min(745px,calc(90vh-200px))]`. Required in practice — the component
+  // has no intrinsic height without one. The toolbar consumes its share from
+  // this budget, so callers only need to account for their own chrome.
   className?: string;
   onReachedBottom?: () => void;
   onLoadError?: (err: Error) => void;
@@ -45,29 +46,68 @@ const MIN_SCALE = 0.5;
 const MAX_SCALE = 3;
 const SCALE_STEP = 0.25;
 const DEFAULT_SCALE = 1;
+// Cap on scale × devicePixelRatio for the canvas backing store. Without it,
+// an A4 page at MAX_SCALE on a DPR-2 display needs ~18M backing pixels,
+// past mobile Safari's ~16.7M canvas ceiling — the page would paint blank.
+// With the cap the worst case is ~(595·4)×(842·4) ≈ 8M pixels.
+const MAX_RASTER_FACTOR = 4;
 
 const LABELS = {
   zh: {
     loading: "載入中…",
     error: "無法載入文件",
+    errorFallback: "您仍可使用上方按鈕下載檔案或在新視窗開啟",
     reload: "重新載入",
     zoomIn: "放大",
     zoomOut: "縮小",
     resetZoom: "重設縮放",
+    zoomHint: "縮放低於 100% 時不計入閱讀進度",
     download: "下載",
-    openInNewTab: "另開新視窗",
+    openInNewTab: "在新視窗開啟",
   },
   en: {
     loading: "Loading…",
     error: "Failed to load document",
+    errorFallback:
+      "You can still download the file or open it in a new tab from the toolbar",
     reload: "Reload",
     zoomIn: "Zoom in",
     zoomOut: "Zoom out",
     resetZoom: "Reset zoom",
+    zoomHint: "Zoom below 100% does not count toward reading progress",
     download: "Download",
     openInNewTab: "Open in new tab",
   },
 } as const;
+
+function ToolbarIconButton({
+  icon: Icon,
+  label,
+  testId,
+  disabled,
+  onClick,
+}: {
+  icon: LucideIcon;
+  label: string;
+  testId: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8"
+      data-testid={testId}
+      title={label}
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <Icon className="h-4 w-4" />
+    </Button>
+  );
+}
 
 export function InlinePdfViewer({
   url,
@@ -83,46 +123,91 @@ export function InlinePdfViewer({
   const [loadError, setLoadError] = useState<Error | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const [scale, setScale] = useState(DEFAULT_SCALE);
+  const [reachedBottom, setReachedBottom] = useState(false);
 
   const latched = useRef(false);
+  // True from a zoom click until every page has re-rendered at the new scale
+  // (plus one frame). While settling, scroll events are ignored: the browser
+  // clamps scrollTop when page canvases resize (react-pdf resizes them in a
+  // passive effect, after our restore below) and dispatches scroll events
+  // that would otherwise satisfy the bottom check without any real reading.
+  const settling = useRef(false);
+  const pendingScrollTop = useRef<number | null>(null);
+
   useEffect(() => {
     latched.current = false;
+    settling.current = false;
+    pendingScrollTop.current = null;
+    setScale(DEFAULT_SCALE);
+    setReachedBottom(false);
   }, [url, reloadToken]);
 
   const fireReached = useCallback(() => {
     if (latched.current) return;
     latched.current = true;
+    setReachedBottom(true);
     onReachedBottom?.();
   }, [onReachedBottom]);
 
-  const handleScroll = useCallback(() => {
-    if (latched.current) return;
+  // Single latch path for both "scrolled to the bottom" and "document fits
+  // without scrolling" (a fitting document has scrollTop 0 and satisfies the
+  // same inequality). Refuses to latch while zoomed below 100% — shrunken
+  // content is not legible reading — and while a zoom transition is settling.
+  const tryLatchAtBottom = useCallback(() => {
+    if (latched.current || settling.current) return;
+    if (scale < DEFAULT_SCALE) return;
     const el = scrollRef.current;
     if (!el) return;
     if (el.scrollHeight - el.scrollTop - el.clientHeight <= SLACK_PX) {
       fireReached();
     }
-  }, [fireReached]);
+  }, [scale, fireReached]);
 
-  // Keep the reading position stable across zoom changes: page height scales
-  // linearly with `scale`, so the equivalent scroll offset is prev * ratio.
-  const pendingScrollTop = useRef<number | null>(null);
-  const zoomTo = useCallback((compute: (prev: number) => number) => {
-    setScale((prev) => {
-      const next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, compute(prev)));
-      if (next !== prev && scrollRef.current) {
-        pendingScrollTop.current = (scrollRef.current.scrollTop * next) / prev;
+  const zoomTo = useCallback(
+    (next: number) => {
+      const clamped = Math.min(MAX_SCALE, Math.max(MIN_SCALE, next));
+      if (clamped === scale) return;
+      const el = scrollRef.current;
+      if (el) {
+        // Page height scales linearly with `scale`, so the equivalent scroll
+        // offset is the previous one times the scale ratio.
+        pendingScrollTop.current = (el.scrollTop * clamped) / scale;
       }
-      return next;
-    });
-  }, []);
+      settling.current = true;
+      setRenderedCount(0);
+      setScale(clamped);
+    },
+    [scale],
+  );
 
+  // Best-effort immediate restore so the viewport doesn't visibly jump. The
+  // canvases still have their old sizes here (react-pdf resizes them in a
+  // passive effect), so this write may be clamped; the settle effect below
+  // re-applies the restore once the new-scale layout is final.
   useLayoutEffect(() => {
     if (pendingScrollTop.current === null) return;
     const el = scrollRef.current;
     if (el) el.scrollTop = pendingScrollTop.current;
-    pendingScrollTop.current = null;
   }, [scale]);
+
+  // Runs once all pages have rendered at the current scale (renderedCount is
+  // reset both on document load and on every zoom change): re-apply the
+  // scroll restore against the final layout, then end the settling window and
+  // re-check the bottom/fits condition on the next frame — which also covers
+  // the initial "short document fits without scrolling" auto-latch.
+  useEffect(() => {
+    if (numPages === null || renderedCount < numPages) return;
+    const el = scrollRef.current;
+    if (el && pendingScrollTop.current !== null) {
+      el.scrollTop = pendingScrollTop.current;
+    }
+    pendingScrollTop.current = null;
+    const id = requestAnimationFrame(() => {
+      settling.current = false;
+      tryLatchAtBottom();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [numPages, renderedCount, tryLatchAtBottom]);
 
   const handleLoadSuccess = useCallback(
     ({ numPages: n }: { numPages: number }) => {
@@ -136,30 +221,6 @@ export function InlinePdfViewer({
   const handlePageRenderSuccess = useCallback(() => {
     setRenderedCount((c) => c + 1);
   }, []);
-
-  // Pdf.js renders each <Page> to canvas asynchronously after onLoadSuccess
-  // fires. Checking the fits-without-scrolling condition immediately would
-  // race against canvas painting and could auto-latch on an empty container.
-  // Wait until every page has reported render success, then check on the
-  // next frame so layout has settled.
-  //
-  // Only auto-latch at the default scale: a zoomed-out document that "fits"
-  // would otherwise unlock the reading gate without the content ever being
-  // legible.
-  useEffect(() => {
-    if (scale !== DEFAULT_SCALE) return;
-    if (numPages === null || renderedCount < numPages) return;
-    const el = scrollRef.current;
-    if (!el) return;
-    const id = requestAnimationFrame(() => {
-      const cur = scrollRef.current;
-      if (!cur) return;
-      if (cur.scrollHeight <= cur.clientHeight + SLACK_PX) {
-        fireReached();
-      }
-    });
-    return () => cancelAnimationFrame(id);
-  }, [numPages, renderedCount, fireReached, scale]);
 
   const handleLoadError = useCallback(
     (err: Error) => {
@@ -178,92 +239,81 @@ export function InlinePdfViewer({
   }, [url]);
 
   const labels = LABELS[locale];
-  const isDocumentReady = numPages !== null;
+  const isDocumentReady = numPages !== null && !loadError;
+  const devicePixelRatio =
+    typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+  const effectiveDpr = Math.min(devicePixelRatio, MAX_RASTER_FACTOR / scale);
 
   return (
-    <div className="flex flex-col overflow-hidden rounded-lg border bg-white">
-      {!loadError && (
-        <div className="flex items-center justify-between gap-2 border-b bg-gray-50 px-2 py-1.5">
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              data-testid="pdf-zoom-out"
-              title={labels.zoomOut}
-              aria-label={labels.zoomOut}
-              disabled={!isDocumentReady || scale <= MIN_SCALE}
-              onClick={() => zoomTo((prev) => prev - SCALE_STEP)}
-            >
-              <ZoomOut className="h-4 w-4" />
-            </Button>
+    <div
+      className={`flex flex-col overflow-hidden rounded-lg border bg-white ${className ?? ""}`}
+    >
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b bg-gray-50 px-2 py-1.5">
+        <div className="flex items-center gap-1">
+          <ToolbarIconButton
+            icon={ZoomOut}
+            label={labels.zoomOut}
+            testId="pdf-zoom-out"
+            disabled={!isDocumentReady || scale <= MIN_SCALE}
+            onClick={() => zoomTo(scale - SCALE_STEP)}
+          />
+          <span
+            data-testid="pdf-zoom-level"
+            className="w-12 text-center text-xs font-medium tabular-nums text-gray-600"
+          >
+            {Math.round(scale * 100)}%
+          </span>
+          <ToolbarIconButton
+            icon={ZoomIn}
+            label={labels.zoomIn}
+            testId="pdf-zoom-in"
+            disabled={!isDocumentReady || scale >= MAX_SCALE}
+            onClick={() => zoomTo(scale + SCALE_STEP)}
+          />
+          <ToolbarIconButton
+            icon={RotateCcw}
+            label={labels.resetZoom}
+            testId="pdf-zoom-reset"
+            disabled={!isDocumentReady || scale === DEFAULT_SCALE}
+            onClick={() => zoomTo(DEFAULT_SCALE)}
+          />
+          {scale < DEFAULT_SCALE && !reachedBottom && (
             <span
-              data-testid="pdf-zoom-level"
-              className="w-12 text-center text-xs font-medium tabular-nums text-gray-600"
+              data-testid="pdf-zoom-hint"
+              className="ml-1 text-xs text-amber-600"
             >
-              {Math.round(scale * 100)}%
+              {labels.zoomHint}
             </span>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              data-testid="pdf-zoom-in"
-              title={labels.zoomIn}
-              aria-label={labels.zoomIn}
-              disabled={!isDocumentReady || scale >= MAX_SCALE}
-              onClick={() => zoomTo((prev) => prev + SCALE_STEP)}
-            >
-              <ZoomIn className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              data-testid="pdf-zoom-reset"
-              title={labels.resetZoom}
-              aria-label={labels.resetZoom}
-              disabled={!isDocumentReady || scale === DEFAULT_SCALE}
-              onClick={() => zoomTo(() => DEFAULT_SCALE)}
-            >
-              <RotateCcw className="h-4 w-4" />
-            </Button>
-          </div>
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              data-testid="pdf-open-new-tab"
-              title={labels.openInNewTab}
-              aria-label={labels.openInNewTab}
-              onClick={handleOpenInNewTab}
-            >
-              <ExternalLink className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              data-testid="pdf-download"
-              title={labels.download}
-              aria-label={labels.download}
-              onClick={handleDownload}
-            >
-              <Download className="h-4 w-4" />
-            </Button>
-          </div>
+          )}
         </div>
-      )}
+        <div className="flex items-center gap-1">
+          <ToolbarIconButton
+            icon={ExternalLink}
+            label={labels.openInNewTab}
+            testId="pdf-open-new-tab"
+            onClick={handleOpenInNewTab}
+          />
+          <ToolbarIconButton
+            icon={Download}
+            label={labels.download}
+            testId="pdf-download"
+            onClick={handleDownload}
+          />
+        </div>
+      </div>
       <div
         ref={scrollRef}
         data-testid="pdf-scroll-container"
-        onScroll={handleScroll}
-        className={`overflow-auto bg-white ${className ?? ""}`}
+        onScroll={tryLatchAtBottom}
+        className="min-h-0 flex-1 overflow-auto bg-white"
       >
         {loadError ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
             <AlertCircle className="h-8 w-8 text-red-500" />
             <p className="text-sm font-medium text-red-700">{labels.error}</p>
+            <p className="text-xs text-muted-foreground">
+              {labels.errorFallback}
+            </p>
             <Button
               size="sm"
               variant="outline"
@@ -301,6 +351,7 @@ export function InlinePdfViewer({
                     key={i + 1}
                     pageNumber={i + 1}
                     scale={scale}
+                    devicePixelRatio={effectiveDpr}
                     renderAnnotationLayer
                     renderTextLayer
                     onRenderSuccess={handlePageRenderSuccess}

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -493,9 +493,9 @@ export function NoticeAgreementStep({
                 "regulations_url",
                 publicDocs.regulations_url,
               )!}
-              // 245px = DialogHeader + DialogContent padding + footer row +
-              // border + the viewer's zoom/download toolbar (~45px).
-              className="h-[min(700px,calc(90vh-245px))]"
+              // 200px = DialogHeader + DialogContent padding + footer row +
+              // border. The viewer's toolbar sizes itself inside this budget.
+              className="h-[min(745px,calc(90vh-200px))]"
               locale={locale}
               onReachedBottom={handleReachedBottom}
               downloadFilename={

--- a/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
+++ b/frontend/components/student-wizard/steps/NoticeAgreementStep.tsx
@@ -493,10 +493,14 @@ export function NoticeAgreementStep({
                 "regulations_url",
                 publicDocs.regulations_url,
               )!}
-              // 200px = DialogHeader + DialogContent padding + footer row + border.
-              className="h-[min(700px,calc(90vh-200px))]"
+              // 245px = DialogHeader + DialogContent padding + footer row +
+              // border + the viewer's zoom/download toolbar (~45px).
+              className="h-[min(700px,calc(90vh-245px))]"
               locale={locale}
               onReachedBottom={handleReachedBottom}
+              downloadFilename={
+                publicDocs.regulations_url_filename || "scholarship-regulations.pdf"
+              }
             />
           )}
           <div className="flex items-center justify-between pt-3 border-t mt-2">

--- a/frontend/lib/utils/download.ts
+++ b/frontend/lib/utils/download.ts
@@ -20,3 +20,19 @@ export function triggerBlobDownload({
   document.body.removeChild(link);
   URL.revokeObjectURL(url);
 }
+
+/**
+ * Trigger a browser download of an already-authenticated same-origin URL
+ * (e.g. an /api/v1/preview/... proxy URL) via a transient anchor.
+ *
+ * Shared by FilePreviewDialog and InlinePdfViewer download buttons.
+ */
+export function triggerFileDownload(url: string, filename: string): void {
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.target = "_blank";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/frontend/lib/utils/download.ts
+++ b/frontend/lib/utils/download.ts
@@ -11,7 +11,10 @@ function downloadViaAnchor({
   const link = document.createElement("a");
   link.href = href;
   link.download = filename;
-  if (target) link.target = target;
+  if (target) {
+    link.target = target;
+    link.rel = "noopener noreferrer";
+  }
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);

--- a/frontend/lib/utils/download.ts
+++ b/frontend/lib/utils/download.ts
@@ -1,3 +1,22 @@
+/** Click a transient anchor to hand a download off to the browser. */
+function downloadViaAnchor({
+  href,
+  filename,
+  target,
+}: {
+  href: string;
+  filename: string;
+  target?: string;
+}): void {
+  const link = document.createElement("a");
+  link.href = href;
+  link.download = filename;
+  if (target) link.target = target;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
 /**
  * Trigger a browser download for a fetched binary export.
  *
@@ -12,27 +31,18 @@ export function triggerBlobDownload({
   filename: string;
 }): void {
   const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  downloadViaAnchor({ href: url, filename });
   URL.revokeObjectURL(url);
 }
 
 /**
- * Trigger a browser download of an already-authenticated same-origin URL
- * (e.g. an /api/v1/preview/... proxy URL) via a transient anchor.
+ * Trigger a browser download of an already-authenticated SAME-ORIGIN URL
+ * (e.g. an /api/v1/preview/... proxy URL). The `download` attribute is only
+ * honored same-origin; do not pass cross-origin URLs — they would open in a
+ * tab instead of downloading.
  *
  * Shared by FilePreviewDialog and InlinePdfViewer download buttons.
  */
 export function triggerFileDownload(url: string, filename: string): void {
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  link.target = "_blank";
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  downloadViaAnchor({ href: url, filename, target: "_blank" });
 }


### PR DESCRIPTION
## Summary

The student wizard's 閱讀獎學金要點 dialog renders the regulations through `InlinePdfViewer` (react-pdf canvas, required for the scroll-to-bottom reading gate) but offered no viewer controls, unlike the apply step's `FilePreviewDialog` which gets zoom/download from the browser's native iframe viewer.

### Commit 1 — add the toolbar
- Zoom out/in (50%–300%, 25% steps), reset, open-in-new-tab, and download buttons on `InlinePdfViewer`.
- Rendering stays on react-pdf canvas through the same-origin `/api/v1/preview` proxy — no iframe, no CSP or `frame-ancestors` changes.
- Shared `triggerFileDownload` helper extracted to `lib/utils/download.ts` and reused by `FilePreviewDialog`.

### Commit 2 — code-review hardening (multi-agent review, 15 findings)
- **Gate bypass fixed:** the scroll restore runs before react-pdf resizes canvases (passive effect), so zooming caused the browser to clamp `scrollTop` to a transient bottom and fire a scroll event that latched the gate without real reading. Both latch paths are now one guarded `tryLatchAtBottom`: it refuses to fire below 100% zoom and during a settling window that lasts until all pages re-render at the new scale.
- Scroll restore is re-applied after settle, so the reading position survives zoom-in instead of clamping to the old layout.
- A toolbar hint explains that zoom below 100% doesn't count toward reading progress (prevents a silent dead-end when a zoomed-out doc fits without scrolling).
- `Page devicePixelRatio` capped so scale × DPR ≤ 4 — keeps the canvas backing store under mobile Safari's ~16.7M-pixel ceiling (pages rendered blank at 300% on DPR-2 devices otherwise).
- Height contract: `className` now sizes the whole viewer (toolbar `shrink-0`, scroll area `flex-1 min-h-0`), removing the magic toolbar-height offset from `NoticeAgreementStep`.
- Toolbar (download / open-in-new-tab) stays available in the load-error state.
- Cleanup: `ToolbarIconButton` dedup, shared `downloadViaAnchor`, zh label aligned with lib/i18n, zoom state reset on `url` change.

## Test plan
- [x] 18 jest tests pass, including new regression tests: the clamp-induced scroll event must not latch the gate; the restore is re-applied post-settle; toolbar survives load errors; zoom clamps at 50%/300%.
- [x] Test helper now emulates browser scroll semantics (clamped `scrollTop` writes dispatch scroll events) so the bypass mechanism is actually exercised.
- [x] `tsc --noEmit` and ESLint clean.
- [ ] Manual smoke: open 閱讀獎學金要點, zoom in/out/download, confirm the agree checkbox only unlocks after genuinely scrolling to the bottom at ≥100% zoom.