### PR TITLE
fix(production-workflows): repair unrunnable templates; promote upstream images instead of rebuilding

### DIFF
--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -141,31 +141,48 @@ cp /path/to/development-repo/.github/production-workflows-examples/backup.yml \
 
 在 production repository 設定以下 secrets（Settings → Secrets and variables → Actions）：
 
+> 沒有任何 workflow 使用 SSH。deploy.yml / backup.yml / health-check.yml 都跑在
+> production AP VM 上的 self-hosted runner（labels `[self-hosted, linux]`），
+> 直接操作本機 docker 與 DB VM 的 5432 埠。GitHub-hosted runner 連不到校內 VM。
+
 #### 部署相關 (deploy.yml)
 
-| Secret Name | Description | Example |
-|-------------|-------------|---------|
-| `DOCKER_USERNAME` | Docker Hub 用戶名 | `your-username` |
-| `DOCKER_PASSWORD` | Docker Hub 密碼或 token | `dckr_pat_xxxxx` |
-| `PRODUCTION_SSH_KEY` | SSH private key for server | `-----BEGIN OPENSSH PRIVATE KEY-----` |
-| `PRODUCTION_SERVER` | Production server hostname | `production.example.com` |
-| `PRODUCTION_USER` | SSH username | `ubuntu` or `deploy` |
-
-#### 備份相關 (backup.yml)
+映像檔推送到 GHCR，使用內建的 `GITHUB_TOKEN`，不需要 Docker Hub 帳密。
+完整清單見 `deploy.yml` 的 `validate-secrets` job 與 `deploy` job 的 `env:` 區塊：
 
 | Secret Name | Description | Example |
 |-------------|-------------|---------|
-| `AWS_ACCESS_KEY_ID` | AWS access key | `AKIAIOSFODNN7EXAMPLE` |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret key | `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` |
-| `AWS_REGION` | AWS region (optional) | `us-east-1` |
-| `BACKUP_S3_BUCKET` | S3 bucket name | `production-backups` |
+| `DOMAIN` | 對外網域 | `ss.aa.nycu.edu.tw` |
+| `SECRET_KEY` | JWT signing key（≥ 32 字元，且必須與 staging 不同） | `openssl rand -hex 32` |
+| `CORS_ORIGINS` | 允許的前端來源 | `https://ss.aa.nycu.edu.tw` |
+| `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` / `DB_NAME` | DB VM 的 PostgreSQL 連線資訊 | `10.x.x.x` / `5432` / … |
+| `REDIS_PASSWORD` | Redis 密碼（prod compose 強制要求） | `openssl rand -base64 24` |
+| `MINIO_HOST` / `MINIO_PORT` / `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` / `MINIO_BUCKET_NAME` / `MINIO_SECURE` | 物件儲存 | `10.x.x.x` / `9000` / … |
+| `PII_ENCRYPTION_KEYS` / `PII_ENCRYPTION_ACTIVE_VERSION` | PII 加密金鑰 JSON | `{"v1":"<key>"}` / `v1` |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASSWORD` | 寄信設定 | `smtp-prod2.nycu.edu.tw` / `587` |
+| `EMAIL_FROM` / `EMAIL_FROM_NAME` | 寄件者（不可含 `ss-test` 或 `測試`） | `noreply@aa.nycu.edu.tw` |
+| `PORTAL_JWT_SERVER_URL` | Portal SSO（不可指向 `portal.test`） | `https://portal.nycu.edu.tw/jwt/portal` |
+| `NEXT_PUBLIC_NYCU_PORTAL_URL` | 前端 Portal 連結 | `https://portal.nycu.edu.tw` |
+| `STUDENT_API_BASE_URL` | 學籍 API（不可是 localhost/mock） | `http://<ip>/api/SoAA` |
+| `SUPER_ADMIN_NYCU_ID` | 可升級為 super_admin 的職編 | `E00001` |
 
-#### 通知相關 (health-check.yml, optional)
+另需 repository variable `PRODUCTION_URL`（例：`https://ss.aa.nycu.edu.tw`）。
+
+#### 環境建置相關 (setting-env.yml)
 
 | Secret Name | Description |
 |-------------|-------------|
-| `SLACK_WEBHOOK_URL` | Slack incoming webhook URL |
-| `DISCORD_WEBHOOK_URL` | Discord webhook URL |
+| `DB_VM_USER` / `DB_VM_SSH_KEY` / `DB_VM_SSH_PORT` | 從 AP VM 佈署 DB VM 用（僅此 workflow 需要） |
+
+#### 備份相關 (backup.yml)
+
+不需要額外 secrets——直接重用上面的 `DB_HOST` / `DB_PORT` / `DB_USER` /
+`DB_PASSWORD` / `DB_NAME`。備份檔留在 AP VM 的 `/var/backups/scholarship-system`
+供 IT 轉存（DB VM 無對外網路）。
+
+#### 健康檢查 (health-check.yml)
+
+重用 `DOMAIN` 與 `REDIS_PASSWORD`；失敗時自動開 issue，恢復後自動關閉。
 
 ### 3. 自訂配置
 
@@ -207,27 +224,23 @@ CUTOFF_DATE=$(date -d '90 days ago' +%Y%m%d)  # 改為 90 天
 
 ## 🔐 安全最佳實踐
 
-### SSH Key 設定
+### Self-hosted Runner
+
+部署與維運 workflow 都跑在 AP VM 上的 self-hosted runner，不使用 SSH 金鑰。
+安裝方式見安裝手冊第 6 節；註冊時 labels 需包含 `self-hosted` 與 `linux`，
+並以 service 方式常駐：
 
 ```bash
-# Generate SSH key pair (on your local machine)
-ssh-keygen -t ed25519 -C "github-actions-deploy" -f ~/.ssh/production_deploy
-
-# Add public key to production server
-ssh-copy-id -i ~/.ssh/production_deploy.pub user@production-server
-
-# Copy private key content (including BEGIN/END lines)
-cat ~/.ssh/production_deploy
-# Add to GitHub Secrets as PRODUCTION_SSH_KEY
+sudo ./svc.sh install
+sudo ./svc.sh start
 ```
 
-### Docker Hub Token
+runner 使用者需要 passwordless sudo（deploy.yml 與 backup.yml 都會用到）。
 
-建議使用 access token 而非密碼：
+### Container Registry
 
-1. Docker Hub → Account Settings → Security → Access Tokens
-2. Create new token with name "GitHub Actions"
-3. Copy token and add to secrets as `DOCKER_PASSWORD`
+映像檔推到 GHCR，登入使用 workflow 內建的 `GITHUB_TOKEN`，
+不需要 Docker Hub 帳號或額外 token。
 
 ### AWS IAM 權限
 

--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -145,10 +145,22 @@ cp /path/to/development-repo/.github/production-workflows-examples/backup.yml \
 > production AP VM 上的 self-hosted runner（labels `[self-hosted, linux]`），
 > 直接操作本機 docker 與 DB VM 的 5432 埠。GitHub-hosted runner 連不到校內 VM。
 
+#### Repository Variables（Settings → Variables → Actions）
+
+| Variable | 必填 | 說明 |
+|----------|------|------|
+| `IMAGE_OWNER` | ✅ | 發布映像檔的 GHCR namespace，也就是**開發 repo 的 owner**（例：`anud18`）。production repo 不建置映像檔，只取用開發流程已經發布、staging 驗過的那一份。 |
+| `PRODUCTION_URL` | ✅ | 例：`https://ss.aa.nycu.edu.tw` |
+| `ENV_FILE` | — | AP VM 上既有 `.env` 的絕對路徑（安裝手冊 5.1，例：`/home/<user>/.env`）。**設了就用它**，GitHub 完全不存這些值。留空則由 deploy.yml 依下方 secrets 產生 `~/scholarship-production/.env`（權限 600）。 |
+| `SSL_CERT_DIR` | — | TLS 憑證資料夾的絕對路徑（例：`/home/<user>/ssl`）。留空則用 repo `nginx/ssl/prod`。兩種 `ENV_FILE` 模式下都以這個變數優先。資料夾內需有 `fullchain.pem`、`privkey.pem`、`chain.pem`。 |
+
 #### 部署相關 (deploy.yml)
 
-映像檔推送到 GHCR，使用內建的 `GITHUB_TOKEN`，不需要 Docker Hub 帳密。
-完整清單見 `deploy.yml` 的 `validate-secrets` job 與 `deploy` job 的 `env:` 區塊：
+**設了 `ENV_FILE` 就不需要下面這些 secrets** — 值放在 AP VM 的 `.env` 裡，
+deploy 時會直接驗證該檔案（缺 key、`portal.test`、`ss-test`、`測試` 等都會擋下）。
+
+留空 `ENV_FILE` 時才需要設定以下 secrets（會被寫成 AP VM 上的 `.env`）。
+另外若上游 packages 是 private，需要 `GH_PAT`（`read:packages`）才能 pull：
 
 | Secret Name | Description | Example |
 |-------------|-------------|---------|
@@ -166,7 +178,15 @@ cp /path/to/development-repo/.github/production-workflows-examples/backup.yml \
 | `STUDENT_API_BASE_URL` | 學籍 API（不可是 localhost/mock） | `http://<ip>/api/SoAA` |
 | `SUPER_ADMIN_NYCU_ID` | 可升級為 super_admin 的職編 | `E00001` |
 
-另需 repository variable `PRODUCTION_URL`（例：`https://ss.aa.nycu.edu.tw`）。
+### Container Registry / 映像檔來源
+
+production repo **不建置也不推送映像檔**。開發 repo 的 pipeline 建好推到 GHCR，
+production 只是把同一份 artifact 拉下來跑，確保上線的東西跟 staging 驗過的是
+同一個 image，而不是從 mirror 過來的原始碼重新 build 出的另一份。
+
+部署指定版本：`Deploy to Production` → Run workflow → 填 `tag`
+（例：`main-2c2b89d6` 或 `v1.2.3`）。不填預設 `latest`；`latest` 會浮動，
+無法回滾，正式上線請指定明確 tag。
 
 #### 環境建置相關 (setting-env.yml)
 

--- a/.github/production-workflows-examples/backup.yml
+++ b/.github/production-workflows-examples/backup.yml
@@ -1,16 +1,35 @@
-# Example Production Backup Workflow
-# Copy this file to your production repository at: .github/workflows/backup.yml
+# Production Backup Workflow
+# Copy this file to the PRIVATE production repository at .github/workflows/backup.yml
 #
-# NOTE: This workflow creates backups on the production server.
-# Database VM does NOT have internet access, so backups are stored locally
-# for IT staff to transfer to external storage.
+# Rewritten for the real two-VM production topology and the self-hosted runner.
+# The previous version could not work as written:
+#   - `runs-on: ubuntu-latest` + `ssh $PRODUCTION_USER@$PRODUCTION_SERVER`:
+#     GitHub-hosted runners cannot route to the campus VMs (the same constraint
+#     that forced deploy.yml onto a self-hosted runner).
+#   - `docker compose exec -T postgres pg_dump` assumed PostgreSQL sits next to
+#     the app. It does not — the AP VM runs app+nginx+redis, while PostgreSQL
+#     and object storage live on the DB VM. There is no `postgres` container to
+#     exec into on the runner host.
+#   - Three quoted-heredoc bodies were written at column 0, which terminated
+#     the enclosing `run: |` block scalar and made the whole file unparseable,
+#     so GitHub rejected it on every push.
+#
+# Now: the job runs ON the AP VM and reaches PostgreSQL over TCP with the same
+# DB_* secrets deploy.yml already uses. No SSH, no PRODUCTION_SSH_KEY.
+#
+# The DB VM has no internet access, so backups stay on disk for IT to collect —
+# see the manifest written by the verify job.
+#
+# Prerequisites:
+#   - Self-hosted runner on the production AP VM, labels [self-hosted, linux].
+#   - Secrets: DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME.
+#   - Passwordless sudo for the runner user (already required by deploy.yml).
 
 name: Backup Production Data
 
 on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC
-    - cron: '0 */6 * * *'  # Every 6 hours (for more frequent backups)
   workflow_dispatch:
     inputs:
       backup_type:
@@ -29,163 +48,99 @@ on:
         default: 7
 
 env:
-  # Backup directory on production server (must exist and be writable)
   BACKUP_DIR: /var/backups/scholarship-system
-  RETENTION_DAYS: 7  # Keep backups for 7 days on server
+  RETENTION_DAYS: 7
+  # Must match the server major version or pg_dump refuses to run.
+  PG_IMAGE: postgres:15-alpine
 
 jobs:
   backup-database:
     name: Backup PostgreSQL Database
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.backup_type == 'full' ||
       github.event.inputs.backup_type == 'database-only'
 
     steps:
-      - name: Create database backup on server
+      - name: Create database backup
         id: db-backup
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
-          RETENTION: ${{ github.event.inputs.retention_days || env.RETENTION_DAYS }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
         run: |
-          BACKUP_TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          set -euo pipefail
           BACKUP_DATE=$(date +%Y%m%d)
-          BACKUP_FILE="database-backup-${BACKUP_TIMESTAMP}.sql.gz"
+          BACKUP_FILE="database-backup-$(date +%Y%m%d-%H%M%S).sql.gz"
+          DEST="${BACKUP_DIR}/database/${BACKUP_DATE}"
 
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          sudo mkdir -p "$DEST"
+          sudo chown -R "$(id -u):$(id -g)" "${BACKUP_DIR}"
+          chmod 750 "${BACKUP_DIR}"
 
-          # Create backup directory structure on server
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << ENDSSH
-            # Ensure backup directory exists
-            sudo mkdir -p ${BACKUP_DIR}/database/${BACKUP_DATE}
-            sudo chown -R $SERVER_USER:$SERVER_USER ${BACKUP_DIR}
-            chmod 750 ${BACKUP_DIR}
+          echo "📁 Backup directory: $DEST"
+          echo "🗄️  Dumping ${DB_NAME} from ${DB_HOST}:${DB_PORT}"
 
-            echo "📁 Backup directory: ${BACKUP_DIR}/database/${BACKUP_DATE}"
+          # pg_dump runs in a throwaway container so the AP VM needs no
+          # postgresql-client package. `set -o pipefail` above means a failed
+          # dump fails the step instead of leaving a truncated .gz behind.
+          docker run --rm -e PGPASSWORD="$DB_PASSWORD" "$PG_IMAGE" \
+            pg_dump -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+                    --no-owner --no-acl \
+            | gzip > "${DEST}/${BACKUP_FILE}"
 
-            # Create database backup
-            cd /opt/scholarship-system
-            docker compose exec -T postgres pg_dump \
-              -U scholarship_user \
-              -d scholarship_db \
-              --format=custom \
-              --compress=9 \
-              | gzip > ${BACKUP_DIR}/database/${BACKUP_DATE}/${BACKUP_FILE}
+          BACKUP_SIZE=$(du -h "${DEST}/${BACKUP_FILE}" | cut -f1)
+          echo "✅ Database backup created (${BACKUP_SIZE})"
+          echo "📍 Location: ${DEST}/${BACKUP_FILE}"
+          chmod 640 "${DEST}/${BACKUP_FILE}"
 
-            # Verify backup was created
-            if [ -f ${BACKUP_DIR}/database/${BACKUP_DATE}/${BACKUP_FILE} ]; then
-              BACKUP_SIZE=\$(du -h ${BACKUP_DIR}/database/${BACKUP_DATE}/${BACKUP_FILE} | cut -f1)
-              echo "✅ Database backup created: ${BACKUP_FILE} (\${BACKUP_SIZE})"
-              echo "📍 Location: ${BACKUP_DIR}/database/${BACKUP_DATE}/${BACKUP_FILE}"
+          ( cd "$DEST" && sha256sum "${BACKUP_FILE}" > "${BACKUP_FILE}.sha256" )
+          echo "🔒 Checksum written"
 
-              # Set permissions for IT access
-              chmod 640 ${BACKUP_DIR}/database/${BACKUP_DATE}/${BACKUP_FILE}
-            else
-              echo "::error::Failed to create database backup"
-              exit 1
-            fi
+          echo "backup_file=${BACKUP_FILE}" >> "$GITHUB_OUTPUT"
+          echo "backup_dest=${DEST}" >> "$GITHUB_OUTPUT"
+          echo "backup_size=${BACKUP_SIZE}" >> "$GITHUB_OUTPUT"
 
-            # Create checksum for integrity verification
-            cd ${BACKUP_DIR}/database/${BACKUP_DATE}
-            sha256sum ${BACKUP_FILE} > ${BACKUP_FILE}.sha256
-            echo "🔐 Checksum created"
-          ENDSSH
-
-          echo "backup_file=${BACKUP_FILE}" >> $GITHUB_OUTPUT
-          echo "backup_date=${BACKUP_DATE}" >> $GITHUB_OUTPUT
-
-      - name: Cleanup old backups on server
+      - name: Verify backup integrity
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
+          DEST: ${{ steps.db-backup.outputs.backup_dest }}
+          BACKUP_FILE: ${{ steps.db-backup.outputs.backup_file }}
+        run: |
+          set -euo pipefail
+          cd "$DEST"
+          sha256sum -c "${BACKUP_FILE}.sha256"
+          echo "✅ Checksum verified"
+
+          # A gzip stream that decompresses cleanly and still carries the
+          # pg_dump header is the cheapest proof the dump is not truncated.
+          gunzip -t "${BACKUP_FILE}"
+
+          # Read the header via command substitution, NOT `gunzip | head | grep`:
+          # `head` exits after 20 lines, `gunzip` dies of SIGPIPE (141), and
+          # `set -o pipefail` then fails the step on a perfectly good backup.
+          HEADER=$(gunzip -c "${BACKUP_FILE}" 2>/dev/null | head -20 || true)
+          case "$HEADER" in
+            *"PostgreSQL database dump"*) ;;
+            *) echo "::error::Backup does not look like pg_dump output"; exit 1 ;;
+          esac
+          echo "✅ Backup content verified"
+
+      - name: Cleanup old database backups
+        env:
           RETENTION: ${{ github.event.inputs.retention_days || env.RETENTION_DAYS }}
         run: |
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << ENDSSH
-            # Calculate cutoff date
-            CUTOFF_DATE=\$(date -d "${RETENTION} days ago" +%Y%m%d)
-            echo "🗑️  Cleaning up backups older than \${CUTOFF_DATE}"
-
-            # Find and delete old backup directories
-            cd ${BACKUP_DIR}/database
-            for dir in */; do
-              dir_date=\${dir%/}  # Remove trailing slash
-              if [ "\$dir_date" -lt "\$CUTOFF_DATE" ] 2>/dev/null; then
-                echo "Deleting old backup: \$dir_date"
-                rm -rf "\$dir_date"
-              fi
-            done
-
-            echo "✅ Cleanup completed"
-          ENDSSH
-
-      - name: Test backup integrity
-        id: integrity-check
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
-        run: |
-          BACKUP_FILE="${{ steps.db-backup.outputs.backup_file }}"
-          BACKUP_DATE="${{ steps.db-backup.outputs.backup_date }}"
-
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << ENDSSH
-            cd /opt/scholarship-system
-
-            # Verify checksum
-            cd ${BACKUP_DIR}/database/${BACKUP_DATE}
-            if sha256sum -c ${BACKUP_FILE}.sha256; then
-              echo "✅ Checksum verification passed"
-            else
-              echo "::error::Checksum verification failed"
-              exit 1
-            fi
-
-            # Test backup can be restored (to temporary database)
-            docker compose exec -T postgres psql -U scholarship_user -d postgres << 'EOSQL'
-              DROP DATABASE IF EXISTS backup_test;
-              CREATE DATABASE backup_test;
-          EOSQL
-
-            # Decompress and restore backup
-            gunzip -c ${BACKUP_DIR}/database/${BACKUP_DATE}/${BACKUP_FILE} | \
-              docker compose exec -T postgres pg_restore \
-                -U scholarship_user \
-                -d backup_test \
-                --no-owner \
-                2>&1 | head -20
-
-            # Verify tables exist
-            TABLE_COUNT=\$(docker compose exec -T postgres psql \
-              -U scholarship_user \
-              -d backup_test \
-              -t -c "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public';" | tr -d ' ')
-
-            echo "Tables in restored backup: \$TABLE_COUNT"
-
-            if [ "\$TABLE_COUNT" -gt 0 ]; then
-              echo "✅ Backup integrity verified (\$TABLE_COUNT tables)"
-            else
-              echo "::error::Backup integrity check failed (no tables found)"
-              exit 1
-            fi
-
-            # Cleanup test database
-            docker compose exec -T postgres psql -U scholarship_user -d postgres \
-              -c "DROP DATABASE backup_test;"
-
-            echo "success=true" >> $GITHUB_OUTPUT
-          ENDSSH
+          set -euo pipefail
+          cd "${BACKUP_DIR}/database"
+          echo "🧹 Removing database backups older than ${RETENTION} days"
+          find . -mindepth 1 -maxdepth 1 -type d -mtime "+${RETENTION}" -print -exec rm -rf {} +
+          echo "Remaining: $(find . -mindepth 1 -maxdepth 1 -type d | wc -l) daily directories"
 
   backup-files:
     name: Backup Application Files
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.backup_type == 'full' ||
@@ -193,333 +148,175 @@ jobs:
 
     steps:
       - name: Backup uploaded files and configs
-        id: files-backup
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
         run: |
-          BACKUP_TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          set -euo pipefail
+          # Resolved here, not in `env:` — workflow env values are literal
+          # strings, so a `$HOME/...` default would never be expanded.
+          DEPLOY_DIR="$HOME/scholarship-production"
           BACKUP_DATE=$(date +%Y%m%d)
-          BACKUP_FILE="files-backup-${BACKUP_TIMESTAMP}.tar.gz"
+          BACKUP_FILE="files-backup-$(date +%Y%m%d-%H%M%S).tar.gz"
+          DEST="${BACKUP_DIR}/files/${BACKUP_DATE}"
 
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          sudo mkdir -p "$DEST"
+          sudo chown -R "$(id -u):$(id -g)" "${BACKUP_DIR}"
+          chmod 750 "${BACKUP_DIR}"
 
-          # Create files backup on server
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << ENDSSH
-            # Ensure backup directory exists
-            sudo mkdir -p ${BACKUP_DIR}/files/${BACKUP_DATE}
-            sudo chown -R $SERVER_USER:$SERVER_USER ${BACKUP_DIR}
-            chmod 750 ${BACKUP_DIR}
+          # Only AP-VM state is in scope here: locally stored uploads plus the
+          # deployment config. Documents in object storage live on the DB VM
+          # and are covered by that VM's own storage backup.
+          echo "📦 Archiving deployment state from ${DEPLOY_DIR}"
+          tar -czf "${DEST}/${BACKUP_FILE}" \
+            -C "${DEPLOY_DIR}" \
+            backend/uploads nginx docker-compose.yml
 
-            cd /opt/scholarship-system
+          BACKUP_SIZE=$(du -h "${DEST}/${BACKUP_FILE}" | cut -f1)
+          echo "✅ File backup created (${BACKUP_SIZE})"
+          chmod 640 "${DEST}/${BACKUP_FILE}"
 
-            # Backup uploaded files, configs, and important data
-            tar -czf ${BACKUP_DIR}/files/${BACKUP_DATE}/${BACKUP_FILE} \
-              backend/uploads/ \
-              docker-compose.yml \
-              .env \
-              2>/dev/null || true
-
-            # Verify backup was created
-            if [ -f ${BACKUP_DIR}/files/${BACKUP_DATE}/${BACKUP_FILE} ]; then
-              BACKUP_SIZE=\$(du -h ${BACKUP_DIR}/files/${BACKUP_DATE}/${BACKUP_FILE} | cut -f1)
-              echo "✅ Files backup created: ${BACKUP_FILE} (\${BACKUP_SIZE})"
-              echo "📍 Location: ${BACKUP_DIR}/files/${BACKUP_DATE}/${BACKUP_FILE}"
-
-              # Set permissions for IT access
-              chmod 640 ${BACKUP_DIR}/files/${BACKUP_DATE}/${BACKUP_FILE}
-
-              # Create checksum
-              cd ${BACKUP_DIR}/files/${BACKUP_DATE}
-              sha256sum ${BACKUP_FILE} > ${BACKUP_FILE}.sha256
-              echo "🔐 Checksum created"
-            else
-              echo "::error::Failed to create files backup"
-              exit 1
-            fi
-          ENDSSH
-
-          echo "backup_file=${BACKUP_FILE}" >> $GITHUB_OUTPUT
-          echo "backup_date=${BACKUP_DATE}" >> $GITHUB_OUTPUT
+          ( cd "$DEST" && sha256sum "${BACKUP_FILE}" > "${BACKUP_FILE}.sha256" )
+          echo "🔒 Checksum written"
 
       - name: Cleanup old file backups
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
           RETENTION: ${{ github.event.inputs.retention_days || env.RETENTION_DAYS }}
         run: |
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << ENDSSH
-            # Calculate cutoff date
-            CUTOFF_DATE=\$(date -d "${RETENTION} days ago" +%Y%m%d)
-            echo "🗑️  Cleaning up file backups older than \${CUTOFF_DATE}"
-
-            # Find and delete old backup directories
-            cd ${BACKUP_DIR}/files
-            for dir in */; do
-              dir_date=\${dir%/}
-              if [ "\$dir_date" -lt "\$CUTOFF_DATE" ] 2>/dev/null; then
-                echo "Deleting old backup: \$dir_date"
-                rm -rf "\$dir_date"
-              fi
-            done
-
-            echo "✅ Cleanup completed"
-          ENDSSH
+          set -euo pipefail
+          cd "${BACKUP_DIR}/files"
+          echo "🧹 Removing file backups older than ${RETENTION} days"
+          find . -mindepth 1 -maxdepth 1 -type d -mtime "+${RETENTION}" -print -exec rm -rf {} +
+          echo "Remaining: $(find . -mindepth 1 -maxdepth 1 -type d | wc -l) daily directories"
 
   verify-backups:
     name: Verify & Report Backups
+    runs-on: [self-hosted, linux]
     needs: [backup-database, backup-files]
     if: always()
-    runs-on: ubuntu-latest
 
     steps:
-      - name: List and verify backups on server
-        id: list-backups
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
+      - name: List and verify backups
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
+          set -uo pipefail
+          echo "=========================================="
+          echo "📊 Backup Status Report"
+          echo "=========================================="
+          echo "📍 Location: ${BACKUP_DIR}"
+          echo ""
 
-          # List backups and calculate sizes
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << 'ENDSSH'
-            echo "📦 Backup Inventory"
-            echo "===================="
-            echo ""
-            echo "📍 Location: ${BACKUP_DIR}"
-            echo ""
-
-            # Database backups
-            echo "🗄️  Database Backups:"
-            if [ -d "${BACKUP_DIR}/database" ]; then
-              cd ${BACKUP_DIR}/database
-              for dir in */; do
-                if [ -d "$dir" ]; then
-                  echo "  📅 ${dir%/}:"
-                  find "$dir" -type f -name "*.sql.gz" -exec du -h {} \; | \
-                    sed 's/^/    /'
-                fi
-              done
-              TOTAL_DB_SIZE=$(du -sh . 2>/dev/null | cut -f1)
-              echo ""
-              echo "  Total database backups size: ${TOTAL_DB_SIZE}"
+          for kind in database files; do
+            echo "🗄️  ${kind} backups:"
+            if [ -d "${BACKUP_DIR}/${kind}" ]; then
+              ( cd "${BACKUP_DIR}/${kind}" && du -sh ./* 2>/dev/null ) || echo "  (empty)"
             else
-              echo "  No database backups found"
+              echo "  No ${kind} backups found"
             fi
-
             echo ""
-            echo "📁 File Backups:"
-            if [ -d "${BACKUP_DIR}/files" ]; then
-              cd ${BACKUP_DIR}/files
-              for dir in */; do
-                if [ -d "$dir" ]; then
-                  echo "  📅 ${dir%/}:"
-                  find "$dir" -type f -name "*.tar.gz" -exec du -h {} \; | \
-                    sed 's/^/    /'
-                fi
-              done
-              TOTAL_FILES_SIZE=$(du -sh . 2>/dev/null | cut -f1)
-              echo ""
-              echo "  Total file backups size: ${TOTAL_FILES_SIZE}"
-            else
-              echo "  No file backups found"
-            fi
+          done
 
-            echo ""
-            echo "💾 Total Backup Storage:"
-            du -sh ${BACKUP_DIR} 2>/dev/null || echo "  Unable to calculate"
-          ENDSSH
+          echo "💾 Total backup storage:"
+          du -sh "${BACKUP_DIR}" 2>/dev/null || echo "  Unable to calculate"
 
       - name: Generate backup manifest for IT
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
         run: |
+          set -euo pipefail
           TODAY=$(date +%Y%m%d)
+          MANIFEST_FILE="${BACKUP_DIR}/backup-manifest-${TODAY}.txt"
+          GENERATED=$(date '+%Y-%m-%d %H:%M:%S %Z')
 
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << ENDSSH
-            # Create manifest file for IT to reference
-            MANIFEST_FILE="${BACKUP_DIR}/backup-manifest-${TODAY}.txt"
+          # Built from `echo` blocks rather than heredocs on purpose: a
+          # heredoc body has to sit flush-left to land unindented in the
+          # output file, and flush-left text terminates the enclosing YAML
+          # block scalar — which is exactly what made this workflow
+          # unparseable before. echo blocks keep the YAML valid.
+          {
+            echo "===================================================================="
+            echo "Scholarship System - Backup Manifest"
+            echo "Generated: ${GENERATED}"
+            echo "===================================================================="
+            echo ""
+            echo "BACKUP LOCATION: ${BACKUP_DIR}"
+            echo ""
+            echo "ACTION REQUIRED BY IT:"
+            echo "These backups are stored on the production AP VM and should be"
+            echo "transferred to external backup storage according to the backup"
+            echo "policy. The DB VM has no internet access."
+            echo ""
+            echo "===================================================================="
+            echo "DATABASE BACKUPS"
+            echo "===================================================================="
+            echo ""
+          } > "${MANIFEST_FILE}"
 
-            cat > "\${MANIFEST_FILE}" <<'MANIFEST'
-====================================================================
-Scholarship System - Backup Manifest
-Generated: $(date '+%Y-%m-%d %H:%M:%S %Z')
-====================================================================
-
-BACKUP LOCATION: ${BACKUP_DIR}
-
-⚠️  ACTION REQUIRED BY IT:
-   These backups are stored on the production server and should be
-   transferred to external backup storage according to the backup policy.
-
-====================================================================
-DATABASE BACKUPS
-====================================================================
-
-MANIFEST
-
-            # List database backups
-            if [ -d "${BACKUP_DIR}/database" ]; then
-              cd ${BACKUP_DIR}/database
+          if [ -d "${BACKUP_DIR}/database" ]; then
+            ( cd "${BACKUP_DIR}/database"
               for dir in */; do
-                if [ -d "\$dir" ]; then
-                  echo "Date: \${dir%/}" >> "\${MANIFEST_FILE}"
-                  find "\$dir" -type f \( -name "*.sql.gz" -o -name "*.sha256" \) \
-                    -exec ls -lh {} \; | \
-                    awk '{printf "  - %s %s %s (%s)\n", \$9, \$6, \$7, \$5}' >> "\${MANIFEST_FILE}"
-                  echo "" >> "\${MANIFEST_FILE}"
-                fi
-              done
-            fi
+                [ -d "$dir" ] || continue
+                echo "Date: ${dir%/}" >> "${MANIFEST_FILE}"
+                find "$dir" -type f \( -name '*.sql.gz' -o -name '*.sha256' \) \
+                  -printf '  - %p  %TY-%Tm-%Td  %s bytes\n' >> "${MANIFEST_FILE}"
+                echo "" >> "${MANIFEST_FILE}"
+              done )
+          fi
 
-            cat >> "\${MANIFEST_FILE}" <<'MANIFEST'
-====================================================================
-FILE BACKUPS
-====================================================================
+          {
+            echo "===================================================================="
+            echo "FILE BACKUPS"
+            echo "===================================================================="
+            echo ""
+          } >> "${MANIFEST_FILE}"
 
-MANIFEST
-
-            # List file backups
-            if [ -d "${BACKUP_DIR}/files" ]; then
-              cd ${BACKUP_DIR}/files
+          if [ -d "${BACKUP_DIR}/files" ]; then
+            ( cd "${BACKUP_DIR}/files"
               for dir in */; do
-                if [ -d "\$dir" ]; then
-                  echo "Date: \${dir%/}" >> "\${MANIFEST_FILE}"
-                  find "\$dir" -type f \( -name "*.tar.gz" -o -name "*.sha256" \) \
-                    -exec ls -lh {} \; | \
-                    awk '{printf "  - %s %s %s (%s)\n", \$9, \$6, \$7, \$5}' >> "\${MANIFEST_FILE}"
-                  echo "" >> "\${MANIFEST_FILE}"
-                fi
-              done
-            fi
+                [ -d "$dir" ] || continue
+                echo "Date: ${dir%/}" >> "${MANIFEST_FILE}"
+                find "$dir" -type f \( -name '*.tar.gz' -o -name '*.sha256' \) \
+                  -printf '  - %p  %TY-%Tm-%Td  %s bytes\n' >> "${MANIFEST_FILE}"
+                echo "" >> "${MANIFEST_FILE}"
+              done )
+          fi
 
-            cat >> "\${MANIFEST_FILE}" <<'MANIFEST'
-====================================================================
-CHECKSUM VERIFICATION
-====================================================================
+          {
+            echo "===================================================================="
+            echo "CHECKSUM VERIFICATION"
+            echo "===================================================================="
+            echo ""
+            echo "To verify backup integrity before transfer:"
+            echo ""
+            echo "  cd ${BACKUP_DIR}/database/YYYYMMDD"
+            echo "  sha256sum -c database-backup-*.sha256"
+            echo ""
+            echo "  cd ${BACKUP_DIR}/files/YYYYMMDD"
+            echo "  sha256sum -c files-backup-*.sha256"
+            echo ""
+            echo "===================================================================="
+            echo "TRANSFER INSTRUCTIONS FOR IT"
+            echo "===================================================================="
+            echo ""
+            echo "1. Verify checksums before transfer"
+            echo "2. Transfer entire daily directories to backup storage"
+            echo "3. Verify transfer completion"
+            echo "4. Files are kept on the AP VM for ${RETENTION_DAYS} days"
+            echo "5. After successful external backup, old files are auto-cleaned"
+            echo ""
+            echo "===================================================================="
+          } >> "${MANIFEST_FILE}"
 
-To verify backup integrity before transfer:
-
-  cd ${BACKUP_DIR}/database/YYYYMMDD
-  sha256sum -c database-backup-*.sha256
-
-  cd ${BACKUP_DIR}/files/YYYYMMDD
-  sha256sum -c files-backup-*.sha256
-
-====================================================================
-TRANSFER INSTRUCTIONS FOR IT
-====================================================================
-
-1. Verify checksums before transfer
-2. Transfer entire daily directories to backup storage
-3. Verify transfer completion
-4. Files are kept on server for ${RETENTION_DAYS} days
-5. After successful external backup, old files are auto-cleaned
-
-====================================================================
-MANIFEST
-
-            chmod 644 "\${MANIFEST_FILE}"
-            echo "✅ Manifest created: \${MANIFEST_FILE}"
-
-            # Display manifest
-            cat "\${MANIFEST_FILE}"
-          ENDSSH
+          chmod 644 "${MANIFEST_FILE}"
+          echo "✅ Manifest created: ${MANIFEST_FILE}"
+          cat "${MANIFEST_FILE}"
 
       - name: Generate backup report
+        if: always()
         run: |
-          cat >> $GITHUB_STEP_SUMMARY <<EOF
-          # 💾 Backup Report
-
-          ## Status
-
-          - Database Backup: ${{ needs.backup-database.result == 'success' && '✅ Success' || '❌ Failed' }}
-          - Files Backup: ${{ needs.backup-files.result == 'success' && '✅ Success' || '❌ Failed' }}
-
-          ## Details
-
-          - **Timestamp**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
-          - **Backup Type**: ${{ github.event.inputs.backup_type || 'Scheduled (Full)' }}
-          - **Retention on Server**: ${{ github.event.inputs.retention_days || env.RETENTION_DAYS }} days
-          - **Server**: ${{ secrets.PRODUCTION_SERVER }}
-
-          ## Backup Location
-
-          \`\`\`
-          ${BACKUP_DIR}/
-          ├── database/
-          │   └── $(date +%Y%m%d)/
-          │       ├── database-backup-*.sql.gz
-          │       └── database-backup-*.sha256
-          └── files/
-              └── $(date +%Y%m%d)/
-                  ├── files-backup-*.tar.gz
-                  └── files-backup-*.sha256
-          \`\`\`
-
-          ## For IT Department
-
-          ⚠️ **Action Required**: Backups are ready for transfer to external storage.
-
-          - Manifest file: \`${BACKUP_DIR}/backup-manifest-$(date +%Y%m%d).txt\`
-          - Verify checksums before transfer
-          - Transfer entire daily directories
-          - Backups auto-cleanup after ${RETENTION_DAYS} days
-
-          ## Next Scheduled Backup
-
-          - Daily: 02:00 UTC
-          - Additional: Every 6 hours
-
-          ## Restore Instructions
-
-          See production documentation for restore procedures.
-          EOF
-
-      - name: Notify on failure
-        if: needs.backup-database.result == 'failure' || needs.backup-files.result == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: '🚨 Production Backup Failed',
-              body: `
-              ## Backup Failure
-
-              One or more backup jobs have failed.
-
-              - Database Backup: ${{ needs.backup-database.result }}
-              - Files Backup: ${{ needs.backup-files.result }}
-
-              **Timestamp**: ${new Date().toISOString()}
-
-              [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-              ## Action Required
-
-              1. Check workflow logs for errors
-              2. Verify server disk space
-              3. Check database connectivity
-              4. Retry backup immediately
-              5. Notify IT if issue persists
-
-              ## Server Information
-
-              - Server: ${{ secrets.PRODUCTION_SERVER }}
-              - Backup Directory: \`${BACKUP_DIR}\`
-              `,
-              labels: ['production', 'backup', 'urgent']
-            })
+          {
+            echo "# 💾 Backup Report"
+            echo ""
+            echo "| Job | Result |"
+            echo "|-----|--------|"
+            echo "| Database backup | ${{ needs.backup-database.result }} |"
+            echo "| Files backup | ${{ needs.backup-files.result }} |"
+            echo ""
+            echo "**Location**: \`${BACKUP_DIR}\` on the production AP VM"
+            echo "**Retention**: ${RETENTION_DAYS} days"
+            echo "**Timestamp**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -155,6 +155,14 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./backend
+          # backend/Dockerfile pulls the React Email templates via
+          # `COPY --from=frontend_emails . /frontend/emails`, so the named
+          # BuildKit context has to be supplied here — without it the build
+          # resolves `frontend_emails` as docker.io/library/frontend_emails
+          # and dies with "pull access denied". Same wiring as the dev repo's
+          # deploy-pipeline.yml and release.yml.
+          build-contexts: |
+            frontend_emails=./frontend/emails
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-backend:${{ steps.version.outputs.version }}

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -7,24 +7,38 @@
 # no nginx validation, placeholder smoke URLs, and a `git checkout HEAD~1`
 # "rollback" that would have desynced the working tree from the images.
 #
+# This repository does NOT build images. The development repository's pipeline
+# publishes them to GHCR once; production promotes that exact artifact, so what
+# runs in production is bit-identical to what staging verified.
+#
 # Prerequisites (one-time, see SECRETS-SETUP-GUIDE.md):
 #   - A self-hosted runner registered on the production AP VM with labels
 #     [self-hosted, linux] (same pattern as setting-env.yml).
 #   - GitHub `production` environment with required reviewers (blocker P6).
-#   - Repository variable PRODUCTION_URL = https://ss.nycu.edu.tw
+#   - Repository variables:
+#       PRODUCTION_URL = https://ss.aa.nycu.edu.tw
+#       IMAGE_OWNER    = GHCR namespace publishing the images (the dev repo's
+#                        owner, e.g. anud18) — required.
+#       SSL_CERT_DIR   = optional; absolute path to the TLS certificate
+#                        directory on the AP VM (e.g. /home/<user>/ssl).
+#                        Defaults to ./nginx/ssl/prod in the deploy directory.
+#   - secrets.GH_PAT with read:packages, if the upstream packages are private.
 #   - All secrets listed in the validate-secrets job below.
 #   - docker-compose.prod-db.yml stack already running on the DB VM.
 
 name: Deploy to Production
 
 on:
+  # NOTE: a code push alone does not produce a new image here — pushing to main
+  # deploys whatever the upstream `latest` tag currently points at. For a
+  # reproducible release, dispatch manually with an explicit tag.
   push:
     branches:
       - main
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Image tag to deploy (default: build from current commit)'
+        description: 'Upstream image tag to deploy (e.g. main-2c2b89d6 or v1.2.3). Defaults to latest.'
         required: false
         type: string
 
@@ -47,6 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate
+        # Only meaningful when the stack is configured from GitHub Secrets.
+        # With ENV_FILE set, the values live on the AP VM and are validated
+        # there by the deploy job's "Resolve environment file" step instead.
+        if: vars.ENV_FILE == ''
         env:
           DOMAIN: ${{ secrets.DOMAIN }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
@@ -114,163 +132,317 @@ jobs:
           [ "$fail" -eq 0 ] || exit 1
           echo "✅ All production secrets validated"
 
-  build-images:
-    name: Build & Push Images
+  # ── Gate 1: the requested images must already exist upstream ──────────────
+  # This repository does NOT build. Images are produced once by the development
+  # repository's pipeline and promoted here unchanged, so what production runs
+  # is bit-identical to what was tested on staging — rebuilding from mirrored
+  # source would produce a different artifact from the one that was verified.
+  resolve-images:
+    name: Resolve Upstream Images
     runs-on: ubuntu-latest
     needs: validate-secrets
     outputs:
       version: ${{ steps.version.outputs.version }}
-    permissions:
-      contents: read
-      packages: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Resolve version
+      - name: Resolve tag and verify images exist
         id: version
+        env:
+          IMAGE_OWNER: ${{ vars.IMAGE_OWNER }}
+          # A PAT with read:packages, needed when the upstream packages are
+          # private. GITHUB_TOKEN is scoped to THIS repo and cannot read
+          # another namespace's packages.
+          GHCR_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          REQUESTED_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            VERSION="${{ github.event.inputs.tag }}"
-          else
-            # Prefer the auto-tag-on-merge tag; fall back to short SHA.
-            VERSION=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
+          set -euo pipefail
+
+          if [ -z "${IMAGE_OWNER}" ]; then
+            echo "::error::Repository variable IMAGE_OWNER is not set."
+            echo "::error::Set it to the GHCR namespace that publishes the images"
+            echo "::error::(the development repository's owner), e.g. 'anud18'."
+            exit 1
           fi
+
+          # `latest` follows the dev repo's main branch. Pin an immutable tag
+          # (e.g. main-<sha> or a release version) for a reproducible deploy —
+          # with `latest`, the rollback path below can only re-pull `latest`,
+          # which is the same moving image.
+          VERSION="${REQUESTED_TAG:-latest}"
+          [ "$VERSION" = "latest" ] && echo "::warning::Deploying the mutable 'latest' tag — pin a tag for a reproducible, rollback-able deploy."
+
+          echo "Resolving ghcr.io/${IMAGE_OWNER}/scholarship-system-{backend,frontend}:${VERSION}"
+          echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+          fail=0
+          for comp in backend frontend; do
+            REF="ghcr.io/${IMAGE_OWNER}/scholarship-system-${comp}:${VERSION}"
+            # manifest inspect fails fast without downloading layers, so a bad
+            # tag is caught here instead of half-way through the deploy.
+            if docker manifest inspect "$REF" >/dev/null 2>&1; then
+              echo "  ✅ $REF"
+            else
+              echo "::error::Image not found or not readable: $REF"
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ] || {
+            echo "::error::Ensure the development pipeline published this tag, and that"
+            echo "::error::secrets.GH_PAT (read:packages) can read the ${IMAGE_OWNER} namespace."
+            exit 1
+          }
+
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Deploying version: $VERSION"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push backend image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./backend
-          # backend/Dockerfile pulls the React Email templates via
-          # `COPY --from=frontend_emails . /frontend/emails`, so the named
-          # BuildKit context has to be supplied here — without it the build
-          # resolves `frontend_emails` as docker.io/library/frontend_emails
-          # and dies with "pull access denied". Same wiring as the dev repo's
-          # deploy-pipeline.yml and release.yml.
-          build-contexts: |
-            frontend_emails=./frontend/emails
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-backend:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-backend:latest
-          cache-from: type=gha,scope=backend
-          cache-to: type=gha,scope=backend,mode=max
-
-      - name: Build and push frontend image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./frontend
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-frontend:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-frontend:latest
-          cache-from: type=gha,scope=frontend
-          cache-to: type=gha,scope=frontend,mode=max
 
   deploy:
     name: Deploy to Production
     # The runner lives ON the production AP VM (campus network) — GitHub-hosted
     # runners cannot reach it. Register with: [self-hosted, linux].
     runs-on: [self-hosted, linux]
-    needs: [validate-secrets, build-images]
+    needs: [validate-secrets, resolve-images]
     environment:
       name: production
       url: ${{ vars.PRODUCTION_URL }}
 
-    # One env block shared by deploy + rollback so the compose interpolation
-    # is identical in both paths. Covers every ${VAR} in docker-compose.prod.yml.
+    # DELIBERATELY MINIMAL. Everything compose interpolates comes from an env
+    # file (see "Resolve environment file"), NOT from the job environment:
+    # compose gives shell variables precedence over --env-file, so exporting
+    # the same keys here would silently shadow an operator-managed .env — and
+    # an unset GitHub secret exports as an EMPTY string, which shadows the
+    # file's value with "" rather than falling back to it.
+    #
+    # Only workflow-authoritative values live here. Both are always non-empty
+    # (IMAGE_OWNER is validated in resolve-images), so overriding is intended:
+    # the workflow decides which image was pulled and therefore which runs.
     env:
-      TAG: ${{ needs.build-images.outputs.version }}
-      DOMAIN: ${{ secrets.DOMAIN }}
-      SECRET_KEY: ${{ secrets.SECRET_KEY }}
-      CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
-      DB_HOST: ${{ secrets.DB_HOST }}
-      DB_PORT: ${{ secrets.DB_PORT }}
-      DB_USER: ${{ secrets.DB_USER }}
-      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-      DB_NAME: ${{ secrets.DB_NAME }}
-      REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-      MINIO_HOST: ${{ secrets.MINIO_HOST }}
-      MINIO_PORT: ${{ secrets.MINIO_PORT }}
-      MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
-      MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-      # Secret name stays MINIO_BUCKET_NAME (no GitHub secret changes for the
-      # RustFS migration); the compose now interpolates ${MINIO_BUCKET} — the
-      # env name config.py actually binds (old MINIO_BUCKET_NAME env was dead).
-      MINIO_BUCKET: ${{ secrets.MINIO_BUCKET_NAME }}
-      MINIO_SECURE: ${{ secrets.MINIO_SECURE }}
-      PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
-      PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
-      SMTP_HOST: ${{ secrets.SMTP_HOST }}
-      SMTP_PORT: ${{ secrets.SMTP_PORT }}
-      SMTP_USER: ${{ secrets.SMTP_USER }}
-      SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
-      EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
-      EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
-      PORTAL_SSO_ENABLED: "true"
-      PORTAL_JWT_SERVER_URL: ${{ secrets.PORTAL_JWT_SERVER_URL }}
-      PORTAL_TEST_MODE: "false"
-      STUDENT_API_ENABLED: "true"
-      STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
-      SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
-      NEXT_PUBLIC_NYCU_PORTAL_URL: ${{ secrets.NEXT_PUBLIC_NYCU_PORTAL_URL }}
+      TAG: ${{ needs.resolve-images.outputs.version }}
+      IMAGE_OWNER: ${{ vars.IMAGE_OWNER }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Authenticate against the UPSTREAM namespace. GITHUB_TOKEN is scoped to
+      # this repository and cannot read another owner's packages, so a PAT with
+      # read:packages is required whenever those packages are private.
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Pull images
         run: |
-          docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-backend:${TAG}
-          docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/scholarship-system-frontend:${TAG}
+          docker pull ${{ env.REGISTRY }}/${IMAGE_OWNER}/scholarship-system-backend:${TAG}
+          docker pull ${{ env.REGISTRY }}/${IMAGE_OWNER}/scholarship-system-frontend:${TAG}
 
       - name: Prepare deployment files
         run: |
           mkdir -p ~/scholarship-production/logs/nginx
           cp docker-compose.prod.yml ~/scholarship-production/docker-compose.yml
+          # Merge (not replace): a certificate directory placed under
+          # ~/scholarship-production/nginx/ssl/prod by the operator must
+          # survive, since the repo ships nginx configs but no keys.
           if [ -d nginx ]; then cp -r nginx ~/scholarship-production/; fi
           if [ -d monitoring ]; then
             sudo rm -rf ~/scholarship-production/monitoring
             cp -r monitoring ~/scholarship-production/
           fi
 
-      - name: Save last-good deployment tag
+      # Two supported ways to configure the stack, chosen by the ENV_FILE
+      # repository variable:
+      #
+      #   ENV_FILE set   — an operator-managed .env already on the AP VM
+      #                    (install manual section 5.1: `touch ~/.env`). Nothing
+      #                    is written; GitHub never holds these values.
+      #   ENV_FILE unset — generated here from GitHub Secrets into the deploy
+      #                    directory, mode 600. This is the default.
+      #
+      # Either way compose is invoked with --env-file, so there is exactly one
+      # source of truth for interpolation.
+      - name: Resolve environment file
+        env:
+          ENV_FILE_VAR: ${{ vars.ENV_FILE }}
+          SSL_CERT_DIR_VAR: ${{ vars.SSL_CERT_DIR }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          MINIO_HOST: ${{ secrets.MINIO_HOST }}
+          MINIO_PORT: ${{ secrets.MINIO_PORT }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          # Secret name stays MINIO_BUCKET_NAME; compose interpolates
+          # ${MINIO_BUCKET} — the env name config.py actually binds.
+          MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
+          MINIO_SECURE: ${{ secrets.MINIO_SECURE }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
+          PORTAL_JWT_SERVER_URL: ${{ secrets.PORTAL_JWT_SERVER_URL }}
+          STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
+          SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
+          NEXT_PUBLIC_NYCU_PORTAL_URL: ${{ secrets.NEXT_PUBLIC_NYCU_PORTAL_URL }}
         run: |
-          CURRENT_RUNNING=""
-          if docker inspect scholarship_backend_prod >/dev/null 2>&1; then
-            CURRENT_RUNNING=$(docker inspect --format='{{index .Config.Labels "org.opencontainers.image.version"}}' scholarship_backend_prod 2>/dev/null || echo "")
+          set -euo pipefail
+
+          if [ -n "${ENV_FILE_VAR}" ]; then
+            ENV_FILE="${ENV_FILE_VAR}"
+            echo "Using operator-managed env file: ${ENV_FILE}"
+            [ -f "${ENV_FILE}" ] || {
+              echo "::error::ENV_FILE points at ${ENV_FILE}, which does not exist on this runner."
+              echo "::error::Create it (see install manual section 5.1) or clear the ENV_FILE variable"
+              echo "::error::to fall back to generating it from GitHub Secrets."
+              exit 1
+            }
+            [ -r "${ENV_FILE}" ] || { echo "::error::${ENV_FILE} is not readable by the runner user."; exit 1; }
+
+            # Fail now on anything compose cannot default, instead of booting a
+            # backend that silently falls back to config.py's dev values.
+            missing=""
+            for k in DOMAIN SECRET_KEY DB_HOST DB_PORT DB_USER DB_PASSWORD DB_NAME \
+                     REDIS_PASSWORD MINIO_HOST MINIO_ACCESS_KEY MINIO_SECRET_KEY \
+                     PII_ENCRYPTION_KEYS SMTP_HOST EMAIL_FROM EMAIL_FROM_NAME \
+                     PORTAL_JWT_SERVER_URL STUDENT_API_BASE_URL SUPER_ADMIN_NYCU_ID \
+                     NEXT_PUBLIC_NYCU_PORTAL_URL CORS_ORIGINS; do
+              grep -qE "^[[:space:]]*${k}=" "${ENV_FILE}" || missing="${missing} ${k}"
+            done
+            [ -z "${missing}" ] || { echo "::error::${ENV_FILE} is missing required keys:${missing}"; exit 1; }
+
+            # Same production guards the validate-secrets job applies to
+            # GitHub Secrets. They live here too because in ENV_FILE mode that
+            # job has nothing to inspect — config.py ships staging defaults, so
+            # a wrong value would not crash, it would quietly run production
+            # against test infrastructure.
+            v() { sed -n "s/^[[:space:]]*$1=//p" "${ENV_FILE}" | tail -1; }
+            fail=0
+            err() { echo "::error::$1"; fail=1; }
+
+            SK="$(v SECRET_KEY)"
+            [ "${#SK}" -ge 32 ] || err "SECRET_KEY must be >= 32 chars (and MUST differ from staging)"
+
+            printf '%s' "$(v PII_ENCRYPTION_KEYS)" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1 \
+              || err "PII_ENCRYPTION_KEYS is not valid JSON"
+
+            case "$(v PORTAL_JWT_SERVER_URL)" in
+              *portal.test*) err "PORTAL_JWT_SERVER_URL points at portal.test (staging)" ;;
+              https://*) : ;;
+              *) err "PORTAL_JWT_SERVER_URL must be https://" ;;
+            esac
+            case "$(v STUDENT_API_BASE_URL)" in
+              *localhost*|*127.0.0.1*|*mock*) err "STUDENT_API_BASE_URL looks like a mock/localhost endpoint" ;;
+            esac
+            case "$(v EMAIL_FROM)" in *ss-test*) err "EMAIL_FROM still uses the staging address" ;; esac
+            case "$(v EMAIL_FROM_NAME)" in *測試*) err "EMAIL_FROM_NAME still contains 測試" ;; esac
+
+            [ "$fail" -eq 0 ] || exit 1
+            echo "✅ All required keys present and validated"
+          else
+            ENV_FILE="$HOME/scholarship-production/.env"
+            echo "Generating ${ENV_FILE} from GitHub Secrets"
+            umask 077
+            {
+              echo "# Generated by deploy.yml — do not edit; changes are overwritten."
+              echo "DOMAIN=${DOMAIN}"
+              echo "SECRET_KEY=${SECRET_KEY}"
+              echo "CORS_ORIGINS=${CORS_ORIGINS}"
+              echo "DB_HOST=${DB_HOST}"
+              echo "DB_PORT=${DB_PORT}"
+              echo "DB_USER=${DB_USER}"
+              echo "DB_PASSWORD=${DB_PASSWORD}"
+              echo "DB_NAME=${DB_NAME}"
+              echo "REDIS_PASSWORD=${REDIS_PASSWORD}"
+              echo "MINIO_HOST=${MINIO_HOST}"
+              echo "MINIO_PORT=${MINIO_PORT}"
+              echo "MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}"
+              echo "MINIO_SECRET_KEY=${MINIO_SECRET_KEY}"
+              echo "MINIO_BUCKET=${MINIO_BUCKET_NAME}"
+              echo "MINIO_SECURE=${MINIO_SECURE}"
+              echo "PII_ENCRYPTION_KEYS=${PII_ENCRYPTION_KEYS}"
+              echo "PII_ENCRYPTION_ACTIVE_VERSION=${PII_ENCRYPTION_ACTIVE_VERSION}"
+              echo "SMTP_HOST=${SMTP_HOST}"
+              echo "SMTP_PORT=${SMTP_PORT}"
+              echo "SMTP_USER=${SMTP_USER}"
+              echo "SMTP_PASSWORD=${SMTP_PASSWORD}"
+              echo "EMAIL_FROM=${EMAIL_FROM}"
+              echo "EMAIL_FROM_NAME=${EMAIL_FROM_NAME}"
+              echo "PORTAL_SSO_ENABLED=true"
+              echo "PORTAL_JWT_SERVER_URL=${PORTAL_JWT_SERVER_URL}"
+              echo "PORTAL_TEST_MODE=false"
+              echo "STUDENT_API_ENABLED=true"
+              echo "STUDENT_API_BASE_URL=${STUDENT_API_BASE_URL}"
+              echo "SUPER_ADMIN_NYCU_ID=${SUPER_ADMIN_NYCU_ID}"
+              echo "NEXT_PUBLIC_NYCU_PORTAL_URL=${NEXT_PUBLIC_NYCU_PORTAL_URL}"
+              [ -n "${SSL_CERT_DIR_VAR}" ] && echo "SSL_CERT_DIR=${SSL_CERT_DIR_VAR}"
+            } > "${ENV_FILE}"
+            chmod 600 "${ENV_FILE}"
+            echo "✅ Wrote $(grep -c '=' "${ENV_FILE}") entries (mode 600)"
           fi
-          if [ -n "$CURRENT_RUNNING" ]; then
-            echo "$CURRENT_RUNNING" > ~/scholarship-production/last-good-tag
-            echo "Saved running tag: $CURRENT_RUNNING"
+
+          echo "ENV_FILE=${ENV_FILE}" >> "$GITHUB_ENV"
+
+          # Read back the values later steps need. Taking DOMAIN from the
+          # resolved file (rather than from secrets) keeps both modes identical.
+          envget() { sed -n "s/^[[:space:]]*$1=//p" "${ENV_FILE}" | tail -1; }
+          echo "DOMAIN=$(envget DOMAIN)" >> "$GITHUB_ENV"
+
+          # Certificate location precedence: the SSL_CERT_DIR repository
+          # variable wins in BOTH modes (it describes where the operator put
+          # the certificate on this host, not a secret), then the env file,
+          # then compose's ./nginx/ssl/prod default.
+          CERT_DIR="${SSL_CERT_DIR_VAR:-$(envget SSL_CERT_DIR)}"
+          echo "CERT_DIR=${CERT_DIR}" >> "$GITHUB_ENV"
+          # Export to compose ONLY when non-empty: an exported empty string
+          # would shadow the env file's value instead of deferring to it.
+          if [ -n "${CERT_DIR}" ]; then
+            echo "SSL_CERT_DIR=${CERT_DIR}" >> "$GITHUB_ENV"
+            echo "Certificate directory (SSL_CERT_DIR): ${CERT_DIR}"
+          else
+            echo "Certificate directory: compose default (./nginx/ssl/prod)"
           fi
+
+      - name: Verify TLS certificates are present
+        run: |
+          cd ~/scholarship-production
+          CERT_DIR="${CERT_DIR:-./nginx/ssl/prod}"
+          echo "Certificate directory: $CERT_DIR"
+          missing=0
+          # nginx.prod.conf references all three; a missing file puts nginx in
+          # a crash loop and the deploy would only fail later, at `nginx -t`,
+          # with a far less obvious message.
+          for f in fullchain.pem privkey.pem chain.pem; do
+            if [ -f "${CERT_DIR}/${f}" ]; then
+              echo "  ✅ ${f}"
+            else
+              echo "::error::Missing certificate file: ${CERT_DIR}/${f}"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || {
+            echo "::error::Place the TLS certificate in ${CERT_DIR}, or set the"
+            echo "::error::repository variable SSL_CERT_DIR to an absolute path on the AP VM"
+            echo "::error::(e.g. /home/<user>/ssl) so private keys stay out of git."
+            exit 1
+          }
 
       - name: Start new containers
         run: |
           cd ~/scholarship-production
-          docker compose down || true
-          docker compose up -d
+          # --env-file is the single source of interpolation values; TAG and
+          # IMAGE_OWNER come from the job env and intentionally take precedence.
+          docker compose --env-file "${ENV_FILE}" down || true
+          docker compose --env-file "${ENV_FILE}" up -d
 
       - name: Validate and reload nginx config
         run: |
@@ -350,10 +522,24 @@ jobs:
         if: failure()
         run: |
           cd ~/scholarship-production
+          # Resolve step may itself have failed, leaving ENV_FILE unset.
+          ENV_FILE="${ENV_FILE:-$HOME/scholarship-production/.env}"
+          if [ ! -f "${ENV_FILE}" ]; then
+            echo "::error::No usable env file (${ENV_FILE}) — cannot roll back automatically."
+            exit 1
+          fi
+          # last-good-tag is written ONLY by the success path above, so it
+          # always names a tag that actually passed health + smoke checks.
           if [ -f last-good-tag ]; then
             PREV_TAG=$(cat last-good-tag)
+            if [ "$PREV_TAG" = "$TAG" ]; then
+              echo "::error::last-good tag is '${PREV_TAG}', identical to the tag that just failed."
+              echo "::error::This happens when deploying the mutable 'latest' tag — rolling back"
+              echo "::error::would re-pull the same image. Redeploy an explicit older tag instead."
+              exit 1
+            fi
             echo "::warning::Deploy of ${TAG} failed — rolling back to ${PREV_TAG}"
-            TAG=$PREV_TAG docker compose up -d
+            TAG=$PREV_TAG docker compose --env-file "${ENV_FILE}" up -d
             sleep 15
             if docker exec scholarship_backend_prod curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
               echo "::notice::Rollback to ${PREV_TAG} succeeded."

--- a/.github/production-workflows-examples/health-check.yml
+++ b/.github/production-workflows-examples/health-check.yml
@@ -1,5 +1,17 @@
-# Example Production Health Check Workflow
-# Copy this file to your production repository at: .github/workflows/health-check.yml
+# Production Health Check Workflow
+# Copy this file to the PRIVATE production repository at .github/workflows/health-check.yml
+#
+# Modeled on the PROVEN dev-repo staging-health-monitor.yml. The previous
+# version of this file was an unedited placeholder: it curled
+# https://api.production.example.com/health (a domain that does not exist, so
+# every run reported the backend down) and reached the DB/Redis by SSHing from
+# a `ubuntu-latest` runner — which cannot route to the campus VMs at all, the
+# same constraint that forced deploy.yml onto a self-hosted runner.
+#
+# Prerequisites:
+#   - The self-hosted runner registered on the production AP VM, labels
+#     [self-hosted, linux] (same runner deploy.yml uses).
+#   - Secrets: DOMAIN, REDIS_PASSWORD (already required by deploy.yml).
 
 name: Production Health Check
 
@@ -11,89 +23,66 @@ on:
 jobs:
   health-check:
     name: Check Application Health
-    runs-on: ubuntu-latest
+    # The runner lives ON the production AP VM, so every probe below is a
+    # direct localhost/container check — the most direct signal of service
+    # availability, with no VPN or SSH hop to fail independently.
+    runs-on: [self-hosted, linux]
+    permissions:
+      issues: write
+      contents: read
 
     steps:
+      # Backend publishes no host port in production (expose-only), so probe
+      # it from inside its own container.
       - name: Check backend API
         id: api-check
         continue-on-error: true
         run: |
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-            --max-time 10 \
-            https://api.production.example.com/health)
+          STATUS=$(docker exec scholarship_backend_prod \
+            curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            http://localhost:8000/health 2>/dev/null || echo "000")
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+          [ "$STATUS" = "200" ] || { echo "::error::Backend API health check failed (HTTP $STATUS)"; exit 1; }
+          echo "✅ Backend API is healthy (HTTP $STATUS)"
 
-          echo "status=$RESPONSE" >> $GITHUB_OUTPUT
-
-          if [ "$RESPONSE" == "200" ]; then
-            echo "✅ Backend API is healthy (HTTP $RESPONSE)"
-            exit 0
-          else
-            echo "::error::Backend API health check failed (HTTP $RESPONSE)"
-            exit 1
-          fi
-
-      - name: Check frontend
+      - name: Check frontend through nginx
         id: frontend-check
         continue-on-error: true
+        env:
+          DOMAIN: ${{ secrets.DOMAIN }}
         run: |
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-            --max-time 10 \
-            https://production.example.com)
+          # End-to-end through the real TLS listener; -k because the probe
+          # targets localhost while the certificate is issued for $DOMAIN.
+          STATUS=$(curl -sk -o /dev/null -w "%{http_code}" --max-time 10 \
+            "https://localhost/" -H "Host: ${DOMAIN}" || echo "000")
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
+          [ "$STATUS" = "200" ] || { echo "::error::Frontend health check failed (HTTP $STATUS)"; exit 1; }
+          echo "✅ Frontend is healthy (HTTP $STATUS)"
 
-          echo "status=$RESPONSE" >> $GITHUB_OUTPUT
-
-          if [ "$RESPONSE" == "200" ]; then
-            echo "✅ Frontend is healthy (HTTP $RESPONSE)"
-            exit 0
-          else
-            echo "::error::Frontend health check failed (HTTP $RESPONSE)"
-            exit 1
-          fi
-
+      # PostgreSQL lives on the DB VM, not next to the app — there is no
+      # `postgres` container here to exec into. /health already opens a real
+      # pooled connection and reports the result, so read that verdict.
       - name: Check database connectivity
         id: db-check
         continue-on-error: true
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
         run: |
-          mkdir -p ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$SERVER_HOST" >> ~/.ssh/known_hosts
-
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << 'ENDSSH'
-            cd /opt/scholarship-system
-            docker compose exec -T postgres pg_isready -U scholarship_user
-          ENDSSH
-
-          if [ $? -eq 0 ]; then
-            echo "✅ Database is healthy"
-          else
-            echo "::error::Database health check failed"
-            exit 1
-          fi
+          BODY=$(docker exec scholarship_backend_prod \
+            curl -s --max-time 10 http://localhost:8000/health 2>/dev/null || echo "{}")
+          echo "$BODY"
+          echo "$BODY" | python3 -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get("database",{}).get("status")=="healthy" else 1)' \
+            || { echo "::error::Database health check failed"; exit 1; }
+          echo "✅ Database is healthy"
 
       - name: Check Redis cache
         id: redis-check
         continue-on-error: true
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_KEY }}
-          SERVER_HOST: ${{ secrets.PRODUCTION_SERVER }}
-          SERVER_USER: ${{ secrets.PRODUCTION_USER }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
         run: |
-          ssh -i ~/.ssh/deploy_key "$SERVER_USER@$SERVER_HOST" << 'ENDSSH'
-            cd /opt/scholarship-system
-            docker compose exec -T redis redis-cli ping
-          ENDSSH
-
-          if [ $? -eq 0 ]; then
-            echo "✅ Redis is healthy"
-          else
-            echo "::error::Redis health check failed"
-            exit 1
-          fi
+          PONG=$(docker exec scholarship_redis_prod \
+            redis-cli --no-auth-warning -a "$REDIS_PASSWORD" ping 2>/dev/null || echo "")
+          [ "$PONG" = "PONG" ] || { echo "::error::Redis health check failed (got '$PONG')"; exit 1; }
+          echo "✅ Redis is healthy"
 
       - name: Generate health report
         if: always()
@@ -110,6 +99,16 @@ jobs:
 
           **Timestamp**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
           EOF
+
+      # Every probe above is continue-on-error, so the job only reaches a
+      # failed conclusion via this explicit gate.
+      - name: Fail the job if any component is down
+        if: |
+          steps.api-check.outcome != 'success' ||
+          steps.frontend-check.outcome != 'success' ||
+          steps.db-check.outcome != 'success' ||
+          steps.redis-check.outcome != 'success'
+        run: exit 1
 
       - name: Create incident issue on failure
         if: failure()
@@ -137,35 +136,21 @@ jobs:
             - Database: ${{ steps.db-check.outcome }}
             - Redis: ${{ steps.redis-check.outcome }}
 
-            ### Actions Required
-
-            1. Check application logs
-            2. Verify server resources
-            3. Test database connectivity
-            4. Review recent deployments
-
-            ### Quick Commands
+            ### Quick Commands (run on the production AP VM)
 
             \`\`\`bash
-            # SSH to server
-            ssh production-server
-
-            # Check container status
-            cd /opt/scholarship-system
+            cd ~/scholarship-production
             docker compose ps
-            docker compose logs --tail=100
-
-            # Check system resources
-            df -h
-            free -h
-            top -n 1
+            docker compose logs --tail=100 backend
+            docker exec scholarship_backend_prod curl -s http://localhost:8000/health
+            df -h; free -h
             \`\`\`
 
             ---
             [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
             `;
 
-            // Check if similar issue already exists
+            // Don't file a fresh issue every 15 minutes during one incident.
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -180,7 +165,6 @@ jobs:
             );
 
             if (recentIssue) {
-              // Add comment to existing issue
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -189,7 +173,6 @@ jobs:
               });
               console.log(`Updated existing issue #${recentIssue.number}`);
             } else {
-              // Create new issue
               const issue = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -200,22 +183,30 @@ jobs:
               console.log(`Created new issue #${issue.data.number}`);
             }
 
-      - name: Send notification (optional)
-        if: failure()
-        run: |
-          # Uncomment and configure your notification method:
-
-          # Slack
-          # curl -X POST -H 'Content-type: application/json' \
-          #   --data '{"text":"🚨 Production health check failed!"}' \
-          #   ${{ secrets.SLACK_WEBHOOK_URL }}
-
-          # Discord
-          # curl -X POST -H 'Content-Type: application/json' \
-          #   --data '{"content":"🚨 Production health check failed!"}' \
-          #   ${{ secrets.DISCORD_WEBHOOK_URL }}
-
-          # Email (using a service)
-          # ...
-
-          echo "Health check failed - notifications would be sent here"
+      - name: Close resolved incident issues
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'production,incident',
+              per_page: 20
+            });
+            for (const issue of issues.data) {
+              if (!issue.title.includes('Production Health Check Failed')) continue;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `✅ All production health checks are passing again. Auto-closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }

--- a/.github/production-workflows-examples/setting-env.yml
+++ b/.github/production-workflows-examples/setting-env.yml
@@ -1367,7 +1367,8 @@ jobs:
           echo "📁 Creating $DEPLOY_DIR and its volume directories..."
           mkdir -p "$DEPLOY_DIR/backend/uploads" \
                    "$DEPLOY_DIR/logs/backend" \
-                   "$DEPLOY_DIR/logs/nginx"
+                   "$DEPLOY_DIR/logs/nginx" \
+                   "$DEPLOY_DIR/nginx/ssl/prod"
           # The backend + nginx containers run as NON-root users and must be
           # able to write uploads/logs into these bind mounts. u+rwX only would
           # leave them unwritable by the container uid; 777 on the mount dirs is
@@ -1385,6 +1386,20 @@ jobs:
           sudo mkdir -p /opt/scholarship/app/redis/data
           sudo chown -R 999:999 /opt/scholarship/app/redis
           echo "   ✅ /opt/scholarship/app/redis/data ($(stat -c '%U:%G' /opt/scholarship/app/redis/data))"
+
+          # deploy.yml hard-fails if these are absent, rather than letting
+          # nginx crash-loop on a missing certificate. The repo ships nginx
+          # configs but no keys — drop the certificate here, or set the
+          # SSL_CERT_DIR repository variable to a path outside the deploy dir.
+          echo ""
+          echo "🔐 TLS certificate directory: $DEPLOY_DIR/nginx/ssl/prod"
+          for f in fullchain.pem privkey.pem chain.pem; do
+            if [ -f "$DEPLOY_DIR/nginx/ssl/prod/$f" ]; then
+              echo "   ✅ $f"
+            else
+              echo "   ⚠️  missing $f — deployment will fail until it is placed here"
+            fi
+          done
 
           echo "   ✅ Created:"
           find "$DEPLOY_DIR" -maxdepth 2 -type d | sed 's/^/      /'

--- a/.github/production-workflows-examples/setting-env.yml
+++ b/.github/production-workflows-examples/setting-env.yml
@@ -1374,6 +1374,18 @@ jobs:
           # the pragmatic choice for a single-tenant VM (the parent dir is owned
           # by the deploy user, and these hold no secrets).
           chmod 777 "$DEPLOY_DIR/backend/uploads" "$DEPLOY_DIR/logs/backend" "$DEPLOY_DIR/logs/nginx"
+
+          # docker-compose.prod.yml declares redis_prod_data as a bind-backed
+          # named volume on /opt/scholarship/app/redis/data. Docker does NOT
+          # create the device path for `type: none, o: bind` — it errors with
+          # "failed to mount local volume: ... no such file or directory", so
+          # `docker compose up -d` dies on a fresh AP VM unless this exists
+          # first. redis:7-alpine runs as uid/gid 999.
+          echo "📁 Creating redis volume device path..."
+          sudo mkdir -p /opt/scholarship/app/redis/data
+          sudo chown -R 999:999 /opt/scholarship/app/redis
+          echo "   ✅ /opt/scholarship/app/redis/data ($(stat -c '%U:%G' /opt/scholarship/app/redis/data))"
+
           echo "   ✅ Created:"
           find "$DEPLOY_DIR" -maxdepth 2 -type d | sed 's/^/      /'
           echo ""

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -42,7 +42,10 @@ services:
 
   # FastAPI Backend
   backend:
-    image: ghcr.io/anud18/scholarship-system-backend:${TAG:-latest}
+    # Images are built and published by the DEVELOPMENT repository's pipeline;
+    # the production repo only consumes them. IMAGE_OWNER is the GHCR namespace
+    # that owns those packages (i.e. the dev repo's owner), not this repo's.
+    image: ghcr.io/${IMAGE_OWNER:-anud18}/scholarship-system-backend:${TAG:-latest}
     container_name: scholarship_backend_prod
     expose:
       - "8000"
@@ -129,7 +132,7 @@ services:
 
   # Next.js Frontend
   frontend:
-    image: ghcr.io/anud18/scholarship-system-frontend:${TAG:-latest}
+    image: ghcr.io/${IMAGE_OWNER:-anud18}/scholarship-system-frontend:${TAG:-latest}
     container_name: scholarship_frontend_prod
     expose:
       - "3000"
@@ -168,7 +171,12 @@ services:
       - "443:443"
     volumes:
       - ./nginx/nginx.prod.conf:/etc/nginx/nginx.conf:ro
-      - ./nginx/ssl/prod:/etc/nginx/ssl:ro
+      # Certificate directory. Defaults to the repo's own nginx/ssl/prod (which
+      # deploy.yml copies into the deploy dir), but can be pointed anywhere on
+      # the AP VM — e.g. SSL_CERT_DIR=/home/<user>/ssl per the install manual —
+      # so private keys never have to live in git. Must contain fullchain.pem,
+      # privkey.pem and chain.pem (nginx.prod.conf references all three).
+      - ${SSL_CERT_DIR:-./nginx/ssl/prod}:/etc/nginx/ssl:ro
       - ./logs/nginx:/var/log/nginx
     depends_on:
       - backend


### PR DESCRIPTION
## Summary

Rehearsed the entire production pipeline end to end against staging infrastructure — a private stand-in repo, a self-hosted runner on the AP VM, and a separate `scholarship_prod_db` on the staging DB VM. Every production workflow except `auto-tag-on-merge.yml` was broken. None of it was reachable by CI, because these templates live outside `.github/workflows/` and are never linted or executed.

## Defects fixed

| File | Defect |
|---|---|
| `backup.yml` | **Unparseable.** Three quoted-heredoc bodies sat at column 0, terminating the enclosing `run: \|` block scalar — GitHub rejected the file on every push. Beyond that, every step SSHed from a `ubuntu-latest` runner (cannot route to campus VMs) and `docker compose exec -T postgres pg_dump` assumed PostgreSQL was colocated with the app when it lives on the DB VM. |
| `deploy.yml` | **Backend image could never build.** `backend/Dockerfile:48` pulls React Email templates via `COPY --from=frontend_emails`; the named BuildKit context was never passed, so it resolved `docker.io/library/frontend_emails` → `pull access denied`. `deploy-pipeline.yml:134` and `release.yml:189` both pass it. |
| `health-check.yml` | **Unedited placeholder that could never fail.** It curled `api.production.example.com`, reached the DB/Redis over SSH from `ubuntu-latest`, and marked every probe `continue-on-error` with no gate afterwards — so the job reported success no matter what was down. Confirmed live: a scheduled run went green while the entire stack was stopped. |
| `setting-env.yml` | Never created `/opt/scholarship/app/redis/data`, which `docker-compose.prod.yml` declares as a bind-backed named volume. Docker does not create the device path for `type: none, o: bind`, so a fresh AP VM died at `docker compose up -d`. |
| `README.md` | Secrets table listed Docker Hub credentials, AWS S3 backup keys and SSH secrets — none used by any workflow. |

## Behaviour changes

**Production no longer builds images.** The development pipeline publishes to GHCR once; production promotes that exact artifact, so what runs in production is bit-identical to what staging verified rather than a second build from mirrored source. `build-images` is replaced by `resolve-images`, which only verifies the requested tags exist (`docker manifest inspect`, no layer download) — 4s instead of ~6m.

**Configuration is now always supplied via `--env-file`.** This forced removing the secrets from the deploy job's `env:` block: compose gives shell variables precedence over `--env-file`, so exporting the same keys would silently shadow an operator-managed file — and an unset GitHub secret exports as an *empty string*, which shadows with `""` rather than falling back. Only `TAG` and `IMAGE_OWNER` remain in the job env, where the workflow is deliberately authoritative.

New repository variables:

| Variable | Required | Purpose |
|---|---|---|
| `IMAGE_OWNER` | yes | GHCR namespace publishing the images (the dev repo's owner). No longer hardcoded in `docker-compose.prod.yml`. |
| `ENV_FILE` | no | Absolute path to an operator-managed `.env` already on the AP VM (install manual §5.1). When set, **no configuration values are stored in GitHub at all**. |
| `SSL_CERT_DIR` | no | Absolute path to the TLS certificate directory; defaults to the repo's `nginx/ssl/prod`, so private keys need not live in git. |

In `ENV_FILE` mode the `validate-secrets` step is skipped — it has nothing to inspect — and the equivalent production guards (`SECRET_KEY` length, PII JSON validity, `portal.test`, `ss-test`, `測試`) run against the env file on the runner instead, alongside a required-key check.

Also: deploy fails early with an actionable message when `fullchain.pem` / `privkey.pem` / `chain.pem` are absent, instead of letting nginx crash-loop and surfacing later as an opaque `nginx -t` failure. And the pre-deploy "save last-good tag" step is gone — it overwrote a known-good tag with a value read from an image label that is either the branch name (`main`) or a base-image leftover (`0.9.30-python3.12-bookworm-slim`). `last-good-tag` is now written only by the success path, and rollback refuses to run when it would redeploy the same tag.

## Verification

All of the following ran green on the rehearsal stack:

- `deploy.yml` full pipeline: `validate-secrets` → `resolve-images` → deploy → nginx validate/reload → `alembic upgrade head` → `seed --prod` → health + smoke checks (4× 200)
- Both configuration modes: secrets-generated `.env` (mode 600) and operator-managed `ENV_FILE`, each confirmed to actually drive the container environment
- Pinned tag (`main-2c2b89d6`) and floating `latest`, including the mutable-tag warning
- `backup.yml`: all three jobs, producing checksummed dumps, tarball and IT manifest
- `health-check.yml`: passes, and now genuinely fails when a component is down

Two bugs of my own were caught by running it rather than reading it: `gunzip | head | grep` under `set -o pipefail` fails with exit 141 (SIGPIPE) and reported a valid dump as corrupt; and an invalid `${#$(...)}` expansion in the env-file guard.

## Note

`.github/production-workflows-examples/` is executable CI/CD delivered to the private production repo by `mirror-to-production.yml`, but nothing in this repo lints or runs it — which is why four broken workflows sat here undetected. Worth adding at minimum a YAML-parse check over that directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmdZTZgfTCF6B2FLcLQfR
