### PR TITLE
chore: add scheduled database backup workflow for staging/production

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -191,7 +191,10 @@ jobs:
     name: Alert on Backup Failure
     runs-on: ubuntu-latest
     needs: [backup-staging, backup-production]
-    if: always() && contains(needs.*.result, 'failure')
+    # 'cancelled' counts as a failure mode: a backup job that hits its
+    # timeout-minutes ends as cancelled, and a silently hung backup is
+    # exactly what this alert must catch.
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     steps:
       - name: Open issue on backup failure
         uses: actions/github-script@v7
@@ -200,9 +203,10 @@ jobs:
           script: |
             const staging = '${{ needs.backup-staging.result }}';
             const production = '${{ needs.backup-production.result }}';
+            const isBad = (result) => result === 'failure' || result === 'cancelled';
             const failed = [
-              ...(staging === 'failure' ? ['staging'] : []),
-              ...(production === 'failure' ? ['production'] : []),
+              ...(isBad(staging) ? [`staging (${staging})`] : []),
+              ...(isBad(production) ? [`production (${production})`] : []),
             ];
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const label = 'db-backup-failed';

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,244 @@
+name: Database Backup
+
+# Scheduled pg_dump backups for the staging and production databases.
+#
+# How it works:
+#   - Jobs run on the self-hosted runner (the DB-VMs sit behind WireGuard,
+#     so GitHub-hosted runners cannot reach them — same constraint as
+#     staging-health-monitor.yml).
+#   - Each job SSHes into the environment's DB-VM and runs
+#     scripts/remote_db_backup.sh, which dumps the postgres container
+#     (custom format, compressed), verifies the archive with
+#     `pg_restore --list`, writes a sha256 checksum, and prunes dated
+#     backup directories past the retention window.
+#   - Backups STAY on the DB-VM under /opt/scholarship/postgres/backups.
+#     Dumps contain PII — they must never be uploaded as GitHub artifacts.
+#   - On any failure an issue labeled `db-backup-failed` is opened
+#     (deduplicated: no new issue while one is still open).
+#
+# Required secrets (per environment):
+#   staging:    STAGING_DB_HOST, STAGING_DB_USER, STAGING_DB_SSH_KEY
+#               (already used by deploy-monitoring-stack.yml)
+#   production: PROD_DB_HOST, PROD_DB_USER, PROD_DB_SSH_KEY
+#
+# Note: production also has an in-container cron backup at 02:00 Taipei
+# (docker-compose.prod-db.yml postgres-backup service). This workflow runs
+# at 03:00 Taipei as an independent, observable backup path — failures
+# surface as GitHub issues instead of dying silently inside a container.
+
+on:
+  schedule:
+    # Cron is UTC; Asia/Taipei = UTC+8.
+    - cron: '30 18 * * *'  # staging    — 02:30 Taipei
+    - cron: '0 19 * * *'   # production — 03:00 Taipei
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to back up'
+        type: choice
+        options:
+          - both
+          - staging
+          - production
+        default: both
+      retention_days:
+        description: 'Days of backups to keep on the DB host'
+        required: false
+        default: '30'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: db-backup
+  cancel-in-progress: false
+
+jobs:
+  backup-staging:
+    name: Backup Staging DB
+    if: >-
+      (github.event_name == 'schedule' && github.event.schedule == '30 18 * * *') ||
+      (github.event_name == 'workflow_dispatch' &&
+       (github.event.inputs.environment == 'staging' || github.event.inputs.environment == 'both'))
+    runs-on: [self-hosted, scholarship, test]
+    environment: staging
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Pre-flight secret check
+        env:
+          REQUIRED_SECRETS: STAGING_DB_HOST STAGING_DB_USER STAGING_DB_SSH_KEY
+          STAGING_DB_HOST: ${{ secrets.STAGING_DB_HOST }}
+          STAGING_DB_USER: ${{ secrets.STAGING_DB_USER }}
+          STAGING_DB_SSH_KEY: ${{ secrets.STAGING_DB_SSH_KEY }}
+        run: |
+          missing=()
+          for var in $REQUIRED_SECRETS; do
+            if [ -z "${!var}" ]; then
+              missing+=("$var")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            exit 1
+          fi
+          echo "✅ All required secrets present"
+
+      - name: Set up SSH key for DB-VM
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.STAGING_DB_SSH_KEY }}" > ~/.ssh/db_backup_staging
+          chmod 600 ~/.ssh/db_backup_staging
+          ssh-keyscan -p 8822 -H ${{ secrets.STAGING_DB_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Run staging backup
+        env:
+          SSH_HOST: ${{ secrets.STAGING_DB_HOST }}
+          SSH_USER: ${{ secrets.STAGING_DB_USER }}
+          SSH_PORT: '8822'
+          DB_CONTAINER: scholarship_postgres_staging
+          ENV_NAME: staging
+          RETENTION_DAYS: ${{ github.event.inputs.retention_days || '30' }}
+        run: |
+          export SSH_KEY_PATH="$HOME/.ssh/db_backup_staging"
+          chmod +x scripts/remote_db_backup.sh
+          scripts/remote_db_backup.sh 2>&1 | tee /tmp/db-backup-staging.log
+          {
+            echo "## Staging DB backup"
+            echo '```'
+            grep -E "BACKUP OK|Pruned|Total dumps" /tmp/db-backup-staging.log || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/db_backup_staging /tmp/db-backup-staging.log
+
+  backup-production:
+    name: Backup Production DB
+    if: >-
+      (github.event_name == 'schedule' && github.event.schedule == '0 19 * * *') ||
+      (github.event_name == 'workflow_dispatch' &&
+       (github.event.inputs.environment == 'production' || github.event.inputs.environment == 'both'))
+    runs-on: [self-hosted, scholarship, test]
+    environment: production
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Pre-flight secret check
+        env:
+          REQUIRED_SECRETS: PROD_DB_HOST PROD_DB_USER PROD_DB_SSH_KEY
+          PROD_DB_HOST: ${{ secrets.PROD_DB_HOST }}
+          PROD_DB_USER: ${{ secrets.PROD_DB_USER }}
+          PROD_DB_SSH_KEY: ${{ secrets.PROD_DB_SSH_KEY }}
+        run: |
+          missing=()
+          for var in $REQUIRED_SECRETS; do
+            if [ -z "${!var}" ]; then
+              missing+=("$var")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}"
+            echo "::error::Configure them (or an org/environment-level equivalent) to enable production DB backups"
+            exit 1
+          fi
+          echo "✅ All required secrets present"
+
+      - name: Set up SSH key for DB-VM
+        env:
+          SSH_PORT: ${{ secrets.PROD_DB_SSH_PORT || '8822' }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PROD_DB_SSH_KEY }}" > ~/.ssh/db_backup_prod
+          chmod 600 ~/.ssh/db_backup_prod
+          ssh-keyscan -p "$SSH_PORT" -H ${{ secrets.PROD_DB_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Run production backup
+        env:
+          SSH_HOST: ${{ secrets.PROD_DB_HOST }}
+          SSH_USER: ${{ secrets.PROD_DB_USER }}
+          SSH_PORT: ${{ secrets.PROD_DB_SSH_PORT || '8822' }}
+          DB_CONTAINER: scholarship_postgres_prod
+          ENV_NAME: production
+          RETENTION_DAYS: ${{ github.event.inputs.retention_days || '30' }}
+        run: |
+          export SSH_KEY_PATH="$HOME/.ssh/db_backup_prod"
+          chmod +x scripts/remote_db_backup.sh
+          scripts/remote_db_backup.sh 2>&1 | tee /tmp/db-backup-prod.log
+          {
+            echo "## Production DB backup"
+            echo '```'
+            grep -E "BACKUP OK|Pruned|Total dumps" /tmp/db-backup-prod.log || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/db_backup_prod /tmp/db-backup-prod.log
+
+  alert-on-failure:
+    name: Alert on Backup Failure
+    runs-on: ubuntu-latest
+    needs: [backup-staging, backup-production]
+    if: always() && contains(needs.*.result, 'failure')
+    steps:
+      - name: Open issue on backup failure
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const staging = '${{ needs.backup-staging.result }}';
+            const production = '${{ needs.backup-production.result }}';
+            const failed = [
+              ...(staging === 'failure' ? ['staging'] : []),
+              ...(production === 'failure' ? ['production'] : []),
+            ];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Dedupe: don't stack a new issue while one is still open.
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'db-backup-failed',
+              state: 'open',
+            });
+            if (issues.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues.data[0].number,
+                body: `Backup failed again for **${failed.join(', ')}**: ${runUrl}`,
+              });
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Database backup failed: ${failed.join(', ')}`,
+              body: [
+                '## Scheduled database backup failed',
+                '',
+                `Failed environment(s): **${failed.join(', ')}**`,
+                `Workflow run: ${runUrl}`,
+                `Detected at: ${new Date().toISOString()}`,
+                '',
+                'Check the run logs, then verify the DB-VM is reachable and the',
+                'postgres container is healthy. Backups live on the DB-VM under',
+                '`/opt/scholarship/postgres/backups`.',
+                '',
+                'This issue was auto-filed by the db-backup workflow. Close it once',
+                'a subsequent backup succeeds.',
+              ].join('\n'),
+              labels: ['db-backup-failed'],
+            });

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -232,17 +232,19 @@ jobs:
             }
 
             // Dedupe: don't stack a new issue while one is still open.
+            // listForRepo returns PRs too — only actual issues count.
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'db-backup-failed',
+              labels: label,
               state: 'open',
             });
-            if (issues.data.length > 0) {
+            const openIssues = issues.data.filter((item) => !item.pull_request);
+            if (openIssues.length > 0) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issues.data[0].number,
+                issue_number: openIssues[0].number,
                 body: `Backup failed again for **${failed.join(', ')}**: ${runUrl}`,
               });
               return;

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -205,6 +205,27 @@ jobs:
               ...(production === 'failure' ? ['production'] : []),
             ];
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const label = 'db-backup-failed';
+
+            // Creating an issue with a label that doesn't exist on the repo
+            // fails, so pre-create it on demand (same approach as
+            // monitoring-alert-issue.yml).
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'b60205',
+                description: 'Scheduled database backup failed',
+              });
+            }
 
             // Dedupe: don't stack a new issue while one is still open.
             const issues = await github.rest.issues.listForRepo({

--- a/scripts/remote_db_backup.sh
+++ b/scripts/remote_db_backup.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Remote database backup driver used by .github/workflows/db-backup.yml.
+#
+# Runs ON the self-hosted runner. SSHes into the DB-VM and dumps the
+# postgres container to a dated directory on that VM (backups stay on the
+# DB host — dumps contain PII and must NOT be uploaded as GitHub artifacts).
+#
+# Required environment variables:
+#   SSH_HOST      DB-VM hostname/IP
+#   SSH_USER      SSH user on the DB-VM
+#   SSH_KEY_PATH  Path to the SSH private key on the runner
+#   DB_CONTAINER  Postgres container name on the DB-VM
+#   ENV_NAME      Environment label used in backup filenames (staging/production)
+# Optional:
+#   SSH_PORT        SSH port on the DB-VM (default: 8822)
+#   RETENTION_DAYS  Days of dated backup directories to keep (default: 30)
+#   BACKUP_ROOT     Backup directory on the DB-VM (default: /opt/scholarship/postgres/backups)
+
+set -euo pipefail
+
+: "${SSH_HOST:?SSH_HOST is required}"
+: "${SSH_USER:?SSH_USER is required}"
+: "${SSH_KEY_PATH:?SSH_KEY_PATH is required}"
+: "${DB_CONTAINER:?DB_CONTAINER is required}"
+: "${ENV_NAME:?ENV_NAME is required}"
+SSH_PORT="${SSH_PORT:-8822}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+BACKUP_ROOT="${BACKUP_ROOT:-/opt/scholarship/postgres/backups}"
+
+if ! [[ "$RETENTION_DAYS" =~ ^[0-9]+$ ]] || [ "$RETENTION_DAYS" -lt 1 ]; then
+    echo "ERROR: RETENTION_DAYS must be a positive integer (got: ${RETENTION_DAYS})" >&2
+    exit 1
+fi
+if ! [[ "$ENV_NAME" =~ ^[a-z0-9_-]+$ ]]; then
+    echo "ERROR: ENV_NAME must match ^[a-z0-9_-]+$ (got: ${ENV_NAME})" >&2
+    exit 1
+fi
+
+echo "=== Database backup: ${ENV_NAME} ==="
+echo "Target: ${SSH_USER}@${SSH_HOST}:${SSH_PORT} container=${DB_CONTAINER}"
+echo "Backup root: ${BACKUP_ROOT} (retention: ${RETENTION_DAYS} days)"
+
+# Pass parameters to the remote shell as safely-quoted env assignments so the
+# remote script body itself can stay single-quoted (no local interpolation).
+REMOTE_ENV=$(printf "DB_CONTAINER=%q ENV_NAME=%q RETENTION_DAYS=%q BACKUP_ROOT=%q" \
+    "$DB_CONTAINER" "$ENV_NAME" "$RETENTION_DAYS" "$BACKUP_ROOT")
+
+ssh -p "$SSH_PORT" -i "$SSH_KEY_PATH" \
+    -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 \
+    "${SSH_USER}@${SSH_HOST}" "${REMOTE_ENV} bash -s" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
+
+if ! docker ps --format '{{.Names}}' | grep -qx "${DB_CONTAINER}"; then
+    log "ERROR: container ${DB_CONTAINER} is not running on $(hostname)"
+    docker ps --format '  running: {{.Names}}' || true
+    exit 1
+fi
+
+# Credentials come from the container itself — pg_dump runs over the
+# container-local unix socket (trust auth), so no password crosses SSH.
+PGUSER=$(docker exec "${DB_CONTAINER}" printenv POSTGRES_USER)
+PGDB=$(docker exec "${DB_CONTAINER}" printenv POSTGRES_DB)
+
+DATE_DIR=$(date +%Y%m%d)
+STAMP=$(date +%Y%m%d_%H%M%S)
+TARGET_DIR="${BACKUP_ROOT}/${DATE_DIR}"
+BACKUP_FILE="scholarship_db_${ENV_NAME}_${STAMP}.dump"
+
+if ! mkdir -p "${TARGET_DIR}" 2>/dev/null; then
+    log "mkdir needs elevated permissions, retrying with sudo -n"
+    sudo -n mkdir -p "${TARGET_DIR}"
+    sudo -n chown "$(id -un):$(id -gn)" "${TARGET_DIR}"
+fi
+
+log "Dumping ${PGDB} from ${DB_CONTAINER} -> ${TARGET_DIR}/${BACKUP_FILE}"
+docker exec "${DB_CONTAINER}" pg_dump \
+    -U "${PGUSER}" -d "${PGDB}" \
+    --format=custom --compress=9 \
+    > "${TARGET_DIR}/${BACKUP_FILE}"
+
+if [ ! -s "${TARGET_DIR}/${BACKUP_FILE}" ]; then
+    log "ERROR: backup file is empty"
+    rm -f "${TARGET_DIR}/${BACKUP_FILE}"
+    exit 1
+fi
+
+# Integrity check: the archive TOC must be readable by pg_restore.
+log "Verifying archive with pg_restore --list"
+if ! docker exec -i "${DB_CONTAINER}" pg_restore --list /dev/stdin \
+        < "${TARGET_DIR}/${BACKUP_FILE}" > /dev/null; then
+    log "ERROR: pg_restore could not read the archive — backup is corrupt"
+    rm -f "${TARGET_DIR}/${BACKUP_FILE}"
+    exit 1
+fi
+
+(cd "${TARGET_DIR}" && sha256sum "${BACKUP_FILE}" > "${BACKUP_FILE}.sha256")
+chmod 640 "${TARGET_DIR}/${BACKUP_FILE}" "${TARGET_DIR}/${BACKUP_FILE}.sha256"
+
+BACKUP_SIZE=$(du -h "${TARGET_DIR}/${BACKUP_FILE}" | cut -f1)
+log "Backup created: ${BACKUP_FILE} (${BACKUP_SIZE})"
+
+# Retention: prune dated directories older than the cutoff. This intentionally
+# applies the same retention to backups written by the in-container cron
+# service (production), which uses the same YYYYMMDD directory layout.
+CUTOFF_DATE=$(date -d "${RETENTION_DAYS} days ago" +%Y%m%d 2>/dev/null \
+    || date -u -d "@$(($(date +%s) - RETENTION_DAYS * 86400))" +%Y%m%d)
+log "Pruning backups older than ${CUTOFF_DATE}"
+DELETED=0
+for dir in "${BACKUP_ROOT}"/*/; do
+    [ -d "${dir}" ] || continue
+    base=$(basename "${dir}")
+    if [[ "${base}" =~ ^[0-9]{8}$ ]] && [ "${base}" -lt "${CUTOFF_DATE}" ]; then
+        log "  deleting ${base}"
+        rm -rf "${dir}"
+        DELETED=$((DELETED + 1))
+    fi
+done
+log "Pruned ${DELETED} old backup directory(ies)"
+
+TOTAL_BACKUPS=$(find "${BACKUP_ROOT}" -name "*.dump" 2>/dev/null | wc -l)
+TOTAL_SIZE=$(du -sh "${BACKUP_ROOT}" 2>/dev/null | cut -f1)
+log "Total dumps on host: ${TOTAL_BACKUPS} (${TOTAL_SIZE})"
+log "BACKUP OK: ${TARGET_DIR}/${BACKUP_FILE} (${BACKUP_SIZE})"
+REMOTE_SCRIPT
+
+echo "=== ${ENV_NAME} backup finished successfully ==="

--- a/scripts/remote_db_backup.sh
+++ b/scripts/remote_db_backup.sh
@@ -84,26 +84,33 @@ if [ ! -w "${TARGET_DIR}" ]; then
     fi
 fi
 
+# Dump to a temp file first and only mv into place once verified, so an
+# interrupted/failed pg_dump never leaves a partial file that a later run
+# (or an operator) could mistake for a valid backup. The trap also covers
+# aborts from `set -e`.
+TMP_FILE="${TARGET_DIR}/${BACKUP_FILE}.part"
+trap 'rm -f "${TMP_FILE}"' EXIT INT TERM
+
 log "Dumping ${PGDB} from ${DB_CONTAINER} -> ${TARGET_DIR}/${BACKUP_FILE}"
 docker exec "${DB_CONTAINER}" pg_dump \
     -U "${PGUSER}" -d "${PGDB}" \
     --format=custom --compress=9 \
-    > "${TARGET_DIR}/${BACKUP_FILE}"
+    > "${TMP_FILE}"
 
-if [ ! -s "${TARGET_DIR}/${BACKUP_FILE}" ]; then
+if [ ! -s "${TMP_FILE}" ]; then
     log "ERROR: backup file is empty"
-    rm -f "${TARGET_DIR}/${BACKUP_FILE}"
     exit 1
 fi
 
 # Integrity check: the archive TOC must be readable by pg_restore.
 log "Verifying archive with pg_restore --list"
 if ! docker exec -i "${DB_CONTAINER}" pg_restore --list /dev/stdin \
-        < "${TARGET_DIR}/${BACKUP_FILE}" > /dev/null; then
+        < "${TMP_FILE}" > /dev/null; then
     log "ERROR: pg_restore could not read the archive — backup is corrupt"
-    rm -f "${TARGET_DIR}/${BACKUP_FILE}"
     exit 1
 fi
+
+mv "${TMP_FILE}" "${TARGET_DIR}/${BACKUP_FILE}"
 
 (cd "${TARGET_DIR}" && sha256sum "${BACKUP_FILE}" > "${BACKUP_FILE}.sha256")
 chmod 640 "${TARGET_DIR}/${BACKUP_FILE}" "${TARGET_DIR}/${BACKUP_FILE}.sha256"

--- a/scripts/remote_db_backup.sh
+++ b/scripts/remote_db_backup.sh
@@ -71,7 +71,17 @@ BACKUP_FILE="scholarship_db_${ENV_NAME}_${STAMP}.dump"
 if ! mkdir -p "${TARGET_DIR}" 2>/dev/null; then
     log "mkdir needs elevated permissions, retrying with sudo -n"
     sudo -n mkdir -p "${TARGET_DIR}"
-    sudo -n chown "$(id -un):$(id -gn)" "${TARGET_DIR}"
+fi
+# The dated directory may already exist but be root-owned — on production the
+# 02:00 in-container cron backup (running as root) creates it first, so a
+# plain `mkdir -p` above succeeds without making it writable for this user.
+if [ ! -w "${TARGET_DIR}" ]; then
+    log "${TARGET_DIR} is not writable, taking ownership with sudo -n"
+    if ! sudo -n chown "$(id -un):$(id -gn)" "${TARGET_DIR}"; then
+        log "ERROR: ${TARGET_DIR} is not writable and sudo -n chown failed"
+        log "       Grant the SSH user write access (or passwordless sudo) on ${BACKUP_ROOT}"
+        exit 1
+    fi
 fi
 
 log "Dumping ${PGDB} from ${DB_CONTAINER} -> ${TARGET_DIR}/${BACKUP_FILE}"
@@ -113,7 +123,15 @@ for dir in "${BACKUP_ROOT}"/*/; do
     base=$(basename "${dir}")
     if [[ "${base}" =~ ^[0-9]{8}$ ]] && [ "${base}" -lt "${CUTOFF_DATE}" ]; then
         log "  deleting ${base}"
-        rm -rf "${dir}"
+        # Old directories may contain root-owned files from the in-container
+        # cron backup; fall back to sudo, and never fail the run over pruning —
+        # the new backup already succeeded at this point.
+        if ! rm -rf "${dir}" 2>/dev/null; then
+            if ! sudo -n rm -rf "${dir}" 2>/dev/null; then
+                log "  WARNING: could not delete ${base} (permissions?) — skipping"
+                continue
+            fi
+        fi
         DELETED=$((DELETED + 1))
     fi
 done

--- a/scripts/remote_db_backup.sh
+++ b/scripts/remote_db_backup.sh
@@ -58,7 +58,7 @@ set -euo pipefail
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
 
-if ! docker ps --format '{{.Names}}' | grep -qx "${DB_CONTAINER}"; then
+if ! docker ps --format '{{.Names}}' | grep -qxF "${DB_CONTAINER}"; then
     log "ERROR: container ${DB_CONTAINER} is not running on $(hostname)"
     docker ps --format '  running: {{.Names}}' || true
     exit 1

--- a/scripts/remote_db_backup.sh
+++ b/scripts/remote_db_backup.sh
@@ -42,8 +42,14 @@ echo "Backup root: ${BACKUP_ROOT} (retention: ${RETENTION_DAYS} days)"
 
 # Pass parameters to the remote shell as safely-quoted env assignments so the
 # remote script body itself can stay single-quoted (no local interpolation).
-REMOTE_ENV=$(printf "DB_CONTAINER=%q ENV_NAME=%q RETENTION_DAYS=%q BACKUP_ROOT=%q" \
-    "$DB_CONTAINER" "$ENV_NAME" "$RETENTION_DAYS" "$BACKUP_ROOT")
+# The command string is parsed by the remote user's LOGIN shell (not
+# necessarily bash), so use POSIX single-quote escaping — `printf %q` can
+# emit bash-only $'...' quoting that /bin/sh would mis-parse.
+shquote() {
+    local escaped=${1//\'/\'\\\'\'}
+    printf "'%s'" "$escaped"
+}
+REMOTE_ENV="DB_CONTAINER=$(shquote "$DB_CONTAINER") ENV_NAME=$(shquote "$ENV_NAME") RETENTION_DAYS=$(shquote "$RETENTION_DAYS") BACKUP_ROOT=$(shquote "$BACKUP_ROOT")"
 
 ssh -p "$SSH_PORT" -i "$SSH_KEY_PATH" \
     -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 \


### PR DESCRIPTION
## Summary

Adds a scheduled `db-backup.yml` workflow that runs daily `pg_dump` backups of the staging and production databases, plus a shared driver script `scripts/remote_db_backup.sh`.

## How it works

- Jobs run on the self-hosted runner (`[self-hosted, scholarship, test]`) — the DB-VMs sit behind WireGuard, so GitHub-hosted runners cannot reach them (same constraint as `staging-health-monitor.yml`).
- Each job SSHes into the environment's DB-VM (port 8822, same pattern as `deploy-monitoring-stack.yml`) and runs the driver script, which:
  - dumps the postgres container via `docker exec pg_dump --format=custom --compress=9` over the container-local unix socket — no DB password crosses SSH or needs to live in secrets
  - verifies the archive with `pg_restore --list` before accepting it
  - writes a `sha256` checksum alongside the dump
  - prunes dated backup directories past the retention window (default 30 days, overridable via `workflow_dispatch` input), using the same `YYYYMMDD/` layout as the existing `scripts/backup.sh`
- Backups **stay on the DB-VM** under `/opt/scholarship/postgres/backups` — dumps contain PII and are never uploaded as GitHub artifacts.
- On failure, an issue labeled `db-backup-failed` is auto-filed, deduplicated against any already-open one.

## Schedule

| Environment | Time (Asia/Taipei) | Cron (UTC) | Container |
|---|---|---|---|
| staging | 02:30 | `30 18 * * *` | `scholarship_postgres_staging` |
| production | 03:00 | `0 19 * * *` | `scholarship_postgres_prod` |

The production run is deliberately offset from the existing 02:00 in-container cron backup (`docker-compose.prod-db.yml` `postgres-backup` service), so this acts as an independent, observable backup path — failures surface as GitHub issues instead of dying silently inside a container.

Manual runs via `workflow_dispatch` can target `staging`, `production`, or `both`, with an optional retention override.

## Required secrets

- **staging**: `STAGING_DB_HOST`, `STAGING_DB_USER`, `STAGING_DB_SSH_KEY` — already configured (used by `deploy-monitoring-stack.yml`), works out of the box.
- **production**: `PROD_DB_HOST`, `PROD_DB_USER`, `PROD_DB_SSH_KEY` (optional `PROD_DB_SSH_PORT`, default 8822) — **new**; until configured, the production job fails its pre-flight check with a clear error rather than silently skipping. The SSH user on the prod DB-VM needs docker access and write access to `/opt/scholarship/postgres/backups` (or passwordless `sudo` for the initial `mkdir`).

## Notes

- Scheduled workflows only fire from the default branch, so the crons activate once this merges.
- Validation done: workflow YAML parse, `bash -n` on the driver, and a dry run with a stubbed `ssh` confirming parameter quoting and remote script syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcDaxG3urZ8Nunbr8m2B5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcDaxG3urZ8Nunbr8m2B5A)_