### PR TITLE
feat(distribution): 每個學院一顆「預設分發」按鈕，並讓撤銷/停發學生維持狀態

### DIFF
--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -200,16 +200,23 @@ async def auto_allocate_preview(
     scholarship_type_id: int = Query(...),
     academic_year: int = Query(...),
     semester: str = Query(...),
+    college_code: Optional[str] = Query(None, description="Restrict suggestions to one college"),
     db: AsyncSession = Depends(get_db),
     current_user=Depends(get_current_admin_user),
 ):
-    """Generate auto-allocation suggestions without persisting."""
+    """Generate auto-allocation suggestions without persisting.
+
+    Pass `college_code` to run the distribution for a single college; quotas are
+    still evaluated against the global live remaining, so the result matches what
+    a whole-scholarship run would suggest for that college.
+    """
     try:
         service = ManualDistributionService(db)
         suggestions = await service.auto_allocate_preview(
             scholarship_type_id=scholarship_type_id,
             academic_year=academic_year,
             semester=semester,
+            college_code=college_code,
         )
         return {
             "success": True,
@@ -380,6 +387,8 @@ async def restore_from_history(
         message = f"Restored {restore_result['restored_count']} allocations from history"
         if restore_result.get("skipped_rejected"):
             message += f" ({restore_result['skipped_rejected']} skipped: sub-type rejected in review)"
+        if restore_result.get("skipped_cancelled"):
+            message += f" ({restore_result['skipped_cancelled']} skipped: application revoked/suspended)"
         return {
             "success": True,
             "message": message,

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -57,6 +57,14 @@ def _config_semester_condition(semester: str):
     return ScholarshipConfiguration.semester == semester
 
 
+# Application-level allocation states that mean "this student was pulled out of
+# the distribution on purpose" (撤銷 / 停發). Cancelling frees the quota slot by
+# flipping CollegeRankingItem.is_allocated to False (see _cancel_allocation), so
+# WITHOUT this gate every unallocated-item path — above all the auto-allocation
+# preview — would read them as free candidates and hand the slot straight back.
+CANCELLED_ALLOCATION_STATUSES = ("revoked", "suspended")
+
+
 def _norm_sub_type(code: Optional[str]) -> str:
     """Normalize a sub-type code for comparison.
 
@@ -135,6 +143,28 @@ async def load_review_items_by_role(db: AsyncSession, app_ids: list[int]) -> dic
     return review_map
 
 
+def _dedupe_preview_items(all_items: list, college_code: Optional[str] = None) -> list:
+    """Select the ranking items auto_allocate_preview should suggest for.
+
+    Keeps the first item per application_id, drops items whose application is
+    missing or soft-deleted, and — when `college_code` is given — keeps only
+    that college's students so an admin can run the distribution one college at
+    a time. The college filter is applied BEFORE the dedup bookkeeping so a
+    skipped application never shadows a later item.
+    """
+    seen_app_ids: set[int] = set()
+    unique_items: list = []
+    for item in all_items:
+        app = item.application
+        if app is None or app.deleted_at is not None or app.id in seen_app_ids:
+            continue
+        if college_code and (app.student_data or {}).get("std_academyno", "") != college_code:
+            continue
+        seen_app_ids.add(app.id)
+        unique_items.append(item)
+    return unique_items
+
+
 def _compute_suggestions(
     unique_items: list,
     default_prefs: list[str],
@@ -191,6 +221,14 @@ def _compute_suggestions(
             continue
 
         app = item.application
+
+        # 撤銷／停發 is a deliberate admin decision — the student keeps that
+        # state and must never be re-suggested, even though cancelling freed
+        # their ranking item (is_allocated=False). No quota is consumed.
+        if app.quota_allocation_status in CANCELLED_ALLOCATION_STATUSES:
+            results.append({"ranking_item_id": item.id, "sub_type_code": None, "allocation_config_id": None})
+            continue
+
         college = (app.student_data or {}).get("std_academyno", "")
 
         # Preferred target config for a renewal: the config its prior slot consumed.
@@ -972,7 +1010,7 @@ class ManualDistributionService:
             for item in items
             if item.application is not None
             and item.application.deleted_at is None
-            and item.application.quota_allocation_status not in ("revoked", "suspended")
+            and item.application.quota_allocation_status not in CANCELLED_ALLOCATION_STATUSES
             and item.is_allocated
             and item.allocated_sub_type
         ]
@@ -1007,7 +1045,7 @@ class ManualDistributionService:
             # Skip applications already revoked/suspended post-finalize. Their
             # ranking item was unallocated (is_allocated=False) by the cancel
             # flow; finalize must never flip them back to approved/allocated.
-            if app.quota_allocation_status in ("revoked", "suspended"):
+            if app.quota_allocation_status in CANCELLED_ALLOCATION_STATUSES:
                 continue
 
             prior_app_state = {
@@ -1192,14 +1230,27 @@ class ManualDistributionService:
             )
             to_restore = [(item, wanted[item.id]) for item in items_result.scalars().all()]
 
-        rejected_map = await self._batch_load_rejected_map(
-            list({item.application_id for item, _ in to_restore if item.application_id is not None})
-        )
+        restore_app_ids = list({item.application_id for item, _ in to_restore if item.application_id is not None})
+        rejected_map = await self._batch_load_rejected_map(restore_app_ids)
+
+        # Applications the admin has since 撤銷/停發 — a snapshot taken before
+        # that cancellation still holds their slot, so restoring it blindly
+        # would resurrect a student who is meant to stay out.
+        cancelled_app_ids: set[int] = set()
+        if restore_app_ids:
+            cancelled_rows = await self.db.execute(
+                select(Application.id).where(
+                    Application.id.in_(restore_app_ids),
+                    Application.quota_allocation_status.in_(CANCELLED_ALLOCATION_STATUSES),
+                )
+            )
+            cancelled_app_ids = set(cancelled_rows.scalars().all())
 
         # Now restore from snapshot — a snapshot may predate a reviewer reject
-        # (不同意), so rejected sub-types are skipped instead of re-allocated.
+        # (不同意) or a 撤銷/停發, so those rows are skipped instead of re-allocated.
         restored_count = 0
         skipped_rejected = 0
+        skipped_cancelled = 0
         for item, alloc_data in to_restore:
             sub_type = _norm_sub_type(alloc_data["sub_type"])
             if item.application_id is not None and sub_type in rejected_map.get(item.application_id, set()):
@@ -1208,6 +1259,14 @@ class ManualDistributionService:
                     "restore_from_history: skipping ranking_item %s — sub_type %s was rejected in review",
                     item.id,
                     alloc_data["sub_type"],
+                )
+                continue
+            if item.application_id in cancelled_app_ids:
+                skipped_cancelled += 1
+                logger.info(
+                    "restore_from_history: skipping ranking_item %s — application %s is revoked/suspended",
+                    item.id,
+                    item.application_id,
                 )
                 continue
             item.is_allocated = True
@@ -1236,7 +1295,11 @@ class ManualDistributionService:
         except Exception:
             logger.warning("Failed to record restore history", exc_info=True)
 
-        return {"restored_count": restored_count, "skipped_rejected": skipped_rejected}
+        return {
+            "restored_count": restored_count,
+            "skipped_rejected": skipped_rejected,
+            "skipped_cancelled": skipped_cancelled,
+        }
 
     async def _validate_allocations(
         self,
@@ -1260,6 +1323,11 @@ class ManualDistributionService:
         # and the admin decides — distribution must not strand on unreviewed
         # applications.
         await self._assert_no_rejected_sub_types(allocations)
+
+        # 撤銷／停發 gate — mirrors the disabled checkbox in the UI so neither a
+        # stale grid nor a crafted request can re-allocate a student the admin
+        # deliberately pulled out of the distribution.
+        await self._assert_no_cancelled_applications(allocations)
 
         # Server-side quota enforcement is net-new (spec §10): the lock gate in
         # allocate/finalize (_assert_round_not_oversubscribed) recounts remaining
@@ -1305,6 +1373,39 @@ class ManualDistributionService:
         )
         if rejected_violations:
             raise ValueError("以下分發之子類型審核不同意，無法分發：" + "、".join(rejected_violations))
+
+    async def _assert_no_cancelled_applications(self, allocations: list[dict[str, Any]]) -> None:
+        """Block any allocation onto a 撤銷 (revoked) / 停發 (suspended) application.
+
+        Cancelling frees the ranking item (``is_allocated=False``) so the slot can
+        go to someone else — which also makes the student look allocatable again.
+        The admin's decision wins: allocating to them is refused here, and
+        restoring them is a separate explicit action (restore_allocation).
+        Only allocations that assign a sub-type are checked (``sub_type_code``
+        set; ``None`` means unallocate, which stays allowed).
+        """
+        allocating = [a for a in allocations if a.get("sub_type_code")]
+        if not allocating:
+            return
+
+        item_ids = [a["ranking_item_id"] for a in allocating]
+        stmt = (
+            select(CollegeRankingItem)
+            .options(selectinload(CollegeRankingItem.application))
+            .where(CollegeRankingItem.id.in_(item_ids))
+        )
+        items = {it.id: it for it in (await self.db.execute(stmt)).scalars().all()}
+
+        violations: list[str] = []
+        for alloc in allocating:
+            item = items.get(alloc["ranking_item_id"])
+            app = item.application if item else None
+            if app is None or app.quota_allocation_status not in CANCELLED_ALLOCATION_STATUSES:
+                continue
+            label = "撤銷" if app.quota_allocation_status == "revoked" else "停發"
+            violations.append(f"{app.app_id}（{label}）")
+        if violations:
+            raise ValueError("以下申請已撤銷／停發，無法分發：" + "、".join(dict.fromkeys(violations)))
 
     def _compute_application_identity(self, app: Application) -> str:
         """
@@ -1406,6 +1507,7 @@ class ManualDistributionService:
         scholarship_type_id: int,
         academic_year: int,
         semester: str,
+        college_code: Optional[str] = None,
     ) -> list[dict]:
         """
         Compute auto-allocation suggestions without persisting any changes.
@@ -1418,6 +1520,13 @@ class ManualDistributionService:
         5. Subtract already-allocated items from tracker.
         6. Sort students: renewal first, then by rank_position ascending.
         7. Allocate sequentially following preference order and quota constraints.
+
+        `college_code` narrows step 2 to that college's students only (admins can
+        run the distribution one college at a time). The quota tracker is still
+        built and decremented globally, so a single-college run consumes exactly
+        the same slots it would in a whole-scholarship run: tracker keys are
+        (config_id, sub_type, college_code), so no other college's students can
+        be affected by the ones skipped here.
 
         Returns list of {"ranking_item_id", "sub_type_code", "allocation_config_id"} dicts.
         Only unallocated items are included in the output.
@@ -1448,13 +1557,9 @@ class ManualDistributionService:
         result = await self.db.execute(items_query)
         all_items = result.scalars().all()
 
-        # Deduplicate by application_id (keep first seen), skip soft-deleted
-        seen_app_ids: set[int] = set()
-        unique_items = []
-        for item in all_items:
-            if item.application and item.application.deleted_at is None and item.application.id not in seen_app_ids:
-                seen_app_ids.add(item.application.id)
-                unique_items.append(item)
+        # Deduplicate by application_id (keep first seen), skip soft-deleted,
+        # and keep only the requested college when one was given.
+        unique_items = _dedupe_preview_items(all_items, college_code)
 
         if not unique_items:
             return []

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -1647,7 +1647,8 @@ class ManualDistributionService:
         # Seed from each consumed config's matrix so per-college caps survive,
         # then subtract every existing global consumer of that config so the
         # tracker reflects live remaining (honors the cross-config pool cap).
-        quota_tracker: dict[tuple[str, int, str], int] = {}
+        # Keys are (config_id, sub_type, college_code) — see _compute_suggestions.
+        quota_tracker: dict[tuple[int, str, str], int] = {}
         for cid, cfg in all_configs.items():
             if not cfg.has_college_quota or not cfg.quotas:
                 continue

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -847,9 +847,17 @@ class ManualDistributionService:
             "allocation_config_id": int|None  (None → defaults to the requesting config)
         }
         sub_type_code=None means unallocate.
+
+        Rows whose application is 撤銷/停發 are skipped entirely: the grid sends
+        every visible row, and a cancelled row arrives as an unallocate, which
+        would clear the allocated_sub_type that _cancel_allocation deliberately
+        preserved for 復發 (restore_allocation re-affirms the slot from it).
+        Their slot state belongs to revoke/suspend/restore, not to a grid save.
         """
         # Validate quota limits first
         await self._validate_allocations(scholarship_type_id, academic_year, semester, allocations)
+
+        cancelled_item_ids = await self._cancelled_ranking_item_ids([a["ranking_item_id"] for a in allocations])
 
         updated_count = 0
         requesting_config = await self._load_config(scholarship_type_id, academic_year, semester)
@@ -858,6 +866,8 @@ class ManualDistributionService:
 
         for alloc in allocations:
             item_id = alloc["ranking_item_id"]
+            if item_id in cancelled_item_ids:
+                continue
             sub_type = alloc.get("sub_type_code")
             alloc_config_id = alloc.get("allocation_config_id") or (requesting_config.id if sub_type else None)
 
@@ -1405,6 +1415,20 @@ class ManualDistributionService:
         )
         if rejected_violations:
             raise ValueError("以下分發之子類型審核不同意，無法分發：" + "、".join(rejected_violations))
+
+    async def _cancelled_ranking_item_ids(self, item_ids: list[int]) -> set[int]:
+        """Ranking items whose application is 撤銷 (revoked) / 停發 (suspended)."""
+        if not item_ids:
+            return set()
+        stmt = (
+            select(CollegeRankingItem.id)
+            .join(Application, CollegeRankingItem.application_id == Application.id)
+            .where(
+                CollegeRankingItem.id.in_(item_ids),
+                Application.quota_allocation_status.in_(CANCELLED_ALLOCATION_STATUSES),
+            )
+        )
+        return set((await self.db.execute(stmt)).scalars().all())
 
     def _assert_no_cancelled_applications(self, resolved: list[tuple[dict[str, Any], Application]]) -> None:
         """Block any allocation onto a 撤銷 (revoked) / 停發 (suspended) application.

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -146,21 +146,34 @@ async def load_review_items_by_role(db: AsyncSession, app_ids: list[int]) -> dic
 def _dedupe_preview_items(all_items: list, college_code: Optional[str] = None) -> list:
     """Select the ranking items auto_allocate_preview should suggest for.
 
-    Keeps the first item per application_id, drops items whose application is
-    missing or soft-deleted, and — when `college_code` is given — keeps only
-    that college's students so an admin can run the distribution one college at
-    a time. The college filter is applied BEFORE the dedup bookkeeping so a
+    One item per application_id, dropping items whose application is missing or
+    soft-deleted, and — when `college_code` is given — keeping only that
+    college's students so an admin can run the distribution one college at a
+    time. The college filter is applied BEFORE the dedup bookkeeping so a
     skipped application never shadows a later item.
+
+    An application can legitimately appear in two finalized rankings, and the
+    duplicate that carries the allocation is PREFERRED — same rule as
+    get_students_for_distribution, so the preview keys its suggestions on the
+    same ranking_item_id the grid renders. Picking the other duplicate would
+    make a suggestion the grid cannot match: silently dropped at best, staged
+    onto a row the admin never saw at worst. Callers must feed items in a
+    deterministic order (rank_position, id) for the same reason.
     """
-    seen_app_ids: set[int] = set()
+    index_by_app: dict[int, int] = {}
     unique_items: list = []
     for item in all_items:
         app = item.application
-        if app is None or app.deleted_at is not None or app.id in seen_app_ids:
+        if app is None or app.deleted_at is not None:
             continue
         if college_code and (app.student_data or {}).get("std_academyno", "") != college_code:
             continue
-        seen_app_ids.add(app.id)
+        existing_idx = index_by_app.get(app.id)
+        if existing_idx is not None:
+            if item.is_allocated and not unique_items[existing_idx].is_allocated:
+                unique_items[existing_idx] = item
+            continue
+        index_by_app[app.id] = len(unique_items)
         unique_items.append(item)
     return unique_items
 
@@ -1226,25 +1239,14 @@ class ManualDistributionService:
         to_restore: list[tuple[CollegeRankingItem, dict[str, Any]]] = []
         if wanted:
             items_result = await self.db.execute(
-                select(CollegeRankingItem).where(CollegeRankingItem.id.in_(list(wanted.keys())))
+                select(CollegeRankingItem)
+                .options(selectinload(CollegeRankingItem.application))
+                .where(CollegeRankingItem.id.in_(list(wanted.keys())))
             )
             to_restore = [(item, wanted[item.id]) for item in items_result.scalars().all()]
 
         restore_app_ids = list({item.application_id for item, _ in to_restore if item.application_id is not None})
         rejected_map = await self._batch_load_rejected_map(restore_app_ids)
-
-        # Applications the admin has since 撤銷/停發 — a snapshot taken before
-        # that cancellation still holds their slot, so restoring it blindly
-        # would resurrect a student who is meant to stay out.
-        cancelled_app_ids: set[int] = set()
-        if restore_app_ids:
-            cancelled_rows = await self.db.execute(
-                select(Application.id).where(
-                    Application.id.in_(restore_app_ids),
-                    Application.quota_allocation_status.in_(CANCELLED_ALLOCATION_STATUSES),
-                )
-            )
-            cancelled_app_ids = set(cancelled_rows.scalars().all())
 
         # Now restore from snapshot — a snapshot may predate a reviewer reject
         # (不同意) or a 撤銷/停發, so those rows are skipped instead of re-allocated.
@@ -1261,12 +1263,23 @@ class ManualDistributionService:
                     alloc_data["sub_type"],
                 )
                 continue
-            if item.application_id in cancelled_app_ids:
+            app = item.application
+            # A snapshot taken before a 撤銷/停發 still holds that student's slot;
+            # re-allocating it would resurrect someone meant to stay out. Write the
+            # slot identity back WITHOUT is_allocated so the cancel state survives:
+            # quota stays free (consumers count on is_allocated — see
+            # _winner_filters) while 復發 can still re-affirm the exact same slot,
+            # which restore_allocation drives off allocated_sub_type.
+            if app is not None and app.quota_allocation_status in CANCELLED_ALLOCATION_STATUSES:
                 skipped_cancelled += 1
+                item.allocated_sub_type = alloc_data["sub_type"]
+                item.allocation_config_id = alloc_data.get("allocation_config_id")
                 logger.info(
-                    "restore_from_history: skipping ranking_item %s — application %s is revoked/suspended",
+                    "restore_from_history: not re-allocating ranking_item %s — application %s is %s "
+                    "(slot identity preserved for 復發)",
                     item.id,
                     item.application_id,
+                    app.quota_allocation_status,
                 )
                 continue
             item.is_allocated = True
@@ -1317,36 +1330,40 @@ class ManualDistributionService:
                 raise ValueError(f"Duplicate ranking item: {item_id}")
             seen_items.add(item_id)
 
+        # Both allocation gates below read the same (allocation → application)
+        # pairs, so resolve them ONCE — a save can carry hundreds of ranking
+        # item ids and each resolve is a query plus its selectin follow-up.
+        resolved = await self._resolve_allocating_apps(allocations)
+
         # Review gate (審核不同意的子類型不可被分發) — an explicit reviewer
         # reject blocks unconditionally. A MISSING professor approval does NOT
         # block: the grid renders it as 未推薦 (matching the 學院推薦 column)
         # and the admin decides — distribution must not strand on unreviewed
         # applications.
-        await self._assert_no_rejected_sub_types(allocations)
+        await self._assert_no_rejected_sub_types(resolved)
 
         # 撤銷／停發 gate — mirrors the disabled checkbox in the UI so neither a
         # stale grid nor a crafted request can re-allocate a student the admin
         # deliberately pulled out of the distribution.
-        await self._assert_no_cancelled_applications(allocations)
+        self._assert_no_cancelled_applications(resolved)
 
         # Server-side quota enforcement is net-new (spec §10): the lock gate in
         # allocate/finalize (_assert_round_not_oversubscribed) recounts remaining
         # under SELECT FOR UPDATE on the consumed config rows and rejects
         # oversubscription. The frontend remaining counts are advisory.
 
-    async def _assert_no_rejected_sub_types(self, allocations: list[dict[str, Any]]) -> None:
-        """Block any allocation to a sub-type an explicit reviewer reject (不同意) covers.
+    async def _resolve_allocating_apps(
+        self, allocations: list[dict[str, Any]]
+    ) -> list[tuple[dict[str, Any], Application]]:
+        """Pair each SUB-TYPE-ASSIGNING allocation with its Application.
 
-        Only allocations that assign a sub-type are checked (``sub_type_code`` set;
-        ``None`` means unallocate). The gate is unconditional — renewal or not —
-        and mirrors the disabled checkbox in the UI so a crafted request can't
-        bypass it. A sub-type the professor merely has NOT approved yet is
-        allocatable: the grid shows it as 未推薦 and the admin decides, so one
-        unreviewed application can't strand the whole distribution.
+        Allocations with ``sub_type_code=None`` mean unallocate and are dropped —
+        no allocation gate applies to them. Shared by the gates in
+        _validate_allocations so they resolve the same rows only once.
         """
         allocating = [a for a in allocations if a.get("sub_type_code")]
         if not allocating:
-            return
+            return []
 
         item_ids = [a["ranking_item_id"] for a in allocating]
         stmt = (
@@ -1362,6 +1379,21 @@ class ManualDistributionService:
             app = item.application if item else None
             if app is not None:
                 resolved.append((alloc, app))
+        return resolved
+
+    async def _assert_no_rejected_sub_types(self, resolved: list[tuple[dict[str, Any], Application]]) -> None:
+        """Block any allocation to a sub-type an explicit reviewer reject (不同意) covers.
+
+        Takes the (allocation, application) pairs from _resolve_allocating_apps —
+        already limited to allocations that assign a sub-type. The gate is
+        unconditional — renewal or not — and mirrors the disabled checkbox in the
+        UI so a crafted request can't bypass it. A sub-type the professor merely
+        has NOT approved yet is allocatable: the grid shows it as 未推薦 and the
+        admin decides, so one unreviewed application can't strand the whole
+        distribution.
+        """
+        if not resolved:
+            return
 
         rejected = await self._batch_load_rejected_map(list({app.id for _, app in resolved}))
         rejected_violations = list(
@@ -1374,36 +1406,22 @@ class ManualDistributionService:
         if rejected_violations:
             raise ValueError("以下分發之子類型審核不同意，無法分發：" + "、".join(rejected_violations))
 
-    async def _assert_no_cancelled_applications(self, allocations: list[dict[str, Any]]) -> None:
+    def _assert_no_cancelled_applications(self, resolved: list[tuple[dict[str, Any], Application]]) -> None:
         """Block any allocation onto a 撤銷 (revoked) / 停發 (suspended) application.
 
         Cancelling frees the ranking item (``is_allocated=False``) so the slot can
         go to someone else — which also makes the student look allocatable again.
         The admin's decision wins: allocating to them is refused here, and
         restoring them is a separate explicit action (restore_allocation).
-        Only allocations that assign a sub-type are checked (``sub_type_code``
-        set; ``None`` means unallocate, which stays allowed).
+        Takes the (allocation, application) pairs from _resolve_allocating_apps,
+        so unallocate rows (``sub_type_code=None``) are already excluded and stay
+        allowed.
         """
-        allocating = [a for a in allocations if a.get("sub_type_code")]
-        if not allocating:
-            return
-
-        item_ids = [a["ranking_item_id"] for a in allocating]
-        stmt = (
-            select(CollegeRankingItem)
-            .options(selectinload(CollegeRankingItem.application))
-            .where(CollegeRankingItem.id.in_(item_ids))
-        )
-        items = {it.id: it for it in (await self.db.execute(stmt)).scalars().all()}
-
-        violations: list[str] = []
-        for alloc in allocating:
-            item = items.get(alloc["ranking_item_id"])
-            app = item.application if item else None
-            if app is None or app.quota_allocation_status not in CANCELLED_ALLOCATION_STATUSES:
-                continue
-            label = "撤銷" if app.quota_allocation_status == "revoked" else "停發"
-            violations.append(f"{app.app_id}（{label}）")
+        violations = [
+            f"{app.app_id}（{'撤銷' if app.quota_allocation_status == 'revoked' else '停發'}）"
+            for _, app in resolved
+            if app.quota_allocation_status in CANCELLED_ALLOCATION_STATUSES
+        ]
         if violations:
             raise ValueError("以下申請已撤銷／停發，無法分發：" + "、".join(dict.fromkeys(violations)))
 
@@ -1548,11 +1566,14 @@ class ManualDistributionService:
 
         ranking_ids = [r.id for r in rankings]
 
-        # Load items with eagerly loaded Application
+        # Load items with eagerly loaded Application. Ordered by (rank_position,
+        # id) — same as get_students_for_distribution — so the dedup below picks
+        # the SAME duplicate the grid renders.
         items_query = (
             select(CollegeRankingItem)
             .options(selectinload(CollegeRankingItem.application))
             .where(CollegeRankingItem.ranking_id.in_(ranking_ids))
+            .order_by(CollegeRankingItem.rank_position, CollegeRankingItem.id)
         )
         result = await self.db.execute(items_query)
         all_items = result.scalars().all()
@@ -1609,8 +1630,9 @@ class ManualDistributionService:
             for sub_type, college_quotas in cfg.quotas.items():
                 if not isinstance(college_quotas, dict):
                     continue
-                for college_code, quota in college_quotas.items():
-                    quota_tracker[(cid, sub_type, college_code)] = int(quota)
+                # NOT `college_code` — that is this method's parameter.
+                for matrix_college, quota in college_quotas.items():
+                    quota_tracker[(cid, sub_type, matrix_college)] = int(quota)
 
         # Subtract every already-allocated ranking item pointing at these configs
         # (across ALL rankings, not just this round — global pool).
@@ -1698,7 +1720,7 @@ class ManualDistributionService:
             raise ValueError(f"Application {application_id} not found")
 
         prior_status = app.quota_allocation_status
-        if prior_status not in ("revoked", "suspended"):
+        if prior_status not in CANCELLED_ALLOCATION_STATUSES:
             raise ValueError(
                 f"Application {application_id} is not revoked/suspended " f"(quota_allocation_status={prior_status})"
             )
@@ -1792,7 +1814,7 @@ class ManualDistributionService:
             raise ValueError(f"Application {application_id} not found")
 
         # 2. Conflict check
-        if app.quota_allocation_status in ("revoked", "suspended"):
+        if app.quota_allocation_status in CANCELLED_ALLOCATION_STATUSES:
             raise ValueError(f"Application {application_id} already {app.quota_allocation_status}")
 
         # 3. 400 check

--- a/backend/app/tests/test_auto_allocate_preview.py
+++ b/backend/app/tests/test_auto_allocate_preview.py
@@ -764,6 +764,23 @@ class TestDedupePreviewItems:
         assert [i.id for i in _dedupe_preview_items(items)] == [101, 102]
         assert [i.id for i in _dedupe_preview_items(items, "")] == [101, 102]
 
+    def test_allocated_duplicate_wins_over_the_first_seen(self, _dedupe_preview_items):
+        """Same rule as get_students_for_distribution: the grid shows the
+        allocated duplicate, so the preview must key on that same item — else it
+        suggests a ranking_item_id the grid cannot match."""
+        app = _make_app(1, college="A")
+        items = [
+            _make_item(101, rank_position=1, app=app),
+            _make_item(102, rank_position=2, app=app, is_allocated=True, allocated_sub_type="nstc"),
+        ]
+        assert [i.id for i in _dedupe_preview_items(items)] == [102]
+        # …and the first-seen item wins when neither duplicate is allocated.
+        plain = [
+            _make_item(201, rank_position=1, app=app),
+            _make_item(202, rank_position=2, app=app),
+        ]
+        assert [i.id for i in _dedupe_preview_items(plain)] == [201]
+
     def test_unknown_college_students_only_match_the_empty_filter(self, _dedupe_preview_items):
         """A student with no std_academyno never leaks into a named college's run."""
         item = _make_item(101, rank_position=1, app=_make_app(1, college=""))

--- a/backend/app/tests/test_auto_allocate_preview.py
+++ b/backend/app/tests/test_auto_allocate_preview.py
@@ -46,9 +46,9 @@ _MOCK_MODULES = [
 
 
 @pytest.fixture(scope="module")
-def _compute_suggestions():
+def _service_module():
     """
-    Provide _compute_suggestions.
+    Provide the manual_distribution_service module (for its pure helpers).
 
     Preferred path: a plain import — in the dev container and CI all real
     dependencies (sqlalchemy, app.models.*) are installed, and importing the
@@ -66,11 +66,11 @@ def _compute_suggestions():
     CI unit lane).
     """
     try:
-        from app.services.manual_distribution_service import _compute_suggestions as real_fn
+        import app.services.manual_distribution_service as real_module
     except ImportError:
         pass
     else:
-        yield real_fn
+        yield real_module
         return
 
     created: dict[str, MagicMock] = {}
@@ -117,11 +117,23 @@ def _compute_suggestions():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    yield module._compute_suggestions
+    yield module
 
     # Remove only the stand-ins we created; real modules were never touched.
     for mod_name in created:
         sys.modules.pop(mod_name, None)
+
+
+@pytest.fixture(scope="module")
+def _compute_suggestions(_service_module):
+    """The pure allocation logic."""
+    return _service_module._compute_suggestions
+
+
+@pytest.fixture(scope="module")
+def _dedupe_preview_items(_service_module):
+    """The pure item-selection step (dedup + optional single-college filter)."""
+    return _service_module._dedupe_preview_items
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +149,8 @@ def _make_app(
     sub_type_preferences: Optional[list] = None,
     renewal_year: Optional[int] = None,
     scholarship_subtype_list: Optional[list] = None,
+    quota_allocation_status: Optional[str] = None,
+    deleted_at=None,
 ) -> SimpleNamespace:
     """Build a minimal Application-like object."""
     return SimpleNamespace(
@@ -147,6 +161,8 @@ def _make_app(
         sub_type_preferences=sub_type_preferences,
         student_data={"std_academyno": college},
         scholarship_subtype_list=scholarship_subtype_list or [],
+        quota_allocation_status=quota_allocation_status,
+        deleted_at=deleted_at,
     )
 
 
@@ -636,6 +652,123 @@ class TestUnknownCollegeGetsNoAllocation:
 
         assert len(results) == 1
         assert results[0] == {"ranking_item_id": 101, "sub_type_code": None, "allocation_config_id": None}
+
+
+class TestCancelledApplicationsNeverSuggested:
+    """撤銷／停發 students keep that state — the preview must not re-allocate them.
+
+    Cancelling frees the ranking item (is_allocated=False) so the slot can go to
+    someone else; without an explicit gate the preview reads them as free
+    candidates and hands the slot straight back to the student it was taken from.
+    """
+
+    @pytest.mark.parametrize("cancel_status", ["revoked", "suspended"])
+    def test_cancelled_student_gets_null_and_keeps_quota(self, _compute_suggestions, cancel_status):
+        own_config_id = 115
+        quota_tracker = _build_quota_tracker({(115, "nstc", "A"): 2})
+
+        cancelled_app = _make_app(
+            1,
+            college="A",
+            sub_type_preferences=["nstc"],
+            quota_allocation_status=cancel_status,
+        )
+        item = _make_item(101, rank_position=1, app=cancelled_app)
+
+        results = _compute_suggestions(
+            unique_items=[item],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115]},
+            quota_tracker=quota_tracker,
+            own_config_id=own_config_id,
+        )
+
+        assert results == [{"ranking_item_id": 101, "sub_type_code": None, "allocation_config_id": None}]
+        # The freed slot stays available for someone else.
+        assert quota_tracker[(115, "nstc", "A")] == 2
+
+    def test_cancelled_student_does_not_block_the_next_ranked_student(self, _compute_suggestions):
+        """The slot freed by a 撤銷 goes to the next candidate, not back to them."""
+        own_config_id = 115
+        quota_tracker = _build_quota_tracker({(115, "nstc", "A"): 1})
+
+        revoked_app = _make_app(1, college="A", sub_type_preferences=["nstc"], quota_allocation_status="revoked")
+        next_app = _make_app(2, college="A", sub_type_preferences=["nstc"])
+
+        results = _compute_suggestions(
+            unique_items=[
+                _make_item(101, rank_position=1, app=revoked_app),
+                _make_item(102, rank_position=2, app=next_app),
+            ],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115]},
+            quota_tracker=quota_tracker,
+            own_config_id=own_config_id,
+        )
+
+        by_item = {r["ranking_item_id"]: r for r in results}
+        assert by_item[101]["sub_type_code"] is None
+        assert by_item[102] == {"ranking_item_id": 102, "sub_type_code": "nstc", "allocation_config_id": 115}
+
+    def test_allocated_status_is_still_suggestible(self, _compute_suggestions):
+        """Only revoked/suspended are gated — a normal status must still allocate."""
+        results = _compute_suggestions(
+            unique_items=[
+                _make_item(
+                    101,
+                    rank_position=1,
+                    app=_make_app(1, college="A", sub_type_preferences=["nstc"], quota_allocation_status="waitlisted"),
+                )
+            ],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115]},
+            quota_tracker=_build_quota_tracker({(115, "nstc", "A"): 1}),
+            own_config_id=115,
+        )
+        assert results[0]["sub_type_code"] == "nstc"
+
+
+class TestDedupePreviewItems:
+    """Item selection for the preview: dedup, soft-delete, single-college filter."""
+
+    def test_keeps_first_item_per_application_and_drops_soft_deleted(self, _dedupe_preview_items):
+        app1 = _make_app(1, college="A")
+        deleted = _make_app(2, college="A", deleted_at="2026-01-01")
+        items = [
+            _make_item(101, rank_position=1, app=app1),
+            _make_item(102, rank_position=2, app=app1),  # duplicate application
+            _make_item(103, rank_position=3, app=deleted),
+            _make_item(104, rank_position=4, app=None),
+        ]
+        assert [i.id for i in _dedupe_preview_items(items)] == [101]
+
+    def test_college_code_narrows_to_that_college(self, _dedupe_preview_items):
+        """The per-college 預設分發 button: only that college's students come back."""
+        items = [
+            _make_item(101, rank_position=1, app=_make_app(1, college="A")),
+            _make_item(102, rank_position=2, app=_make_app(2, college="B")),
+            _make_item(103, rank_position=3, app=_make_app(3, college="A")),
+        ]
+        assert [i.id for i in _dedupe_preview_items(items, "A")] == [101, 103]
+        assert [i.id for i in _dedupe_preview_items(items, "B")] == [102]
+
+    def test_no_college_code_returns_every_college(self, _dedupe_preview_items):
+        """Falsy college_code must NOT narrow the whole-scholarship run."""
+        items = [
+            _make_item(101, rank_position=1, app=_make_app(1, college="A")),
+            _make_item(102, rank_position=2, app=_make_app(2, college="B")),
+        ]
+        assert [i.id for i in _dedupe_preview_items(items)] == [101, 102]
+        assert [i.id for i in _dedupe_preview_items(items, "")] == [101, 102]
+
+    def test_unknown_college_students_only_match_the_empty_filter(self, _dedupe_preview_items):
+        """A student with no std_academyno never leaks into a named college's run."""
+        item = _make_item(101, rank_position=1, app=_make_app(1, college=""))
+        assert _dedupe_preview_items([item], "A") == []
+        assert [i.id for i in _dedupe_preview_items([item])] == [101]
 
 
 class TestPreferenceOrderRespected:

--- a/backend/app/tests/test_manual_distribution_professor_gate.py
+++ b/backend/app/tests/test_manual_distribution_professor_gate.py
@@ -371,3 +371,28 @@ async def test_restore_skips_cancelled_application(db: AsyncSession):
     reaffirmed = await db.get(CollegeRankingItem, item_id)
     await db.refresh(reaffirmed)
     assert reaffirmed.is_allocated is True
+
+
+@pytest.mark.asyncio
+async def test_save_does_not_wipe_a_cancelled_students_preserved_slot(db: AsyncSession):
+    """The grid posts EVERY visible row, so a 撤銷 row arrives as an unallocate.
+
+    Acting on it would clear allocated_sub_type — the very field
+    _cancel_allocation preserves so 復發 can re-affirm the same slot. allocate()
+    must skip cancelled rows entirely.
+    """
+    service, item_id, sch_id = await _setup(db, suffix="cancelsave", allocated_sub_type="nstc")
+    item = await db.get(CollegeRankingItem, item_id)
+    app = await db.get(Application, item.application_id)
+    cfg_id = item.allocation_config_id
+    app.quota_allocation_status = "revoked"
+    item.is_allocated = False
+    await db.commit()
+
+    await service.allocate(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": None}], admin_user_id=1)
+
+    refreshed = await db.get(CollegeRankingItem, item_id)
+    await db.refresh(refreshed)
+    assert refreshed.is_allocated is False
+    assert refreshed.allocated_sub_type == "nstc"
+    assert refreshed.allocation_config_id == cfg_id

--- a/backend/app/tests/test_manual_distribution_professor_gate.py
+++ b/backend/app/tests/test_manual_distribution_professor_gate.py
@@ -279,3 +279,78 @@ async def test_restore_skips_rejected_subtype(db: AsyncSession):
     )
     assert result["restored_count"] == 0
     assert result["skipped_rejected"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 撤銷／停發 gate (用戶需求): a student the admin pulled out of the distribution
+# keeps that state — no allocation writer may hand the slot back. Cancelling
+# frees the ranking item (is_allocated=False) precisely so the slot can go to
+# someone else, which is what makes the student look allocatable again.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_allocate_blocked_when_application_revoked(db: AsyncSession):
+    service, item_id, sch_id = await _setup(db, suffix="revgate", allocated_sub_type="nstc")
+    item = await db.get(CollegeRankingItem, item_id)
+    app = await db.get(Application, item.application_id)
+    app.quota_allocation_status = "revoked"
+    item.is_allocated = False
+    await db.commit()
+    with pytest.raises(ValueError, match="撤銷"):
+        await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
+
+
+@pytest.mark.asyncio
+async def test_allocate_blocked_when_application_suspended(db: AsyncSession):
+    service, item_id, sch_id = await _setup(db, suffix="suspgate", allocated_sub_type="nstc")
+    item = await db.get(CollegeRankingItem, item_id)
+    app = await db.get(Application, item.application_id)
+    app.quota_allocation_status = "suspended"
+    item.is_allocated = False
+    await db.commit()
+    with pytest.raises(ValueError, match="停發"):
+        await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
+
+
+@pytest.mark.asyncio
+async def test_unallocate_allowed_for_cancelled_application(db: AsyncSession):
+    # sub_type_code=None means unallocate — the gate must not deadlock a
+    # cancelled row that still carries a staged allocation.
+    service, item_id, sch_id = await _setup(db, suffix="cancelunalloc")
+    item = await db.get(CollegeRankingItem, item_id)
+    app = await db.get(Application, item.application_id)
+    app.quota_allocation_status = "revoked"
+    await db.commit()
+    await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": None}])
+
+
+@pytest.mark.asyncio
+async def test_allocate_allowed_for_normal_allocation_status(db: AsyncSession):
+    # Only revoked/suspended are gated — an ordinary status still allocates.
+    service, item_id, sch_id = await _setup(db, suffix="normalstatus")
+    item = await db.get(CollegeRankingItem, item_id)
+    app = await db.get(Application, item.application_id)
+    app.quota_allocation_status = "waitlisted"
+    await db.commit()
+    await service._validate_allocations(sch_id, YEAR, SEM, [{"ranking_item_id": item_id, "sub_type_code": "nstc"}])
+
+
+@pytest.mark.asyncio
+async def test_restore_skips_cancelled_application(db: AsyncSession):
+    # A history snapshot predating the 撤銷 must not resurrect the allocation.
+    service, item_id, sch_id = await _setup(db, suffix="cancelrestore")
+    item = await db.get(CollegeRankingItem, item_id)
+    app = await db.get(Application, item.application_id)
+    app.quota_allocation_status = "revoked"
+    await db.commit()
+    result = await service.restore_from_history(
+        sch_id,
+        YEAR,
+        SEM,
+        {str(item_id): {"sub_type": "nstc", "allocation_config_id": None, "status": "allocated"}},
+    )
+    assert result["restored_count"] == 0
+    assert result["skipped_cancelled"] == 1
+    refreshed = await db.get(CollegeRankingItem, item_id)
+    assert refreshed.is_allocated is False

--- a/backend/app/tests/test_manual_distribution_professor_gate.py
+++ b/backend/app/tests/test_manual_distribution_professor_gate.py
@@ -338,19 +338,36 @@ async def test_allocate_allowed_for_normal_allocation_status(db: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_restore_skips_cancelled_application(db: AsyncSession):
-    # A history snapshot predating the 撤銷 must not resurrect the allocation.
-    service, item_id, sch_id = await _setup(db, suffix="cancelrestore")
+    # A history snapshot predating the 撤銷 must not resurrect the allocation —
+    # but it must not destroy the slot identity either: _cancel_allocation keeps
+    # allocated_sub_type precisely so 復發 can re-affirm the same slot, and
+    # restore_from_history clears every item before re-applying the snapshot.
+    service, item_id, sch_id = await _setup(db, suffix="cancelrestore", allocated_sub_type="nstc")
     item = await db.get(CollegeRankingItem, item_id)
     app = await db.get(Application, item.application_id)
+    cfg_id = item.allocation_config_id
+    # Simulate the post-cancel state: slot freed, sub-type preserved.
     app.quota_allocation_status = "revoked"
+    item.is_allocated = False
     await db.commit()
+
     result = await service.restore_from_history(
         sch_id,
         YEAR,
         SEM,
-        {str(item_id): {"sub_type": "nstc", "allocation_config_id": None, "status": "allocated"}},
+        {str(item_id): {"sub_type": "nstc", "allocation_config_id": cfg_id, "status": "allocated"}},
     )
     assert result["restored_count"] == 0
     assert result["skipped_cancelled"] == 1
+
     refreshed = await db.get(CollegeRankingItem, item_id)
+    await db.refresh(refreshed)
+    # Still cancelled (no quota consumed) …
     assert refreshed.is_allocated is False
+    # … but 復發 can still re-affirm the exact same slot.
+    assert refreshed.allocated_sub_type == "nstc"
+    assert refreshed.allocation_config_id == cfg_id
+    await service.restore_allocation(app.id, admin_user_id=1)
+    reaffirmed = await db.get(CollegeRankingItem, item_id)
+    await db.refresh(reaffirmed)
+    assert reaffirmed.is_allocated is True

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -1549,7 +1549,11 @@ export function ManualDistributionPanel({
                               colSpan={14 + subTypeCols.length}
                               className="px-4 py-1.5 text-xs font-bold text-slate-600 border-y border-slate-300"
                             >
-                              <div className="flex items-center justify-between gap-3">
+                              {/* Left-aligned next to the college name: the row
+                                  spans 14+N columns, so a right-aligned button
+                                  would sit off-screen until the admin scrolls
+                                  the table horizontally. */}
+                              <div className="flex items-center gap-3">
                                 <span>{collegeName}</span>
                                 <Button
                                   size="sm"

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -23,6 +23,7 @@ import type {
 import {
   buildCollegeNameMap,
   getSavedAllocation,
+  isCancelledAllocation,
   makeColKey,
   resolveCollegeName,
 } from "@/lib/api/modules/manual-distribution";
@@ -71,6 +72,7 @@ import {
   AlertTriangle,
   ArrowRight,
   RefreshCw,
+  Wand2,
 } from "lucide-react";
 
 interface ManualDistributionPanelProps {
@@ -320,6 +322,10 @@ export function ManualDistributionPanel({
     }>;
   } | null>(null);
   const [previewApplied, setPreviewApplied] = useState(false);
+  // college_code currently running the per-college 預設分發 button (null = idle).
+  const [autoAllocatingCollege, setAutoAllocatingCollege] = useState<
+    string | null
+  >(null);
   // Renewal-aware panel state (Phase 8.2): approved renewals occupying slots,
   // remaining quota per (sub_type × allocation_year), and ranked candidates
   // with challenge metadata. Independent of `students` / `quotaStatus` —
@@ -420,12 +426,21 @@ export function ManualDistributionPanel({
           // Preview is optional; proceed without it
         }
 
-        // Apply auto-preview suggestions for unallocated students
+        // Apply auto-preview suggestions for unallocated students. 撤銷/停發
+        // students are excluded on both sides (the backend skips them, and this
+        // guard keeps a stale response from staging one behind the disabled
+        // checkbox, where the admin could not untick it before saving).
+        const cancelledItemIds = new Set(
+          studentsResp.data
+            .filter(isCancelledAllocation)
+            .map(s => s.ranking_item_id)
+        );
         let hasPreview = false;
         for (const suggestion of previewSuggestions) {
           if (
             suggestion.sub_type_code &&
             suggestion.allocation_config_id != null &&
+            !cancelledItemIds.has(suggestion.ranking_item_id) &&
             !allocMap.get(suggestion.ranking_item_id)
           ) {
             allocMap.set(suggestion.ranking_item_id, {
@@ -797,11 +812,18 @@ export function ManualDistributionPanel({
       );
       if (resp.success && resp.data) {
         const skipped = resp.data.skipped_rejected ?? 0;
+        const skippedCancelled = resp.data.skipped_cancelled ?? 0;
+        const notes = [
+          skipped > 0 ? `${skipped} 筆因審核不同意已略過` : "",
+          skippedCancelled > 0
+            ? `${skippedCancelled} 筆因已撤銷／停發已略過`
+            : "",
+        ].filter(Boolean);
         setSaveMessage({
           type: "success",
           text:
             `成功還原 ${resp.data.restored_count} 筆分配紀錄` +
-            (skipped > 0 ? `（${skipped} 筆因審核不同意已略過）` : ""),
+            (notes.length > 0 ? `（${notes.join("，")}）` : ""),
         });
         setShowHistoryDialog(false);
         await reloadServerSnapshot();
@@ -815,6 +837,94 @@ export function ManualDistributionPanel({
       setIsRestoring(false);
     }
   };
+
+  /**
+   * Run the default distribution for ONE college.
+   *
+   * Same algorithm as the on-load auto-preview, scoped server-side to this
+   * college (quotas are still evaluated globally). Staged locally only —
+   * nothing is persisted until the admin presses 儲存 — and it never overwrites
+   * a cell that already carries an allocation (saved or hand-picked), so it is
+   * safe to press repeatedly: it only fills the blanks.
+   */
+  const handleCollegeAutoAllocate = useCallback(
+    async (collegeCode: string, collegeName: string) => {
+      if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
+        return;
+      setAutoAllocatingCollege(collegeCode);
+      setSaveMessage(null);
+      try {
+        const resp =
+          await apiClient.manualDistribution.getAutoAllocatePreview(
+            scholarshipTypeId,
+            selectedAcademicYear,
+            selectedSemester,
+            collegeCode
+          );
+        if (!resp.success || !resp.data) {
+          setSaveMessage({
+            type: "error",
+            text: resp.message || `${collegeName} 預設分發失敗`,
+          });
+          return;
+        }
+        // Guard against a suggestion for a student outside this group — the
+        // button must never touch rows the admin is not looking at — and against
+        // 撤銷/停發 students, who keep their state and stay unallocated.
+        const groupItemIds = new Set(
+          students
+            .filter(
+              s =>
+                (s.college_code || "") === collegeCode &&
+                !isCancelledAllocation(s)
+            )
+            .map(s => s.ranking_item_id)
+        );
+        const next = new Map(localAllocations);
+        let filled = 0;
+        for (const suggestion of resp.data.suggestions) {
+          if (
+            suggestion.sub_type_code &&
+            suggestion.allocation_config_id != null &&
+            groupItemIds.has(suggestion.ranking_item_id) &&
+            !next.get(suggestion.ranking_item_id)
+          ) {
+            next.set(suggestion.ranking_item_id, {
+              sub_type: suggestion.sub_type_code,
+              config_id: suggestion.allocation_config_id,
+            });
+            filled++;
+          }
+        }
+        if (filled > 0) {
+          setLocalAllocations(next);
+          setPreviewApplied(true);
+        }
+        setSaveMessage({
+          type: "success",
+          text:
+            filled > 0
+              ? `${collegeName}：已預設分配 ${filled} 筆，請確認後儲存`
+              : `${collegeName}：無可預設分配的名額（學生已分配完畢或名額已用盡）`,
+        });
+      } catch (error) {
+        logger.error("College auto-allocate error", { error: error });
+        setSaveMessage({
+          type: "error",
+          text: `${collegeName} 預設分發時發生錯誤`,
+        });
+      } finally {
+        setAutoAllocatingCollege(null);
+      }
+    },
+    [
+      scholarshipTypeId,
+      selectedAcademicYear,
+      selectedSemester,
+      students,
+      localAllocations,
+    ]
+  );
 
   // Apply filters
   const filteredStudents = useMemo(() => {
@@ -1429,7 +1539,40 @@ export function ManualDistributionPanel({
                               colSpan={14 + subTypeCols.length}
                               className="px-4 py-1.5 text-xs font-bold text-slate-600 border-y border-slate-300"
                             >
-                              {collegeName}
+                              <div className="flex items-center justify-between gap-3">
+                                <span>{collegeName}</span>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="h-6 px-2 text-[11px] font-medium"
+                                  disabled={
+                                    !collegeCode ||
+                                    autoAllocatingCollege !== null ||
+                                    isLoading ||
+                                    isSaving ||
+                                    isFinalizing ||
+                                    isRestoring
+                                  }
+                                  title={
+                                    collegeCode
+                                      ? `依排名與志願序自動預設分配 ${collegeName} 尚未核配的學生（僅填空白，儲存前可修改）`
+                                      : "無學院代碼，無法執行預設分發"
+                                  }
+                                  onClick={() =>
+                                    handleCollegeAutoAllocate(
+                                      collegeCode,
+                                      collegeName
+                                    )
+                                  }
+                                >
+                                  {autoAllocatingCollege === collegeCode ? (
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                  ) : (
+                                    <Wand2 className="h-3 w-3" />
+                                  )}
+                                  <span className="ml-1">預設分發</span>
+                                </Button>
+                              </div>
                             </td>
                           </tr>
                           {collegeStudents.map(student => {

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -654,7 +654,11 @@ export function ManualDistributionPanel({
     sub_type: string,
     config_id: number
   ) => {
-    const cur = localAllocationsRef.current.get(rankingItemId);
+    // Read the render-scoped state, NOT localAllocationsRef: the ref is written
+    // in an effect (it exists so an await'd handler can see edits made while its
+    // request was in flight) and can therefore trail the committed render that
+    // produced this click.
+    const cur = localAllocations.get(rankingItemId);
     const isUncheck =
       cur?.sub_type === sub_type && cur?.config_id === config_id;
     // Remember a deliberate clear so 預設分發 leaves that row alone.

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { logger } from "@/lib/utils/logger";
 import { useCollegeManagement } from "@/contexts/college-management-context";
 import { useReferenceData } from "@/hooks/use-reference-data";
@@ -21,10 +21,12 @@ import type {
   ReleaseChainItem,
 } from "@/lib/api/modules/manual-distribution";
 import {
+  buildCollegeBudget,
   buildCollegeNameMap,
   getSavedAllocation,
   isCancelledAllocation,
   makeColKey,
+  mergeSuggestions,
   resolveCollegeName,
 } from "@/lib/api/modules/manual-distribution";
 import { User } from "@/types/user";
@@ -292,6 +294,13 @@ export function ManualDistributionPanel({
   const [localAllocations, setLocalAllocations] = useState<
     Map<number, LocalAlloc | null>
   >(new Map());
+  // Mirror of localAllocations for async handlers: an await'd handler must merge
+  // into the CURRENT staged map, not the one captured when it started, or it
+  // silently reverts checkbox edits made while its request was in flight.
+  const localAllocationsRef = useRef(localAllocations);
+  useEffect(() => {
+    localAllocationsRef.current = localAllocations;
+  }, [localAllocations]);
   const [collegeFilter, setCollegeFilter] = useState<string>("");
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
@@ -426,35 +435,27 @@ export function ManualDistributionPanel({
           // Preview is optional; proceed without it
         }
 
-        // Apply auto-preview suggestions for unallocated students. 撤銷/停發
-        // students are excluded on both sides (the backend skips them, and this
-        // guard keeps a stale response from staging one behind the disabled
-        // checkbox, where the admin could not untick it before saving).
-        const cancelledItemIds = new Set(
+        // Apply auto-preview suggestions for unallocated students. Eligible =
+        // rows the grid actually renders, minus 撤銷/停發 — a suggestion for a
+        // row that is not on screen (a duplicate ranking item, or a cancelled
+        // student behind a disabled checkbox) would be saved without the admin
+        // ever being able to see or untick it. No budget: this runs against a
+        // fresh server snapshot, so the backend's own quota counts are exact.
+        const eligibleItemIds = new Set(
           studentsResp.data
-            .filter(isCancelledAllocation)
+            .filter(s => !isCancelledAllocation(s))
             .map(s => s.ranking_item_id)
         );
-        let hasPreview = false;
-        for (const suggestion of previewSuggestions) {
-          if (
-            suggestion.sub_type_code &&
-            suggestion.allocation_config_id != null &&
-            !cancelledItemIds.has(suggestion.ranking_item_id) &&
-            !allocMap.get(suggestion.ranking_item_id)
-          ) {
-            allocMap.set(suggestion.ranking_item_id, {
-              sub_type: suggestion.sub_type_code,
-              config_id: suggestion.allocation_config_id,
-            });
-            hasPreview = true;
-          }
-        }
+        const merged = mergeSuggestions(
+          allocMap,
+          previewSuggestions,
+          eligibleItemIds
+        );
         // Commit students together with their seeded allocations so no render
         // sees new students against stale local state (the matrix reads both).
         setStudents(studentsResp.data);
-        setPreviewApplied(hasPreview);
-        setLocalAllocations(allocMap);
+        setPreviewApplied(merged.filled > 0);
+        setLocalAllocations(merged.next);
       }
       if (quotaResp.success && quotaResp.data) {
         setQuotaStatus(quotaResp.data);
@@ -842,10 +843,14 @@ export function ManualDistributionPanel({
    * Run the default distribution for ONE college.
    *
    * Same algorithm as the on-load auto-preview, scoped server-side to this
-   * college (quotas are still evaluated globally). Staged locally only —
-   * nothing is persisted until the admin presses 儲存 — and it never overwrites
-   * a cell that already carries an allocation (saved or hand-picked), so it is
-   * safe to press repeatedly: it only fills the blanks.
+   * college (quotas are still evaluated globally). It covers the college's WHOLE
+   * ranking, not just the rows a 搜尋 filter leaves on screen — the suggestions
+   * are a rank-ordered plan, and applying half of one would hand a slot to the
+   * wrong student.
+   *
+   * Staged locally only — nothing is persisted until the admin presses 儲存 —
+   * and it never overwrites a cell that already carries an allocation (saved or
+   * hand-picked), so it is safe to press repeatedly: it only fills the blanks.
    */
   const handleCollegeAutoAllocate = useCallback(
     async (collegeCode: string, collegeName: string) => {
@@ -854,13 +859,12 @@ export function ManualDistributionPanel({
       setAutoAllocatingCollege(collegeCode);
       setSaveMessage(null);
       try {
-        const resp =
-          await apiClient.manualDistribution.getAutoAllocatePreview(
-            scholarshipTypeId,
-            selectedAcademicYear,
-            selectedSemester,
-            collegeCode
-          );
+        const resp = await apiClient.manualDistribution.getAutoAllocatePreview(
+          scholarshipTypeId,
+          selectedAcademicYear,
+          selectedSemester,
+          collegeCode
+        );
         if (!resp.success || !resp.data) {
           setSaveMessage({
             type: "error",
@@ -868,10 +872,10 @@ export function ManualDistributionPanel({
           });
           return;
         }
-        // Guard against a suggestion for a student outside this group — the
-        // button must never touch rows the admin is not looking at — and against
+        const suggestions = resp.data.suggestions;
+        // Eligible = this college's rows only (never touch another group), minus
         // 撤銷/停發 students, who keep their state and stay unallocated.
-        const groupItemIds = new Set(
+        const eligibleItemIds = new Set(
           students
             .filter(
               s =>
@@ -880,31 +884,37 @@ export function ManualDistributionPanel({
             )
             .map(s => s.ranking_item_id)
         );
-        const next = new Map(localAllocations);
-        let filled = 0;
-        for (const suggestion of resp.data.suggestions) {
-          if (
-            suggestion.sub_type_code &&
-            suggestion.allocation_config_id != null &&
-            groupItemIds.has(suggestion.ranking_item_id) &&
-            !next.get(suggestion.ranking_item_id)
-          ) {
-            next.set(suggestion.ranking_item_id, {
-              sub_type: suggestion.sub_type_code,
-              config_id: suggestion.allocation_config_id,
-            });
-            filled++;
-          }
-        }
+        // Read through the ref, NOT the value captured before the await: the
+        // checkboxes stay live during the request, and merging into the stale
+        // map would silently revert anything the admin ticked meanwhile.
+        const staged = localAllocationsRef.current;
+        // The backend counted only PERSISTED consumers, so cap the merge by this
+        // college's matrix row minus what is already staged — otherwise
+        // hand-picking first and then pressing this button over-allocates the
+        // college (the save-time gate only recounts the global pool).
+        const budget = buildCollegeBudget(
+          quotaStatus,
+          students,
+          staged,
+          collegeCode
+        );
+        const { next, filled, blocked } = mergeSuggestions(
+          staged,
+          suggestions,
+          eligibleItemIds,
+          budget
+        );
         if (filled > 0) {
           setLocalAllocations(next);
           setPreviewApplied(true);
         }
+        const overflowNote =
+          blocked > 0 ? `，另有 ${blocked} 筆因學院名額已滿未分配` : "";
         setSaveMessage({
           type: "success",
           text:
             filled > 0
-              ? `${collegeName}：已預設分配 ${filled} 筆，請確認後儲存`
+              ? `${collegeName}：已預設分配 ${filled} 筆${overflowNote}，請確認後儲存`
               : `${collegeName}：無可預設分配的名額（學生已分配完畢或名額已用盡）`,
         });
       } catch (error) {
@@ -922,7 +932,7 @@ export function ManualDistributionPanel({
       selectedAcademicYear,
       selectedSemester,
       students,
-      localAllocations,
+      quotaStatus,
     ]
   );
 
@@ -1589,13 +1599,15 @@ export function ManualDistributionPanel({
                             const isChallenge = !!challengeMeta;
                             // Application-level allocation status drives the
                             // row status control + disables 核配 checkboxes.
-                            const cancelStatus: AllocationStatus =
-                              student.quota_allocation_status === "revoked"
-                                ? "revoked"
-                                : student.quota_allocation_status === "suspended"
-                                  ? "suspended"
-                                  : "normal";
-                            const isCancelled = cancelStatus !== "normal";
+                            // One definition of 撤銷/停發 for the whole screen:
+                            // the row-disabling logic and the auto-allocate
+                            // guards must never disagree about who is cancelled.
+                            const isCancelled = isCancelledAllocation(student);
+                            const cancelStatus: AllocationStatus = !isCancelled
+                              ? "normal"
+                              : (student.quota_allocation_status as
+                                  | "revoked"
+                                  | "suspended");
                             return (
                               <tr
                                 key={student.ranking_item_id}

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -301,6 +301,12 @@ export function ManualDistributionPanel({
   useEffect(() => {
     localAllocationsRef.current = localAllocations;
   }, [localAllocations]);
+  // Rows the admin explicitly unticked. In localAllocations an untick and a
+  // never-allocated row are BOTH null, so without this the per-college
+  // 預設分發 would re-fill a row the admin deliberately cleared — including one
+  // whose saved allocation they were removing. Reset whenever local state is
+  // reseeded from the server (the clear is then either saved or discarded).
+  const [clearedItemIds, setClearedItemIds] = useState<Set<number>>(new Set());
   const [collegeFilter, setCollegeFilter] = useState<string>("");
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
@@ -402,6 +408,7 @@ export function ManualDistributionPanel({
     setIsLoading(true);
     setSaveMessage(null);
     setPreviewApplied(false);
+    setClearedItemIds(new Set());
     try {
       const [studentsResp, quotaResp] = await Promise.all([
         apiClient.manualDistribution.getStudents(
@@ -491,8 +498,10 @@ export function ManualDistributionPanel({
       setStudents(studentsResp.data);
       setLocalAllocations(seedAllocations(studentsResp.data));
       // The reseed is server-only, so any auto-preview suggestions are gone
-      // (saved or discarded) — clear the "已自動預設分配" notice.
+      // (saved or discarded) — clear the "已自動預設分配" notice, and with it
+      // the record of deliberate unticks (now persisted or thrown away).
       setPreviewApplied(false);
+      setClearedItemIds(new Set());
     }
     if (quotaResp.success && quotaResp.data) {
       setQuotaStatus(quotaResp.data);
@@ -637,11 +646,24 @@ export function ManualDistributionPanel({
     sub_type: string,
     config_id: number
   ) => {
+    const cur = localAllocationsRef.current.get(rankingItemId);
+    const isUncheck =
+      cur?.sub_type === sub_type && cur?.config_id === config_id;
+    // Remember a deliberate clear so 預設分發 leaves that row alone.
+    setClearedItemIds(prev => {
+      const next = new Set(prev);
+      if (isUncheck) next.add(rankingItemId);
+      else next.delete(rankingItemId);
+      return next;
+    });
     setLocalAllocations(prev => {
       const next = new Map(prev);
-      const cur = next.get(rankingItemId);
+      const prevAlloc = next.get(rankingItemId);
       // Radio-like: clicking active → uncheck; clicking other → set exclusively
-      if (cur?.sub_type === sub_type && cur?.config_id === config_id) {
+      if (
+        prevAlloc?.sub_type === sub_type &&
+        prevAlloc?.config_id === config_id
+      ) {
         next.set(rankingItemId, null);
       } else {
         next.set(rankingItemId, { sub_type, config_id });
@@ -849,8 +871,9 @@ export function ManualDistributionPanel({
    * wrong student.
    *
    * Staged locally only — nothing is persisted until the admin presses 儲存 —
-   * and it never overwrites a cell that already carries an allocation (saved or
-   * hand-picked), so it is safe to press repeatedly: it only fills the blanks.
+   * and it never touches a row that already carries an allocation (saved or
+   * hand-picked) NOR one the admin explicitly unticked (clearedItemIds), so it
+   * is safe to press repeatedly: it only fills rows nobody has decided on.
    */
   const handleCollegeAutoAllocate = useCallback(
     async (collegeCode: string, collegeName: string) => {
@@ -874,13 +897,16 @@ export function ManualDistributionPanel({
         }
         const suggestions = resp.data.suggestions;
         // Eligible = this college's rows only (never touch another group), minus
-        // 撤銷/停發 students, who keep their state and stay unallocated.
+        // 撤銷/停發 students, who keep their state and stay unallocated, and
+        // minus rows the admin explicitly unticked — pressing the button again
+        // must not undo a deliberate clear.
         const eligibleItemIds = new Set(
           students
             .filter(
               s =>
                 (s.college_code || "") === collegeCode &&
-                !isCancelledAllocation(s)
+                !isCancelledAllocation(s) &&
+                !clearedItemIds.has(s.ranking_item_id)
             )
             .map(s => s.ranking_item_id)
         );
@@ -933,6 +959,7 @@ export function ManualDistributionPanel({
       selectedSemester,
       students,
       quotaStatus,
+      clearedItemIds,
     ]
   );
 
@@ -1074,6 +1101,9 @@ export function ManualDistributionPanel({
                     <AlertDialogAction
                       onClick={() => {
                         setLocalAllocations(new Map());
+                        // 清空 is "start over", not a per-row decision — leave
+                        // every row open to 預設分發 again.
+                        setClearedItemIds(new Set());
                       }}
                     >
                       確認清空

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -448,6 +448,14 @@ export function ManualDistributionPanel({
         // student behind a disabled checkbox) would be saved without the admin
         // ever being able to see or untick it. No budget: this runs against a
         // fresh server snapshot, so the backend's own quota counts are exact.
+        //
+        // Quota status is the same kind of prerequisite: the 核配 columns are
+        // derived from it, so if it failed to load the grid renders NO columns
+        // and staged suggestions would be invisible yet still saved.
+        const hasQuota =
+          quotaResp.success &&
+          !!quotaResp.data &&
+          Object.keys(quotaResp.data).length > 0;
         const eligibleItemIds = new Set(
           studentsResp.data
             .filter(s => !isCancelledAllocation(s))
@@ -455,7 +463,7 @@ export function ManualDistributionPanel({
         );
         const merged = mergeSuggestions(
           allocMap,
-          previewSuggestions,
+          hasQuota ? previewSuggestions : [],
           eligibleItemIds
         );
         // Commit students together with their seeded allocations so no render
@@ -879,6 +887,17 @@ export function ManualDistributionPanel({
     async (collegeCode: string, collegeName: string) => {
       if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
         return;
+      // No columns means quota status never loaded (or carries no allocatable
+      // slot). Without it there is no per-college cap to enforce AND nothing on
+      // screen to show what was staged — refuse rather than stage invisible,
+      // uncapped allocations that 儲存 would happily persist.
+      if (subTypeCols.length === 0) {
+        setSaveMessage({
+          type: "error",
+          text: "名額資料尚未載入，無法執行預設分發，請重新整理後再試",
+        });
+        return;
+      }
       setAutoAllocatingCollege(collegeCode);
       setSaveMessage(null);
       try {
@@ -959,6 +978,7 @@ export function ManualDistributionPanel({
       selectedSemester,
       students,
       quotaStatus,
+      subTypeCols,
       clearedItemIds,
     ]
   );
@@ -1591,6 +1611,7 @@ export function ManualDistributionPanel({
                                   className="h-6 px-2 text-[11px] font-medium"
                                   disabled={
                                     !collegeCode ||
+                                    subTypeCols.length === 0 ||
                                     autoAllocatingCollege !== null ||
                                     isLoading ||
                                     isSaving ||
@@ -1598,9 +1619,11 @@ export function ManualDistributionPanel({
                                     isRestoring
                                   }
                                   title={
-                                    collegeCode
-                                      ? `依排名與志願序自動預設分配 ${collegeName} 尚未核配的學生（僅填空白，儲存前可修改）`
-                                      : "無學院代碼，無法執行預設分發"
+                                    !collegeCode
+                                      ? "無學院代碼，無法執行預設分發"
+                                      : subTypeCols.length === 0
+                                        ? "名額資料尚未載入，無法執行預設分發"
+                                        : `依排名與志願序自動預設分配 ${collegeName} 尚未核配的學生（僅填空白，儲存前可修改）`
                                   }
                                   onClick={() =>
                                     handleCollegeAutoAllocate(

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7435,6 +7435,10 @@ export interface paths {
         /**
          * Auto Allocate Preview
          * @description Generate auto-allocation suggestions without persisting.
+         *
+         *     Pass `college_code` to run the distribution for a single college; quotas are
+         *     still evaluated against the global live remaining, so the result matches what
+         *     a whole-scholarship run would suggest for that college.
          */
         get: operations["auto_allocate_preview_api_v1_manual_distribution_auto_allocate_preview_get"];
         put?: never;
@@ -23039,6 +23043,8 @@ export interface operations {
                 scholarship_type_id: number;
                 academic_year: number;
                 semester: string;
+                /** @description Restrict suggestions to one college */
+                college_code?: string | null;
             };
             header?: never;
             path?: never;

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -14,7 +14,13 @@
  * 16 cases.
  */
 
-import { createManualDistributionApi } from "../manual-distribution";
+import {
+  buildCollegeBudget,
+  createManualDistributionApi,
+  isCancelledAllocation,
+  makeColKey,
+  mergeSuggestions,
+} from "../manual-distribution";
 import { typedClient } from "../../typed-client";
 
 jest.mock("../../typed-client", () => ({
@@ -492,5 +498,146 @@ describe("createManualDistributionApi", () => {
       expect.objectContaining({ method: "POST" })
     );
     expect(res.success).toBe(true);
+  });
+});
+
+// ─── mergeSuggestions / buildCollegeBudget ────────────────────────────
+//
+// The staging rules shared by the on-load auto-preview and the per-college
+// 預設分發 button. SECURITY-CRITICAL: what these two functions stage is what
+// 儲存 persists, and the save-time server gate only recounts the GLOBAL pool —
+// the per-college matrix cap is enforced here.
+
+describe("mergeSuggestions", () => {
+  const suggestion = (
+    ranking_item_id: number,
+    sub_type_code: string | null = "nstc",
+    allocation_config_id: number | null = 115
+  ) => ({ ranking_item_id, sub_type_code, allocation_config_id });
+
+  it("fills only eligible, still-blank rows and never mutates the input map", () => {
+    const current = new Map([[2, { sub_type: "moe_1w", config_id: 115 }]]);
+    const res = mergeSuggestions(
+      current,
+      [suggestion(1), suggestion(2), suggestion(3)],
+      new Set([1, 2]) // 3 is not in the grid / not this college
+    );
+    expect(res.filled).toBe(1);
+    expect(res.next.get(1)).toEqual({ sub_type: "nstc", config_id: 115 });
+    // 2 keeps the admin's hand-picked value; 3 was never eligible.
+    expect(res.next.get(2)).toEqual({ sub_type: "moe_1w", config_id: 115 });
+    expect(res.next.has(3)).toBe(false);
+    expect(current.size).toBe(1);
+  });
+
+  it("skips suggestions with no sub_type or no config (unallocatable rows)", () => {
+    const res = mergeSuggestions(
+      new Map(),
+      [suggestion(1, null, null), suggestion(2, "nstc", null)],
+      new Set([1, 2])
+    );
+    expect(res.filled).toBe(0);
+    expect(res.next.size).toBe(0);
+  });
+
+  it("stops at the per-college budget and reports the overflow", () => {
+    // College has 2 nstc slots; 3 students suggested for it.
+    const budget = new Map([[makeColKey("nstc", 115), 2]]);
+    const res = mergeSuggestions(
+      new Map(),
+      [suggestion(1), suggestion(2), suggestion(3)],
+      new Set([1, 2, 3]),
+      budget
+    );
+    expect(res.filled).toBe(2);
+    expect(res.blocked).toBe(1);
+    expect(res.next.has(3)).toBe(false);
+  });
+
+  it("leaves columns absent from the budget uncapped (non-matrix configs)", () => {
+    const budget = new Map([[makeColKey("moe_1w", 115), 0]]);
+    const res = mergeSuggestions(
+      new Map(),
+      [suggestion(1), suggestion(2)],
+      new Set([1, 2]),
+      budget
+    );
+    expect(res.filled).toBe(2);
+    expect(res.blocked).toBe(0);
+  });
+});
+
+describe("buildCollegeBudget", () => {
+  const quotaStatus = {
+    nstc: {
+      display_name: "國科會",
+      by_config: [
+        {
+          config_id: 115,
+          config_code: "phd_115",
+          academic_year: 115,
+          is_own: true,
+          total: 10,
+          remaining: 8,
+          by_college: {
+            C: { total: 2, allocated: 1, remaining: 1 },
+            D: { total: 5, allocated: 0, remaining: 5 },
+          },
+        },
+      ],
+    },
+    moe_1w: {
+      display_name: "教育部",
+      by_config: [
+        {
+          config_id: 115,
+          config_code: "phd_115",
+          academic_year: 115,
+          is_own: true,
+          total: 4,
+          remaining: 4,
+          by_college: null, // no per-college matrix
+        },
+      ],
+    },
+  } as unknown as Parameters<typeof buildCollegeBudget>[0];
+
+  const student = (ranking_item_id: number, college_code: string) =>
+    ({ ranking_item_id, college_code }) as never;
+
+  it("subtracts allocations STAGED for that college from its matrix total", () => {
+    const budget = buildCollegeBudget(
+      quotaStatus,
+      [student(1, "C"), student(2, "C"), student(3, "D")],
+      new Map([
+        [1, { sub_type: "nstc", config_id: 115 }],
+        [3, { sub_type: "nstc", config_id: 115 }], // college D — must not count
+      ]),
+      "C"
+    );
+    expect(budget.get(makeColKey("nstc", 115))).toBe(1);
+  });
+
+  it("omits columns with no per-college matrix so they stay uncapped", () => {
+    const budget = buildCollegeBudget(quotaStatus, [], new Map(), "C");
+    expect(budget.has(makeColKey("moe_1w", 115))).toBe(false);
+  });
+
+  it("omits colleges the matrix does not list", () => {
+    const budget = buildCollegeBudget(quotaStatus, [], new Map(), "Z");
+    expect(budget.size).toBe(0);
+  });
+});
+
+describe("isCancelledAllocation", () => {
+  const s = (quota_allocation_status: string | null) =>
+    ({ quota_allocation_status }) as never;
+
+  it("is true only for 撤銷/停發", () => {
+    expect(isCancelledAllocation(s("revoked"))).toBe(true);
+    expect(isCancelledAllocation(s("suspended"))).toBe(true);
+    expect(isCancelledAllocation(s("allocated"))).toBe(false);
+    expect(isCancelledAllocation(s("rejected"))).toBe(false);
+    expect(isCancelledAllocation(s(null))).toBe(false);
   });
 });

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -602,10 +602,25 @@ describe("buildCollegeBudget", () => {
     },
   } as unknown as Parameters<typeof buildCollegeBudget>[0];
 
-  const student = (ranking_item_id: number, college_code: string) =>
-    ({ ranking_item_id, college_code }) as never;
+  // college C: total 2, allocated 1 (globally — may include rows this grid
+  // never shows, e.g. an approved renewal), remaining 1.
+  const student = (
+    ranking_item_id: number,
+    college_code: string,
+    saved?: { sub_type: string; config_id: number }
+  ) =>
+    ({
+      ranking_item_id,
+      college_code,
+      is_allocated: !!saved,
+      allocated_sub_type: saved?.sub_type ?? null,
+      allocation_config_id: saved?.config_id ?? null,
+    }) as never;
 
-  it("subtracts allocations STAGED for that college from its matrix total", () => {
+  it("starts from live remaining, not total, and charges unsaved staging", () => {
+    // Baseline remaining=1; student 1 is a FRESH tick (no saved allocation), so
+    // it consumes the last slot. A total-based baseline would have said 1 left —
+    // headroom that a consumer outside this grid already took.
     const budget = buildCollegeBudget(
       quotaStatus,
       [student(1, "C"), student(2, "C"), student(3, "D")],
@@ -615,7 +630,31 @@ describe("buildCollegeBudget", () => {
       ]),
       "C"
     );
+    expect(budget.get(makeColKey("nstc", 115))).toBe(0);
+  });
+
+  it("nets a row staged exactly as saved to zero", () => {
+    // The saved row is already inside `remaining`; re-staging it unchanged must
+    // not double-charge the college.
+    const saved = { sub_type: "nstc", config_id: 115 };
+    const budget = buildCollegeBudget(
+      quotaStatus,
+      [student(1, "C", saved)],
+      new Map([[1, saved]]),
+      "C"
+    );
     expect(budget.get(makeColKey("nstc", 115))).toBe(1);
+  });
+
+  it("frees a slot when a saved allocation is unticked", () => {
+    const saved = { sub_type: "nstc", config_id: 115 };
+    const budget = buildCollegeBudget(
+      quotaStatus,
+      [student(1, "C", saved)],
+      new Map([[1, null]]),
+      "C"
+    );
+    expect(budget.get(makeColKey("nstc", 115))).toBe(2);
   });
 
   it("omits columns with no per-college matrix so they stay uncapped", () => {

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -250,6 +250,28 @@ describe("createManualDistributionApi", () => {
     );
   });
 
+  it("getAutoAllocatePreview spreads college_code for a single-college run", async () => {
+    // Pin: the per-college 預設分發 button scopes the preview to one
+    // college. The param must only appear when supplied — an empty
+    // string would narrow the whole-scholarship run to nothing.
+    mockedRaw.GET.mockResolvedValueOnce({});
+    const api = createManualDistributionApi();
+    await api.getAutoAllocatePreview(7, 114, "first", "C");
+    expect(mockedRaw.GET).toHaveBeenCalledWith(
+      "/api/v1/manual-distribution/auto-allocate-preview",
+      {
+        params: {
+          query: {
+            scholarship_type_id: 7,
+            academic_year: 114,
+            semester: "first",
+            college_code: "C",
+          },
+        },
+      }
+    );
+  });
+
   // ─── generateRostersFromDistribution ──────────────────────────────
 
   it("generateRostersFromDistribution POSTs with optional flags", async () => {

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -170,6 +170,96 @@ export interface AllocationSuggestion {
   allocation_config_id: number | null;
 }
 
+export interface MergeSuggestionsResult {
+  /** A NEW map — callers must not mutate `current`. */
+  next: Map<number, LocalAlloc | null>;
+  /** How many blank rows the suggestions filled. */
+  filled: number;
+  /** Suggestions dropped because the per-college budget was exhausted. */
+  blocked: number;
+}
+
+/**
+ * Merge auto-allocation suggestions into the staged allocation map.
+ *
+ * Single implementation for the on-load preview and the per-college 預設分發
+ * button, so both apply the same rules: only rows in `eligibleItemIds` (in the
+ * grid, right college, not 撤銷/停發), only rows with NO allocation yet (saved
+ * or hand-picked selections are never overwritten).
+ *
+ * `budget` (from buildCollegeBudget) caps how many more rows may be staged per
+ * (sub_type, config) column. It is REQUIRED whenever suggestions are merged on
+ * top of unsaved staged work: the backend computes suggestions against
+ * persisted consumers only, so without it a hand-picked-then-auto-filled
+ * college can exceed its matrix row. The map is mutated as budget is consumed.
+ */
+export function mergeSuggestions(
+  current: Map<number, LocalAlloc | null>,
+  suggestions: AllocationSuggestion[],
+  eligibleItemIds: Set<number>,
+  budget?: Map<string, number>
+): MergeSuggestionsResult {
+  const next = new Map(current);
+  let filled = 0;
+  let blocked = 0;
+  for (const s of suggestions) {
+    if (!s.sub_type_code || s.allocation_config_id == null) continue;
+    if (!eligibleItemIds.has(s.ranking_item_id)) continue;
+    if (next.get(s.ranking_item_id)) continue;
+    const key = makeColKey(s.sub_type_code, s.allocation_config_id);
+    if (budget) {
+      const left = budget.get(key);
+      // Absent key = no per-college cap for that column (non-matrix config).
+      if (left !== undefined) {
+        if (left <= 0) {
+          blocked++;
+          continue;
+        }
+        budget.set(key, left - 1);
+      }
+    }
+    next.set(s.ranking_item_id, {
+      sub_type: s.sub_type_code,
+      config_id: s.allocation_config_id,
+    });
+    filled++;
+  }
+  return { next, filled, blocked };
+}
+
+/**
+ * Remaining per-(sub_type, config) headroom for ONE college: its matrix total
+ * minus everything currently staged for that college (staged ⊇ saved, since the
+ * grid seeds local state from the server snapshot).
+ *
+ * Columns whose config carries no per-college matrix (`by_college === null`)
+ * are omitted — they have no per-college cap to enforce.
+ */
+export function buildCollegeBudget(
+  quotaStatus: QuotaStatus,
+  students: DistributionStudent[],
+  allocations: Map<number, LocalAlloc | null>,
+  collegeCode: string
+): Map<string, number> {
+  const budget = new Map<string, number>();
+  for (const [sub_type, stData] of Object.entries(quotaStatus)) {
+    for (const cfg of stData.by_config) {
+      const cell = cfg.by_college?.[collegeCode];
+      if (!cell) continue;
+      budget.set(makeColKey(sub_type, cfg.config_id), cell.total);
+    }
+  }
+  for (const s of students) {
+    if ((s.college_code || "") !== collegeCode) continue;
+    const alloc = allocations.get(s.ranking_item_id);
+    if (!alloc) continue;
+    const key = makeColKey(alloc.sub_type, alloc.config_id);
+    const left = budget.get(key);
+    if (left !== undefined) budget.set(key, left - 1);
+  }
+  return budget;
+}
+
 export interface AllocateRequest {
   scholarship_type_id: number;
   academic_year: number;

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -210,6 +210,16 @@ export interface RestoreResult {
   restored_count: number;
   /** Snapshot rows NOT restored because the sub-type was rejected (不同意) in review. */
   skipped_rejected: number;
+  /** Snapshot rows NOT restored because the application is now 撤銷/停發. */
+  skipped_cancelled: number;
+}
+
+/** True when the student was pulled out of the distribution (撤銷/停發) and must not be (re)allocated. */
+export function isCancelledAllocation(s: DistributionStudent): boolean {
+  return (
+    s.quota_allocation_status === "revoked" ||
+    s.quota_allocation_status === "suspended"
+  );
 }
 
 export interface RosterSummary {
@@ -544,11 +554,16 @@ export function createManualDistributionApi() {
 
     /**
      * Get auto-allocation preview suggestions.
+     *
+     * Pass `college_code` to run the distribution for a single college — the
+     * backend still evaluates quotas globally, so the suggestions match what a
+     * whole-scholarship run would produce for that college.
      */
     getAutoAllocatePreview: async (
       scholarship_type_id: number,
       academic_year: number,
-      semester: string
+      semester: string,
+      college_code?: string
     ): Promise<ApiResponse<{ suggestions: AllocationSuggestion[] }>> => {
       const response = await typedClient.raw.GET(
         "/api/v1/manual-distribution/auto-allocate-preview",
@@ -558,6 +573,7 @@ export function createManualDistributionApi() {
               scholarship_type_id,
               academic_year,
               semester,
+              ...(college_code ? { college_code } : {}),
             },
           },
         }

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -228,9 +228,18 @@ export function mergeSuggestions(
 }
 
 /**
- * Remaining per-(sub_type, config) headroom for ONE college: its matrix total
- * minus everything currently staged for that college (staged ⊇ saved, since the
- * grid seeds local state from the server snapshot).
+ * Remaining per-(sub_type, config) headroom for ONE college, as of the CURRENT
+ * staged state.
+ *
+ * Baseline is the server's LIVE `remaining`, not the matrix `total`: consumers
+ * count globally (winners in any finalized ranking plus approved renewals — see
+ * consumers_by_college), so a `total`-based baseline would silently hand out
+ * headroom already taken by rows this grid never shows.
+ *
+ * `remaining` has already subtracted each row's SAVED allocation, so only
+ * unsaved changes may move the budget: a saved row adds its slot back, the
+ * staged allocation then takes one. A row staged exactly as saved nets to zero;
+ * an untick frees a slot; a fresh tick consumes one.
  *
  * Columns whose config carries no per-college matrix (`by_college === null`)
  * are omitted — they have no per-college cap to enforce.
@@ -246,16 +255,19 @@ export function buildCollegeBudget(
     for (const cfg of stData.by_config) {
       const cell = cfg.by_college?.[collegeCode];
       if (!cell) continue;
-      budget.set(makeColKey(sub_type, cfg.config_id), cell.total);
+      budget.set(makeColKey(sub_type, cfg.config_id), cell.remaining);
     }
   }
-  for (const s of students) {
-    if ((s.college_code || "") !== collegeCode) continue;
-    const alloc = allocations.get(s.ranking_item_id);
-    if (!alloc) continue;
+  const bump = (alloc: LocalAlloc | null | undefined, delta: number) => {
+    if (!alloc) return;
     const key = makeColKey(alloc.sub_type, alloc.config_id);
     const left = budget.get(key);
-    if (left !== undefined) budget.set(key, left - 1);
+    if (left !== undefined) budget.set(key, left + delta);
+  };
+  for (const s of students) {
+    if ((s.college_code || "") !== collegeCode) continue;
+    bump(getSavedAllocation(s), +1); // give the saved slot back …
+    bump(allocations.get(s.ranking_item_id), -1); // … then charge what is staged
   }
   return budget;
 }


### PR DESCRIPTION
## 摘要

管理員原本只能在開頁時吃到一次「全獎學金」的自動預設分發。這個 PR 讓分發表格的**每個學院分組標題**多一顆 `預設分發` 按鈕，可以一個學院一個學院跑；同時修掉一組「撤銷／停發的學生會被重新分發到」的缺陷。

## 1. 每學院預設分發

- `GET /manual-distribution/auto-allocate-preview` 新增選填的 `college_code`。**只縮小候選名單**，配額 tracker 仍以全域 live remaining 建立與遞減 — tracker 的 key 是 `(config_id, sub_type, college_code)`，所以單一學院跑出來的結果與整批跑對該學院的結果完全一致。
- 抽出 `_dedupe_preview_items()`（去重 + 學院過濾）成純函式，可在 unit lane 測試；並補上 `ORDER BY (rank_position, id)` 與「已分配的重複項優先」，與 `get_students_for_distribution` 一致，否則建議可能對到畫面上不存在的 ranking item。
- 前端只**暫存**在畫面上（沿用既有「請確認後儲存」流程），且**只填空白格** — 已存檔或管理員手動勾選的都不覆蓋，所以重複按也安全。
- 合併時以該學院矩陣上限扣掉已暫存數量為上限（`buildCollegeBudget`），因為後端只算已存檔的消費者，而儲存時的鎖定檢查只重算全域配額。超出的會回報「另有 N 筆因學院名額已滿未分配」。
- 按鈕涵蓋該學院的**整份排名**，不是搜尋框過濾後的子集：後端回的是依排名順序的計畫，只套用一部分會把名額給錯人。

## 2. 撤銷／停發的學生維持狀態，不會被分發到

`_cancel_allocation` 會把 `is_allocated` 設回 `false` 來釋出名額，這也讓那些學生看起來像「未分配的候選人」。原本有四條路徑會把名額還給他們：

| 路徑 | 修正 |
|---|---|
| `_compute_suggestions`（預設分發） | 撤銷/停發直接回 `None`，**且不消耗配額**（讓出的名額給下一位） |
| `allocate()` | 新增 `_assert_no_cancelled_applications` 伺服端擋門 → 400「以下申請已撤銷／停發，無法分發」 |
| `restore_from_history()` | 跳過已撤銷/停發的快照列，回傳 `skipped_cancelled`；但**保留 slot 識別**（寫回 `allocated_sub_type`／`allocation_config_id`，不設 `is_allocated`），否則 `restore_allocation`（復發）會失效 |
| `allocate()` 的 unallocate 分支 | 表格會送出所有可見列，撤銷列會以 `sub_type_code=null` 進來並清掉 `allocated_sub_type`；現在整列跳過 |

`finalize()` 原本就有這條規則，改為共用 `CANCELLED_ALLOCATION_STATUSES` 常數。復發（`restore_allocation`）是另一條明確路徑，不受影響。

## 測試

- 後端：`test_auto_allocate_preview.py` 新增 9 項（撤銷/停發不被建議且不吃配額、讓出的名額給下一位、學院過濾、已分配的重複項優先）；`test_manual_distribution_professor_gate.py` 新增 6 項 DB 測試（撤銷/停發擋 allocate、取消勾選仍可、restore 跳過並保留 slot、儲存不清掉 slot）。
- 前端：`manual-distribution.test.ts` 新增 8 項（`mergeSuggestions` 的合併與每學院上限、`buildCollegeBudget`、`isCancelledAllocation`、`college_code` query 參數）。
- lint/型別：black、flake8 `B904,B014`、logger traceback AST invariant、tsc、eslint 皆通過；`schema.d.ts` 已用 openapi-typescript 重新產生。

## localhost 端對端驗證（Playwright）

用 `docker compose -f docker-compose.dev.yml` 起完整環境，種入兩個學院的資料（電機學院 4 人、資訊學院 3 人，其中 `APP-114-0-00003 黃柏翰` 為撤銷狀態），以 admin 身分驅動 `獎學金分發 → 博士生獎學金 → 114 學年度 / 全年`：

| 步驟 | 結果 |
|---|---|
| 清空所有勾選後按「電機學院」的 `預設分發` | 電機學院 3 筆勾選、資訊學院 0 筆 — 只影響該學院 |
| 訊息 | 「電機學院：已預設分配 3 筆，請確認後儲存」 |
| 黃柏翰（撤銷）該列 | 未勾選、4 個 checkbox 皆 disabled、title =「此學生已撤銷／停發，無法核配獎學金類別」 |
| 再按「資訊學院」的 `預設分發` | 兩個學院各 3 筆 |
| 儲存後 DB | 6 位非撤銷學生 `is_allocated=t, allocated_sub_type=nstc`；黃柏翰 `is_allocated=f` 且 `allocated_sub_type` 仍為 `nstc`（復發可用） |
| `POST .../applications/3/restore` | `success=true`，`quota_allocation_status=allocated, is_allocated=t` |

API 層另外直接驗證：`auto-allocate-preview?college_code=E` 只回該學院的 4 筆（撤銷那筆為 `null`），不帶參數則回全部 7 筆；對撤銷學生 POST `/allocate` 回 HTTP 400「以下申請已撤銷／停發，無法分發：APP-114-0-00003（撤銷）」。

實機驗證也帶出兩處修正：`allocate()` 的 unallocate 缺陷（儲存後 `allocated_sub_type` 被清空，已補回歸測試），以及按鈕位置 — 分組標題列橫跨 14+N 欄，靠右對齊時要把寬表往右捲才看得到，改為緊接在學院名稱旁。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hz7xEWB8qFqknZCGDyXdHA