### PR TITLE
feat: implement card view for college application review

### DIFF
--- a/frontend/components/college/review/ApplicationCardView.tsx
+++ b/frontend/components/college/review/ApplicationCardView.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+/**
+ * 學院審核 - 卡片檢視。
+ *
+ * 與同層的表格檢視顯示相同欄位，只是改用卡片排版，適合在較窄的螢幕
+ * 或需要快速掃視少量申請時使用。
+ */
+
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Award, Eye, School } from "lucide-react";
+import {
+  ApplicationStatus,
+  getApplicationStatusLabel,
+  getApplicationStatusBadgeVariant,
+} from "@/lib/enums";
+import {
+  useReferenceData,
+  getStudyingStatusName,
+  getAcademyName,
+  getDepartmentName,
+} from "@/hooks/use-reference-data";
+import type { Application } from "@/lib/api/types";
+import {
+  NationalityIdentity,
+  ProfessorRecommendation,
+  formatAppliedDate,
+} from "./application-summary-fields";
+
+type Locale = "zh" | "en";
+
+interface ApplicationCardViewProps {
+  applications: Application[];
+  locale: Locale;
+  getSubTypeName: (subTypeCode: string | undefined, locale: Locale) => string;
+  onView: (app: Application) => void;
+}
+
+function FieldRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <span className="text-xs text-muted-foreground shrink-0 pt-0.5">
+        {label}
+      </span>
+      <div className="text-sm text-right">{children}</div>
+    </div>
+  );
+}
+
+export function ApplicationCardView({
+  applications,
+  locale,
+  getSubTypeName,
+  onView,
+}: ApplicationCardViewProps) {
+  const { studyingStatuses, academies, departments } = useReferenceData();
+
+  if (applications.length === 0) {
+    return (
+      <div className="py-12 text-center text-sm text-muted-foreground">
+        {locale === "zh" ? "沒有符合條件的申請" : "No matching applications"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {applications.map(app => (
+        <Card key={app.id} className="flex flex-col">
+          <CardHeader className="pb-3">
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="font-medium truncate">
+                  {app.student_name || "未提供姓名"}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {app.student_id || "未提供學號"}
+                </span>
+              </div>
+              <Badge
+                variant={getApplicationStatusBadgeVariant(
+                  app.status as ApplicationStatus
+                )}
+                className="shrink-0"
+              >
+                {app.status_zh ||
+                  getApplicationStatusLabel(
+                    app.status as ApplicationStatus,
+                    locale
+                  )}
+              </Badge>
+            </div>
+          </CardHeader>
+
+          <CardContent className="flex-1 space-y-3">
+            <div className="flex items-center gap-2 text-sm">
+              <School className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="truncate">
+                {getAcademyName(app.academy_code, academies)}
+                <span className="text-muted-foreground">
+                  {" · "}
+                  {getDepartmentName(app.department_code, departments)}
+                </span>
+              </span>
+            </div>
+
+            <div className="flex items-center gap-2 text-sm">
+              <Award className="h-4 w-4 text-muted-foreground shrink-0" />
+              <span className="truncate">
+                {app.scholarship_type_zh || app.scholarship_type}
+              </span>
+              <Badge
+                variant={app.is_renewal ? "secondary" : "default"}
+                className="ml-auto shrink-0"
+              >
+                {app.is_renewal ? "續領" : "初領"}
+              </Badge>
+            </div>
+
+            <div className="space-y-1.5 border-t pt-3">
+              <FieldRow label={locale === "zh" ? "國籍 / 身分" : "Nationality"}>
+                <NationalityIdentity app={app} locale={locale} />
+              </FieldRow>
+              <FieldRow label={locale === "zh" ? "在學學期數" : "Terms"}>
+                {app.student_termcount || "-"}
+              </FieldRow>
+              <FieldRow label={locale === "zh" ? "在學狀態" : "Study Status"}>
+                {app.scholarship_period_status !== undefined &&
+                app.scholarship_period_status !== null
+                  ? getStudyingStatusName(
+                      app.scholarship_period_status,
+                      studyingStatuses
+                    )
+                  : "-"}
+              </FieldRow>
+            </div>
+
+            <div className="space-y-1.5 border-t pt-3">
+              <span className="text-xs text-muted-foreground">
+                {locale === "zh" ? "教授推薦" : "Prof. Review"}
+              </span>
+              <div className="flex flex-wrap gap-1">
+                <ProfessorRecommendation
+                  app={app}
+                  locale={locale}
+                  getSubTypeName={getSubTypeName}
+                />
+              </div>
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex items-center justify-between pt-3 border-t">
+            <span className="text-xs text-muted-foreground">
+              {locale === "zh" ? "申請時間" : "Applied"}{" "}
+              {formatAppliedDate(app.created_at)}
+            </span>
+            <Button variant="outline" size="sm" onClick={() => onView(app)}>
+              <Eye className="h-4 w-4 mr-1" />
+              {locale === "zh" ? "檢視" : "View"}
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/college/review/ApplicationReviewPanel.tsx
+++ b/frontend/components/college/review/ApplicationReviewPanel.tsx
@@ -68,6 +68,12 @@ import {
   exportDepartmentSummary,
   exportDepartmentSummaryBulk,
 } from "@/lib/api/modules/college";
+import { ApplicationCardView } from "./ApplicationCardView";
+import {
+  NationalityIdentity,
+  ProfessorRecommendation,
+  formatAppliedDate,
+} from "./application-summary-fields";
 
 interface ApplicationReviewPanelProps {
   user: User;
@@ -796,6 +802,9 @@ export function ApplicationReviewPanel({
               variant={viewMode === "card" ? "default" : "ghost"}
               size="sm"
               onClick={() => setViewMode("card")}
+              title={locale === "zh" ? "卡片檢視" : "Card view"}
+              aria-label={locale === "zh" ? "卡片檢視" : "Card view"}
+              aria-pressed={viewMode === "card"}
             >
               <Grid className="h-4 w-4" />
             </Button>
@@ -803,6 +812,9 @@ export function ApplicationReviewPanel({
               variant={viewMode === "table" ? "default" : "ghost"}
               size="sm"
               onClick={() => setViewMode("table")}
+              title={locale === "zh" ? "表格檢視" : "Table view"}
+              aria-label={locale === "zh" ? "表格檢視" : "Table view"}
+              aria-pressed={viewMode === "table"}
             >
               <List className="h-4 w-4" />
             </Button>
@@ -998,6 +1010,14 @@ export function ApplicationReviewPanel({
               </CardTitle>
             </CardHeader>
             <CardContent>
+              {viewMode === "card" ? (
+                <ApplicationCardView
+                  applications={filteredApplications}
+                  locale={locale}
+                  getSubTypeName={getSubTypeName}
+                  onView={setSelectedApplication}
+                />
+              ) : (
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -1066,39 +1086,7 @@ export function ApplicationReviewPanel({
 
                       {/* 3. 國籍/身分 — #68 */}
                       <TableCell>
-                        {(() => {
-                          const sd =
-                            ((app as unknown) as {
-                              student_data?: {
-                                std_nation?: string | null;
-                                std_identity?: number | string | null;
-                              };
-                            })?.student_data ?? null;
-                          const idMap: Record<number | string, string> = {
-                            1: "本國生",
-                            2: "僑生",
-                            3: "外籍生",
-                            4: "陸生",
-                            5: "港澳生",
-                            6: "外籍交換生",
-                          };
-                          const idCode = sd?.std_identity;
-                          const idLabel =
-                            idCode != null && idCode !== ""
-                              ? idMap[idCode as keyof typeof idMap] ||
-                                `${locale === "zh" ? "身分別" : "Identity"} ${idCode}`
-                              : null;
-                          return (
-                            <div className="flex flex-col gap-0.5">
-                              <span className="text-sm">
-                                {sd?.std_nation || "-"}
-                              </span>
-                              <span className="text-xs text-muted-foreground">
-                                {idLabel || "-"}
-                              </span>
-                            </div>
-                          );
-                        })()}
+                        <NationalityIdentity app={app} locale={locale} />
                       </TableCell>
 
                       {/* 4. 在學學期數 */}
@@ -1131,56 +1119,11 @@ export function ApplicationReviewPanel({
 
                       {/* 6.5 教授推薦 */}
                       <TableCell>
-                        {app.professor_review_items && app.professor_review_items.length > 0 ? (
-                          <div className="flex flex-col gap-0.5">
-                            {app.professor_review_items.map(
-                              (
-                                item: {
-                                  sub_type_code: string;
-                                  recommendation: string;
-                                  comments?: string;
-                                },
-                                idx: number
-                              ) => (
-                              <TooltipProvider key={`${item.sub_type_code}-${idx}`}>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Badge
-                                      variant={item.recommendation === "approve" ? "outline" : "destructive"}
-                                      className={`text-xs cursor-default ${item.recommendation === "approve" ? "border-emerald-500 text-emerald-700 bg-emerald-50" : ""}`}
-                                    >
-                                      {getSubTypeName(item.sub_type_code, locale)}: {item.recommendation === "approve"
-                                        ? (locale === "zh" ? "推薦" : "Approve")
-                                        : (locale === "zh" ? "不推薦" : "Reject")}
-                                    </Badge>
-                                  </TooltipTrigger>
-                                  {item.comments && (
-                                    <TooltipContent>
-                                      {item.recommendation === "reject" && (
-                                        <p className="font-medium text-xs mb-1">
-                                          {locale === "zh" ? "不同意理由" : "Reason for Reject"}
-                                        </p>
-                                      )}
-                                      <p className="max-w-xs whitespace-pre-wrap">{item.comments}</p>
-                                    </TooltipContent>
-                                  )}
-                                </Tooltip>
-                              </TooltipProvider>
-                            ))}
-                          </div>
-                        ) : app.requires_professor_recommendation ? (
-                          // Professor step required but no recommendation yet —
-                          // show "教授審核中" instead of a blank cell so college
-                          // reviewers know the app is still awaiting the professor.
-                          <Badge
-                            variant="outline"
-                            className="text-xs cursor-default border-amber-500 text-amber-700 bg-amber-50"
-                          >
-                            {locale === "zh" ? "教授審核中" : "Under prof. review"}
-                          </Badge>
-                        ) : (
-                          <span className="text-sm text-muted-foreground">—</span>
-                        )}
+                        <ProfessorRecommendation
+                          app={app}
+                          locale={locale}
+                          getSubTypeName={getSubTypeName}
+                        />
                       </TableCell>
 
                       {/* 7. 狀態 */}
@@ -1199,18 +1142,7 @@ export function ApplicationReviewPanel({
                       </TableCell>
 
                       {/* 8. 申請時間 */}
-                      <TableCell>
-                        {app.created_at
-                          ? new Date(app.created_at).toLocaleDateString(
-                              "zh-TW",
-                              {
-                                year: "numeric",
-                                month: "2-digit",
-                                day: "2-digit",
-                              }
-                            )
-                          : "-"}
-                      </TableCell>
+                      <TableCell>{formatAppliedDate(app.created_at)}</TableCell>
 
                       {/* 9. 操作 */}
                       <TableCell>
@@ -1226,6 +1158,7 @@ export function ApplicationReviewPanel({
                   ))}
                 </TableBody>
               </Table>
+              )}
             </CardContent>
           </Card>
         </>

--- a/frontend/components/college/review/application-summary-fields.tsx
+++ b/frontend/components/college/review/application-summary-fields.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+/**
+ * Presentational fields shared by the college review 表格檢視 / 卡片檢視.
+ *
+ * Both views render the same application facts, so the non-trivial bits
+ * (SIS 身分別 decoding, 教授推薦 badges) live here to avoid drift.
+ */
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { Application } from "@/lib/api/types";
+
+type Locale = "zh" | "en";
+
+/** SIS 身分別代碼 → 中文標籤 (student_data.std_identity) */
+const IDENTITY_LABELS: Record<string, string> = {
+  "1": "本國生",
+  "2": "僑生",
+  "3": "外籍生",
+  "4": "陸生",
+  "5": "港澳生",
+  "6": "外籍交換生",
+};
+
+interface StudentIdentitySnapshot {
+  std_nation?: string | null;
+  std_identity?: number | string | null;
+}
+
+const identitySnapshot = (app: Application): StudentIdentitySnapshot =>
+  (app.student_data as StudentIdentitySnapshot | undefined) ?? {};
+
+export function getNationality(app: Application): string | null {
+  return identitySnapshot(app).std_nation || null;
+}
+
+export function getIdentityLabel(
+  app: Application,
+  locale: Locale
+): string | null {
+  const code = identitySnapshot(app).std_identity;
+  if (code === null || code === undefined || code === "") return null;
+  return (
+    IDENTITY_LABELS[String(code)] ||
+    `${locale === "zh" ? "身分別" : "Identity"} ${code}`
+  );
+}
+
+export function formatAppliedDate(createdAt?: string): string {
+  if (!createdAt) return "-";
+  return new Date(createdAt).toLocaleDateString("zh-TW", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+/** 國籍 / 身分別 */
+export function NationalityIdentity({
+  app,
+  locale,
+}: {
+  app: Application;
+  locale: Locale;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-sm">{getNationality(app) || "-"}</span>
+      <span className="text-xs text-muted-foreground">
+        {getIdentityLabel(app, locale) || "-"}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * 教授推薦徽章。無推薦紀錄但流程需要教授審核時顯示「教授審核中」，
+ * 讓學院端知道申請仍卡在教授關卡，而不是看到空白。
+ */
+export function ProfessorRecommendation({
+  app,
+  locale,
+  getSubTypeName,
+}: {
+  app: Application;
+  locale: Locale;
+  getSubTypeName: (subTypeCode: string | undefined, locale: Locale) => string;
+}) {
+  const items = app.professor_review_items;
+
+  if (!items || items.length === 0) {
+    if (app.requires_professor_recommendation) {
+      return (
+        <Badge
+          variant="outline"
+          className="text-xs cursor-default border-amber-500 text-amber-700 bg-amber-50"
+        >
+          {locale === "zh" ? "教授審核中" : "Under prof. review"}
+        </Badge>
+      );
+    }
+    return <span className="text-sm text-muted-foreground">—</span>;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      {items.map((item, idx) => {
+        const isApprove = item.recommendation === "approve";
+        return (
+          <TooltipProvider key={`${item.sub_type_code}-${idx}`}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge
+                  variant={isApprove ? "outline" : "destructive"}
+                  className={`text-xs cursor-default ${
+                    isApprove
+                      ? "border-emerald-500 text-emerald-700 bg-emerald-50"
+                      : ""
+                  }`}
+                >
+                  {getSubTypeName(item.sub_type_code, locale)}:{" "}
+                  {isApprove
+                    ? locale === "zh"
+                      ? "推薦"
+                      : "Approve"
+                    : locale === "zh"
+                      ? "不推薦"
+                      : "Reject"}
+                </Badge>
+              </TooltipTrigger>
+              {item.comments && (
+                <TooltipContent>
+                  {!isApprove && (
+                    <p className="font-medium text-xs mb-1">
+                      {locale === "zh" ? "不同意理由" : "Reason for Reject"}
+                    </p>
+                  )}
+                  <p className="max-w-xs whitespace-pre-wrap">
+                    {item.comments}
+                  </p>
+                </TooltipContent>
+              )}
+            </Tooltip>
+          </TooltipProvider>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/contexts/college-management-context.tsx
+++ b/frontend/contexts/college-management-context.tsx
@@ -188,8 +188,8 @@ export function CollegeManagementProvider({
     fetchCollegeApplications,
   } = useCollegeApplications();
 
-  // View state
-  const [viewMode, setViewMode] = useState<"card" | "table">("card");
+  // View state — 預設維持表格檢視（欄位最完整），卡片檢視為使用者主動切換
+  const [viewMode, setViewMode] = useState<"card" | "table">("table");
   const [selectedApplication, setSelectedApplication] = useState<Application | null>(null);
 
   // Tab management


### PR DESCRIPTION
## 問題

學院審核頁面右上角的「田字格 / 清單」兩顆按鈕看起來是檢視切換，但按了沒反應。

`ApplicationReviewPanel.tsx` 裡的 `viewMode` 只被拿來決定按鈕自己的 variant（哪一顆是藍底），完全沒有參與清單渲染 —— 申請清單永遠直接渲染 `<Table>`。所以點擊只會讓藍底在兩顆之間移動，下面的內容不變。

對照組：教授端 `reviewer-dashboard.tsx:502` 是有實作的（`viewMode === "card" ? renderCardView() : renderTableView()`）。

## 改動

**新增**
- `ApplicationCardView.tsx` — 卡片檢視本體。響應式網格（`md:2 / xl:3` 欄），欄位與表格一致：姓名+學號、狀態徽章、學院·系所、獎學金類型+初領/續領、國籍/身分、在學學期數、在學狀態、教授推薦徽章（含 tooltip 不同意理由）、申請時間、檢視按鈕。空清單顯示「沒有符合條件的申請」。
- `application-summary-fields.tsx` — 兩種檢視共用的欄位元件（`NationalityIdentity`、`ProfessorRecommendation`、`formatAppliedDate`）。原本 SIS 身分別解碼與教授推薦徽章寫死在 table cell 裡，抽出來避免兩邊實作漂移。

**修改**
- `ApplicationReviewPanel.tsx` — 接上 `viewMode === "card" ? <ApplicationCardView/> : <Table/>`；三個 cell 改用共用元件（淨 -67 行）；切換鈕補上 `title` / `aria-label` / `aria-pressed`，hover 會顯示「卡片檢視」「表格檢視」。
- `college-management-context.tsx` — `viewMode` 預設值 `"card"` → `"table"`。原本預設是 card 但畫面永遠渲染表格；改成 table，現有使用者一進來版面不變，要卡片自己按。

## 測試

localhost dev env，`cs_college` / 博士生獎學金 114 全年：

- [x] `bunx tsc --noEmit` 無錯
- [x] `bunx eslint` 四個檔案無警告
- [x] 切到卡片檢視：兩筆申請正確渲染，推薦/不推薦徽章顏色與表格一致
- [x] 切回表格檢視：欄位與重構前完全相同（國籍/身分、教授推薦、申請時間）
- [x] 卡片的「檢視」開啟同一個 `學院審核 - APP-114-0-00001` dialog（含審核操作分頁）
- [x] frontend 容器無編譯錯誤，無新增 console error

沒有後端改動，沒有 API/schema 變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BreALouAZT3TFAR4XtGrpS