### PR TITLE
fix: resolve 未知入學方式 by hardcoding NYCU std_enrolltype reference values

### DIFF
--- a/backend/app/api/v1/endpoints/reference_data.py
+++ b/backend/app/api/v1/endpoints/reference_data.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import selectinload
 
 from app.core.cache import cached
 from app.core.deps import get_db
+from app.core.enroll_types import merge_enroll_types
 from app.models.application import Application
 from app.models.enums import ApplicationCycle, Semester
 from app.models.scholarship import (
@@ -136,16 +137,9 @@ async def get_enroll_types(
     result = await session.execute(query.order_by(EnrollType.degreeId, EnrollType.code))
     enroll_types = result.scalars().all()
 
-    data = [
-        {
-            "degree_id": enroll_type.degreeId,
-            "code": enroll_type.code,
-            "name": enroll_type.name,
-            "name_en": enroll_type.name_en,
-            "degree_name": enroll_type.degree.name if enroll_type.degree else None,
-        }
-        for enroll_type in enroll_types
-    ]
+    # DB rows first, hardcoded NYCU fallback fills any gaps so every valid
+    # std_enrolltype code resolves to a real name (no more "未知入學方式").
+    data = merge_enroll_types(enroll_types)
     return ApiResponse(success=True, message="Enroll types retrieved successfully", data=data)
 
 
@@ -172,7 +166,9 @@ async def get_all_reference_data(
     return ApiResponse(success=True, message="Reference data retrieved successfully", data=data)
 
 
-@cached(key_fn=lambda *_, **__: "refdata:all:v2", ttl=86400)  # 24 h; :v2 busts stale pre-academy_code cache on deploy
+@cached(
+    key_fn=lambda *_, **__: "refdata:all:v3", ttl=86400
+)  # 24 h; :v3 busts stale pre-enroll_types-fallback cache on deploy
 async def _get_all_reference_data_cached(session: AsyncSession) -> dict:
     """Server-side cached body of /reference-data/all. See the wrapper above for
     the no-store HTTP header rationale."""
@@ -234,16 +230,7 @@ async def _get_all_reference_data_cached(session: AsyncSession) -> dict:
             }
             for department in departments
         ],
-        "enroll_types": [
-            {
-                "degree_id": enroll_type.degreeId,
-                "code": enroll_type.code,
-                "name": enroll_type.name,
-                "name_en": enroll_type.name_en,
-                "degree_name": enroll_type.degree.name if enroll_type.degree else None,
-            }
-            for enroll_type in enroll_types
-        ],
+        "enroll_types": merge_enroll_types(enroll_types),
         "sub_type_translations": sub_type_translations,
     }
 

--- a/backend/app/core/enroll_types.py
+++ b/backend/app/core/enroll_types.py
@@ -1,0 +1,136 @@
+"""
+Hardcoded NYCU ``std_enrolltype`` reference values.
+
+The ``enroll_types`` table in the database has historically been empty (no seed
+migration, no SQL dump) on every environment — dev, staging, and prod alike.
+As a result the frontend ``getEnrollTypeName`` helper
+(``frontend/hooks/use-reference-data.ts``) could never resolve a name and fell
+back to ``未知入學方式 (code)`` for every student, even for valid codes like
+``1`` (招生考試一般生).
+
+Rather than ship a database migration (the values are a stable NYCU SIS
+contract, not environment-specific config), we hardcode the canonical mapping
+here and expose it as a fallback that the reference-data endpoints merge in
+whenever the DB lookup comes up short.
+
+Source of truth: NYCU Student Information System ``std_enrolltype`` field.
+Confirmed against codebase usage in:
+  - ``mock-student-api/main.py`` (codes 1, 2, 4, 8, 9)
+  - ``backend/app/db/seed_scholarship_configs.py`` (codes 2,5,6,7 and 8,9,10,11)
+  - ``backend/app/services/college_ranking_export_service.py``
+    (``DIRECT_PHD_ENROLLTYPE_CODES = {8,9,10,11}``)
+  - ``backend/app/tests/test_college_ranking_export_service.py``
+"""
+
+from typing import Any
+
+# Degree IDs (matches ``backend/app/db/seed_scholarship_configs.py`` and the
+# ``degrees`` table seed in migration 6d5b1940bf8a):
+#   1 = 博士 (PhD)
+#   2 = 碩士 (Master)
+#   3 = 學士 (Undergraduate)
+_DEGREE_IDS: tuple[int, ...] = (1, 2, 3)
+
+# Canonical NYCU std_enrolltype code → (Chinese name, English name).
+# Codes are stable across all degrees; the same enrollment channel can apply
+# to PhD / Master / Undergrad students (e.g. code 1 = 招生考試一般生 is valid
+# for all three). Degree-specific channels like 逕博 (8-11) are technically
+# PhD-only, but including them for all degrees is harmless — the eligibility
+# rules in ``seed_scholarship_configs.py`` enforce degree constraints, not
+# this display-only reference table.
+_ENROLL_TYPE_ENTRIES: tuple[tuple[int, str, str], ...] = (
+    (1, "招生考試一般生", "Admission Exam - General"),
+    (2, "招生考試在職生", "Admission Exam - In-service"),
+    (3, "選讀生", "Selected Studies"),
+    (4, "推甄一般生", "Recommendation - General"),
+    (5, "推甄在職生", "Recommendation - In-service"),
+    (6, "僑生", "Overseas Chinese Student"),
+    (7, "外籍生", "International Student"),
+    (8, "大學逕博", "Direct PhD (from Bachelor)"),
+    (9, "碩士逕博", "Direct PhD (from Master)"),
+    (10, "跨校學士逕博", "Direct PhD (Cross-university, from Bachelor)"),
+    (11, "跨校碩士逕博", "Direct PhD (Cross-university, from Master)"),
+    (12, "雙聯學位", "Dual Degree"),
+    (17, "陸生", "Mainland Chinese Student"),
+    (18, "轉校", "Transfer Student"),
+    (26, "專案入學", "Project Admission"),
+    (29, "TIGP", "TIGP (Taiwan International Graduate Program)"),
+    (30, "其他", "Other"),
+)
+
+
+def get_hardcoded_enroll_types() -> list[dict[str, Any]]:
+    """Return the canonical NYCU enroll_types list, one entry per
+    (degree_id, code) pair.
+
+    The shape mirrors what ``reference_data.py`` builds from DB rows so the
+    frontend ``getEnrollTypeName`` helper can consume it unchanged:
+    ``{degree_id, code, name, name_en, degree_name}``.
+
+    ``degree_name`` is left ``None`` — the frontend does not read it for the
+    lookup (only ``degree_id`` + ``code`` + ``name``), and the DB-sourced
+    version populates it via a join that has no equivalent here.
+    """
+    return [
+        {
+            "degree_id": degree_id,
+            "code": str(code),
+            "name": name_zh,
+            "name_en": name_en,
+            "degree_name": None,
+        }
+        for degree_id in _DEGREE_IDS
+        for code, name_zh, name_en in _ENROLL_TYPE_ENTRIES
+    ]
+
+
+def merge_enroll_types(db_rows: list[Any]) -> list[dict[str, Any]]:
+    """Merge DB-sourced enroll_types with the hardcoded fallback.
+
+    DB rows win when present (so admins can still override via the DB if a
+    future migration populates the table). For any ``(degree_id, code)`` pair
+    missing from the DB, the hardcoded value fills the gap — guaranteeing that
+    every valid NYCU ``std_enrolltype`` code resolves to a real display name
+    instead of the ``未知入學方式 (code)`` fallback.
+
+    Args:
+        db_rows: SQLAlchemy ``EnrollType`` model instances (or any objects
+            with ``degreeId``, ``code``, ``name``, ``name_en``, ``degree``
+            attributes) as returned by ``select(EnrollType)``.
+
+    Returns:
+        List of dicts shaped like the ``enroll_types`` entries in the
+        ``/reference-data/all`` response.
+    """
+    seen: set[tuple[int, str]] = set()
+    merged: list[dict[str, Any]] = []
+
+    for row in db_rows:
+        degree_id = getattr(row, "degreeId", None)
+        code = getattr(row, "code", None)
+        if degree_id is None or code is None:
+            continue
+        code_str = str(code)
+        key = (int(degree_id), code_str)
+        if key in seen:
+            continue
+        seen.add(key)
+        degree = getattr(row, "degree", None)
+        merged.append(
+            {
+                "degree_id": int(degree_id),
+                "code": code_str,
+                "name": getattr(row, "name", None),
+                "name_en": getattr(row, "name_en", None),
+                "degree_name": getattr(degree, "name", None) if degree is not None else None,
+            }
+        )
+
+    for entry in get_hardcoded_enroll_types():
+        key = (int(entry["degree_id"]), str(entry["code"]))
+        if key not in seen:
+            merged.append(entry)
+            seen.add(key)
+
+    merged.sort(key=lambda e: (e["degree_id"], int(e["code"])))
+    return merged

--- a/backend/app/tests/test_enroll_types_fallback.py
+++ b/backend/app/tests/test_enroll_types_fallback.py
@@ -1,0 +1,117 @@
+"""
+Tests for the hardcoded NYCU ``std_enrolltype`` fallback.
+
+Context: the ``enroll_types`` DB table has historically been empty on every
+environment (no seed migration), so the frontend ``getEnrollTypeName`` helper
+always fell back to ``未知入學方式 (code)``. ``app.core.enroll_types`` ships a
+hardcoded canonical mapping merged into the reference-data endpoints so every
+valid NYCU code resolves to a real name.
+
+These tests pin the contract:
+  - empty DB ⇒ all 17 codes × 3 degrees are returned (51 rows)
+  - code 1 resolves to ``招生考試一般生`` (the reported bug)
+  - direct-PhD codes 8-11 are present with their canonical names
+  - DB rows take precedence over the hardcoded fallback (admin override path)
+  - the merge is idempotent and sorted by (degree_id, code)
+"""
+
+import pytest
+
+from app.core.enroll_types import get_hardcoded_enroll_types, merge_enroll_types
+
+
+class _FakeRow:
+    """Mimics a SQLAlchemy ``EnrollType`` row for the merge function."""
+
+    def __init__(self, degree_id, code, name="DB_ROW", name_en="DB Row", degree=None):
+        self.degreeId = degree_id
+        self.code = code
+        self.name = name
+        self.name_en = name_en
+        self.degree = degree
+
+
+def test_hardcoded_list_covers_all_three_degrees_and_canonical_codes():
+    """The seed must cover degrees 1/2/3 and the 17 canonical NYCU codes."""
+    entries = get_hardcoded_enroll_types()
+    degree_ids = {e["degree_id"] for e in entries}
+    assert degree_ids == {1, 2, 3}, f"missing degrees: {degree_ids}"
+
+    # 17 canonical codes × 3 degrees = 51
+    assert len(entries) == 51, f"expected 51 entries, got {len(entries)}"
+
+    codes_per_degree = {
+        degree_id: sorted(int(e["code"]) for e in entries if e["degree_id"] == degree_id) for degree_id in (1, 2, 3)
+    }
+    expected_codes = sorted([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 17, 18, 26, 29, 30])
+    for degree_id, codes in codes_per_degree.items():
+        assert codes == expected_codes, f"degree {degree_id} codes mismatch: {codes}"
+
+
+def test_code_1_resolves_to_admission_exam_general():
+    """Pin the reported bug: code 1 must NOT show '未知入學方式'.
+
+    Regression guard for the issue where every student's 入學方式 displayed as
+    '未知入學方式 (1)' because the enroll_types table was empty."""
+    entries = get_hardcoded_enroll_types()
+    for degree_id in (1, 2, 3):
+        match = next(e for e in entries if e["degree_id"] == degree_id and e["code"] == "1")
+        assert (
+            match["name"] == "招生考試一般生"
+        ), f"degree {degree_id} code 1 should be 招生考試一般生, got {match['name']!r}"
+
+
+def test_direct_phd_codes_8_through_11_present_with_canonical_names():
+    """Codes 8-11 identify direct-track PhD students and are referenced by
+    ``DIRECT_PHD_ENROLLTYPE_CODES`` in college_ranking_export_service.py and
+    by the 逕讀博士獎學金 eligibility rule in seed_scholarship_configs.py."""
+    entries = get_hardcoded_enroll_types()
+    expected = {
+        "8": "大學逕博",
+        "9": "碩士逕博",
+        "10": "跨校學士逕博",
+        "11": "跨校碩士逕博",
+    }
+    phd_entries = {e["code"]: e["name"] for e in entries if e["degree_id"] == 1}
+    for code, name in expected.items():
+        assert phd_entries.get(code) == name, f"PhD code {code} should be {name!r}, got {phd_entries.get(code)!r}"
+
+
+def test_merge_with_empty_db_returns_full_hardcoded_set():
+    """Empty DB rows ⇒ merge falls back to the full hardcoded list."""
+    merged = merge_enroll_types([])
+    assert len(merged) == 51
+    # Sorted by (degree_id, code-as-int)
+    assert merged[0] == {
+        "degree_id": 1,
+        "code": "1",
+        "name": "招生考試一般生",
+        "name_en": "Admission Exam - General",
+        "degree_name": None,
+    }
+
+
+def test_db_rows_take_precedence_over_hardcoded_fallback():
+    """When the DB has a row for (degree_id, code), it wins over the hardcoded
+    value — so admins can still override via the database if a future migration
+    populates the table with corrected names."""
+    db_row = _FakeRow(degree_id=3, code=1, name="DB_OVERRIDE", name_en="DB Override")
+    merged = merge_enroll_types([db_row])
+
+    match = next(d for d in merged if d["degree_id"] == 3 and d["code"] == "1")
+    assert match["name"] == "DB_OVERRIDE"
+    assert match["name_en"] == "DB Override"
+
+    # Other codes for degree 3 still come from the hardcoded fallback
+    other = next(d for d in merged if d["degree_id"] == 3 and d["code"] == "8")
+    assert other["name"] == "大學逕博"
+
+
+def test_merge_is_sorted_by_degree_id_then_numeric_code():
+    """The merge output must be sorted by (degree_id, numeric code) so the
+    frontend dropdown renders codes in natural order (1, 2, ..., 30) rather
+    than lexicographic (1, 10, 11, 12, 17, 18, 2, 26, ...)."""
+    merged = merge_enroll_types([])
+    for degree_id in (1, 2, 3):
+        codes = [int(d["code"]) for d in merged if d["degree_id"] == degree_id]
+        assert codes == sorted(codes), f"codes not sorted for degree {degree_id}: {codes}"


### PR DESCRIPTION
## Problem

學院 role 查看 申請清單 → 點進去學生資訊 → 入學資訊的入學方式顯示「未知入學方式 (1)」。

## Root cause

The `enroll_types` reference table in the database is **empty (0 rows)** on every environment — dev, staging, and prod alike. There is no seed migration, no SQL dump, and no hardcoded fallback anywhere in the codebase:

```
scholarship_postgres_dev=# SELECT ... FROM enroll_types;
 degreeId | code | name | name_en 
----------+------+------+---------
(0 rows)
```

The frontend `getEnrollTypeName` (`frontend/hooks/use-reference-data.ts:335`) falls back to `未知入學方式 (code)` whenever it can't find a match in `enrollTypes`. With an empty table, **every** code falls back — even valid ones like `1` (招生考試一般生).

Code `1` does have a real value. The canonical NYCU `std_enrolltype` mapping (confirmed against `mock-student-api/main.py`, `seed_scholarship_configs.py`, and `college_ranking_export_service.py`):

| code | meaning |
|---|---|
| 1 | 招生考試一般生 |
| 2 | 招生考試在職生 |
| 3 | 選讀生 |
| 4 | 推甄一般生 |
| 5 | 推甄在職生 |
| 6 | 僑生 |
| 7 | 外籍生 |
| 8 | 大學逕博 |
| 9 | 碩士逕博 |
| 10 | 跨校學士逕博 |
| 11 | 跨校碩士逕博 |
| 12 | 雙聯學位 |
| 17 | 陸生 |
| 18 | 轉校 |
| 26 | 專案入學 |
| 29 | TIGP |
| 30 | 其他 |

## Fix

Hardcode the 17 canonical NYCU `std_enrolltype` codes × 3 degrees in the backend (no DB migration — these are a stable SIS contract, not environment-specific config).

### Changes

- **`backend/app/core/enroll_types.py`** (new): hardcoded `_ENROLL_TYPE_ENTRIES` (17 codes × zh/en names) and `merge_enroll_types()` that merges DB rows with the hardcoded fallback. DB rows win when present (admin override path); the fallback fills the gaps so every valid code resolves to a real name.
- **`backend/app/api/v1/endpoints/reference_data.py`**: `/enroll-types` and `/reference-data/all` now call `merge_enroll_types()` instead of building the list from DB rows only. Cache key bumped `refdata:all:v2` → `refdata:all:v3` to bust the stale empty-list cache on deploy.
- **`backend/app/tests/test_enroll_types_fallback.py`** (new): 6 tests pinning code 1 resolves to 招生考試一般生, direct-PhD codes 8-11 present, DB-row precedence, sort order.

### Why hardcode instead of migrate?

Per user direction — these values are a stable NYCU SIS contract referenced across `mock-student-api`, `seed_scholarship_configs.py` (`DIRECT_PHD_ENROLLTYPE_CODES = {8,9,10,11}`), and `college_ranking_export_service.py`. A hardcoded constant keeps them version-controlled alongside the code that consumes them, rather than buried in a migration that admins would have to remember to run.

## Verification

- `backend/app/tests/test_enroll_types_fallback.py` — 6 new tests pass
- `test_reference_data_response_shape.py`, `test_student_models_helpers.py`, `test_student_schemas.py`, `test_college_ranking_export_service.py`, `test_college_ranking_export_pure_helpers.py` — 141 tests pass, no regressions
- `black` / `flake8` clean on new files
- Manual check: `merge_enroll_types([])` returns 51 entries; `code=1, degree_id=3` resolves to `招生考試一般生` (no longer 未知入學方式)

## Note

The dev backend container (`scholarship_backend_dev`) has a broken bind mount pointing at a deleted worktree (`.claude/worktrees/manual-dist-recommendation-display/backend`) — it shows `unhealthy` and `/app` is empty. This is unrelated to this fix but blocks local end-to-end verification until the container is restarted with a valid mount.