### PR TITLE
feat: show professor and college recommendation on the manual distribution page

### DIFF
--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -93,6 +93,48 @@ async def load_rejected_subtype_map(db: AsyncSession, app_ids: list[int]) -> dic
     return rejected_map
 
 
+async def load_review_items_by_role(db: AsyncSession, app_ids: list[int]) -> dict[int, dict[str, list[dict[str, Any]]]]:
+    """Load per-sub-type review verdicts grouped by reviewer role for a batch of applications.
+
+    Returns {application_id: {"professor": [...], "college": [...]}} where each
+    entry is {"sub_type_code", "recommendation", "comments"} — the same summary
+    shape the college review list exposes as professor_review_items. Admin
+    reviews are excluded on purpose: the manual-distribution grid IS the admin
+    decision surface, so only the upstream 教授/學院 verdicts are displayed.
+    Sub-type codes are normalized with _norm_sub_type (matches rejected_sub_types).
+    """
+    review_map: dict[int, dict[str, list[dict[str, Any]]]] = {}
+    if not app_ids:
+        return review_map
+    query = (
+        select(
+            ApplicationReview.application_id,
+            User.role,
+            ApplicationReviewItem.sub_type_code,
+            ApplicationReviewItem.recommendation,
+            ApplicationReviewItem.comments,
+        )
+        .join(ApplicationReviewItem, ApplicationReviewItem.review_id == ApplicationReview.id)
+        .join(User, User.id == ApplicationReview.reviewer_id)
+        .where(
+            ApplicationReview.application_id.in_(app_ids),
+            User.role.in_([UserRole.professor, UserRole.college]),
+        )
+        .order_by(ApplicationReview.reviewed_at, ApplicationReviewItem.id)
+    )
+    result = await db.execute(query)
+    for app_id, role, sub_type_code, recommendation, comments in result:
+        role_key = role.value if hasattr(role, "value") else str(role)
+        review_map.setdefault(app_id, {}).setdefault(role_key, []).append(
+            {
+                "sub_type_code": _norm_sub_type(sub_type_code),
+                "recommendation": recommendation,
+                "comments": comments,
+            }
+        )
+    return review_map
+
+
 def _compute_suggestions(
     unique_items: list,
     default_prefs: list[str],
@@ -388,6 +430,10 @@ class ManualDistributionService:
         """See load_rejected_subtype_map (module-level, shared with the renewal path)."""
         return await load_rejected_subtype_map(self.db, app_ids)
 
+    async def _batch_load_review_items(self, app_ids: list[int]) -> dict[int, dict[str, list[dict[str, Any]]]]:
+        """See load_review_items_by_role (module-level)."""
+        return await load_review_items_by_role(self.db, app_ids)
+
     async def _bulk_system_received_months(
         self,
         items: list[CollegeRankingItem],
@@ -460,7 +506,7 @@ class ManualDistributionService:
         # when an application appears in more than one finalized ranking.
         items_query = (
             select(CollegeRankingItem)
-            .options(selectinload(CollegeRankingItem.application))
+            .options(selectinload(CollegeRankingItem.application).selectinload(Application.scholarship_configuration))
             .where(CollegeRankingItem.ranking_id.in_(ranking_ids))
             .order_by(CollegeRankingItem.rank_position, CollegeRankingItem.id)
         )
@@ -470,6 +516,10 @@ class ManualDistributionService:
         # Batch-load rejected sub-types from professor reviews
         app_ids = [item.application.id for item in items if item.application]
         rejected_map = await self._batch_load_rejected_map(app_ids)
+
+        # Batch-load per-sub-type 教授/學院 review verdicts for the
+        # recommendation display columns.
+        review_items_map = await self._batch_load_review_items(app_ids)
 
         # Bulk-compute system received_months for all students in one query.
         # Admin-imported overrides (source="imported") take precedence over
@@ -512,12 +562,27 @@ class ManualDistributionService:
                 rm_value = system_months.get(student_id_value) if student_id_value else None
                 rm_source = "system" if rm_value is not None else None
 
+            app_reviews = review_items_map.get(app.id, {})
+            cfg = app.scholarship_configuration
+
             student = {
                 "ranking_item_id": item.id,
                 "application_id": app.id,
                 "rank_position": item.rank_position,
                 "applied_sub_types": app.scholarship_subtype_list or [],
                 "rejected_sub_types": list(rejected_map.get(app.id, set())),
+                # Per-sub-type 推薦/不推薦 verdicts from the unified review
+                # table, split by reviewer role for the 教授推薦/學院推薦
+                # display columns. The college's PRIMARY verdict is the
+                # finalized ranking itself (college_rejected below) — its
+                # review items only supplement it. requires_professor_
+                # recommendation lets the UI distinguish "審核中" (step
+                # required, no verdict yet) from "—" (no professor step).
+                "professor_review_items": app_reviews.get("professor", []),
+                "college_review_items": app_reviews.get("college", []),
+                "requires_professor_recommendation": bool(
+                    cfg and cfg.requires_professor_review_for(bool(app.is_renewal))
+                ),
                 "allocated_sub_type": item.allocated_sub_type,
                 # Config whose quota this slot consumes — the frontend grid
                 # seeds the checked column from (allocated_sub_type,

--- a/backend/app/tests/test_manual_distribution_dedup.py
+++ b/backend/app/tests/test_manual_distribution_dedup.py
@@ -45,6 +45,7 @@ async def test_dedup_prefers_allocated_item_over_unallocated_duplicate():
         suspend_reason=None,
         is_renewal=False,
         renewal_year=None,
+        scholarship_configuration=None,
     )
     unallocated = _item(11, 1, app=app, is_allocated=False)
     allocated = _item(12, 2, app=app, is_allocated=True, allocated_sub_type="nstc")
@@ -68,6 +69,7 @@ async def test_dedup_prefers_allocated_item_over_unallocated_duplicate():
     svc = ManualDistributionService(db)
     # Isolate the dedup: stub the per-student/bulk helpers.
     svc._batch_load_rejected_map = AsyncMock(return_value={})
+    svc._batch_load_review_items = AsyncMock(return_value={})
     svc._bulk_system_received_months = AsyncMock(return_value={})
     svc._compute_application_identity = MagicMock(return_value="114新申請")
     svc._compute_term_count = MagicMock(return_value=1)
@@ -96,6 +98,7 @@ async def test_dedup_keeps_single_row_when_no_allocation():
         suspend_reason=None,
         is_renewal=False,
         renewal_year=None,
+        scholarship_configuration=None,
     )
     i1 = _item(21, 1, app=app, is_allocated=False)
     i2 = _item(22, 2, app=app, is_allocated=False)
@@ -115,6 +118,7 @@ async def test_dedup_keeps_single_row_when_no_allocation():
     db.execute = AsyncMock(side_effect=_execute)
     svc = ManualDistributionService(db)
     svc._batch_load_rejected_map = AsyncMock(return_value={})
+    svc._batch_load_review_items = AsyncMock(return_value={})
     svc._bulk_system_received_months = AsyncMock(return_value={})
     svc._compute_application_identity = MagicMock(return_value="114新申請")
     svc._compute_term_count = MagicMock(return_value=1)
@@ -146,6 +150,7 @@ async def test_items_query_orders_by_rank_then_id_for_determinism():
     db.execute = AsyncMock(side_effect=_execute)
     svc = ManualDistributionService(db)
     svc._batch_load_rejected_map = AsyncMock(return_value={})
+    svc._batch_load_review_items = AsyncMock(return_value={})
     svc._bulk_system_received_months = AsyncMock(return_value={})
 
     await svc.get_students_for_distribution(2, 114, "yearly")
@@ -173,6 +178,7 @@ async def test_dedup_both_allocated_collapses_to_single_deterministic_row():
         suspend_reason=None,
         is_renewal=False,
         renewal_year=None,
+        scholarship_configuration=None,
     )
     a1 = _item(31, 1, app=app, is_allocated=True, allocated_sub_type="nstc")
     a2 = _item(32, 2, app=app, is_allocated=True, allocated_sub_type="moe_1w")
@@ -192,6 +198,7 @@ async def test_dedup_both_allocated_collapses_to_single_deterministic_row():
     db.execute = AsyncMock(side_effect=_execute)
     svc = ManualDistributionService(db)
     svc._batch_load_rejected_map = AsyncMock(return_value={})
+    svc._batch_load_review_items = AsyncMock(return_value={})
     svc._bulk_system_received_months = AsyncMock(return_value={})
     svc._compute_application_identity = MagicMock(return_value="114新申請")
     svc._compute_term_count = MagicMock(return_value=1)

--- a/backend/app/tests/test_manual_distribution_review_display.py
+++ b/backend/app/tests/test_manual_distribution_review_display.py
@@ -1,0 +1,229 @@
+"""Tests for the 教授推薦/學院推薦 display fields on manual-distribution rows.
+
+get_students_for_distribution must expose, per student row:
+  - professor_review_items / college_review_items: per-sub-type verdicts
+    ({sub_type_code, recommendation, comments}) split by reviewer role, with
+    admin reviews excluded (the grid IS the admin decision surface);
+  - requires_professor_recommendation: renewal-aware config flag so the UI can
+    distinguish 審核中 (professor step required, no verdict yet) from — (no
+    professor step at all).
+
+The college's PRIMARY verdict is the finalized ranking itself (the existing
+college_rejected field) — college review items only supplement it, so there is
+no requires_college_review flag.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import ApplicationStatus, ReviewStage, Semester
+from app.models.review import ApplicationReview, ApplicationReviewItem
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.manual_distribution_service import ManualDistributionService
+
+YEAR = 114
+SEM = Semester.first.value
+
+
+async def _make_user(db: AsyncSession, *, suffix: str, role: UserRole) -> User:
+    user = User(
+        nycu_id=f"rvd_{role.value}_{suffix}",
+        name=f"Rvd {role.value} {suffix}",
+        email=f"rvd_{role.value}_{suffix}@u.edu",
+        user_type=UserType.student if role == UserRole.student else UserType.employee,
+        role=role,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _add_review(
+    db: AsyncSession,
+    *,
+    application_id: int,
+    reviewer: User,
+    items: list[tuple[str, str, str | None]],
+) -> None:
+    """Add one ApplicationReview with (sub_type_code, recommendation, comments) items."""
+    review = ApplicationReview(
+        application_id=application_id,
+        reviewer_id=reviewer.id,
+        recommendation="approve" if all(rec == "approve" for _, rec, _ in items) else "partial_approve",
+        reviewed_at=datetime.now(timezone.utc),
+    )
+    db.add(review)
+    await db.commit()
+    await db.refresh(review)
+    for sub_type_code, recommendation, comments in items:
+        db.add(
+            ApplicationReviewItem(
+                review_id=review.id,
+                sub_type_code=sub_type_code,
+                recommendation=recommendation,
+                comments=comments,
+            )
+        )
+    await db.commit()
+
+
+async def _setup(
+    db: AsyncSession,
+    *,
+    suffix: str,
+    requires_prof: bool = True,
+    renewal_requires_prof: bool = False,
+    is_renewal: bool = False,
+) -> tuple[ManualDistributionService, Application, int]:
+    """Student + config + application + finalized ranking item.
+
+    Returns (service, application, scholarship_type_id).
+    """
+    student = await _make_user(db, suffix=suffix, role=UserRole.student)
+
+    sch = ScholarshipType(code=f"rvd_sch_{suffix}", name=f"Rvd Sch {suffix}", status="active")
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        config_code=f"rvd_cfg_{suffix}",
+        config_name=f"Rvd cfg {suffix}",
+        academic_year=YEAR,
+        semester=SEM,
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        requires_professor_recommendation=requires_prof,
+        renewal_requires_professor_review=renewal_requires_prof,
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+
+    app = Application(
+        app_id=f"APP-RVD-{suffix}",
+        user_id=student.id,
+        scholarship_type_id=sch.id,
+        scholarship_configuration_id=cfg.id,
+        sub_type_selection_mode="multiple",
+        is_renewal=is_renewal,
+        academic_year=YEAR,
+        semester=Semester.first.value,
+        review_stage=ReviewStage.college_ranked.value,
+        status=ApplicationStatus.submitted.value,
+        scholarship_subtype_list=["nstc", "moe_1w"],
+        agree_terms=True,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+
+    ranking = CollegeRanking(
+        scholarship_type_id=sch.id,
+        sub_type_code="default",
+        academic_year=YEAR,
+        semester=SEM,
+        total_applications=1,
+        total_quota=5,
+        is_finalized=True,
+    )
+    db.add(ranking)
+    await db.commit()
+    await db.refresh(ranking)
+
+    item = CollegeRankingItem(ranking_id=ranking.id, application_id=app.id, rank_position=1)
+    db.add(item)
+    await db.commit()
+
+    return ManualDistributionService(db), app, sch.id
+
+
+@pytest.mark.asyncio
+async def test_rows_split_review_items_by_role_and_exclude_admin(db: AsyncSession):
+    service, app, sch_id = await _setup(db, suffix="split")
+    professor = await _make_user(db, suffix="split", role=UserRole.professor)
+    college = await _make_user(db, suffix="split", role=UserRole.college)
+    admin = await _make_user(db, suffix="split", role=UserRole.admin)
+
+    await _add_review(
+        db,
+        application_id=app.id,
+        reviewer=professor,
+        items=[("nstc", "approve", None), ("moe_1w", "reject", "名額有限")],
+    )
+    await _add_review(db, application_id=app.id, reviewer=college, items=[("nstc", "approve", "同意")])
+    await _add_review(db, application_id=app.id, reviewer=admin, items=[("nstc", "reject", "admin 不算")])
+
+    rows = await service.get_students_for_distribution(sch_id, YEAR, SEM)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["professor_review_items"] == [
+        {"sub_type_code": "nstc", "recommendation": "approve", "comments": None},
+        {"sub_type_code": "moe_1w", "recommendation": "reject", "comments": "名額有限"},
+    ]
+    assert row["college_review_items"] == [{"sub_type_code": "nstc", "recommendation": "approve", "comments": "同意"}]
+    assert row["requires_professor_recommendation"] is True
+
+
+@pytest.mark.asyncio
+async def test_rows_without_reviews_expose_empty_lists_and_config_flag(db: AsyncSession):
+    service, _app, sch_id = await _setup(db, suffix="empty", requires_prof=False)
+
+    rows = await service.get_students_for_distribution(sch_id, YEAR, SEM)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["professor_review_items"] == []
+    assert row["college_review_items"] == []
+    assert row["requires_professor_recommendation"] is False
+
+
+@pytest.mark.asyncio
+async def test_review_item_sub_type_codes_are_normalized(db: AsyncSession):
+    """Codes are admin-defined free-form strings — the display fields must be
+    normalized (lowercase/stripped) exactly like rejected_sub_types so the
+    frontend can match them against config column keys."""
+    service, app, sch_id = await _setup(db, suffix="norm")
+    professor = await _make_user(db, suffix="norm", role=UserRole.professor)
+
+    await _add_review(db, application_id=app.id, reviewer=professor, items=[(" NSTC ", "approve", None)])
+
+    rows = await service.get_students_for_distribution(sch_id, YEAR, SEM)
+
+    assert rows[0]["professor_review_items"] == [
+        {"sub_type_code": "nstc", "recommendation": "approve", "comments": None}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_renewal_rows_ignore_general_professor_flag(db: AsyncSession):
+    """Renewals read renewal_requires_professor_review, NOT the general flag —
+    a renewal of a scholarship whose new-application flow needs a professor
+    step must not show 教授審核中 when the renewal flow skips that step."""
+    service, _app, sch_id = await _setup(
+        db, suffix="renew", requires_prof=True, renewal_requires_prof=False, is_renewal=True
+    )
+
+    rows = await service.get_students_for_distribution(sch_id, YEAR, SEM)
+
+    assert rows[0]["requires_professor_recommendation"] is False
+
+
+@pytest.mark.asyncio
+async def test_renewal_rows_use_renewal_professor_flag(db: AsyncSession):
+    service, _app, sch_id = await _setup(
+        db, suffix="renew2", requires_prof=False, renewal_requires_prof=True, is_renewal=True
+    )
+
+    rows = await service.get_students_for_distribution(sch_id, YEAR, SEM)
+
+    assert rows[0]["requires_professor_recommendation"] is True

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -111,6 +111,7 @@ const VERDICT_CHIP = {
   approve: `${VERDICT_CHIP_BASE} bg-emerald-50 text-emerald-700 border-emerald-300`,
   reject: `${VERDICT_CHIP_BASE} bg-red-50 text-red-600 border-red-300`,
   pending: `${VERDICT_CHIP_BASE} bg-amber-50 text-amber-700 border-amber-300`,
+  none: `${VERDICT_CHIP_BASE} bg-slate-50 text-slate-500 border-slate-300`,
 };
 
 /**
@@ -142,6 +143,70 @@ function ReviewItemChips({
           </span>
         );
       })}
+    </>
+  );
+}
+
+/**
+ * 學院推薦 per-sub-type chips: one chip for EVERY applied sub-type, so a
+ * sub-type the college rejected (不推薦) or never gave a verdict on (未推薦)
+ * is written out instead of silently omitted. Any reject wins over approve
+ * (matches the rejected_sub_types convention); review items on sub-types
+ * outside the applied list are still appended so no verdict is lost.
+ */
+function CollegeSubTypeVerdictChips({
+  appliedSubTypes,
+  items,
+  quotaStatus,
+}: {
+  appliedSubTypes: string[];
+  items: ReviewItemSummary[];
+  quotaStatus: QuotaStatus;
+}) {
+  const norm = (code: string) => code.toLowerCase().trim();
+  const applied = Array.from(new Set(appliedSubTypes.map(norm)));
+  const labelFor = (code: string) =>
+    getSubTypeShortName(code, quotaStatus[code]?.display_name || code);
+  const extras = items.filter(item => !applied.includes(norm(item.sub_type_code)));
+  return (
+    <>
+      {applied.map(code => {
+        const verdicts = items.filter(item => norm(item.sub_type_code) === code);
+        const reject = verdicts.find(item => item.recommendation !== "approve");
+        const approve = verdicts.find(item => item.recommendation === "approve");
+        if (reject) {
+          return (
+            <span
+              key={code}
+              title={reject.comments || undefined}
+              className={VERDICT_CHIP.reject}
+            >
+              {labelFor(code)}: 不推薦
+            </span>
+          );
+        }
+        if (approve) {
+          return (
+            <span
+              key={code}
+              title={approve.comments || undefined}
+              className={VERDICT_CHIP.approve}
+            >
+              {labelFor(code)}: 推薦
+            </span>
+          );
+        }
+        return (
+          <span
+            key={code}
+            title="學院未對此子類型作出推薦審核"
+            className={VERDICT_CHIP.none}
+          >
+            {labelFor(code)}: 未推薦
+          </span>
+        );
+      })}
+      <ReviewItemChips items={extras} quotaStatus={quotaStatus} />
     </>
   );
 }
@@ -1471,7 +1536,10 @@ export function ManualDistributionPanel({
                                         排名: 推薦
                                       </span>
                                     )}
-                                    <ReviewItemChips
+                                    <CollegeSubTypeVerdictChips
+                                      appliedSubTypes={
+                                        student.applied_sub_types || []
+                                      }
                                       items={student.college_review_items || []}
                                       quotaStatus={quotaStatus}
                                     />

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -10,6 +10,7 @@ import type {
   DistributionStudent,
   LocalAlloc,
   QuotaStatus,
+  ReviewItemSummary,
   SubTypeConfigCol,
   DistributionHistoryRecord,
   RestoreRequest,
@@ -102,6 +103,47 @@ function getSubTypeShortName(sub_type: string, display_name: string): string {
   return display_name.length > 7
     ? display_name.slice(0, 6) + "…"
     : display_name;
+}
+
+const VERDICT_CHIP_BASE =
+  "inline-flex items-center w-fit px-1 py-0.5 rounded border text-[10px] leading-none whitespace-nowrap";
+const VERDICT_CHIP = {
+  approve: `${VERDICT_CHIP_BASE} bg-emerald-50 text-emerald-700 border-emerald-300`,
+  reject: `${VERDICT_CHIP_BASE} bg-red-50 text-red-600 border-red-300`,
+  pending: `${VERDICT_CHIP_BASE} bg-amber-50 text-amber-700 border-amber-300`,
+};
+
+/**
+ * Per-sub-type 推薦/不推薦 chips for the 教授推薦/學院推薦 columns
+ * (reviewer comments on hover); renders nothing when there are no verdicts.
+ */
+function ReviewItemChips({
+  items,
+  quotaStatus,
+}: {
+  items: ReviewItemSummary[];
+  quotaStatus: QuotaStatus;
+}) {
+  return (
+    <>
+      {items.map((item, idx) => {
+        const label = getSubTypeShortName(
+          item.sub_type_code,
+          quotaStatus[item.sub_type_code]?.display_name || item.sub_type_code
+        );
+        const isApprove = item.recommendation === "approve";
+        return (
+          <span
+            key={`${item.sub_type_code}-${idx}`}
+            title={item.comments || undefined}
+            className={isApprove ? VERDICT_CHIP.approve : VERDICT_CHIP.reject}
+          >
+            {label}: {isApprove ? "推薦" : "不推薦"}
+          </span>
+        );
+      })}
+    </>
+  );
 }
 
 export function ManualDistributionPanel({
@@ -1174,7 +1216,7 @@ export function ManualDistributionPanel({
             <div className="overflow-x-auto">
               <table
                 className="w-full text-left border-collapse text-xs"
-                style={{ minWidth: `${950 + subTypeCols.length * 85}px` }}
+                style={{ minWidth: `${1140 + subTypeCols.length * 85}px` }}
               >
                 <thead className="bg-slate-50 text-[13px] text-slate-600">
                   {/* Row 1 */}
@@ -1190,6 +1232,18 @@ export function ManualDistributionPanel({
                       className="px-1.5 py-1.5 border border-slate-200 font-semibold w-32 text-[11px]"
                     >
                       申請類別
+                    </th>
+                    <th
+                      rowSpan={2}
+                      className="px-1.5 py-1.5 border border-slate-200 font-semibold w-24 text-[11px]"
+                    >
+                      教授推薦
+                    </th>
+                    <th
+                      rowSpan={2}
+                      className="px-1.5 py-1.5 border border-slate-200 font-semibold w-24 text-[11px]"
+                    >
+                      學院推薦
                     </th>
                     {subTypeCols.length > 0 && (
                       <th
@@ -1282,7 +1336,7 @@ export function ManualDistributionPanel({
                   {filteredStudents.length === 0 ? (
                     <tr>
                       <td
-                        colSpan={12 + subTypeCols.length}
+                        colSpan={14 + subTypeCols.length}
                         className="px-4 py-10 text-center text-slate-500"
                       >
                         {students.length === 0
@@ -1304,7 +1358,7 @@ export function ManualDistributionPanel({
                             className="bg-slate-100"
                           >
                             <td
-                              colSpan={12 + subTypeCols.length}
+                              colSpan={14 + subTypeCols.length}
                               className="px-4 py-1.5 text-xs font-bold text-slate-600 border-y border-slate-300"
                             >
                               {collegeName}
@@ -1372,6 +1426,56 @@ export function ManualDistributionPanel({
                                       —
                                     </span>
                                   )}
+                                </td>
+                                <td className="px-1.5 py-1.5 border-r border-slate-100 leading-snug">
+                                  {(student.professor_review_items || [])
+                                    .length > 0 ? (
+                                    <div className="flex flex-col gap-0.5">
+                                      <ReviewItemChips
+                                        items={student.professor_review_items}
+                                        quotaStatus={quotaStatus}
+                                      />
+                                    </div>
+                                  ) : student.requires_professor_recommendation ? (
+                                    <span
+                                      className={VERDICT_CHIP.pending}
+                                      title="教授尚未完成推薦審核"
+                                    >
+                                      審核中
+                                    </span>
+                                  ) : (
+                                    <span className="text-[11px] text-slate-400">
+                                      —
+                                    </span>
+                                  )}
+                                </td>
+                                <td className="px-1.5 py-1.5 border-r border-slate-100 leading-snug">
+                                  <div className="flex flex-col gap-0.5">
+                                    {/* The ranking IS the college's primary
+                                        verdict: rows only exist once the
+                                        college finalized its ranking, and
+                                        N (college_rejected) means 不推薦.
+                                        Review-tab verdicts supplement it. */}
+                                    {student.college_rejected ? (
+                                      <span
+                                        className={VERDICT_CHIP.reject}
+                                        title="學院於確認排名將此生標記為 N（不推薦）"
+                                      >
+                                        排名: 不推薦
+                                      </span>
+                                    ) : (
+                                      <span
+                                        className={VERDICT_CHIP.approve}
+                                        title="已列入學院確認排名"
+                                      >
+                                        排名: 推薦
+                                      </span>
+                                    )}
+                                    <ReviewItemChips
+                                      items={student.college_review_items || []}
+                                      quotaStatus={quotaStatus}
+                                    />
+                                  </div>
                                 </td>
                                 {subTypeCols.map(col => {
                                   const isApplied =

--- a/frontend/e2e/specs/manual-dist-recommendation-columns.spec.ts
+++ b/frontend/e2e/specs/manual-dist-recommendation-columns.spec.ts
@@ -1,0 +1,404 @@
+/**
+ * Scenario: 教授推薦 / 學院推薦 recommendation columns on the admin manual
+ * distribution grid (管理員手動分發).
+ *
+ * The feature adds two columns between 申請類別 and the 核配 checkbox group:
+ *
+ *   教授推薦 — per-sub-type verdict chips built from professor review items
+ *     ("國科會: 推薦" emerald / "教育部: 不推薦" red, reviewer comment in the
+ *     title attr); an amber "審核中" chip when the config requires a professor
+ *     recommendation but no professor review exists yet; "—" when there is no
+ *     professor step at all.
+ *   學院推薦 — ALWAYS leads with the ranking verdict chip: "排名: 推薦" (emerald)
+ *     normally, "排名: 不推薦" (red) when the ranking item has college_rejected
+ *     (the 排序 cell then shows a red "N") — followed by any per-sub-type
+ *     college-role review chips.
+ *
+ * Admin-role reviews are excluded from BOTH columns — the grid IS the admin
+ * decision surface.
+ *
+ * This spec seeds four ranked applications (all college C, scholarship phd /
+ * config 5 / 114 全年) plus one finalized college ranking directly via SQL,
+ * logs in as admin, opens the manual-distribution grid, asserts the chips, and
+ * saves labeled screenshot evidence. It only READS the grid — no allocate /
+ * finalize is triggered, so it leaves distribution state untouched.
+ */
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { authContext } from "../helpers/auth";
+import { FRONTEND_URL } from "../helpers/env";
+import { pool } from "../helpers/db";
+import * as fs from "fs";
+import * as path from "path";
+
+const SCHOLARSHIP_TYPE_ID = 2;
+const CONFIG_ID = 5;
+const ACADEMIC_YEAR = 114;
+const COLLEGE_CODE = "C";
+const RANKING_NAME = "E2E-REC-DISPLAY"; // idempotency tag for our seeded ranking
+const APP_PREFIX = "APP-114-0-9"; // our app_ids: APP-114-0-9000x
+
+const PROFESSOR_ID = 12; // cs_professor
+const COLLEGE_REVIEWER_ID = 13; // cs_college (college_code C)
+const ADMIN_ID = 1; // admin — must NOT appear in either column
+
+const EVIDENCE_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "docs",
+  "staging-tests",
+  "2026-07-22",
+  "01-manual-dist-recommendation"
+);
+
+interface SeedStudent {
+  appId: string;
+  userId: number;
+  nycuId: string;
+  name: string;
+  rank: number;
+  renewal: boolean;
+  collegeRejected: boolean;
+}
+
+const STUDENTS: SeedStudent[] = [
+  // App1 — professor partial_approve (nstc approve, moe_1w reject) + college approve(nstc)
+  {
+    appId: "APP-114-0-90001",
+    userId: 14,
+    nycuId: "csphd0001",
+    name: "王博士研究生",
+    rank: 1,
+    renewal: false,
+    collegeRejected: false,
+  },
+  // App2 — NO reviews → 教授推薦 = 審核中
+  {
+    appId: "APP-114-0-90002",
+    userId: 15,
+    nycuId: "csphd0002",
+    name: "陳AI博士",
+    rank: 2,
+    renewal: false,
+    collegeRejected: false,
+  },
+  // App3 — professor approve(nstc, moe_1w); college_rejected → red N + 排名: 不推薦
+  {
+    appId: "APP-114-0-90003",
+    userId: 16,
+    nycuId: "csphd0003",
+    name: "林機器學習博士",
+    rank: 3,
+    renewal: false,
+    collegeRejected: true,
+  },
+  // App4 — renewal; ONLY an admin reject review → excluded → 教授推薦 = 審核中
+  {
+    appId: "APP-114-0-90004",
+    userId: 6,
+    nycuId: "stuphd001",
+    name: "王博士",
+    rank: 4,
+    renewal: true,
+    collegeRejected: false,
+  },
+];
+
+const ADMIN_ONLY_COMMENT = "admin 審查不應顯示";
+const PROF_MOE_REJECT_COMMENT = "名額有限，僅推薦國科會";
+
+test.describe.configure({ mode: "serial" });
+
+async function purgeSeed(): Promise<void> {
+  const { rows } = await pool.query<{ id: number }>(
+    "SELECT id FROM applications WHERE app_id LIKE $1",
+    [`${APP_PREFIX}%`]
+  );
+  const ids = rows.map(r => r.id);
+  if (ids.length > 0) {
+    await pool.query(
+      `DELETE FROM application_review_items
+         WHERE review_id IN (SELECT id FROM application_reviews WHERE application_id = ANY($1))`,
+      [ids]
+    );
+    await pool.query("DELETE FROM application_reviews WHERE application_id = ANY($1)", [ids]);
+    await pool.query("DELETE FROM college_ranking_items WHERE application_id = ANY($1)", [ids]);
+  }
+  await pool.query(
+    "DELETE FROM college_ranking_items WHERE ranking_id IN (SELECT id FROM college_rankings WHERE ranking_name = $1)",
+    [RANKING_NAME]
+  );
+  await pool.query("DELETE FROM college_rankings WHERE ranking_name = $1", [RANKING_NAME]);
+  if (ids.length > 0) {
+    await pool.query("DELETE FROM applications WHERE id = ANY($1)", [ids]);
+  }
+}
+
+async function insertReview(
+  applicationId: number,
+  reviewerId: number,
+  recommendation: string,
+  items: Array<{ sub_type_code: string; recommendation: string; comments: string | null }>
+): Promise<void> {
+  const { rows } = await pool.query<{ id: number }>(
+    `INSERT INTO application_reviews (application_id, reviewer_id, recommendation, reviewed_at, created_at)
+       VALUES ($1, $2, $3, now(), now()) RETURNING id`,
+    [applicationId, reviewerId, recommendation]
+  );
+  const reviewId = rows[0].id;
+  for (const item of items) {
+    await pool.query(
+      `INSERT INTO application_review_items (review_id, sub_type_code, recommendation, comments)
+         VALUES ($1, $2, $3, $4)`,
+      [reviewId, item.sub_type_code, item.recommendation, item.comments]
+    );
+  }
+}
+
+async function seed(): Promise<void> {
+  await purgeSeed();
+
+  // 1. Applications
+  for (const s of STUDENTS) {
+    const studentData = {
+      std_academyno: COLLEGE_CODE,
+      std_stdcode: s.nycuId,
+      std_cname: s.name,
+      trm_academyname: "資訊學院",
+      trm_depname: "資訊工程學系",
+      trm_termcount: "3",
+      std_nation: "中華民國",
+    };
+    await pool.query(
+      `INSERT INTO applications
+         (app_id, user_id, scholarship_type_id, scholarship_configuration_id,
+          scholarship_subtype_list, sub_type_selection_mode, sub_scholarship_type,
+          is_renewal, renewal_year, status, review_stage, academic_year, semester,
+          student_data, agree_terms, created_at, updated_at)
+       VALUES ($1, $2, $3, $4,
+          $5::json, 'multiple', 'nstc',
+          $6, $7, 'submitted', 'college_ranked', $8, NULL,
+          $9::json, true, now(), now())`,
+      [
+        s.appId,
+        s.userId,
+        SCHOLARSHIP_TYPE_ID,
+        CONFIG_ID,
+        JSON.stringify(["nstc", "moe_1w"]),
+        s.renewal,
+        s.renewal ? ACADEMIC_YEAR : null,
+        ACADEMIC_YEAR,
+        JSON.stringify(studentData),
+      ]
+    );
+  }
+
+  const { rows: appRows } = await pool.query<{ id: number; app_id: string }>(
+    "SELECT id, app_id FROM applications WHERE app_id = ANY($1)",
+    [STUDENTS.map(s => s.appId)]
+  );
+  const appDbId: Record<string, number> = {};
+  for (const r of appRows) appDbId[r.app_id] = r.id;
+
+  // 2. One finalized college ranking (college C, phd, 114, yearly)
+  const { rows: rk } = await pool.query<{ id: number }>(
+    `INSERT INTO college_rankings
+       (scholarship_type_id, sub_type_code, academic_year, semester, college_code,
+        ranking_name, total_applications, total_quota, is_finalized, ranking_status,
+        finalized_at, finalized_by, created_by, created_at, updated_at)
+     VALUES ($1, 'default', $2, NULL, $3, $4, $5, 5, true, 'finalized',
+        now(), $6, $6, now(), now())
+     RETURNING id`,
+    [SCHOLARSHIP_TYPE_ID, ACADEMIC_YEAR, COLLEGE_CODE, RANKING_NAME, STUDENTS.length, COLLEGE_REVIEWER_ID]
+  );
+  const rankingId = rk[0].id;
+
+  // 3. Ranking items (rank 1-4; App3 college_rejected)
+  for (const s of STUDENTS) {
+    await pool.query(
+      `INSERT INTO college_ranking_items
+         (ranking_id, application_id, rank_position, college_rejected, is_supplementary,
+          status, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, false, 'ranked', now(), now())`,
+      [rankingId, appDbId[s.appId], s.rank, s.collegeRejected]
+    );
+  }
+
+  // 4. Reviews
+  // App1: professor partial_approve (nstc approve / moe_1w reject) + college approve(nstc)
+  await insertReview(appDbId["APP-114-0-90001"], PROFESSOR_ID, "partial_approve", [
+    { sub_type_code: "nstc", recommendation: "approve", comments: null },
+    { sub_type_code: "moe_1w", recommendation: "reject", comments: PROF_MOE_REJECT_COMMENT },
+  ]);
+  await insertReview(appDbId["APP-114-0-90001"], COLLEGE_REVIEWER_ID, "approve", [
+    { sub_type_code: "nstc", recommendation: "approve", comments: "學院同意" },
+  ]);
+  // App2: (no reviews)
+  // App3: professor approve both sub-types
+  await insertReview(appDbId["APP-114-0-90003"], PROFESSOR_ID, "approve", [
+    { sub_type_code: "nstc", recommendation: "approve", comments: null },
+    { sub_type_code: "moe_1w", recommendation: "approve", comments: null },
+  ]);
+  // App4: ADMIN reject only — MUST NOT appear in either column
+  await insertReview(appDbId["APP-114-0-90004"], ADMIN_ID, "reject", [
+    { sub_type_code: "nstc", recommendation: "reject", comments: ADMIN_ONLY_COMMENT },
+  ]);
+}
+
+/** Locate the data <tr> whose 學號 cell holds the given nycu_id (unique per row). */
+function rowFor(page: Page, nycuId: string): Locator {
+  return page.locator("tbody tr").filter({ hasText: nycuId });
+}
+
+/** 教授推薦 is the 3rd column (index 2); 學院推薦 is the 4th (index 3). */
+function profCell(row: Locator): Locator {
+  return row.locator("td").nth(2);
+}
+function collegeCell(row: Locator): Locator {
+  return row.locator("td").nth(3);
+}
+
+test.describe("Admin manual distribution — 教授推薦 / 學院推薦 columns", () => {
+  test.beforeAll(async () => {
+    fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+    await seed();
+  });
+
+  test.afterAll(async () => {
+    await purgeSeed();
+  });
+
+  test("recommendation chips render per role, admin reviews hidden, college_rejected shows red N", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      baseURL: FRONTEND_URL,
+      viewport: { width: 1920, height: 2200 },
+      deviceScaleFactor: 2,
+      locale: "zh-TW",
+    });
+    await authContext(context, "admin");
+    const page = await context.newPage();
+
+    try {
+      // First navigation compiles the page — be generous.
+      await page.goto("/", { waitUntil: "networkidle", timeout: 90_000 });
+
+      // Admin top-level tab → 獎學金分發
+      await page.getByRole("tab", { name: "獎學金分發" }).first().click({ timeout: 60_000 });
+      // Scholarship-type tab (博士生獎學金) — may already be active.
+      try {
+        await page.getByRole("tab", { name: /博士生獎學金/ }).first().click({ timeout: 8_000 });
+      } catch {
+        /* already selected */
+      }
+      await page.getByRole("heading", { name: /手動分發/ }).first().waitFor({ timeout: 60_000 });
+
+      // Native <select>s — pick 114 學年度 + 全年 so the grid loads.
+      const yearSel = page
+        .locator("select")
+        .filter({ has: page.locator("option", { hasText: "選擇學年度" }) })
+        .first();
+      const semSel = page
+        .locator("select")
+        .filter({ has: page.locator("option", { hasText: "選擇學期" }) })
+        .first();
+      await yearSel.selectOption({ label: "114 學年度" });
+      await semSel.selectOption({ label: "全年" });
+
+      // Grid ready when the seeded rows render (學號 is unique per row).
+      await expect(rowFor(page, "csphd0001")).toBeVisible({ timeout: 60_000 });
+      await expect(rowFor(page, "stuphd001")).toBeVisible({ timeout: 30_000 });
+      await page.waitForTimeout(500);
+      await page.evaluate(() => window.scrollTo(0, 0));
+
+      // ---- Evidence screenshots (captured before assertions so they persist) ----
+      // The panel renders two tables (quota matrix, then the student grid) — pick
+      // the grid by the recommendation header it uniquely contains.
+      const gridTable = page
+        .locator("table")
+        .filter({ hasText: "教授推薦" })
+        .first();
+      await gridTable.screenshot({ path: path.join(EVIDENCE_DIR, "01-grid-overview.png") });
+
+      const rankHeader = page.getByRole("columnheader", { name: "排序" }).first();
+      const collegeHeader = page.getByRole("columnheader", { name: "學院推薦" }).first();
+      const rankBox = await rankHeader.boundingBox();
+      const collegeBox = await collegeHeader.boundingBox();
+      const app4Box = await rowFor(page, "stuphd001").boundingBox();
+      if (rankBox && collegeBox && app4Box) {
+        const x = Math.max(0, rankBox.x - 4);
+        const y = Math.max(0, rankBox.y - 4);
+        const width = collegeBox.x + collegeBox.width - x + 6;
+        const height = app4Box.y + app4Box.height - y + 6;
+        await page.screenshot({
+          path: path.join(EVIDENCE_DIR, "02-professor-college-columns.png"),
+          clip: { x, y, width, height },
+        });
+      }
+
+      const row3Box = await rowFor(page, "csphd0003").boundingBox();
+      if (rankBox && collegeBox && row3Box) {
+        const x = Math.max(0, rankBox.x - 4);
+        const width = collegeBox.x + collegeBox.width - x + 6;
+        await page.screenshot({
+          path: path.join(EVIDENCE_DIR, "03-college-rejected-row.png"),
+          clip: { x, y: row3Box.y - 6, width, height: row3Box.height + 12 },
+        });
+      }
+
+      // ---------------------------- Assertions ----------------------------
+
+      // Group 1 — headers exist
+      await expect(page.getByRole("columnheader", { name: "教授推薦" })).toBeVisible();
+      await expect(page.getByRole("columnheader", { name: "學院推薦" })).toBeVisible();
+
+      // Group 2 — App1 (csphd0001)
+      const row1 = rowFor(page, "csphd0001");
+      const prof1 = profCell(row1);
+      await expect(prof1).toContainText("國科會: 推薦");
+      await expect(prof1).toContainText("教育部: 不推薦");
+      // reviewer comment surfaced in the moe_1w reject chip's title attr
+      const rejectChip = prof1.locator(`[title="${PROF_MOE_REJECT_COMMENT}"]`);
+      await expect(rejectChip).toHaveText("教育部: 不推薦");
+      const college1 = collegeCell(row1);
+      // ranking verdict chip (approve) — located by its title, then the college review chip
+      await expect(college1.locator('[title="已列入學院確認排名"]')).toContainText("排名: 推薦");
+      await expect(college1).toContainText("國科會: 推薦");
+
+      // Group 3 — App2 (csphd0002): no reviews
+      const row2 = rowFor(page, "csphd0002");
+      await expect(profCell(row2).locator('[title="教授尚未完成推薦審核"]')).toHaveText("審核中");
+      await expect(collegeCell(row2).locator('[title="已列入學院確認排名"]')).toContainText(
+        "排名: 推薦"
+      );
+
+      // Group 4 — App3 (csphd0003): college_rejected
+      const row3 = rowFor(page, "csphd0003");
+      const rankCell3 = row3.locator("td").first();
+      await expect(rankCell3.locator("span.text-red-600")).toHaveText("N");
+      const college3 = collegeCell(row3);
+      await expect(
+        college3.locator('[title="學院於確認排名將此生標記為 N（不推薦）"]')
+      ).toContainText("排名: 不推薦");
+      // no approve ranking chip on a rejected row
+      await expect(college3.locator('[title="已列入學院確認排名"]')).toHaveCount(0);
+      const prof3 = profCell(row3);
+      await expect(prof3).toContainText("國科會: 推薦");
+      await expect(prof3).toContainText("教育部: 推薦");
+
+      // Group 5 — App4 (stuphd001, renewal): admin review excluded
+      const row4 = rowFor(page, "stuphd001");
+      await expect(profCell(row4).locator('[title="教授尚未完成推薦審核"]')).toHaveText("審核中");
+      // admin comment must appear NOWHERE on the page
+      await expect(page.getByText(ADMIN_ONLY_COMMENT)).toHaveCount(0);
+      await expect(page.locator(`[title="${ADMIN_ONLY_COMMENT}"]`)).toHaveCount(0);
+      // no reject chip in either column for app4
+      await expect(profCell(row4)).not.toContainText("不推薦");
+      await expect(collegeCell(row4)).not.toContainText("不推薦");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/frontend/e2e/specs/manual-dist-recommendation-columns.spec.ts
+++ b/frontend/e2e/specs/manual-dist-recommendation-columns.spec.ts
@@ -11,8 +11,9 @@
  *     professor step at all.
  *   學院推薦 — ALWAYS leads with the ranking verdict chip: "排名: 推薦" (emerald)
  *     normally, "排名: 不推薦" (red) when the ranking item has college_rejected
- *     (the 排序 cell then shows a red "N") — followed by any per-sub-type
- *     college-role review chips.
+ *     (the 排序 cell then shows a red "N") — followed by one chip per APPLIED
+ *     sub-type: "國科會: 推薦" / "教育部: 不推薦" from college-role review
+ *     items, or gray "未推薦" when the college gave no verdict for it.
  *
  * Admin-role reviews are excluded from BOTH columns — the grid IS the admin
  * decision surface.
@@ -63,7 +64,7 @@ interface SeedStudent {
 }
 
 const STUDENTS: SeedStudent[] = [
-  // App1 — professor partial_approve (nstc approve, moe_1w reject) + college approve(nstc)
+  // App1 — professor partial_approve (nstc approve, moe_1w reject) + college partial (nstc approve, moe_1w reject)
   {
     appId: "APP-114-0-90001",
     userId: 14,
@@ -107,6 +108,7 @@ const STUDENTS: SeedStudent[] = [
 
 const ADMIN_ONLY_COMMENT = "admin 審查不應顯示";
 const PROF_MOE_REJECT_COMMENT = "名額有限，僅推薦國科會";
+const COLLEGE_MOE_REJECT_COMMENT = "學院不推薦教育部方案";
 
 test.describe.configure({ mode: "serial" });
 
@@ -231,8 +233,9 @@ async function seed(): Promise<void> {
     { sub_type_code: "nstc", recommendation: "approve", comments: null },
     { sub_type_code: "moe_1w", recommendation: "reject", comments: PROF_MOE_REJECT_COMMENT },
   ]);
-  await insertReview(appDbId["APP-114-0-90001"], COLLEGE_REVIEWER_ID, "approve", [
+  await insertReview(appDbId["APP-114-0-90001"], COLLEGE_REVIEWER_ID, "partial_approve", [
     { sub_type_code: "nstc", recommendation: "approve", comments: "學院同意" },
+    { sub_type_code: "moe_1w", recommendation: "reject", comments: COLLEGE_MOE_REJECT_COMMENT },
   ]);
   // App2: (no reviews)
   // App3: professor approve both sub-types
@@ -363,9 +366,13 @@ test.describe("Admin manual distribution — 教授推薦 / 學院推薦 columns
       const rejectChip = prof1.locator(`[title="${PROF_MOE_REJECT_COMMENT}"]`);
       await expect(rejectChip).toHaveText("教育部: 不推薦");
       const college1 = collegeCell(row1);
-      // ranking verdict chip (approve) — located by its title, then the college review chip
+      // ranking verdict chip (approve) — located by its title, then the college review chips
       await expect(college1.locator('[title="已列入學院確認排名"]')).toContainText("排名: 推薦");
       await expect(college1).toContainText("國科會: 推薦");
+      // college reject is written out, comment on hover
+      await expect(college1.locator(`[title="${COLLEGE_MOE_REJECT_COMMENT}"]`)).toHaveText(
+        "教育部: 不推薦"
+      );
 
       // Group 3 — App2 (csphd0002): no reviews
       const row2 = rowFor(page, "csphd0002");
@@ -373,6 +380,9 @@ test.describe("Admin manual distribution — 教授推薦 / 學院推薦 columns
       await expect(collegeCell(row2).locator('[title="已列入學院確認排名"]')).toContainText(
         "排名: 推薦"
       );
+      // no college verdict → every applied sub-type written out as 未推薦
+      await expect(collegeCell(row2)).toContainText("國科會: 未推薦");
+      await expect(collegeCell(row2)).toContainText("教育部: 未推薦");
 
       // Group 4 — App3 (csphd0003): college_rejected
       const row3 = rowFor(page, "csphd0003");
@@ -384,6 +394,8 @@ test.describe("Admin manual distribution — 教授推薦 / 學院推薦 columns
       ).toContainText("排名: 不推薦");
       // no approve ranking chip on a rejected row
       await expect(college3.locator('[title="已列入學院確認排名"]')).toHaveCount(0);
+      await expect(college3).toContainText("國科會: 未推薦");
+      await expect(college3).toContainText("教育部: 未推薦");
       const prof3 = profCell(row3);
       await expect(prof3).toContainText("國科會: 推薦");
       await expect(prof3).toContainText("教育部: 推薦");
@@ -394,9 +406,12 @@ test.describe("Admin manual distribution — 教授推薦 / 學院推薦 columns
       // admin comment must appear NOWHERE on the page
       await expect(page.getByText(ADMIN_ONLY_COMMENT)).toHaveCount(0);
       await expect(page.locator(`[title="${ADMIN_ONLY_COMMENT}"]`)).toHaveCount(0);
-      // no reject chip in either column for app4
+      // no reject chip in either column for app4 — the admin's nstc reject
+      // must NOT surface, so nstc renders as 未推薦, not 不推薦
       await expect(profCell(row4)).not.toContainText("不推薦");
       await expect(collegeCell(row4)).not.toContainText("不推薦");
+      await expect(collegeCell(row4)).toContainText("國科會: 未推薦");
+      await expect(collegeCell(row4)).toContainText("教育部: 未推薦");
     } finally {
       await context.close();
     }

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -9,12 +9,27 @@ import { typedClient } from "../typed-client";
 import { toApiResponse } from "../compat";
 import type { ApiResponse } from "../types";
 
+/** One reviewer verdict for one sub-type, shown in the 教授推薦/學院推薦 columns. */
+export interface ReviewItemSummary {
+  /** Normalized (lowercase/stripped) sub-type code, matching rejected_sub_types. */
+  sub_type_code: string;
+  /** "approve" | "reject" */
+  recommendation: string;
+  comments: string | null;
+}
+
 export interface DistributionStudent {
   ranking_item_id: number;
   application_id: number;
   rank_position: number;
   applied_sub_types: string[];
   rejected_sub_types: string[];
+  /** Per-sub-type professor verdicts (教授推薦 column). */
+  professor_review_items: ReviewItemSummary[];
+  /** Per-sub-type college review verdicts supplementing the ranking verdict (學院推薦 column); admin reviews excluded. The college's PRIMARY verdict is the finalized ranking: college_rejected below. */
+  college_review_items: ReviewItemSummary[];
+  /** Config requires a professor recommendation step (renewal-aware) — distinguishes 審核中 from no step. */
+  requires_professor_recommendation: boolean;
   allocated_sub_type: string | null;
   /** Config whose quota this student's slot consumes. Seed the checked column from (allocated_sub_type, allocation_config_id). */
   allocation_config_id: number | null;


### PR DESCRIPTION
## Summary

The admin manual-distribution grid (管理員手動分發) now shows, per ranked student, whether the **professor** and the **college** recommended the application — two new columns between 申請類別 and the 核配 checkbox group.

- **教授推薦** — one 推薦/不推薦 chip per sub-type the professor reviewed (`國科會: 推薦` emerald / `教育部: 不推薦` red, reviewer comment on hover); amber `審核中` when the config requires a professor recommendation step (renewal-aware via `renewal_requires_professor_review`) but no verdict exists yet; `—` when the scholarship has no professor step.
- **學院推薦** — always leads with the ranking verdict: the finalized ranking IS the college's primary decision, so the chip reads `排名: 推薦`, or red `排名: 不推薦` for `college_rejected` (N) students — followed by **one chip per applied sub-type**: `國科會/教育部: 推薦` / `不推薦` from college review items (any reject wins, comment on hover), or gray `未推薦` when the college gave no verdict for that sub-type. Nothing is silently omitted.
- **Admin-role reviews are excluded from both columns** — this grid is the admin's own decision surface.

### Backend

- New `load_review_items_by_role()` (`manual_distribution_service.py`) batch-loads per-sub-type verdicts `{sub_type_code, recommendation, comments}` from the unified review table joined to `users`, split by reviewer role (professor/college). Sub-type codes normalized like `rejected_sub_types`.
- `get_students_for_distribution` rows gain `professor_review_items`, `college_review_items`, and renewal-aware `requires_professor_recommendation`; the items query now eager-loads `Application.scholarship_configuration` (async lazy-load hazard otherwise).
- No OpenAPI regen needed — this endpoint's response body is hand-typed (`DistributionStudent`), not generated.

### Frontend

- `ReviewItemChips` + the two columns in `ManualDistributionPanel.tsx`; `ReviewItemSummary` interface in `lib/api/modules/manual-distribution.ts`. Empty-state colSpans and table `minWidth` bumped accordingly.

### Design note

An adversarial review pass caught that the naive version (college column driven purely by college-role `ApplicationReview` rows) would have rendered a bogus `審核中` for every ranked student — the college ranking flow never creates review rows. The column therefore leads with the ranking verdict, and there is deliberately no `requires_college_review` field.

## Evidence (Playwright)

Read-only e2e spec `frontend/e2e/specs/manual-dist-recommendation-columns.spec.ts` — seeds 4 ranked applications via SQL (professor partial-approve with comment / no review / `college_rejected` / renewal with admin-only review), asserts all five chip states, green 2× consecutively. Full gallery on the [`evidence/2026-07-22`](https://github.com/anud18/scholarship-system/tree/evidence/2026-07-22) branch.

**Column close-up** — row 1: partial professor approval + college partial (教育部 reject written out); row 2: pending professor review, both sub-types 未推薦; row N: college-rejected; row 4: renewal whose admin-only review is correctly hidden (nstc shows 未推薦, not 不推薦):

![professor/college columns](https://raw.githubusercontent.com/anud18/scholarship-system/evidence/2026-07-22/docs/staging-tests/2026-07-22/01-manual-dist-recommendation/02-professor-college-columns.png)

**學院推薦 verdict states** — all three chip states in one clip: `推薦` (emerald) / `不推薦` (red, college's reject written out) / `未推薦` (gray, no college verdict for that sub-type):

![college verdict states](https://raw.githubusercontent.com/anud18/scholarship-system/evidence/2026-07-22/docs/staging-tests/2026-07-22/01-manual-dist-recommendation/04-college-verdict-states.png)

**Grid overview** — columns sit between 申請類別 and 獲獎獎學金類別（核配勾選）:

![grid overview](https://raw.githubusercontent.com/anud18/scholarship-system/evidence/2026-07-22/docs/staging-tests/2026-07-22/01-manual-dist-recommendation/01-grid-overview.png)

**College-rejected row** — red `N` in 排序 with `排名: 不推薦`:

![college rejected row](https://raw.githubusercontent.com/anud18/scholarship-system/evidence/2026-07-22/docs/staging-tests/2026-07-22/01-manual-dist-recommendation/03-college-rejected-row.png)

## Test plan

- [x] 5 new backend service tests (`test_manual_distribution_review_display.py`): role split + admin exclusion, empty-state flags, sub-type code normalization, both renewal-flag branches
- [x] 49 manual-distribution backend tests pass locally (in-mem SQLite, `--no-cov`); dedup fixtures updated for the new batch loader
- [x] `black --check`, `flake8 --select=B904,B014`, `tsc --noEmit` clean; module jest tests (20) pass
- [x] Playwright spec green 2× against the dev stack (screenshots above)
- [ ] CI green on this PR
- [ ] Manual smoke on staging after merge (real college-submitted review data)
