### PR TITLE
fix(roster): specific missing-config exclusion reasons; missing bank account no longer excludes

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -678,8 +678,9 @@ async def preview_roster_students(
                 "missing_data": 0,
                 "verification_failed": 0,
                 "rules_failed": 0,
-                "no_bank_account": 0,
             },
+            # 缺少銀行帳戶不排除造冊，僅提醒補件（撥款前仍會擋）
+            "missing_bank_account_count": 0,
             "total_amount": 0.0,
             "verification_stats": {
                 "verified": 0,
@@ -777,10 +778,12 @@ async def preview_roster_students(
                 logger.warning(f"Eligibility validation failed for application {application.id}", exc_info=True)
                 student_info["is_eligible"] = True  # Don't exclude on validation error
 
-            # Validation Step 4: Bank account check
+            # Validation Step 4: Bank account check（僅提醒，不影響納入與否）
             bank_account, field_name = extract_bank_account(application)
             student_info["has_bank_account"] = bool(bank_account)
             student_info["bank_account_field"] = field_name
+            if not bank_account:
+                summary["missing_bank_account_count"] += 1
 
             # Validation Step 5: Final inclusion decision
             is_included = True
@@ -798,12 +801,6 @@ async def preview_roster_students(
                 failed_rules = student_info["failed_rules"]
                 exclusion_reason = f"不符合獎學金規則: {'; '.join(failed_rules)}"
                 summary["exclusion_breakdown"]["rules_failed"] += 1
-
-            # Check bank account
-            elif not bank_account:
-                is_included = False
-                exclusion_reason = "缺少銀行帳戶資訊"
-                summary["exclusion_breakdown"]["no_bank_account"] += 1
 
             student_info["is_included"] = is_included
             student_info["exclusion_reason"] = exclusion_reason

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -782,8 +782,6 @@ async def preview_roster_students(
             bank_account, field_name = extract_bank_account(application)
             student_info["has_bank_account"] = bool(bank_account)
             student_info["bank_account_field"] = field_name
-            if not bank_account:
-                summary["missing_bank_account_count"] += 1
 
             # Validation Step 5: Final inclusion decision
             is_included = True
@@ -804,6 +802,11 @@ async def preview_roster_students(
 
             student_info["is_included"] = is_included
             student_info["exclusion_reason"] = exclusion_reason
+
+            # 只統計「仍列入造冊」但缺帳戶的學生 — 這個數字驅動前端的補件提醒，
+            # 被其他原因排除者不需補件，不應計入
+            if is_included and not bank_account:
+                summary["missing_bank_account_count"] += 1
 
             if is_included:
                 summary["included_count"] += 1

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -817,7 +817,8 @@ class RosterService:
                 exclusion_reasons.append(f"不符合獎學金規則: {'; '.join(failed_rules)}")
             else:
                 exclusion_reasons.append("不符合獎學金資格條件")
-        # 3. 檢查銀行帳戶資訊
+        # 3. 擷取銀行帳戶資訊（僅作快照與提醒用，「缺少銀行帳戶」不構成排除原因：
+        #    學生補件後即可撥款；撥款合格與否由 is_qualified 屬性另行把關）
         # IMPORTANT: Support both nested (schema-compliant) and flat (legacy) data structures
         form_data = application.submitted_form_data or {}
         form_fields = form_data.get("fields", {})
@@ -837,7 +838,6 @@ class RosterService:
                 break
 
         if not bank_account:
-            exclusion_reasons.append("缺少銀行帳戶資訊")
             logger.warning(
                 f"Application {application.id} missing bank account. "
                 f"Checked nested and flat structures. submitted_form_data keys: {list(form_data.keys())}"
@@ -1066,16 +1066,23 @@ class RosterService:
             scholarship_config = application.scholarship_configuration
 
             if not scholarship_config or not student:
-                if not student and not scholarship_config:
-                    missing_reason = "缺少學生資訊/獎學金配置"
-                elif not student:
-                    missing_reason = "缺少學生資訊"
-                else:
-                    missing_reason = "缺少獎學金配置"
+                # 具體說明缺的是哪個關聯、為什麼會缺，讓管理員能直接修資料，
+                # 而不是只看到「缺少獎學金配置」卻不知道原因。
+                app_ref = getattr(application, "app_id", None) or f"#{application.id}"
+                missing_reasons: List[str] = []
+                if not student:
+                    missing_reasons.append(
+                        f"申請 {app_ref} 找不到對應的學生帳號（applications.user_id 無對應使用者，帳號可能已被刪除）"
+                    )
+                if not scholarship_config:
+                    missing_reasons.append(
+                        f"申請 {app_ref} 未關聯獎學金配置（applications.scholarship_configuration_id 為空，"
+                        f"常見於資料匯入或舊資料未建立配置關聯），無法載入該期驗證規則"
+                    )
 
                 return {
                     "is_eligible": False,
-                    "failed_rules": [missing_reason],
+                    "failed_rules": missing_reasons,
                     "warning_rules": [],
                     "details": {},
                 }

--- a/backend/app/tests/test_excel_export_generate_remarks.py
+++ b/backend/app/tests/test_excel_export_generate_remarks.py
@@ -98,10 +98,10 @@ def test_excluded_with_reason_includes_reason(service):
     """Pin: when is_included=False AND exclusion_reason is set, the reason
     surfaces in the remarks. This is the auditor's primary signal for
     "why didn't this student get paid?"."""
-    item = _make_item(is_included=False, exclusion_reason="缺少銀行帳戶資訊")
+    item = _make_item(is_included=False, exclusion_reason="學籍驗證未通過: graduated")
     roster = _make_roster()
     result = service._generate_remarks(item, roster)
-    assert "排除原因: 缺少銀行帳戶資訊" in result
+    assert "排除原因: 學籍驗證未通過: graduated" in result
 
 
 def test_excluded_without_reason_omits_reason_label(service):

--- a/backend/app/tests/test_excel_export_service_rows.py
+++ b/backend/app/tests/test_excel_export_service_rows.py
@@ -356,14 +356,15 @@ def test_is_manual_removal_detects_lock_and_reconcile_prefixes(service):
         is True
     )
     assert (
-        service._is_manual_removal(_mk_scope_item("c", is_included=False, exclusion_reason="缺少銀行帳戶資訊")) is False
+        service._is_manual_removal(_mk_scope_item("c", is_included=False, exclusion_reason="學籍驗證未通過: graduated"))
+        is False
     )
     assert service._is_manual_removal(_mk_scope_item("d", is_included=True, exclusion_reason=None)) is False
 
 
 def test_get_roster_items_default_keeps_auto_excluded_hides_manual(service):
     included = _mk_scope_item("納入", is_included=True)
-    auto_excluded = _mk_scope_item("自動排除", is_included=False, exclusion_reason="缺少銀行帳戶資訊")
+    auto_excluded = _mk_scope_item("自動排除", is_included=False, exclusion_reason="學籍驗證未通過: graduated")
     manual = _mk_scope_item("手動移除", is_included=False, exclusion_reason="鎖定後移除[停發]：x")
     roster = SimpleNamespace(items=[included, auto_excluded, manual])
 

--- a/backend/app/tests/test_roster_eligibility.py
+++ b/backend/app/tests/test_roster_eligibility.py
@@ -320,40 +320,63 @@ def test_and_semantics_all_pass_returns_eligible(service, monkeypatch):
 
 
 def test_missing_student_returns_ineligible_with_reason(service):
-    """Pin: application with no `.student` relationship → ineligible,
-    `failed_rules=['缺少學生資訊']`. Data-integrity hole that must
-    surface in the Excel exclusion reason, not silently pass."""
+    """Pin: application with no `.student` relationship → ineligible, and
+    the reason names the application AND explains the technical cause
+    (dangling `user_id`) so operators can fix the data instead of guessing.
+    Data-integrity hole that must surface in the Excel exclusion reason,
+    not silently pass."""
     application = _make_application(student=None, scholarship_config=_make_scholarship_config())
     application.student = None  # explicit
     result = service._validate_student_eligibility(application, academic_year=113, period_label="113-01")
 
     assert result["is_eligible"] is False
-    assert result["failed_rules"] == ["缺少學生資訊"]
+    assert len(result["failed_rules"]) == 1
+    reason = result["failed_rules"][0]
+    assert "#42" in reason  # names the application (falls back to id when app_id is absent)
+    assert "user_id 無對應使用者" in reason
     assert result["warning_rules"] == []
 
 
 def test_missing_scholarship_config_returns_ineligible_with_reason(service):
     """Pin: application with no `.scholarship_configuration` relationship
-    → ineligible, `failed_rules=['缺少獎學金配置']`."""
+    → ineligible, and the reason explains the actual cause (NULL
+    `scholarship_configuration_id`, typically imported/legacy data) rather
+    than the old opaque '缺少獎學金配置'."""
     application = _make_application(scholarship_config=None)
     application.scholarship_configuration = None  # explicit
     result = service._validate_student_eligibility(application, academic_year=113, period_label="113-01")
 
     assert result["is_eligible"] is False
-    assert result["failed_rules"] == ["缺少獎學金配置"]
+    assert len(result["failed_rules"]) == 1
+    reason = result["failed_rules"][0]
+    assert "#42" in reason
+    assert "scholarship_configuration_id 為空" in reason
+    assert "未關聯獎學金配置" in reason
 
 
-def test_missing_both_student_and_config_combines_reason(service):
+def test_missing_both_student_and_config_lists_both_reasons(service):
     """Pin: when BOTH student and scholarship_configuration are missing,
-    the reason combines both ('缺少學生資訊/獎學金配置'). The order matters
-    because the operator's Excel cell parses by exact string match."""
+    each problem is reported as its own entry (student first) so the
+    operator UI's failed-rules list shows two concrete, fixable items."""
     application = _make_application()
     application.student = None
     application.scholarship_configuration = None
     result = service._validate_student_eligibility(application, academic_year=113, period_label="113-01")
 
     assert result["is_eligible"] is False
-    assert result["failed_rules"] == ["缺少學生資訊/獎學金配置"]
+    assert len(result["failed_rules"]) == 2
+    assert "user_id 無對應使用者" in result["failed_rules"][0]
+    assert "scholarship_configuration_id 為空" in result["failed_rules"][1]
+
+
+def test_missing_config_reason_uses_app_id_when_available(service):
+    """Pin: the reason prefers the human-facing `app_id` (e.g.
+    APP-113-1-00001) over the raw primary key when the application has one."""
+    application = _make_application(scholarship_config=None, app_id="APP-113-1-00001")
+    application.scholarship_configuration = None
+    result = service._validate_student_eligibility(application, academic_year=113, period_label="113-01")
+
+    assert "APP-113-1-00001" in result["failed_rules"][0]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/tests/test_roster_service_core.py
+++ b/backend/app/tests/test_roster_service_core.py
@@ -225,11 +225,12 @@ def test_create_roster_item_included_when_bank_account_present(service: RosterSe
     assert item.bank_account == "00012345678"
 
 
-def test_create_roster_item_excluded_when_bank_account_missing(service: RosterService) -> None:
-    """No bank account anywhere in submitted_form_data ⇒ is_included=False
-    with the 缺少銀行帳戶資訊 reason. Critical because we cannot pay a
-    student with no account number — and the exclusion_reason is what the
-    operator sees in the UI to know WHY they were dropped."""
+def test_create_roster_item_included_when_bank_account_missing(service: RosterService) -> None:
+    """No bank account anywhere in submitted_form_data ⇒ the student is STILL
+    included in the roster (is_included=True, no exclusion_reason) — a missing
+    account is a fixable補件 issue, not an eligibility problem. Payment
+    readiness is gated separately by `is_qualified`, which stays False until
+    the account is filled in."""
     roster = _make_roster()
     application = _make_application(bank_account=None)
 
@@ -241,9 +242,10 @@ def test_create_roster_item_excluded_when_bank_account_missing(service: RosterSe
         eligibility_result={"is_eligible": True, "failed_rules": [], "warning_rules": []},
     )
 
-    assert item.is_included is False
-    assert item.exclusion_reason == "缺少銀行帳戶資訊"
+    assert item.is_included is True
+    assert item.exclusion_reason is None
     assert item.bank_account == ""
+    assert not item.is_qualified  # 撥款仍被擋，直到補齊帳戶
 
 
 def test_create_roster_item_excluded_when_verification_failed(service: RosterService) -> None:

--- a/frontend/components/roster/StudentRosterPreview.tsx
+++ b/frontend/components/roster/StudentRosterPreview.tsx
@@ -16,7 +16,13 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Users, DollarSign, Building2, InfoIcon } from "lucide-react";
+import {
+  Users,
+  DollarSign,
+  Building2,
+  InfoIcon,
+  AlertTriangle,
+} from "lucide-react";
 import { apiClient } from "@/lib/api";
 import {
   useReferenceData,
@@ -68,8 +74,9 @@ interface PreviewData {
       missing_data: number;
       verification_failed: number;
       rules_failed: number;
-      no_bank_account: number;
     };
+    // 缺少銀行帳戶不排除造冊，僅提醒補件
+    missing_bank_account_count: number;
     total_amount: number;
     verification_stats: {
       verified: number;
@@ -405,6 +412,17 @@ export function StudentRosterPreview({
         </Card>
       </div>
 
+      {/* Missing bank account warning — 不排除造冊，但需提醒補件 */}
+      {data.summary.missing_bank_account_count > 0 && (
+        <Alert className="border-orange-300 bg-orange-50 text-orange-800">
+          <AlertTriangle className="h-4 w-4 !text-orange-600" />
+          <AlertDescription>
+            有 {data.summary.missing_bank_account_count}{" "}
+            位學生尚未填寫銀行帳戶資訊，仍會列入造冊，但撥款前需補齊帳戶資料。
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* Student List */}
       <Card>
         <CardHeader>
@@ -482,7 +500,7 @@ export function StudentRosterPreview({
                     <p className="text-sm text-muted-foreground mb-3">
                       共 {data.summary.excluded_count} 位學生被排除
                     </p>
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
                       <div className="p-2 bg-gray-50 rounded border">
                         <div className="text-xs text-gray-600">缺少資料</div>
                         <div className="text-lg font-semibold">
@@ -499,12 +517,6 @@ export function StudentRosterPreview({
                         <div className="text-xs text-gray-600">規則失敗</div>
                         <div className="text-lg font-semibold">
                           {data.summary.exclusion_breakdown.rules_failed}
-                        </div>
-                      </div>
-                      <div className="p-2 bg-gray-50 rounded border">
-                        <div className="text-xs text-gray-600">無銀行帳戶</div>
-                        <div className="text-lg font-semibold">
-                          {data.summary.exclusion_breakdown.no_bank_account}
                         </div>
                       </div>
                     </div>

--- a/frontend/components/roster/StudentValidationDetail.tsx
+++ b/frontend/components/roster/StudentValidationDetail.tsx
@@ -155,7 +155,7 @@ export function StudentValidationDetail({ student }: StudentValidationDetailProp
               <div>
                 <div className="font-semibold text-orange-900 text-xs mb-1">銀行帳戶資訊</div>
                 <div className="text-orange-700 text-xs">
-                  學生尚未填寫銀行帳戶資訊
+                  學生尚未填寫銀行帳戶資訊（仍列入造冊，撥款前需補齊帳戶資料）
                   {student.bank_account_field && (
                     <span className="block mt-1 text-orange-600">
                       欄位名稱: {student.bank_account_field}

--- a/frontend/e2e/specs/admin-revoke-suspend.spec.ts
+++ b/frontend/e2e/specs/admin-revoke-suspend.spec.ts
@@ -418,9 +418,9 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
 const SETUP_STUDENT2 = "csphd0002";
 
 // A missing bank account no longer excludes an item from the roster (it is
-// only a 補件 warning now), but the fixture applications still carry one so
-// the generated items are fully payable and the revoked entry surfaces via
-// get_revoked_suspended_for_roster (PR #916 soft-delete gate on is_included).
+// only a 補件 warning now), so it doesn't affect the is_included gate that
+// get_revoked_suspended_for_roster filters on (PR #916). The fixture
+// applications still carry one so the generated items are fully payable.
 const SETUP_FORM_DATA = {
   fields: {
     bank_account: {

--- a/frontend/e2e/specs/admin-revoke-suspend.spec.ts
+++ b/frontend/e2e/specs/admin-revoke-suspend.spec.ts
@@ -417,10 +417,10 @@ test.describe("admin revoke dialog — confirm disabled until reason filled", ()
 // Second student for describe #2 suspend sub-fixture (csphd0002).
 const SETUP_STUDENT2 = "csphd0002";
 
-// Roster generation marks an item is_included=false ("缺少銀行帳戶資訊") when
-// the application has no bank account, and get_revoked_suspended_for_roster
-// only returns is_included=true items (PR #916 soft-delete gate) — so the
-// fixture applications must carry one for the revoked entry to surface.
+// A missing bank account no longer excludes an item from the roster (it is
+// only a 補件 warning now), but the fixture applications still carry one so
+// the generated items are fully payable and the revoked entry surfaces via
+// get_revoked_suspended_for_roster (PR #916 soft-delete gate on is_included).
 const SETUP_FORM_DATA = {
   fields: {
     bank_account: {


### PR DESCRIPTION
## Summary
This PR improves operational visibility into data integrity issues and clarifies the role of bank account information in roster eligibility. Missing student/scholarship configuration relationships now surface concrete, actionable error messages that help operators fix data directly. Bank account information is reclassified from an exclusion criterion to a pre-payment checklist item, allowing students to be included in rosters and supplemented before disbursement.

## Key Changes

### Backend: Enhanced Data Integrity Messaging
- **Eligibility validation** (`_validate_student_eligibility`): Replaced opaque error messages ("缺少學生資訊", "缺少獎學金配置") with detailed, actionable reasons that:
  - Name the application (using `app_id` when available, falling back to `#id`)
  - Explain the technical cause (e.g., "user_id 無對應使用者", "scholarship_configuration_id 為空")
  - List each missing relationship as a separate failed rule (not combined)
  - Help operators understand why data is missing and how to fix it

### Backend: Bank Account Reclassification
- **Roster item creation** (`_create_roster_item`): Removed "缺少銀行帳戶資訊" from exclusion reasons
  - Missing bank account no longer sets `is_included=False`
  - Students are included in rosters even without bank account information
  - Payment readiness is gated separately by `is_qualified` attribute
  - Logging still captures missing accounts for operator awareness

- **Roster summary** (`get_roster_summary`): 
  - Removed `no_bank_account` from `exclusion_breakdown`
  - Added `missing_bank_account_count` to track students needing account supplementation
  - Clarified in comments that missing accounts are 補件 (supplementation) issues, not eligibility issues

### Frontend: Updated UI and Messaging
- **StudentRosterPreview**: 
  - Moved bank account status from exclusion breakdown grid to a dedicated orange warning alert
  - Alert message clarifies that missing accounts don't exclude students but require supplementation before payment
  - Reduced exclusion breakdown grid from 4 columns to 3 (removed "無銀行帳戶" column)

- **StudentValidationDetail**: Updated bank account warning text to clarify students remain in roster but need account data before disbursement

### Tests: Updated Assertions
- **Eligibility tests**: Updated to verify detailed error messages include application reference and technical cause
- **Roster item tests**: Changed expectations so missing bank account results in `is_included=True` with `is_qualified=False`
- **Excel export tests**: Updated test data to use realistic exclusion reasons (e.g., "學籍驗證未通過: graduated") instead of bank account messages

### Documentation Updates
- E2E test comments clarified that missing bank accounts no longer exclude items from rosters
- Code comments throughout explain the distinction between eligibility (inclusion in roster) and payment readiness (qualified status)

## Implementation Details
- Error messages follow a consistent pattern: `申請 {app_ref} {specific_issue}（{technical_cause}）`
- Bank account information is still captured and tracked but treated as a pre-payment checklist item
- The `is_qualified` attribute remains the gate for actual payment processing
- All changes maintain backward compatibility with existing roster data structures

https://claude.ai/code/session_01Pd2JeTWNE6GhN8sc4TZN2W