### PR TITLE
fix(roster): 造冊人數以「納入造冊」為準，排除原因改用繁體中文

### DIFF
--- a/backend/alembic/versions/roster_counts_included_001.py
+++ b/backend/alembic/versions/roster_counts_included_001.py
@@ -1,0 +1,113 @@
+"""Recompute roster counts from 納入造冊 + 繁中化 exclusion_reason.
+
+# Why
+
+造冊列表 / 造冊詳情 對同一份名單顯示兩個數字：
+
+  - 造冊詳情「納入造冊人數」= COUNT(payment_roster_items.is_included)  → 47
+  - 造冊列表「N 人」= payment_rosters.qualified_count                  → 13
+
+`qualified_count` 產生時是以舊的 `PaymentRosterItem.is_qualified`
+（= 已驗證 + 納入造冊 + **有郵局帳號**）計算，因此缺郵局帳號的學生被算成
+「不合格」並且不計入 total_amount——但他們其實仍在造冊名單內（補件即可撥款）。
+
+程式端已改以 `is_included` 為唯一判準（與 `_recompute_roster_totals_sync`、
+Excel「納入造冊」欄同源）。本 migration 將**既有**造冊的統計欄位重算，
+讓歷史資料與新邏輯一致。
+
+# 同時處理
+
+`exclusion_reason` 過去把英文列舉值直接寫進使用者可見文案
+（`學籍驗證未通過: suspended`）。此處一併改寫為繁體中文
+（`學籍驗證未通過：休學中`），對應 STUDENT_VERIFICATION_STATUS_LABELS。
+
+# Safety
+
+純資料 migration，無 DDL。以 `to_regclass` 檢查資料表存在後才執行，
+在尚未建立造冊資料表的資料庫上為 no-op。downgrade 不還原數字
+（舊值已無法從 items 反推出「有無郵局帳號」以外的資訊），僅還原文案格式。
+
+Revision ID: roster_counts_included_001
+Revises: received_months_ledger_001
+Create Date: 2026-07-28
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "roster_counts_included_001"
+down_revision = "received_months_ledger_001"
+branch_labels = None
+depends_on = None
+
+
+# 英文列舉值 → 繁體中文標籤（對應 app.models.payment_roster
+# .STUDENT_VERIFICATION_STATUS_LABELS）
+_STATUS_LABELS = {
+    "verified": "已驗證",
+    "graduated": "已畢業",
+    "suspended": "休學中",
+    "withdrawn": "已退學",
+    "api_error": "驗證錯誤",
+    "not_found": "查無此人",
+}
+
+_RECOMPUTE_SQL = sa.text("""
+    UPDATE payment_rosters r
+       SET total_applications = s.total_count,
+           qualified_count    = s.included_count,
+           disqualified_count = s.total_count - s.included_count,
+           total_amount       = s.included_amount
+      FROM (
+            SELECT roster_id,
+                   COUNT(*) AS total_count,
+                   COUNT(*) FILTER (WHERE is_included) AS included_count,
+                   COALESCE(
+                       SUM(scholarship_amount) FILTER (WHERE is_included), 0
+                   ) AS included_amount
+              FROM payment_roster_items
+             GROUP BY roster_id
+           ) s
+     WHERE r.id = s.roster_id
+    """)
+
+
+def _tables_exist(bind) -> bool:
+    return all(
+        bind.execute(sa.text("SELECT to_regclass(:t)"), {"t": table}).scalar() is not None
+        for table in ("payment_rosters", "payment_roster_items")
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _tables_exist(bind):
+        return
+
+    for value, label in _STATUS_LABELS.items():
+        bind.execute(
+            sa.text("""
+                UPDATE payment_roster_items
+                   SET exclusion_reason = :new_reason
+                 WHERE exclusion_reason = :old_reason
+                """),
+            {"old_reason": f"學籍驗證未通過: {value}", "new_reason": f"學籍驗證未通過：{label}"},
+        )
+
+    bind.execute(_RECOMPUTE_SQL)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not _tables_exist(bind):
+        return
+
+    for value, label in _STATUS_LABELS.items():
+        bind.execute(
+            sa.text("""
+                UPDATE payment_roster_items
+                   SET exclusion_reason = :new_reason
+                 WHERE exclusion_reason = :old_reason
+                """),
+            {"old_reason": f"學籍驗證未通過：{label}", "new_reason": f"學籍驗證未通過: {value}"},
+        )

--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -27,6 +27,7 @@ from app.models.payment_roster import (
     RosterStatus,
     RosterTriggerType,
     StudentVerificationStatus,
+    verification_status_label,
 )
 from app.models.user import User, UserRole
 from app.schemas.response import ApiResponse
@@ -794,7 +795,7 @@ async def preview_roster_students(
             # Check verification status
             if verification_status != StudentVerificationStatus.VERIFIED:
                 is_included = False
-                exclusion_reason = f"學籍驗證未通過: {verification_status.value}"
+                exclusion_reason = f"學籍驗證未通過：{verification_status_label(verification_status)}"
                 summary["exclusion_breakdown"]["verification_failed"] += 1
 
             # Check eligibility rules
@@ -1331,7 +1332,7 @@ async def get_roster_items(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=500),
     verification_status: Optional[StudentVerificationStatus] = Query(None),
-    is_qualified: Optional[bool] = Query(None),
+    is_included: Optional[bool] = Query(None),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -1358,8 +1359,8 @@ async def get_roster_items(
         # 套用篩選條件
         if verification_status:
             stmt = stmt.where(PaymentRosterItem.verification_status == verification_status)
-        if is_qualified is not None:
-            stmt = stmt.where(PaymentRosterItem.is_qualified == is_qualified)
+        if is_included is not None:
+            stmt = stmt.where(PaymentRosterItem.is_included.is_(is_included))
 
         # 分頁查詢
         stmt = stmt.order_by(PaymentRosterItem.created_at).offset(skip).limit(limit)
@@ -1895,11 +1896,11 @@ async def get_roster_statistics(
             ).scalar()
             verification_stats[status_val.value] = item_count
 
-        # 統計合格/不合格人數
+        # 統計納入造冊/排除人數（與造冊詳情、Excel「納入造冊」欄同源）
         qualified_stmt = (
             select(count())
             .select_from(PaymentRosterItem)
-            .where(PaymentRosterItem.roster_id == roster_id, PaymentRosterItem.is_qualified.is_(True))
+            .where(PaymentRosterItem.roster_id == roster_id, PaymentRosterItem.is_included.is_(True))
         )
         qualified_result = await db.execute(qualified_stmt)
         qualified_count = qualified_result.scalar() or 0
@@ -1907,7 +1908,7 @@ async def get_roster_statistics(
         disqualified_stmt = (
             select(count())
             .select_from(PaymentRosterItem)
-            .where(PaymentRosterItem.roster_id == roster_id, PaymentRosterItem.is_qualified.is_(False))
+            .where(PaymentRosterItem.roster_id == roster_id, PaymentRosterItem.is_included.is_(False))
         )
         disqualified_result = await db.execute(disqualified_stmt)
         disqualified_count = disqualified_result.scalar() or 0

--- a/backend/app/models/payment_roster.py
+++ b/backend/app/models/payment_roster.py
@@ -62,6 +62,24 @@ class StudentVerificationStatus(enum.Enum):
     NOT_FOUND = "not_found"  # 查無此人
 
 
+# 學籍驗證狀態的繁體中文顯示名稱（單一真相來源）。exclusion_reason 會直接呈現在
+# 造冊詳情與 Excel 的「排除原因」欄位，屬使用者可見文案，不得外洩英文列舉值。
+# excel_export_service / student_verification_service 的標籤一律轉呼叫此表。
+STUDENT_VERIFICATION_STATUS_LABELS = {
+    StudentVerificationStatus.VERIFIED: "已驗證",
+    StudentVerificationStatus.GRADUATED: "已畢業",
+    StudentVerificationStatus.SUSPENDED: "休學中",
+    StudentVerificationStatus.WITHDRAWN: "已退學",
+    StudentVerificationStatus.API_ERROR: "驗證錯誤",
+    StudentVerificationStatus.NOT_FOUND: "查無此人",
+}
+
+
+def verification_status_label(status: StudentVerificationStatus) -> str:
+    """取得學籍驗證狀態的繁體中文顯示名稱（未知狀態退回原始值）。"""
+    return STUDENT_VERIFICATION_STATUS_LABELS.get(status, getattr(status, "value", str(status)))
+
+
 # exclusion_reason 前綴：標記「鎖定後手動移除」與「比對分發移除」兩種
 # 人為移除（相對於產生造冊時因資格不符的自動排除）。由 roster_service 寫入、
 # 由 excel_export_service 的審閱視圖過濾——共用同一份常數避免兩端漂移。
@@ -239,7 +257,8 @@ class PaymentRosterItem(Base):
     verification_at = Column(DateTime(timezone=True))  # 驗證時間
     verification_snapshot = Column(JSON)  # 驗證時的完整資料快照
 
-    # 是否納入造冊
+    # 是否納入造冊 — 造冊人數/總金額的唯一判準（Excel「納入造冊」欄同源）。
+    # 缺少郵局帳號「不」影響此旗標：學生補件即可撥款，僅在 Excel 說明欄提醒。
     is_included = Column(Boolean, default=True, nullable=False)
     exclusion_reason = Column(String(500))  # 排除原因
 
@@ -280,17 +299,12 @@ class PaymentRosterItem(Base):
         return f"<PaymentRosterItem(id={self.id}, student={self.student_name}, amount={self.scholarship_amount})>"
 
     @property
-    def is_qualified(self) -> bool:
-        """撥款合格：學籍驗證通過 + 納入造冊 + 有郵局帳號"""
-        return self.verification_status == StudentVerificationStatus.VERIFIED and self.is_included and self.bank_account
-
-    @property
     def is_eligible(self) -> bool | None:
         """規則資格：造冊產生當下的獎學金規則驗證快照判定。
 
-        Distinct from is_qualified (payment readiness) — this reflects the
-        rule engine's verdict frozen at generation time. None when the item
-        predates rule-validation snapshots.
+        Distinct from is_included (whether the row is counted in the roster) —
+        this reflects the rule engine's verdict frozen at generation time.
+        None when the item predates rule-validation snapshots.
         """
         if not self.rule_validation_result:
             return None
@@ -303,7 +317,7 @@ class PaymentRosterItem(Base):
         if not self.is_included:
             remarks.append(f"排除原因: {self.exclusion_reason}")
         elif self.verification_status != StudentVerificationStatus.VERIFIED:
-            remarks.append(f"學籍狀態: {self.verification_status.value}")
+            remarks.append(f"學籍狀態: {verification_status_label(self.verification_status)}")
         elif not self.bank_account:
             remarks.append("缺少郵局帳號資訊")
         else:

--- a/backend/app/schemas/roster.py
+++ b/backend/app/schemas/roster.py
@@ -245,7 +245,7 @@ class RosterItemSummaryResponse(BaseModel):
     student_id_number: str
     scholarship_amount: Decimal
     verification_status: StudentVerificationStatus
-    is_qualified: bool
+    is_included: bool
 
 
 # 統計和報表相關模型

--- a/backend/app/services/excel_export_service.py
+++ b/backend/app/services/excel_export_service.py
@@ -19,6 +19,7 @@ from app.core.config import settings
 from app.core.exceptions import FileStorageError
 from app.models.payment_roster import (
     MANUAL_REMOVAL_PREFIXES,
+    STUDENT_VERIFICATION_STATUS_LABELS,
     PaymentRoster,
     PaymentRosterItem,
     StudentVerificationStatus,
@@ -356,7 +357,7 @@ class ExcelExportService:
                     logger.error(f"Failed to upload Excel file to MinIO: {minio_error}", exc_info=True)
                     logger.warning(f"Excel file remains available locally at: {file_path}")
 
-            qualified_count = sum(1 for item in roster_items if item.is_qualified and item.is_included)
+            qualified_count = sum(1 for item in roster_items if item.is_included)
             disqualified_count = len(roster_items) - qualified_count
 
             logger.info(f"Excel export completed: {file_name} ({file_size} bytes)")
@@ -904,8 +905,8 @@ class ExcelExportService:
                 roster.completed_at.strftime("%Y-%m-%d %H:%M:%S") if roster.completed_at else "",
             ],
             ["總申請數", roster.total_applications or 0],
-            ["合格人數", roster.qualified_count or 0],
-            ["不合格人數", roster.disqualified_count or 0],
+            ["納入造冊人數", roster.qualified_count or 0],
+            ["排除人數", roster.disqualified_count or 0],
             ["總金額", float(roster.total_amount) if roster.total_amount else 0],
             ["學籍驗證啟用", "是" if roster.student_verification_enabled else "否"],
             ["API失敗次數", roster.verification_api_failures or 0],
@@ -993,16 +994,13 @@ class ExcelExportService:
         return "; ".join(remarks)
 
     def _get_verification_status_label(self, status) -> str:
-        """取得驗證狀態標籤"""
-        labels = {
-            "verified": "已驗證",
-            "graduated": "已畢業",
-            "suspended": "休學中",
-            "withdrawn": "已退學",
-            "api_error": "驗證錯誤",
-            "not_found": "查無此人",
-        }
-        return labels.get(status.value if hasattr(status, "value") else str(status), str(status))
+        """取得驗證狀態標籤。文案取自 STUDENT_VERIFICATION_STATUS_LABELS
+        （單一真相來源），此處僅負責 enum/字串兩種輸入的正規化。"""
+        raw = status.value if hasattr(status, "value") else str(status)
+        for member, label in STUDENT_VERIFICATION_STATUS_LABELS.items():
+            if member.value == raw:
+                return label
+        return str(status)
 
     def _calculate_file_hash(self, file_path: str) -> str:
         """計算檔案SHA256雜湊值"""

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -32,6 +32,7 @@ from app.models.payment_roster import (
     RosterStatus,
     RosterTriggerType,
     StudentVerificationStatus,
+    verification_status_label,
 )
 from app.models.roster_audit import RosterAuditAction, RosterAuditLevel, RosterAuditLog
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipRule
@@ -367,7 +368,9 @@ class RosterService:
                         roster, application, verification_result, verification_status, eligibility_result
                     )
 
-                    if roster_item.is_qualified:
+                    # 統計以「納入造冊」為準，與 Excel 的「納入造冊」欄、
+                    # 造冊詳情的「納入造冊人數」及 _recompute_roster_totals_sync 同源
+                    if roster_item.is_included:
                         qualified_count += 1
                         total_amount += roster_item.scholarship_amount
                     else:
@@ -416,7 +419,7 @@ class RosterService:
             audit_service.log_roster_operation(
                 roster_id=roster.id,
                 action=RosterAuditAction.CREATE,
-                title=f"造冊資料產生: 合格{qualified_count}人, 不合格{disqualified_count}人",
+                title=f"造冊資料產生: 納入造冊{qualified_count}人, 排除{disqualified_count}人",
                 user_id=created_by_user_id,
                 user_name=user_name,
                 description=f"造冊資料產生完成，總金額: ${total_amount}，API失敗: {verification_failures}次",
@@ -482,7 +485,7 @@ class RosterService:
             actual_total = sum(
                 item.scholarship_amount
                 for item in roster.items
-                if item.is_included and item.is_qualified and item.scholarship_amount is not None
+                if item.is_included and item.scholarship_amount is not None
             )
             if abs(float(actual_total) - float(roster.total_amount)) > 0.01:
                 errors.append(f"總金額不一致: 計算值={actual_total}, 儲存值={roster.total_amount}")
@@ -809,7 +812,7 @@ class RosterService:
 
         # 1. 檢查學籍驗證狀態
         if verification_status != StudentVerificationStatus.VERIFIED:
-            exclusion_reasons.append(f"學籍驗證未通過: {verification_status.value}")
+            exclusion_reasons.append(f"學籍驗證未通過：{verification_status_label(verification_status)}")
         # 2. 檢查獎學金規則符合性
         elif eligibility_result and not eligibility_result.get("is_eligible", True):
             failed_rules = eligibility_result.get("failed_rules", [])
@@ -817,8 +820,9 @@ class RosterService:
                 exclusion_reasons.append(f"不符合獎學金規則: {'; '.join(failed_rules)}")
             else:
                 exclusion_reasons.append("不符合獎學金資格條件")
-        # 3. 擷取銀行帳戶資訊（僅作快照與提醒用，「缺少銀行帳戶」不構成排除原因：
-        #    學生補件後即可撥款；撥款合格與否由 is_qualified 屬性另行把關）
+        # 3. 擷取銀行帳戶資訊（僅作快照與提醒用，「缺少銀行帳戶」不構成排除原因，
+        #    也不影響造冊人數／總金額：學生補件後即可撥款。缺帳號僅在 Excel
+        #    說明欄提示「缺少郵局帳號資訊」，供承辦人催補件）
         # IMPORTANT: Support both nested (schema-compliant) and flat (legacy) data structures
         form_data = application.submitted_form_data or {}
         form_fields = form_data.get("fields", {})
@@ -1844,7 +1848,8 @@ class RosterService:
                     roster, application, verification_result, verification_status, eligibility_result
                 )
 
-                if roster_item.is_qualified:
+                # 同 generate_roster：統計以「納入造冊」為準
+                if roster_item.is_included:
                     qualified_count += 1
                     total_amount += roster_item.scholarship_amount
                 else:
@@ -1893,7 +1898,7 @@ class RosterService:
         audit_service.log_roster_operation(
             roster_id=roster.id,
             action=RosterAuditAction.CREATE,
-            title=f"批次造冊產生: {sub_type} {allocation_year}年度 合格{qualified_count}人",
+            title=f"批次造冊產生: {sub_type} {allocation_year}年度 納入造冊{qualified_count}人",
             user_id=created_by_user_id,
             user_name=user_name,
             description=f"計畫編號: {project_number or '未設定'}，總金額: ${total_amount}",

--- a/backend/app/services/student_verification_service.py
+++ b/backend/app/services/student_verification_service.py
@@ -13,7 +13,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 from app.core.config import settings
 from app.core.exceptions import StudentVerificationError
-from app.models.payment_roster import StudentVerificationStatus
+from app.models.payment_roster import STUDENT_VERIFICATION_STATUS_LABELS, StudentVerificationStatus
 
 logger = logging.getLogger(__name__)
 
@@ -431,14 +431,8 @@ class StudentVerificationService:
         取得驗證狀態的顯示標籤
         """
         labels = {
-            "zh": {
-                StudentVerificationStatus.VERIFIED: "已驗證",
-                StudentVerificationStatus.GRADUATED: "已畢業",
-                StudentVerificationStatus.SUSPENDED: "休學中",
-                StudentVerificationStatus.WITHDRAWN: "已退學",
-                StudentVerificationStatus.API_ERROR: "驗證錯誤",
-                StudentVerificationStatus.NOT_FOUND: "查無此人",
-            },
+            # zh 文案取自 STUDENT_VERIFICATION_STATUS_LABELS（單一真相來源）
+            "zh": STUDENT_VERIFICATION_STATUS_LABELS,
             "en": {
                 StudentVerificationStatus.VERIFIED: "Verified",
                 StudentVerificationStatus.GRADUATED: "Graduated",

--- a/backend/app/tests/test_excel_export_generate_remarks.py
+++ b/backend/app/tests/test_excel_export_generate_remarks.py
@@ -98,10 +98,10 @@ def test_excluded_with_reason_includes_reason(service):
     """Pin: when is_included=False AND exclusion_reason is set, the reason
     surfaces in the remarks. This is the auditor's primary signal for
     "why didn't this student get paid?"."""
-    item = _make_item(is_included=False, exclusion_reason="學籍驗證未通過: graduated")
+    item = _make_item(is_included=False, exclusion_reason="學籍驗證未通過：已畢業")
     roster = _make_roster()
     result = service._generate_remarks(item, roster)
-    assert "排除原因: 學籍驗證未通過: graduated" in result
+    assert "排除原因: 學籍驗證未通過：已畢業" in result
 
 
 def test_excluded_without_reason_omits_reason_label(service):

--- a/backend/app/tests/test_excel_export_service_rows.py
+++ b/backend/app/tests/test_excel_export_service_rows.py
@@ -356,7 +356,7 @@ def test_is_manual_removal_detects_lock_and_reconcile_prefixes(service):
         is True
     )
     assert (
-        service._is_manual_removal(_mk_scope_item("c", is_included=False, exclusion_reason="學籍驗證未通過: graduated"))
+        service._is_manual_removal(_mk_scope_item("c", is_included=False, exclusion_reason="學籍驗證未通過：已畢業"))
         is False
     )
     assert service._is_manual_removal(_mk_scope_item("d", is_included=True, exclusion_reason=None)) is False
@@ -364,7 +364,7 @@ def test_is_manual_removal_detects_lock_and_reconcile_prefixes(service):
 
 def test_get_roster_items_default_keeps_auto_excluded_hides_manual(service):
     included = _mk_scope_item("納入", is_included=True)
-    auto_excluded = _mk_scope_item("自動排除", is_included=False, exclusion_reason="學籍驗證未通過: graduated")
+    auto_excluded = _mk_scope_item("自動排除", is_included=False, exclusion_reason="學籍驗證未通過：已畢業")
     manual = _mk_scope_item("手動移除", is_included=False, exclusion_reason="鎖定後移除[停發]：x")
     roster = SimpleNamespace(items=[included, auto_excluded, manual])
 
@@ -490,7 +490,7 @@ def test_unverified_and_excluded_and_missing_bank_fills_red(service):
     item = _make_item(student_name="乙", bank_account=None, is_included=False)
     item.verification_status = "graduated"
     item.is_eligible = False
-    item.exclusion_reason = "學籍驗證未通過: graduated"
+    item.exclusion_reason = "學籍驗證未通過：已畢業"
 
     rows, fills = service._prepare_excel_data(roster, [item], [])
 
@@ -498,7 +498,7 @@ def test_unverified_and_excluded_and_missing_bank_fills_red(service):
     assert r["學籍驗證"] == "已畢業"
     assert r["規則資格"] == "不符合"
     assert r["納入造冊"] == "否"
-    assert r["排除原因"] == "學籍驗證未通過: graduated"
+    assert r["排除原因"] == "學籍驗證未通過：已畢業"
     assert f["學籍驗證"] == "red"
     assert f["規則資格"] == "red"
     assert f["帳號"] == "red"
@@ -560,7 +560,7 @@ def test_create_excel_file_writes_headers_and_fills(service, tmp_path):
     item = _make_item(student_name="甲", bank_account=None, is_included=False)
     item.verification_status = "withdrawn"
     item.is_eligible = False
-    item.exclusion_reason = "學籍驗證未通過: withdrawn"
+    item.exclusion_reason = "學籍驗證未通過：已退學"
     item.rule_validation_result = {
         "is_eligible": False,
         "details": {"rule_3": {"passed": False, "rule_name": "GPA", "is_hard_rule": True}},

--- a/backend/app/tests/test_payment_roster_model.py
+++ b/backend/app/tests/test_payment_roster_model.py
@@ -2,22 +2,22 @@
 Pure-property tests for `PaymentRoster` and `PaymentRosterItem` models.
 
 These drive the payment workflow — the LAST gate before money moves.
-A `is_qualified` regression would either:
-- Pay students with un-verified accounts → bank kicks the file back,
-  delay
-- Block qualified students → finance team support ticket flood
+`is_included` is the single judgement that decides who is on the roster,
+how many people it reports and how much money it totals; a regression
+would either drop qualified students off the payment file or inflate the
+declared total.
 
 The lock-state transitions are immutability invariants: a locked
 roster MUST NOT be re-locked (would overwrite the `locked_by`
 attribution → audit-trail forgery).
 
-8 helpers / properties covered:
+7 helpers / properties covered:
 - `PaymentRoster.is_locked / can_be_modified / is_completed`
 - `PaymentRoster.lock()`
 - `PaymentRoster.generate_excel_filename()`
-- `PaymentRosterItem.is_qualified`
 - `PaymentRosterItem.is_eligible`
 - `PaymentRosterItem.generate_excel_remarks()`
+- `verification_status_label()`
 """
 
 import re
@@ -26,10 +26,12 @@ from datetime import datetime, timezone
 import pytest
 
 from app.models.payment_roster import (
+    STUDENT_VERIFICATION_STATUS_LABELS,
     PaymentRoster,
     PaymentRosterItem,
     RosterStatus,
     StudentVerificationStatus,
+    verification_status_label,
 )
 
 
@@ -130,28 +132,22 @@ def test_excel_filename_format():
     assert re.search(r"_\d{8}_\d{6}\.xlsx$", fn)
 
 
-# ─── PaymentRosterItem.is_qualified ────────────────────────────────
+# ─── verification_status_label ─────────────────────────────────────
 
 
-def test_is_qualified_all_conditions():
-    """All three must hold: VERIFIED + is_included + bank_account."""
-    assert _item().is_qualified
+def test_verification_status_labels_are_traditional_chinese():
+    """exclusion_reason / Excel 欄位直接顯示這些標籤，不得外洩英文列舉值
+    (e.g. `學籍驗證未通過: suspended`)。"""
+    for status in StudentVerificationStatus:
+        label = verification_status_label(status)
+        assert label != status.value
+        assert not re.search(r"[A-Za-z_]", label)
 
 
-def test_is_qualified_false_when_not_verified():
-    assert not _item(verification_status=StudentVerificationStatus.GRADUATED).is_qualified
-    assert not _item(verification_status=StudentVerificationStatus.WITHDRAWN).is_qualified
-
-
-def test_is_qualified_false_when_not_included():
-    """Explicit exclusion blocks payment."""
-    assert not _item(is_included=False).is_qualified
-
-
-def test_is_qualified_false_when_no_bank_account():
-    """Missing bank account blocks payment (can't wire money to nowhere)."""
-    assert not _item(bank_account=None).is_qualified
-    assert not _item(bank_account="").is_qualified
+def test_verification_status_label_covers_every_member():
+    """A new StudentVerificationStatus member without a label would leak
+    its raw value into the UI — pin the map's completeness."""
+    assert set(STUDENT_VERIFICATION_STATUS_LABELS) == set(StudentVerificationStatus)
 
 
 # ─── PaymentRosterItem.is_eligible ─────────────────────────────────
@@ -171,12 +167,14 @@ def test_is_eligible_reflects_snapshot_verdict():
     assert _item(rule_validation_result={"is_eligible": False, "failed_rules": []}).is_eligible is False
 
 
-def test_is_eligible_distinct_from_is_qualified():
-    """規則資格 (is_eligible) vs 撥款合格 (is_qualified): a student can
-    pass the scholarship rules yet be unpayable (no bank account)."""
+def test_missing_bank_account_stays_included():
+    """規則資格 (is_eligible) 與納入造冊 (is_included) 都不受郵局帳號影響：
+    缺帳號是可補件的行政缺漏，不得把學生踢出造冊名單/人數/總金額。
+    提醒僅出現在 Excel 說明欄。"""
     item = _item(bank_account=None, rule_validation_result={"is_eligible": True})
     assert item.is_eligible is True
-    assert not item.is_qualified
+    assert item.is_included is True
+    assert "缺少郵局帳號資訊" in item.generate_excel_remarks("2024-09", "PHD")
 
 
 # ─── PaymentRosterItem.generate_excel_remarks ──────────────────────
@@ -202,10 +200,11 @@ def test_excel_remarks_excluded_shows_reason():
 
 
 def test_excel_remarks_unverified_shows_verification_status():
-    """Verification failure → status value (e.g. 'graduated') in remarks."""
+    """Verification failure → 繁體中文 status label in remarks (never the
+    raw enum value — the 說明欄 is承辦人-facing)."""
     item = _item(verification_status=StudentVerificationStatus.GRADUATED)
     remarks = item.generate_excel_remarks("2024-09", "PHD")
-    assert "學籍狀態: graduated" in remarks
+    assert "學籍狀態: 已畢業" in remarks
 
 
 def test_excel_remarks_missing_bank_account_flagged():

--- a/backend/app/tests/test_roster_service_core.py
+++ b/backend/app/tests/test_roster_service_core.py
@@ -228,9 +228,8 @@ def test_create_roster_item_included_when_bank_account_present(service: RosterSe
 def test_create_roster_item_included_when_bank_account_missing(service: RosterService) -> None:
     """No bank account anywhere in submitted_form_data ⇒ the student is STILL
     included in the roster (is_included=True, no exclusion_reason) — a missing
-    account is a fixable補件 issue, not an eligibility problem. Payment
-    readiness is gated separately by `is_qualified`, which stays False until
-    the account is filled in."""
+    account is a fixable補件 issue, not an eligibility problem, so it must not
+    shrink 造冊人數/總金額 either. The only trace is the Excel 說明欄 reminder."""
     roster = _make_roster()
     application = _make_application(bank_account=None)
 
@@ -245,14 +244,14 @@ def test_create_roster_item_included_when_bank_account_missing(service: RosterSe
     assert item.is_included is True
     assert item.exclusion_reason is None
     assert item.bank_account == ""
-    assert not item.is_qualified  # 撥款仍被擋，直到補齊帳戶
 
 
 def test_create_roster_item_excluded_when_verification_failed(service: RosterService) -> None:
     """A non-VERIFIED status (graduated, suspended, withdrawn, api_error,
     not_found) excludes the student regardless of bank account presence.
-    Pin: the exclusion_reason explicitly includes the failed status's
-    .value so operators can see which kind of failure occurred."""
+    Pin: the exclusion_reason names the failed status in 繁體中文 so
+    operators can see which kind of failure occurred — the raw enum value
+    (`graduated`) must never reach the UI/Excel."""
     roster = _make_roster()
     application = _make_application(bank_account="00012345678")
 
@@ -265,7 +264,8 @@ def test_create_roster_item_excluded_when_verification_failed(service: RosterSer
     )
 
     assert item.is_included is False
-    assert "graduated" in item.exclusion_reason
+    assert item.exclusion_reason == "學籍驗證未通過：已畢業"
+    assert "graduated" not in item.exclusion_reason
     assert item.verification_status == StudentVerificationStatus.GRADUATED
 
 

--- a/backend/app/tests/test_roster_validate_consistency.py
+++ b/backend/app/tests/test_roster_validate_consistency.py
@@ -36,14 +36,14 @@ def service():
 def _make_item(
     *,
     is_included=True,
-    is_qualified=True,
+    bank_account="0001234567",
     scholarship_amount=1000,
     student_id_number="A123456789",
     student_name="王小明",
 ):
     return SimpleNamespace(
         is_included=is_included,
-        is_qualified=is_qualified,
+        bank_account=bank_account,
         scholarship_amount=scholarship_amount,
         student_id_number=student_id_number,
         student_name=student_name,
@@ -160,14 +160,15 @@ def test_excluded_items_not_summed(service):
     assert not any("總金額不一致" in e for e in result["errors"])
 
 
-def test_unqualified_items_not_summed(service):
-    """Pin: is_qualified=False items NOT summed (even if is_included=True).
-    The two flags are AND-gated for inclusion in the financial total."""
+def test_missing_bank_account_still_summed(service):
+    """Pin: 缺郵局帳號的學生仍計入總金額 — is_included 是唯一判準。
+    造冊詳情「納入造冊人數/總金額」、Excel「納入造冊」欄與此驗證同源，
+    任何額外的 AND-gate 都會讓三者再度對不起來。"""
     items = [
-        _make_item(is_included=True, is_qualified=True, scholarship_amount=1000),
-        _make_item(is_included=True, is_qualified=False, scholarship_amount=99999),
+        _make_item(is_included=True, scholarship_amount=1000),
+        _make_item(is_included=True, bank_account=None, scholarship_amount=1000),
     ]
-    roster = _make_roster(items=items, qualified_count=1, disqualified_count=1, total_amount=1000)
+    roster = _make_roster(items=items, qualified_count=2, disqualified_count=0, total_amount=2000)
     result = service.validate_roster_consistency(roster)
     assert not any("總金額不一致" in e for e in result["errors"])
 

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -1392,7 +1392,7 @@ export function ManualDistributionPanel({
                     </span>
                   )}
                   <span className="text-blue-600">
-                    合格 {r.qualified_count} 人，${r.total_amount}
+                    納入造冊 {r.qualified_count} 人，${r.total_amount}
                   </span>
                 </div>
               ))}

--- a/frontend/e2e/specs/roster-admin.spec.ts
+++ b/frontend/e2e/specs/roster-admin.spec.ts
@@ -117,7 +117,7 @@ test.describe("Admin roster management flows @nightly", () => {
 
     const res = await apiAs<{
       success: boolean;
-      data: Array<{ id: number; is_qualified: boolean | null }>;
+      data: Array<{ id: number; is_included: boolean }>;
     }>(login.token, "GET", `/payment-rosters/${rosterId}/items`);
     pushTrace(runState, res.traceId);
 
@@ -129,11 +129,11 @@ test.describe("Admin roster management flows @nightly", () => {
     expect(Array.isArray(res.body.data)).toBe(true);
 
     if (res.body.data.length > 0) {
-      // Every item must expose the is_qualified flag (may be null when
-      // student_verification_enabled=false and GPA rules don't apply).
+      // Every item must expose is_included — it is the single flag that
+      // decides 造冊人數/總金額 in both the list and the detail dialog.
       for (const item of res.body.data) {
         expect(typeof item.id).toBe("number");
-        expect("is_qualified" in item).toBe(true);
+        expect(typeof item.is_included).toBe("boolean");
       }
       // Stash for the exclude test.
       excludedItemId = res.body.data[0].id;

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -21458,7 +21458,7 @@ export interface operations {
                 skip?: number;
                 limit?: number;
                 verification_status?: components["schemas"]["StudentVerificationStatus"] | null;
-                is_qualified?: boolean | null;
+                is_included?: boolean | null;
             };
             header?: never;
             path: {

--- a/frontend/lib/api/modules/payment-rosters.ts
+++ b/frontend/lib/api/modules/payment-rosters.ts
@@ -218,7 +218,7 @@ export function createPaymentRostersApi() {
       params?: {
         skip?: number;
         limit?: number;
-        is_qualified?: boolean | null;
+        is_included?: boolean | null;
       }
     ): Promise<ApiResponse<unknown>> => {
       const response = await typedClient.raw.GET(


### PR DESCRIPTION
## 問題

造冊列表顯示「13 人 / \$520,000」，但同一份造冊的詳情與 Excel「納入造冊」欄是「47 人 / \$1,880,000」。稽核紀錄也寫成「合格13人, 不合格39人」。

另外，排除原因把英文列舉值直接顯示給使用者：`學籍驗證未通過: suspended`。

## Root cause

系統裡同時存在兩套「誰在造冊名單上」的定義：

| 位置 | 判準 | 結果 |
|---|---|---|
| 造冊詳情「納入造冊人數」、Excel「納入造冊」欄、`_recompute_roster_totals_sync`（增/刪/回復後重算） | `is_included` | 47 |
| 造冊產生時寫入 `payment_rosters.qualified_count` / `total_amount` | `is_qualified` = 已驗證 **+ 納入造冊 + 有郵局帳號** | 13 |

`_create_roster_item` 的註解早已寫明「缺少銀行帳戶不構成排除原因（學生補件後即可撥款）」，但實際存下來的統計仍套用了這道 gate — 34 位沒填郵局帳號的學生被算成不合格，他們的 \$1,360,000 也從總金額中消失。

## 修改

- **移除 `PaymentRosterItem.is_qualified`。** `is_included` 成為造冊人數／總金額的唯一判準，套用於 `generate_roster`、批次分發→造冊路徑、`validate_roster_consistency`、Excel 統計與 statistics endpoint。缺郵局帳號只保留 Excel 說明欄的「缺少郵局帳號資訊」提醒。
- **順帶修掉兩個潛在 bug**：`is_qualified` 是純 Python property，所以 `GET /items?is_qualified=` 實際編譯成 `WHERE false`（永遠查不到東西），而 `/statistics` 會在 `.is_()` 上丟 `AttributeError`。兩處改用真正的 `is_included` 欄位，query param 一併更名為 `is_included`。
- **排除原因繁體中文化**：`學籍驗證未通過: suspended` → `學籍驗證未通過：休學中`。在 enum 旁新增 `STUDENT_VERIFICATION_STATUS_LABELS` 作為單一真相來源，原本 `excel_export_service` / `student_verification_service` 兩份重複的標籤表改為轉呼叫它。Excel 統計頁的「合格/不合格人數」改為「納入造冊/排除人數」。
- **資料 migration `roster_counts_included_001`**：對既有造冊由 items 重算 `qualified_count` / `disqualified_count` / `total_amount`，並改寫已存進 DB 的英文排除原因。純資料異動、無 DDL，資料表不存在時為 no-op。

## Test plan

- [x] Backend 全套測試：**4879 passed, 2 skipped**
- [x] Migration 在全新 Postgres DB 上 `upgrade head` 成功，且 `downgrade -1 && upgrade head` 對既有資料驗證過：一筆存成 1/2/\$40,000 的造冊重算為 2/1/\$80,000，排除原因同時被翻成中文
- [x] `black --check` / `flake8 --select=B904,B014,F401,E501` / `tsc --noEmit` 全部乾淨
- [x] 更新了 pin 舊語意的測試（`test_payment_roster_model`、`test_roster_validate_consistency`、`test_roster_service_core`）與帶英文排除原因的 Excel fixtures
- [ ] 人工驗證：重新產生一份造冊，確認列表人數 == 造冊詳情「納入造冊人數」== Excel「納入造冊」筆數，且排除原因顯示中文

### 注意事項

`schema.d.ts` 只手動改了 query param 更名那一行，沒有整份重跑 generator — 本機的 `openapi-typescript` 版本與 repo 內既有檔案不一致，重跑會產生約 130 行無關的 `Record<string, never>` / `Format: binary` 差異。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019dwh2AGxV5jvERBw91SH1Z
