### PR TITLE
fix: accept non-ASCII filenames in application file upload

### DIFF
--- a/backend/app/services/minio_service.py
+++ b/backend/app/services/minio_service.py
@@ -6,6 +6,7 @@ MinIO文件儲存服務
 import hashlib
 import io
 import logging
+import os
 import uuid
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Tuple
@@ -193,24 +194,31 @@ class MinIOService:
             if not file.filename:
                 raise HTTPException(status_code=400, detail="No filename provided")
 
-            # Sanitize the filename first (strips path components / unsafe chars)
-            # so a payload like "evil.pdf.exe" or "../../etc/passwd" cannot survive.
-            safe_filename = secure_filename(file.filename)
-
-            # Validate the extension on the *sanitized* name, taking the final
-            # extension only (defends against double-extension bypass).
-            file_extension = safe_filename.rsplit(".", 1)[-1].lower() if "." in safe_filename else ""
+            # Validate the final extension of the ORIGINAL filename — the
+            # sanitizer strips a fully non-ASCII name like 勞保證明.pdf down
+            # to "pdf" (no dot), which made valid uploads fail with 415.
+            # Trailing spaces/dots are trimmed so "report.pdf " still passes;
+            # splitext keeps only the final extension (double-extension defense).
+            stem, ext = os.path.splitext(file.filename.strip().rstrip(". "))
+            file_extension = ext[1:].lower()
             if file_extension not in settings.allowed_file_types_list:
                 raise HTTPException(status_code=415, detail="Invalid file type")
 
-            # 生成object名稱
+            # Sanitize the stem (a fully non-ASCII stem falls back to
+            # "unnamed_file") and re-attach the validated extension.
+            safe_filename = f"{secure_filename(stem)}.{file_extension}"
+
+            # 生成object名稱 — the uuid suffix keeps same-second uploads of
+            # identically-sanitized names (e.g. two Chinese filenames that
+            # both collapse to "unnamed_file") from overwriting each other.
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            unique_suffix = uuid.uuid4().hex[:8]
             # 標準化 file_type 為複數形式
             if file_type == "doc":
                 folder_name = "documents"
             else:
                 folder_name = f"{file_type}s"
-            object_name = f"applications/{application_id}/{folder_name}/{timestamp}_{safe_filename}"
+            object_name = f"applications/{application_id}/{folder_name}/{timestamp}_{unique_suffix}_{safe_filename}"
 
             # 上傳到MinIO
             self.client.put_object(

--- a/backend/app/tests/test_minio_service_unit.py
+++ b/backend/app/tests/test_minio_service_unit.py
@@ -112,6 +112,70 @@ async def test_upload_file_double_extension_bypass_blocked(minio_service, monkey
 
 
 @pytest.mark.asyncio
+async def test_upload_file_chinese_filename_keeps_extension(minio_service, monkeypatch):
+    """A fully non-ASCII filename (勞保加保證明.pdf) must pass extension
+    validation and keep .pdf on the stored object name — sanitizing before
+    the extension check used to strip it to "pdf" and 415 the upload."""
+    monkeypatch.setattr("app.services.minio_service.settings", _make_settings())
+
+    upload = _build_upload_file("勞保加保證明.pdf", b"data")
+    minio_service.client.put_object.return_value = None
+
+    object_name, size = await MinIOService.upload_file(minio_service, upload, application_id=1, file_type="doc")
+
+    assert object_name.startswith("applications/1/documents/")
+    assert object_name.endswith("unnamed_file.pdf")
+    assert size == len(b"data")
+    minio_service.client.put_object.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_file_trailing_space_in_filename_accepted(minio_service, monkeypatch):
+    """Trailing whitespace/dots after the extension ("report.pdf ") must not
+    fail extension validation — the pre-fix code tolerated them via
+    sanitize-first, so the fix must not regress that."""
+    monkeypatch.setattr("app.services.minio_service.settings", _make_settings())
+
+    upload = _build_upload_file("report.pdf ", b"data")
+    minio_service.client.put_object.return_value = None
+
+    object_name, _ = await MinIOService.upload_file(minio_service, upload, application_id=1, file_type="doc")
+
+    assert object_name.endswith("report.pdf")
+
+
+@pytest.mark.asyncio
+async def test_upload_file_object_names_unique_within_same_second(minio_service, monkeypatch):
+    """Two non-ASCII filenames both sanitize to "unnamed_file"; uploads in the
+    same second must still get distinct object names (no silent overwrite)."""
+    monkeypatch.setattr("app.services.minio_service.settings", _make_settings())
+    minio_service.client.put_object.return_value = None
+
+    name1, _ = await MinIOService.upload_file(
+        minio_service, _build_upload_file("勞保加保證明.pdf", b"a"), application_id=1, file_type="doc"
+    )
+    name2, _ = await MinIOService.upload_file(
+        minio_service, _build_upload_file("存摺封面.pdf", b"b"), application_id=1, file_type="doc"
+    )
+
+    assert name1 != name2
+
+
+@pytest.mark.asyncio
+async def test_upload_file_no_extension_rejected(minio_service, monkeypatch):
+    """A filename without any extension must still be rejected."""
+    monkeypatch.setattr("app.services.minio_service.settings", _make_settings())
+
+    upload = _build_upload_file("README", b"data")
+
+    with pytest.raises(HTTPException) as exc:
+        await MinIOService.upload_file(minio_service, upload, application_id=1, file_type="doc")
+
+    assert exc.value.status_code == 415
+    minio_service.client.put_object.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_upload_file_s3_error(minio_service, monkeypatch):
     monkeypatch.setattr("app.services.minio_service.settings", _make_settings())
 


### PR DESCRIPTION
## Summary
- Students uploading documents with fully-Chinese filenames (e.g. `勞保加保證明.pdf`) got **HTTP 415 "Invalid file type"** when submitting a scholarship application.
- Root cause: `upload_file` sanitized the filename *before* validating its extension. `secure_filename()` replaces every non-ASCII character with `_`, collapses runs, then strips leading `_`/`.` — collapsing `勞保加保證明.pdf` to `pdf` (no dot), so the extension check saw an empty extension and rejected the upload.

## Changes
- Validate the final extension of the **original** filename (trimmed of trailing spaces/dots) via `os.path.splitext` — the double-extension defense (`report.pdf.exe` → 415) is preserved, and previously-accepted names like `report.pdf ` still pass.
- Sanitize only the stem, then re-attach the validated extension for the MinIO object name; a fully non-ASCII stem falls back to `unnamed_file`. The original filename shown to users is unaffected (stored separately in `ApplicationFile.original_filename`).
- Add a short uuid suffix to object names — without it, two Chinese-named files uploaded in the same second would both sanitize to `unnamed_file.pdf` with an identical second-resolution timestamp and silently overwrite each other in MinIO.

## Code review
Ran multi-angle `/code-review` on the diff; adopted the confirmed findings (trailing-space regression, same-second overwrite, `rpartition` → `splitext` simplification).

## Test plan
- [x] `test_minio_service_unit.py` — 20 passed in the dev container, including new regression tests: Chinese filename keeps `.pdf`, trailing-space filename accepted, extensionless filename rejected (415), same-second uploads get distinct object names, double-extension bypass still blocked
- [x] `black --check --line-length=120` clean
- [x] `flake8 --select=B904,B014,F401` clean