### PR TITLE
fix(security): close auth bypass, roster PII exposure and file-proxy XSS ahead of vulnerability scan

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -53,9 +53,40 @@ async def populate_college_info(user_data: UserResponse, db: AsyncSession, user:
 
 @router.post("/register", status_code=status.HTTP_201_CREATED)
 @rate_limit(requests=10, window_seconds=600)  # 10 registrations / 10 min per IP
-async def register(request: Request, user_data: UserCreate, db: AsyncSession = Depends(get_db)):
-    """Register a new user"""
+async def register(
+    request: Request,
+    user_data: UserCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a user account. Admin-only — `UserCreate.role` is caller-supplied.
+
+    SECURITY: this endpoint used to be anonymous while `UserCreate` accepts a
+    `role` field, so anyone could POST {"nycu_id": <their own id>, "role":
+    "super_admin"} to plant a privileged row. That row survives a *legitimate*
+    Portal SSO login, because `_find_or_create_user` deliberately preserves
+    pre-authorized super_admin/admin/college roles
+    (portal_sso_service.py:285-290) — turning self-registration into a full
+    privilege escalation. Account creation must therefore stay behind the same
+    role-assignment permission as POST /pre-authorize/user.
+    """
     client_ip = _client_ip(request)
+
+    if not current_user.can_assign_roles():
+        logger.warning(
+            "SECURITY: non-admin attempted user creation via /auth/register",
+            extra={
+                "user_id": current_user.id,
+                "role": current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role),
+                "attempted_nycu_id": getattr(user_data, "nycu_id", None),
+                "attempted_role": getattr(getattr(user_data, "role", None), "value", None),
+                "ip": client_ip,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient permissions to create users",
+        )
     try:
         auth_service = AuthService(db)
         user = await auth_service.register_user(user_data)
@@ -103,7 +134,20 @@ async def register(request: Request, user_data: UserCreate, db: AsyncSession = D
 @router.post("/login")
 @rate_limit(requests=20, window_seconds=300)  # 20 attempts / 5 min per IP — slows brute force
 async def login(request: Request, login_data: UserLogin, db: AsyncSession = Depends(get_db)):
-    """Login user and return access token"""
+    """Development-only login: exchanges a known nycu_id/email for a token.
+
+    SECURITY: `AuthService.authenticate_user` performs NO credential check —
+    `UserLogin` carries only `username`, and the User model has no password
+    column at all (real authentication is NYCU Portal SSO). Left ungated, a
+    single anonymous POST with a guessable identifier such as
+    "admin@nycu.edu.tw" mints a valid admin JWT. It is therefore hard-gated
+    behind `enable_mock_sso`, exactly like /mock-sso/login and /dev-profiles/*
+    below, so it 404s wherever ENABLE_MOCK_SSO=false (production and staging)
+    while dev/E2E/pytest keep working.
+    """
+    if not settings.enable_mock_sso:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+
     client_ip = _client_ip(request)
     try:
         auth_service = AuthService(db)

--- a/backend/app/api/v1/endpoints/files.py
+++ b/backend/app/api/v1/endpoints/files.py
@@ -3,6 +3,7 @@ File proxy endpoints for secure file access
 """
 
 import logging
+import os
 import urllib.parse
 from typing import Optional
 
@@ -15,12 +16,62 @@ from sqlalchemy.orm import selectinload
 from app.core.security import verify_token
 from app.db.deps import get_db
 from app.models.application import Application, ApplicationFile
-from app.models.user import UserRole
+from app.models.user import User, UserRole
 from app.services.auth_service import AuthService
 from app.services.minio_service import minio_service
+from app.utils.application_helpers import get_college_code_from_data
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+# SECURITY: never echo the client-supplied MIME type back on our own origin.
+# ApplicationFile.mime_type / .content_type are persisted verbatim from the
+# uploader's multipart part header (application_service.py), and upload
+# validation only checks the file *extension*. Serving an attacker-chosen
+# "text/html" or "image/svg+xml" with Content-Disposition: inline would execute
+# script same-origin against a reviewer's session — and this FastAPI response
+# bypasses the Next.js middleware CSP entirely. Derive the type from the
+# already-validated extension instead, and fall back to a non-renderable type.
+_SAFE_CONTENT_TYPES = {
+    ".pdf": "application/pdf",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+_FALLBACK_CONTENT_TYPE = "application/octet-stream"
+
+
+def _safe_content_type(filename: Optional[str]) -> str:
+    """Map a stored filename to a safe, non-scriptable Content-Type."""
+    _, ext = os.path.splitext((filename or "").strip().rstrip(". ").lower())
+    return _SAFE_CONTENT_TYPES.get(ext, _FALLBACK_CONTENT_TYPE)
+
+
+def _assert_college_may_access(current_user: User, application: Application, file_id: int) -> None:
+    """Restrict a 學院 reviewer to applications from their own college.
+
+    The project's access model scopes college staff by ``std_academyno`` (see
+    college_review_service). This branch previously fell through to an
+    unconditional ``pass`` for UserRole.college, letting College-A staff stream
+    any other college's transcripts and bank passbooks by walking file ids.
+    """
+    user_college = (current_user.college_code or "").strip()
+    owner_college = (get_college_code_from_data(application.student_data or {}) or "").strip()
+    if not user_college or user_college != owner_college:
+        logger.warning(
+            "SECURITY: college user attempted cross-college file access",
+            extra={
+                "user_id": current_user.id,
+                "user_college": user_college,
+                "owner_college": owner_college,
+                "file_id": file_id,
+                "application_id": application.id,
+            },
+        )
+        # 404 rather than 403 so the response does not confirm the file exists.
+        raise HTTPException(status_code=404, detail="File not found")
 
 
 @router.get("/applications/{application_id}/files/{file_id}")
@@ -98,12 +149,11 @@ async def get_file_proxy(
                     },
                 )
                 raise HTTPException(status_code=403, detail="Access denied - no relationship with student")
-        elif current_user.role in [
-            UserRole.college,
-            UserRole.admin,
-            UserRole.super_admin,
-        ]:
-            # College, Admin, and Super Admin can access any file
+        elif current_user.role == UserRole.college:
+            # College staff are scoped to their own college's applicants.
+            _assert_college_may_access(current_user, application, file_id)
+        elif current_user.role in (UserRole.admin, UserRole.super_admin):
+            # Admin and Super Admin can access any file
             pass
         else:
             # Other roles are not allowed
@@ -123,8 +173,9 @@ async def get_file_proxy(
 
         file_stream = minio_service.get_file_stream(file_record.object_name)
 
-        # Determine content type
-        content_type = file_record.mime_type or file_record.content_type or "application/octet-stream"
+        # Determine content type from the validated extension, never from the
+        # client-supplied MIME stored at upload time (see _safe_content_type).
+        content_type = _safe_content_type(file_record.filename)
 
         # Create streaming response
         def generate():
@@ -138,9 +189,14 @@ async def get_file_proxy(
         # Handle filename encoding for non-ASCII characters (e.g., Chinese)
         encoded_filename = urllib.parse.quote(file_record.filename, safe="")
 
+        # Only render inline for types we recognise as safe; anything unknown is
+        # forced to download so the browser never renders it in our origin.
+        disposition = "inline" if content_type != _FALLBACK_CONTENT_TYPE else "attachment"
+
         headers = {
-            "Content-Disposition": f"inline; filename*=UTF-8''{encoded_filename}",
+            "Content-Disposition": f"{disposition}; filename*=UTF-8''{encoded_filename}",
             "Cache-Control": "private, max-age=3600",  # Cache for 1 hour
+            "X-Content-Type-Options": "nosniff",
         }
 
         return StreamingResponse(generate(), media_type=content_type, headers=headers)
@@ -227,12 +283,11 @@ async def download_file_proxy(
                     },
                 )
                 raise HTTPException(status_code=403, detail="Access denied - no relationship with student")
-        elif current_user.role in [
-            UserRole.college,
-            UserRole.admin,
-            UserRole.super_admin,
-        ]:
-            # College, Admin, and Super Admin can access any file
+        elif current_user.role == UserRole.college:
+            # College staff are scoped to their own college's applicants.
+            _assert_college_may_access(current_user, application, file_id)
+        elif current_user.role in (UserRole.admin, UserRole.super_admin):
+            # Admin and Super Admin can access any file
             pass
         else:
             # Other roles are not allowed
@@ -252,8 +307,9 @@ async def download_file_proxy(
 
         file_stream = minio_service.get_file_stream(file_record.object_name)
 
-        # Determine content type
-        content_type = file_record.mime_type or file_record.content_type or "application/octet-stream"
+        # Determine content type from the validated extension, never from the
+        # client-supplied MIME stored at upload time (see _safe_content_type).
+        content_type = _safe_content_type(file_record.filename)
 
         # Create streaming response with download headers
         def generate():
@@ -270,6 +326,7 @@ async def download_file_proxy(
         headers = {
             "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
             "Cache-Control": "no-cache",
+            "X-Content-Type-Options": "nosniff",
         }
 
         return StreamingResponse(generate(), media_type=content_type, headers=headers)

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -455,6 +455,10 @@ async def list_payment_rosters(
     取得造冊清單
     Get payment roster list
     """
+    # SECURITY: roster rows embed recipient 身分證字號 and 郵局帳號. Every mutating
+    # handler in this router already role-checks; the read/export handlers did not,
+    # so any authenticated user (including a student) could read every roster.
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
     from app.models.scholarship import ScholarshipConfiguration
 
     try:
@@ -1284,6 +1288,7 @@ async def get_payment_roster(
     取得特定造冊詳細資訊
     Get specific payment roster details
     """
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
     try:
         # 使用 eager loading 避免 MissingGreenlet 錯誤
         stmt = (
@@ -1334,6 +1339,7 @@ async def get_roster_items(
     取得造冊明細項目
     Get roster items
     """
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
     try:
         # 檢查造冊是否存在
         roster_stmt = select(PaymentRoster).where(PaymentRoster.id == roster_id)
@@ -1494,6 +1500,7 @@ def preview_roster_export(
     預覽造冊Excel匯出內容
     Preview roster Excel export content
     """
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
     try:
         roster = db.query(PaymentRoster).filter(PaymentRoster.id == roster_id).first()
 
@@ -1596,6 +1603,7 @@ def export_roster_to_excel(
     匯出造冊至Excel (STD_UP_MIXLISTA格式)
     Export roster to Excel (STD_UP_MIXLISTA format)
     """
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
     try:
         roster = db.query(PaymentRoster).filter(PaymentRoster.id == roster_id).first()
 
@@ -1688,6 +1696,7 @@ async def download_roster_excel(
     下載造冊Excel檔案 (支援MinIO和本地檔案)
     Download roster Excel file (supports MinIO and local files)
     """
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
     # trace_id is injected by add_trace_id_middleware (see backend/app/main.py).
     # We thread it into every download-path log line so the e2e diagnose helper
     # (frontend/e2e/helpers/logs.ts) can correlate failures via grep — without
@@ -1861,6 +1870,7 @@ async def get_roster_statistics(
     取得造冊統計資訊
     Get roster statistics
     """
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
     try:
         stmt = select(PaymentRoster).where(PaymentRoster.id == roster_id)
 
@@ -2131,6 +2141,7 @@ async def get_roster_audit_logs(
     取得造冊稽核日誌
     Get roster audit logs
     """
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
     try:
         stmt = select(PaymentRoster).where(PaymentRoster.id == roster_id)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -109,13 +109,22 @@ async def lifespan(_app: FastAPI):
                 LOGGER.exception("Error during scheduler shutdown: %s", exc)
 
 
+# Interactive API docs and the OpenAPI schema enumerate every route, parameter
+# and model for an anonymous caller — nginx forwards all of /api/ to this app, so
+# in production they are internet-reachable and reliably flagged by vulnerability
+# scanners as information disclosure. Keep them on everywhere EXCEPT a real
+# production deployment; `settings.testing` keeps CI's `bun run api:generate`
+# working (that job sets CI/TESTING but leaves ENVIRONMENT at its "production"
+# default).
+_expose_api_docs = settings.environment != "production" or settings.testing
+
 app = FastAPI(
     title=settings.app_name,
     version=settings.app_version,
     description="A comprehensive scholarship application and approval management system",
-    openapi_url="/api/v1/openapi.json",
-    docs_url="/api/v1/docs",
-    redoc_url="/api/v1/redoc",
+    openapi_url="/api/v1/openapi.json" if _expose_api_docs else None,
+    docs_url="/api/v1/docs" if _expose_api_docs else None,
+    redoc_url="/api/v1/redoc" if _expose_api_docs else None,
     lifespan=lifespan,
     redirect_slashes=False,  # Disable automatic slash redirects to prevent 307 in both dev and staging
 )

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -237,7 +237,11 @@ class ApplicationUpdate(BaseModel):
 
     scholarship_subtype_list: Optional[List[str]] = Field(None, description="獎學金子類型列表")
     form_data: Optional[ApplicationFormData] = Field(None, description="表單資料")
-    status: Optional[str] = Field(None, description="申請狀態")
+    # SECURITY: `status` is deliberately NOT accepted here. It used to be assigned
+    # straight onto the model in ApplicationService.update_application, letting a
+    # student PUT {"status": "approved"} onto their own editable draft and skip
+    # professor review, college ranking and quota allocation entirely. Workflow
+    # transitions belong to the guarded PUT /applications/{id}/status path.
     agree_terms: Optional[bool] = Field(None, description="同意條款")
     is_renewal: Optional[bool] = Field(None, description="是否為續領申請")
     sub_type_preferences: Optional[List[str]] = Field(None, description="Ordered sub-type preference list")

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1038,9 +1038,7 @@ class ApplicationService:
             # Serialize form data to handle datetime objects properly
             application.submitted_form_data = self._serialize_for_json(update_data.form_data.dict())
 
-        # 更新狀態
-        if update_data.status:
-            application.status = update_data.status
+        # NOTE: status is intentionally not updatable here — see ApplicationUpdate.
 
         # 更新續領申請標識
         if update_data.is_renewal is not None:
@@ -1062,8 +1060,6 @@ class ApplicationService:
 
         await self.db.commit()
         await self.db.refresh(application)
-        if update_data.status:
-            await self._invalidate_app_caches()
 
         # Clone bank account proof document when saving draft or updating application
         # This ensures the document is available in the application

--- a/backend/app/tests/test_application_service.py
+++ b/backend/app/tests/test_application_service.py
@@ -465,12 +465,19 @@ class TestApplicationService:
         mock_application.files = []
         mock_application.scholarship_subtype_list = []
         mock_application.app_id = "APP-2024-001"
+        mock_application.status = ApplicationStatus.draft
 
+        # SECURITY regression: a client may still POST a "status" key, but
+        # ApplicationUpdate no longer declares the field, so pydantic drops it
+        # and update_application must never write it. Previously this let a
+        # student PUT {"status": "approved"} onto their own draft and skip the
+        # entire review workflow.
         update_data = ApplicationUpdate(
             form_data=ApplicationFormData(fields={}, documents=[]),
-            status=ApplicationStatus.draft.value,
+            status=ApplicationStatus.approved.value,
             is_renewal=True,
         )
+        assert not hasattr(update_data, "status")
 
         with (
             patch.object(service, "_get_application_model", new_callable=AsyncMock, return_value=mock_application),
@@ -481,7 +488,8 @@ class TestApplicationService:
             result = await service.update_application(application_id, update_data, mock_user)
 
             assert result == mock_application
-            assert mock_application.status == ApplicationStatus.draft.value
+            # Status is untouched by the generic update path.
+            assert mock_application.status == ApplicationStatus.draft
             assert mock_application.is_renewal
             mock_commit.assert_called_once()
             mock_refresh.assert_called_once()

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -104,7 +104,16 @@ export interface paths {
         put?: never;
         /**
          * Register
-         * @description Register a new user
+         * @description Create a user account. Admin-only — `UserCreate.role` is caller-supplied.
+         *
+         *     SECURITY: this endpoint used to be anonymous while `UserCreate` accepts a
+         *     `role` field, so anyone could POST {"nycu_id": <their own id>, "role":
+         *     "super_admin"} to plant a privileged row. That row survives a *legitimate*
+         *     Portal SSO login, because `_find_or_create_user` deliberately preserves
+         *     pre-authorized super_admin/admin/college roles
+         *     (portal_sso_service.py:285-290) — turning self-registration into a full
+         *     privilege escalation. Account creation must therefore stay behind the same
+         *     role-assignment permission as POST /pre-authorize/user.
          */
         post: operations["register_api_v1_auth_register_post"];
         delete?: never;
@@ -124,7 +133,16 @@ export interface paths {
         put?: never;
         /**
          * Login
-         * @description Login user and return access token
+         * @description Development-only login: exchanges a known nycu_id/email for a token.
+         *
+         *     SECURITY: `AuthService.authenticate_user` performs NO credential check —
+         *     `UserLogin` carries only `username`, and the User model has no password
+         *     column at all (real authentication is NYCU Portal SSO). Left ungated, a
+         *     single anonymous POST with a guessable identifier such as
+         *     "admin@nycu.edu.tw" mints a valid admin JWT. It is therefore hard-gated
+         *     behind `enable_mock_sso`, exactly like /mock-sso/login and /dev-profiles/*
+         *     below, so it 404s wherever ENABLE_MOCK_SSO=false (production and staging)
+         *     while dev/E2E/pytest keep working.
          */
         post: operations["login_api_v1_auth_login_post"];
         delete?: never;
@@ -8439,11 +8457,6 @@ export interface components {
             scholarship_subtype_list?: string[] | null;
             /** @description 表單資料 */
             form_data?: components["schemas"]["ApplicationFormData"] | null;
-            /**
-             * Status
-             * @description 申請狀態
-             */
-            status?: string | null;
             /**
              * Agree Terms
              * @description 同意條款


### PR DESCRIPTION
Full-codebase security audit ahead of the upcoming production 弱點掃描. Six findings survived independent adversarial verification (confidence >= 8) and are fixed here, plus one scanner-hygiene item.

Threat model is the **production** deployment: nginx `location /api/` forwards everything under `/api/` to FastAPI, so all of these are reachable from the internet.

## Findings fixed

| # | Severity | Issue | Location |
|---|----------|-------|----------|
| 1 | **HIGH** | Passwordless login mints an admin JWT for any known identifier | `services/auth_service.py:76` |
| 2 | **HIGH** | Anonymous `/auth/register` with caller-supplied `role` -> super_admin | `endpoints/auth.py:54` |
| 3 | **HIGH** | 8 roster read/export endpoints authenticate but never authorize | `endpoints/payment_rosters.py` |
| 4 | **HIGH** | Client-settable application `status` (self-approval) | `services/application_service.py:1042` |
| 5 | **HIGH** | Stored XSS via client-controlled MIME served `inline` | `endpoints/files.py:127` |
| 6 | MEDIUM | College staff could read any college's files | `endpoints/files.py:101,230` |

### 1 + 2 chain to full compromise
`authenticate_user()` performs **no credential check** — `UserLogin` has only `username` and the User model has no password column (real auth is Portal SSO). One anonymous POST with `admin@nycu.edu.tw` returned a valid admin token.

Worse, #2 does **not** depend on #1: `_find_or_create_user` deliberately preserves pre-authorized `super_admin`/`admin`/`college` roles (`portal_sso_service.py:285-290`), so an attacker could anonymously register their **own real NYCU ID** as `super_admin`, then log in through **legitimate Portal SSO** and be super_admin. Any student with a portal account could do this.

### 3 exposes bulk PII
Roster rows carry `student_id_number` (身分證字號) and `bank_account` (郵局帳號). Any student token could `GET /api/v1/payment-rosters` and dump every roster, then walk `/{id}/items` and `/{id}/download` by sequential id.

## Approach
Each fix reuses the guard the codebase already established elsewhere rather than inventing a new one:
- `/auth/login` gated on `enable_mock_sso`, exactly like the sibling `/mock-sso/*` and `/dev-profiles/*` routes. `config.validate_production_secrets` already refuses to boot production with mock SSO on, so this is structurally enforced, not convention.
- `/auth/register` requires `can_assign_roles()` — the same permission `POST /pre-authorize/user` enforces.
- Roster reads use the router's existing `check_user_roles([admin, super_admin], ...)`.
- College file access scopes on `std_academyno` and returns 404, matching `college_review_service` and `test_authz_scoping_endpoints`.

## Behaviour changes to be aware of
- `POST /api/v1/auth/login` now **404s in production and staging** (`ENABLE_MOCK_SSO=false`). Dev, staging-e2e and pytest set it `true` and are unaffected. No production UI calls it — real login is Portal SSO.
- `POST /api/v1/auth/register` now requires an admin token.
- College users can no longer open files for applications whose `student_data` has no `std_academyno`; this fails closed by design.
- `ApplicationUpdate.status` is removed from the OpenAPI schema. `schema.d.ts` is **not** regenerated in this PR to avoid mixing in 39 hunks of pre-existing generator drift — `bun run api:generate` should be run separately.

## Test plan
- [x] Full backend suite: **4728 passed**. The 4 remaining failures are pre-existing and unrelated — confirmed by re-running them on a stashed (pristine) tree. They fail only because the dev container sets `DEBUG=true`, so `TestDevEndpointsDebugGate` (which asserts the gate blocks when debug is off) inverts. CI and production run `DEBUG=false`, where the admin+debug double gate works correctly.
- [x] `black --check --line-length=120` — 620 files clean
- [x] `flake8 --select=B904,B014,F401,F821` — clean
- [x] `tsc --noEmit` — clean
- [x] Live verification on the dev stack: anonymous `/auth/register` -> 401; student token -> 403 on roster list/detail/items/download/statistics/audit-logs; admin -> 200; dev login still works
- [ ] Confirm `ENABLE_MOCK_SSO=false` on the production host before deploy
- [ ] Rotate `SECRET_KEY` after deploy to invalidate any JWT minted through the passwordless path, and review access logs for `POST /api/v1/auth/login`