### PR TITLE
fix: don't block manual distribution on missing professor approval

### DIFF
--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -576,7 +576,7 @@ class ManualDistributionService:
                 # display columns. The college's PRIMARY verdict is the
                 # finalized ranking itself (college_rejected below) — its
                 # review items only supplement it. requires_professor_
-                # recommendation lets the UI distinguish "審核中" (step
+                # recommendation lets the UI distinguish 未推薦 chips (step
                 # required, no verdict yet) from "—" (no professor step).
                 "professor_review_items": app_reviews.get("professor", []),
                 "college_review_items": app_reviews.get("college", []),
@@ -1254,26 +1254,27 @@ class ManualDistributionService:
                 raise ValueError(f"Duplicate ranking item: {item_id}")
             seen_items.add(item_id)
 
-        # Review gate (教授審核不同意的子類型不可被分發) — two layers, see
-        # _assert_professor_approved: an unconditional rejection gate plus a
-        # positive professor-approval gate with renewal/config exemptions.
-        await self._assert_professor_approved(allocations)
+        # Review gate (審核不同意的子類型不可被分發) — an explicit reviewer
+        # reject blocks unconditionally. A MISSING professor approval does NOT
+        # block: the grid renders it as 未推薦 (matching the 學院推薦 column)
+        # and the admin decides — distribution must not strand on unreviewed
+        # applications.
+        await self._assert_no_rejected_sub_types(allocations)
 
         # Server-side quota enforcement is net-new (spec §10): the lock gate in
         # allocate/finalize (_assert_round_not_oversubscribed) recounts remaining
         # under SELECT FOR UPDATE on the consumed config rows and rejects
         # oversubscription. The frontend remaining counts are advisory.
 
-    async def _assert_professor_approved(self, allocations: list[dict[str, Any]]) -> None:
-        """Block any allocation to a sub-type the review rejected or the professor did not approve.
+    async def _assert_no_rejected_sub_types(self, allocations: list[dict[str, Any]]) -> None:
+        """Block any allocation to a sub-type an explicit reviewer reject (不同意) covers.
 
         Only allocations that assign a sub-type are checked (``sub_type_code`` set;
-        ``None`` means unallocate). The rejection gate is unconditional: a sub-type
-        with an explicit reviewer reject (不同意) can never be allocated, renewal or
-        not. The positive approval gate additionally requires an explicit professor
-        approve, exempting renewal applications and scholarships that don't require
-        a professor recommendation — for those there is no professor approval to
-        enforce against.
+        ``None`` means unallocate). The gate is unconditional — renewal or not —
+        and mirrors the disabled checkbox in the UI so a crafted request can't
+        bypass it. A sub-type the professor merely has NOT approved yet is
+        allocatable: the grid shows it as 未推薦 and the admin decides, so one
+        unreviewed application can't strand the whole distribution.
         """
         allocating = [a for a in allocations if a.get("sub_type_code")]
         if not allocating:
@@ -1282,7 +1283,7 @@ class ManualDistributionService:
         item_ids = [a["ranking_item_id"] for a in allocating]
         stmt = (
             select(CollegeRankingItem)
-            .options(selectinload(CollegeRankingItem.application).selectinload(Application.scholarship_configuration))
+            .options(selectinload(CollegeRankingItem.application))
             .where(CollegeRankingItem.id.in_(item_ids))
         )
         items = {it.id: it for it in (await self.db.execute(stmt)).scalars().all()}
@@ -1294,8 +1295,6 @@ class ManualDistributionService:
             if app is not None:
                 resolved.append((alloc, app))
 
-        # Layer 1 — rejection gate (unconditional, no exemptions): mirrors the
-        # disabled checkbox in the UI so a crafted request can't bypass it.
         rejected = await self._batch_load_rejected_map(list({app.id for _, app in resolved}))
         rejected_violations = list(
             dict.fromkeys(
@@ -1306,50 +1305,6 @@ class ManualDistributionService:
         )
         if rejected_violations:
             raise ValueError("以下分發之子類型審核不同意，無法分發：" + "、".join(rejected_violations))
-
-        # Layer 2 — positive approval gate (skip renewal apps and scholarships
-        # without a professor recommendation step).
-        gated: list[tuple[dict[str, Any], Application]] = []
-        for alloc, app in resolved:
-            if app.is_renewal:
-                continue
-            cfg = app.scholarship_configuration
-            if not (cfg and cfg.requires_professor_recommendation):
-                continue
-            gated.append((alloc, app))
-
-        if not gated:
-            return
-
-        approved = await self._professor_approved_sub_types({app.id for _, app in gated})
-
-        violations = []
-        for alloc, app in gated:
-            if _norm_sub_type(alloc["sub_type_code"]) not in approved.get(app.id, set()):
-                violations.append(f"{app.app_id} → {alloc['sub_type_code']}")
-
-        if violations:
-            raise ValueError("以下分發未取得教授對該子類型的核准，無法分發：" + "、".join(violations))
-
-    async def _professor_approved_sub_types(self, app_ids: set[int]) -> dict[int, set[str]]:
-        """application_id → set of sub_type_codes a professor recommended ``approve``."""
-        if not app_ids:
-            return {}
-        stmt = (
-            select(ApplicationReview.application_id, ApplicationReviewItem.sub_type_code)
-            .join(ApplicationReviewItem, ApplicationReviewItem.review_id == ApplicationReview.id)
-            .join(User, User.id == ApplicationReview.reviewer_id)
-            .where(
-                ApplicationReview.application_id.in_(app_ids),
-                User.role == UserRole.professor,
-                ApplicationReviewItem.recommendation == "approve",
-            )
-        )
-        result = await self.db.execute(stmt)
-        approved: dict[int, set[str]] = {}
-        for app_id, sub_type_code in result.all():
-            approved.setdefault(app_id, set()).add(_norm_sub_type(sub_type_code))
-        return approved
 
     def _compute_application_identity(self, app: Application) -> str:
         """

--- a/backend/app/tests/test_manual_distribution_professor_gate.py
+++ b/backend/app/tests/test_manual_distribution_professor_gate.py
@@ -1,18 +1,18 @@
-"""Tests for the professor-review gates on manual distribution.
+"""Tests for the review-reject gate on manual distribution.
 
-Rules (用戶需求):
-  1. 分發時一定要教授有同意「那個」子類型才能被分發到 (positive approval gate).
-  2. 教授審核「不同意」的子類型，分發時絕不可被分發到 (rejection gate).
+Rule (用戶需求): 審核「不同意」的子類型，分發時絕不可被分發到 (rejection
+gate, no exemptions — renewal or not, professor step or not). A sub-type the
+professor merely has NOT approved (no review at all, or no verdict on that
+sub-type) IS allocatable: the grid renders it as 未推薦 (same convention as
+the 學院推薦 column) and the admin decides — one unreviewed application must
+not strand the whole distribution (2026-07 staging fix; the former positive
+professor-approval gate was removed).
 
-Both are enforced in ManualDistributionService._validate_allocations (called
-first by allocate()), so a violation blocks the whole allocate() call before
-any mutation. The rejection gate additionally guards finalize() (rejects may
-arrive after the allocation was saved) and restore_from_history() (a snapshot
-may predate the reject).
-
-Exemptions (positive approval gate ONLY — the rejection gate has none):
-  - renewal applications (續領豁免)
-  - scholarships that don't require a professor recommendation step
+The gate is enforced in ManualDistributionService._validate_allocations
+(called first by allocate()), so a violation blocks the whole allocate() call
+before any mutation. It additionally guards finalize() (rejects may arrive
+after the allocation was saved) and restore_from_history() (a snapshot may
+predate the reject).
 """
 
 from datetime import datetime, timezone
@@ -164,32 +164,30 @@ async def test_allocate_allowed_when_professor_approved_that_subtype(db: AsyncSe
 
 
 @pytest.mark.asyncio
-async def test_allocate_blocked_for_subtype_professor_did_not_approve(db: AsyncSession):
+async def test_allocate_allowed_for_subtype_professor_did_not_review(db: AsyncSession):
     service, item_id, sch_id = await _setup(db, suffix="wrongsub", approved_sub_types=["nstc"])
-    # Professor approved nstc only; allocating to moe_1w must be blocked.
-    with pytest.raises(ValueError, match="教授"):
-        await service._validate_allocations(
-            sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "moe_1w"}]
-        )
+    # Professor approved nstc only; moe_1w has no verdict → shown as 未推薦
+    # in the grid but still allocatable (no positive-approval gate).
+    await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "moe_1w"}])
 
 
 @pytest.mark.asyncio
-async def test_allocate_blocked_when_no_professor_review(db: AsyncSession):
+async def test_allocate_allowed_when_no_professor_review(db: AsyncSession):
+    # No professor review at all — must NOT block the distribution.
     service, item_id, sch_id = await _setup(db, suffix="noreview", approved_sub_types=None)
-    with pytest.raises(ValueError, match="教授"):
-        await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
+    await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
 
 
 @pytest.mark.asyncio
-async def test_allocate_exempts_renewal_application(db: AsyncSession):
-    # Renewal app with no professor approval — must still be allocatable.
+async def test_allocate_allows_renewal_without_professor_review(db: AsyncSession):
+    # Renewal app with no professor approval — allocatable.
     service, item_id, sch_id = await _setup(db, suffix="renewal", is_renewal=True, approved_sub_types=None)
     await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
 
 
 @pytest.mark.asyncio
-async def test_allocate_exempts_scholarship_without_professor_step(db: AsyncSession):
-    # Scholarship that doesn't require professor recommendation — no gate.
+async def test_allocate_allows_scholarship_without_professor_step(db: AsyncSession):
+    # Scholarship that doesn't require professor recommendation — allocatable.
     service, item_id, sch_id = await _setup(db, suffix="noprof", requires_prof=False, approved_sub_types=None)
     await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
 
@@ -201,7 +199,7 @@ async def test_unallocate_is_never_blocked(db: AsyncSession):
     await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": None}])
 
 
-# --- Rejection gate (教授不同意 → 絕不可分發, no exemptions) ---
+# --- Rejection gate (審核不同意 → 絕不可分發, no exemptions) ---
 
 
 @pytest.mark.asyncio
@@ -217,8 +215,7 @@ async def test_allocate_blocked_when_professor_rejected_subtype(db: AsyncSession
 
 @pytest.mark.asyncio
 async def test_allocate_blocked_when_rejected_even_without_professor_step(db: AsyncSession):
-    # requires_professor_recommendation=False exempts the positive approval
-    # gate, but an explicit reject must still block.
+    # Even without a professor-recommendation step, an explicit reject blocks.
     service, item_id, sch_id = await _setup(db, suffix="rejnoprof", requires_prof=False, rejected_sub_types=["nstc"])
     with pytest.raises(ValueError, match="不同意"):
         await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
@@ -226,8 +223,7 @@ async def test_allocate_blocked_when_rejected_even_without_professor_step(db: As
 
 @pytest.mark.asyncio
 async def test_allocate_blocked_when_rejected_for_renewal(db: AsyncSession):
-    # Renewal exemption applies to the positive approval gate only — an
-    # explicit reject still blocks a renewal allocation.
+    # An explicit reject blocks a renewal allocation too.
     service, item_id, sch_id = await _setup(db, suffix="rejrenew", is_renewal=True, rejected_sub_types=["nstc"])
     with pytest.raises(ValueError, match="不同意"):
         await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])

--- a/backend/app/tests/test_manual_distribution_review_display.py
+++ b/backend/app/tests/test_manual_distribution_review_display.py
@@ -5,8 +5,8 @@ get_students_for_distribution must expose, per student row:
     ({sub_type_code, recommendation, comments}) split by reviewer role, with
     admin reviews excluded (the grid IS the admin decision surface);
   - requires_professor_recommendation: renewal-aware config flag so the UI can
-    distinguish 審核中 (professor step required, no verdict yet) from — (no
-    professor step at all).
+    distinguish 未推薦 chips (professor step required, no verdict yet) from —
+    (no professor step at all).
 
 The college's PRIMARY verdict is the finalized ranking itself (the existing
 college_rejected field) — college review items only supplement it, so there is
@@ -208,7 +208,7 @@ async def test_review_item_sub_type_codes_are_normalized(db: AsyncSession):
 async def test_renewal_rows_ignore_general_professor_flag(db: AsyncSession):
     """Renewals read renewal_requires_professor_review, NOT the general flag —
     a renewal of a scholarship whose new-application flow needs a professor
-    step must not show 教授審核中 when the renewal flow skips that step."""
+    step must not show 教授未推薦 chips when the renewal flow skips that step."""
     service, _app, sch_id = await _setup(
         db, suffix="renew", requires_prof=True, renewal_requires_prof=False, is_renewal=True
     )

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -110,7 +110,6 @@ const VERDICT_CHIP_BASE =
 const VERDICT_CHIP = {
   approve: `${VERDICT_CHIP_BASE} bg-emerald-50 text-emerald-700 border-emerald-300`,
   reject: `${VERDICT_CHIP_BASE} bg-red-50 text-red-600 border-red-300`,
-  pending: `${VERDICT_CHIP_BASE} bg-amber-50 text-amber-700 border-amber-300`,
   none: `${VERDICT_CHIP_BASE} bg-slate-50 text-slate-500 border-slate-300`,
 };
 
@@ -148,20 +147,24 @@ function ReviewItemChips({
 }
 
 /**
- * 學院推薦 per-sub-type chips: one chip for EVERY applied sub-type, so a
- * sub-type the college rejected (不推薦) or never gave a verdict on (未推薦)
- * is written out instead of silently omitted. Any reject wins over approve
- * (matches the rejected_sub_types convention); review items on sub-types
- * outside the applied list are still appended so no verdict is lost.
+ * Per-sub-type verdict chips for the 教授推薦/學院推薦 columns: one chip for
+ * EVERY applied sub-type, so a sub-type the reviewer rejected (不推薦) or
+ * never gave a verdict on (未推薦) is written out instead of silently
+ * omitted. Any reject wins over approve (matches the rejected_sub_types
+ * convention); review items on sub-types outside the applied list are still
+ * appended so no verdict is lost.
  */
-function CollegeSubTypeVerdictChips({
+function SubTypeVerdictChips({
   appliedSubTypes,
   items,
   quotaStatus,
+  noVerdictTitle,
 }: {
   appliedSubTypes: string[];
   items: ReviewItemSummary[];
   quotaStatus: QuotaStatus;
+  /** Tooltip on the gray 未推薦 chip — names which reviewer gave no verdict. */
+  noVerdictTitle: string;
 }) {
   const norm = (code: string) => code.toLowerCase().trim();
   const applied = Array.from(new Set(appliedSubTypes.map(norm)));
@@ -199,7 +202,7 @@ function CollegeSubTypeVerdictChips({
         return (
           <span
             key={code}
-            title="學院未對此子類型作出推薦審核"
+            title={noVerdictTitle}
             className={VERDICT_CHIP.none}
           >
             {labelFor(code)}: 未推薦
@@ -1494,19 +1497,37 @@ export function ManualDistributionPanel({
                                 </td>
                                 <td className="px-1.5 py-1.5 border-r border-slate-100 leading-snug">
                                   {(student.professor_review_items || [])
-                                    .length > 0 ? (
+                                    .length > 0 ||
+                                  (student.requires_professor_recommendation &&
+                                    (student.applied_sub_types || []).length >
+                                      0) ? (
                                     <div className="flex flex-col gap-0.5">
-                                      <ReviewItemChips
-                                        items={student.professor_review_items}
+                                      {/* Same convention as 學院推薦: a chip
+                                          per applied sub-type, and a missing
+                                          professor verdict renders as 未推薦
+                                          — it no longer blocks allocation,
+                                          the admin decides. */}
+                                      <SubTypeVerdictChips
+                                        appliedSubTypes={
+                                          student.applied_sub_types || []
+                                        }
+                                        items={
+                                          student.professor_review_items || []
+                                        }
                                         quotaStatus={quotaStatus}
+                                        noVerdictTitle="教授未對此子類型作出推薦審核"
                                       />
                                     </div>
                                   ) : student.requires_professor_recommendation ? (
+                                    /* Professor step required but the
+                                       scholarship has no sub-types and no
+                                       verdict yet — chips would be empty, so
+                                       write the 未推薦 out explicitly. */
                                     <span
-                                      className={VERDICT_CHIP.pending}
-                                      title="教授尚未完成推薦審核"
+                                      className={VERDICT_CHIP.none}
+                                      title="教授未作出推薦審核"
                                     >
-                                      審核中
+                                      未推薦
                                     </span>
                                   ) : (
                                     <span className="text-[11px] text-slate-400">
@@ -1536,12 +1557,13 @@ export function ManualDistributionPanel({
                                         排名: 推薦
                                       </span>
                                     )}
-                                    <CollegeSubTypeVerdictChips
+                                    <SubTypeVerdictChips
                                       appliedSubTypes={
                                         student.applied_sub_types || []
                                       }
                                       items={student.college_review_items || []}
                                       quotaStatus={quotaStatus}
+                                      noVerdictTitle="學院未對此子類型作出推薦審核"
                                     />
                                   </div>
                                 </td>

--- a/frontend/e2e/specs/manual-dist-recommendation-columns.spec.ts
+++ b/frontend/e2e/specs/manual-dist-recommendation-columns.spec.ts
@@ -4,11 +4,12 @@
  *
  * The feature adds two columns between 申請類別 and the 核配 checkbox group:
  *
- *   教授推薦 — per-sub-type verdict chips built from professor review items
- *     ("國科會: 推薦" emerald / "教育部: 不推薦" red, reviewer comment in the
- *     title attr); an amber "審核中" chip when the config requires a professor
- *     recommendation but no professor review exists yet; "—" when there is no
- *     professor step at all.
+ *   教授推薦 — one chip per APPLIED sub-type built from professor review
+ *     items ("國科會: 推薦" emerald / "教育部: 不推薦" red, reviewer comment
+ *     in the title attr), gray "未推薦" for sub-types the professor gave no
+ *     verdict on (a missing approval no longer blocks allocation); a single
+ *     unlabeled gray "未推薦" when the step is required but the scholarship
+ *     has no sub-types; "—" when there is no professor step at all.
  *   學院推薦 — ALWAYS leads with the ranking verdict chip: "排名: 推薦" (emerald)
  *     normally, "排名: 不推薦" (red) when the ranking item has college_rejected
  *     (the 排序 cell then shows a red "N") — followed by one chip per APPLIED
@@ -74,7 +75,7 @@ const STUDENTS: SeedStudent[] = [
     renewal: false,
     collegeRejected: false,
   },
-  // App2 — NO reviews → 教授推薦 = 審核中
+  // App2 — NO reviews → 教授推薦 = per-sub-type 未推薦 chips
   {
     appId: "APP-114-0-90002",
     userId: 15,
@@ -94,7 +95,7 @@ const STUDENTS: SeedStudent[] = [
     renewal: false,
     collegeRejected: true,
   },
-  // App4 — renewal; ONLY an admin reject review → excluded → 教授推薦 = 審核中
+  // App4 — renewal; ONLY an admin reject review → excluded → 教授推薦 = 未推薦 chips
   {
     appId: "APP-114-0-90004",
     userId: 6,
@@ -374,9 +375,15 @@ test.describe("Admin manual distribution — 教授推薦 / 學院推薦 columns
         "教育部: 不推薦"
       );
 
-      // Group 3 — App2 (csphd0002): no reviews
+      // Group 3 — App2 (csphd0002): no reviews → every applied sub-type
+      // written out as 未推薦 in the professor column too (no 審核中 blocker)
       const row2 = rowFor(page, "csphd0002");
-      await expect(profCell(row2).locator('[title="教授尚未完成推薦審核"]')).toHaveText("審核中");
+      const prof2 = profCell(row2);
+      await expect(prof2).toContainText("國科會: 未推薦");
+      await expect(prof2).toContainText("教育部: 未推薦");
+      await expect(
+        prof2.locator('[title="教授未對此子類型作出推薦審核"]')
+      ).toHaveCount(2);
       await expect(collegeCell(row2).locator('[title="已列入學院確認排名"]')).toContainText(
         "排名: 推薦"
       );
@@ -400,9 +407,11 @@ test.describe("Admin manual distribution — 教授推薦 / 學院推薦 columns
       await expect(prof3).toContainText("國科會: 推薦");
       await expect(prof3).toContainText("教育部: 推薦");
 
-      // Group 5 — App4 (stuphd001, renewal): admin review excluded
+      // Group 5 — App4 (stuphd001, renewal): admin review excluded → both
+      // sub-types 未推薦 in the professor column
       const row4 = rowFor(page, "stuphd001");
-      await expect(profCell(row4).locator('[title="教授尚未完成推薦審核"]')).toHaveText("審核中");
+      await expect(profCell(row4)).toContainText("國科會: 未推薦");
+      await expect(profCell(row4)).toContainText("教育部: 未推薦");
       // admin comment must appear NOWHERE on the page
       await expect(page.getByText(ADMIN_ONLY_COMMENT)).toHaveCount(0);
       await expect(page.locator(`[title="${ADMIN_ONLY_COMMENT}"]`)).toHaveCount(0);

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7719,7 +7719,9 @@ export interface components {
             /** Message */
             message: string;
             /** Data */
-            data?: Record<string, never>[] | null;
+            data?: {
+                [key: string]: unknown;
+            }[] | null;
             /** Errors */
             errors?: string[] | null;
             /** Trace Id */
@@ -7735,7 +7737,9 @@ export interface components {
             /** Message */
             message: string;
             /** Data */
-            data?: Record<string, never> | null;
+            data?: {
+                [key: string]: unknown;
+            } | null;
             /** Errors */
             errors?: string[] | null;
             /** Trace Id */
@@ -7931,7 +7935,9 @@ export interface components {
              * Validation Rules
              * @description Validation rules
              */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * ApplicationDocumentUpdate
@@ -7969,7 +7975,9 @@ export interface components {
             /** Example File Url */
             example_file_url?: string | null;
             /** Validation Rules */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * ApplicationFieldCreate
@@ -8042,7 +8050,9 @@ export interface components {
              * Field Options
              * @description Field options
              */
-            field_options?: Record<string, never>[] | null;
+            field_options?: {
+                [key: string]: unknown;
+            }[] | null;
             /**
              * Display Order
              * @description Display order
@@ -8069,12 +8079,16 @@ export interface components {
              * Validation Rules
              * @description Validation rules
              */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Conditional Rules
              * @description Conditional rules
              */
-            conditional_rules?: Record<string, never> | null;
+            conditional_rules?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Include In College Export
              * @description Whether this field appears in the college Excel export
@@ -8113,7 +8127,9 @@ export interface components {
             /** Step Value */
             step_value?: number | null;
             /** Field Options */
-            field_options?: Record<string, never>[] | null;
+            field_options?: {
+                [key: string]: unknown;
+            }[] | null;
             /** Display Order */
             display_order?: number | null;
             /** Is Active */
@@ -8123,9 +8139,13 @@ export interface components {
             /** Help Text En */
             help_text_en?: string | null;
             /** Validation Rules */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
             /** Conditional Rules */
-            conditional_rules?: Record<string, never> | null;
+            conditional_rules?: {
+                [key: string]: unknown;
+            } | null;
             /** Include In College Export */
             include_in_college_export?: boolean | null;
             /** Export Column Label */
@@ -8309,9 +8329,13 @@ export interface components {
             /** Semester */
             semester?: string | null;
             /** Student Data */
-            student_data: Record<string, never>;
+            student_data: {
+                [key: string]: unknown;
+            };
             /** Submitted Form Data */
-            submitted_form_data: Record<string, never>;
+            submitted_form_data: {
+                [key: string]: unknown;
+            };
             /**
              * Agree Terms
              * @default false
@@ -8340,7 +8364,9 @@ export interface components {
              */
             updated_at: string;
             /** Meta Data */
-            meta_data?: Record<string, never> | null;
+            meta_data?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Reviews
              * @default []
@@ -8543,7 +8569,9 @@ export interface components {
              * Updates
              * @description 要更新的欄位
              */
-            updates: Record<string, never>;
+            updates: {
+                [key: string]: unknown;
+            };
         };
         /** Body_create_ranking_api_v1_college_review_rankings_post */
         Body_create_ranking_api_v1_college_review_rankings_post: {
@@ -8581,10 +8609,7 @@ export interface components {
         };
         /** Body_create_supplementary_doc_api_v1_system_settings_supplementary_docs_post */
         Body_create_supplementary_doc_api_v1_system_settings_supplementary_docs_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
             /** Title */
             title: string;
@@ -8604,35 +8629,25 @@ export interface components {
         };
         /** Body_extract_bank_info_from_passbook_api_v1_user_profiles_bank_passbook_ocr_post */
         Body_extract_bank_info_from_passbook_api_v1_user_profiles_bank_passbook_ocr_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_extract_text_from_document_api_v1_user_profiles_document_ocr_post */
         Body_extract_text_from_document_api_v1_user_profiles_document_ocr_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_import_received_months_api_v1_manual_distribution_import_received_months_post */
         Body_import_received_months_api_v1_manual_distribution_import_received_months_post: {
             /**
              * File
-             * Format: binary
              * @description Excel file with columns: 學號, 已領月份數
              */
             file: string;
         };
         /** Body_import_whitelist_excel_api_v1_scholarship_configurations__id__whitelist_import_post */
         Body_import_whitelist_excel_api_v1_scholarship_configurations__id__whitelist_import_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_portal_sso_verify_api_v1_auth_portal_sso_verify_post */
@@ -8671,10 +8686,7 @@ export interface components {
         };
         /** Body_supplementary_import_api_v1_college_review_rankings__ranking_id__supplementary_import_post */
         Body_supplementary_import_api_v1_college_review_rankings__ranking_id__supplementary_import_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_update_matrix_quota_api_v1_scholarship_configurations_matrix_quota_put */
@@ -8690,17 +8702,13 @@ export interface components {
         };
         /** Body_upload_bank_document_file_api_v1_user_profiles_me_bank_document_file_post */
         Body_upload_bank_document_file_api_v1_user_profiles_me_bank_document_file_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_batch_documents_api_v1_college_review_batch_import__batch_id__documents_post */
         Body_upload_batch_documents_api_v1_college_review_batch_import__batch_id__documents_post: {
             /**
              * File
-             * Format: binary
              * @description 包含所有文件的 ZIP 檔案
              */
             file: string;
@@ -8709,58 +8717,41 @@ export interface components {
         Body_upload_batch_import_data_api_v1_college_review_batch_import_upload_data_post: {
             /**
              * File
-             * Format: binary
              * @description Excel或CSV檔案
              */
             file: string;
         };
         /** Body_upload_document_example_api_v1_application_fields_documents__document_id__upload_example_post */
         Body_upload_document_example_api_v1_application_fields_documents__document_id__upload_example_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_file_alias_api_v1_applications__id__files_post */
         Body_upload_file_alias_api_v1_applications__id__files_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_file_api_v1_applications__id__files_upload_post */
         Body_upload_file_api_v1_applications__id__files_upload_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post */
         Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post: {
             /**
              * File
-             * Format: binary
              * @description 續領生 Excel 或 CSV 檔案
              */
             file: string;
         };
         /** Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post */
         Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_terms_document_api_v1_scholarships__scholarship_type__upload_terms_post */
         Body_upload_terms_document_api_v1_scholarships__scholarship_type__upload_terms_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /**
@@ -8804,7 +8795,9 @@ export interface components {
              * Parameters
              * @description Operation-specific parameters
              */
-            parameters?: Record<string, never> | null;
+            parameters?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * BulkScholarshipAssignRequest
@@ -9014,7 +9007,9 @@ export interface components {
              */
             email_domain: string | null;
             /** Custom Attributes */
-            custom_attributes?: Record<string, never> | null;
+            custom_attributes?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * DocumentData
@@ -9143,7 +9138,9 @@ export interface components {
              * Validation Rules
              * @description 驗證規則
              */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** EligibleScholarshipResponse */
         EligibleScholarshipResponse: {
@@ -9353,9 +9350,13 @@ export interface components {
          */
         FormConfigSaveRequest: {
             /** Fields */
-            fields: Record<string, never>[];
+            fields: {
+                [key: string]: unknown;
+            }[];
             /** Documents */
-            documents: Record<string, never>[];
+            documents: {
+                [key: string]: unknown;
+            }[];
             /** Application Document Note */
             application_document_note?: string | null;
             /** Application Document Note En */
@@ -9482,7 +9483,9 @@ export interface components {
              * Metadata
              * @description 額外資料
              */
-            metadata?: Record<string, never> | null;
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * NotificationUpdate
@@ -9506,7 +9509,9 @@ export interface components {
             /** Expires At */
             expires_at?: string | null;
             /** Metadata */
-            metadata?: Record<string, never> | null;
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Is Dismissed
              * @description 是否已關閉
@@ -9922,7 +9927,9 @@ export interface components {
              * Notification Settings
              * @description 通知設定
              */
-            notification_settings?: Record<string, never> | null;
+            notification_settings?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * RosterScheduleStatus
@@ -9935,7 +9942,6 @@ export interface components {
          * @description 更新排程狀態模型
          */
         RosterScheduleStatusUpdate: {
-            /** @description 排程狀態 */
             status: components["schemas"]["RosterScheduleStatus"];
         };
         /**
@@ -9984,7 +9990,9 @@ export interface components {
              * Notification Settings
              * @description 通知設定
              */
-            notification_settings?: Record<string, never> | null;
+            notification_settings?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * RosterStatus
@@ -10766,9 +10774,13 @@ export interface components {
              */
             preferred_language: string;
             /** Privacy Settings */
-            privacy_settings?: Record<string, never> | null;
+            privacy_settings?: {
+                [key: string]: unknown;
+            } | null;
             /** Custom Fields */
-            custom_fields?: Record<string, never> | null;
+            custom_fields?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * UserProfileUpdate
@@ -10786,9 +10798,13 @@ export interface components {
             /** Preferred Language */
             preferred_language?: string | null;
             /** Privacy Settings */
-            privacy_settings?: Record<string, never> | null;
+            privacy_settings?: {
+                [key: string]: unknown;
+            } | null;
             /** Custom Fields */
-            custom_fields?: Record<string, never> | null;
+            custom_fields?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * UserRole
@@ -10845,7 +10861,9 @@ export interface components {
              * Students
              * @description 學生列表 [{'nycu_id': '0856001', 'sub_type': 'nstc'}, ...]
              */
-            students: Record<string, never>[];
+            students: {
+                [key: string]: unknown;
+            }[];
         };
         /**
          * WhitelistBatchRemoveRequest
@@ -11533,7 +11551,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -13695,7 +13715,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -13750,7 +13772,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -16673,7 +16697,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -16739,7 +16765,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -16875,7 +16903,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -19353,7 +19383,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -19384,7 +19416,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -19415,7 +19449,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -19446,7 +19482,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -19477,7 +19515,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -28,7 +28,7 @@ export interface DistributionStudent {
   professor_review_items: ReviewItemSummary[];
   /** Per-sub-type college review verdicts supplementing the ranking verdict (學院推薦 column); admin reviews excluded. The college's PRIMARY verdict is the finalized ranking: college_rejected below. */
   college_review_items: ReviewItemSummary[];
-  /** Config requires a professor recommendation step (renewal-aware) — distinguishes 審核中 from no step. */
+  /** Config requires a professor recommendation step (renewal-aware) — distinguishes 未推薦 chips (step required, no verdict yet) from "—" (no professor step). */
   requires_professor_recommendation: boolean;
   allocated_sub_type: string | null;
   /** Config whose quota this student's slot consumes. Seed the checked column from (allocated_sub_type, allocation_config_id). */


### PR DESCRIPTION
## Summary

On staging, saving a manual distribution raised 「以下分發未取得教授對該子類型的核准，無法分發」 whenever any allocated sub-type lacked an explicit professor approval, aborting the whole allocate call and stranding the entire distribution.

- **Backend**: remove the positive professor-approval gate from `_validate_allocations` (`_assert_professor_approved` → `_assert_no_rejected_sub_types`). Only an explicit reviewer reject (審核不同意) still blocks — unconditionally, on allocate/finalize/restore, no renewal/config exemptions. Delete the dead `_professor_approved_sub_types` helper.
- **Frontend**: the 教授推薦 column now follows the 學院推薦 convention — one chip per applied sub-type (推薦 / 不推薦 / gray 未推薦 when the professor gave no verdict) via the shared `SubTypeVerdictChips`, replacing the blanket amber 審核中 chip. A required professor step on a scholarship with no sub-types shows a single gray 未推薦; "—" still means no professor step at all.
- **Tests**: gate tests inverted to assert allocation is allowed without professor approval; all rejection-gate tests unchanged. E2e spec 審核中 assertions replaced with 未推薦 chip assertions.

Once deployed, the stuck staging distribution needs no data repair — the admin just re-saves; unapproved sub-types render as 未推薦 instead of blocking.

## Test plan

- [x] `test_manual_distribution_professor_gate.py` + `test_manual_distribution_review_display.py` — 18/18 pass
- [x] black / flake8 (B904, B014) clean on touched backend files
- [x] frontend `tsc --noEmit` clean
- [x] Adversarial multi-agent review sweep: no other code path enforces the removed gate; no stale references; broader manual-distribution/renewal/college-review test sweep green
- [ ] CI green on this PR