### PR TITLE
fix: link supplementary-import applications to scholarship configuration

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -24,6 +24,7 @@ from app.core.security import require_college, require_scholarship_manager
 from app.db.deps import get_db
 from app.models.audit_log import AuditAction, AuditLog
 from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import Semester
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.student import Department
 from app.models.user import User, UserRole
@@ -1402,20 +1403,29 @@ async def supplementary_import(
         ScholarshipConfiguration.is_active.is_(True),
     ]
     if normalized_semester is None:
-        cfg_conditions.append(ScholarshipConfiguration.semester.is_(None))
+        # Yearly cycles store semester as either NULL or "yearly" — match both
+        # (same rule as CollegeReviewService.assert_ranking_within_deadline).
+        cfg_conditions.append(
+            or_(
+                ScholarshipConfiguration.semester.is_(None),
+                ScholarshipConfiguration.semester == Semester.yearly.value,
+            )
+        )
     else:
         cfg_conditions.append(ScholarshipConfiguration.semester == normalized_semester)
 
-    cfg_stmt = select(ScholarshipConfiguration).where(and_(*cfg_conditions))
+    cfg_stmt = select(ScholarshipConfiguration).where(and_(*cfg_conditions)).limit(1)
     cfg = (await db.execute(cfg_stmt)).scalar_one_or_none()
     if not cfg or not cfg.allow_supplementary_import:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="補充匯入功能尚未開放")
 
-    # Build label→code map from scholarship sub_type_configs
+    # Build label→code map from scholarship sub_type_configs. Loop variable must
+    # NOT be named "cfg" — that name is the resolved ScholarshipConfiguration
+    # above, which is passed to create_applications_and_items below.
     label_to_code = {
-        cfg.name: cfg.sub_type_code
-        for cfg in (getattr(ranking.scholarship_type, "sub_type_configs", None) or [])
-        if cfg.name and cfg.sub_type_code
+        stc.name: stc.sub_type_code
+        for stc in (getattr(ranking.scholarship_type, "sub_type_configs", None) or [])
+        if stc.name and stc.sub_type_code
     }
 
     # Load dynamic fields (same query as export)

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -1507,9 +1507,11 @@ async def supplementary_import(
     # Upsert user profiles (bank_account, advisor_name)
     await service.upsert_user_profiles(user_map, rows)
 
-    # Create applications + ranking items
+    # Create applications + ranking items. Pass the resolved configuration so
+    # every application carries scholarship_configuration_id — roster rule
+    # validation depends on it (issue #1213).
     imported_count = await service.create_applications_and_items(
-        rows, user_map, student_data_map, ranking, max_existing_rank
+        rows, user_map, student_data_map, ranking, max_existing_rank, cfg
     )
     ranking.total_applications = len(ranking.items) + imported_count
     await db.commit()

--- a/backend/app/services/supplementary_import_service.py
+++ b/backend/app/services/supplementary_import_service.py
@@ -345,9 +345,13 @@ class SupplementaryImportService:
         「未關聯獎學金配置」(issue #1213).
         """
         from sqlalchemy import select
-        from app.models.application import Application, ApplicationStatus
+        from app.models.application import Application
         from app.models.application_sequence import ApplicationSequence
         from app.models.college_review import CollegeRankingItem
+        from app.services.application_builder import (
+            build_submitted_application_values,
+            derive_sub_scholarship_type,
+        )
 
         if scholarship_configuration is None:
             raise ValueError(
@@ -384,6 +388,11 @@ class SupplementaryImportService:
         seq_record.last_sequence = base_seq + len(rows)
         await self.db.flush()
 
+        # Shared submitted-application invariants (status/status_name/review_stage/
+        # submitted_at/amount/scholarship_name) — same source as the student and
+        # batch-import paths; one shared timestamp for the whole import is intended.
+        submitted_values = build_submitted_application_values(ranking.scholarship_type, scholarship_configuration)
+
         created = 0
         for idx, row in enumerate(rows):
             user = user_map.get(row.student_id)
@@ -408,17 +417,27 @@ class SupplementaryImportService:
             # scholarship_subtype_list is what the manual-distribution panel reads
             # as `applied_sub_types`; sub_type_preferences is the ordered preference list
             # used by allocation logic. Set both from the Excel 申請獎學金類別 column so
-            # admin can see + distribute supplementary students.
+            # admin can see + distribute supplementary students. The Excel cell encodes
+            # an explicit 志願 order, so we keep it verbatim (no moe_1w reordering).
+            # sub_scholarship_type must reflect the first preference — roster rule
+            # validation selects rule sets by it, and the default "general" would
+            # pick the wrong rules.
             app = Application(
                 app_id=app_id,
                 user_id=user.id,
                 scholarship_type_id=ranking.scholarship_type_id,
                 scholarship_configuration_id=scholarship_configuration.id,
+                scholarship_name=submitted_values["scholarship_name"],
+                amount=submitted_values["amount"],
                 academic_year=ranking.academic_year,
                 semester=ranking.semester,
-                status=ApplicationStatus.submitted,
+                status=submitted_values["status"],
+                status_name=submitted_values["status_name"],
+                review_stage=submitted_values["review_stage"],
+                submitted_at=submitted_values["submitted_at"],
                 sub_type_selection_mode=ranking.scholarship_type.sub_type_selection_mode,
                 student_data=sis_data,
+                sub_scholarship_type=derive_sub_scholarship_type(row.sub_type_preferences),
                 scholarship_subtype_list=list(row.sub_type_preferences or []),
                 sub_type_preferences=row.sub_type_preferences,
                 submitted_form_data=submitted_form_data,

--- a/backend/app/services/supplementary_import_service.py
+++ b/backend/app/services/supplementary_import_service.py
@@ -333,15 +333,27 @@ class SupplementaryImportService:
         student_data_map: Dict[str, dict],
         ranking,  # CollegeRanking ORM object
         max_existing_rank: int,
+        scholarship_configuration,  # ScholarshipConfiguration ORM object (same period as ranking)
     ) -> int:
         """Create Application + CollegeRankingItem for each supplementary row.
 
         Returns count of created items.
+
+        `scholarship_configuration` is required: roster rule validation loads
+        that period's rules via applications.scholarship_configuration_id, so
+        an application created without it gets excluded from 造冊 with
+        「未關聯獎學金配置」(issue #1213).
         """
         from sqlalchemy import select
         from app.models.application import Application, ApplicationStatus
         from app.models.application_sequence import ApplicationSequence
         from app.models.college_review import CollegeRankingItem
+
+        if scholarship_configuration is None:
+            raise ValueError(
+                "找不到對應的獎學金配置，無法補充匯入（applications.scholarship_configuration_id "
+                "不可為空，否則造冊時會被排除）。請先建立該學年/學期的獎學金配置。"
+            )
 
         if not rows:
             return 0
@@ -401,6 +413,7 @@ class SupplementaryImportService:
                 app_id=app_id,
                 user_id=user.id,
                 scholarship_type_id=ranking.scholarship_type_id,
+                scholarship_configuration_id=scholarship_configuration.id,
                 academic_year=ranking.academic_year,
                 semester=ranking.semester,
                 status=ApplicationStatus.submitted,

--- a/backend/app/tests/test_supplementary_import_service.py
+++ b/backend/app/tests/test_supplementary_import_service.py
@@ -134,11 +134,11 @@ class TestCreateApplicationsAndItems:
         scholarship_subtype_list — supplementary import must populate it
         (not just sub_type_preferences) or imported students go invisible there.
         """
-        from app.models.scholarship import ScholarshipType
+        from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
         from app.models.college_review import CollegeRanking
         from app.models.user import User as UserModel
 
-        # Minimal scholarship + ranking + creator
+        # Minimal scholarship + config + ranking + creator
         scholarship = ScholarshipType(
             code="phd_subtype_test",
             name="Test",
@@ -146,6 +146,16 @@ class TestCreateApplicationsAndItems:
             status="active",
         )
         db.add(scholarship)
+        await db.flush()
+
+        config = ScholarshipConfiguration(
+            scholarship_type_id=scholarship.id,
+            academic_year=114,
+            config_name="Test 114學年",
+            config_code="phd_subtype_test_114",
+            amount=30000,
+        )
+        db.add(config)
         await db.flush()
 
         creator = UserModel(
@@ -188,7 +198,7 @@ class TestCreateApplicationsAndItems:
         user_map = await service.find_or_create_users(student_data_map)
 
         created = await service.create_applications_and_items(
-            rows, user_map, student_data_map, ranking, max_existing_rank=0
+            rows, user_map, student_data_map, ranking, max_existing_rank=0, scholarship_configuration=config
         )
         await db.flush()
         assert created == 1
@@ -202,3 +212,25 @@ class TestCreateApplicationsAndItems:
             "scholarship_subtype_list must be populated so manual distribution panel " "renders the applied sub-types"
         )
         assert app_row.sub_type_preferences == ["nstc", "moe_1w"]
+        assert app_row.scholarship_configuration_id == config.id, (
+            "scholarship_configuration_id must be set or roster rule validation "
+            "excludes the student with 未關聯獎學金配置 (issue #1213)"
+        )
+
+    async def test_rejects_missing_scholarship_configuration(self, db: AsyncSession):
+        """Creating supplementary applications without a resolved configuration
+        must fail up front — a NULL scholarship_configuration_id application
+        gets excluded from 造冊 later (issue #1213).
+        """
+        service = SupplementaryImportService(db, student_service=AsyncMock())
+        rows = [SupplementaryRow("310460051", 1, ["nstc"], None, None, {})]
+
+        with pytest.raises(ValueError, match="找不到對應的獎學金配置"):
+            await service.create_applications_and_items(
+                rows,
+                user_map={},
+                student_data_map={},
+                ranking=None,
+                max_existing_rank=0,
+                scholarship_configuration=None,
+            )

--- a/backend/app/tests/test_supplementary_import_service.py
+++ b/backend/app/tests/test_supplementary_import_service.py
@@ -216,6 +216,14 @@ class TestCreateApplicationsAndItems:
             "scholarship_configuration_id must be set or roster rule validation "
             "excludes the student with 未關聯獎學金配置 (issue #1213)"
         )
+        # Shared submitted-application invariants (application_builder parity):
+        # roster rule validation selects rule sets by sub_scholarship_type, so
+        # the "general" default would pick the wrong rules.
+        assert app_row.sub_scholarship_type == "nstc"
+        assert app_row.status == ApplicationStatus.submitted
+        assert app_row.submitted_at is not None
+        assert app_row.amount == 30000
+        assert app_row.scholarship_name == "Test 114學年"
 
     async def test_rejects_missing_scholarship_configuration(self, db: AsyncSession):
         """Creating supplementary applications without a resolved configuration


### PR DESCRIPTION
## Summary

Closes the remaining live path that creates applications without `scholarship_configuration_id` (refs #1213).

Supplementary import (補充人, `POST /rankings/{id}/supplementary-import`) created `Application` rows with a NULL `scholarship_configuration_id`. Roster rule validation (`roster_service.py`) loads that period's validation rules through this FK, so every supplementary student was later excluded from 造冊 with:

```
不符合獎學金規則: 申請 APP-… 未關聯獎學金配置（applications.scholarship_configuration_id 為空…）
```

This is the same failure mode reported in #1213 for pre-`9625945a` batch imports — batch import and renewal import already set the FK; supplementary import was the last import path that didn't.

## Changes

- **`ranking_management.py`**: the endpoint already resolves the matching `ScholarshipConfiguration` (same yearly-vs-semester rule, via `_normalize_semester_value`) to read `allow_supplementary_import` and 403s when it's missing — it now passes that resolved config through to the service instead of dropping it.
- **`supplementary_import_service.py`**: `create_applications_and_items` takes the configuration as a required parameter, writes `scholarship_configuration_id` on every created application, and hard-fails with a clear message if the configuration is missing (mirrors the batch-import gate; defense-in-depth behind the endpoint's 403).
- **Tests**: existing creation test now asserts the FK is set; new test covers the missing-configuration guard.

Existing staging rows created by this path before the fix still need the backfill SQL from #1213.

## Test plan

- [x] `app/tests/test_supplementary_import_service.py` — 9 passed (includes new FK assertion + missing-config guard test)
- [x] `app/tests/test_supplementary_import_endpoints.py` — 5 passed
- [x] `black --check --line-length=120` clean on touched files
- [x] `flake8 --select=B904,B014` clean on touched files
