### PR TITLE
fix: fail-open scholarship filter, three always-500 endpoints, and silent config decryption failure

### DIFF
--- a/backend/app/api/v1/endpoints/admin/email_templates.py
+++ b/backend/app/api/v1/endpoints/admin/email_templates.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import require_admin
 from app.db.deps import get_db
-from app.models.system_setting import EmailTemplate
+from app.models.system_setting import EmailTemplate, SendingType
 from app.models.audit_log import AuditAction, AuditLog
 from app.models.user import User
 from app.schemas.common import EmailTemplateSchema, EmailTemplateUpdateSchema
@@ -38,8 +38,17 @@ async def get_email_template(
     """Get email template by key (admin only)"""
     template = await EmailTemplateService.get_template(db, key)
     if not template:
+        # Empty scaffold so the admin UI can author a not-yet-existing template.
+        # `sending_type` is required by the schema and was omitted here, which made
+        # pydantic raise and turned every unknown key into a 500 (issue #1225).
         template_data = EmailTemplateSchema(
-            key=key, subject_template="", body_template="", cc=None, bcc=None, updated_at=None
+            key=key,
+            subject_template="",
+            body_template="",
+            cc=None,
+            bcc=None,
+            sending_type=SendingType.single,
+            updated_at=None,
         )
     else:
         template_data = EmailTemplateSchema.model_validate(template)

--- a/backend/app/api/v1/endpoints/applications.py
+++ b/backend/app/api/v1/endpoints/applications.py
@@ -340,6 +340,13 @@ async def get_application(
     service = ApplicationService(db)
     result = await service.get_application_by_id(id, current_user)
 
+    # `get_application_by_id` returns None when the row does not exist or the
+    # caller may not see it. Falling through passed None to _serialize_result,
+    # which raised TypeError -> 500 instead of 404 (issue #1225). Returning the
+    # same 404 in both cases also avoids confirming that a hidden id exists.
+    if result is None:
+        raise NotFoundError(f"Application {id} not found")
+
     # Log audit trail for viewing application
     audit_service = ApplicationAuditService(db)
     await audit_service.log_view_application(

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1412,8 +1412,14 @@ class ApplicationService:
             stmt = select(ScholarshipType).where(ScholarshipType.code == scholarship_type)
             result = await self.db.execute(stmt)
             scholarship = result.scalar_one_or_none()
-            if scholarship:
-                query = query.where(Application.scholarship_type_id == scholarship.id)
+            if not scholarship:
+                # Fail closed. Previously an unrecognised code left the predicate
+                # off entirely, so a garbage filter value returned *everything* the
+                # caller may see rather than nothing — and because the parameter
+                # then never changed the result set, ZAP's boolean-comparison probe
+                # read that as a SQL-injection signal (issue #1225).
+                return []
+            query = query.where(Application.scholarship_type_id == scholarship.id)
 
         # Apply pagination
         query = query.offset(skip).limit(limit)

--- a/backend/app/services/config_management_service.py
+++ b/backend/app/services/config_management_service.py
@@ -4,6 +4,7 @@ Handles system configuration with encryption for sensitive values
 """
 
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -14,6 +15,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.regex_validator import RegexValidationError, safe_regex_match
 from app.models.system_setting import ConfigCategory, ConfigDataType, ConfigurationAuditLog, SystemSetting
+
+logger = logging.getLogger(__name__)
+
+# Fernet tokens are base64url of a payload whose first byte is the 0x80 version
+# marker, so every one of them starts with this prefix. Used to tell "this was
+# encrypted and we can no longer read it" apart from "this predates encryption".
+_FERNET_PREFIX = "gAAAAA"
 
 
 class ConfigEncryption:
@@ -71,8 +79,23 @@ class ConfigurationService:
             try:
                 value = self.encryption.decrypt_value(value)
             except Exception:
-                # If decryption fails, return as-is (might be unencrypted legacy value or empty)
-                pass
+                if isinstance(value, str) and value.startswith(_FERNET_PREFIX):
+                    # This IS a Fernet token, so the key no longer matches it —
+                    # almost always SECRET_KEY rotated without re-encrypting, since
+                    # ConfigEncryption derives its key from SECRET_KEY. Returning the
+                    # ciphertext as though it were plaintext is the dangerous outcome:
+                    # an SMTP password silently becomes a garbage string and mail
+                    # delivery fails with no clear cause. Surface it and hand back an
+                    # empty value so the credential is unusable rather than wrong.
+                    logger.error(
+                        "Failed to decrypt sensitive configuration; SECRET_KEY may have been "
+                        "rotated without re-encrypting. Re-enter this value in the admin UI.",
+                        extra={"config_key": setting.key},
+                        exc_info=True,
+                    )
+                    value = ""
+                # Otherwise it predates encryption and is stored as plaintext;
+                # returning it unchanged is correct.
 
         # Convert to appropriate type
         if setting.data_type == ConfigDataType.boolean:

--- a/backend/app/services/user_profile_service.py
+++ b/backend/app/services/user_profile_service.py
@@ -14,7 +14,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.models.user_profile import UserProfile, UserProfileHistory
 from app.schemas.user_profile import (
     BankDocumentPhotoUpload,
@@ -574,7 +574,11 @@ class UserProfileService:
 
     async def get_users_with_incomplete_profiles(self) -> List[Dict[str, Any]]:
         """Get users with incomplete profiles for admin dashboard"""
-        stmt = select(User, UserProfile).outerjoin(UserProfile).where(User.role == "STUDENT")
+        # Enum members are lowercase to match the PostgreSQL `userrole` enum
+        # (see CLAUDE.md enum consistency rules). The literal "STUDENT" made
+        # asyncpg raise InvalidTextRepresentationError, so this endpoint returned
+        # 500 unconditionally.
+        stmt = select(User, UserProfile).outerjoin(UserProfile).where(User.role == UserRole.student)
 
         result = await self.db.execute(stmt)
         users_profiles = result.all()
@@ -588,14 +592,14 @@ class UserProfileService:
                 completion_percentage = profile.profile_completion_percentage
                 missing_info = []
 
+                # Keep this list in step with UserProfile.profile_completion_percentage,
+                # which scores exactly two sections. The previous code also tested
+                # `preferred_email` and `phone_number`; neither attribute exists on
+                # UserProfile, so this raised AttributeError on every profile row.
                 if not profile.has_complete_bank_info:
                     missing_info.append("銀行帳戶資訊")
                 if not profile.has_advisor_info:
                     missing_info.append("指導教授資訊")
-                if not profile.preferred_email:
-                    missing_info.append("聯絡Email")
-                if not profile.phone_number:
-                    missing_info.append("聯絡電話")
 
             if completion_percentage < 80:  # Consider <80% as incomplete
                 incomplete_users.append(


### PR DESCRIPTION
Fixes the non-security defects surfaced by the ZAP active scan (#1225) plus the silent-decryption footgun found while writing up the `SECRET_KEY` rotation procedure (#1223).

Two of these turned out to be real broken endpoints, not just wrong status codes.

## 1. Fail-open `scholarship_type` filter — `application_service.py`

`get_applications_for_review` resolved the supplied code to a `ScholarshipType` and, when nothing matched, simply **skipped the predicate** — so a garbage filter value returned everything the caller was allowed to see.

Not a security hole (the endpoint is `require_staff` and per-role row scoping still applies), but it is what produced the false-positive **SQL Injection** alert: because the parameter never changed the result set, ZAP's boolean-comparison probe read the payloads as successful manipulation. The query is pure SQLAlchemy ORM with bound parameters and was never injectable.

| `scholarship_type` | before | after |
|---|---|---|
| `nonexistent_xyz` | 1 row | **0 rows** |
| `' OR '1'='1' -- ` | 1 row | **0 rows** |

## 2. Three endpoints that always returned 500

- **`GET /applications/{id}`** — `get_application_by_id` returns `None` for a missing/invisible row and the endpoint passed that into `_serialize_result`, raising `TypeError`. Now raises `NotFoundError` → **404**. Returning the same 404 in both cases also avoids confirming that a hidden id exists.

- **`GET /user-profiles/admin/incomplete`** — two stacked bugs, this endpoint has **never** returned a successful response:
  1. the query filtered on the literal `"STUDENT"` while the PostgreSQL `userrole` enum stores lowercase values, so asyncpg raised `InvalidTextRepresentationError` on every call (exactly the enum-casing rule in CLAUDE.md);
  2. behind that, the completeness loop read `profile.preferred_email` and `profile.phone_number` — **neither attribute exists on `UserProfile`**. Now filters on `UserRole.student` and scores only the two sections `profile_completion_percentage` actually counts (bank info, advisor info).

- **`GET /admin/email-template`** — the not-found branch deliberately builds an empty scaffold for the admin UI but omitted `sending_type`, which `EmailTemplateSchema` requires, so pydantic raised on every unknown key. Supplies `SendingType.single`; the scaffold behaviour is preserved.

Verified live: `404`, `200`, `200` respectively (all three were `500`).

## 3. Silent configuration decryption failure — `config_management_service.py`

`get_decrypted_value` caught every exception and returned the stored value unchanged. Correct for values written before encryption existed; wrong when the value is a Fernet token we can no longer read — which is what happens if `SECRET_KEY` is rotated without re-encrypting, since `ConfigEncryption` derives its key from `SECRET_KEY`. An SMTP password was handed back as raw ciphertext and mail delivery failed with no diagnosable cause.

Now distinguishes the two by the Fernet version prefix: a real token that fails to decrypt is logged at ERROR with the config key and returns empty (credential unusable rather than silently wrong); anything else is treated as legacy plaintext exactly as before.

This matters because rotating `SECRET_KEY` is a pending action in #1223 — it is required to invalidate any admin JWT minted through the passwordless login path closed in #1222, since `/auth/refresh` will renew such a token indefinitely.

## Test plan
- [x] Full backend suite: **4730 passed**. The 3 remaining failures are the known `TestDevEndpointsDebugGate` cases that only fail inside the dev container because it sets `DEBUG=true`; they assert the gate blocks when debug is off and pass in CI.
- [x] `black --check --line-length=120` — 620 files clean
- [x] `flake8 --select=B904,B014,F401,F821` — clean
- [x] Live verification of all four behaviours against the dev stack

Closes #1225