### PR TITLE
docs: trim derivable content from CLAUDE.md and scope guidance to subdirs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,18 +4,7 @@ Please use English for git commit messages.
 
 ## Development Environment
 
-**Use `docker compose -f docker-compose.dev.yml` for all local development.**
-
-```bash
-# Start all services
-docker compose -f docker-compose.dev.yml up
-
-# View logs
-docker compose -f docker-compose.dev.yml logs -f
-
-# Restart a specific service
-docker compose -f docker-compose.dev.yml restart backend
-```
+**Use `docker compose -f docker-compose.dev.yml` for all local development.** (There are nine `docker-compose.*.yml` files — dev is never the default `docker-compose.yml`.)
 
 This spins up the full stack (backend, frontend, database, RustFS object storage (S3 API, service name `minio`), mock student API) with hot-reload enabled.
 
@@ -84,31 +73,11 @@ semester = Column(
 - Use **UPPERCASE** enum member names
 - Values must match backend/database exactly (lowercase)
 
-```typescript
-// ✅ CORRECT
-export enum Semester {
-    FIRST = 'first',
-    SECOND = 'second',
-    YEARLY = 'yearly'
-}
-```
-
 #### PostgreSQL Database
 - Enum values are always **lowercase**
 - Match Python enum values exactly
 
-```sql
-CREATE TYPE semester AS ENUM ('first', 'second', 'yearly');
-```
-
-#### Current System Enums
-- **Semester**: `first`, `second`, `yearly`
-- **UserRole**: `student`, `professor`, `college`, `admin`, `super_admin`
-- **ApplicationCycle**: `semester`, `yearly`
-- **QuotaManagementMode**: `none`, `simple`, `college_based`, `matrix_based`
-- **SubTypeSelectionMode**: `single`, `multiple`, `hierarchical`
-- **UserType**: `student`, `employee`
-- **EmployeeStatus**: `在職`, `退休`, `在學`, `畢業` (Chinese values)
+The authoritative list of current system enums is `backend/app/models/enums.py` (mirrored in `frontend/lib/enums.ts`). Note one non-obvious case: **EmployeeStatus** values are Chinese (`在職`, `退休`, `在學`, `畢業`), not romanized.
 
 #### Special Case: Scholarship Sub-Types (Configuration-Driven)
 
@@ -155,80 +124,7 @@ If you see `LookupError: 'value' is not among the defined enum values`:
 
 ### 5. API Response Standardization
 
-**CRITICAL**: All API endpoints MUST return a consistent ApiResponse format for frontend compatibility.
-
-#### Standard Format
-```python
-{
-    "success": bool,
-    "message": str,
-    "data": any  # Can be dict, list, Pydantic model, or None
-}
-```
-
-#### Backend Implementation Rules
-
-**Remove response_model decorators**:
-```python
-# ❌ WRONG - Using response_model
-@router.get("/users", response_model=List[UserResponse])
-async def get_users():
-    return users
-
-# ✅ CORRECT - Manual dict wrapping
-@router.get("/users")
-async def get_users():
-    return {
-        "success": True,
-        "message": "Users retrieved successfully",
-        "data": [user.model_dump() for user in users],
-    }
-```
-
-**Converting Pydantic Schemas**:
-```python
-# For Pydantic v2 (preferred)
-response_data.model_dump()
-
-# Fallback for v1
-response_data.dict()
-
-# Safe universal conversion
-response_data.model_dump() if hasattr(response_data, "model_dump") else response_data.dict()
-```
-
-**Wrapping PaginatedResponse**:
-```python
-# ❌ WRONG - Direct return
-return PaginatedResponse(items=items, total=total, page=page, size=size)
-
-# ✅ CORRECT - Wrapped in ApiResponse
-response_data = PaginatedResponse(items=items, total=total, page=page, size=size)
-return {
-    "success": True,
-    "message": "Data retrieved successfully",
-    "data": response_data.model_dump(),
-}
-```
-
-#### Frontend Compatibility
-The frontend `api.ts` automatically detects ApiResponse format:
-```typescript
-// Frontend auto-detection (already implemented)
-if ("success" in data && "message" in data) {
-    return data as ApiResponse<T>;
-}
-```
-
-#### Migration Checklist
-When standardizing existing endpoints:
-- [ ] Remove `response_model=` parameter from `@router` decorator
-- [ ] Wrap return statement in `{success, message, data}` dict format
-- [ ] Convert Pydantic schemas using `.model_dump()` or `.dict()`
-- [ ] Remove unused imports (MessageResponse, specific response models)
-- [ ] Run `python -m black` for auto-formatting
-- [ ] Verify with `python -m flake8` (check F401 unused imports)
-- [ ] Test endpoint returns expected format
+**CRITICAL**: All API endpoints MUST return a consistent `{success, message, data}` ApiResponse dict — never a `response_model=` decorator. Full rules, examples and the migration checklist: `backend/CLAUDE.md`.
 
 ### 6. Application ID Format
 
@@ -256,9 +152,6 @@ Examples:
 - **Auto-Creation**: Sequence records are created automatically when first application is made
 
 Implementation: `backend/app/models/application_sequence.py` + `_generate_app_id` in `backend/app/services/application_service.py`.
-
-#### Migration
-Migration `6b5cb44d2fe3` creates the `application_sequences` table and initializes sequences from existing applications.
 
 ### 7. Application Data Structure Principles
 
@@ -320,50 +213,7 @@ CI validates type sync automatically. Backend must be running on `localhost:8000
 
 ## Database Initialization & Migration Standards
 
-### Database Volume Recreation
-**ALWAYS** use the automated script for clean database rebuilds:
-
-```bash
-./scripts/reset_database.sh
-./scripts/reset_database.sh --dry-run  # Preview steps
-```
-
-### Alembic Migration Development Rules
-**CRITICAL**: Always include existence checks in migrations:
-
-```python
-# ✅ CORRECT - Check before creating
-def upgrade() -> None:
-    bind = op.get_bind()
-    inspector = sa.inspect(bind)
-    existing_tables = inspector.get_table_names()
-
-    if 'new_table' not in existing_tables:
-        op.create_table('new_table', ...)
-
-# ❌ WRONG - Direct creation without checks
-def upgrade() -> None:
-    op.create_table('new_table', ...)  # May fail if exists
-```
-
-### Database Constraint Requirements
-Ensure all constraints used in seed scripts exist in SQLAlchemy models:
-
-```python
-# ✅ CORRECT - Define constraints for ON CONFLICT
-class ApplicationField(Base):
-    __tablename__ = "application_fields"
-    __table_args__ = (
-        UniqueConstraint('scholarship_type', 'field_name', name='uq_application_field_type_name'),
-    )
-```
-
-### Migration Testing
-Before creating any migration:
-- Test on fresh database using `./scripts/reset_database.sh`
-- Include existence checks for all DDL operations
-- Verify seed scripts work with new constraints
-- Test rollback functionality
+**ALWAYS** rebuild the database with `./scripts/reset_database.sh` (`--dry-run` to preview) — never by hand. Every migration MUST include existence checks before DDL. Full rules, examples and the pre-migration test checklist: `backend/CLAUDE.md`.
 
 ## Path Security & Backslash Handling
 
@@ -397,99 +247,12 @@ if not resolved_path.startswith(expected_dir):
 
 ## File Upload & Preview Architecture
 
-### Three-Layer Architecture
-```
-Frontend → Next.js Proxy → FastAPI → MinIO
-```
+Files flow `Frontend → Next.js proxy → FastAPI → MinIO`. **Never** hand out direct MinIO URLs, and store `object_name` in the DB, not a full URL. For the proxy header contract (the missing-`Content-Length` trap that produces false "password protected" PDF errors) and the rest of the rules, use the **file-upload-preview** skill.
 
-**Why Next.js Proxy?**
-- Token authentication handling
-- Internal Docker network communication
-- CORS management
-- Centralized error handling
+## Backend Testing, Lint, CI & Model Gotchas
 
-### Critical Implementation Rules
-1. **Store object_name, not full URL** in database
-2. **Always use Next.js proxy** for file access (never direct MinIO URLs)
-3. **Pass token via query parameter** for authentication
-4. **Use INTERNAL_API_URL** for Docker network communication
-5. **Preserve all headers** from backend when proxying
-
-### Required HTTP Headers for PDF Preview
-When proxying files through Next.js, preserve these headers:
-
-```typescript
-return new NextResponse(fileBuffer, {
-  headers: {
-    "Content-Type": contentType,                           // File type
-    "Content-Disposition": contentDisposition,             // Preserve from backend
-    "Content-Length": fileBuffer.byteLength.toString(),    // File size (REQUIRED)
-    "Accept-Ranges": "bytes",                              // Range support
-    "Cache-Control": "private, max-age=3600",
-  },
-});
-```
-
-**CRITICAL**: Missing `Content-Length` or incomplete `Content-Disposition` can cause PDF viewer errors (including false "password protected" errors).
-
-### Environment Variables
-```bash
-# Backend
-MINIO_ENDPOINT=minio:9000
-MINIO_BUCKET=scholarship-documents
-
-# Frontend
-NEXT_PUBLIC_API_URL=http://localhost:8000
-INTERNAL_API_URL=http://backend:8000  # Docker internal network
-```
-
-## Testing, Lint & CI Standards
-
-Hard-won from the 2026-05-30 backend-test-backlog cleanup (cleared ~150 failures). Follow these to avoid re-introducing the same classes of failure.
-
-### CI suite layout (`.github/workflows/ci.yml`)
-- **unit**: `app/tests/test_*.py -m "not integration and not asyncio"` — sync tests only.
-- **integration**: `app/tests/test_*_service*.py -m "integration or asyncio"` — async tests. `asyncio_mode = auto`, so any `async def test_` is auto-collected here (it is EXCLUDED from unit).
-- **smoke**: explicit file list (includes `test_critical_workflows.py`). The former dedicated `critical-workflows` lane was removed as redundant — that file already runs in smoke + integration.
-- A test that is `@pytest.mark.asyncio` / `async def` runs in **integration**, not unit. Converting a sync test to async moves it between suites.
-
-### Lint is HARD-gated — black passing is NOT enough
-Before committing backend changes, run **all three**:
-```bash
-uvx --from "black==26.3.1" black --check --line-length=120 backend/app
-flake8 app --select=B904,B014 --max-line-length=120     # CI fails hard on these
-python -m pytest app/tests/<touched_file> -p no:cacheprovider   # in the dev container
-```
-- **B904**: `raise` inside `except` must use `raise ... from exc` (or `from None`).
-- **B014**: no redundant exception tuples — `PermissionError` ⊂ `OSError`, so write `except OSError`, never `except (PermissionError, OSError)`.
-- **WARNING/ERROR-traceback AST invariant** (`test_no_logger_warning_traceback_loss.py`, `test_no_logger_error_traceback_loss.py`): any `logger.warning(...)` / `logger.error(...)` that interpolates the exception variable inside an `except` block MUST also pass `exc_info=True` (or drop the interpolation). The trace gets discarded otherwise.
-
-### Test-fixture pitfalls (the recurring failures)
-- **Never build a model with `Model.__new__(Model)` / `object.__new__(Model)` then set attributes** — it bypasses `__init__`, so `_sa_instance_state` is missing and the first instrumented-attribute write raises `'NoneType' object has no attribute 'set'`. Use `Model(**defaults)`; for vestigial/non-column keys or duck-typed relationship stubs use `m = Model(); m.__dict__.update(defaults)` (or `m.__dict__["rel"] = SimpleNamespace(...)`).
-- **Keep fixtures in sync with the model.** Passing a removed/renamed column raises `'<field>' is an invalid keyword argument for <Model>`. Known removals: `ScholarshipType.category` (gone; status lives in `status`), `Application.student_id` (student data is external-API now; FK is `user_id`), `User` uses `nycu_id`/`name`/`status` (NOT `username`/`full_name`/`is_active`).
-- **Enum vs string in in-memory objects.** A DB-loaded model returns the **enum member** (`Enum` column), but an in-memory fixture holds exactly what you passed. Methods compare against the enum member (`status == ApplicationStatus.submitted`), so pass the member, not `.value`, when constructing test objects — otherwise predicates like `is_editable` / `get_review_stage` silently mismatch.
-- **No sync-calling-async.** Service methods on async-session services are `async`; tests must be `async def` + `await` + use the async `db` fixture (not `db_sync`). A sync call returns an un-awaited coroutine → `'coroutine' object has no attribute 'id'`.
-- **No env- or cache-dependent assertions.** Settings have non-None defaults (e.g. `student_api_enabled=True`, SIS URLs), so a bare service is "configured" everywhere — `monkeypatch` settings to force the state you assert. The dev container has Redis; CI does not — clear `@cached` state in an autouse fixture (`await invalidate("<prefix>")`) so one test's payload doesn't leak into another.
-- **No flaky randomness.** Don't corrupt the *last* base64 char of a random-nonce envelope to test tamper-detection (it can hit only padding bits → no corruption → `DID NOT RAISE`); corrupt a **middle** char (a full byte). Verify determinism by running the test ~30×.
-
-## Model & Schema Gotchas
-
-- **ScholarshipType vs ScholarshipConfiguration split.** Application-period dates, `academic_year`, `amount`, the period-detection properties (`is_renewal_application_period`, `current_application_type`, …) and `can_student_apply*` live on **ScholarshipConfiguration**, NOT `ScholarshipType`. Building these on a `ScholarshipType` is a bug.
-- **Renamed-relationship bug class.** Several latent `AttributeError`s came from an incomplete rename: `Application.user`→`.student`, `Application.scholarship_type`→`.scholarship_type_ref`, notification `application.scholarship_type`→`application.scholarship_name`. When you rename a relationship, **grep the whole repo** for the old name (services, endpoints, AND tests that stub it).
-- **Coalesce nullable JSON into required-dict response fields.** `ApplicationListResponse.student_data` / `submitted_form_data` are required `Dict`; a draft can have `student_data IS NULL`. Always write `student_data=application.student_data or {}` (see the canonical builders) — passing `None` raises a pydantic `dict_type` error.
-- **Pydantic v2 cross-field validators run in field-definition order.** A `@field_validator` on a field reading a flag defined *later* sees that flag as unset. Use `@model_validator(mode="after")` for any rule that spans fields (e.g. renewal-review-dates-require-the-`requires_*`-flag).
-- **Enum "pin" tripwire tests** (`test_shared_enums_value_contract.py`) intentionally fail when an enum gains a value — the correct response is to update the count AFTER confirming dependent frontend switches / admin filters handle the new value, not to delete the test.
-
-## Performance Patterns
-
-- **Eager-load to-one relationships read inside loops.** A `db.query(Application).all()` whose rows later read `application.student` / `application.scholarship_configuration.scholarship_type` in a loop is N+1. Add `.options(joinedload(Application.student), joinedload(Application.scholarship_configuration).joinedload(...))` (many-to-one → `joinedload` is safe, no row multiplication).
-- **Index foreign keys and audit-trail lookups.** PostgreSQL does NOT auto-index FKs. Index columns filtered/ordered on hot paths (e.g. `applications.scholarship_configuration_id`; composite `audit_logs(resource_type, resource_id, created_at)`), and declare them in the model `__table_args__` so autogenerate stays in sync.
-- **Lazy-load heavy frontend libs.** Import `xlsx` / `react-pdf` via `await import(...)` inside the handler (make the handler `async`), not at module top, to keep them out of the initial chunk.
+Backend test-suite layout, the hard-gated lint commands (black + flake8 `B904,B014` + the `exc_info=True` AST invariant), the recurring test-fixture pitfalls, the ScholarshipType-vs-ScholarshipConfiguration split and the other model/schema gotchas live in `backend/CLAUDE.md` (loaded automatically when working under `backend/`). Frontend performance patterns live in `frontend/CLAUDE.md`.
 
 ## Review-Flow Policy
 
 - A **professor full-reject is terminal for the professor**: it sets `application.status = rejected`, and the professor **cannot re-review** that application (the review endpoint returns HTTP 403). Only **college/admin** may revert it (回發) — that is a separate, explicit edit path, not a professor re-submit.
-
----
-
-**Remember**: Create a flexible, maintainable system where new scholarship types can be added through database configuration without code changes.

--- a/.claude/skills/file-upload-preview/SKILL.md
+++ b/.claude/skills/file-upload-preview/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: file-upload-preview
+description: Architecture and required HTTP headers for the file upload/preview chain (Frontend → Next.js proxy → FastAPI → MinIO/RustFS). Use when adding or debugging document upload, file download, or in-browser PDF/image preview — especially when a PDF viewer errors, falsely reports "password protected", truncates, or a file URL 403s/404s through the proxy.
+---
+
+# File Upload & Preview Architecture
+
+## Three-Layer Architecture
+```
+Frontend → Next.js Proxy → FastAPI → MinIO
+```
+
+**Why Next.js Proxy?**
+- Token authentication handling
+- Internal Docker network communication
+- CORS management
+- Centralized error handling
+
+## Critical Implementation Rules
+1. **Store object_name, not full URL** in database
+2. **Always use Next.js proxy** for file access (never direct MinIO URLs)
+3. **Pass token via query parameter** for authentication
+4. **Use INTERNAL_API_URL** for Docker network communication
+5. **Preserve all headers** from backend when proxying
+
+## Required HTTP Headers for PDF Preview
+When proxying files through Next.js, preserve these headers:
+
+```typescript
+return new NextResponse(fileBuffer, {
+  headers: {
+    "Content-Type": contentType,                           // File type
+    "Content-Disposition": contentDisposition,             // Preserve from backend
+    "Content-Length": fileBuffer.byteLength.toString(),    // File size (REQUIRED)
+    "Accept-Ranges": "bytes",                              // Range support
+    "Cache-Control": "private, max-age=3600",
+  },
+});
+```
+
+**CRITICAL**: Missing `Content-Length` or incomplete `Content-Disposition` can cause PDF viewer errors (including false "password protected" errors).
+
+## Environment Variables
+
+The object-storage and proxy env vars (`MINIO_ENDPOINT`, `MINIO_BUCKET`, `NEXT_PUBLIC_API_URL`, `INTERNAL_API_URL`) are declared in `docker-compose.dev.yml` — read them there rather than assuming values. Note `INTERNAL_API_URL` points at the Docker-internal `backend` host, not `localhost`.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,138 @@
+# Backend Guidelines (FastAPI / SQLAlchemy / Alembic)
+
+Loaded when working under `backend/`. Project-wide rules live in `.claude/CLAUDE.md`.
+
+## API Response Standardization
+
+**CRITICAL**: All API endpoints MUST return a consistent ApiResponse format for frontend compatibility.
+
+### Standard Format
+```python
+{
+    "success": bool,
+    "message": str,
+    "data": any  # Can be dict, list, Pydantic model, or None
+}
+```
+
+### Backend Implementation Rules
+
+**Remove response_model decorators**:
+```python
+# ❌ WRONG - Using response_model
+@router.get("/users", response_model=List[UserResponse])
+async def get_users():
+    return users
+
+# ✅ CORRECT - Manual dict wrapping
+@router.get("/users")
+async def get_users():
+    return {
+        "success": True,
+        "message": "Users retrieved successfully",
+        "data": [user.model_dump() for user in users],
+    }
+```
+
+Convert Pydantic schemas with `.model_dump()` (v2). `PaginatedResponse` is **not** a top-level return — wrap it too: `data=response_data.model_dump()`.
+
+The frontend `api.ts` auto-detects this shape (`"success" in data && "message" in data`), so a non-wrapped endpoint silently falls through to the raw-body path.
+
+### Migration Checklist
+When standardizing existing endpoints:
+- [ ] Remove `response_model=` parameter from `@router` decorator
+- [ ] Wrap return statement in `{success, message, data}` dict format
+- [ ] Convert Pydantic schemas using `.model_dump()`
+- [ ] Remove unused imports (MessageResponse, specific response models)
+- [ ] Run `python -m black` for auto-formatting
+- [ ] Verify with `python -m flake8` (check F401 unused imports)
+- [ ] Test endpoint returns expected format
+
+## Database Initialization & Migration Standards
+
+### Database Volume Recreation
+**ALWAYS** use the automated script for clean database rebuilds:
+
+```bash
+./scripts/reset_database.sh
+./scripts/reset_database.sh --dry-run  # Preview steps
+```
+
+### Alembic Migration Development Rules
+**CRITICAL**: Always include existence checks in migrations:
+
+```python
+# ✅ CORRECT - Check before creating
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = inspector.get_table_names()
+
+    if 'new_table' not in existing_tables:
+        op.create_table('new_table', ...)
+
+# ❌ WRONG - Direct creation without checks
+def upgrade() -> None:
+    op.create_table('new_table', ...)  # May fail if exists
+```
+
+### Database Constraint Requirements
+Ensure all constraints used in seed scripts exist in SQLAlchemy models:
+
+```python
+# ✅ CORRECT - Define constraints for ON CONFLICT
+class ApplicationField(Base):
+    __tablename__ = "application_fields"
+    __table_args__ = (
+        UniqueConstraint('scholarship_type', 'field_name', name='uq_application_field_type_name'),
+    )
+```
+
+### Migration Testing
+Before creating any migration:
+- Test on fresh database using `./scripts/reset_database.sh`
+- Include existence checks for all DDL operations
+- Verify seed scripts work with new constraints
+- Test rollback functionality
+
+## Testing, Lint & CI Standards
+
+Hard-won from the 2026-05-30 backend-test-backlog cleanup (cleared ~150 failures). Follow these to avoid re-introducing the same classes of failure.
+
+### CI suite layout (`.github/workflows/ci.yml`)
+- **unit**: `app/tests/test_*.py -m "not integration and not asyncio"` — sync tests only.
+- **integration**: `app/tests/test_*_service*.py -m "integration or asyncio"` — async tests. `asyncio_mode = auto`, so any `async def test_` is auto-collected here (it is EXCLUDED from unit).
+- **smoke**: explicit file list (includes `test_critical_workflows.py`). The former dedicated `critical-workflows` lane was removed as redundant — that file already runs in smoke + integration.
+- A test that is `@pytest.mark.asyncio` / `async def` runs in **integration**, not unit. Converting a sync test to async moves it between suites.
+
+### Lint is HARD-gated — black passing is NOT enough
+Before committing backend changes, run **all three**:
+```bash
+uvx --from "black==26.3.1" black --check --line-length=120 backend/app
+flake8 app --select=B904,B014 --max-line-length=120     # CI fails hard on these
+python -m pytest app/tests/<touched_file> -p no:cacheprovider   # in the dev container
+```
+- **B904**: `raise` inside `except` must use `raise ... from exc` (or `from None`).
+- **B014**: no redundant exception tuples — `PermissionError` ⊂ `OSError`, so write `except OSError`, never `except (PermissionError, OSError)`.
+- **WARNING/ERROR-traceback AST invariant** (`test_no_logger_warning_traceback_loss.py`, `test_no_logger_error_traceback_loss.py`): any `logger.warning(...)` / `logger.error(...)` that interpolates the exception variable inside an `except` block MUST also pass `exc_info=True` (or drop the interpolation). The trace gets discarded otherwise.
+
+### Test-fixture pitfalls (the recurring failures)
+- **Never build a model with `Model.__new__(Model)` / `object.__new__(Model)` then set attributes** — it bypasses `__init__`, so `_sa_instance_state` is missing and the first instrumented-attribute write raises `'NoneType' object has no attribute 'set'`. Use `Model(**defaults)`; for vestigial/non-column keys or duck-typed relationship stubs use `m = Model(); m.__dict__.update(defaults)` (or `m.__dict__["rel"] = SimpleNamespace(...)`).
+- **Keep fixtures in sync with the model.** Passing a removed/renamed column raises `'<field>' is an invalid keyword argument for <Model>`. Known removals: `ScholarshipType.category` (gone; status lives in `status`), `Application.student_id` (student data is external-API now; FK is `user_id`), `User` uses `nycu_id`/`name`/`status` (NOT `username`/`full_name`/`is_active`).
+- **Enum vs string in in-memory objects.** A DB-loaded model returns the **enum member** (`Enum` column), but an in-memory fixture holds exactly what you passed. Methods compare against the enum member (`status == ApplicationStatus.submitted`), so pass the member, not `.value`, when constructing test objects — otherwise predicates like `is_editable` / `get_review_stage` silently mismatch.
+- **No sync-calling-async.** Service methods on async-session services are `async`; tests must be `async def` + `await` + use the async `db` fixture (not `db_sync`). A sync call returns an un-awaited coroutine → `'coroutine' object has no attribute 'id'`.
+- **No env- or cache-dependent assertions.** Settings have non-None defaults (e.g. `student_api_enabled=True`, SIS URLs), so a bare service is "configured" everywhere — `monkeypatch` settings to force the state you assert. The dev container has Redis; CI does not — clear `@cached` state in an autouse fixture (`await invalidate("<prefix>")`) so one test's payload doesn't leak into another.
+- **No flaky randomness.** Don't corrupt the *last* base64 char of a random-nonce envelope to test tamper-detection (it can hit only padding bits → no corruption → `DID NOT RAISE`); corrupt a **middle** char (a full byte). Verify determinism by running the test ~30×.
+
+## Model & Schema Gotchas
+
+- **ScholarshipType vs ScholarshipConfiguration split.** Application-period dates, `academic_year`, `amount`, the period-detection properties (`is_renewal_application_period`, `current_application_type`, …) and `can_student_apply*` live on **ScholarshipConfiguration**, NOT `ScholarshipType`. Building these on a `ScholarshipType` is a bug.
+- **Renamed-relationship bug class.** Several latent `AttributeError`s came from an incomplete rename: `Application.user`→`.student`, `Application.scholarship_type`→`.scholarship_type_ref`, notification `application.scholarship_type`→`application.scholarship_name`. When you rename a relationship, **grep the whole repo** for the old name (services, endpoints, AND tests that stub it).
+- **Coalesce nullable JSON into required-dict response fields.** `ApplicationListResponse.student_data` / `submitted_form_data` are required `Dict`; a draft can have `student_data IS NULL`. Always write `student_data=application.student_data or {}` (see the canonical builders) — passing `None` raises a pydantic `dict_type` error.
+- **Pydantic v2 cross-field validators run in field-definition order.** A `@field_validator` on a field reading a flag defined *later* sees that flag as unset. Use `@model_validator(mode="after")` for any rule that spans fields (e.g. renewal-review-dates-require-the-`requires_*`-flag).
+- **Enum "pin" tripwire tests** (`test_shared_enums_value_contract.py`) intentionally fail when an enum gains a value — the correct response is to update the count AFTER confirming dependent frontend switches / admin filters handle the new value, not to delete the test.
+
+## Performance Patterns
+
+- **Eager-load to-one relationships read inside loops.** A `db.query(Application).all()` whose rows later read `application.student` / `application.scholarship_configuration.scholarship_type` in a loop is N+1. Add `.options(joinedload(Application.student), joinedload(Application.scholarship_configuration).joinedload(...))` (many-to-one → `joinedload` is safe, no row multiplication).
+- **Index foreign keys and audit-trail lookups.** PostgreSQL does NOT auto-index FKs. Index columns filtered/ordered on hot paths (e.g. `applications.scholarship_configuration_id`; composite `audit_logs(resource_type, resource_id, created_at)`), and declare them in the model `__table_args__` so autogenerate stays in sync.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,7 @@
+# Frontend Guidelines (Next.js)
+
+Loaded when working under `frontend/`. Project-wide rules live in `.claude/CLAUDE.md`.
+
+## Performance Patterns
+
+- **Lazy-load heavy frontend libs.** Import `xlsx` / `react-pdf` via `await import(...)` inside the handler (make the handler `async`), not at module top, to keep them out of the initial chunk.


### PR DESCRIPTION
## Summary

The root `.claude/CLAUDE.md` loads into **every** session. It had grown to 22KB, roughly half of which was either reconstructible from the codebase or only relevant when working on one subtree. This trims it to 11KB without removing any guidance.

## Cut as derivable from the repo

| What | Why |
|---|---|
| `docker compose up / logs -f / restart` block | Standard invocations; the "use `dev.yml`" directive stays |
| TypeScript + SQL enum example blocks | Generic language syntax; the actual rules are in the bullets above them |
| "Current System Enums" list | Verbatim copy of `backend/app/models/enums.py` — replaced with a pointer, keeping the non-obvious Chinese `EmployeeStatus` values |
| Pydantic `.model_dump()` conversion + frontend auto-detection blocks | Generic Pydantic v2 API + a copy of `frontend/lib/api.ts` |
| Alembic revision-id note | Migration history |
| Object-storage env var block | Verbatim from `docker-compose.dev.yml` |
| Closing "**Remember**" line | Restates §3 |

## Moved to lazily-loaded locations (one-line pointers left behind)

- **`backend/CLAUDE.md`** (new) — API response standardization, database init & migration standards, testing/lint/CI standards, model & schema gotchas, backend performance patterns. Loads when working under `backend/`.
- **`frontend/CLAUDE.md`** (new) — lazy-load pattern for `xlsx` / `react-pdf`.
- **`.claude/skills/file-upload-preview/SKILL.md`** (new) — proxy architecture and the `Content-Length` header contract for PDF preview. Body loads on invocation; only the description stays resident.

## Deliberately unchanged

Both security sections (path traversal, regex injection) and every other "never do X" rule stay in the always-loaded root file by design — a safety prohibition must not live somewhere that might not be loaded when it matters.

**Net: 22KB → 11KB always resident (~2.7k fewer est. tokens per session), no guidance lost.**

## Test plan

- [x] Verified every substantive line removed from the root file is present verbatim in one of the new files, or is one of the deliberate cuts listed above
- [x] `file-upload-preview` skill registers and appears in the skill listing
- [ ] Confirm CI passes (docs-only change; no code paths touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)