### PR TITLE
feat(export): 學院匯出的動態文件合併加入學生資料彙整，更名為「申請資料合併檔」

### DIFF
--- a/backend/app/services/application_field_service.py
+++ b/backend/app/services/application_field_service.py
@@ -20,6 +20,7 @@ from app.schemas.application_field import (
     ApplicationFieldUpdate,
     ScholarshipFormConfigResponse,
 )
+from app.services.form_field_labels import FIXED_FIELD_LABELS
 
 
 class ApplicationFieldService:
@@ -273,7 +274,7 @@ class ApplicationFieldService:
             "id": 0,  # Temporary ID for fixed field
             "scholarship_type": scholarship_type,
             "field_name": "postal_account",
-            "field_label": "郵局帳號",
+            "field_label": FIXED_FIELD_LABELS["postal_account"],
             "field_label_en": "Post Office/ESUN Bank Account Number",
             "field_type": "text",
             "is_required": True,
@@ -341,7 +342,7 @@ class ApplicationFieldService:
                 "id": 0,  # Temporary ID for fixed field
                 "scholarship_type": scholarship_type,
                 "field_name": "advisor_name",
-                "field_label": "指導教授姓名",
+                "field_label": FIXED_FIELD_LABELS["advisor_name"],
                 "field_label_en": "Advisor Name",
                 "field_type": "text",
                 "is_required": True,
@@ -367,7 +368,7 @@ class ApplicationFieldService:
                 "id": 0,  # Temporary ID for fixed field
                 "scholarship_type": scholarship_type,
                 "field_name": "advisor_email",
-                "field_label": "指導教授Email",
+                "field_label": FIXED_FIELD_LABELS["advisor_email"],
                 "field_label_en": "Advisor Email",
                 "field_type": "email",
                 "is_required": True,
@@ -393,7 +394,7 @@ class ApplicationFieldService:
                 "id": 0,  # Temporary ID for fixed field
                 "scholarship_type": scholarship_type,
                 "field_name": "advisor_nycu_id",
-                "field_label": "指導教授本校人事編號",
+                "field_label": FIXED_FIELD_LABELS["advisor_nycu_id"],
                 "field_label_en": "Advisor NYCU ID",
                 "field_type": "text",
                 "is_required": True,

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -65,10 +65,14 @@ FILE_TYPE_LABELS: Dict[str, str] = {
     "other": "其他文件",
 }
 
+# SIS 攻讀學位 codes. Descending, NOT ascending — 1 is the highest degree.
+# Authoritative sources, all agreeing: the `degrees` reference table the
+# frontend renders from (1=博士, 2=碩士, 3=學士), the std_degree field doc in
+# app/schemas/student.py, and StudentInfo.get_student_type() mapping "1"→phd.
 DEGREE_LABELS: Dict[str, str] = {
-    "1": "學士",
+    "1": "博士",
     "2": "碩士",
-    "3": "博士",
+    "3": "學士",
 }
 
 

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -1,8 +1,9 @@
 """
 Export Package Service
 
-Generates ZIP files containing student application materials
-organized by department, with auto-generated summary PDFs.
+Generates ZIP files containing student application materials organized by
+department, with auto-generated summary PDFs and, per student, one merged
+申請資料合併檔 PDF holding that summary plus their dynamic documents.
 """
 
 import asyncio
@@ -32,11 +33,18 @@ from sqlalchemy.orm import selectinload
 from app.models.application import Application
 from app.models.scholarship import ScholarshipType
 from app.services.export_summary_tables import build_embedded_summary_tables
+from app.services.form_field_labels import load_form_field_labels, resolve_field_label
 from app.services.minio_service import MinIOService
 from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
 from app.services.pdf_merge import MergeItem, build_merged_pdf
 
 logger = logging.getLogger(__name__)
+
+# The per-student summary PDF shipped standalone AND as the first document of
+# the merged PDF, and the merged PDF that stitches it together with the
+# student's admin-configured dynamic documents.
+SUMMARY_PDF_LABEL = "學生資料彙整"
+MERGED_PDF_LABEL = "申請資料合併檔"
 
 # file_type -> Chinese display name
 FILE_TYPE_LABELS: Dict[str, str] = {
@@ -91,7 +99,7 @@ def _unique_zip_path(zf: zipfile.ZipFile, path: str) -> str:
     """Return `path`, suffixed with _2/_3/… if the ZIP already holds an entry
     at that name. zipfile happily writes duplicate names and most extractors
     then keep only the last one, silently shadowing the other file — e.g. an
-    admin-configured dynamic document named exactly 動態文件合併 colliding with
+    admin-configured dynamic document named exactly 申請資料合併檔 colliding with
     the merged PDF, or two same-type download failures sharing one error path."""
 
     def _taken(name: str) -> bool:
@@ -172,6 +180,10 @@ class ExportPackageService:
         scholarship_type = await self._get_scholarship_type(scholarship_type_id)
         scholarship_name = scholarship_type.name
 
+        # 1.5 zh-TW labels for the submitted form fields. Loaded once here because
+        # _generate_summary_pdf is sync and runs inside the per-student loop.
+        field_labels = await load_form_field_labels(self.db, scholarship_type.code)
+
         # 2. Query applications with files
         applications = await self._query_applications(scholarship_type_id, academic_year, semester, college_code)
 
@@ -216,7 +228,9 @@ class ExportPackageService:
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
             for dept_folder, apps in sorted(dept_groups.items()):
                 for app in apps:
-                    await self._add_application_to_zip(zf, dept_folder, app, scholarship_name, academic_year, semester)
+                    await self._add_application_to_zip(
+                        zf, dept_folder, app, scholarship_name, academic_year, semester, field_labels
+                    )
             for inner_path, payload in summary_tables.items():
                 zf.writestr(inner_path, payload)
 
@@ -290,23 +304,36 @@ class ExportPackageService:
         scholarship_name: str,
         academic_year: int,
         semester: Optional[str],
+        field_labels: Dict[str, str],
     ) -> None:
-        """Add one application's files + summary PDF to the ZIP."""
+        """Add one application's files + summary PDF + merged PDF to the ZIP."""
         student = app.student_data or {}
         std_code = _sanitize_filename(student.get("std_stdcode", "unknown"))
         std_name = _sanitize_filename(student.get("std_cname", "未知"))
         student_folder = f"{std_code}_{std_name}"
         base_path = f"{dept_folder}/{student_folder}"
 
-        # Generate summary PDF
+        # Generate summary PDF. Kept in memory as well: it leads the merged PDF
+        # below, so reviewers open one file and start at the student's data.
         student_prefix = f"{std_code}_{std_name}"
+        summary_item: Optional[MergeItem] = None
         try:
-            pdf_bytes = self._generate_summary_pdf(app, scholarship_name, academic_year, semester)
-            zf.writestr(f"{base_path}/{student_prefix}_學生資料彙整.pdf", pdf_bytes)
+            pdf_bytes = self._generate_summary_pdf(app, scholarship_name, academic_year, semester, field_labels)
+            # _unique_zip_path here too: two applications can share one
+            # base_path (same student code + name in one department, e.g. a
+            # rejected and a resubmitted application), and a duplicate ZIP
+            # entry would silently drop one of the two summaries.
+            summary_path = _unique_zip_path(zf, f"{base_path}/{student_prefix}_{SUMMARY_PDF_LABEL}.pdf")
+            zf.writestr(summary_path, pdf_bytes)
+            summary_item = MergeItem(
+                label=SUMMARY_PDF_LABEL,
+                filename=summary_path.rsplit("/", 1)[-1],
+                content=pdf_bytes,
+            )
         except Exception as e:
             logger.exception(f"Failed to generate summary PDF for app {app.id}")
             zf.writestr(
-                f"{base_path}/_錯誤_彙整PDF生成失敗.txt",
+                _unique_zip_path(zf, f"{base_path}/_錯誤_彙整PDF生成失敗.txt"),
                 f"PDF 生成失敗：{str(e)}",
             )
 
@@ -355,8 +382,12 @@ class ExportPackageService:
                     )
                 )
 
-        # Extra per-student PDF stitching all dynamic documents together
-        if dynamic_items:
+        # Extra per-student PDF stitching the summary and all dynamic documents
+        # together. Built for every student, so a student who uploaded no
+        # dynamic documents still gets one (holding just their summary) and
+        # reviewers can work from the same file throughout the folder tree.
+        merge_items = ([summary_item] if summary_item else []) + dynamic_items
+        if merge_items:
             semester_map = {"first": "第一學期", "second": "第二學期"}
             semester_label = semester_map.get(semester, "全學年") if semester else "全學年"
             try:
@@ -364,21 +395,21 @@ class ExportPackageService:
                 # student — inline they would stall the whole event loop.
                 merged_bytes = await asyncio.to_thread(
                     build_merged_pdf,
-                    title="學生動態文件合併",
+                    title=MERGED_PDF_LABEL,
                     subtitle_lines=[
                         f"{scholarship_name} {academic_year}學年度 {semester_label}",
                         # Display surface: raw SIS values (sanitization is for
                         # ZIP paths), with the same fallbacks as folder naming.
                         f"{student.get('std_stdcode', 'unknown')} {student.get('std_cname', '未知')}",
                     ],
-                    items=dynamic_items,
+                    items=merge_items,
                 )
-                zf.writestr(_unique_zip_path(zf, f"{base_path}/{student_prefix}_動態文件合併.pdf"), merged_bytes)
+                zf.writestr(_unique_zip_path(zf, f"{base_path}/{student_prefix}_{MERGED_PDF_LABEL}.pdf"), merged_bytes)
             except Exception as e:
-                logger.exception(f"Failed to build merged dynamic-documents PDF for app {app.id}")
+                logger.exception(f"Failed to build merged application PDF for app {app.id}")
                 zf.writestr(
-                    _unique_zip_path(zf, f"{base_path}/_錯誤_動態文件合併PDF生成失敗.txt"),
-                    f"動態文件合併 PDF 生成失敗：{str(e)}",
+                    _unique_zip_path(zf, f"{base_path}/_錯誤_{MERGED_PDF_LABEL}PDF生成失敗.txt"),
+                    f"{MERGED_PDF_LABEL} PDF 生成失敗：{str(e)}",
                 )
 
     def _generate_summary_pdf(
@@ -387,6 +418,7 @@ class ExportPackageService:
         scholarship_name: str,
         academic_year: int,
         semester: Optional[str],
+        field_labels: Dict[str, str],
     ) -> bytes:
         """Generate a student summary PDF using reportlab."""
         student = app.student_data or {}
@@ -439,7 +471,7 @@ class ExportPackageService:
         # Header + Title
         elements.append(Paragraph(f"{scholarship_name} {academic_year}學年度 {semester_label}", s_header))
         elements.append(Spacer(1, 3 * mm))
-        elements.append(Paragraph("學生資料彙整", s_title))
+        elements.append(Paragraph(SUMMARY_PDF_LABEL, s_title))
         elements.append(Spacer(1, 6 * mm))
 
         # Section 1: Basic Info
@@ -484,10 +516,17 @@ class ExportPackageService:
             elements.append(Paragraph("三、表單填寫資料", s_section))
             elements.append(Spacer(1, 2 * mm))
             form_rows = []
+            seen_rows = set()
             for field_id in sorted(fields_data.keys()):
                 field = fields_data[field_id]
-                label = field.get("label", field.get("field_id", field_id))
+                label = resolve_field_label(field_id, field_labels)
                 value = str(field.get("value", "—") or "—")
+                # postal_account and account_number both hold the 郵局帳號 the
+                # student typed, so once translated they collapse to the same
+                # row — print it once instead of twice.
+                if (label, value) in seen_rows:
+                    continue
+                seen_rows.add((label, value))
                 form_rows.append((label, value))
             elements.append(self._build_table(form_rows, s_normal, table_style))
             elements.append(Spacer(1, 4 * mm))

--- a/backend/app/services/export_package_service.py
+++ b/backend/app/services/export_package_service.py
@@ -33,7 +33,11 @@ from sqlalchemy.orm import selectinload
 from app.models.application import Application
 from app.models.scholarship import ScholarshipType
 from app.services.export_summary_tables import build_embedded_summary_tables
-from app.services.form_field_labels import load_form_field_labels, resolve_field_label
+from app.services.form_field_labels import (
+    ACCOUNT_FIELD_SYNONYMS,
+    load_form_field_labels,
+    resolve_field_label,
+)
 from app.services.minio_service import MinIOService
 from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
 from app.services.pdf_merge import MergeItem, build_merged_pdf
@@ -180,10 +184,6 @@ class ExportPackageService:
         scholarship_type = await self._get_scholarship_type(scholarship_type_id)
         scholarship_name = scholarship_type.name
 
-        # 1.5 zh-TW labels for the submitted form fields. Loaded once here because
-        # _generate_summary_pdf is sync and runs inside the per-student loop.
-        field_labels = await load_form_field_labels(self.db, scholarship_type.code)
-
         # 2. Query applications with files
         applications = await self._query_applications(scholarship_type_id, academic_year, semester, college_code)
 
@@ -192,6 +192,11 @@ class ExportPackageService:
 
         if len(applications) > 200:
             raise ValueError(f"申請筆數超過上限 (200)，請縮小篩選範圍（目前 {len(applications)} 筆）")
+
+        # 2.5 zh-TW labels for the submitted form fields. Loaded once, after the
+        # rejection guards above, because _generate_summary_pdf is sync and runs
+        # inside the per-student loop.
+        field_labels = await load_form_field_labels(self.db, scholarship_type.code)
 
         # Derive college name from first application's student_data
         college_name = None
@@ -310,13 +315,11 @@ class ExportPackageService:
         student = app.student_data or {}
         std_code = _sanitize_filename(student.get("std_stdcode", "unknown"))
         std_name = _sanitize_filename(student.get("std_cname", "未知"))
-        student_folder = f"{std_code}_{std_name}"
-        base_path = f"{dept_folder}/{student_folder}"
+        student_prefix = f"{std_code}_{std_name}"
+        base_path = f"{dept_folder}/{student_prefix}"
 
         # Generate summary PDF. Kept in memory as well: it leads the merged PDF
         # below, so reviewers open one file and start at the student's data.
-        student_prefix = f"{std_code}_{std_name}"
-        summary_item: Optional[MergeItem] = None
         try:
             pdf_bytes = self._generate_summary_pdf(app, scholarship_name, academic_year, semester, field_labels)
             # _unique_zip_path here too: two applications can share one
@@ -335,6 +338,15 @@ class ExportPackageService:
             zf.writestr(
                 _unique_zip_path(zf, f"{base_path}/_錯誤_彙整PDF生成失敗.txt"),
                 f"PDF 生成失敗：{str(e)}",
+            )
+            # Still list it in the merge as a placeholder page: a reviewer
+            # working only from the merged PDF must not read a missing summary
+            # as "this student submitted no personal data".
+            summary_item = MergeItem(
+                label=SUMMARY_PDF_LABEL,
+                filename=f"{student_prefix}_{SUMMARY_PDF_LABEL}.pdf",
+                content=None,
+                error=f"{SUMMARY_PDF_LABEL} PDF 生成失敗：{str(e)}",
             )
 
         # Add uploaded files from ApplicationFile records; keep the bytes of
@@ -378,39 +390,37 @@ class ExportPackageService:
                         label=item_label,
                         filename=af.original_filename or af.object_name or "",
                         content=file_bytes,
-                        error=fetch_error,
+                        error=f"檔案下載失敗：{fetch_error}" if fetch_error else None,
                     )
                 )
 
         # Extra per-student PDF stitching the summary and all dynamic documents
-        # together. Built for every student, so a student who uploaded no
-        # dynamic documents still gets one (holding just their summary) and
-        # reviewers can work from the same file throughout the folder tree.
-        merge_items = ([summary_item] if summary_item else []) + dynamic_items
-        if merge_items:
-            semester_map = {"first": "第一學期", "second": "第二學期"}
-            semester_label = semester_map.get(semester, "全學年") if semester else "全學年"
-            try:
-                # to_thread: pypdf/Pillow/reportlab do seconds of pure CPU per
-                # student — inline they would stall the whole event loop.
-                merged_bytes = await asyncio.to_thread(
-                    build_merged_pdf,
-                    title=MERGED_PDF_LABEL,
-                    subtitle_lines=[
-                        f"{scholarship_name} {academic_year}學年度 {semester_label}",
-                        # Display surface: raw SIS values (sanitization is for
-                        # ZIP paths), with the same fallbacks as folder naming.
-                        f"{student.get('std_stdcode', 'unknown')} {student.get('std_cname', '未知')}",
-                    ],
-                    items=merge_items,
-                )
-                zf.writestr(_unique_zip_path(zf, f"{base_path}/{student_prefix}_{MERGED_PDF_LABEL}.pdf"), merged_bytes)
-            except Exception as e:
-                logger.exception(f"Failed to build merged application PDF for app {app.id}")
-                zf.writestr(
-                    _unique_zip_path(zf, f"{base_path}/_錯誤_{MERGED_PDF_LABEL}PDF生成失敗.txt"),
-                    f"{MERGED_PDF_LABEL} PDF 生成失敗：{str(e)}",
-                )
+        # together. Built for every student — summary_item is always present, so
+        # a student who uploaded no dynamic documents still gets one holding
+        # just their summary and reviewers work from the same file throughout.
+        semester_map = {"first": "第一學期", "second": "第二學期"}
+        semester_label = semester_map.get(semester, "全學年") if semester else "全學年"
+        try:
+            # to_thread: pypdf/Pillow/reportlab do seconds of pure CPU per
+            # student — inline they would stall the whole event loop.
+            merged_bytes = await asyncio.to_thread(
+                build_merged_pdf,
+                title=MERGED_PDF_LABEL,
+                subtitle_lines=[
+                    f"{scholarship_name} {academic_year}學年度 {semester_label}",
+                    # Display surface: raw SIS values (sanitization is for
+                    # ZIP paths), with the same fallbacks as folder naming.
+                    f"{student.get('std_stdcode', 'unknown')} {student.get('std_cname', '未知')}",
+                ],
+                items=[summary_item] + dynamic_items,
+            )
+            zf.writestr(_unique_zip_path(zf, f"{base_path}/{student_prefix}_{MERGED_PDF_LABEL}.pdf"), merged_bytes)
+        except Exception as e:
+            logger.exception(f"Failed to build merged application PDF for app {app.id}")
+            zf.writestr(
+                _unique_zip_path(zf, f"{base_path}/_錯誤_{MERGED_PDF_LABEL}PDF生成失敗.txt"),
+                f"{MERGED_PDF_LABEL} PDF 生成失敗：{str(e)}",
+            )
 
     def _generate_summary_pdf(
         self,
@@ -516,18 +526,24 @@ class ExportPackageService:
             elements.append(Paragraph("三、表單填寫資料", s_section))
             elements.append(Spacer(1, 2 * mm))
             form_rows = []
-            seen_rows = set()
+            seen_account_rows = set()
             for field_id in sorted(fields_data.keys()):
                 field = fields_data[field_id]
                 label = resolve_field_label(field_id, field_labels)
                 value = str(field.get("value", "—") or "—")
-                # postal_account and account_number both hold the 郵局帳號 the
-                # student typed, so once translated they collapse to the same
-                # row — print it once instead of twice.
-                if (label, value) in seen_rows:
-                    continue
-                seen_rows.add((label, value))
+                # postal_account and account_number are two ids for the one
+                # 郵局帳號 the student typed, so once translated they print the
+                # identical row twice. Scoped to that pair: two genuinely
+                # distinct fields that happen to share a label both stay
+                # visible, and differing account values stay visible too.
+                if field_id in ACCOUNT_FIELD_SYNONYMS:
+                    if (label, value) in seen_account_rows:
+                        continue
+                    seen_account_rows.add((label, value))
                 form_rows.append((label, value))
+            # Row order stays keyed on field_id: sorting on the zh-TW label
+            # would order by CJK codepoint, no more meaningful to a reviewer
+            # than the id and needlessly unstable when a label is edited.
             elements.append(self._build_table(form_rows, s_normal, table_style))
             elements.append(Spacer(1, 4 * mm))
 

--- a/backend/app/services/form_field_labels.py
+++ b/backend/app/services/form_field_labels.py
@@ -1,0 +1,66 @@
+"""zh-TW labels for the dynamic form fields stored in an application.
+
+`Application.submitted_form_data["fields"]` entries carry only the English
+`field_id` (see `app.schemas.application.DynamicFormField` — there is no
+`label` key), so every surface that renders submitted form data has to
+resolve the Chinese label itself.
+
+Two sources feed the map:
+- `application_fields.field_label` — the admin-configured fields, keyed by
+  `ScholarshipType.code`.
+- `FIXED_FIELD_LABELS` — the "fixed" fields `ApplicationFieldService` injects
+  into the form config at runtime. They are NOT rows in `application_fields`,
+  so this module is their single source of truth.
+"""
+
+from typing import Dict, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application_field import ApplicationField
+
+# field_id -> zh-TW label for the fields injected by
+# ApplicationFieldService._create_fixed_bank_account_field /
+# _create_fixed_advisor_fields, which have no application_fields row.
+FIXED_FIELD_LABELS: Dict[str, str] = {
+    "postal_account": "郵局帳號",
+    # Minted by the student wizard next to postal_account (see
+    # buildApplicationFormFields) and carries the same 郵局帳號 value.
+    "account_number": "郵局帳號",
+    "advisor_name": "指導教授姓名",
+    "advisor_email": "指導教授Email",
+    "advisor_nycu_id": "指導教授本校人事編號",
+}
+
+
+async def load_form_field_labels(db: AsyncSession, scholarship_code: Optional[str]) -> Dict[str, str]:
+    """Build the field_id -> zh-TW label map for one scholarship type.
+
+    Admin-configured rows win over the fixed defaults: `bulk_update_fields`
+    re-inserts whatever the admin UI posts, so a fixed field can also exist as
+    a real row, and then the admin owns its label.
+
+    Deliberately NOT filtered by `is_active` — a field deactivated after a
+    student submitted still needs its label to render that submission.
+    """
+    labels = dict(FIXED_FIELD_LABELS)
+    if not scholarship_code:
+        return labels
+
+    stmt = select(ApplicationField.field_name, ApplicationField.field_label).where(
+        ApplicationField.scholarship_type == scholarship_code
+    )
+    for field_name, field_label in (await db.execute(stmt)).all():
+        if field_name and field_label:
+            labels[field_name] = field_label
+    return labels
+
+
+def resolve_field_label(field_id: str, labels: Dict[str, str]) -> str:
+    """zh-TW label for one field id, falling back to the raw id.
+
+    Admin-created ids and batch-import `custom_<x>` columns can have no
+    definition at all — showing the raw id beats showing nothing.
+    """
+    return labels.get(field_id) or field_id

--- a/backend/app/services/form_field_labels.py
+++ b/backend/app/services/form_field_labels.py
@@ -8,9 +8,8 @@ resolve the Chinese label itself.
 Two sources feed the map:
 - `application_fields.field_label` — the admin-configured fields, keyed by
   `ScholarshipType.code`.
-- `FIXED_FIELD_LABELS` — the "fixed" fields `ApplicationFieldService` injects
-  into the form config at runtime. They are NOT rows in `application_fields`,
-  so this module is their single source of truth.
+- `FIXED_FIELD_LABELS` — built-in ids that are NOT rows in `application_fields`
+  and so have no admin-configured label, making this module their only source.
 """
 
 from typing import Dict, Optional
@@ -20,29 +19,44 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.application_field import ApplicationField
 
-# field_id -> zh-TW label for the fields injected by
-# ApplicationFieldService._create_fixed_bank_account_field /
-# _create_fixed_advisor_fields, which have no application_fields row.
+# field_id -> zh-TW label for the built-in ids, none of which is an
+# application_fields row:
+#   postal_account / advisor_* — injected into the form config at runtime by
+#     ApplicationFieldService._create_fixed_bank_account_field and
+#     _create_fixed_advisor_fields.
+#   account_number / bank_account — account ids minted client-side or carried
+#     by older submissions; both are probed as stored field keys by
+#     bank_verification_service, roster_service and payment_rosters.
 FIXED_FIELD_LABELS: Dict[str, str] = {
     "postal_account": "郵局帳號",
-    # Minted by the student wizard next to postal_account (see
-    # buildApplicationFormFields) and carries the same 郵局帳號 value.
     "account_number": "郵局帳號",
+    "bank_account": "銀行帳戶",
     "advisor_name": "指導教授姓名",
     "advisor_email": "指導教授Email",
     "advisor_nycu_id": "指導教授本校人事編號",
 }
 
+# The ids that carry the one account number a student typed. They resolve to
+# the same label, so the summary PDF prints only the first of an identical
+# (label, value) pair — see _generate_summary_pdf.
+ACCOUNT_FIELD_SYNONYMS = frozenset({"postal_account", "account_number"})
+
 
 async def load_form_field_labels(db: AsyncSession, scholarship_code: Optional[str]) -> Dict[str, str]:
     """Build the field_id -> zh-TW label map for one scholarship type.
+
+    Uses `field_label`, not `export_column_label`: the latter renames a column
+    of the 學生資料彙整表 workbook (phd/contact_phone exports as 學生手機), which
+    is not what the form field is called on a form-data page.
 
     Admin-configured rows win over the fixed defaults: `bulk_update_fields`
     re-inserts whatever the admin UI posts, so a fixed field can also exist as
     a real row, and then the admin owns its label.
 
-    Deliberately NOT filtered by `is_active` — a field deactivated after a
-    student submitted still needs its label to render that submission.
+    Deliberately NOT filtered by `is_active`, so a field deactivated after a
+    student submitted still renders. Note this cannot rescue a field the admin
+    *removed*: `bulk_update_fields` hard-deletes rows, and `resolve_field_label`
+    then falls back to the raw id for those historical submissions.
     """
     labels = dict(FIXED_FIELD_LABELS)
     if not scholarship_code:

--- a/backend/app/services/pdf_merge.py
+++ b/backend/app/services/pdf_merge.py
@@ -55,8 +55,10 @@ class ImageTooLargeError(Exception):
 class MergeItem:
     """One document to merge: display label + original filename + raw bytes.
 
-    ``content=None`` means the file could not be downloaded; the merged PDF
-    gets a placeholder page for it (carrying ``error``) so the document list
+    ``content=None`` means the document could not be included — it failed to
+    download, or the export generated it and that generation failed. ``error``
+    carries the ready-to-render zh-TW reason (the caller knows which case it
+    is); the merged PDF shows it on a placeholder page so the document list
     stays complete.
     """
 
@@ -95,7 +97,7 @@ def _render_item(item: MergeItem, heading: str) -> bytes:
     the image path instead of a misleading unreadable-PDF placeholder.
     """
     if item.content is None:
-        return _placeholder_page(heading, f"檔案下載失敗：{item.error or '未知錯誤'}")
+        return _placeholder_page(heading, item.error or "此文件無法納入合併檔（未知錯誤）")
 
     if _looks_like_pdf(item.content):
         try:

--- a/backend/app/services/pdf_merge.py
+++ b/backend/app/services/pdf_merge.py
@@ -1,9 +1,9 @@
-"""Merge student-uploaded documents into a single PDF.
+"""Merge a student's application documents into a single PDF.
 
-The college export package ships each student's uploaded files individually
-inside the ZIP; reviewers additionally get one PDF per student that stitches
-the admin-configured dynamic documents together so they can be read in a
-single pass.
+The college export package ships each student's files individually inside the
+ZIP; reviewers additionally get one 申請資料合併檔 PDF per student that stitches
+the generated 學生資料彙整 summary and the admin-configured dynamic documents
+together so they can be read in a single pass.
 
 Only PDF and JPG/PNG content is rendered inline: PDF pages are appended
 (owner-password-only encryption is unlocked with the empty user password,

--- a/backend/app/tests/test_export_package_dynamic_merge.py
+++ b/backend/app/tests/test_export_package_dynamic_merge.py
@@ -1,9 +1,11 @@
-"""Integration tests: generate_export_zip ships one extra per-student PDF
-merging that student's admin-configured dynamic documents (file_type not in
-FILE_TYPE_LABELS). Fixed-type files (transcript, …) stay out of the merge;
-students with no dynamic documents get no merged PDF; a download failure
-becomes a placeholder page inside the merge; and a wholesale merge failure
-degrades to a `_錯誤_…txt` without losing the rest of the ZIP.
+"""Integration tests: generate_export_zip ships one extra per-student
+申請資料合併檔 PDF merging that student's 學生資料彙整 summary with their
+admin-configured dynamic documents (file_type not in FILE_TYPE_LABELS).
+Fixed-type files (transcript, …) stay out of the merge; the merged PDF is
+built for every student (a student with no dynamic documents gets one holding
+just the summary); a download failure becomes a placeholder page inside the
+merge; and a wholesale merge failure degrades to a `_錯誤_…txt` without losing
+the rest of the ZIP.
 
 Uses a fake MinIO (dict of object_name → bytes) and the real reportlab/pypdf
 pipeline — the WQY CJK font is available in the backend image and CI.
@@ -45,7 +47,7 @@ def _mk_file(file_type, original_filename, object_name, mime_type="application/p
     )
 
 
-def _mk_app(app_id, user_id, std_code, cname, files):
+def _mk_app(app_id, user_id, std_code, cname, files, submitted_form_data=None):
     a = Application(
         user_id=user_id,
         scholarship_type_id=1,
@@ -57,6 +59,7 @@ def _mk_app(app_id, user_id, std_code, cname, files):
             "std_stdcode": std_code,
             "std_cname": cname,
         },
+        submitted_form_data=submitted_form_data or {},
     )
     a.id = app_id
     # Bypass relationship instrumentation — SimpleNamespace file stubs are
@@ -102,11 +105,15 @@ def _stype():
     return SimpleNamespace(name="某獎學金", code="phd", sub_type_configs=[])
 
 
-async def _run_export(monkeypatch, apps, minio):
+async def _run_export(monkeypatch, apps, minio, field_labels=None):
     async def _fake_aux(db, *, scholarship_type, applications):
         return ([], {}, {}, {})
 
     monkeypatch.setattr("app.services.export_summary_tables.load_export_aux_data", _fake_aux)
+    monkeypatch.setattr(
+        "app.services.export_package_service.load_form_field_labels",
+        _coro_returning(field_labels if field_labels is not None else {}),
+    )
 
     svc = ExportPackageService(db=None, minio_service=minio)
     monkeypatch.setattr(svc, "_get_scholarship_type", _coro_returning(_stype()))
@@ -122,7 +129,7 @@ async def _run_export(monkeypatch, apps, minio):
 
 
 @pytest.mark.asyncio
-async def test_merged_pdf_covers_dynamic_docs_only(monkeypatch):
+async def test_merged_pdf_covers_summary_and_dynamic_docs_only(monkeypatch):
     minio = _FakeMinio(
         {
             "obj/transcript.pdf": _blank_pdf(1),
@@ -142,29 +149,79 @@ async def test_merged_pdf_covers_dynamic_docs_only(monkeypatch):
                 _mk_file("社團證明", "club.png", "obj/club.png", mime_type="image/png"),
             ],
         ),
-        # Only fixed-type files → must NOT get a merged PDF
+        # Only fixed-type files → still gets a merged PDF, holding just the summary
         _mk_app(2, 12, "002", "乙", [_mk_file("transcript", "transcript.pdf", "obj/transcript.pdf")]),
     ]
 
     zf = await _run_export(monkeypatch, apps, minio)
     names = zf.namelist()
 
-    merged_path = "1000_A系/001_甲/001_甲_動態文件合併.pdf"
+    merged_path = "1000_A系/001_甲/001_甲_申請資料合併檔.pdf"
     assert merged_path in names
-    assert not any("002_乙" in n and n.endswith("動態文件合併.pdf") for n in names)
+    assert "1000_A系/002_乙/002_乙_申請資料合併檔.pdf" in names
 
-    # Individual files are still shipped alongside the merge
+    # Individual files are still shipped alongside the merge, and the summary
+    # PDF stays in the folder in its own right.
     assert "1000_A系/001_甲/001_甲_成績單.pdf" in names
     assert "1000_A系/001_甲/001_甲_語言檢定證明.pdf" in names
+    assert "1000_A系/001_甲/001_甲_學生資料彙整.pdf" in names
 
     reader = PdfReader(io.BytesIO(zf.read(merged_path)))
-    # cover(1) + sep+2 pages (toefl) + sep+1 page (club image) = 6
-    assert len(reader.pages) == 6
+    # cover(1) + sep+1 page (summary) + sep+2 pages (toefl) + sep+1 page (club image) = 8
+    assert len(reader.pages) == 8
     cover = reader.pages[0].extract_text()
+    assert "申請資料合併檔" in cover
+    assert "學生資料彙整" in cover
     assert "語言檢定證明" in cover
     assert "社團證明" in cover
     assert "成績單" not in cover
     assert "001 甲" in cover
+
+    # The no-dynamic-documents student's merge is summary-only:
+    # cover(1) + sep+1 page (summary) = 3
+    solo = PdfReader(io.BytesIO(zf.read("1000_A系/002_乙/002_乙_申請資料合併檔.pdf")))
+    assert len(solo.pages) == 3
+    solo_cover = solo.pages[0].extract_text()
+    assert "學生資料彙整" in solo_cover
+    assert "成績單" not in solo_cover
+
+
+@pytest.mark.asyncio
+async def test_field_labels_reach_the_summary_pdf_inside_the_zip(monkeypatch):
+    # Wiring test: generate_export_zip loads the label map once and threads it
+    # down to _generate_summary_pdf. Dropping that argument anywhere in the
+    # chain silently reverts 三、表單填寫資料 to English field ids.
+    apps = [
+        _mk_app(
+            1,
+            11,
+            "001",
+            "甲",
+            [],
+            submitted_form_data={
+                "fields": {
+                    "master_school_info": {"field_id": "master_school_info", "value": "交大資工所"},
+                    "advisor_name": {"field_id": "advisor_name", "value": "王教授"},
+                },
+                "documents": [],
+            },
+        )
+    ]
+
+    zf = await _run_export(
+        monkeypatch,
+        apps,
+        _FakeMinio({}),
+        field_labels={"master_school_info": "碩士畢業學校/學院/系所", "advisor_name": "指導教授姓名"},
+    )
+
+    summary = PdfReader(io.BytesIO(zf.read("1000_A系/001_甲/001_甲_學生資料彙整.pdf")))
+    text = "\n".join(page.extract_text() for page in summary.pages)
+
+    assert "碩士畢業學校/學院/系所" in text
+    assert "指導教授姓名" in text
+    assert "master_school_info" not in text
+    assert "advisor_name" not in text
 
 
 @pytest.mark.asyncio
@@ -189,13 +246,13 @@ async def test_download_failure_becomes_placeholder_page(monkeypatch):
     names = zf.namelist()
 
     assert "1000_A系/001_甲/_錯誤_找不到檔案_社團證明.txt" in names
-    merged_path = "1000_A系/001_甲/001_甲_動態文件合併.pdf"
+    merged_path = "1000_A系/001_甲/001_甲_申請資料合併檔.pdf"
     assert merged_path in names
 
     reader = PdfReader(io.BytesIO(zf.read(merged_path)))
-    # cover(1) + sep+1 page (toefl) + sep+1 placeholder = 5
-    assert len(reader.pages) == 5
-    placeholder_text = reader.pages[4].extract_text()
+    # cover(1) + sep+1 page (summary) + sep+1 page (toefl) + sep+1 placeholder = 7
+    assert len(reader.pages) == 7
+    placeholder_text = reader.pages[6].extract_text()
     assert "檔案下載失敗" in placeholder_text
     # The concrete fetch error surfaces on the placeholder page, matching
     # the per-file error txt, so reviewers see the actual reason
@@ -204,17 +261,17 @@ async def test_download_failure_becomes_placeholder_page(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_merged_pdf_name_collision_keeps_both_entries(monkeypatch):
-    # An admin-configured dynamic document named exactly 動態文件合併 must not
+    # An admin-configured dynamic document named exactly 申請資料合併檔 must not
     # shadow (or be shadowed by) the merged artifact — the second writer gets
     # a _2 suffix instead of a duplicate ZIP entry.
     minio = _FakeMinio({"obj/tricky.pdf": _blank_pdf(1)})
-    apps = [_mk_app(1, 11, "001", "甲", [_mk_file("動態文件合併", "tricky.pdf", "obj/tricky.pdf")])]
+    apps = [_mk_app(1, 11, "001", "甲", [_mk_file("申請資料合併檔", "tricky.pdf", "obj/tricky.pdf")])]
 
     zf = await _run_export(monkeypatch, apps, minio)
     names = zf.namelist()
 
-    assert "1000_A系/001_甲/001_甲_動態文件合併.pdf" in names  # the student's upload
-    assert "1000_A系/001_甲/001_甲_動態文件合併_2.pdf" in names  # the merged artifact
+    assert "1000_A系/001_甲/001_甲_申請資料合併檔.pdf" in names  # the student's upload
+    assert "1000_A系/001_甲/001_甲_申請資料合併檔_2.pdf" in names  # the merged artifact
     assert len(names) == len(set(names))  # no duplicate ZIP entries anywhere
 
 
@@ -244,10 +301,10 @@ async def test_two_same_type_download_failures_get_distinct_error_files(monkeypa
     assert len(names) == len(set(names))
 
     # Both failures still appear in the merged PDF as placeholder pages:
-    # cover(1) + 2 * (separator + download-failure placeholder) = 5
-    merged = zf.read("1000_A系/001_甲/001_甲_動態文件合併.pdf")
+    # cover(1) + sep+1 page (summary) + 2 * (separator + download-failure placeholder) = 7
+    merged = zf.read("1000_A系/001_甲/001_甲_申請資料合併檔.pdf")
     reader = PdfReader(io.BytesIO(merged))
-    assert len(reader.pages) == 5
+    assert len(reader.pages) == 7
 
 
 @pytest.mark.asyncio
@@ -266,7 +323,7 @@ async def test_merge_failure_degrades_to_error_placeholder(monkeypatch):
     # Merge failure never aborts the export: materials + summary PDF intact
     assert "1000_A系/001_甲/001_甲_語言檢定證明.pdf" in names
     assert "1000_A系/001_甲/001_甲_學生資料彙整.pdf" in names
-    assert not any(n.endswith("動態文件合併.pdf") for n in names)
-    error_path = "1000_A系/001_甲/_錯誤_動態文件合併PDF生成失敗.txt"
+    assert not any(n.endswith("申請資料合併檔.pdf") for n in names)
+    error_path = "1000_A系/001_甲/_錯誤_申請資料合併檔PDF生成失敗.txt"
     assert error_path in names
     assert "merge exploded" in zf.read(error_path).decode("utf-8")

--- a/backend/app/tests/test_export_package_dynamic_merge.py
+++ b/backend/app/tests/test_export_package_dynamic_merge.py
@@ -105,7 +105,7 @@ def _stype():
     return SimpleNamespace(name="某獎學金", code="phd", sub_type_configs=[])
 
 
-async def _run_export(monkeypatch, apps, minio, field_labels=None):
+async def _run_export(monkeypatch, apps, minio, field_labels=None, summary_pdf=None):
     async def _fake_aux(db, *, scholarship_type, applications):
         return ([], {}, {}, {})
 
@@ -118,6 +118,8 @@ async def _run_export(monkeypatch, apps, minio, field_labels=None):
     svc = ExportPackageService(db=None, minio_service=minio)
     monkeypatch.setattr(svc, "_get_scholarship_type", _coro_returning(_stype()))
     monkeypatch.setattr(svc, "_query_applications", _coro_returning(apps))
+    if summary_pdf is not None:
+        monkeypatch.setattr(svc, "_generate_summary_pdf", summary_pdf)
 
     buf, _ = await svc.generate_export_zip(
         scholarship_type_id=1,
@@ -257,6 +259,36 @@ async def test_download_failure_becomes_placeholder_page(monkeypatch):
     # The concrete fetch error surfaces on the placeholder page, matching
     # the per-file error txt, so reviewers see the actual reason
     assert "NoSuchKey" in placeholder_text
+
+
+@pytest.mark.asyncio
+async def test_summary_failure_becomes_a_placeholder_inside_the_merge(monkeypatch):
+    # A reviewer working only from 申請資料合併檔 must not read a missing summary
+    # as "this student submitted no personal data" — the merge lists it as a
+    # placeholder page carrying the real reason.
+    minio = _FakeMinio({"obj/toefl.pdf": _blank_pdf(1)})
+    apps = [_mk_app(1, 11, "001", "甲", [_mk_file("語言檢定證明", "toefl.pdf", "obj/toefl.pdf")])]
+
+    def _boom(*a, **k):
+        raise RuntimeError("彙整爆炸")
+
+    zf = await _run_export(monkeypatch, apps, minio, summary_pdf=_boom)
+    names = zf.namelist()
+
+    assert "1000_A系/001_甲/_錯誤_彙整PDF生成失敗.txt" in names
+    assert not any(n.endswith("_學生資料彙整.pdf") for n in names)
+
+    merged_path = "1000_A系/001_甲/001_甲_申請資料合併檔.pdf"
+    assert merged_path in names
+    reader = PdfReader(io.BytesIO(zf.read(merged_path)))
+    # cover(1) + sep+1 placeholder (summary) + sep+1 page (toefl) = 5
+    assert len(reader.pages) == 5
+    assert "學生資料彙整" in reader.pages[0].extract_text()
+    placeholder = reader.pages[2].extract_text()
+    assert "學生資料彙整 PDF 生成失敗" in placeholder
+    assert "彙整爆炸" in placeholder
+    # Not mislabelled as a download failure — nothing was downloaded.
+    assert "檔案下載失敗" not in placeholder
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_export_package_embeds_summary.py
+++ b/backend/app/tests/test_export_package_embeds_summary.py
@@ -3,8 +3,12 @@ table rows match the student folders. Avoids DB / MinIO by monkeypatching
 ensure_cjk_font, _query_applications, _get_scholarship_type,
 _generate_summary_pdf, load_form_field_labels and load_export_aux_data.
 
-The per-student 申請資料合併檔 merge still runs for real (it wraps the stubbed
-summary bytes), so reportlab/pypdf are exercised via pdf_merge.
+The per-student 申請資料合併檔 merge still runs for real, so this file DOES
+depend on the CJK font: `build_merged_pdf` calls `pdf_merge`'s own
+`ensure_cjk_font`, which the patch above (bound in export_package_service's
+namespace) does not cover. The stubbed `b"%PDF-1.4 fake"` summary passes the
+magic-bytes check but fails to parse, so it lands as an unreadable-PDF
+placeholder page inside the merge rather than being embedded.
 """
 
 import io

--- a/backend/app/tests/test_export_package_embeds_summary.py
+++ b/backend/app/tests/test_export_package_embeds_summary.py
@@ -1,7 +1,10 @@
 """Integration test: generate_export_zip embeds the 申請總表 workbooks and the
-table rows match the student folders. Avoids DB / MinIO / reportlab font by
-monkeypatching ensure_cjk_font, _query_applications, _get_scholarship_type,
-_generate_summary_pdf, and load_export_aux_data.
+table rows match the student folders. Avoids DB / MinIO by monkeypatching
+ensure_cjk_font, _query_applications, _get_scholarship_type,
+_generate_summary_pdf, load_form_field_labels and load_export_aux_data.
+
+The per-student 申請資料合併檔 merge still runs for real (it wraps the stubbed
+summary bytes), so reportlab/pypdf are exercised via pdf_merge.
 """
 
 import io
@@ -48,6 +51,7 @@ async def test_export_zip_contains_summary_tables_matching_folders(monkeypatch):
         return ([], {}, {}, {})
 
     monkeypatch.setattr("app.services.export_summary_tables.load_export_aux_data", _fake_aux)
+    monkeypatch.setattr("app.services.export_package_service.load_form_field_labels", _coro_returning({}))
 
     apps = [
         _mk_app(1, 11, "1000", "A系", "001", "甲"),
@@ -100,6 +104,7 @@ async def test_export_zip_degrades_when_summary_build_fails_wholesale(monkeypatc
     # Wholesale failure of the summary-table builder (e.g. an aux-data DB error
     # before the per-table try/except) must not lose the materials ZIP.
     monkeypatch.setattr("app.services.export_package_service.build_embedded_summary_tables", _boom)
+    monkeypatch.setattr("app.services.export_package_service.load_form_field_labels", _coro_returning({}))
 
     apps = [_mk_app(1, 11, "1000", "A系", "001", "甲")]
     stype = SimpleNamespace(name="某獎學金", code="phd", sub_type_configs=[])

--- a/backend/app/tests/test_export_package_pure_helpers.py
+++ b/backend/app/tests/test_export_package_pure_helpers.py
@@ -112,7 +112,7 @@ class TestFileTypeLabels:
         # bank_book are minted by batch_import's doc_type_map. Every
         # fixed type MUST be listed here or it is misclassified as an
         # admin-configured dynamic document and swept into the merged
-        # 動態文件合併.pdf.
+        # 申請資料合併檔.pdf.
         expected_keys = {
             "transcript",
             "research_proposal",
@@ -213,7 +213,8 @@ class TestLabelForFileType:
 class TestIsDynamicDocumentType:
     """Pin: the merged-PDF selector. Only admin-configured dynamic documents
     (file_type IS the configured document_name) join the per-student
-    動態文件合併.pdf; every fixed type and the 其他文件 bucket stay out."""
+    申請資料合併檔.pdf alongside the generated summary; every fixed type and the
+    其他文件 bucket stay out."""
 
     @pytest.mark.parametrize("fixed_type", sorted(FILE_TYPE_LABELS.keys()))
     def test_every_fixed_type_is_not_dynamic(self, fixed_type):
@@ -230,7 +231,7 @@ class TestIsDynamicDocumentType:
 class TestUniqueZipPath:
     """Pin: duplicate-entry defense. zipfile writes duplicate names without
     error and most extractors keep only the last, silently shadowing a file
-    (e.g. a dynamic document named 動態文件合併 vs the merged artifact)."""
+    (e.g. a dynamic document named 申請資料合併檔 vs the merged artifact)."""
 
     def _zf_with(self, names):
         import io

--- a/backend/app/tests/test_export_package_pure_helpers.py
+++ b/backend/app/tests/test_export_package_pure_helpers.py
@@ -173,10 +173,17 @@ class TestDegreeLabels:
         assert set(DEGREE_LABELS.keys()) == {"1", "2", "3"}
 
     def test_degree_labels_are_zh_tw(self):
-        # Pin: zh-TW canonical names — 學士/碩士/博士.
-        assert DEGREE_LABELS["1"] == "學士"
+        # Pin: zh-TW canonical names, DESCENDING — 1 is the highest
+        # degree, not the lowest. This pin previously asserted the
+        # inverted order, which printed 學位 學士 on every PhD
+        # student's export. Three authoritative sources agree on the
+        # order below: the `degrees` reference table the frontend
+        # renders from, the std_degree doc in app/schemas/student.py
+        # ("1:博士, 2:碩士, 3:學士"), and StudentInfo.get_student_type()
+        # mapping "1" -> phd. Do not "restore" the ascending order.
+        assert DEGREE_LABELS["1"] == "博士"
         assert DEGREE_LABELS["2"] == "碩士"
-        assert DEGREE_LABELS["3"] == "博士"
+        assert DEGREE_LABELS["3"] == "學士"
 
     def test_keys_are_strings_not_ints(self):
         # Pin: SIS API returns std_degree as INT but the labels

--- a/backend/app/tests/test_export_package_summary_pdf.py
+++ b/backend/app/tests/test_export_package_summary_pdf.py
@@ -1,0 +1,132 @@
+"""Tests for `ExportPackageService._generate_summary_pdf` — the per-student
+學生資料彙整 PDF, focused on 三、表單填寫資料.
+
+The stored `submitted_form_data["fields"]` entries carry only the English
+`field_id` (there is no `label` key on DynamicFormField), so the label column
+must come from the field-label map, not from the id.
+
+Uses the real reportlab pipeline — the WQY CJK font is available in the
+backend image and CI.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from pypdf import PdfReader
+
+import io
+
+from app.services.export_package_service import ExportPackageService
+from app.services.form_field_labels import FIXED_FIELD_LABELS
+
+
+def _mk_app(fields):
+    return SimpleNamespace(
+        id=1,
+        student_data={
+            "std_stdcode": "001",
+            "std_cname": "甲",
+            "trm_depname": "A系",
+            "trm_academyname": "某學院",
+            "trm_degree": "3",
+        },
+        submitted_form_data={"fields": fields, "documents": []},
+    )
+
+
+def _field(field_id, value):
+    return {"field_id": field_id, "field_type": "text", "value": value, "required": True}
+
+
+def _summary_text(fields, field_labels):
+    svc = ExportPackageService(db=None, minio_service=None)
+    pdf = svc._generate_summary_pdf(_mk_app(fields), "某獎學金", 114, "first", field_labels)
+    return "\n".join(page.extract_text() for page in PdfReader(io.BytesIO(pdf)).pages)
+
+
+class TestFormFieldSection:
+    def test_configured_field_renders_its_chinese_label_not_the_id(self):
+        text = _summary_text(
+            {"master_school_info": _field("master_school_info", "交大資工所")},
+            {"master_school_info": "碩士畢業學校/學院/系所"},
+        )
+
+        assert "三、表單填寫資料" in text
+        assert "碩士畢業學校/學院/系所" in text
+        assert "交大資工所" in text
+        assert "master_school_info" not in text
+
+    def test_runtime_injected_fixed_fields_render_in_chinese(self):
+        # postal_account / advisor_* have no application_fields row — before
+        # FIXED_FIELD_LABELS they printed as raw English ids.
+        text = _summary_text(
+            {
+                "advisor_name": _field("advisor_name", "王教授"),
+                "advisor_email": _field("advisor_email", "prof@nycu.edu.tw"),
+                "advisor_nycu_id": _field("advisor_nycu_id", "P12345"),
+            },
+            dict(FIXED_FIELD_LABELS),
+        )
+
+        assert "指導教授姓名" in text
+        assert "指導教授本校人事編號" in text
+        assert "advisor_name" not in text
+        assert "advisor_nycu_id" not in text
+
+    def test_postal_account_and_account_number_collapse_to_one_row(self):
+        # Both ids hold the same 郵局帳號 the student typed; translated they
+        # would otherwise print the identical row twice.
+        text = _summary_text(
+            {
+                "account_number": _field("account_number", "12341234123412"),
+                "postal_account": _field("postal_account", "12341234123412"),
+            },
+            dict(FIXED_FIELD_LABELS),
+        )
+
+        assert text.count("郵局帳號") == 1
+        assert text.count("12341234123412") == 1
+
+    def test_differing_values_under_one_label_both_render(self):
+        # The de-dupe is on (label, value) — a genuine discrepancy between the
+        # two account ids must stay visible to the reviewer.
+        text = _summary_text(
+            {
+                "account_number": _field("account_number", "111"),
+                "postal_account": _field("postal_account", "222"),
+            },
+            dict(FIXED_FIELD_LABELS),
+        )
+
+        assert text.count("郵局帳號") == 2
+        assert "111" in text
+        assert "222" in text
+
+    def test_undefined_field_id_falls_back_to_the_raw_id(self):
+        # Batch import accepts any custom_<x> column, so an id with no
+        # definition must still render rather than vanish.
+        text = _summary_text({"custom_thing": _field("custom_thing", "某值")}, {})
+
+        assert "custom_thing" in text
+        assert "某值" in text
+
+    def test_section_omitted_when_no_form_fields(self):
+        text = _summary_text({}, dict(FIXED_FIELD_LABELS))
+
+        assert "三、表單填寫資料" not in text
+        # the sections that do not depend on submitted data are still there
+        assert "一、基本資料" in text
+        assert "學生資料彙整" in text
+
+
+class TestSummaryPdfBasics:
+    @pytest.mark.parametrize(
+        "semester,expected",
+        [("first", "第一學期"), ("second", "第二學期"), (None, "全學年")],
+    )
+    def test_header_carries_scholarship_year_and_semester(self, semester, expected):
+        svc = ExportPackageService(db=None, minio_service=None)
+        pdf = svc._generate_summary_pdf(_mk_app({}), "某獎學金", 114, semester, {})
+        text = PdfReader(io.BytesIO(pdf)).pages[0].extract_text()
+
+        assert "某獎學金 114學年度 " + expected in text

--- a/backend/app/tests/test_export_package_summary_pdf.py
+++ b/backend/app/tests/test_export_package_summary_pdf.py
@@ -87,7 +87,7 @@ class TestFormFieldSection:
         assert text.count("郵局帳號") == 1
         assert text.count("12341234123412") == 1
 
-    def test_differing_values_under_one_label_both_render(self):
+    def test_differing_account_values_both_render(self):
         # The de-dupe is on (label, value) — a genuine discrepancy between the
         # two account ids must stay visible to the reviewer.
         text = _summary_text(
@@ -101,6 +101,36 @@ class TestFormFieldSection:
         assert text.count("郵局帳號") == 2
         assert "111" in text
         assert "222" in text
+
+    def test_two_distinct_fields_sharing_a_label_and_value_both_render(self):
+        # application_fields has no uniqueness constraint on field_label, so two
+        # real questions can share one label. The de-dupe is scoped to the
+        # account synonyms precisely so neither answer is swallowed here.
+        text = _summary_text(
+            {
+                "guardian_note": _field("guardian_note", "無"),
+                "student_note": _field("student_note", "無"),
+            },
+            {"guardian_note": "備註", "student_note": "備註"},
+        )
+
+        assert text.count("備註") == 2
+        assert text.count("無") == 2
+
+    def test_rows_are_ordered_by_field_id_not_by_label(self):
+        # Pin the ordering key. Sorting on the zh-TW label would order by CJK
+        # codepoint (乙 U+4E59 < 甲 U+7532) — no more meaningful to a reviewer
+        # than the id, and it would reshuffle the PDF whenever a label is
+        # edited. Deliberately unchanged by the label work.
+        text = _summary_text(
+            {
+                "aaa_first_by_id": _field("aaa_first_by_id", "v1"),
+                "zzz_last_by_id": _field("zzz_last_by_id", "v2"),
+            },
+            {"aaa_first_by_id": "乙標籤", "zzz_last_by_id": "甲標籤"},
+        )
+
+        assert text.index("乙標籤") < text.index("甲標籤")
 
     def test_undefined_field_id_falls_back_to_the_raw_id(self):
         # Batch import accepts any custom_<x> column, so an id with no

--- a/backend/app/tests/test_export_package_summary_pdf.py
+++ b/backend/app/tests/test_export_package_summary_pdf.py
@@ -20,7 +20,7 @@ from app.services.export_package_service import ExportPackageService
 from app.services.form_field_labels import FIXED_FIELD_LABELS
 
 
-def _mk_app(fields):
+def _mk_app(fields, trm_degree="1"):
     return SimpleNamespace(
         id=1,
         student_data={
@@ -28,7 +28,7 @@ def _mk_app(fields):
             "std_cname": "甲",
             "trm_depname": "A系",
             "trm_academyname": "某學院",
-            "trm_degree": "3",
+            "trm_degree": trm_degree,
         },
         submitted_form_data={"fields": fields, "documents": []},
     )
@@ -147,6 +147,27 @@ class TestFormFieldSection:
         # the sections that do not depend on submitted data are still there
         assert "一、基本資料" in text
         assert "學生資料彙整" in text
+
+
+class TestDegreeRendering:
+    """The rendered 學位 row, not just the DEGREE_LABELS dict. SIS codes run
+    DESCENDING (1 is the highest degree); the inverted map this replaces made
+    every PhD student's export read 學位 學士."""
+
+    @pytest.mark.parametrize("code,expected", [("1", "博士"), ("2", "碩士"), ("3", "學士")])
+    def test_degree_row_matches_the_sis_code(self, code, expected):
+        svc = ExportPackageService(db=None, minio_service=None)
+        pdf = svc._generate_summary_pdf(_mk_app({}, trm_degree=code), "某獎學金", 114, "first", {})
+        text = PdfReader(io.BytesIO(pdf)).pages[0].extract_text()
+
+        assert f"學位\n{expected}" in text
+
+    def test_unknown_degree_code_falls_back_to_the_raw_value(self):
+        svc = ExportPackageService(db=None, minio_service=None)
+        pdf = svc._generate_summary_pdf(_mk_app({}, trm_degree="9"), "某獎學金", 114, "first", {})
+        text = PdfReader(io.BytesIO(pdf)).pages[0].extract_text()
+
+        assert "學位\n9" in text
 
 
 class TestSummaryPdfBasics:

--- a/backend/app/tests/test_form_field_labels.py
+++ b/backend/app/tests/test_form_field_labels.py
@@ -1,0 +1,140 @@
+"""Tests for `app.services.form_field_labels` — the field_id → zh-TW label map
+behind 三、表單填寫資料 in the export summary PDF.
+
+`submitted_form_data["fields"]` entries carry only the English `field_id`, so
+without this map the PDF prints `postal_account` / `advisor_name` where the
+reviewer expects 郵局帳號 / 指導教授姓名.
+"""
+
+import pytest
+
+from app.services.application_field_service import ApplicationFieldService
+from app.services.form_field_labels import (
+    FIXED_FIELD_LABELS,
+    load_form_field_labels,
+    resolve_field_label,
+)
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeDb:
+    """Minimal AsyncSession double capturing the statement it was handed."""
+
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+        self.statements = []
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        return _FakeResult(self.rows)
+
+
+class TestFixedFieldLabels:
+    """Pin: the fields ApplicationFieldService injects at runtime have NO
+    application_fields row, so this dict is their only label source."""
+
+    def test_covers_every_runtime_injected_field(self):
+        assert set(FIXED_FIELD_LABELS) == {
+            "postal_account",
+            "account_number",
+            "advisor_name",
+            "advisor_email",
+            "advisor_nycu_id",
+        }
+
+    def test_postal_account_and_account_number_share_one_label(self):
+        # Both ids carry the same 郵局帳號 the student typed (the wizard mints
+        # account_number next to postal_account) — the summary PDF relies on
+        # the identical label to collapse them into one row.
+        assert FIXED_FIELD_LABELS["postal_account"] == "郵局帳號"
+        assert FIXED_FIELD_LABELS["account_number"] == "郵局帳號"
+
+    def test_all_labels_are_non_empty_chinese(self):
+        for key, label in FIXED_FIELD_LABELS.items():
+            assert label, f"FIXED_FIELD_LABELS[{key!r}] is empty"
+            assert any("一" <= c <= "鿿" for c in label), f"FIXED_FIELD_LABELS[{key!r}] = {label!r} has no CJK"
+
+    def test_application_field_service_uses_the_shared_constants(self):
+        # DRY link: the injected form-config fields and the export PDF must not
+        # drift apart into two label sources.
+        svc = ApplicationFieldService(db=None)
+        assert svc._create_fixed_bank_account_field()["field_label"] == FIXED_FIELD_LABELS["postal_account"]
+        advisor_labels = {f["field_name"]: f["field_label"] for f in svc._create_fixed_advisor_fields()}
+        assert advisor_labels == {
+            "advisor_name": FIXED_FIELD_LABELS["advisor_name"],
+            "advisor_email": FIXED_FIELD_LABELS["advisor_email"],
+            "advisor_nycu_id": FIXED_FIELD_LABELS["advisor_nycu_id"],
+        }
+
+
+class TestLoadFormFieldLabels:
+    @pytest.mark.asyncio
+    async def test_db_rows_merge_on_top_of_the_fixed_defaults(self):
+        db = _FakeDb([("master_school_info", "碩士畢業學校/學院/系所"), ("contact_phone", "聯絡電話")])
+        labels = await load_form_field_labels(db, "phd")
+
+        assert labels["master_school_info"] == "碩士畢業學校/學院/系所"
+        assert labels["contact_phone"] == "聯絡電話"
+        # fixed defaults survive alongside the queried rows
+        assert labels["advisor_name"] == "指導教授姓名"
+
+    @pytest.mark.asyncio
+    async def test_admin_row_overrides_a_fixed_default(self):
+        # bulk_update_fields re-inserts whatever the admin UI posts, so a fixed
+        # field can also exist as a real row — then the admin owns the label.
+        db = _FakeDb([("postal_account", "匯款帳號")])
+        labels = await load_form_field_labels(db, "phd")
+        assert labels["postal_account"] == "匯款帳號"
+
+    @pytest.mark.asyncio
+    async def test_blank_names_and_labels_are_skipped(self):
+        db = _FakeDb([("", "空欄位"), ("advisor_name", None), ("ok_field", "有效標籤")])
+        labels = await load_form_field_labels(db, "phd")
+
+        assert labels["ok_field"] == "有效標籤"
+        assert "" not in labels
+        # a NULL label must not blank out the fixed default
+        assert labels["advisor_name"] == "指導教授姓名"
+
+    @pytest.mark.asyncio
+    async def test_missing_scholarship_code_skips_the_query(self):
+        db = _FakeDb([("master_school_info", "碩士畢業學校")])
+        labels = await load_form_field_labels(db, None)
+
+        assert db.statements == []
+        assert labels == FIXED_FIELD_LABELS
+        assert labels is not FIXED_FIELD_LABELS  # never hand out the module constant
+
+    @pytest.mark.asyncio
+    async def test_query_is_not_filtered_by_is_active(self):
+        # A field deactivated after submission still needs its label to render
+        # the submission that used it.
+        db = _FakeDb()
+        await load_form_field_labels(db, "phd")
+
+        sql = str(db.statements[0]).lower()
+        assert "scholarship_type" in sql
+        assert "is_active" not in sql
+
+
+class TestResolveFieldLabel:
+    def test_known_id_maps_to_its_label(self):
+        assert resolve_field_label("advisor_name", FIXED_FIELD_LABELS) == "指導教授姓名"
+
+    def test_unknown_id_falls_back_to_the_raw_id(self):
+        # Admin-created ids and batch-import custom_<x> columns can have no
+        # definition — showing the raw id beats showing nothing.
+        assert resolve_field_label("custom_thing", FIXED_FIELD_LABELS) == "custom_thing"
+
+    def test_empty_label_falls_back_to_the_raw_id(self):
+        assert resolve_field_label("weird", {"weird": ""}) == "weird"
+
+    def test_empty_map_falls_back_to_the_raw_id(self):
+        assert resolve_field_label("advisor_name", {}) == "advisor_name"

--- a/backend/app/tests/test_form_field_labels.py
+++ b/backend/app/tests/test_form_field_labels.py
@@ -10,6 +10,7 @@ import pytest
 
 from app.services.application_field_service import ApplicationFieldService
 from app.services.form_field_labels import (
+    ACCOUNT_FIELD_SYNONYMS,
     FIXED_FIELD_LABELS,
     load_form_field_labels,
     resolve_field_label,
@@ -37,24 +38,30 @@ class _FakeDb:
 
 
 class TestFixedFieldLabels:
-    """Pin: the fields ApplicationFieldService injects at runtime have NO
-    application_fields row, so this dict is their only label source."""
+    """Pin: these built-in ids have NO application_fields row, so this dict is
+    their only label source."""
 
-    def test_covers_every_runtime_injected_field(self):
+    def test_covers_every_built_in_field_id(self):
         assert set(FIXED_FIELD_LABELS) == {
             "postal_account",
             "account_number",
+            "bank_account",
             "advisor_name",
             "advisor_email",
             "advisor_nycu_id",
         }
 
+    def test_every_account_synonym_has_a_label(self):
+        # The synonym set drives the summary PDF's de-dupe; an id in it with no
+        # label would de-dupe on a raw English id instead.
+        assert ACCOUNT_FIELD_SYNONYMS <= set(FIXED_FIELD_LABELS)
+
     def test_postal_account_and_account_number_share_one_label(self):
-        # Both ids carry the same 郵局帳號 the student typed (the wizard mints
-        # account_number next to postal_account) — the summary PDF relies on
-        # the identical label to collapse them into one row.
+        # Both ids carry the same 郵局帳號 the student typed — the summary PDF
+        # relies on the identical label to collapse them into one row.
         assert FIXED_FIELD_LABELS["postal_account"] == "郵局帳號"
         assert FIXED_FIELD_LABELS["account_number"] == "郵局帳號"
+        assert set(ACCOUNT_FIELD_SYNONYMS) == {"postal_account", "account_number"}
 
     def test_all_labels_are_non_empty_chinese(self):
         for key, label in FIXED_FIELD_LABELS.items():

--- a/backend/app/tests/test_pdf_merge.py
+++ b/backend/app/tests/test_pdf_merge.py
@@ -1,5 +1,5 @@
 """Unit tests for `app.services.pdf_merge.build_merged_pdf` — the per-student
-merged dynamic-documents PDF shipped inside the college export ZIP.
+申請資料合併檔 PDF shipped inside the college export ZIP.
 
 Layout contract pinned here: page 1 is a cover listing every document, then
 each document contributes one separator page followed by its own pages —
@@ -50,7 +50,7 @@ def _encrypted_pdf(user_password, owner_password=None):
 
 def _merge(items):
     return build_merged_pdf(
-        title="學生動態文件合併",
+        title="申請資料合併檔",
         subtitle_lines=["某獎學金 114學年度 第一學期", "001 甲"],
         items=items,
     )
@@ -77,7 +77,7 @@ class TestBuildMergedPdf:
             ]
         )
         cover = PdfReader(io.BytesIO(out)).pages[0].extract_text()
-        assert "學生動態文件合併" in cover
+        assert "申請資料合併檔" in cover
         assert "某獎學金 114學年度 第一學期" in cover
         assert cover.index("1. 語言檢定證明") < cover.index("2. 社團證明")
 

--- a/backend/app/tests/test_pdf_merge.py
+++ b/backend/app/tests/test_pdf_merge.py
@@ -138,13 +138,21 @@ class TestBuildMergedPdf:
         assert len(reader.pages) == 3
         assert round(reader.pages[2].mediabox.width) == 200
 
-    def test_missing_content_gets_download_failure_placeholder(self):
-        out = _merge([MergeItem(label="證明", filename="lost.pdf", content=None, error="minio 404")])
+    def test_missing_content_renders_the_callers_reason_verbatim(self):
+        # `error` is the ready-to-render reason — the caller knows whether the
+        # document failed to download or failed to be generated.
+        out = _merge([MergeItem(label="證明", filename="lost.pdf", content=None, error="檔案下載失敗：minio 404")])
         reader = PdfReader(io.BytesIO(out))
         assert len(reader.pages) == 3
         text = reader.pages[2].extract_text()
         assert "檔案下載失敗" in text
         assert "minio 404" in text
+
+    def test_missing_content_without_a_reason_still_gets_a_placeholder(self):
+        out = _merge([MergeItem(label="證明", filename="lost.pdf", content=None)])
+        reader = PdfReader(io.BytesIO(out))
+        assert len(reader.pages) == 3
+        assert "此文件無法納入合併檔" in reader.pages[2].extract_text()
 
     def test_bad_document_never_aborts_good_neighbours(self):
         out = _merge(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -168,7 +168,7 @@ dependencies = [
 
     # PDF generation
     "reportlab==4.4.10",
-    "pypdf==6.14.2",  # Merged dynamic-documents PDF in the export package (pdf_merge.py)
+    "pypdf==6.14.2",  # Merged 申請資料合併檔 PDF in the export package (pdf_merge.py)
 
     # Logging and monitoring
     "structlog==24.4.0",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -58,7 +58,7 @@ openpyxl==3.1.2
 
 # PDF generation
 reportlab==4.4.10  # Used by export_package_service
-pypdf==6.14.2  # Merged dynamic-documents PDF in the export package (pdf_merge.py)
+pypdf==6.14.2  # Merged 申請資料合併檔 PDF in the export package (pdf_merge.py)
 
 # Logging and monitoring
 structlog==24.4.0  # Updated for Python 3.13 compatibility


### PR DESCRIPTION
## 需求

1. 學院端匯出申請資料的動態文件合併內容加上「學生資料彙整」那份檔案
2. 名字改成「申請資料合併檔」
3. 表單填寫內容裡面的 column 應該用中文，不是英文

## 變更內容

### 1 + 2. 申請資料合併檔

每位學生的合併 PDF 現在以該生的「學生資料彙整」為第一份文件，後接其動態文件；`動態文件合併` → `申請資料合併檔` 全面更名（ZIP 檔名、PDF 封面標題、錯誤檔名與訊息、docstring、相依套件註解）。舊名稱在 repo 中已無殘留。

依討論確認的兩個決定：

- **每位學生都產生**：沒有動態文件的學生也會有一份（內容只有彙整），學院端流程一致。
- **保留獨立的 `學生資料彙整.pdf`**：合併檔是額外的閱讀便利檔，原本各自獨立的檔案照舊。

```
1000_資工系/
  001_王小明/
    001_王小明_學生資料彙整.pdf        ← 保留
    001_王小明_語言檢定證明.pdf
    001_王小明_申請資料合併檔.pdf      ← 彙整 + 語言檢定證明
  002_李小華/                          (只交成績單，無動態文件)
    002_李小華_學生資料彙整.pdf
    002_李小華_成績單.pdf
    002_李小華_申請資料合併檔.pdf      ← 只含彙整
```

### 3. 表單填寫資料改用中文欄位名

這是一個實際的 bug，不只是少查表。`DynamicFormField` 沒有 `label` 欄位（見 `backend/app/schemas/application.py`），所以

```python
label = field.get("label", field.get("field_id", field_id))
```

**永遠**落到英文 `field_id`。

新增 `backend/app/services/form_field_labels.py`，將 `application_fields.field_label`（以 `ScholarshipType.code` 為 key）疊在內建 id 之上。只查 DB 是不夠的 —— `postal_account` / `advisor_*` 由 `ApplicationFieldService` 在 runtime 注入、`account_number` 由前端 wizard 產生，這些都沒有 `application_fields` 資料列，只查 DB 會讓它們繼續顯示英文。`application_field_service.py` 現在改讀同一份常數，兩邊不會再各自漂移。

`postal_account` 與 `account_number` 帶的是同一組郵局帳號，翻成中文後會印出兩列一模一樣的資料，因此針對這組同義 id 做去重（僅限這組：`application_fields` 的 `field_label` 沒有唯一性限制，全域去重會吃掉兩個真的不同、但標籤與答案剛好相同的欄位）。

## 測試

- 後端全測試綠：**4795 passed, 2 skipped**
- `black --check` 與 `flake8 --select=B904,B014` 皆通過
- 新增 35 個測試（`test_form_field_labels.py`、`test_export_package_summary_pdf.py`），含一個 wiring 測試，可攔截 label map 在呼叫鏈中被漏傳
- 對 dev DB 實際資料驗證：兩筆申請的 7 個 field id 全數以中文呈現、無英文外洩，重複的郵局帳號正確收斂成一列

## Review 後的修正（第二個 commit）

- **合併檔的破洞**：若 `_generate_summary_pdf` 拋錯，合併檔原本會安靜地少掉彙整 —— 只看合併檔的審查者會誤以為該生沒填任何資料。現在改為插入一頁 placeholder 並帶出真正原因。連帶讓 `MergeItem.error` 改為「可直接呈現的原因」，否則產生失敗會被 `pdf_merge` 冠上「檔案下載失敗」而誤導。
- **`bank_account`** 補進標籤表：有四處 probe list 把它當成已儲存的帳號欄位 key，否則仍可能漏出英文 id。
- label map 移到「無資料 / 超過 200 筆」的擋門之後才載入；移除重複的 `student_prefix`/`student_folder`。

### 明確不做（附理由）

- **改用 `display_order` 排序**：實作到一半被自己的測試推翻 —— 依中文標籤排序得到的是 CJK codepoint 順序（乙 U+4E59 早於 甲 U+7532），對讀者而言並不比 field id 更有意義；而對照的 XLSX 欄位集合本來就不同。維持原排序並加測試釘住理由。
- **續領匯入的舊版扁平 `submitted_form_data`**：`renewal_import_service` 寫入的資料沒有 `"fields"` key，那些申請根本不會出現「三、表單填寫資料」。這是既有且不同性質的 bug（整段缺失，而非語言錯誤），本 PR 未觸碰。
- **`export_column_label`**：刻意不用。它是用來改「學生資料彙整表」的欄位標題（`phd/contact_phone` 匯出為「學生手機」），在表單資料頁上該欄位就叫「聯絡電話」。

## Test plan

- [ ] 學院帳號登入 → 申請審查 → 「匯出申請資料」下載 ZIP
- [ ] 確認每位學生資料夾內同時有 `_學生資料彙整.pdf` 與 `_申請資料合併檔.pdf`
- [ ] 開啟 `申請資料合併檔.pdf`，確認封面標題為「申請資料合併檔」、收錄文件第 1 項為「學生資料彙整」
- [ ] 確認無動態文件的學生也有合併檔（內容只有彙整）
- [ ] 確認彙整 PDF 的「三、表單填寫資料」欄位名為中文

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8esGdLeofTLCXh5sPLAWH