### PR TITLE
fix: empty nationality/identity column in college ranking table

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -523,6 +523,16 @@ async def get_ranking(
                                 for subtype in (item.application.scholarship_subtype_list or [])
                             ]
                         ),
+                        # #68: 國籍/身分 — expose only the two snapshot keys the
+                        # ranking table reads, not the full SIS snapshot.
+                        "student_data": {
+                            "std_nation": student_data.get("std_nation") or student_data.get("nationality"),
+                            "std_identity": (
+                                student_data.get("std_identity")
+                                if student_data.get("std_identity") is not None
+                                else student_data.get("identity")
+                            ),
+                        },
                         # Minimal student info - only what's needed for ranking display
                         "student_info": {
                             "display_name": student_name,

--- a/backend/app/tests/test_ranking_management_endpoints.py
+++ b/backend/app/tests/test_ranking_management_endpoints.py
@@ -500,6 +500,38 @@ class TestRankingFlowAndEnvelope:
         assert body["data"]["ranking_name"] == "ENG nstc ranking"
         assert body["data"]["items"] == []
 
+    async def test_get_detail_items_include_nationality_snapshot(
+        self, client, login, db, rank_users, ranking_eng, ranking_eng_items
+    ):
+        """#1205 follow-up: ranking detail items must surface the 國籍/身分
+        snapshot keys (std_nation/std_identity, with legacy nationality/identity
+        aliases) so the college ranking table doesn't render "-"."""
+        apps = (
+            (
+                await db.execute(
+                    select(Application).where(Application.id.in_([item.application_id for item in ranking_eng_items]))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        by_id = {a.id: a for a in apps}
+        app1 = by_id[ranking_eng_items[0].application_id]
+        app2 = by_id[ranking_eng_items[1].application_id]
+        app1.student_data = {**app1.student_data, "std_nation": "中華民國", "std_identity": 1}
+        app2.student_data = {**app2.student_data, "nationality": "美國", "identity": 2}
+        await db.commit()
+
+        login(rank_users["college_eng"])
+        response = await client.get(f"{RANKINGS_URL}/{ranking_eng.id}")
+        assert response.status_code == 200
+        items = response.json()["data"]["items"]
+        assert len(items) == 2
+        snapshots = {item["student_id"]: item["application"]["student_data"] for item in items}
+        assert snapshots["S001"] == {"std_nation": "中華民國", "std_identity": 1}
+        # Legacy alias keys fall back to the canonical snapshot keys
+        assert snapshots["S002"] == {"std_nation": "美國", "std_identity": 2}
+
     async def test_update_ranking_name_200(self, client, login, rank_users, ranking_eng):
         login(rank_users["college_eng"])
         response = await client.put(f"{RANKINGS_URL}/{ranking_eng.id}", json={"ranking_name": "Renamed"})

--- a/backend/app/tests/test_ranking_management_endpoints.py
+++ b/backend/app/tests/test_ranking_management_endpoints.py
@@ -518,7 +518,10 @@ class TestRankingFlowAndEnvelope:
         by_id = {a.id: a for a in apps}
         app1 = by_id[ranking_eng_items[0].application_id]
         app2 = by_id[ranking_eng_items[1].application_id]
-        app1.student_data = {**app1.student_data, "std_nation": "中華民國", "std_identity": 1}
+        # app1 also pins the falsy-zero case: std_identity=0 must be preserved,
+        # NOT fall through to the legacy "identity" alias (an `or`-based
+        # fallback would regress this to 1).
+        app1.student_data = {**app1.student_data, "std_nation": "中華民國", "std_identity": 0, "identity": 1}
         app2.student_data = {**app2.student_data, "nationality": "美國", "identity": 2}
         await db.commit()
 
@@ -528,7 +531,7 @@ class TestRankingFlowAndEnvelope:
         items = response.json()["data"]["items"]
         assert len(items) == 2
         snapshots = {item["student_id"]: item["application"]["student_data"] for item in items}
-        assert snapshots["S001"] == {"std_nation": "中華民國", "std_identity": 1}
+        assert snapshots["S001"] == {"std_nation": "中華民國", "std_identity": 0}
         # Legacy alias keys fall back to the canonical snapshot keys
         assert snapshots["S002"] == {"std_nation": "美國", "std_identity": 2}
 

--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -363,6 +363,11 @@ export function RankingManagementPanel({
               status?: string;
               review_status?: string;
               student_info?: { display_name?: string; student_id?: string };
+              // #68: nationality/identity snapshot keys for the 國籍/身分 column
+              student_data?: {
+                std_nation?: string | null;
+                std_identity?: number | string | null;
+              };
             };
           }
           const rankingPayload = response.data as {
@@ -398,6 +403,7 @@ export function RankingManagementPanel({
               department_name: item.application?.department_name,
               department_code: item.application?.department_code,
               scholarship_type: item.application?.scholarship_type,
+              student_data: item.application?.student_data,
               sub_type: item.sub_type,
               eligible_subtypes: item.application?.eligible_subtypes || [],
               rank_position: item.rank_position,

--- a/frontend/components/college/ranking/RankingManagementPanel.tsx
+++ b/frontend/components/college/ranking/RankingManagementPanel.tsx
@@ -357,7 +357,18 @@ export function RankingManagementPanel({
               department_name?: string;
               department_code?: string;
               scholarship_type?: string;
-              eligible_subtypes?: string[];
+              // Objects (not plain codes): backend returns per-subtype review
+              // status, consumed as-is by CollegeRankingTable.
+              eligible_subtypes?: Array<{
+                code: string;
+                is_rejected: boolean;
+                rejected_by?: {
+                  role: string;
+                  name: string;
+                  reviewed_at: string;
+                };
+                rejection_reason?: string;
+              }>;
               is_renewal?: boolean;
               renewal_year?: number | null;
               status?: string;


### PR DESCRIPTION
## Problem

Follow-up to #1205. That PR fixed the 國籍/身分 column in the college **review list**, but the college **ranking view** (學院學生排序/申請排名, `CollegeRankingTable`) still renders "-" for every row, even though the table has had the column and identity-label mapping since #68.

Two independent gaps in the data pipeline:

1. **Backend** — `GET /api/v1/college-review/rankings/{id}` (`ranking_management.py`) builds a lightweight application DTO per ranking item that never included the `student_data` snapshot keys the table reads (`std_nation` / `std_identity`).
2. **Frontend** — `RankingManagementPanel.tsx` re-maps each ranking item into the table's `Application` shape and dropped `student_data`, so even present data would never have reached the table.

## Fix

- `backend/app/api/v1/endpoints/college_review/ranking_management.py` — the ranking detail item payload now includes a minimal `student_data` block with exactly the two keys the table reads, using the same fallback chain as #1205: `std_nation` falls back to the legacy `nationality` alias, and `std_identity` uses an explicit `None`-check (not `or`, so a falsy identity code isn't dropped) falling back to legacy `identity`. Only these two keys are exposed, not the full SIS snapshot.
- `frontend/components/college/ranking/RankingManagementPanel.tsx` — pass `student_data` through the ranking-item transform (and add it to the inline payload type) so it reaches `CollegeRankingTable`, which already renders 國籍 and maps identity codes to labels (本國生/僑生/外籍生/陸生/港澳生/外籍交換生).

No OpenAPI regeneration needed (endpoint returns untyped dicts). No change to the table component itself — it was already wired for this data.

## Tests

- New endpoint test `test_get_detail_items_include_nationality_snapshot` in `test_ranking_management_endpoints.py` pins both the canonical keys (`std_nation`/`std_identity`) and the legacy-alias fallback (`nationality`/`identity`) in the ranking detail item payload.
- All 53 tests in the file pass; black (26.3.1) and flake8 (B904/B014) gates clean; frontend `tsc --noEmit` and eslint clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qR93HDCgZTbtxTG8bmNru

---
_Generated by [Claude Code](https://claude.ai/code/session_013qR93HDCgZTbtxTG8bmNru)_