### PR TITLE
test: align bank passbook test with post-#1218 lookup

### DIFF
--- a/backend/app/tests/test_bank_verification.py
+++ b/backend/app/tests/test_bank_verification.py
@@ -279,14 +279,39 @@ class TestBankVerificationService:
         mock_document = ApplicationFile()
         mock_document.filename = "passbook.pdf"
 
+        # The filename lookup tolerates duplicate rows, so it reads scalars().first()
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = mock_document
+        mock_result.scalars.return_value.first.return_value = mock_document
         mock_db.execute.return_value = mock_result
 
         result = await verification_service.get_bank_passbook_document(application)
 
         assert result == mock_document
         mock_db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_bank_passbook_document_falls_back_to_filename(self, verification_service, mock_db):
+        """A dangling file_id (row replaced by re-upload) still resolves via filename"""
+        application = Application()
+        application.id = 1
+        application.submitted_form_data = {
+            "documents": [{"document_id": "bank_account_cover", "file_id": 999, "filename": "passbook.pdf"}]
+        }
+
+        mock_document = ApplicationFile()
+        mock_document.filename = "passbook.pdf"
+
+        # First execute (file_id lookup) misses, second (filename lookup) hits
+        missing_result = MagicMock()
+        missing_result.scalar_one_or_none.return_value = None
+        found_result = MagicMock()
+        found_result.scalars.return_value.first.return_value = mock_document
+        mock_db.execute.side_effect = [missing_result, found_result]
+
+        result = await verification_service.get_bank_passbook_document(application)
+
+        assert result == mock_document
+        assert mock_db.execute.await_count == 2
 
     @pytest.mark.asyncio
     async def test_get_bank_passbook_document_not_found(self, verification_service, mock_db):


### PR DESCRIPTION
## Summary

`main` has been red since PR #1218 merged: the **Backend Tests (integration)** lane fails on
`app/tests/test_bank_verification.py::TestBankVerificationService::test_get_bank_passbook_document`.

PR #1218 rewrote the filename fallback in `BankVerificationService.get_bank_passbook_document`
(`backend/app/services/bank_verification_service.py:178`) from `scalar_one_or_none()` to
`scalars().first()`, so that duplicate rows left behind by a re-upload — or by the
`dedupe_application_files_001` migration — no longer raise `MultipleResultsFound`.

The test still stubbed only `scalar_one_or_none`, so the service received an unstubbed `MagicMock`:

```
AssertionError: assert <MagicMock name='mock.execute().scalars().first()'> == <ApplicationFile(...)>
```

The production change is correct and intentional; the **test** was stale. Fixed the test.

## Changes

- Mock `scalars().first()` instead of `scalar_one_or_none()` in `test_get_bank_passbook_document`.
- Add `test_get_bank_passbook_document_falls_back_to_filename` — regression coverage for the behavior
  #1218 actually introduced and shipped untested: a dangling `file_id` (row replaced by a re-upload)
  misses, and the filename query still resolves the surviving row.

No production code changed.

## Test plan

All three backend CI lanes reproduced locally against this branch:

| Lane | Result |
|---|---|
| unit | 3111 passed |
| integration | 1624 passed, 2 skipped |
| smoke | 24 passed |

Integration was `1622 passed, 1 failed` on `main`; it is now 1624 (the repaired test plus the new one).

- [x] `black --check --line-length=120` clean on the touched file
- [x] `flake8 --select=B904,B014,F401` clean on the touched file

## Note — unrelated failure on the same commit

The `Deployment Pipeline` / **Deploy to Staging** failure on `main@c440fbea` is **not** caused by #1218.
It is staging infra on the self-hosted runner (`nginx: [error] invalid PID number "" in "/run/nginx.pid"`,
plus an unconfigured `secrets.PII_ENCRYPTION_KEYS`). Rollback succeeded and staging is healthy.
Out of scope here — tracked separately.