### PR TITLE
fix(distribution): 預設分發 plans against the screen, not the saved state

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,64 @@
+# Scholarship System
+
+Handles scholarship applications from student submission through professor and
+college review, quota distribution, and payment roster generation.
+
+## Language
+
+### Distribution
+
+**分發 (Distribution)**:
+Deciding which ranked students receive a quota slot, and from which sub-type and
+year's quota. Happens after a college finalizes its ranking.
+_Avoid_: allocation (reserved for a single student's slot), assignment
+
+**名額 (Quota Slot)**:
+One fundable place, owned by a (sub-type × configuration × college) cell of the
+quota matrix. A student holds at most one.
+_Avoid_: quota (that is the count of slots), place
+
+**核配 (Allocation)**:
+The pairing of one student with one 名額. A student's allocation names both the
+sub-type and the configuration whose quota the slot is drawn from.
+_Avoid_: award (that is post-確認分發), grant
+
+**已儲存分配 (Saved Allocation)**:
+An allocation persisted to the database. The state the system would act on if
+everyone went home now.
+_Avoid_: committed, confirmed (確認分發 means something else)
+
+**暫存分配 (Staged Allocation)**:
+An allocation the admin has made on screen but not yet saved. The distribution
+screen's authoritative state — 預設分發 and every quota count on the page are
+computed against 暫存分配, never against 已儲存分配.
+_Avoid_: local allocation, draft, unsaved change
+
+**未決 (Undecided)**:
+A student with no 暫存分配. Being 未決 is the only thing that makes a student
+eligible for 預設分發 — unticking a box returns the student to 未決, and their
+slot is immediately available to someone else.
+_Avoid_: blank, empty, cleared, unallocated (that describes an outcome, not a
+state)
+
+**預設分發 (Default Distribution)**:
+Filling every 未決 student the algorithm can place, by rank and preference
+order, without disturbing anyone already decided. Idempotent: pressing it twice
+changes nothing the second time.
+_Avoid_: auto-allocate, preview, suggestion
+
+**未分配原因 (Unallocated Reason)**:
+Why 預設分發 could not place a particular student — 名額已滿, 審核不同意,
+未申請該類別, 已撤銷停發, or 學院不推薦. Determined where the allocation
+decision is made, never inferred afterwards.
+_Avoid_: skip reason, error
+
+**確認分發 (Finalize)**:
+Locking a distribution: allocated students become approved, the rest rejected.
+The point after which a student 持有獎助 (holds an award) rather than merely a
+名額.
+_Avoid_: confirm, commit, approve
+
+**撤銷／停發 (Cancelled Allocation)**:
+An admin decision to pull a student out of the distribution entirely. Frees
+their 名額 but, unlike 未決, never makes them a candidate again.
+_Avoid_: cancelled, removed, excluded

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -238,6 +238,10 @@ async def auto_allocate_preview(
             "message": "Auto-allocation preview generated",
             "data": {"suggestions": suggestions},
         }
+    except ValueError as e:
+        # A malformed overlay (e.g. the same ranking item staged twice) — same
+        # 400 `allocate` gives for the same wire shape.
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except Exception as e:
         logger.error("Error generating auto-allocation preview: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to generate auto-allocation preview") from e

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -45,6 +45,17 @@ class AllocateRequest(BaseModel):
     allocations: list[AllocationItem]
 
 
+class AutoAllocatePreviewRequest(BaseModel):
+    scholarship_type_id: int
+    academic_year: int
+    semester: str
+    college_code: Optional[str] = None  # Restrict suggestions to one college
+    # The caller's on-screen allocations for every row it renders, all colleges
+    # — same shape as AllocateRequest.allocations, a null sub_type_code meaning
+    # 未決. None (the field omitted) falls back to the saved state.
+    staged: Optional[list[AllocationItem]] = None
+
+
 class FinalizeRequest(BaseModel):
     scholarship_type_id: int
     academic_year: int
@@ -195,12 +206,9 @@ async def get_distribution_state(
     }
 
 
-@router.get("/auto-allocate-preview")
+@router.post("/auto-allocate-preview")
 async def auto_allocate_preview(
-    scholarship_type_id: int = Query(...),
-    academic_year: int = Query(...),
-    semester: str = Query(...),
-    college_code: Optional[str] = Query(None, description="Restrict suggestions to one college"),
+    request: AutoAllocatePreviewRequest,
     db: AsyncSession = Depends(get_db),
     current_user=Depends(get_current_admin_user),
 ):
@@ -209,14 +217,21 @@ async def auto_allocate_preview(
     Pass `college_code` to run the distribution for a single college; quotas are
     still evaluated against the global live remaining, so the result matches what
     a whole-scholarship run would suggest for that college.
+
+    Pass `staged` — the caller's on-screen allocations for every row it renders,
+    every college — to have the suggestions computed against that state instead
+    of the saved one. Unticked rows free their slot immediately; hand-ticked rows
+    are treated as decided. POST rather than GET because that state is a body,
+    not a query string; nothing is written either way.
     """
     try:
         service = ManualDistributionService(db)
         suggestions = await service.auto_allocate_preview(
-            scholarship_type_id=scholarship_type_id,
-            academic_year=academic_year,
-            semester=semester,
-            college_code=college_code,
+            scholarship_type_id=request.scholarship_type_id,
+            academic_year=request.academic_year,
+            semester=request.semester,
+            college_code=request.college_code,
+            staged=[item.model_dump() for item in request.staged] if request.staged is not None else None,
         )
         return {
             "success": True,

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -73,6 +73,11 @@ UNALLOCATED_CANCELLED = "cancelled"
 UNALLOCATED_QUOTA_FULL = "quota_full"
 UNALLOCATED_REVIEW_REJECTED = "review_rejected"
 UNALLOCATED_NOT_APPLIED = "not_applied"
+# The student's college has no cell in the quota matrix at all — an unmapped
+# 學院代碼, or a config that carries no per-college quota. Distinct from
+# quota_full: no amount of quota fixes it, so saying 「名額不足」 would send the
+# admin to edit a matrix row that does not exist.
+UNALLOCATED_NO_COLLEGE_QUOTA = "no_college_quota"
 
 
 def _holds_award(app: Application) -> bool:
@@ -383,7 +388,15 @@ def _compute_suggestions(
                 }
             )
         elif preferences:
-            results.append(_unplaced(item.id, UNALLOCATED_QUOTA_FULL))
+            # A missing tracker key reads as zero remaining, so "ran out" and
+            # "never had a cell" are the same failure here — tell them apart by
+            # asking whether any cell exists at all.
+            has_cell = any(
+                (cid, sub_type, college) in quota_tracker
+                for sub_type in preferences
+                for cid in allowed_configs_by_sub_type.get(sub_type, [own_config_id])
+            )
+            results.append(_unplaced(item.id, UNALLOCATED_QUOTA_FULL if has_cell else UNALLOCATED_NO_COLLEGE_QUOTA))
         elif applicable:
             # Every sub-type they could draw was rejected (不同意) in review.
             results.append(_unplaced(item.id, UNALLOCATED_REVIEW_REJECTED))
@@ -1786,6 +1799,12 @@ class ManualDistributionService:
                 item_id = row.get("ranking_item_id")
                 if item_id not in items_by_id:
                     continue
+                # Reject duplicates rather than letting the last one win, exactly
+                # as `allocate` does for this same wire shape: a row staged twice
+                # would silently collapse, freeing its slot from the tracker while
+                # the screen still shows it taken.
+                if item_id in staged_map:
+                    raise ValueError(f"Duplicate ranking item: {item_id}")
                 sub_type_code = row.get("sub_type_code")
                 if not sub_type_code:
                     staged_map[item_id] = None

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -64,6 +64,16 @@ def _config_semester_condition(semester: str):
 # preview — would read them as free candidates and hand the slot straight back.
 CANCELLED_ALLOCATION_STATUSES = ("revoked", "suspended")
 
+# Why 預設分發 could not place a student. Emitted per ranking item so the grid
+# can say WHICH student and WHY instead of inferring it from what it can see —
+# a reject from a reviewer role the grid does not render (admin) is otherwise
+# invisible, and "quota full" is indistinguishable from "never a candidate".
+UNALLOCATED_COLLEGE_REJECTED = "college_rejected"
+UNALLOCATED_CANCELLED = "cancelled"
+UNALLOCATED_QUOTA_FULL = "quota_full"
+UNALLOCATED_REVIEW_REJECTED = "review_rejected"
+UNALLOCATED_NOT_APPLIED = "not_applied"
+
 
 def _holds_award(app: Application) -> bool:
     """Does this application hold a funded award — or, if 撤銷/停發, get one back
@@ -180,7 +190,11 @@ def _canonical_sub_type(code: Optional[str], allowed_configs_by_sub_type: dict[s
     return normalized
 
 
-def _dedupe_preview_items(all_items: list, college_code: Optional[str] = None) -> list:
+def _dedupe_preview_items(
+    all_items: list,
+    college_code: Optional[str] = None,
+    staged_ids: Optional[set[int]] = None,
+) -> list:
     """Select the ranking items auto_allocate_preview should suggest for.
 
     One item per application_id, dropping items whose application is missing or
@@ -190,13 +204,24 @@ def _dedupe_preview_items(all_items: list, college_code: Optional[str] = None) -
     skipped application never shadows a later item.
 
     An application can legitimately appear in two finalized rankings, and the
-    duplicate that carries the allocation is PREFERRED — same rule as
-    get_students_for_distribution, so the preview keys its suggestions on the
-    same ranking_item_id the grid renders. Picking the other duplicate would
+    duplicate the GRID renders is preferred, so the preview keys its suggestions
+    on a ranking_item_id the grid can match. Picking the other duplicate would
     make a suggestion the grid cannot match: silently dropped at best, staged
-    onto a row the admin never saw at worst. Callers must feed items in a
+    onto a row the admin never saw at worst. `staged_ids` — the rows the caller
+    has on screen — is the direct evidence of which duplicate that is; without
+    it, fall back to the persisted allocation (the rule
+    get_students_for_distribution uses). Callers must feed items in a
     deterministic order (rank_position, id) for the same reason.
     """
+    staged_ids = staged_ids or set()
+
+    def _preferred(candidate, incumbent) -> bool:
+        if staged_ids:
+            candidate_staged = candidate.id in staged_ids
+            if candidate_staged != (incumbent.id in staged_ids):
+                return candidate_staged
+        return bool(candidate.is_allocated) and not incumbent.is_allocated
+
     index_by_app: dict[int, int] = {}
     unique_items: list = []
     for item in all_items:
@@ -207,7 +232,7 @@ def _dedupe_preview_items(all_items: list, college_code: Optional[str] = None) -
             continue
         existing_idx = index_by_app.get(app.id)
         if existing_idx is not None:
-            if item.is_allocated and not unique_items[existing_idx].is_allocated:
+            if _preferred(item, unique_items[existing_idx]):
                 unique_items[existing_idx] = item
             continue
         index_by_app[app.id] = len(unique_items)
@@ -223,6 +248,7 @@ def _compute_suggestions(
     quota_tracker: dict[tuple, int],
     own_config_id: int,
     rejected_map: Optional[dict[int, set[str]]] = None,
+    undecided_ids: Optional[set[int]] = None,
 ) -> list[dict]:
     """
     Pure allocation logic (no DB access).  Extracted so it can be unit-tested
@@ -232,7 +258,7 @@ def _compute_suggestions(
     ----------
     unique_items:
         CollegeRankingItem objects (with .application pre-loaded) already
-        deduplicated by application_id.  Already-allocated items are skipped.
+        deduplicated by application_id.
     default_prefs:
         Ordered sub_type codes; last-resort preference fallback.
     prev_alloc_configs:
@@ -249,25 +275,46 @@ def _compute_suggestions(
         The requesting config id (default target when no prior slot applies).
     rejected_map:
         {application_id: {rejected_sub_type_codes}} — excluded from allocation.
+    undecided_ids:
+        Ranking item ids that are 未決 on the CALLER's screen and therefore open
+        to a suggestion. Everything else is already decided — either staged by
+        hand or saved — and is skipped (its quota was charged when the tracker
+        was seeded). Omit to fall back to the persisted `is_allocated` flag,
+        which is only correct when nothing is staged.
 
     Returns
     -------
     list[dict]
-        [{"ranking_item_id", "sub_type_code", "allocation_config_id"}, ...]
-        One entry per unallocated input item, in allocation order.
+        [{"ranking_item_id", "sub_type_code", "allocation_config_id", "reason"}, ...]
+        One entry per 未決 input item, in allocation order. `reason` is None on a
+        successful allocation and an UNALLOCATED_REASON_* code otherwise.
     """
     if rejected_map is None:
         rejected_map = {}
+
+    def _is_undecided(item) -> bool:
+        if undecided_ids is None:
+            return not item.is_allocated
+        return item.id in undecided_ids
+
     sorted_items = sorted(
-        [item for item in unique_items if not item.is_allocated],
+        [item for item in unique_items if _is_undecided(item)],
         key=lambda i: (0 if i.application.is_renewal else 1, i.rank_position),
     )
 
     results: list[dict] = []
 
+    def _unplaced(item_id: int, reason: str) -> dict:
+        return {
+            "ranking_item_id": item_id,
+            "sub_type_code": None,
+            "allocation_config_id": None,
+            "reason": reason,
+        }
+
     for item in sorted_items:
         if getattr(item, "college_rejected", False):
-            results.append({"ranking_item_id": item.id, "sub_type_code": None, "allocation_config_id": None})
+            results.append(_unplaced(item.id, UNALLOCATED_COLLEGE_REJECTED))
             continue
 
         app = item.application
@@ -276,7 +323,7 @@ def _compute_suggestions(
         # state and must never be re-suggested, even though cancelling freed
         # their ranking item (is_allocated=False). No quota is consumed.
         if app.quota_allocation_status in CANCELLED_ALLOCATION_STATUSES:
-            results.append({"ranking_item_id": item.id, "sub_type_code": None, "allocation_config_id": None})
+            results.append(_unplaced(item.id, UNALLOCATED_CANCELLED))
             continue
 
         college = (app.student_data or {}).get("std_academyno", "")
@@ -294,12 +341,15 @@ def _compute_suggestions(
         # a raw `in` test silently emptied the whole preference list and the
         # student came out unallocatable with quota still free.
         applied_set = {_norm_sub_type(p) for p in applied}
-        preferences: list[str] = [
+        # Kept separately from `preferences` so an empty preference list can say
+        # WHICH filter emptied it: sub-types the student may draw before review
+        # is considered, versus what survives review.
+        applicable: list[str] = [
             canonical
             for canonical in (_canonical_sub_type(p, allowed_configs_by_sub_type) for p in raw_prefs)
             if (_norm_sub_type(canonical) in applied_set if applied_set else True)
-            and _norm_sub_type(canonical) not in rejected
         ]
+        preferences: list[str] = [c for c in applicable if _norm_sub_type(c) not in rejected]
 
         allocated_sub_type: Optional[str] = None
         allocated_config: Optional[int] = None
@@ -323,13 +373,22 @@ def _compute_suggestions(
             if allocated_sub_type:
                 break
 
-        results.append(
-            {
-                "ranking_item_id": item.id,
-                "sub_type_code": allocated_sub_type,
-                "allocation_config_id": allocated_config,
-            }
-        )
+        if allocated_sub_type:
+            results.append(
+                {
+                    "ranking_item_id": item.id,
+                    "sub_type_code": allocated_sub_type,
+                    "allocation_config_id": allocated_config,
+                    "reason": None,
+                }
+            )
+        elif preferences:
+            results.append(_unplaced(item.id, UNALLOCATED_QUOTA_FULL))
+        elif applicable:
+            # Every sub-type they could draw was rejected (不同意) in review.
+            results.append(_unplaced(item.id, UNALLOCATED_REVIEW_REJECTED))
+        else:
+            results.append(_unplaced(item.id, UNALLOCATED_NOT_APPLIED))
 
     return results
 
@@ -1604,16 +1663,17 @@ class ManualDistributionService:
         academic_year: int,
         semester: str,
         college_code: Optional[str] = None,
+        staged: Optional[list[dict]] = None,
     ) -> list[dict]:
         """
         Compute auto-allocation suggestions without persisting any changes.
 
         Algorithm:
         1. Load finalized CollegeRanking records + their items (with Application eager-loaded).
-        2. Deduplicate items by application_id (keep first seen).
+        2. Deduplicate items by application_id (keep the one the caller renders).
         3. Load default preferences and previous allocation years for renewal students.
         4. Build quota tracker from config (current year + prior years per sub-type).
-        5. Subtract already-allocated items from tracker.
+        5. Subtract the allocations in force — see `staged` — from the tracker.
         6. Sort students: renewal first, then by rank_position ascending.
         7. Allocate sequentially following preference order and quota constraints.
 
@@ -1624,8 +1684,18 @@ class ManualDistributionService:
         (config_id, sub_type, college_code), so no other college's students can
         be affected by the ones skipped here.
 
-        Returns list of {"ranking_item_id", "sub_type_code", "allocation_config_id"} dicts.
-        Only unallocated items are included in the output.
+        `staged` is the caller's on-screen state — [{"ranking_item_id",
+        "sub_type_code", "allocation_config_id"}] covering EVERY row it renders,
+        for every college, with a null sub_type_code for a 未決 row. Where it
+        speaks, it overrides the database: a row the admin unticked frees its
+        slot for someone else here and now, and a row they ticked by hand is
+        already decided — charged against the quota, never re-suggested. Without
+        it the tracker falls back to the persisted allocations, which is only
+        the truth when nothing is staged (the first load of a fresh screen).
+
+        Returns list of {"ranking_item_id", "sub_type_code",
+        "allocation_config_id", "reason"} dicts — one per 未決 item, `reason`
+        naming why when nothing could be allocated.
         """
         # --- Step 0: Load finalized rankings ---
         ranking_query = select(CollegeRanking).where(
@@ -1656,9 +1726,17 @@ class ManualDistributionService:
         result = await self.db.execute(items_query)
         all_items = result.scalars().all()
 
-        # Deduplicate by application_id (keep first seen), skip soft-deleted,
-        # and keep only the requested college when one was given.
-        unique_items = _dedupe_preview_items(all_items, college_code)
+        # Index the raw rows before dedup: the staged overlay is keyed on
+        # ranking_item_id across EVERY college, so charging it needs items the
+        # college filter is about to drop.
+        items_by_id = {item.id: item for item in all_items}
+        staged_ids = (
+            {row["ranking_item_id"] for row in staged if row.get("ranking_item_id") in items_by_id} if staged else set()
+        )
+
+        # Deduplicate by application_id (keeping the row the caller renders),
+        # skip soft-deleted, and keep only the requested college when one was given.
+        unique_items = _dedupe_preview_items(all_items, college_code, staged_ids)
 
         if not unique_items:
             return []
@@ -1697,6 +1775,26 @@ class ManualDistributionService:
                 c["config_id"] for c in await self.distributable_pool(requesting_config, st)
             ]
 
+        # Resolve the overlay against the config's own spelling of each sub-type,
+        # so a staged "NSTC" charges the same tracker cell a suggested "nstc"
+        # would. A staged sub-type with no config attached consumes the
+        # requesting config, matching how `allocate` reads the same wire shape.
+        staged_map: Optional[dict[int, Optional[tuple[str, int]]]] = None
+        if staged is not None:
+            staged_map = {}
+            for row in staged:
+                item_id = row.get("ranking_item_id")
+                if item_id not in items_by_id:
+                    continue
+                sub_type_code = row.get("sub_type_code")
+                if not sub_type_code:
+                    staged_map[item_id] = None
+                    continue
+                staged_map[item_id] = (
+                    _canonical_sub_type(sub_type_code, allowed_configs_by_sub_type),
+                    row.get("allocation_config_id") or requesting_config.id,
+                )
+
         # --- Step 2: Build the per-(config, sub_type, college) tracker ---
         # Seed from each consumed config's matrix so per-college caps survive,
         # then subtract every existing global consumer of that config so the
@@ -1725,6 +1823,11 @@ class ManualDistributionService:
         )
         existing_items = (await self.db.execute(existing_stmt)).scalars().all()
         for ex in existing_items:
+            # A row the caller has on screen is accounted for by the overlay
+            # below — charging the saved allocation too would bill it twice, and
+            # would keep billing it after the admin unticked the box.
+            if staged_map is not None and ex.id in staged_map:
+                continue
             if not ex.allocated_sub_type or ex.application is None:
                 continue
             college = (ex.application.student_data or {}).get("std_academyno", "")
@@ -1748,6 +1851,32 @@ class ManualDistributionService:
             if key in quota_tracker:
                 quota_tracker[key] = max(0, quota_tracker[key] - 1)
 
+        # Charge every allocation staged on screen, for EVERY college — the
+        # quota pool is shared, so one college's unsaved ticks are the reason
+        # another college may have nothing left to hand out.
+        if staged_map is not None:
+            for item_id, staged_alloc in staged_map.items():
+                if staged_alloc is None:
+                    continue
+                sub_type, cfg_id = staged_alloc
+                item = items_by_id.get(item_id)
+                if item is None or item.application is None:
+                    continue
+                college = (item.application.student_data or {}).get("std_academyno", "")
+                key = (cfg_id, sub_type, college)
+                if key in quota_tracker:
+                    quota_tracker[key] = max(0, quota_tracker[key] - 1)
+
+        # Who is still open to a suggestion. A row absent from the overlay is
+        # one the caller never rendered, so its saved state is all we know.
+        undecided_ids: Optional[set[int]] = None
+        if staged_map is not None:
+            undecided_ids = {
+                item.id
+                for item in unique_items
+                if (staged_map[item.id] is None if item.id in staged_map else not item.is_allocated)
+            }
+
         # Load rejected sub-types from professor reviews.
         app_ids = [item.application.id for item in unique_items]
         rejected_map = await self._batch_load_rejected_map(app_ids)
@@ -1760,6 +1889,7 @@ class ManualDistributionService:
             quota_tracker=quota_tracker,
             own_config_id=requesting_config.id,
             rejected_map=rejected_map,
+            undecided_ids=undecided_ids,
         )
 
     async def revoke_allocation(self, application_id: int, admin_user_id: int, reason: str) -> dict:

--- a/backend/app/tests/test_auto_allocate_preview.py
+++ b/backend/app/tests/test_auto_allocate_preview.py
@@ -1102,3 +1102,42 @@ class TestDedupePrefersTheRowTheGridRenders:
         allocated = _make_item(102, rank_position=1, app=app, is_allocated=True)
 
         assert [i.id for i in _dedupe_preview_items([plain, allocated], None, {999})] == [102]
+
+
+class TestNoCollegeQuotaIsNotQuotaFull:
+    """「名額不足」 must mean a cell that ran out, not a cell that never existed.
+
+    A missing tracker key reads as zero remaining, so both look identical from
+    the allocation loop — and telling an admin 名額不足 for an unmapped 學院代碼
+    sends them to edit a matrix row that is not there.
+    """
+
+    def _run(self, _compute_suggestions, college, tracker):
+        app = _make_app(1, college=college, sub_type_preferences=["nstc"])
+        return _compute_suggestions(
+            unique_items=[_make_item(101, 1, app)],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115]},
+            quota_tracker=_build_quota_tracker(tracker),
+            own_config_id=115,
+        )
+
+    def test_exhausted_cell_is_quota_full(self, _compute_suggestions):
+        results = self._run(_compute_suggestions, "A", {(115, "nstc", "A"): 0})
+        assert results[0]["reason"] == "quota_full"
+
+    def test_college_absent_from_the_matrix(self, _compute_suggestions):
+        # The matrix lists college A only; this student is in Z.
+        results = self._run(_compute_suggestions, "Z", {(115, "nstc", "A"): 5})
+        assert results[0]["reason"] == "no_college_quota"
+
+    def test_unmapped_empty_college_code(self, _compute_suggestions):
+        # std_academyno missing entirely — the grid renders these under 未知.
+        results = self._run(_compute_suggestions, "", {(115, "nstc", "A"): 5})
+        assert results[0]["reason"] == "no_college_quota"
+
+    def test_config_with_no_per_college_matrix_at_all(self, _compute_suggestions):
+        # has_college_quota=False seeds no tracker entries whatsoever.
+        results = self._run(_compute_suggestions, "A", {})
+        assert results[0]["reason"] == "no_college_quota"

--- a/backend/app/tests/test_auto_allocate_preview.py
+++ b/backend/app/tests/test_auto_allocate_preview.py
@@ -141,6 +141,15 @@ def _dedupe_preview_items(_service_module):
 # ---------------------------------------------------------------------------
 
 
+def _alloc(result: dict) -> dict:
+    """Just the allocation decision, without the diagnostic `reason`.
+
+    Lets a test about WHO gets WHAT stay silent about why an unplaced student
+    was unplaced — the reason codes have their own tests below.
+    """
+    return {k: result[k] for k in ("ranking_item_id", "sub_type_code", "allocation_config_id")}
+
+
 def _make_app(
     app_id: int,
     college: str = "A",
@@ -225,8 +234,8 @@ class TestNewApplicantsAllocatedToCurrentYearNstcFirst:
         )
 
         assert len(results) == 2
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
-        assert results[1] == {"ranking_item_id": 102, "sub_type_code": "nstc", "allocation_config_id": 115}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
+        assert _alloc(results[1]) == {"ranking_item_id": 102, "sub_type_code": "nstc", "allocation_config_id": 115}
 
 
 class TestRenewalStudentsSortedBeforeNew:
@@ -299,7 +308,7 @@ class TestRenewalTargetsPreviousAllocationConfig:
         )
 
         assert len(results) == 1
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 114}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 114}
 
 
 class TestRenewalFallbackToOwnConfigWhenPriorExhausted:
@@ -332,7 +341,7 @@ class TestRenewalFallbackToOwnConfigWhenPriorExhausted:
 
         assert len(results) == 1
         # Falls back to own config since prior (114) is exhausted
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
 
 
 class TestQuotaExhaustedFallsToNextPreference:
@@ -363,7 +372,7 @@ class TestQuotaExhaustedFallsToNextPreference:
         )
 
         assert len(results) == 1
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "moe_1w", "allocation_config_id": 115}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "moe_1w", "allocation_config_id": 115}
 
 
 class TestAllQuotasExhaustedReturnsNull:
@@ -394,7 +403,7 @@ class TestAllQuotasExhaustedReturnsNull:
         )
 
         assert len(results) == 1
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": None, "allocation_config_id": None}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": None, "allocation_config_id": None}
 
 
 class TestNullPreferencesUsesConfigDefaults:
@@ -426,7 +435,7 @@ class TestNullPreferencesUsesConfigDefaults:
 
         assert len(results) == 1
         # Uses default prefs: nstc exhausted, falls to moe_1w
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "moe_1w", "allocation_config_id": 115}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "moe_1w", "allocation_config_id": 115}
 
 
 class TestAlreadyAllocatedStudentsSkipped:
@@ -502,9 +511,9 @@ class TestPerCollegeQuotaRespected:
 
         assert len(results) == 2
         # First student gets nstc (rank 1)
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
         # Second student gets nothing (quota exhausted for both sub-types in college A)
-        assert results[1] == {"ranking_item_id": 102, "sub_type_code": None, "allocation_config_id": None}
+        assert _alloc(results[1]) == {"ranking_item_id": 102, "sub_type_code": None, "allocation_config_id": None}
 
 
 class TestRenewalWithPriorConfigNotLinked:
@@ -540,7 +549,7 @@ class TestRenewalWithPriorConfigNotLinked:
 
         assert len(results) == 1
         # Since 112 not in allowed for nstc, falls back to own config (115)
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
 
 
 class TestNoDedupInComputeSuggestions:
@@ -620,7 +629,7 @@ class TestRenewalWithNoPreviousApplicationId:
         )
 
         assert len(results) == 1
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
 
 
 class TestUnknownCollegeGetsNoAllocation:
@@ -651,7 +660,7 @@ class TestUnknownCollegeGetsNoAllocation:
         )
 
         assert len(results) == 1
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": None, "allocation_config_id": None}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": None, "allocation_config_id": None}
 
 
 class TestCancelledApplicationsNeverSuggested:
@@ -684,7 +693,14 @@ class TestCancelledApplicationsNeverSuggested:
             own_config_id=own_config_id,
         )
 
-        assert results == [{"ranking_item_id": 101, "sub_type_code": None, "allocation_config_id": None}]
+        assert results == [
+            {
+                "ranking_item_id": 101,
+                "sub_type_code": None,
+                "allocation_config_id": None,
+                "reason": "cancelled",
+            }
+        ]
         # The freed slot stays available for someone else.
         assert quota_tracker[(115, "nstc", "A")] == 2
 
@@ -710,7 +726,7 @@ class TestCancelledApplicationsNeverSuggested:
 
         by_item = {r["ranking_item_id"]: r for r in results}
         assert by_item[101]["sub_type_code"] is None
-        assert by_item[102] == {"ranking_item_id": 102, "sub_type_code": "nstc", "allocation_config_id": 115}
+        assert _alloc(by_item[102]) == {"ranking_item_id": 102, "sub_type_code": "nstc", "allocation_config_id": 115}
 
     def test_allocated_status_is_still_suggestible(self, _compute_suggestions):
         """Only revoked/suspended are gated — a normal status must still allocate."""
@@ -749,7 +765,7 @@ class TestPreferenceCodesAreMatchedNormalized:
             own_config_id=115,
         )
         # …and the ALLOCATED code is the config's own spelling, not the student's.
-        assert results[0] == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
+        assert _alloc(results[0]) == {"ranking_item_id": 101, "sub_type_code": "nstc", "allocation_config_id": 115}
 
     def test_applied_list_variant_is_matched_too(self, _compute_suggestions):
         app = _make_app(1, college="A", sub_type_preferences=["nstc"], scholarship_subtype_list=[" NSTC "])
@@ -932,3 +948,157 @@ class TestPreferenceOrderRespected:
 
         assert len(results) == 1
         assert results[0]["sub_type_code"] == "moe_1w"
+
+
+# ---------------------------------------------------------------------------
+# The screen, not the database: `undecided_ids` decides who is still a candidate
+# ---------------------------------------------------------------------------
+
+
+class TestUndecidedIdsOverrideThePersistedFlag:
+    """預設分發 must plan against the admin's CURRENT screen.
+
+    `undecided_ids` is that screen's 未決 rows. Without it the algorithm reads
+    `is_allocated` — the saved state — and a slot the admin just unticked stays
+    invisible while a row they just ticked gets re-suggested.
+    """
+
+    def _fixture(self):
+        """Two ranked students in college A, one nstc slot, item 101 saved into it."""
+        app1 = _make_app(1, college="A", sub_type_preferences=["nstc"])
+        app2 = _make_app(2, college="A", sub_type_preferences=["nstc"])
+        return [
+            _make_item(101, rank_position=1, app=app1, is_allocated=True, allocated_sub_type="nstc"),
+            _make_item(102, rank_position=2, app=app2),
+        ]
+
+    def _run(self, _compute_suggestions, items, quota, undecided_ids):
+        return _compute_suggestions(
+            unique_items=items,
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115]},
+            quota_tracker=_build_quota_tracker({(115, "nstc", "A"): quota}),
+            own_config_id=115,
+            undecided_ids=undecided_ids,
+        )
+
+    def test_untick_frees_the_slot_for_the_next_ranked_student(self, _compute_suggestions):
+        """Admin unticks the saved winner: the caller reports 101 AND 102 未決.
+
+        The slot it released is charged to nobody, so the tracker the caller
+        seeded has 1 free — and rank order gives it back to 101 first.
+        """
+        results = self._run(_compute_suggestions, self._fixture(), quota=1, undecided_ids={101, 102})
+
+        assert [r["ranking_item_id"] for r in results] == [101, 102]
+        assert results[0]["sub_type_code"] == "nstc"
+        assert results[1]["sub_type_code"] is None
+        assert results[1]["reason"] == "quota_full"
+
+    def test_hand_ticked_row_is_decided_and_never_re_suggested(self, _compute_suggestions):
+        """102 ticked by hand (absent from undecided_ids) — only 101 is planned for."""
+        results = self._run(_compute_suggestions, self._fixture(), quota=1, undecided_ids={101})
+
+        assert [r["ranking_item_id"] for r in results] == [101]
+
+    def test_without_undecided_ids_the_saved_flag_still_rules(self, _compute_suggestions):
+        """No overlay (a fresh screen): fall back to is_allocated, as before."""
+        results = self._run(_compute_suggestions, self._fixture(), quota=1, undecided_ids=None)
+
+        assert [r["ranking_item_id"] for r in results] == [102]
+
+    def test_an_undecided_row_that_is_saved_allocated_is_still_planned_for(self, _compute_suggestions):
+        """A saved row the admin unticked is 未決 even though is_allocated is True."""
+        results = self._run(_compute_suggestions, self._fixture(), quota=1, undecided_ids={101})
+
+        assert [r["ranking_item_id"] for r in results] == [101]
+        assert results[0]["sub_type_code"] == "nstc"
+
+
+class TestUnallocatedReasons:
+    """Every unplaced student says WHY, so the grid never has to guess."""
+
+    def _run(self, _compute_suggestions, item, quota=5, rejected_map=None):
+        return _compute_suggestions(
+            unique_items=[item],
+            default_prefs=["nstc"],
+            prev_alloc_configs={},
+            allowed_configs_by_sub_type={"nstc": [115], "moe_1w": [115]},
+            quota_tracker=_build_quota_tracker({(115, "nstc", "A"): quota}),
+            own_config_id=115,
+            rejected_map=rejected_map,
+        )
+
+    def test_successful_allocation_carries_no_reason(self, _compute_suggestions):
+        app = _make_app(1, college="A", sub_type_preferences=["nstc"])
+        results = self._run(_compute_suggestions, _make_item(101, 1, app))
+
+        assert results[0]["sub_type_code"] == "nstc"
+        assert results[0]["reason"] is None
+
+    def test_quota_full(self, _compute_suggestions):
+        app = _make_app(1, college="A", sub_type_preferences=["nstc"])
+        results = self._run(_compute_suggestions, _make_item(101, 1, app), quota=0)
+
+        assert results[0]["reason"] == "quota_full"
+
+    def test_review_rejected(self, _compute_suggestions):
+        """Applied for nstc, a reviewer said 不同意 — quota is irrelevant."""
+        app = _make_app(1, college="A", sub_type_preferences=["nstc"], scholarship_subtype_list=["nstc"])
+        results = self._run(_compute_suggestions, _make_item(101, 1, app), rejected_map={1: {"nstc"}})
+
+        assert results[0]["reason"] == "review_rejected"
+
+    def test_not_applied(self, _compute_suggestions):
+        """Only applied for moe_2w, which this config has no quota row for."""
+        app = _make_app(1, college="A", sub_type_preferences=["nstc"], scholarship_subtype_list=["moe_2w"])
+        results = self._run(_compute_suggestions, _make_item(101, 1, app))
+
+        assert results[0]["reason"] == "not_applied"
+
+    def test_cancelled(self, _compute_suggestions):
+        app = _make_app(1, college="A", sub_type_preferences=["nstc"], quota_allocation_status="revoked")
+        results = self._run(_compute_suggestions, _make_item(101, 1, app))
+
+        assert results[0]["reason"] == "cancelled"
+
+    def test_college_rejected(self, _compute_suggestions):
+        app = _make_app(1, college="A", sub_type_preferences=["nstc"])
+        item = _make_item(101, 1, app)
+        item.college_rejected = True
+        results = self._run(_compute_suggestions, item)
+
+        assert results[0]["reason"] == "college_rejected"
+
+    def test_review_rejected_beats_quota_full_when_both_apply(self, _compute_suggestions):
+        """A rejected student is never a quota problem — say the actionable thing."""
+        app = _make_app(1, college="A", sub_type_preferences=["nstc"], scholarship_subtype_list=["nstc"])
+        results = self._run(_compute_suggestions, _make_item(101, 1, app), quota=0, rejected_map={1: {"nstc"}})
+
+        assert results[0]["reason"] == "review_rejected"
+
+
+class TestDedupePrefersTheRowTheGridRenders:
+    """With an overlay, the row the caller staged IS the row it renders."""
+
+    def test_staged_duplicate_wins_over_the_allocated_one(self, _dedupe_preview_items):
+        app = _make_app(1, college="A")
+        allocated = _make_item(101, rank_position=1, app=app, is_allocated=True)
+        staged = _make_item(102, rank_position=1, app=app)
+
+        assert [i.id for i in _dedupe_preview_items([allocated, staged], None, {102})] == [102]
+
+    def test_falls_back_to_the_allocated_duplicate_without_an_overlay(self, _dedupe_preview_items):
+        app = _make_app(1, college="A")
+        plain = _make_item(101, rank_position=1, app=app)
+        allocated = _make_item(102, rank_position=1, app=app, is_allocated=True)
+
+        assert [i.id for i in _dedupe_preview_items([plain, allocated], None, set())] == [102]
+
+    def test_an_overlay_that_names_neither_duplicate_keeps_the_old_rule(self, _dedupe_preview_items):
+        app = _make_app(1, college="A")
+        plain = _make_item(101, rank_position=1, app=app)
+        allocated = _make_item(102, rank_position=1, app=app, is_allocated=True)
+
+        assert [i.id for i in _dedupe_preview_items([plain, allocated], None, {999})] == [102]

--- a/backend/app/tests/test_auto_allocate_preview_staged.py
+++ b/backend/app/tests/test_auto_allocate_preview_staged.py
@@ -320,3 +320,45 @@ async def test_a_row_missing_from_the_overlay_falls_back_to_its_saved_state(
     by_item = await _preview(db, college_code="D", staged=_staged((first.id, None, None), (second.id, None, None)))
 
     assert d_item.id not in by_item, "still allocated in the database, so still decided"
+
+
+# ---------------------------------------------------------------------------
+# Malformed / degenerate overlays
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_same_row_staged_twice_is_rejected(db, college_c, config_one_slot_per_college):
+    """`allocate` raises on a duplicated ranking item; so must the preview.
+
+    A dict build would let the last entry win, so the row's slot vanishes from
+    the tracker while the screen still shows it taken — and the run hands that
+    slot to somebody else.
+    """
+    first, second = college_c
+
+    with pytest.raises(ValueError, match=f"Duplicate ranking item: {first.id}"):
+        await _preview(
+            db,
+            staged=_staged(
+                (first.id, "nstc", config_one_slot_per_college.id),
+                (first.id, None, None),
+                (second.id, None, None),
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_empty_overlay_means_an_empty_screen_not_a_cleared_one(db, college_c):
+    """`staged=[]` says "I render no rows", so the saved state still stands.
+
+    This is why the grid must send an explicit null per row when the admin
+    presses 清空 — an empty list would silently restore the very distribution
+    they just cleared.
+    """
+    first, second = college_c
+
+    by_item = await _preview(db, staged=[])
+
+    assert first.id not in by_item, "the saved allocation still holds its slot"
+    assert by_item[second.id]["reason"] == "quota_full"

--- a/backend/app/tests/test_auto_allocate_preview_staged.py
+++ b/backend/app/tests/test_auto_allocate_preview_staged.py
@@ -1,0 +1,322 @@
+"""Pin: 預設分發 plans against the admin's SCREEN, not the saved distribution.
+
+`auto_allocate_preview` used to build its quota tracker purely from persisted
+`CollegeRankingItem.is_allocated` rows. An admin who unticked a saved allocation
+saw a free slot on screen that the algorithm could not see: it produced no
+suggestion for it, and the grid reported 「名額已用盡」 while showing headroom.
+
+These cover the `staged` overlay that fixes it — the caller's on-screen
+allocations for every row it renders:
+
+- an unticked row (staged null) releases its slot HERE AND NOW,
+- a hand-ticked row (staged non-null) is charged for its slot and is never
+  re-suggested, whether or not it was ever saved,
+- another college's unsaved ticks still consume the shared pool,
+- omitting the overlay keeps the old saved-state behaviour.
+
+The conftest provides `db` as the async session (AsyncSession).
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.models.application import Application, ApplicationStatus
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.services.manual_distribution_service import ManualDistributionService
+
+SCHOLARSHIP_TYPE_ID = 1
+ACADEMIC_YEAR = 114
+SEMESTER = "first"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — one college with ONE nstc slot and two ranked candidates, so every
+# assertion below is about who holds that single slot.
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def admin_user(db):
+    from app.models.user import User, UserRole, UserType
+
+    u = User(
+        nycu_id="admin_staged_preview",
+        email="admin_staged_preview@nycu.edu.tw",
+        name="Admin Staged Preview",
+        role=UserRole.admin,
+        user_type=UserType.employee,
+    )
+    db.add(u)
+    await db.commit()
+    await db.refresh(u)
+    return u
+
+
+@pytest_asyncio.fixture
+async def config_one_slot_per_college(db):
+    """One nstc slot for college C, one for college D."""
+    from app.models.scholarship import ScholarshipConfiguration
+
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=SCHOLARSHIP_TYPE_ID,
+        config_code="STAGED-114",
+        config_name="Staged overlay 114",
+        academic_year=ACADEMIC_YEAR,
+        semester=SEMESTER,
+        amount=50000,
+        has_college_quota=True,
+        quotas={"nstc": {"C": 1, "D": 1}},
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+    return cfg
+
+
+@pytest_asyncio.fixture
+async def ranking(db, admin_user):
+    r = CollegeRanking(
+        scholarship_type_id=SCHOLARSHIP_TYPE_ID,
+        sub_type_code="nstc",
+        academic_year=ACADEMIC_YEAR,
+        semester=SEMESTER,
+        ranking_name="Staged overlay ranking",
+        is_finalized=True,
+        ranking_status="finalized",
+        created_by=admin_user.id,
+    )
+    db.add(r)
+    await db.commit()
+    await db.refresh(r)
+    return r
+
+
+async def _make_candidate(db, ranking, admin_user, *, app_id, college, rank, allocated_config_id=None):
+    """A ranked applicant for nstc; `allocated_config_id` marks a SAVED allocation.
+
+    Each candidate gets its own user: applications are unique per
+    (user, scholarship_type, year, semester).
+    """
+    from app.models.enums import ReviewStage
+    from app.models.scholarship import SubTypeSelectionMode
+    from app.models.user import User, UserRole, UserType
+
+    student = User(
+        nycu_id=f"student_{app_id}",
+        email=f"{app_id}@nycu.edu.tw",
+        name=app_id,
+        role=UserRole.student,
+        user_type=UserType.student,
+    )
+    db.add(student)
+    await db.commit()
+    await db.refresh(student)
+
+    app = Application(
+        user_id=student.id,
+        app_id=app_id,
+        scholarship_type_id=SCHOLARSHIP_TYPE_ID,
+        academic_year=ACADEMIC_YEAR,
+        semester=SEMESTER,
+        status=ApplicationStatus.submitted,
+        review_stage=ReviewStage.student_draft,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        scholarship_subtype_list=["nstc"],
+        student_data={"std_academyno": college, "std_cname": app_id},
+        quota_allocation_status=None,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+
+    item = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=app.id,
+        rank_position=rank,
+        is_allocated=allocated_config_id is not None,
+        allocated_sub_type="nstc" if allocated_config_id is not None else None,
+        allocation_config_id=allocated_config_id,
+        status="allocated" if allocated_config_id is not None else "ranked",
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    return app, item
+
+
+@pytest_asyncio.fixture
+async def college_c(db, ranking, admin_user, config_one_slot_per_college):
+    """Rank 1 holds the college's only SAVED nstc slot; rank 2 is waiting."""
+    _, first = await _make_candidate(
+        db,
+        ranking,
+        admin_user,
+        app_id="APP-STAGED-C1",
+        college="C",
+        rank=1,
+        allocated_config_id=config_one_slot_per_college.id,
+    )
+    _, second = await _make_candidate(db, ranking, admin_user, app_id="APP-STAGED-C2", college="C", rank=2)
+    return first, second
+
+
+def _staged(*rows):
+    """Build an overlay: (item_id, sub_type or None) pairs."""
+    return [
+        {
+            "ranking_item_id": item_id,
+            "sub_type_code": sub_type,
+            "allocation_config_id": config_id,
+        }
+        for item_id, sub_type, config_id in rows
+    ]
+
+
+async def _preview(db, staged=None, college_code=None):
+    svc = ManualDistributionService(db)
+    suggestions = await svc.auto_allocate_preview(
+        scholarship_type_id=SCHOLARSHIP_TYPE_ID,
+        academic_year=ACADEMIC_YEAR,
+        semester=SEMESTER,
+        college_code=college_code,
+        staged=staged,
+    )
+    return {s["ranking_item_id"]: s for s in suggestions}
+
+
+# ---------------------------------------------------------------------------
+# The core fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_without_an_overlay_the_saved_allocation_still_holds_the_slot(db, college_c):
+    """Baseline: nothing staged, so the saved winner keeps the only slot."""
+    first, second = college_c
+
+    by_item = await _preview(db)
+
+    assert first.id not in by_item, "a saved allocation is not re-planned for"
+    assert by_item[second.id]["sub_type_code"] is None
+    assert by_item[second.id]["reason"] == "quota_full"
+
+
+@pytest.mark.asyncio
+async def test_unticking_a_saved_allocation_releases_the_slot_immediately(db, college_c, config_one_slot_per_college):
+    """The heart of it: the admin unticks rank 1 WITHOUT saving.
+
+    The screen now shows a free slot, so the run must hand one out — to rank 1
+    again, because releasing a slot does not forfeit your place in the ranking.
+    """
+    first, second = college_c
+
+    by_item = await _preview(db, staged=_staged((first.id, None, None), (second.id, None, None)))
+
+    assert by_item[first.id]["sub_type_code"] == "nstc"
+    assert by_item[first.id]["allocation_config_id"] == config_one_slot_per_college.id
+    assert by_item[second.id]["reason"] == "quota_full", "the college still only has one slot"
+
+
+@pytest.mark.asyncio
+async def test_a_hand_ticked_row_takes_the_released_slot_and_is_left_alone(db, college_c, config_one_slot_per_college):
+    """Admin unticks rank 1 and ticks rank 2 instead — both unsaved.
+
+    Rank 2 is decided, so it is not re-planned for; its unsaved tick is charged
+    against the college's only slot, which is why rank 1 now reads quota_full.
+    Reading the database instead would give rank 1 the slot AND leave rank 2
+    ticked — two winners for one slot.
+    """
+    first, second = college_c
+
+    by_item = await _preview(
+        db,
+        staged=_staged((first.id, None, None), (second.id, "nstc", config_one_slot_per_college.id)),
+    )
+
+    assert second.id not in by_item, "a hand-ticked row is decided; never re-suggested"
+    assert by_item[first.id]["sub_type_code"] is None
+    assert by_item[first.id]["reason"] == "quota_full"
+
+
+@pytest.mark.asyncio
+async def test_re_staging_the_saved_allocation_is_a_no_op(db, college_c, config_one_slot_per_college):
+    """The overlay a freshly-loaded screen sends: staged == saved.
+
+    Charging both the saved row and its overlay twin would bill one slot twice,
+    turning a merely-full college into an over-drawn one.
+    """
+    first, second = college_c
+
+    by_item = await _preview(
+        db,
+        staged=_staged((first.id, "nstc", config_one_slot_per_college.id), (second.id, None, None)),
+    )
+
+    assert first.id not in by_item
+    assert by_item[second.id]["reason"] == "quota_full"
+
+
+@pytest.mark.asyncio
+async def test_a_variant_spelling_in_the_overlay_still_charges_the_slot(db, college_c, config_one_slot_per_college):
+    """Sub-types are free-form strings; " NSTC " must hit the same quota cell."""
+    first, second = college_c
+
+    by_item = await _preview(
+        db,
+        staged=_staged((first.id, " NSTC ", config_one_slot_per_college.id), (second.id, None, None)),
+    )
+
+    assert by_item[second.id]["reason"] == "quota_full", "an uncanonical spelling must not free the slot"
+
+
+# ---------------------------------------------------------------------------
+# The pool is shared: one college's unsaved work constrains another's run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_another_colleges_unsaved_tick_consumes_the_shared_pool(
+    db, ranking, admin_user, college_c, config_one_slot_per_college
+):
+    """A single-college run still sees every college's staged state.
+
+    College D's slot is staged by hand; the run for college C must not be
+    disturbed by it, but the charge must land — otherwise pressing 預設分發 per
+    college in turn over-draws a pool that is counted globally.
+    """
+    first, second = college_c
+    _, d_item = await _make_candidate(db, ranking, admin_user, app_id="APP-STAGED-D1", college="D", rank=1)
+
+    by_item = await _preview(
+        db,
+        college_code="C",
+        staged=_staged(
+            (first.id, None, None),
+            (second.id, None, None),
+            (d_item.id, "nstc", config_one_slot_per_college.id),
+        ),
+    )
+
+    assert d_item.id not in by_item, "a single-college run only plans for that college"
+    assert by_item[first.id]["sub_type_code"] == "nstc", "college C's own slot is untouched by D"
+
+
+@pytest.mark.asyncio
+async def test_a_row_missing_from_the_overlay_falls_back_to_its_saved_state(
+    db, ranking, admin_user, college_c, config_one_slot_per_college
+):
+    """The caller never rendered college D, so D's saved allocation still counts."""
+    first, second = college_c
+    _, d_item = await _make_candidate(
+        db,
+        ranking,
+        admin_user,
+        app_id="APP-STAGED-D2",
+        college="D",
+        rank=1,
+        allocated_config_id=config_one_slot_per_college.id,
+    )
+
+    by_item = await _preview(db, college_code="D", staged=_staged((first.id, None, None), (second.id, None, None)))
+
+    assert d_item.id not in by_item, "still allocated in the database, so still decided"

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -21,15 +21,17 @@ import type {
   ReleaseChainItem,
 } from "@/lib/api/modules/manual-distribution";
 import {
-  buildCollegeBudget,
   buildCollegeNameMap,
   getSavedAllocation,
   isCancelledAllocation,
   makeColKey,
   mergeSuggestions,
+  reasonsBySuggestion,
   resolveCollegeName,
-  summarizeUnallocated,
+  summarizeReasons,
+  toStagedItems,
   UNALLOCATED_REASON_LABEL,
+  type UnallocatedReason,
 } from "@/lib/api/modules/manual-distribution";
 import { User } from "@/types/user";
 import { Button } from "@/components/ui/button";
@@ -86,7 +88,10 @@ interface ManualDistributionPanelProps {
 
 const ALL_ACADEMIES_SYSTEM = "__all__";
 
-/** Seed local allocation state from the server snapshot (null = unallocated). */
+/** In-flight marker for the whole-page 預設分發 run; no college_code collides. */
+const ALL_COLLEGES = "__all_colleges__";
+
+/** Seed local allocation state from the server snapshot (null = 未決). */
 function seedAllocations(
   students: DistributionStudent[]
 ): Map<number, LocalAlloc | null> {
@@ -303,12 +308,12 @@ export function ManualDistributionPanel({
   useEffect(() => {
     localAllocationsRef.current = localAllocations;
   }, [localAllocations]);
-  // Rows the admin explicitly unticked. In localAllocations an untick and a
-  // never-allocated row are BOTH null, so without this the per-college
-  // 預設分發 would re-fill a row the admin deliberately cleared — including one
-  // whose saved allocation they were removing. Reset whenever local state is
-  // reseeded from the server (the clear is then either saved or discarded).
-  const [clearedItemIds, setClearedItemIds] = useState<Set<number>>(new Set());
+  // Why the last 預設分發 run left a row 未決, keyed by ranking_item_id. Comes
+  // straight from the backend, which is the only place that can tell a review
+  // reject from an exhausted quota. Cleared whenever the grid is reseeded.
+  const [unallocatedReasons, setUnallocatedReasons] = useState<
+    Map<number, UnallocatedReason>
+  >(new Map());
   const [collegeFilter, setCollegeFilter] = useState<string>("");
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
@@ -339,7 +344,7 @@ export function ManualDistributionPanel({
     }>;
   } | null>(null);
   const [previewApplied, setPreviewApplied] = useState(false);
-  // college_code currently running the per-college 預設分發 button (null = idle).
+  // Which 預設分發 run is in flight: a college_code, ALL_COLLEGES, or null (idle).
   const [autoAllocatingCollege, setAutoAllocatingCollege] = useState<
     string | null
   >(null);
@@ -412,7 +417,7 @@ export function ManualDistributionPanel({
     setIsLoading(true);
     setSaveMessage(null);
     setPreviewApplied(false);
-    setClearedItemIds(new Set());
+    setUnallocatedReasons(new Map());
     try {
       const [studentsResp, quotaResp] = await Promise.all([
         apiClient.manualDistribution.getStudents(
@@ -437,7 +442,11 @@ export function ManualDistributionPanel({
             await apiClient.manualDistribution.getAutoAllocatePreview(
               scholarshipTypeId,
               selectedAcademicYear,
-              selectedSemester
+              selectedSemester,
+              undefined,
+              // The overlay a fresh screen would send equals the saved state, so
+              // it is omitted: the server's own snapshot IS this screen.
+              undefined
             );
           if (previewResp.success && previewResp.data) {
             previewSuggestions = previewResp.data.suggestions;
@@ -446,12 +455,11 @@ export function ManualDistributionPanel({
           // Preview is optional; proceed without it
         }
 
-        // Apply auto-preview suggestions for unallocated students. Eligible =
-        // rows the grid actually renders, minus 撤銷/停發 — a suggestion for a
-        // row that is not on screen (a duplicate ranking item, or a cancelled
-        // student behind a disabled checkbox) would be saved without the admin
-        // ever being able to see or untick it. No budget: this runs against a
-        // fresh server snapshot, so the backend's own quota counts are exact.
+        // Apply auto-preview suggestions for 未決 students. Eligible = rows the
+        // grid actually renders, minus 撤銷/停發 — a suggestion for a row that is
+        // not on screen (a duplicate ranking item, or a cancelled student behind
+        // a disabled checkbox) would be saved without the admin ever being able
+        // to see or untick it.
         //
         // Quota status is the same kind of prerequisite: the 核配 columns are
         // derived from it, so if it failed to load the grid renders NO columns
@@ -475,6 +483,9 @@ export function ManualDistributionPanel({
         setStudents(studentsResp.data);
         setPreviewApplied(merged.filled > 0);
         setLocalAllocations(merged.next);
+        setUnallocatedReasons(
+          hasQuota ? reasonsBySuggestion(previewSuggestions) : new Map()
+        );
       }
       if (quotaResp.success && quotaResp.data) {
         setQuotaStatus(quotaResp.data);
@@ -511,9 +522,9 @@ export function ManualDistributionPanel({
       setLocalAllocations(seedAllocations(studentsResp.data));
       // The reseed is server-only, so any auto-preview suggestions are gone
       // (saved or discarded) — clear the "已自動預設分配" notice, and with it
-      // the record of deliberate unticks (now persisted or thrown away).
+      // the reasons, which described a screen that no longer exists.
       setPreviewApplied(false);
-      setClearedItemIds(new Set());
+      setUnallocatedReasons(new Map());
     }
     if (quotaResp.success && quotaResp.data) {
       setQuotaStatus(quotaResp.data);
@@ -658,18 +669,13 @@ export function ManualDistributionPanel({
     sub_type: string,
     config_id: number
   ) => {
-    // Read the render-scoped state, NOT localAllocationsRef: the ref is written
-    // in an effect (it exists so an await'd handler can see edits made while its
-    // request was in flight) and can therefore trail the committed render that
-    // produced this click.
-    const cur = localAllocations.get(rankingItemId);
-    const isUncheck =
-      cur?.sub_type === sub_type && cur?.config_id === config_id;
-    // Remember a deliberate clear so 預設分發 leaves that row alone.
-    setClearedItemIds(prev => {
-      const next = new Set(prev);
-      if (isUncheck) next.add(rankingItemId);
-      else next.delete(rankingItemId);
+    // Unticking returns the row to 未決 — nothing else is remembered about it.
+    // A 未決 row is open to 預設分發 again and its slot is free for someone
+    // else; to keep a student out of the round entirely, use 撤銷/停發.
+    setUnallocatedReasons(prev => {
+      if (!prev.has(rankingItemId)) return prev;
+      const next = new Map(prev);
+      next.delete(rankingItemId);
       return next;
     });
     setLocalAllocations(prev => {
@@ -878,27 +884,30 @@ export function ManualDistributionPanel({
   };
 
   /**
-   * Run the default distribution for ONE college.
+   * Run the default distribution — for ONE college, or for all of them when
+   * `collegeCode` is null.
    *
-   * Same algorithm as the on-load auto-preview, scoped server-side to this
-   * college (quotas are still evaluated globally). It covers the college's WHOLE
-   * ranking, not just the rows a 搜尋 filter leaves on screen — the suggestions
-   * are a rank-ordered plan, and applying half of one would hand a slot to the
-   * wrong student.
+   * The plan is computed against THIS SCREEN: the current staged allocations go
+   * up with the request, so a box the admin unticked has genuinely released its
+   * slot and a box they ticked by hand has genuinely taken one. Reading the
+   * saved distribution instead is what made the button report 「名額已用盡」 next
+   * to visibly empty columns.
+   *
+   * It covers the WHOLE ranking in scope, not just the rows a 搜尋 filter leaves
+   * on screen — the suggestions are a rank-ordered plan, and applying half of
+   * one would hand a slot to the wrong student.
    *
    * Staged locally only — nothing is persisted until the admin presses 儲存 —
-   * and it never touches a row that already carries an allocation (saved or
-   * hand-picked) NOR one the admin explicitly unticked (clearedItemIds), so it
-   * is safe to press repeatedly: it only fills rows nobody has decided on.
+   * and it only fills 未決 rows, so it is safe to press repeatedly and never
+   * overwrites a deliberate tick.
    */
-  const handleCollegeAutoAllocate = useCallback(
-    async (collegeCode: string, collegeName: string) => {
+  const handleAutoAllocate = useCallback(
+    async (collegeCode: string | null, scopeName: string) => {
       if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
         return;
       // No columns means quota status never loaded (or carries no allocatable
-      // slot). Without it there is no per-college cap to enforce AND nothing on
-      // screen to show what was staged — refuse rather than stage invisible,
-      // uncapped allocations that 儲存 would happily persist.
+      // slot). Without it there is nothing on screen to show what was staged —
+      // refuse rather than stage invisible allocations that 儲存 would persist.
       if (subTypeCols.length === 0) {
         setSaveMessage({
           type: "error",
@@ -906,93 +915,81 @@ export function ManualDistributionPanel({
         });
         return;
       }
-      setAutoAllocatingCollege(collegeCode);
+      setAutoAllocatingCollege(collegeCode ?? ALL_COLLEGES);
       setSaveMessage(null);
       try {
+        // Read through the ref, NOT the value captured before the await: the
+        // checkboxes stay live during the request, so both the overlay sent up
+        // and the map merged into must be the latest committed state.
         const resp = await apiClient.manualDistribution.getAutoAllocatePreview(
           scholarshipTypeId,
           selectedAcademicYear,
           selectedSemester,
-          collegeCode
+          collegeCode ?? undefined,
+          toStagedItems(localAllocationsRef.current)
         );
         if (!resp.success || !resp.data) {
           setSaveMessage({
             type: "error",
-            text: resp.message || `${collegeName} 預設分發失敗`,
+            text: resp.message || `${scopeName} 預設分發失敗`,
           });
           return;
         }
         const suggestions = resp.data.suggestions;
-        // Eligible = this college's rows only (never touch another group), minus
-        // 撤銷/停發 students, who keep their state and stay unallocated, and
-        // minus rows the admin explicitly unticked — pressing the button again
-        // must not undo a deliberate clear.
+        // Eligible = the rows in scope (never touch another group), minus
+        // 撤銷/停發 students, who keep their state and stay unallocated.
         const eligibleItemIds = new Set(
           students
             .filter(
               s =>
-                (s.college_code || "") === collegeCode &&
-                !isCancelledAllocation(s) &&
-                !clearedItemIds.has(s.ranking_item_id)
+                (collegeCode === null ||
+                  (s.college_code || "") === collegeCode) &&
+                !isCancelledAllocation(s)
             )
             .map(s => s.ranking_item_id)
         );
-        // Read through the ref, NOT the value captured before the await: the
-        // checkboxes stay live during the request, and merging into the stale
-        // map would silently revert anything the admin ticked meanwhile.
-        const staged = localAllocationsRef.current;
-        // The backend counted only PERSISTED consumers, so cap the merge by this
-        // college's matrix row minus what is already staged — otherwise
-        // hand-picking first and then pressing this button over-allocates the
-        // college (the save-time gate only recounts the global pool).
-        const budget = buildCollegeBudget(
-          quotaStatus,
-          students,
-          staged,
-          collegeCode
-        );
-        const { next, filled, blocked } = mergeSuggestions(
-          staged,
+        const { next, filled } = mergeSuggestions(
+          localAllocationsRef.current,
           suggestions,
-          eligibleItemIds,
-          budget
+          eligibleItemIds
         );
         if (filled > 0) {
           setLocalAllocations(next);
           setPreviewApplied(true);
         }
-        let text: string;
-        if (filled > 0) {
-          const overflowNote =
-            blocked > 0 ? `，另有 ${blocked} 筆因學院名額已滿未分配` : "";
-          text = `${collegeName}：已預設分配 ${filled} 筆${overflowNote}，請確認後儲存`;
-        } else {
-          // Nothing staged: say WHY per row rather than guessing 「名額已用盡」.
-          // A review reject is the common invisible cause — the 教授推薦/學院推薦
-          // columns only render professor and college verdicts, so a reject from
-          // another reviewer role blocks every sub-type with nothing on screen
-          // to explain it. Only this branch needs the breakdown, so the scan
-          // stays off the path that did allocate something.
-          const stillBlank = students.filter(
-            s =>
-              (s.college_code || "") === collegeCode &&
-              !next.get(s.ranking_item_id) &&
-              !clearedItemIds.has(s.ranking_item_id)
-          );
-          const reasons = summarizeUnallocated(stillBlank)
-            .map(
-              ({ reason, count }) =>
-                `${count} 筆${UNALLOCATED_REASON_LABEL[reason]}`
-            )
-            .join("、");
-          text = `${collegeName}：無可預設分配${reasons ? `（${reasons}）` : ""}`;
-        }
+        // Refresh the explanation for every row this run considered: an
+        // allocated row loses its old one, an unplaced row takes the backend's
+        // verdict. Rows out of scope keep whatever an earlier run said.
+        const runReasons = reasonsBySuggestion(suggestions);
+        setUnallocatedReasons(prev => {
+          const merged = new Map(prev);
+          for (const s of suggestions) {
+            if (s.sub_type_code) merged.delete(s.ranking_item_id);
+          }
+          for (const [itemId, reason] of runReasons) {
+            merged.set(itemId, reason);
+          }
+          return merged;
+        });
+
+        const breakdown = summarizeReasons(runReasons)
+          .map(
+            ({ reason, count }) =>
+              `${count} 筆${UNALLOCATED_REASON_LABEL[reason]}`
+          )
+          .join("、");
+        const text =
+          filled > 0
+            ? `${scopeName}：已預設分配 ${filled} 筆${
+                breakdown ? `，另有 ${breakdown}` : ""
+              }，請確認後儲存`
+            : `${scopeName}：無可預設分配${breakdown ? `（${breakdown}）` : ""}`;
         setSaveMessage({ type: "success", text });
       } catch (error) {
-        logger.error("College auto-allocate error", { error: error });
+        logger.error("Auto-allocate error", { error: error });
         setSaveMessage({
           type: "error",
-          text: `${collegeName} 預設分發時發生錯誤`,
+          text: `${scopeName} 預設分發時發生錯誤`,
         });
       } finally {
         setAutoAllocatingCollege(null);
@@ -1003,9 +1000,7 @@ export function ManualDistributionPanel({
       selectedAcademicYear,
       selectedSemester,
       students,
-      quotaStatus,
       subTypeCols,
-      clearedItemIds,
     ]
   );
 
@@ -1125,6 +1120,31 @@ export function ManualDistributionPanel({
                 <Download className="h-4 w-4 mr-1" />
                 匯出 Excel
               </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={
+                  subTypeCols.length === 0 ||
+                  autoAllocatingCollege !== null ||
+                  isLoading ||
+                  isSaving ||
+                  isFinalizing ||
+                  isRestoring
+                }
+                title={
+                  subTypeCols.length === 0
+                    ? "名額資料尚未載入，無法執行預設分發"
+                    : "依排名與志願序自動預設分配所有學院尚未核配的學生（依目前畫面狀態計算，僅填空白，儲存前可修改）"
+                }
+                onClick={() => handleAutoAllocate(null, "全部學院")}
+              >
+                {autoAllocatingCollege === ALL_COLLEGES ? (
+                  <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                ) : (
+                  <Wand2 className="h-4 w-4 mr-1" />
+                )}
+                全部預設分發
+              </Button>
               <AlertDialog>
                 <AlertDialogTrigger asChild>
                   <Button
@@ -1146,10 +1166,10 @@ export function ManualDistributionPanel({
                     <AlertDialogCancel>取消</AlertDialogCancel>
                     <AlertDialogAction
                       onClick={() => {
+                        // Every row back to 未決, and no stale explanation of a
+                        // distribution that no longer exists.
                         setLocalAllocations(new Map());
-                        // 清空 is "start over", not a per-row decision — leave
-                        // every row open to 預設分發 again.
-                        setClearedItemIds(new Set());
+                        setUnallocatedReasons(new Map());
                       }}
                     >
                       確認清空
@@ -1649,13 +1669,10 @@ export function ManualDistributionPanel({
                                       ? "無學院代碼，無法執行預設分發"
                                       : subTypeCols.length === 0
                                         ? "名額資料尚未載入，無法執行預設分發"
-                                        : `依排名與志願序自動預設分配 ${collegeName} 尚未核配的學生（僅填空白，儲存前可修改）`
+                                        : `依排名與志願序自動預設分配 ${collegeName} 尚未核配的學生（依目前畫面狀態計算，僅填空白，儲存前可修改）`
                                   }
                                   onClick={() =>
-                                    handleCollegeAutoAllocate(
-                                      collegeCode,
-                                      collegeName
-                                    )
+                                    handleAutoAllocate(collegeCode, collegeName)
                                   }
                                 >
                                   {autoAllocatingCollege === collegeCode ? (
@@ -1674,6 +1691,12 @@ export function ManualDistributionPanel({
                             const curAlloc = localAllocations.get(
                               student.ranking_item_id
                             );
+                            // Only meaningful while the row is still 未決: once
+                            // it carries an allocation, whatever stopped an
+                            // earlier run no longer describes it.
+                            const unallocatedReason = curAlloc
+                              ? undefined
+                              : unallocatedReasons.get(student.ranking_item_id);
                             // Phase 8.2: surface challenge metadata from the
                             // /state payload (keyed by application_id).
                             const challengeMeta = challengeAppMap.get(
@@ -1809,6 +1832,24 @@ export function ManualDistributionPanel({
                                       quotaStatus={quotaStatus}
                                       noVerdictTitle="學院未對此子類型作出推薦審核"
                                     />
+                                    {/* Why the last 預設分發 left this row
+                                        blank, straight from the backend.
+                                        撤銷/停發 is omitted — the row's own
+                                        status control already says so. */}
+                                    {unallocatedReason &&
+                                      unallocatedReason !== "cancelled" && (
+                                        <span
+                                          className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-50 text-amber-700 border border-amber-200"
+                                          title={`預設分發未分配：${UNALLOCATED_REASON_LABEL[unallocatedReason]}`}
+                                        >
+                                          未分配:{" "}
+                                          {
+                                            UNALLOCATED_REASON_LABEL[
+                                              unallocatedReason
+                                            ]
+                                          }
+                                        </span>
+                                      )}
                                   </div>
                                 </td>
                                 {subTypeCols.map(col => {

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -30,7 +30,7 @@ import {
   resolveCollegeName,
   summarizeReasons,
   toStagedItems,
-  UNALLOCATED_REASON_LABEL,
+  unallocatedReasonLabel,
   type UnallocatedReason,
 } from "@/lib/api/modules/manual-distribution";
 import { User } from "@/types/user";
@@ -957,14 +957,20 @@ export function ManualDistributionPanel({
           setLocalAllocations(next);
           setPreviewApplied(true);
         }
-        // Refresh the explanation for every row this run considered: an
-        // allocated row loses its old one, an unplaced row takes the backend's
-        // verdict. Rows out of scope keep whatever an earlier run said.
+        // Refresh the explanation for every row this run considered: a row it
+        // actually staged loses its old one, an unplaced row takes the
+        // backend's verdict. Rows out of scope keep whatever an earlier run
+        // said. Keyed on what the merge STAGED, not on what the server
+        // suggested — a suggestion the merge dropped as ineligible leaves the
+        // row 未決, so clearing its reason would strip the only explanation on
+        // screen.
         const runReasons = reasonsBySuggestion(suggestions);
         setUnallocatedReasons(prev => {
           const merged = new Map(prev);
           for (const s of suggestions) {
-            if (s.sub_type_code) merged.delete(s.ranking_item_id);
+            if (s.sub_type_code && next.get(s.ranking_item_id)) {
+              merged.delete(s.ranking_item_id);
+            }
           }
           for (const [itemId, reason] of runReasons) {
             merged.set(itemId, reason);
@@ -975,7 +981,7 @@ export function ManualDistributionPanel({
         const breakdown = summarizeReasons(runReasons)
           .map(
             ({ reason, count }) =>
-              `${count} 筆${UNALLOCATED_REASON_LABEL[reason]}`
+              `${count} 筆${unallocatedReasonLabel(reason)}`
           )
           .join("、");
         const text =
@@ -1166,9 +1172,14 @@ export function ManualDistributionPanel({
                     <AlertDialogCancel>取消</AlertDialogCancel>
                     <AlertDialogAction
                       onClick={() => {
-                        // Every row back to 未決, and no stale explanation of a
-                        // distribution that no longer exists.
-                        setLocalAllocations(new Map());
+                        // Every row explicitly 未決 — NOT an empty map. An empty
+                        // map says nothing about these rows, so 儲存 would send
+                        // no allocations and clear nothing, and 預設分發 would
+                        // send an empty overlay and fall straight back to the
+                        // saved distribution the admin just cleared.
+                        setLocalAllocations(
+                          new Map(students.map(s => [s.ranking_item_id, null]))
+                        );
                         setUnallocatedReasons(new Map());
                       }}
                     >
@@ -1836,20 +1847,17 @@ export function ManualDistributionPanel({
                                         blank, straight from the backend.
                                         撤銷/停發 is omitted — the row's own
                                         status control already says so. */}
-                                    {unallocatedReason &&
-                                      unallocatedReason !== "cancelled" && (
-                                        <span
-                                          className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-50 text-amber-700 border border-amber-200"
-                                          title={`預設分發未分配：${UNALLOCATED_REASON_LABEL[unallocatedReason]}`}
-                                        >
-                                          未分配:{" "}
-                                          {
-                                            UNALLOCATED_REASON_LABEL[
-                                              unallocatedReason
-                                            ]
-                                          }
-                                        </span>
-                                      )}
+                                    {unallocatedReason && (
+                                      <span
+                                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-50 text-amber-700 border border-amber-200"
+                                        title={`預設分發未分配：${unallocatedReasonLabel(unallocatedReason)}`}
+                                      >
+                                        未分配:{" "}
+                                        {unallocatedReasonLabel(
+                                          unallocatedReason
+                                        )}
+                                      </span>
+                                    )}
                                   </div>
                                 </td>
                                 {subTypeCols.map(col => {
@@ -1884,8 +1892,19 @@ export function ManualDistributionPanel({
                                   // its success path reseeds localAllocations
                                   // from the server, which would silently
                                   // revert any tick made mid-request.
+                                  //
+                                  // 預設分發 counts too. It sends the staged map
+                                  // up and merges the reply back into it, so a
+                                  // tick landing in between is both lost AND
+                                  // uncounted — the server would hand out a slot
+                                  // it does not know was just taken, and nothing
+                                  // downstream re-checks the per-college matrix
+                                  // (the save gate only recounts the global pool).
                                   const isMutating =
-                                    isSaving || isFinalizing || isRestoring;
+                                    isSaving ||
+                                    isFinalizing ||
+                                    isRestoring ||
+                                    autoAllocatingCollege !== null;
                                   // A rejected sub-type can't be (re)checked,
                                   // but a cell that is ALREADY checked must
                                   // stay clickable so the admin can uncheck it

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7432,6 +7432,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        get?: never;
+        put?: never;
         /**
          * Auto Allocate Preview
          * @description Generate auto-allocation suggestions without persisting.
@@ -7439,10 +7441,14 @@ export interface paths {
          *     Pass `college_code` to run the distribution for a single college; quotas are
          *     still evaluated against the global live remaining, so the result matches what
          *     a whole-scholarship run would suggest for that college.
+         *
+         *     Pass `staged` — the caller's on-screen allocations for every row it renders,
+         *     every college — to have the suggestions computed against that state instead
+         *     of the saved one. Unticked rows free their slot immediately; hand-ticked rows
+         *     are treated as decided. POST rather than GET because that state is a body,
+         *     not a query string; nothing is written either way.
          */
-        get: operations["auto_allocate_preview_api_v1_manual_distribution_auto_allocate_preview_get"];
-        put?: never;
-        post?: never;
+        post: operations["auto_allocate_preview_api_v1_manual_distribution_auto_allocate_preview_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -8513,6 +8519,19 @@ export interface components {
              * @default false
              */
             overwrite_existing: boolean;
+        };
+        /** AutoAllocatePreviewRequest */
+        AutoAllocatePreviewRequest: {
+            /** Scholarship Type Id */
+            scholarship_type_id: number;
+            /** Academic Year */
+            academic_year: number;
+            /** Semester */
+            semester: string;
+            /** College Code */
+            college_code?: string | null;
+            /** Staged */
+            staged?: components["schemas"]["AllocationItem"][] | null;
         };
         /**
          * BankInfoUpdate
@@ -23045,20 +23064,18 @@ export interface operations {
             };
         };
     };
-    auto_allocate_preview_api_v1_manual_distribution_auto_allocate_preview_get: {
+    auto_allocate_preview_api_v1_manual_distribution_auto_allocate_preview_post: {
         parameters: {
-            query: {
-                scholarship_type_id: number;
-                academic_year: number;
-                semester: string;
-                /** @description Restrict suggestions to one college */
-                college_code?: string | null;
-            };
+            query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AutoAllocatePreviewRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7755,9 +7755,7 @@ export interface components {
             /** Message */
             message: string;
             /** Data */
-            data?: {
-                [key: string]: unknown;
-            }[] | null;
+            data?: Record<string, never>[] | null;
             /** Errors */
             errors?: string[] | null;
             /** Trace Id */
@@ -7773,9 +7771,7 @@ export interface components {
             /** Message */
             message: string;
             /** Data */
-            data?: {
-                [key: string]: unknown;
-            } | null;
+            data?: Record<string, never> | null;
             /** Errors */
             errors?: string[] | null;
             /** Trace Id */
@@ -7971,9 +7967,7 @@ export interface components {
              * Validation Rules
              * @description Validation rules
              */
-            validation_rules?: {
-                [key: string]: unknown;
-            } | null;
+            validation_rules?: Record<string, never> | null;
         };
         /**
          * ApplicationDocumentUpdate
@@ -8011,9 +8005,7 @@ export interface components {
             /** Example File Url */
             example_file_url?: string | null;
             /** Validation Rules */
-            validation_rules?: {
-                [key: string]: unknown;
-            } | null;
+            validation_rules?: Record<string, never> | null;
         };
         /**
          * ApplicationFieldCreate
@@ -8086,9 +8078,7 @@ export interface components {
              * Field Options
              * @description Field options
              */
-            field_options?: {
-                [key: string]: unknown;
-            }[] | null;
+            field_options?: Record<string, never>[] | null;
             /**
              * Display Order
              * @description Display order
@@ -8115,16 +8105,12 @@ export interface components {
              * Validation Rules
              * @description Validation rules
              */
-            validation_rules?: {
-                [key: string]: unknown;
-            } | null;
+            validation_rules?: Record<string, never> | null;
             /**
              * Conditional Rules
              * @description Conditional rules
              */
-            conditional_rules?: {
-                [key: string]: unknown;
-            } | null;
+            conditional_rules?: Record<string, never> | null;
             /**
              * Include In College Export
              * @description Whether this field appears in the college Excel export
@@ -8163,9 +8149,7 @@ export interface components {
             /** Step Value */
             step_value?: number | null;
             /** Field Options */
-            field_options?: {
-                [key: string]: unknown;
-            }[] | null;
+            field_options?: Record<string, never>[] | null;
             /** Display Order */
             display_order?: number | null;
             /** Is Active */
@@ -8175,13 +8159,9 @@ export interface components {
             /** Help Text En */
             help_text_en?: string | null;
             /** Validation Rules */
-            validation_rules?: {
-                [key: string]: unknown;
-            } | null;
+            validation_rules?: Record<string, never> | null;
             /** Conditional Rules */
-            conditional_rules?: {
-                [key: string]: unknown;
-            } | null;
+            conditional_rules?: Record<string, never> | null;
             /** Include In College Export */
             include_in_college_export?: boolean | null;
             /** Export Column Label */
@@ -8365,13 +8345,9 @@ export interface components {
             /** Semester */
             semester?: string | null;
             /** Student Data */
-            student_data: {
-                [key: string]: unknown;
-            };
+            student_data: Record<string, never>;
             /** Submitted Form Data */
-            submitted_form_data: {
-                [key: string]: unknown;
-            };
+            submitted_form_data: Record<string, never>;
             /**
              * Agree Terms
              * @default false
@@ -8400,9 +8376,7 @@ export interface components {
              */
             updated_at: string;
             /** Meta Data */
-            meta_data?: {
-                [key: string]: unknown;
-            } | null;
+            meta_data?: Record<string, never> | null;
             /**
              * Reviews
              * @default []
@@ -8613,9 +8587,7 @@ export interface components {
              * Updates
              * @description 要更新的欄位
              */
-            updates: {
-                [key: string]: unknown;
-            };
+            updates: Record<string, never>;
         };
         /** Body_create_ranking_api_v1_college_review_rankings_post */
         Body_create_ranking_api_v1_college_review_rankings_post: {
@@ -8653,7 +8625,10 @@ export interface components {
         };
         /** Body_create_supplementary_doc_api_v1_system_settings_supplementary_docs_post */
         Body_create_supplementary_doc_api_v1_system_settings_supplementary_docs_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
             /** Title */
             title: string;
@@ -8673,25 +8648,35 @@ export interface components {
         };
         /** Body_extract_bank_info_from_passbook_api_v1_user_profiles_bank_passbook_ocr_post */
         Body_extract_bank_info_from_passbook_api_v1_user_profiles_bank_passbook_ocr_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_extract_text_from_document_api_v1_user_profiles_document_ocr_post */
         Body_extract_text_from_document_api_v1_user_profiles_document_ocr_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_import_received_months_api_v1_manual_distribution_import_received_months_post */
         Body_import_received_months_api_v1_manual_distribution_import_received_months_post: {
             /**
              * File
+             * Format: binary
              * @description Excel file with columns: 學號, 已領月份數
              */
             file: string;
         };
         /** Body_import_whitelist_excel_api_v1_scholarship_configurations__id__whitelist_import_post */
         Body_import_whitelist_excel_api_v1_scholarship_configurations__id__whitelist_import_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_portal_sso_verify_api_v1_auth_portal_sso_verify_post */
@@ -8730,7 +8715,10 @@ export interface components {
         };
         /** Body_supplementary_import_api_v1_college_review_rankings__ranking_id__supplementary_import_post */
         Body_supplementary_import_api_v1_college_review_rankings__ranking_id__supplementary_import_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_update_matrix_quota_api_v1_scholarship_configurations_matrix_quota_put */
@@ -8746,13 +8734,17 @@ export interface components {
         };
         /** Body_upload_bank_document_file_api_v1_user_profiles_me_bank_document_file_post */
         Body_upload_bank_document_file_api_v1_user_profiles_me_bank_document_file_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_upload_batch_documents_api_v1_college_review_batch_import__batch_id__documents_post */
         Body_upload_batch_documents_api_v1_college_review_batch_import__batch_id__documents_post: {
             /**
              * File
+             * Format: binary
              * @description 包含所有文件的 ZIP 檔案
              */
             file: string;
@@ -8761,41 +8753,58 @@ export interface components {
         Body_upload_batch_import_data_api_v1_college_review_batch_import_upload_data_post: {
             /**
              * File
+             * Format: binary
              * @description Excel或CSV檔案
              */
             file: string;
         };
         /** Body_upload_document_example_api_v1_application_fields_documents__document_id__upload_example_post */
         Body_upload_document_example_api_v1_application_fields_documents__document_id__upload_example_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_upload_file_alias_api_v1_applications__id__files_post */
         Body_upload_file_alias_api_v1_applications__id__files_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_upload_file_api_v1_applications__id__files_upload_post */
         Body_upload_file_api_v1_applications__id__files_upload_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post */
         Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post: {
             /**
              * File
+             * Format: binary
              * @description 續領生 Excel 或 CSV 檔案
              */
             file: string;
         };
         /** Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post */
         Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /** Body_upload_terms_document_api_v1_scholarships__scholarship_type__upload_terms_post */
         Body_upload_terms_document_api_v1_scholarships__scholarship_type__upload_terms_post: {
-            /** File */
+            /**
+             * File
+             * Format: binary
+             */
             file: string;
         };
         /**
@@ -8839,9 +8848,7 @@ export interface components {
              * Parameters
              * @description Operation-specific parameters
              */
-            parameters?: {
-                [key: string]: unknown;
-            } | null;
+            parameters?: Record<string, never> | null;
         };
         /**
          * BulkScholarshipAssignRequest
@@ -9051,9 +9058,7 @@ export interface components {
              */
             email_domain: string | null;
             /** Custom Attributes */
-            custom_attributes?: {
-                [key: string]: unknown;
-            } | null;
+            custom_attributes?: Record<string, never> | null;
         };
         /**
          * DocumentData
@@ -9182,9 +9187,7 @@ export interface components {
              * Validation Rules
              * @description 驗證規則
              */
-            validation_rules?: {
-                [key: string]: unknown;
-            } | null;
+            validation_rules?: Record<string, never> | null;
         };
         /** EligibleScholarshipResponse */
         EligibleScholarshipResponse: {
@@ -9394,13 +9397,9 @@ export interface components {
          */
         FormConfigSaveRequest: {
             /** Fields */
-            fields: {
-                [key: string]: unknown;
-            }[];
+            fields: Record<string, never>[];
             /** Documents */
-            documents: {
-                [key: string]: unknown;
-            }[];
+            documents: Record<string, never>[];
             /** Application Document Note */
             application_document_note?: string | null;
             /** Application Document Note En */
@@ -9527,9 +9526,7 @@ export interface components {
              * Metadata
              * @description 額外資料
              */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
+            metadata?: Record<string, never> | null;
         };
         /**
          * NotificationUpdate
@@ -9553,9 +9550,7 @@ export interface components {
             /** Expires At */
             expires_at?: string | null;
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
+            metadata?: Record<string, never> | null;
             /**
              * Is Dismissed
              * @description 是否已關閉
@@ -9971,9 +9966,7 @@ export interface components {
              * Notification Settings
              * @description 通知設定
              */
-            notification_settings?: {
-                [key: string]: unknown;
-            } | null;
+            notification_settings?: Record<string, never> | null;
         };
         /**
          * RosterScheduleStatus
@@ -9986,6 +9979,7 @@ export interface components {
          * @description 更新排程狀態模型
          */
         RosterScheduleStatusUpdate: {
+            /** @description 排程狀態 */
             status: components["schemas"]["RosterScheduleStatus"];
         };
         /**
@@ -10034,9 +10028,7 @@ export interface components {
              * Notification Settings
              * @description 通知設定
              */
-            notification_settings?: {
-                [key: string]: unknown;
-            } | null;
+            notification_settings?: Record<string, never> | null;
         };
         /**
          * RosterStatus
@@ -10818,13 +10810,9 @@ export interface components {
              */
             preferred_language: string;
             /** Privacy Settings */
-            privacy_settings?: {
-                [key: string]: unknown;
-            } | null;
+            privacy_settings?: Record<string, never> | null;
             /** Custom Fields */
-            custom_fields?: {
-                [key: string]: unknown;
-            } | null;
+            custom_fields?: Record<string, never> | null;
         };
         /**
          * UserProfileUpdate
@@ -10842,13 +10830,9 @@ export interface components {
             /** Preferred Language */
             preferred_language?: string | null;
             /** Privacy Settings */
-            privacy_settings?: {
-                [key: string]: unknown;
-            } | null;
+            privacy_settings?: Record<string, never> | null;
             /** Custom Fields */
-            custom_fields?: {
-                [key: string]: unknown;
-            } | null;
+            custom_fields?: Record<string, never> | null;
         };
         /**
          * UserRole
@@ -10905,9 +10889,7 @@ export interface components {
              * Students
              * @description 學生列表 [{'nycu_id': '0856001', 'sub_type': 'nstc'}, ...]
              */
-            students: {
-                [key: string]: unknown;
-            }[];
+            students: Record<string, never>[];
         };
         /**
          * WhitelistBatchRemoveRequest
@@ -11595,9 +11577,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": Record<string, never>;
             };
         };
         responses: {
@@ -13759,9 +13739,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": Record<string, never>;
             };
         };
         responses: {
@@ -13816,9 +13794,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": Record<string, never>;
             };
         };
         responses: {
@@ -16741,9 +16717,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": Record<string, never>;
             };
         };
         responses: {
@@ -16809,9 +16783,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": Record<string, never>;
             };
         };
         responses: {
@@ -16947,9 +16919,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": {
-                    [key: string]: unknown;
-                };
+                "application/json": Record<string, never>;
             };
         };
         responses: {
@@ -19427,9 +19397,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -19460,9 +19428,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -19493,9 +19459,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -19526,9 +19490,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -19559,9 +19521,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7755,7 +7755,9 @@ export interface components {
             /** Message */
             message: string;
             /** Data */
-            data?: Record<string, never>[] | null;
+            data?: {
+                [key: string]: unknown;
+            }[] | null;
             /** Errors */
             errors?: string[] | null;
             /** Trace Id */
@@ -7771,7 +7773,9 @@ export interface components {
             /** Message */
             message: string;
             /** Data */
-            data?: Record<string, never> | null;
+            data?: {
+                [key: string]: unknown;
+            } | null;
             /** Errors */
             errors?: string[] | null;
             /** Trace Id */
@@ -7967,7 +7971,9 @@ export interface components {
              * Validation Rules
              * @description Validation rules
              */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * ApplicationDocumentUpdate
@@ -8005,7 +8011,9 @@ export interface components {
             /** Example File Url */
             example_file_url?: string | null;
             /** Validation Rules */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * ApplicationFieldCreate
@@ -8078,7 +8086,9 @@ export interface components {
              * Field Options
              * @description Field options
              */
-            field_options?: Record<string, never>[] | null;
+            field_options?: {
+                [key: string]: unknown;
+            }[] | null;
             /**
              * Display Order
              * @description Display order
@@ -8105,12 +8115,16 @@ export interface components {
              * Validation Rules
              * @description Validation rules
              */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Conditional Rules
              * @description Conditional rules
              */
-            conditional_rules?: Record<string, never> | null;
+            conditional_rules?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Include In College Export
              * @description Whether this field appears in the college Excel export
@@ -8149,7 +8163,9 @@ export interface components {
             /** Step Value */
             step_value?: number | null;
             /** Field Options */
-            field_options?: Record<string, never>[] | null;
+            field_options?: {
+                [key: string]: unknown;
+            }[] | null;
             /** Display Order */
             display_order?: number | null;
             /** Is Active */
@@ -8159,9 +8175,13 @@ export interface components {
             /** Help Text En */
             help_text_en?: string | null;
             /** Validation Rules */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
             /** Conditional Rules */
-            conditional_rules?: Record<string, never> | null;
+            conditional_rules?: {
+                [key: string]: unknown;
+            } | null;
             /** Include In College Export */
             include_in_college_export?: boolean | null;
             /** Export Column Label */
@@ -8345,9 +8365,13 @@ export interface components {
             /** Semester */
             semester?: string | null;
             /** Student Data */
-            student_data: Record<string, never>;
+            student_data: {
+                [key: string]: unknown;
+            };
             /** Submitted Form Data */
-            submitted_form_data: Record<string, never>;
+            submitted_form_data: {
+                [key: string]: unknown;
+            };
             /**
              * Agree Terms
              * @default false
@@ -8376,7 +8400,9 @@ export interface components {
              */
             updated_at: string;
             /** Meta Data */
-            meta_data?: Record<string, never> | null;
+            meta_data?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Reviews
              * @default []
@@ -8587,7 +8613,9 @@ export interface components {
              * Updates
              * @description 要更新的欄位
              */
-            updates: Record<string, never>;
+            updates: {
+                [key: string]: unknown;
+            };
         };
         /** Body_create_ranking_api_v1_college_review_rankings_post */
         Body_create_ranking_api_v1_college_review_rankings_post: {
@@ -8625,10 +8653,7 @@ export interface components {
         };
         /** Body_create_supplementary_doc_api_v1_system_settings_supplementary_docs_post */
         Body_create_supplementary_doc_api_v1_system_settings_supplementary_docs_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
             /** Title */
             title: string;
@@ -8648,35 +8673,25 @@ export interface components {
         };
         /** Body_extract_bank_info_from_passbook_api_v1_user_profiles_bank_passbook_ocr_post */
         Body_extract_bank_info_from_passbook_api_v1_user_profiles_bank_passbook_ocr_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_extract_text_from_document_api_v1_user_profiles_document_ocr_post */
         Body_extract_text_from_document_api_v1_user_profiles_document_ocr_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_import_received_months_api_v1_manual_distribution_import_received_months_post */
         Body_import_received_months_api_v1_manual_distribution_import_received_months_post: {
             /**
              * File
-             * Format: binary
              * @description Excel file with columns: 學號, 已領月份數
              */
             file: string;
         };
         /** Body_import_whitelist_excel_api_v1_scholarship_configurations__id__whitelist_import_post */
         Body_import_whitelist_excel_api_v1_scholarship_configurations__id__whitelist_import_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_portal_sso_verify_api_v1_auth_portal_sso_verify_post */
@@ -8715,10 +8730,7 @@ export interface components {
         };
         /** Body_supplementary_import_api_v1_college_review_rankings__ranking_id__supplementary_import_post */
         Body_supplementary_import_api_v1_college_review_rankings__ranking_id__supplementary_import_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_update_matrix_quota_api_v1_scholarship_configurations_matrix_quota_put */
@@ -8734,17 +8746,13 @@ export interface components {
         };
         /** Body_upload_bank_document_file_api_v1_user_profiles_me_bank_document_file_post */
         Body_upload_bank_document_file_api_v1_user_profiles_me_bank_document_file_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_batch_documents_api_v1_college_review_batch_import__batch_id__documents_post */
         Body_upload_batch_documents_api_v1_college_review_batch_import__batch_id__documents_post: {
             /**
              * File
-             * Format: binary
              * @description 包含所有文件的 ZIP 檔案
              */
             file: string;
@@ -8753,58 +8761,41 @@ export interface components {
         Body_upload_batch_import_data_api_v1_college_review_batch_import_upload_data_post: {
             /**
              * File
-             * Format: binary
              * @description Excel或CSV檔案
              */
             file: string;
         };
         /** Body_upload_document_example_api_v1_application_fields_documents__document_id__upload_example_post */
         Body_upload_document_example_api_v1_application_fields_documents__document_id__upload_example_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_file_alias_api_v1_applications__id__files_post */
         Body_upload_file_alias_api_v1_applications__id__files_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_file_api_v1_applications__id__files_upload_post */
         Body_upload_file_api_v1_applications__id__files_upload_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post */
         Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post: {
             /**
              * File
-             * Format: binary
              * @description 續領生 Excel 或 CSV 檔案
              */
             file: string;
         };
         /** Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post */
         Body_upload_system_doc_api_v1_system_settings_upload__doc_key__post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /** Body_upload_terms_document_api_v1_scholarships__scholarship_type__upload_terms_post */
         Body_upload_terms_document_api_v1_scholarships__scholarship_type__upload_terms_post: {
-            /**
-             * File
-             * Format: binary
-             */
+            /** File */
             file: string;
         };
         /**
@@ -8848,7 +8839,9 @@ export interface components {
              * Parameters
              * @description Operation-specific parameters
              */
-            parameters?: Record<string, never> | null;
+            parameters?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * BulkScholarshipAssignRequest
@@ -9058,7 +9051,9 @@ export interface components {
              */
             email_domain: string | null;
             /** Custom Attributes */
-            custom_attributes?: Record<string, never> | null;
+            custom_attributes?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * DocumentData
@@ -9187,7 +9182,9 @@ export interface components {
              * Validation Rules
              * @description 驗證規則
              */
-            validation_rules?: Record<string, never> | null;
+            validation_rules?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** EligibleScholarshipResponse */
         EligibleScholarshipResponse: {
@@ -9397,9 +9394,13 @@ export interface components {
          */
         FormConfigSaveRequest: {
             /** Fields */
-            fields: Record<string, never>[];
+            fields: {
+                [key: string]: unknown;
+            }[];
             /** Documents */
-            documents: Record<string, never>[];
+            documents: {
+                [key: string]: unknown;
+            }[];
             /** Application Document Note */
             application_document_note?: string | null;
             /** Application Document Note En */
@@ -9526,7 +9527,9 @@ export interface components {
              * Metadata
              * @description 額外資料
              */
-            metadata?: Record<string, never> | null;
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * NotificationUpdate
@@ -9550,7 +9553,9 @@ export interface components {
             /** Expires At */
             expires_at?: string | null;
             /** Metadata */
-            metadata?: Record<string, never> | null;
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Is Dismissed
              * @description 是否已關閉
@@ -9966,7 +9971,9 @@ export interface components {
              * Notification Settings
              * @description 通知設定
              */
-            notification_settings?: Record<string, never> | null;
+            notification_settings?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * RosterScheduleStatus
@@ -9979,7 +9986,6 @@ export interface components {
          * @description 更新排程狀態模型
          */
         RosterScheduleStatusUpdate: {
-            /** @description 排程狀態 */
             status: components["schemas"]["RosterScheduleStatus"];
         };
         /**
@@ -10028,7 +10034,9 @@ export interface components {
              * Notification Settings
              * @description 通知設定
              */
-            notification_settings?: Record<string, never> | null;
+            notification_settings?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * RosterStatus
@@ -10810,9 +10818,13 @@ export interface components {
              */
             preferred_language: string;
             /** Privacy Settings */
-            privacy_settings?: Record<string, never> | null;
+            privacy_settings?: {
+                [key: string]: unknown;
+            } | null;
             /** Custom Fields */
-            custom_fields?: Record<string, never> | null;
+            custom_fields?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * UserProfileUpdate
@@ -10830,9 +10842,13 @@ export interface components {
             /** Preferred Language */
             preferred_language?: string | null;
             /** Privacy Settings */
-            privacy_settings?: Record<string, never> | null;
+            privacy_settings?: {
+                [key: string]: unknown;
+            } | null;
             /** Custom Fields */
-            custom_fields?: Record<string, never> | null;
+            custom_fields?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * UserRole
@@ -10889,7 +10905,9 @@ export interface components {
              * Students
              * @description 學生列表 [{'nycu_id': '0856001', 'sub_type': 'nstc'}, ...]
              */
-            students: Record<string, never>[];
+            students: {
+                [key: string]: unknown;
+            }[];
         };
         /**
          * WhitelistBatchRemoveRequest
@@ -11577,7 +11595,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -13739,7 +13759,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -13794,7 +13816,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -16717,7 +16741,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -16783,7 +16809,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -16919,7 +16947,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -19397,7 +19427,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -19428,7 +19460,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -19459,7 +19493,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -19490,7 +19526,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -19521,7 +19559,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -15,13 +15,13 @@
  */
 
 import {
-  buildCollegeBudget,
-  classifyUnallocated,
   createManualDistributionApi,
   isCancelledAllocation,
-  makeColKey,
   mergeSuggestions,
-  summarizeUnallocated,
+  reasonsBySuggestion,
+  summarizeReasons,
+  toStagedItems,
+  UNALLOCATED_REASON_LABEL,
 } from "../manual-distribution";
 import { typedClient } from "../../typed-client";
 
@@ -237,22 +237,19 @@ describe("createManualDistributionApi", () => {
 
   // ─── getAutoAllocatePreview ───────────────────────────────────────
 
-  it("getAutoAllocatePreview GETs /auto-allocate-preview (preview only, no DB writes)", async () => {
-    // Pin: preview endpoint — server returns suggestions WITHOUT
-    // mutating allocations. Pin so refactor doesn't accidentally
-    // change it to a destructive POST.
-    mockedRaw.GET.mockResolvedValueOnce({});
+  it("getAutoAllocatePreview omits college_code and staged when not supplied", async () => {
+    // POST carries the staged overlay in a body, but still writes nothing —
+    // a refactor must not turn it into a destructive call.
+    mockedRaw.POST.mockResolvedValueOnce({});
     const api = createManualDistributionApi();
     await api.getAutoAllocatePreview(7, 114, "first");
-    expect(mockedRaw.GET).toHaveBeenCalledWith(
+    expect(mockedRaw.POST).toHaveBeenCalledWith(
       "/api/v1/manual-distribution/auto-allocate-preview",
       {
-        params: {
-          query: {
-            scholarship_type_id: 7,
-            academic_year: 114,
-            semester: "first",
-          },
+        body: {
+          scholarship_type_id: 7,
+          academic_year: 114,
+          semester: "first",
         },
       }
     );
@@ -260,21 +257,43 @@ describe("createManualDistributionApi", () => {
 
   it("getAutoAllocatePreview spreads college_code for a single-college run", async () => {
     // Pin: the per-college 預設分發 button scopes the preview to one
-    // college. The param must only appear when supplied — an empty
+    // college. The field must only appear when supplied — an empty
     // string would narrow the whole-scholarship run to nothing.
-    mockedRaw.GET.mockResolvedValueOnce({});
+    mockedRaw.POST.mockResolvedValueOnce({});
     const api = createManualDistributionApi();
     await api.getAutoAllocatePreview(7, 114, "first", "C");
-    expect(mockedRaw.GET).toHaveBeenCalledWith(
+    expect(mockedRaw.POST).toHaveBeenCalledWith(
       "/api/v1/manual-distribution/auto-allocate-preview",
       {
-        params: {
-          query: {
-            scholarship_type_id: 7,
-            academic_year: 114,
-            semester: "first",
-            college_code: "C",
-          },
+        body: {
+          scholarship_type_id: 7,
+          academic_year: 114,
+          semester: "first",
+          college_code: "C",
+        },
+      }
+    );
+  });
+
+  it("getAutoAllocatePreview sends the staged overlay so the plan follows the screen", async () => {
+    // Pin: without this the server plans against the SAVED distribution, and a
+    // slot the admin just unticked stays invisible to it.
+    mockedRaw.POST.mockResolvedValueOnce({});
+    const api = createManualDistributionApi();
+    const staged = [
+      { ranking_item_id: 1, sub_type_code: null, allocation_config_id: null },
+      { ranking_item_id: 2, sub_type_code: "nstc", allocation_config_id: 115 },
+    ];
+    await api.getAutoAllocatePreview(7, 114, "first", "C", staged);
+    expect(mockedRaw.POST).toHaveBeenCalledWith(
+      "/api/v1/manual-distribution/auto-allocate-preview",
+      {
+        body: {
+          scholarship_type_id: 7,
+          academic_year: 114,
+          semester: "first",
+          college_code: "C",
+          staged,
         },
       }
     );
@@ -503,12 +522,12 @@ describe("createManualDistributionApi", () => {
   });
 });
 
-// ─── mergeSuggestions / buildCollegeBudget ────────────────────────────
+// ─── mergeSuggestions ─────────────────────────────────────────────────
 //
-// The staging rules shared by the on-load auto-preview and the per-college
-// 預設分發 button. SECURITY-CRITICAL: what these two functions stage is what
-// 儲存 persists, and the save-time server gate only recounts the GLOBAL pool —
-// the per-college matrix cap is enforced here.
+// The staging rules shared by the on-load auto-preview and the 預設分發
+// buttons. What these stage is what 儲存 persists — but the quota cap now
+// lives server-side, where the suggestions are computed against this same
+// staged map (see getAutoAllocatePreview's `staged`).
 
 describe("mergeSuggestions", () => {
   const suggestion = (
@@ -517,7 +536,7 @@ describe("mergeSuggestions", () => {
     allocation_config_id: number | null = 115
   ) => ({ ranking_item_id, sub_type_code, allocation_config_id });
 
-  it("fills only eligible, still-blank rows and never mutates the input map", () => {
+  it("fills only eligible 未決 rows and never mutates the input map", () => {
     const current = new Map([[2, { sub_type: "moe_1w", config_id: 115 }]]);
     const res = mergeSuggestions(
       current,
@@ -542,131 +561,45 @@ describe("mergeSuggestions", () => {
     expect(res.next.size).toBe(0);
   });
 
-  it("stops at the per-college budget and reports the overflow", () => {
-    // College has 2 nstc slots; 3 students suggested for it.
-    const budget = new Map([[makeColKey("nstc", 115), 2]]);
+  it("fills a row that is present-but-null — 未決 is not 'decided'", () => {
+    // An unticked row and a never-touched row are both 未決. The server was
+    // told so and planned for it, so the merge must not second-guess it.
+    const res = mergeSuggestions(
+      new Map([[1, null]]),
+      [suggestion(1)],
+      new Set([1])
+    );
+    expect(res.filled).toBe(1);
+    expect(res.next.get(1)).toEqual({ sub_type: "nstc", config_id: 115 });
+  });
+
+  it("applies every suggestion it is given — no client-side quota cap", () => {
+    // The server allocated these against the staged map it was sent, so a
+    // second cap here could only drop a row it deliberately allocated.
     const res = mergeSuggestions(
       new Map(),
       [suggestion(1), suggestion(2), suggestion(3)],
-      new Set([1, 2, 3]),
-      budget
+      new Set([1, 2, 3])
     );
-    expect(res.filled).toBe(2);
-    expect(res.blocked).toBe(1);
-    expect(res.next.has(3)).toBe(false);
-  });
-
-  it("leaves columns absent from the budget uncapped (non-matrix configs)", () => {
-    const budget = new Map([[makeColKey("moe_1w", 115), 0]]);
-    const res = mergeSuggestions(
-      new Map(),
-      [suggestion(1), suggestion(2)],
-      new Set([1, 2]),
-      budget
-    );
-    expect(res.filled).toBe(2);
-    expect(res.blocked).toBe(0);
+    expect(res.filled).toBe(3);
   });
 });
 
-describe("buildCollegeBudget", () => {
-  const quotaStatus = {
-    nstc: {
-      display_name: "國科會",
-      by_config: [
-        {
-          config_id: 115,
-          config_code: "phd_115",
-          academic_year: 115,
-          is_own: true,
-          total: 10,
-          remaining: 8,
-          by_college: {
-            C: { total: 2, allocated: 1, remaining: 1 },
-            D: { total: 5, allocated: 0, remaining: 5 },
-          },
-        },
-      ],
-    },
-    moe_1w: {
-      display_name: "教育部",
-      by_config: [
-        {
-          config_id: 115,
-          config_code: "phd_115",
-          academic_year: 115,
-          is_own: true,
-          total: 4,
-          remaining: 4,
-          by_college: null, // no per-college matrix
-        },
-      ],
-    },
-  } as unknown as Parameters<typeof buildCollegeBudget>[0];
-
-  // college C: total 2, allocated 1 (globally — may include rows this grid
-  // never shows, e.g. an approved renewal), remaining 1.
-  const student = (
-    ranking_item_id: number,
-    college_code: string,
-    saved?: { sub_type: string; config_id: number }
-  ) =>
-    ({
-      ranking_item_id,
-      college_code,
-      is_allocated: !!saved,
-      allocated_sub_type: saved?.sub_type ?? null,
-      allocation_config_id: saved?.config_id ?? null,
-    }) as never;
-
-  it("starts from live remaining, not total, and charges unsaved staging", () => {
-    // Baseline remaining=1; student 1 is a FRESH tick (no saved allocation), so
-    // it consumes the last slot. A total-based baseline would have said 1 left —
-    // headroom that a consumer outside this grid already took.
-    const budget = buildCollegeBudget(
-      quotaStatus,
-      [student(1, "C"), student(2, "C"), student(3, "D")],
-      new Map([
-        [1, { sub_type: "nstc", config_id: 115 }],
-        [3, { sub_type: "nstc", config_id: 115 }], // college D — must not count
-      ]),
-      "C"
-    );
-    expect(budget.get(makeColKey("nstc", 115))).toBe(0);
-  });
-
-  it("nets a row staged exactly as saved to zero", () => {
-    // The saved row is already inside `remaining`; re-staging it unchanged must
-    // not double-charge the college.
-    const saved = { sub_type: "nstc", config_id: 115 };
-    const budget = buildCollegeBudget(
-      quotaStatus,
-      [student(1, "C", saved)],
-      new Map([[1, saved]]),
-      "C"
-    );
-    expect(budget.get(makeColKey("nstc", 115))).toBe(1);
-  });
-
-  it("frees a slot when a saved allocation is unticked", () => {
-    const saved = { sub_type: "nstc", config_id: 115 };
-    const budget = buildCollegeBudget(
-      quotaStatus,
-      [student(1, "C", saved)],
-      new Map([[1, null]]),
-      "C"
-    );
-    expect(budget.get(makeColKey("nstc", 115))).toBe(2);
-  });
-
-  it("omits columns with no per-college matrix so they stay uncapped", () => {
-    const budget = buildCollegeBudget(quotaStatus, [], new Map(), "C");
-    expect(budget.has(makeColKey("moe_1w", 115))).toBe(false);
-  });
-
-  it("omits colleges the matrix does not list", () => {
-    const budget = buildCollegeBudget(quotaStatus, [], new Map(), "Z");
-    expect(budget.size).toBe(0);
+describe("toStagedItems", () => {
+  it("sends every row, 未決 ones as explicit nulls", () => {
+    // The overlay must be complete: a row it omits falls back to the SAVED
+    // state server-side, which is exactly the bug this replaced.
+    expect(
+      toStagedItems(
+        new Map([
+          [1, { sub_type: "nstc", config_id: 115 }],
+          [2, null],
+        ])
+      )
+    ).toEqual([
+      { ranking_item_id: 1, sub_type_code: "nstc", allocation_config_id: 115 },
+      { ranking_item_id: 2, sub_type_code: null, allocation_config_id: null },
+    ]);
   });
 });
 
@@ -683,88 +616,57 @@ describe("isCancelledAllocation", () => {
   });
 });
 
-describe("classifyUnallocated / summarizeUnallocated", () => {
-  const student = (o: Record<string, unknown>) =>
+describe("reasonsBySuggestion / summarizeReasons", () => {
+  const s = (
+    ranking_item_id: number,
+    sub_type_code: string | null,
+    reason?: string | null
+  ) =>
     ({
-      quota_allocation_status: null,
-      college_rejected: false,
-      applied_sub_types: ["nstc"],
-      rejected_sub_types: [],
-      ...o,
+      ranking_item_id,
+      sub_type_code,
+      allocation_config_id: sub_type_code ? 115 : null,
+      reason,
     }) as never;
 
-  it("reports the college's rejection first, matching the backend's order", () => {
-    // _compute_suggestions short-circuits on college_rejected BEFORE it reads
-    // quota_allocation_status, so that is what actually stopped the allocation.
-    expect(classifyUnallocated(student({ college_rejected: true }))).toBe(
-      "college_rejected"
-    );
-    expect(
-      classifyUnallocated(
-        student({ quota_allocation_status: "revoked", college_rejected: true })
-      )
-    ).toBe("college_rejected");
+  it("keeps only the rows the run could not place", () => {
+    const reasons = reasonsBySuggestion([
+      s(1, "nstc", null),
+      s(2, null, "quota_full"),
+      s(3, null, "review_rejected"),
+    ]);
+    expect(reasons.get(1)).toBeUndefined();
+    expect(reasons.get(2)).toBe("quota_full");
+    expect(reasons.get(3)).toBe("review_rejected");
   });
 
-  it("reports 撤銷/停發 when the college did not reject", () => {
-    expect(
-      classifyUnallocated(student({ quota_allocation_status: "revoked" }))
-    ).toBe("cancelled");
-    expect(
-      classifyUnallocated(student({ quota_allocation_status: "suspended" }))
-    ).toBe("cancelled");
-  });
-
-  it("reports an empty application", () => {
-    expect(classifyUnallocated(student({ applied_sub_types: [] }))).toBe(
-      "not_applied"
-    );
-  });
-
-  it("reports a review reject only when it covers EVERY applied sub-type", () => {
-    // The invisible case: a reject from a role the 教授推薦/學院推薦 columns
-    // don't render still blocks the allocation.
-    expect(
-      classifyUnallocated(
-        student({
-          applied_sub_types: ["nstc", "moe_1w"],
-          rejected_sub_types: ["nstc", "moe_1w"],
-        })
-      )
-    ).toBe("review_rejected");
-    // One sub-type still open ⇒ the blocker was quota, not the review.
-    expect(
-      classifyUnallocated(
-        student({
-          applied_sub_types: ["nstc", "moe_1w"],
-          rejected_sub_types: ["nstc"],
-        })
-      )
-    ).toBe("no_quota");
-  });
-
-  it("compares sub-type codes normalized, like the backend", () => {
-    expect(
-      classifyUnallocated(
-        student({ applied_sub_types: [" NSTC"], rejected_sub_types: ["nstc"] })
-      )
-    ).toBe("review_rejected");
-  });
-
-  it("falls through to 名額不足 for an otherwise allocatable student", () => {
-    expect(classifyUnallocated(student({}))).toBe("no_quota");
+  it("ignores an unplaced row with no reason rather than inventing one", () => {
+    // The frontend must never guess: a reject from a reviewer role the grid
+    // does not render looks identical to an exhausted quota from here.
+    expect(reasonsBySuggestion([s(1, null, null)]).size).toBe(0);
   });
 
   it("tallies reasons, most common first", () => {
-    expect(
-      summarizeUnallocated([
-        student({ applied_sub_types: ["nstc"], rejected_sub_types: ["nstc"] }),
-        student({ applied_sub_types: ["nstc"], rejected_sub_types: ["nstc"] }),
-        student({}),
-      ])
-    ).toEqual([
+    const reasons = reasonsBySuggestion([
+      s(1, null, "review_rejected"),
+      s(2, null, "review_rejected"),
+      s(3, null, "quota_full"),
+    ]);
+    expect(summarizeReasons(reasons)).toEqual([
       { reason: "review_rejected", count: 2 },
-      { reason: "no_quota", count: 1 },
+      { reason: "quota_full", count: 1 },
+    ]);
+  });
+
+  it("labels every reason the backend can emit", () => {
+    // Pin: the union mirrors the UNALLOCATED_* constants in
+    // manual_distribution_service.py — a new code must land in both.
+    expect(Object.keys(UNALLOCATED_REASON_LABEL).sort()).toEqual([
+      "cancelled",
+      "college_rejected",
+      "not_applied",
+      "quota_full",
+      "review_rejected",
     ]);
   });
 });

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -21,7 +21,9 @@ import {
   reasonsBySuggestion,
   summarizeReasons,
   toStagedItems,
+  unallocatedReasonLabel,
   UNALLOCATED_REASON_LABEL,
+  type UnallocatedReason,
 } from "../manual-distribution";
 import { typedClient } from "../../typed-client";
 
@@ -270,6 +272,26 @@ describe("createManualDistributionApi", () => {
           academic_year: 114,
           semester: "first",
           college_code: "C",
+        },
+      }
+    );
+  });
+
+  it("getAutoAllocatePreview sends an EMPTY overlay rather than dropping it", async () => {
+    // `[]` is truthy in JS and falsy in Python, so a truthiness guard here
+    // would ship "no rows are allocated" and have the server read "no overlay
+    // given" — silently planning against the SAVED distribution instead.
+    mockedRaw.POST.mockResolvedValueOnce({});
+    const api = createManualDistributionApi();
+    await api.getAutoAllocatePreview(7, 114, "first", undefined, []);
+    expect(mockedRaw.POST).toHaveBeenCalledWith(
+      "/api/v1/manual-distribution/auto-allocate-preview",
+      {
+        body: {
+          scholarship_type_id: 7,
+          academic_year: 114,
+          semester: "first",
+          staged: [],
         },
       }
     );
@@ -658,15 +680,31 @@ describe("reasonsBySuggestion / summarizeReasons", () => {
     ]);
   });
 
+  it("drops 撤銷/停發 rows — they were never candidates", () => {
+    // They render their own status control, and counting them would report a
+    // dozen "failures" for a college where nothing actually went wrong.
+    expect(reasonsBySuggestion([s(1, null, "cancelled")]).size).toBe(0);
+  });
+
   it("labels every reason the backend can emit", () => {
     // Pin: the union mirrors the UNALLOCATED_* constants in
     // manual_distribution_service.py — a new code must land in both.
     expect(Object.keys(UNALLOCATED_REASON_LABEL).sort()).toEqual([
       "cancelled",
       "college_rejected",
+      "no_college_quota",
       "not_applied",
       "quota_full",
       "review_rejected",
     ]);
+  });
+
+  it("falls back to the raw code for a reason this build has not learnt", () => {
+    // The union is hand-kept and the response is untyped, so a backend that
+    // ships a new code first must not render 「未分配: undefined」.
+    expect(unallocatedReasonLabel("quota_full")).toBe("名額不足");
+    expect(
+      unallocatedReasonLabel("brand_new_code" as UnallocatedReason)
+    ).toBe("brand_new_code");
   });
 });

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -290,7 +290,8 @@ export type UnallocatedReason =
   | "college_rejected"
   | "not_applied"
   | "review_rejected"
-  | "quota_full";
+  | "quota_full"
+  | "no_college_quota";
 
 export const UNALLOCATED_REASON_LABEL: Record<UnallocatedReason, string> = {
   cancelled: "已撤銷／停發",
@@ -298,15 +299,32 @@ export const UNALLOCATED_REASON_LABEL: Record<UnallocatedReason, string> = {
   not_applied: "未申請可分配的子類型",
   review_rejected: "審核不同意",
   quota_full: "名額不足",
+  no_college_quota: "該學院無此類別名額",
 };
 
-/** ranking_item_id → why it was left 未決, for the rows the run could not place. */
+/**
+ * Label for a reason code, surviving one the backend added and this build has
+ * not learnt yet. The union is a hand-kept mirror of the UNALLOCATED_*
+ * constants and the response is untyped, so an unknown code reaches here with
+ * no type error — showing the raw code beats 「未分配: undefined」.
+ */
+export function unallocatedReasonLabel(reason: UnallocatedReason): string {
+  return UNALLOCATED_REASON_LABEL[reason] ?? reason;
+}
+
+/**
+ * ranking_item_id → why it was left 未決, for the rows the run could not place.
+ *
+ * 撤銷/停發 rows are dropped: they were never candidates, and the grid already
+ * states their status on the row itself. Counting them would report a dozen
+ * "failures" for a college where nothing actually went wrong.
+ */
 export function reasonsBySuggestion(
   suggestions: AllocationSuggestion[]
 ): Map<number, UnallocatedReason> {
   const reasons = new Map<number, UnallocatedReason>();
   for (const s of suggestions) {
-    if (s.sub_type_code || !s.reason) continue;
+    if (s.sub_type_code || !s.reason || s.reason === "cancelled") continue;
     reasons.set(s.ranking_item_id, s.reason);
   }
   return reasons;
@@ -681,7 +699,11 @@ export function createManualDistributionApi() {
             academic_year,
             semester,
             ...(college_code ? { college_code } : {}),
-            ...(staged ? { staged } : {}),
+            // `staged !== undefined`, not a truthiness test: an EMPTY overlay is
+            // a real answer ("this screen renders no rows") and JS and Python
+            // disagree about `[]`, so a truthiness test here would ship one
+            // meaning and have the server read another.
+            ...(staged !== undefined ? { staged } : {}),
           } as never,
         }
       );

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -170,108 +170,59 @@ export interface AllocationSuggestion {
   ranking_item_id: number;
   sub_type_code: string | null;
   allocation_config_id: number | null;
+  /** Why nothing could be allocated. Null on a successful suggestion. */
+  reason?: UnallocatedReason | null;
 }
 
 export interface MergeSuggestionsResult {
   /** A NEW map — callers must not mutate `current`. */
   next: Map<number, LocalAlloc | null>;
-  /** How many blank rows the suggestions filled. */
+  /** How many 未決 rows the suggestions filled. */
   filled: number;
-  /** Suggestions dropped because the per-college budget was exhausted. */
-  blocked: number;
 }
 
 /**
  * Merge auto-allocation suggestions into the staged allocation map.
  *
- * Single implementation for the on-load preview and the per-college 預設分發
- * button, so both apply the same rules: only rows in `eligibleItemIds` (in the
- * grid, right college, not 撤銷/停發), only rows with NO allocation yet (saved
- * or hand-picked selections are never overwritten).
+ * Single implementation for the on-load preview and the 預設分發 buttons, so
+ * both apply the same rules: only rows in `eligibleItemIds` (in the grid, right
+ * college, not 撤銷/停發), and only 未決 rows — a row already carrying an
+ * allocation is decided, and is never overwritten.
  *
- * `budget` (from buildCollegeBudget) caps how many more rows may be staged per
- * (sub_type, config) column. It is REQUIRED whenever suggestions are merged on
- * top of unsaved staged work: the backend computes suggestions against
- * persisted consumers only, so without it a hand-picked-then-auto-filled
- * college can exceed its matrix row. The map is mutated as budget is consumed.
+ * No quota cap here. The suggestions were computed against the same staged map
+ * this merges into (see getAutoAllocatePreview's `staged`), so the server has
+ * already spent exactly the headroom the screen has left; a second cap applied
+ * here could only wrongly drop a row the server deliberately allocated.
  */
 export function mergeSuggestions(
   current: Map<number, LocalAlloc | null>,
   suggestions: AllocationSuggestion[],
-  eligibleItemIds: Set<number>,
-  budget?: Map<string, number>
+  eligibleItemIds: Set<number>
 ): MergeSuggestionsResult {
   const next = new Map(current);
   let filled = 0;
-  let blocked = 0;
   for (const s of suggestions) {
     if (!s.sub_type_code || s.allocation_config_id == null) continue;
     if (!eligibleItemIds.has(s.ranking_item_id)) continue;
     if (next.get(s.ranking_item_id)) continue;
-    const key = makeColKey(s.sub_type_code, s.allocation_config_id);
-    if (budget) {
-      const left = budget.get(key);
-      // Absent key = no per-college cap for that column (non-matrix config).
-      if (left !== undefined) {
-        if (left <= 0) {
-          blocked++;
-          continue;
-        }
-        budget.set(key, left - 1);
-      }
-    }
     next.set(s.ranking_item_id, {
       sub_type: s.sub_type_code,
       config_id: s.allocation_config_id,
     });
     filled++;
   }
-  return { next, filled, blocked };
+  return { next, filled };
 }
 
-/**
- * Remaining per-(sub_type, config) headroom for ONE college, as of the CURRENT
- * staged state.
- *
- * Baseline is the server's LIVE `remaining`, not the matrix `total`: consumers
- * count globally (winners in any finalized ranking plus approved renewals — see
- * consumers_by_college), so a `total`-based baseline would silently hand out
- * headroom already taken by rows this grid never shows.
- *
- * `remaining` has already subtracted each row's SAVED allocation, so only
- * unsaved changes may move the budget: a saved row adds its slot back, the
- * staged allocation then takes one. A row staged exactly as saved nets to zero;
- * an untick frees a slot; a fresh tick consumes one.
- *
- * Columns whose config carries no per-college matrix (`by_college === null`)
- * are omitted — they have no per-college cap to enforce.
- */
-export function buildCollegeBudget(
-  quotaStatus: QuotaStatus,
-  students: DistributionStudent[],
-  allocations: Map<number, LocalAlloc | null>,
-  collegeCode: string
-): Map<string, number> {
-  const budget = new Map<string, number>();
-  for (const [sub_type, stData] of Object.entries(quotaStatus)) {
-    for (const cfg of stData.by_config) {
-      const cell = cfg.by_college?.[collegeCode];
-      if (!cell) continue;
-      budget.set(makeColKey(sub_type, cfg.config_id), cell.remaining);
-    }
-  }
-  const bump = (alloc: LocalAlloc | null | undefined, delta: number) => {
-    if (!alloc) return;
-    const key = makeColKey(alloc.sub_type, alloc.config_id);
-    const left = budget.get(key);
-    if (left !== undefined) budget.set(key, left + delta);
-  };
-  for (const s of students) {
-    if ((s.college_code || "") !== collegeCode) continue;
-    bump(getSavedAllocation(s), +1); // give the saved slot back …
-    bump(allocations.get(s.ranking_item_id), -1); // … then charge what is staged
-  }
-  return budget;
+/** The staged map on the wire — every row the grid renders, 未決 rows included. */
+export function toStagedItems(
+  allocations: Map<number, LocalAlloc | null>
+): AllocationItem[] {
+  return Array.from(allocations.entries()).map(([ranking_item_id, alloc]) => ({
+    ranking_item_id,
+    sub_type_code: alloc?.sub_type ?? null,
+    allocation_config_id: alloc?.config_id ?? null,
+  }));
 }
 
 export interface AllocateRequest {
@@ -326,59 +277,47 @@ export function isCancelledAllocation(s: DistributionStudent): boolean {
   );
 }
 
-/** Sub-type codes are free-form strings; compare them normalized (mirrors the backend's _norm_sub_type). */
-function normSubType(code: string | null | undefined): string {
-  return (code ?? "").toLowerCase().trim();
-}
-
+/**
+ * Why 預設分發 could not place a student. Decided by the backend, which is the
+ * only place that knows — a reject from a reviewer role the grid does not
+ * render is invisible here, and "the quota ran out" cannot be told apart from
+ * "they were never a candidate" by looking at the row.
+ *
+ * Mirrors the UNALLOCATED_* constants in manual_distribution_service.py.
+ */
 export type UnallocatedReason =
   | "cancelled"
   | "college_rejected"
   | "not_applied"
   | "review_rejected"
-  | "no_quota";
+  | "quota_full";
 
 export const UNALLOCATED_REASON_LABEL: Record<UnallocatedReason, string> = {
   cancelled: "已撤銷／停發",
   college_rejected: "學院不予推薦",
-  not_applied: "未申請任何子類型",
+  not_applied: "未申請可分配的子類型",
   review_rejected: "審核不同意",
-  no_quota: "名額不足",
+  quota_full: "名額不足",
 };
 
-/**
- * Why the auto-allocation could not place this student.
- *
- * Only meaningful for a row the backend returned no sub-type for. The order
- * mirrors the backend's own short-circuits in _compute_suggestions, so the
- * reason shown is the one that actually stopped it. "no_quota" is the residual:
- * the student is allocatable but every sub-type they want is exhausted.
- *
- * Exists because 「名額已用盡」 was being reported for rows that were really
- * blocked by a review reject — including rejects from a reviewer whose verdict
- * the 教授推薦/學院推薦 columns do not render, leaving no visible explanation.
- */
-export function classifyUnallocated(s: DistributionStudent): UnallocatedReason {
-  // college_rejected FIRST — _compute_suggestions short-circuits on it before
-  // it ever reads quota_allocation_status, so for a row that is both, the
-  // college's rejection is what actually stopped the allocation. (The 撤銷/停發
-  // state is not hidden by this: the row renders its own status control.)
-  if (s.college_rejected) return "college_rejected";
-  if (isCancelledAllocation(s)) return "cancelled";
-  const applied = s.applied_sub_types ?? [];
-  if (applied.length === 0) return "not_applied";
-  const rejected = new Set((s.rejected_sub_types ?? []).map(normSubType));
-  if (applied.every(a => rejected.has(normSubType(a)))) return "review_rejected";
-  return "no_quota";
+/** ranking_item_id → why it was left 未決, for the rows the run could not place. */
+export function reasonsBySuggestion(
+  suggestions: AllocationSuggestion[]
+): Map<number, UnallocatedReason> {
+  const reasons = new Map<number, UnallocatedReason>();
+  for (const s of suggestions) {
+    if (s.sub_type_code || !s.reason) continue;
+    reasons.set(s.ranking_item_id, s.reason);
+  }
+  return reasons;
 }
 
-/** Reason → count over the given students, most common first; zero counts omitted. */
-export function summarizeUnallocated(
-  students: DistributionStudent[]
+/** Reason → count, most common first; zero counts omitted. */
+export function summarizeReasons(
+  reasons: Map<number, UnallocatedReason>
 ): Array<{ reason: UnallocatedReason; count: number }> {
   const tally = new Map<UnallocatedReason, number>();
-  for (const s of students) {
-    const reason = classifyUnallocated(s);
+  for (const reason of reasons.values()) {
     tally.set(reason, (tally.get(reason) ?? 0) + 1);
   }
   return [...tally.entries()]
@@ -717,29 +656,33 @@ export function createManualDistributionApi() {
     },
 
     /**
-     * Get auto-allocation preview suggestions.
+     * Get auto-allocation preview suggestions. Writes nothing.
      *
      * Pass `college_code` to run the distribution for a single college — the
      * backend still evaluates quotas globally, so the suggestions match what a
      * whole-scholarship run would produce for that college.
+     *
+     * Pass `staged` — the grid's CURRENT allocations for every row it renders,
+     * every college — to have the plan computed against the screen instead of
+     * the saved distribution. Omit it only on a screen that has staged nothing.
      */
     getAutoAllocatePreview: async (
       scholarship_type_id: number,
       academic_year: number,
       semester: string,
-      college_code?: string
+      college_code?: string,
+      staged?: AllocationItem[]
     ): Promise<ApiResponse<{ suggestions: AllocationSuggestion[] }>> => {
-      const response = await typedClient.raw.GET(
+      const response = await typedClient.raw.POST(
         "/api/v1/manual-distribution/auto-allocate-preview",
         {
-          params: {
-            query: {
-              scholarship_type_id,
-              academic_year,
-              semester,
-              ...(college_code ? { college_code } : {}),
-            },
-          },
+          body: {
+            scholarship_type_id,
+            academic_year,
+            semester,
+            ...(college_code ? { college_code } : {}),
+            ...(staged ? { staged } : {}),
+          } as never,
         }
       );
       return toApiResponse(response) as ApiResponse<{


### PR DESCRIPTION
## The bug

管理員手動分發頁面的「預設分發」按鈕看的是**儲存後的狀態**，不是**當前畫面的狀態**。

`auto-allocate-preview` built its quota tracker from persisted `CollegeRankingItem.is_allocated` rows while the admin's grid held unsaved staged allocations. A slot freed by unticking a box therefore did not exist as far as the algorithm was concerned — it produced no suggestion for it, and the grid reported 「名額已用盡」 next to visibly empty 核配 columns. The frontend's local `buildCollegeBudget` could only shrink that result, never create one.

## The fix

The endpoint now takes the caller's on-screen allocations as a **`staged` overlay** — the same wire shape 儲存 already sends, covering every row the grid renders, every college — and lets it override the database:

- an **unticked** row releases its slot here and now,
- a **hand-ticked** row is charged for one and is never re-suggested.

Still writes nothing; `POST` only because that state is a body, not a query string.

### Consequences

- **未決 is the single eligibility rule.** `clearedItemIds` is gone — unticking returns a row to 未決 and 預設分發 may fill it again. To hold a student out of the round, use 撤銷/停發, the one state that frees the slot *without* making them a candidate. (This intentionally reverses `dd9613f1`.)
- **A hand-picked tick is never overwritten** and consumes quota, so the button is idempotent.
- **The client-side quota cap is deleted.** The server now spends exactly the headroom the screen has left, so a second cap could only wrongly drop a row it deliberately allocated. To keep that safe, 預設分發 freezes the 核配 boxes for its duration (like 儲存/確認分發/還原 already do) — otherwise a tick landing mid-request is both lost and uncounted, and nothing downstream re-checks the per-college matrix (`_assert_round_not_oversubscribed` recounts only the global pool).
- **Every unplaced student carries a reason**, decided where the allocation is made: `quota_full` / `review_rejected` / `not_applied` / `no_college_quota` / `college_rejected` / `cancelled`. The frontend no longer guesses — a reject from a reviewer role the grid does not render was previously invisible and got reported as 「名額已用盡」. Shown as a per-row badge plus a summary in the message bar.
- **New 全部預設分發 button** runs every college in one pass.
- `_dedupe_preview_items` prefers the duplicate the caller staged — direct evidence of the row the grid renders.

`CONTEXT.md` (new) records the vocabulary this rests on, notably **未決** as a state distinct from 撤銷/停發.

## Second commit — code-review findings

- **清空 emptied the staged Map**, so 預設分發 sent `staged: []` — truthy in JS, falsy in Python — and the server read it as "no overlay given", falling back to the saved distribution and reproducing the exact bug this PR fixes. Same root cause meant 清空 + 儲存 cleared nothing (pre-existing on `main`: an empty map ⇒ empty `allocations` ⇒ `allocate` touches nothing). 清空 now marks every row explicitly 未決; the API guards on `staged !== undefined`.
- 「名額不足」 was reported for a college with **no cell in the matrix at all** — an unmapped 學院代碼 — sending the admin to edit a row that does not exist. Split out as `no_college_quota`.
- The toolbar tallied 撤銷/停發 rows the badge deliberately suppresses, so a college with 12 cancelled students read as 12 failures.
- A suggestion the merge dropped as ineligible still cleared that row's reason, stripping the only explanation from a row that stayed 未決.
- An unknown reason code rendered 「未分配: undefined」.
- The overlay accepted a ranking item twice where `allocate` rejects it — last-wins collapsed the row and freed its slot twice. Now the same 400.

## Test plan

- [x] Backend: 51 unit + 9 service-level tests in the touched files; **850** in a distribution-wide sweep (`-k "distribution or allocate or roster or college_review"`). New `test_auto_allocate_preview_staged.py` pins the DB-level overlay — the decisive case being `test_a_hand_ticked_row_takes_the_released_slot_and_is_left_alone` (reading the DB instead produces two winners for one slot).
- [x] Frontend: 1413 tests / 101 suites; `tsc --noEmit` clean.
- [x] Lint: `black --check`, `flake8 --select=B904,B014,F401,E501` clean.
- [x] API, old vs new, against a fixture where college C's rank 1 held the pool's only slot, saved:

  | Request | Result |
  |---|---|
  | no overlay *(old behaviour)* | rank 1 not planned for — its slot invisible |
  | both rows 未決 *(unticked)* | rank 1 reclaims the slot; rank 2 → `quota_full` |
  | rank 2 hand-ticked | rank 2 untouched; rank 1 → `quota_full` |

- [x] Browser (Playwright, seeded dev stack): untick → press 預設分發 → **the box ticks immediately**, no save, no reload. Message 「資訊學院：已預設分配 1 筆，另有 1 筆名額不足，請確認後儲存」; rank 2 shows `未分配: 名額不足`. Negative pass: a hand-tick survives the button and is charged to the quota. 全部預設分發 sends no `college_code` with the full overlay. 清空 → 預設分發 sends explicit 未決 rows and re-plans from scratch. Every checkbox reports `disabled: true` mid-run. DB unchanged throughout; no backend errors.

## Notes for the reviewer

- `schema.d.ts` is **+29/−12** — only this endpoint, hand-ported from a real generator run.

  Running `bun run api:generate` against a **local dev container** also rewrites 39 `{[key: string]: unknown}` index signatures to `Record<string, never>` across unrelated schemas — types that mean *empty* object rather than *any* object. That is **not** an `openapi-typescript` problem (lockfile and CI agree on 7.13.0): it is the backend it reads. This dev container's pydantic emits `{"type": "object"}` for those fields where CI's emits `additionalProperties: true`, and the two generate different TypeScript. **CI's backend is the authority.**

  Practical upshot for anyone touching this file: check `git diff --stat frontend/lib/api/generated/schema.d.ts` before staging it — if it is much larger than your endpoint's own hunks, your container's pydantic differs from CI's and you should keep only your hunks. Worth pinning the backend dependency separately so `api:generate` is reproducible.
- Not addressed: `manual_distribution_service.py` is 2789 lines and `ManualDistributionPanel.tsx` 2675, both past the documented 800-line ceiling. Pre-existing; splitting them is not this fix's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GP1bMc9dekS7gSiLX467gN

