### PR TITLE
fix: stop advertising /api/v1/docs from the root endpoint in production

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -352,12 +352,15 @@ async def get_pool_status(current_user: User = Depends(require_admin)):
 @app.get("/")
 async def root():
     """Root endpoint with API information"""
+    # Read the URLs back off the app rather than repeating the literals: they are
+    # None whenever the docs are disabled (production — see _expose_api_docs), and
+    # advertising a link that 404s is worse than not advertising it at all.
     return {
         "success": True,
         "message": f"Welcome to {settings.app_name}",
         "version": settings.app_version,
-        "docs_url": "/api/v1/docs",
-        "redoc_url": "/api/v1/redoc",
+        **({"docs_url": app.docs_url} if app.docs_url else {}),
+        **({"redoc_url": app.redoc_url} if app.redoc_url else {}),
     }
 
 

--- a/backend/app/tests/test_health.py
+++ b/backend/app/tests/test_health.py
@@ -34,6 +34,24 @@ def test_root_endpoint():
     assert "version" in data
 
 
+def test_root_endpoint_never_advertises_disabled_docs():
+    """Root must not link to docs that are turned off.
+
+    `_expose_api_docs` in app.main drops docs_url/redoc_url in production, so a
+    hardcoded link there would point at a 404. Assert the payload tracks whatever
+    the app actually routes, in either direction.
+    """
+    client = TestClient(app)
+    data = client.get("/").json()
+
+    for key, url in (("docs_url", app.docs_url), ("redoc_url", app.redoc_url)):
+        if url is None:
+            assert key not in data, f"{key} advertised while the docs route is disabled"
+        else:
+            assert data[key] == url
+            assert client.get(url).status_code == 200
+
+
 @pytest.mark.asyncio
 async def test_health_endpoint_async():
     """Test health check endpoint async"""


### PR DESCRIPTION
Follow-up to #1230 / #1222.

## Problem

`GET /` hardcoded the docs links:

```python
return {
    "success": True,
    "message": f"Welcome to {settings.app_name}",
    "version": settings.app_version,
    "docs_url": "/api/v1/docs",     # <- 404 in production
    "redoc_url": "/api/v1/redoc",   # <- 404 in production
}
```

But #1222 made those routes conditional — `_expose_api_docs` is False when `ENVIRONMENT=production`, so FastAPI serves `docs_url`/`redoc_url` as `None`. Staging and production were handing every caller two links that cannot resolve. (Same mismatch that broke the deploy smoke test in #1230, just in the response body instead of CI.)

## Fix

Read the URLs back off the `app` object rather than repeating the literals — single source of truth — and omit the keys when the routes are disabled. Nothing else in the codebase consumed them (`grep docs_url` hits only `main.py`).

## Test plan

New invariant test in `test_health.py` asserts the root payload tracks whatever the app actually routes, in either direction.

- [x] `pytest app/tests/test_health.py` → 4 passed
- [x] black `--line-length=120` + flake8 `B904,B014` clean
- [x] `ENVIRONMENT=development` → `{..., docs_url, redoc_url}`, `/api/v1/docs` 200
- [x] `ENVIRONMENT=production` → `{success, message, version}`, `/api/v1/docs` 404

## Unrelated sharp edge noticed

`Settings.testing` (`config.py:306`) is truthy for **any** non-empty value, so `TESTING=false` still counts as testing and would re-expose the docs in production. Staging/prod compose don't set it, so nothing is broken today — flagging, not fixing here.