### PR TITLE
ci: fix staging deploy failing on /api/v1/docs 404 smoke test

### DIFF
--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -321,7 +321,9 @@ jobs:
       - name: Smoke tests
         run: |
           curl -fsk "https://localhost/health" -H "Host: ${DOMAIN}" >/dev/null || exit 1
-          curl -fsk "https://localhost/api/v1/docs" -H "Host: ${DOMAIN}" >/dev/null || exit 1
+          # /api/v1/docs is intentionally disabled when ENVIRONMENT=production
+          # (backend/app/main.py) — smoke-test a real mounted API route instead.
+          curl -fsk "https://localhost/api/v1/scholarships" -H "Host: ${DOMAIN}" >/dev/null || exit 1
           # Frontend through nginx
           code=$(curl -sk -o /dev/null -w '%{http_code}' "https://localhost/" -H "Host: ${DOMAIN}")
           [ "$code" = "200" ] || { echo "::error::Frontend returned $code"; exit 1; }

--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -326,10 +326,16 @@ jobs:
         run: |
           echo "Running smoke tests..."
 
-          # Test API endpoints
+          # Test API endpoints.
+          #
+          # Do NOT smoke-test /api/v1/docs here: staging runs with
+          # ENVIRONMENT=production (see docker-compose.staging.yml), and
+          # backend/app/main.py deliberately serves docs_url/redoc_url/openapi_url
+          # as None in that case, so Swagger UI 404s by design. Hit a real mounted
+          # API route instead — that proves the v1 router is wired up, which is
+          # what the docs check was standing in for.
           curl -f http://localhost:8000/health || exit 1
-          sleep 60
-          curl -f http://localhost:8000/api/v1/docs || exit 1
+          curl -f http://localhost:8000/api/v1/scholarships || exit 1
 
           echo "✅ Smoke tests passed"
 


### PR DESCRIPTION
## Problem

Every `Deployment Pipeline` → **Deploy to Staging** run has failed since #1222 merged (5f4dacd). Failing runs: 5f4dacd, eb172b7, 6e72b1c, 25e0d4c.

```
Running smoke tests...
100   289  100   289 ...              <- /health OK
curl: (22) The requested URL returned error: 404   <- /api/v1/docs
##[error]Process completed with exit code 1.
```

## Root cause

#1222 intentionally stopped exposing the interactive API docs, because they enumerate every route/parameter/model to an anonymous caller and nginx forwards all of `/api/` to the app:

```python
# backend/app/main.py
_expose_api_docs = settings.environment != "production" or settings.testing
app = FastAPI(..., docs_url="/api/v1/docs" if _expose_api_docs else None, ...)
```

Staging deliberately runs with `ENVIRONMENT: production` (`docker-compose.staging.yml:43`), so `/api/v1/docs` 404s **by design**. The smoke test was asserting the exact behaviour the security hardening removed.

The `sleep 60` added in 25e0d4c was a misdiagnosis — this is not a slow boot. The log shows `/health` returning a fully healthy payload (DB connected) immediately before the 404; the route simply isn't in the table.

## Fix

Smoke-test `GET /api/v1/scholarships` instead — unauthenticated, already used by the Staging Validation job, and it proves what the docs check stood in for: the v1 router is mounted and serving. Dropped the `sleep 60`.

Applied the same substitution to `.github/production-workflows-examples/deploy.yml`, which would hit the identical 404 (production is `ENVIRONMENT=production` too).

## Test plan

- [ ] Merge and confirm **Deploy to Staging** goes green
- [ ] Confirm **Staging Validation** (already curls `/api/v1/scholarships`) still passes