### PR TITLE
fix(seed): open the phd_114 renewal window so 匯入續領生 works on a fresh DB

### DIFF
--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -223,16 +223,21 @@ async def seed_scholarship_configurations(session: AsyncSession) -> None:
             },
             "amount": 40000,
             "currency": "TWD",
-            "renewal_application_start_date": now - timedelta(days=90),
-            "renewal_application_end_date": now - timedelta(days=60),
+            # The renewal cycle runs alongside the general cycle (續領 and 新申請
+            # open together in the real PhD process). Keeping it OPEN is what
+            # makes the admin 匯入續領生 surface usable on a freshly seeded DB —
+            # `renewal_import` rejects the upload with HTTP 400
+            # "此獎學金配置目前不在續領期間" whenever this window has closed.
+            "renewal_application_start_date": now - timedelta(days=45),
+            "renewal_application_end_date": now + timedelta(days=15),
             "application_start_date": now - timedelta(days=45),
             "application_end_date": now + timedelta(days=15),
             "renewal_requires_professor_review": True,
-            "renewal_professor_review_start": now - timedelta(days=55),
-            "renewal_professor_review_end": now - timedelta(days=40),
+            "renewal_professor_review_start": now - timedelta(days=5),
+            "renewal_professor_review_end": now + timedelta(days=30),
             "renewal_requires_college_review": True,
-            "renewal_college_review_start": now - timedelta(days=35),
-            "renewal_college_review_end": now - timedelta(days=20),
+            "renewal_college_review_start": now - timedelta(days=5),
+            "renewal_college_review_end": now + timedelta(days=60),
             "requires_professor_recommendation": True,
             "professor_review_start": now - timedelta(days=5),
             "professor_review_end": now + timedelta(days=30),


### PR DESCRIPTION
Closes #1226

## Problem

The nightly `e2e-full` lane has failed **every night since 2026-07-12**, the first nightly after `renewal-import.spec.ts` landed. The spec dies at its first assertion:

```
Error: upload failed: HTTP 400
> 147 | expect(uploadResp.ok(), `upload failed: HTTP ${uploadResp.status()}`).toBe(true);
```

The failure screenshot in the nightly artifact shows the real reason inline on the panel:

> 此獎學金配置目前不在續領期間，無法匯入續領生

## Root cause — seed data, not the feature

`renewal_import.upload` gates on `ScholarshipConfiguration.is_renewal_application_period` (`backend/app/api/v1/endpoints/renewal_import.py:89`). That gate is intentional. The problem is that the seeded `phd_114` config put its whole renewal cycle **in the past**:

| window | seeded as |
| --- | --- |
| renewal application | `now-90d` → `now-60d` |
| renewal professor review | `now-55d` → `now-40d` |
| renewal college review | `now-35d` → `now-20d` |

So on any freshly seeded database — which is exactly what the nightly builds — the 匯入續領生 surface is unusable and every upload 400s. The spec only ever passed locally against a long-lived dev DB whose renewal window had been opened by hand; it has never been green in CI.

## Fix

Shift the renewal cycle to mirror the general cycle already seeded for the same config, so 續領 and 新申請 are open together — which is how the real PhD process runs them:

| window | now |
| --- | --- |
| renewal application | `now-45d` → `now+15d` |
| renewal professor review | `now-5d` → `now+30d` |
| renewal college review | `now-5d` → `now+60d` |

Blast radius is small and was checked: `is_renewal_application_period` has no production consumer besides this gate (`current_application_type` / `can_student_apply` are model-only), and in `EligibilityService` the renewal window is only consulted when the general window is **closed** — it is open for this config, so student eligibility is unchanged.

## Test plan

Reproduced CI conditions exactly: throwaway Postgres DB, `alembic upgrade head` + `python -m app.seed` from this branch, backend re-pointed at it, then the **full** Playwright suite (no `--grep`).

- [x] `renewal-import.spec.ts` passes end-to-end — upload → preview (2 passed / 1 skipped) → confirm → nstc 造冊 with both renewals labelled `114續領`
- [x] Full suite: 46 passed, 1 skipped. The one failure (`admin-preview-dialog-render.spec.ts`) is a local dev-server first-render timing flake unrelated to this change — it passes on re-run in isolation, and it passed in the nightly this PR fixes
- [x] `black --check --line-length=120`, `flake8 --select=B904,B014`
- [x] `pytest test_enroll_types_fallback.py test_renewal_import_endpoints.py test_renewal_import_service.py` — 18 passed

Confirm green by re-running the nightly workflow (`workflow_dispatch`) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)