### PR TITLE
fix(distribution): 子類型代碼比對正規化，修正 staging 上「預設分發按了沒反應」

### DIFF
--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -143,6 +143,24 @@ async def load_review_items_by_role(db: AsyncSession, app_ids: list[int]) -> dic
     return review_map
 
 
+def _canonical_sub_type(code: Optional[str], allowed_configs_by_sub_type: dict[str, list[int]]) -> str:
+    """Map a student-supplied sub-type string onto the config's own spelling.
+
+    The quota tracker and the allowed-config index are keyed by the EXACT keys of
+    `ScholarshipConfiguration.quotas`, while a student's applied/preference lists
+    are free-form strings stored by other code paths. Matching them normalized
+    (lower/strip) and returning the config's spelling keeps the downstream
+    lookups exact — and keeps `allocated_sub_type` written in the canonical form
+    the quota columns use. Unknown codes pass through normalized, which simply
+    finds no quota, exactly as before.
+    """
+    normalized = _norm_sub_type(code)
+    for configured in allowed_configs_by_sub_type:
+        if _norm_sub_type(configured) == normalized:
+            return configured
+    return normalized
+
+
 def _dedupe_preview_items(all_items: list, college_code: Optional[str] = None) -> list:
     """Select the ranking items auto_allocate_preview should suggest for.
 
@@ -251,9 +269,17 @@ def _compute_suggestions(
         applied = app.scholarship_subtype_list or []
         rejected = rejected_map.get(app.id, set())
         raw_prefs: list[str] = app.sub_type_preferences or applied or default_prefs
-        applied_set = set(applied)
+        # Compare NORMALIZED on both sides. sub_type_preferences and
+        # scholarship_subtype_list are free-form admin/student-supplied strings
+        # written by different code paths, so "NSTC" / " nstc" vs "nstc" happens;
+        # a raw `in` test silently emptied the whole preference list and the
+        # student came out unallocatable with quota still free.
+        applied_set = {_norm_sub_type(p) for p in applied}
         preferences: list[str] = [
-            p for p in raw_prefs if (p in applied_set if applied_set else True) and _norm_sub_type(p) not in rejected
+            canonical
+            for canonical in (_canonical_sub_type(p, allowed_configs_by_sub_type) for p in raw_prefs)
+            if (_norm_sub_type(canonical) in applied_set if applied_set else True)
+            and _norm_sub_type(canonical) not in rejected
         ]
 
         allocated_sub_type: Optional[str] = None

--- a/backend/app/tests/test_auto_allocate_preview.py
+++ b/backend/app/tests/test_auto_allocate_preview.py
@@ -731,6 +731,65 @@ class TestCancelledApplicationsNeverSuggested:
         assert results[0]["sub_type_code"] == "nstc"
 
 
+class TestPreferenceCodesAreMatchedNormalized:
+    """sub_type_preferences and scholarship_subtype_list are written by different
+    code paths, so their spelling can differ. A raw string comparison silently
+    emptied the whole preference list and the student came out unallocatable
+    with quota still free (staging 114, 資訊學院/人社院)."""
+
+    @pytest.mark.parametrize("pref", ["NSTC", " nstc", "nstc ", "Nstc"])
+    def test_case_and_whitespace_variants_still_allocate(self, _compute_suggestions, pref):
+        app = _make_app(1, college="A", sub_type_preferences=[pref], scholarship_subtype_list=["nstc"])
+        results = _compute_suggestions(
+            unique_items=[_make_item(101, rank_position=1, app=app)],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115]},
+            quota_tracker=_build_quota_tracker({(115, "nstc", "A"): 1}),
+            own_config_id=115,
+        )
+        # …and the ALLOCATED code is the config's own spelling, not the student's.
+        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
+
+    def test_applied_list_variant_is_matched_too(self, _compute_suggestions):
+        app = _make_app(1, college="A", sub_type_preferences=["nstc"], scholarship_subtype_list=[" NSTC "])
+        results = _compute_suggestions(
+            unique_items=[_make_item(101, rank_position=1, app=app)],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115]},
+            quota_tracker=_build_quota_tracker({(115, "nstc", "A"): 1}),
+            own_config_id=115,
+        )
+        assert results[0]["sub_type_code"] == "nstc"
+
+    def test_a_sub_type_never_applied_for_is_still_excluded(self, _compute_suggestions):
+        """Normalizing must not turn the applied-list filter into a no-op."""
+        app = _make_app(1, college="A", sub_type_preferences=["moe_1w"], scholarship_subtype_list=["nstc"])
+        results = _compute_suggestions(
+            unique_items=[_make_item(101, rank_position=1, app=app)],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115], "moe_1w": [115]},
+            quota_tracker=_build_quota_tracker({(115, "nstc", "A"): 1, (115, "moe_1w", "A"): 1}),
+            own_config_id=115,
+        )
+        assert results[0]["sub_type_code"] is None
+
+    def test_reviewer_reject_still_blocks_a_variant_spelling(self, _compute_suggestions):
+        app = _make_app(1, college="A", sub_type_preferences=["NSTC"], scholarship_subtype_list=["nstc"])
+        results = _compute_suggestions(
+            unique_items=[_make_item(101, rank_position=1, app=app)],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115]},
+            quota_tracker=_build_quota_tracker({(115, "nstc", "A"): 1}),
+            own_config_id=115,
+            rejected_map={1: {"nstc"}},
+        )
+        assert results[0]["sub_type_code"] is None
+
+
 class TestDedupePreviewItems:
     """Item selection for the preview: dedup, soft-delete, single-college filter."""
 

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -28,6 +28,8 @@ import {
   makeColKey,
   mergeSuggestions,
   resolveCollegeName,
+  summarizeUnallocated,
+  UNALLOCATED_REASON_LABEL,
 } from "@/lib/api/modules/manual-distribution";
 import { User } from "@/types/user";
 import { Button } from "@/components/ui/button";
@@ -959,12 +961,29 @@ export function ManualDistributionPanel({
         }
         const overflowNote =
           blocked > 0 ? `，另有 ${blocked} 筆因學院名額已滿未分配` : "";
+        // Nothing staged: say WHY per row rather than guessing 「名額已用盡」.
+        // A review reject is the common invisible cause — the 教授推薦/學院推薦
+        // columns only render professor and college verdicts, so a reject from
+        // another reviewer role blocks every sub-type with nothing on screen to
+        // explain it.
+        const stillBlank = students.filter(
+          s =>
+            (s.college_code || "") === collegeCode &&
+            !next.get(s.ranking_item_id) &&
+            !clearedItemIds.has(s.ranking_item_id)
+        );
+        const reasons = summarizeUnallocated(stillBlank)
+          .map(
+            ({ reason, count }) =>
+              `${count} 筆${UNALLOCATED_REASON_LABEL[reason]}`
+          )
+          .join("、");
         setSaveMessage({
           type: "success",
           text:
             filled > 0
               ? `${collegeName}：已預設分配 ${filled} 筆${overflowNote}，請確認後儲存`
-              : `${collegeName}：無可預設分配的名額（學生已分配完畢或名額已用盡）`,
+              : `${collegeName}：無可預設分配${reasons ? `（${reasons}）` : ""}`,
         });
       } catch (error) {
         logger.error("College auto-allocate error", { error: error });

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -959,32 +959,33 @@ export function ManualDistributionPanel({
           setLocalAllocations(next);
           setPreviewApplied(true);
         }
-        const overflowNote =
-          blocked > 0 ? `，另有 ${blocked} 筆因學院名額已滿未分配` : "";
-        // Nothing staged: say WHY per row rather than guessing 「名額已用盡」.
-        // A review reject is the common invisible cause — the 教授推薦/學院推薦
-        // columns only render professor and college verdicts, so a reject from
-        // another reviewer role blocks every sub-type with nothing on screen to
-        // explain it.
-        const stillBlank = students.filter(
-          s =>
-            (s.college_code || "") === collegeCode &&
-            !next.get(s.ranking_item_id) &&
-            !clearedItemIds.has(s.ranking_item_id)
-        );
-        const reasons = summarizeUnallocated(stillBlank)
-          .map(
-            ({ reason, count }) =>
-              `${count} 筆${UNALLOCATED_REASON_LABEL[reason]}`
-          )
-          .join("、");
-        setSaveMessage({
-          type: "success",
-          text:
-            filled > 0
-              ? `${collegeName}：已預設分配 ${filled} 筆${overflowNote}，請確認後儲存`
-              : `${collegeName}：無可預設分配${reasons ? `（${reasons}）` : ""}`,
-        });
+        let text: string;
+        if (filled > 0) {
+          const overflowNote =
+            blocked > 0 ? `，另有 ${blocked} 筆因學院名額已滿未分配` : "";
+          text = `${collegeName}：已預設分配 ${filled} 筆${overflowNote}，請確認後儲存`;
+        } else {
+          // Nothing staged: say WHY per row rather than guessing 「名額已用盡」.
+          // A review reject is the common invisible cause — the 教授推薦/學院推薦
+          // columns only render professor and college verdicts, so a reject from
+          // another reviewer role blocks every sub-type with nothing on screen
+          // to explain it. Only this branch needs the breakdown, so the scan
+          // stays off the path that did allocate something.
+          const stillBlank = students.filter(
+            s =>
+              (s.college_code || "") === collegeCode &&
+              !next.get(s.ranking_item_id) &&
+              !clearedItemIds.has(s.ranking_item_id)
+          );
+          const reasons = summarizeUnallocated(stillBlank)
+            .map(
+              ({ reason, count }) =>
+                `${count} 筆${UNALLOCATED_REASON_LABEL[reason]}`
+            )
+            .join("、");
+          text = `${collegeName}：無可預設分配${reasons ? `（${reasons}）` : ""}`;
+        }
+        setSaveMessage({ type: "success", text });
       } catch (error) {
         logger.error("College auto-allocate error", { error: error });
         setSaveMessage({

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -693,18 +693,26 @@ describe("classifyUnallocated / summarizeUnallocated", () => {
       ...o,
     }) as never;
 
-  it("reports 撤銷/停發 before anything else", () => {
+  it("reports the college's rejection first, matching the backend's order", () => {
+    // _compute_suggestions short-circuits on college_rejected BEFORE it reads
+    // quota_allocation_status, so that is what actually stopped the allocation.
+    expect(classifyUnallocated(student({ college_rejected: true }))).toBe(
+      "college_rejected"
+    );
     expect(
       classifyUnallocated(
         student({ quota_allocation_status: "revoked", college_rejected: true })
       )
-    ).toBe("cancelled");
+    ).toBe("college_rejected");
   });
 
-  it("reports the college's own rejection", () => {
-    expect(classifyUnallocated(student({ college_rejected: true }))).toBe(
-      "college_rejected"
-    );
+  it("reports 撤銷/停發 when the college did not reject", () => {
+    expect(
+      classifyUnallocated(student({ quota_allocation_status: "revoked" }))
+    ).toBe("cancelled");
+    expect(
+      classifyUnallocated(student({ quota_allocation_status: "suspended" }))
+    ).toBe("cancelled");
   });
 
   it("reports an empty application", () => {

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -16,10 +16,12 @@
 
 import {
   buildCollegeBudget,
+  classifyUnallocated,
   createManualDistributionApi,
   isCancelledAllocation,
   makeColKey,
   mergeSuggestions,
+  summarizeUnallocated,
 } from "../manual-distribution";
 import { typedClient } from "../../typed-client";
 
@@ -678,5 +680,83 @@ describe("isCancelledAllocation", () => {
     expect(isCancelledAllocation(s("allocated"))).toBe(false);
     expect(isCancelledAllocation(s("rejected"))).toBe(false);
     expect(isCancelledAllocation(s(null))).toBe(false);
+  });
+});
+
+describe("classifyUnallocated / summarizeUnallocated", () => {
+  const student = (o: Record<string, unknown>) =>
+    ({
+      quota_allocation_status: null,
+      college_rejected: false,
+      applied_sub_types: ["nstc"],
+      rejected_sub_types: [],
+      ...o,
+    }) as never;
+
+  it("reports 撤銷/停發 before anything else", () => {
+    expect(
+      classifyUnallocated(
+        student({ quota_allocation_status: "revoked", college_rejected: true })
+      )
+    ).toBe("cancelled");
+  });
+
+  it("reports the college's own rejection", () => {
+    expect(classifyUnallocated(student({ college_rejected: true }))).toBe(
+      "college_rejected"
+    );
+  });
+
+  it("reports an empty application", () => {
+    expect(classifyUnallocated(student({ applied_sub_types: [] }))).toBe(
+      "not_applied"
+    );
+  });
+
+  it("reports a review reject only when it covers EVERY applied sub-type", () => {
+    // The invisible case: a reject from a role the 教授推薦/學院推薦 columns
+    // don't render still blocks the allocation.
+    expect(
+      classifyUnallocated(
+        student({
+          applied_sub_types: ["nstc", "moe_1w"],
+          rejected_sub_types: ["nstc", "moe_1w"],
+        })
+      )
+    ).toBe("review_rejected");
+    // One sub-type still open ⇒ the blocker was quota, not the review.
+    expect(
+      classifyUnallocated(
+        student({
+          applied_sub_types: ["nstc", "moe_1w"],
+          rejected_sub_types: ["nstc"],
+        })
+      )
+    ).toBe("no_quota");
+  });
+
+  it("compares sub-type codes normalized, like the backend", () => {
+    expect(
+      classifyUnallocated(
+        student({ applied_sub_types: [" NSTC"], rejected_sub_types: ["nstc"] })
+      )
+    ).toBe("review_rejected");
+  });
+
+  it("falls through to 名額不足 for an otherwise allocatable student", () => {
+    expect(classifyUnallocated(student({}))).toBe("no_quota");
+  });
+
+  it("tallies reasons, most common first", () => {
+    expect(
+      summarizeUnallocated([
+        student({ applied_sub_types: ["nstc"], rejected_sub_types: ["nstc"] }),
+        student({ applied_sub_types: ["nstc"], rejected_sub_types: ["nstc"] }),
+        student({}),
+      ])
+    ).toEqual([
+      { reason: "review_rejected", count: 2 },
+      { reason: "no_quota", count: 1 },
+    ]);
   });
 });

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -357,8 +357,12 @@ export const UNALLOCATED_REASON_LABEL: Record<UnallocatedReason, string> = {
  * the 教授推薦/學院推薦 columns do not render, leaving no visible explanation.
  */
 export function classifyUnallocated(s: DistributionStudent): UnallocatedReason {
-  if (isCancelledAllocation(s)) return "cancelled";
+  // college_rejected FIRST — _compute_suggestions short-circuits on it before
+  // it ever reads quota_allocation_status, so for a row that is both, the
+  // college's rejection is what actually stopped the allocation. (The 撤銷/停發
+  // state is not hidden by this: the row renders its own status control.)
   if (s.college_rejected) return "college_rejected";
+  if (isCancelledAllocation(s)) return "cancelled";
   const applied = s.applied_sub_types ?? [];
   if (applied.length === 0) return "not_applied";
   const rejected = new Set((s.rejected_sub_types ?? []).map(normSubType));

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -324,6 +324,62 @@ export function isCancelledAllocation(s: DistributionStudent): boolean {
   );
 }
 
+/** Sub-type codes are free-form strings; compare them normalized (mirrors the backend's _norm_sub_type). */
+function normSubType(code: string | null | undefined): string {
+  return (code ?? "").toLowerCase().trim();
+}
+
+export type UnallocatedReason =
+  | "cancelled"
+  | "college_rejected"
+  | "not_applied"
+  | "review_rejected"
+  | "no_quota";
+
+export const UNALLOCATED_REASON_LABEL: Record<UnallocatedReason, string> = {
+  cancelled: "已撤銷／停發",
+  college_rejected: "學院不予推薦",
+  not_applied: "未申請任何子類型",
+  review_rejected: "審核不同意",
+  no_quota: "名額不足",
+};
+
+/**
+ * Why the auto-allocation could not place this student.
+ *
+ * Only meaningful for a row the backend returned no sub-type for. The order
+ * mirrors the backend's own short-circuits in _compute_suggestions, so the
+ * reason shown is the one that actually stopped it. "no_quota" is the residual:
+ * the student is allocatable but every sub-type they want is exhausted.
+ *
+ * Exists because 「名額已用盡」 was being reported for rows that were really
+ * blocked by a review reject — including rejects from a reviewer whose verdict
+ * the 教授推薦/學院推薦 columns do not render, leaving no visible explanation.
+ */
+export function classifyUnallocated(s: DistributionStudent): UnallocatedReason {
+  if (isCancelledAllocation(s)) return "cancelled";
+  if (s.college_rejected) return "college_rejected";
+  const applied = s.applied_sub_types ?? [];
+  if (applied.length === 0) return "not_applied";
+  const rejected = new Set((s.rejected_sub_types ?? []).map(normSubType));
+  if (applied.every(a => rejected.has(normSubType(a)))) return "review_rejected";
+  return "no_quota";
+}
+
+/** Reason → count over the given students, most common first; zero counts omitted. */
+export function summarizeUnallocated(
+  students: DistributionStudent[]
+): Array<{ reason: UnallocatedReason; count: number }> {
+  const tally = new Map<UnallocatedReason, number>();
+  for (const s of students) {
+    const reason = classifyUnallocated(s);
+    tally.set(reason, (tally.get(reason) ?? 0) + 1);
+  }
+  return [...tally.entries()]
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
 export interface RosterSummary {
   id: number;
   roster_code: string;


### PR DESCRIPTION
## 問題

Staging 上按「預設分發」沒有任何反應。實際上端點有正常回應，但**每一筆建議都是 `sub_type_code: null`**：

```
GET /manual-distribution/auto-allocate-preview?scholarship_type_id=2&academic_year=114&semester=yearly&college_code=C
→ 28 筆全部 {"sub_type_code": null, "allocation_config_id": null}
```

而同一時間配額表顯示資訊學院 `國科會·phd_114` 還有 **4/15**、人社院 **4/4**，學生也都有申請子類型。名額和申請都在，卻一個都分不出來。

在本機用三個學生重現 staging 情境（一個 admin 角色留下否決、一個志願序大小寫不符、一個對照組），修正前三個全部回 `null`，症狀完全吻合。找到兩個原因，其中一個是真的 bug。

## 原因一：申請清單比對沒有正規化（bug）

`_compute_suggestions` 這一行裡，否決檢查用了 `_norm_sub_type`，但「有沒有申請這個子類型」卻是**原字串**比對：

```python
preferences = [p for p in raw_prefs if (p in applied_set if applied_set else True) and _norm_sub_type(p) not in rejected]
```

`sub_type_preferences` 與 `scholarship_subtype_list` 是由不同程式路徑寫入的自由字串（依 CLAUDE.md，子類型不是 enum 約束的）。只要出現 `"NSTC"` / `" nstc"` 對上 `"nstc"`，整份志願序就會被過濾成空的 —— 學生完全分不到，而名額明明還在，畫面上也沒有任何線索。

**修正**：兩邊都以 `_norm_sub_type` 比對；另新增 `_canonical_sub_type()`，把學生的拼法映射回 config `quotas` 的正式 key，確保 quota tracker 與 allowed-config 查表仍精確，寫入 DB 的 `allocated_sub_type` 也維持正式拼法。

## 原因二：擋住的理由看不見（非 bug，但訊息誤導）

`load_rejected_subtype_map` 會撈**任何角色**的否決，但表格的「教授推薦／學院推薦」兩欄只顯示 professor 與 college 的意見。所以其他角色（例如 admin）留下的否決會擋掉所有子類型，畫面上卻只顯示「未推薦」。

按鈕原本一律回報「學生已分配完畢或名額已用盡」，在這種情況下是錯的。現在改為逐列判斷真正原因並回報：**已撤銷／停發 · 學院不予推薦 · 未申請任何子類型 · 審核不同意 · 名額不足**。

（該學生的核配格 tooltip 本來就有「審核不同意（不推薦）國科會 · phd_114」，格子層級看得到；問題只在整體訊息誤導。）

## 驗證（dev stack 端對端）

| 學生 | 情境 | 修正前 | 修正後 |
|---|---|---|---|
| 王思涵 | admin 角色的審核不同意 | `null` | `null`（正確擋住） |
| 李承翰 | 志願序 `["NSTC", " moe_1w"]` | **`null`** | **`nstc` ✓** |
| 吳孟儒 | 對照組 | `nstc` | `nstc` ✓ |

以 admin 身分在 `獎學金分發 → 博士生獎學金 → 114 學年度 / 全年` 實際操作：清空後按資訊學院的「預設分發」→ 訊息「已預設分配 2 筆，請確認後儲存」；再按一次 → 「無可預設分配（1 筆審核不同意）」，不再是誤導的「名額已用盡」。

## 測試

- 後端新增 7 項：大小寫／空白變體仍可分配、寫入的是 config 的正式拼法、從未申請過的子類型仍被排除（正規化不能讓過濾失效）、審核否決仍擋得住變體拼法。
- 前端新增 7 項：`classifyUnallocated` 的優先序（撤銷 → 學院否決 → 未申請 → 審核不同意 → 名額不足）、只有「所有已申請子類型都被否決」才算審核不同意、代碼正規化比對、`summarizeUnallocated` 依數量排序。
- 後端 65 項、前端 38 項全數通過；black、flake8 `B904,B014`、tsc、eslint 皆過。

## 尚待確認

我無法從沙箱連到 staging，所以「staging 就是原因一」是**推測** —— 症狀完全吻合，但未直接證實。部署後若仍有學生分不到，新的訊息會直接指出屬於哪一類原因，不需要再猜。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hz7xEWB8qFqknZCGDyXdHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hz7xEWB8qFqknZCGDyXdHA)_