### PR TITLE
fix(application-detail): show 指導教授 values and stop 郵局帳號 duplicating

### DIFF
--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -364,6 +364,11 @@ class ApplicationResponse(BaseModel):
     postal_account: Optional[str] = Field(
         None, description="郵局帳號（來自學生 UserProfile.account_number，非 submitted_form_data）"
     )
+    # 指導教授資訊與郵局帳號一樣存放在 UserProfile（申請精靈的固定欄位區塊），
+    # 表單設定卻把它們列為 advisor_* 固定欄位，因此表單資料頁需要從這裡取值。
+    advisor_name: Optional[str] = Field(None, description="指導教授姓名（來自學生 UserProfile）")
+    advisor_email: Optional[str] = Field(None, description="指導教授Email（來自學生 UserProfile）")
+    advisor_nycu_id: Optional[str] = Field(None, description="指導教授本校人事編號（來自學生 UserProfile）")
 
     # === Academic Organization ===
     academy_code: Optional[str] = None  # std_academyno / trm_academyno

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -259,6 +259,27 @@ class ApplicationService:
             **student_fields,  # Spread extracted student fields
         )
 
+    async def _load_profile_owned_fields(self, user_id: int) -> Dict[str, Optional[str]]:
+        """讀取存放在 UserProfile 的固定欄位（郵局帳號、指導教授資訊）。
+
+        申請精靈把這幾個欄位存進 UserProfile 而非 submitted_form_data，但表單設定
+        (ApplicationFieldService.inject_fixed_fields) 仍會把它們列為 postal_account /
+        advisor_* 固定欄位。前端表單資料頁若只看 submitted_form_data，這些欄位一律
+        顯示「未填寫」，所以由這裡把權威值一併帶進 ApplicationResponse。
+
+        No profile row yet (student has never saved the section) → all None.
+        """
+        from app.models.user_profile import UserProfile
+
+        result = await self.db.execute(select(UserProfile).where(UserProfile.user_id == user_id))
+        profile = result.scalar_one_or_none()
+        return {
+            "postal_account": profile.account_number if profile else None,
+            "advisor_name": profile.advisor_name if profile else None,
+            "advisor_email": profile.advisor_email if profile else None,
+            "advisor_nycu_id": profile.advisor_nycu_id if profile else None,
+        }
+
     def _convert_semester_to_string(self, semester) -> Optional[str]:
         """
         Convert semester to string format for schema validation
@@ -906,13 +927,10 @@ class ApplicationService:
         if not student_fields.get("student_no") and application.student:
             student_fields["student_no"] = application.student.nycu_id
 
-        # 郵局帳號 lives on the student's UserProfile (student self-service and
-        # batch import both write it there — never into submitted_form_data).
-        from app.models.user_profile import UserProfile
-
-        profile_result = await self.db.execute(select(UserProfile).where(UserProfile.user_id == application.user_id))
-        student_profile = profile_result.scalar_one_or_none()
-        postal_account = student_profile.account_number if student_profile else None
+        # 郵局帳號 and 指導教授資訊 live on the student's UserProfile (the wizard's
+        # fixed-field section and batch import both write them there — never into
+        # submitted_form_data), so every form-data view has to read them from here.
+        profile_owned_fields = await self._load_profile_owned_fields(application.user_id)
 
         # Build sub_type labels from scholarship.sub_type_configs
         sub_type_labels = {}
@@ -997,7 +1015,7 @@ class ApplicationService:
             "scholarship_name": scholarship_name,
             "amount": amount,
             "currency": currency,
-            "postal_account": postal_account,
+            **profile_owned_fields,  # 郵局帳號 + 指導教授資訊 (UserProfile-owned)
             **student_fields,  # Spread extracted student fields
             # Workflow configuration flags
             "requires_professor_recommendation": bool(

--- a/backend/app/tests/test_application_service_core.py
+++ b/backend/app/tests/test_application_service_core.py
@@ -31,6 +31,7 @@ from app.models.application import Application, ApplicationStatus
 from app.models.enums import ReviewStage
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
 from app.models.user import User, UserRole, UserType
+from app.models.user_profile import UserProfile
 from app.schemas.application import ApplicationFormData, ApplicationUpdate, DynamicFormField
 from app.services.application_service import ApplicationService
 
@@ -278,6 +279,54 @@ async def test_get_nonexistent_application_returns_none(db: AsyncSession, silenc
     result = await service.get_application_by_id(999_999, student)
 
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_application_by_id — UserProfile-owned fixed fields. 郵局帳號 and the
+# 指導教授 trio are form-config fields (ApplicationFieldService injects them)
+# that the wizard writes to UserProfile, never into submitted_form_data, so
+# the detail response is the only place a form-data view can read them. Losing
+# them here makes every one of those fields render as「未填寫」.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_exposes_profile_owned_fixed_fields(db: AsyncSession, silence_collaborators):
+    student = await _seed_user(db, role=UserRole.student, name="S", nycu_id="s_get_prof")
+    cfg = await _seed_config(db, suffix="get_prof")
+    app = await _seed_app(db, student=student, config=cfg, status=ApplicationStatus.submitted.value, suffix="get_prof")
+    db.add(
+        UserProfile(
+            user_id=student.id,
+            account_number="12341234123412",
+            advisor_name="王老師",
+            advisor_email="advisor@nycu.edu.tw",
+            advisor_nycu_id="A12345",
+        )
+    )
+    await db.commit()
+    service = ApplicationService(db)
+
+    result = await service.get_application_by_id(app.id, student)
+
+    assert result.postal_account == "12341234123412"
+    assert result.advisor_name == "王老師"
+    assert result.advisor_email == "advisor@nycu.edu.tw"
+    assert result.advisor_nycu_id == "A12345"
+
+
+@pytest.mark.asyncio
+async def test_get_profile_owned_fields_are_none_without_profile(db: AsyncSession, silence_collaborators):
+    """A student who never saved the fixed-field section has no UserProfile row."""
+    student = await _seed_user(db, role=UserRole.student, name="S", nycu_id="s_get_noprof")
+    cfg = await _seed_config(db, suffix="get_noprof")
+    app = await _seed_app(db, student=student, config=cfg, status=ApplicationStatus.draft.value, suffix="get_noprof")
+    service = ApplicationService(db)
+
+    result = await service.get_application_by_id(app.id, student)
+
+    assert result.postal_account is None
+    assert result.advisor_name is None
+    assert result.advisor_email is None
+    assert result.advisor_nycu_id is None
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/components/__tests__/application-form-data-display.test.tsx
+++ b/frontend/components/__tests__/application-form-data-display.test.tsx
@@ -397,6 +397,56 @@ describe("ApplicationFormDataDisplay", () => {
       });
     });
 
+    it("does not merge fields the scholarship's form config never declared", async () => {
+      // 指導教授 fields are only injected when the scholarship requires
+      // professor review; a profile filled in for another scholarship must not
+      // add them to this application's form data.
+      const application = {
+        advisor_name: "王老師",
+        postal_account: "12341234123412",
+        submitted_form_data: {
+          fields: { contact_phone: { value: "0987878978" } },
+        },
+      };
+
+      render(
+        <ApplicationFormDataDisplay
+          formData={application}
+          locale="zh"
+          fieldLabels={{
+            postal_account: { zh: "郵局帳號", en: "Post Office Account" },
+          }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("12341234123412")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("王老師")).not.toBeInTheDocument();
+    });
+
+    it("still reports 無表單資料 when nothing was submitted", async () => {
+      // A profile value alone is not evidence the student filled a form in.
+      const application = {
+        postal_account: "12341234123412",
+        advisor_name: "王老師",
+        submitted_form_data: { fields: {} },
+      };
+
+      render(
+        <ApplicationFormDataDisplay
+          formData={application}
+          locale="zh"
+          fieldLabels={fixedFieldLabels}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("無表單資料")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("12341234123412")).not.toBeInTheDocument();
+    });
+
     it("prefers the submitted snapshot over the current profile value", async () => {
       const application = {
         postal_account: "99999999999999",

--- a/frontend/components/__tests__/application-form-data-display.test.tsx
+++ b/frontend/components/__tests__/application-form-data-display.test.tsx
@@ -290,6 +290,136 @@ describe("ApplicationFormDataDisplay", () => {
     // (not currently testing async behavior since it depends on timing)
   });
 
+  // The 郵局帳號 / 指導教授 fixed fields are in every scholarship's form config
+  // but live on the student's UserProfile, so the detail response — not
+  // submitted_form_data — is where their values come from. See
+  // `lib/utils/profile-owned-fields.ts`.
+  describe("UserProfile-owned fixed fields", () => {
+    const fixedFieldLabels = {
+      postal_account: { zh: "郵局帳號", en: "Post Office Account" },
+      advisor_name: { zh: "指導教授姓名", en: "Advisor Name" },
+      advisor_email: { zh: "指導教授Email", en: "Advisor Email" },
+      advisor_nycu_id: { zh: "指導教授本校人事編號", en: "Advisor NYCU ID" },
+    };
+
+    it("renders 郵局帳號 once when the submitted snapshot uses the account_number alias", async () => {
+      const application = {
+        postal_account: "12341234123412",
+        submitted_form_data: {
+          fields: { account_number: { value: "12341234123412" } },
+        },
+      };
+
+      render(
+        <ApplicationFormDataDisplay
+          formData={application}
+          locale="zh"
+          fieldLabels={fixedFieldLabels}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByText("郵局帳號")).toHaveLength(1);
+        expect(screen.getByText("12341234123412")).toBeInTheDocument();
+      });
+    });
+
+    it("renders 郵局帳號 once when the snapshot stores both synonyms", async () => {
+      // Submissions from the older wizard carry postal_account AND
+      // account_number, both holding the one account the student typed.
+      const application = {
+        submitted_form_data: {
+          fields: {
+            postal_account: { value: "12341234123412" },
+            account_number: { value: "12341234123412" },
+          },
+        },
+      };
+
+      render(
+        <ApplicationFormDataDisplay
+          formData={application}
+          locale="zh"
+          fieldLabels={fixedFieldLabels}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByText("郵局帳號")).toHaveLength(1);
+        expect(screen.getAllByText("12341234123412")).toHaveLength(1);
+      });
+    });
+
+    it("renders 指導教授 values from the application instead of 未填寫", async () => {
+      const application = {
+        advisor_name: "王老師",
+        advisor_email: "advisor@nycu.edu.tw",
+        advisor_nycu_id: "A12345",
+        submitted_form_data: {
+          fields: { contact_phone: { value: "0987878978" } },
+        },
+      };
+
+      render(
+        <ApplicationFormDataDisplay
+          formData={application}
+          locale="zh"
+          fieldLabels={fixedFieldLabels}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("王老師")).toBeInTheDocument();
+        expect(screen.getByText("advisor@nycu.edu.tw")).toBeInTheDocument();
+        expect(screen.getByText("A12345")).toBeInTheDocument();
+        // Only 郵局帳號 is genuinely unfilled here.
+        expect(screen.getAllByText("未填寫")).toHaveLength(1);
+      });
+    });
+
+    it("still shows 未填寫 when the student never filled the section in", async () => {
+      const application = {
+        submitted_form_data: {
+          fields: { contact_phone: { value: "0987878978" } },
+        },
+      };
+
+      render(
+        <ApplicationFormDataDisplay
+          formData={application}
+          locale="zh"
+          fieldLabels={fixedFieldLabels}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByText("未填寫")).toHaveLength(4);
+      });
+    });
+
+    it("prefers the submitted snapshot over the current profile value", async () => {
+      const application = {
+        postal_account: "99999999999999",
+        submitted_form_data: {
+          fields: { account_number: { value: "12341234123412" } },
+        },
+      };
+
+      render(
+        <ApplicationFormDataDisplay
+          formData={application}
+          locale="zh"
+          fieldLabels={fixedFieldLabels}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("12341234123412")).toBeInTheDocument();
+        expect(screen.queryByText("99999999999999")).not.toBeInTheDocument();
+      });
+    });
+  });
+
   it("should handle malformed form data gracefully", async () => {
     const formData = {
       submitted_form_data: {

--- a/frontend/components/application-detail-dialog.tsx
+++ b/frontend/components/application-detail-dialog.tsx
@@ -502,6 +502,11 @@ export function ApplicationDetailDialog({
     // and 郵局帳號 gets rendered a second time in the 申請表單欄位 card.
     const assignField = (rawFieldId: string, value: any) => {
       const fieldId = canonicalizeFieldId(rawFieldId);
+      // First writer wins, matching ApplicationFormDataDisplay — otherwise a
+      // legacy submission carrying both synonyms could resolve to a different
+      // account here than in the 動態申請欄位 card.
+      if (fieldId in dynamicFields || fieldId in basicFields) return;
+
       if (applicationFields.includes(fieldId)) {
         dynamicFields[fieldId] = value;
       } else {

--- a/frontend/components/application-detail-dialog.tsx
+++ b/frontend/components/application-detail-dialog.tsx
@@ -46,6 +46,7 @@ import {
   formatFieldName,
   formatDisplayValue,
 } from "@/lib/utils/application-helpers";
+import { canonicalizeFieldId } from "@/lib/utils/profile-owned-fields";
 import { useReferenceData, getDegreeName } from "@/hooks/use-reference-data";
 import {
   getAcademyName,
@@ -496,10 +497,25 @@ export function ApplicationDetailDialog({
     const dynamicFields: Record<string, any> = {};
     const basicFields: Record<string, any> = {};
 
-    // 處理後端的 submitted_form_data.fields 結構
-    if (formData.submitted_form_data && formData.submitted_form_data.fields) {
-      // 後端結構：{ submitted_form_data: { fields: { field_id: { value: "..." } } } }
-      Object.entries(formData.submitted_form_data.fields).forEach(
+    // 郵局帳號 is submitted as `account_number` but the form config calls it
+    // `postal_account`; without canonicalizing it counts as an extra「基本欄位」
+    // and 郵局帳號 gets rendered a second time in the 申請表單欄位 card.
+    const assignField = (rawFieldId: string, value: any) => {
+      const fieldId = canonicalizeFieldId(rawFieldId);
+      if (applicationFields.includes(fieldId)) {
+        dynamicFields[fieldId] = value;
+      } else {
+        basicFields[fieldId] = value;
+      }
+    };
+
+    // 後端結構：{ submitted_form_data: { fields: { field_id: { value: "..." } } } }
+    // 或已展開的 { fields: ... }
+    const wrappedFields =
+      formData.submitted_form_data?.fields || formData.fields;
+
+    if (wrappedFields) {
+      Object.entries(wrappedFields).forEach(
         ([fieldId, fieldData]: [string, any]) => {
           if (
             fieldData &&
@@ -513,36 +529,7 @@ export function ApplicationDetailDialog({
               fieldId !== "files" &&
               fieldId !== "agree_terms"
             ) {
-              if (applicationFields.includes(fieldId)) {
-                dynamicFields[fieldId] = value;
-              } else {
-                basicFields[fieldId] = value;
-              }
-            }
-          }
-        }
-      );
-    } else if (formData.fields) {
-      // 直接處理 fields 結構
-      Object.entries(formData.fields).forEach(
-        ([fieldId, fieldData]: [string, any]) => {
-          if (
-            fieldData &&
-            typeof fieldData === "object" &&
-            "value" in fieldData
-          ) {
-            const value = fieldData.value;
-            if (
-              value &&
-              value !== "" &&
-              fieldId !== "files" &&
-              fieldId !== "agree_terms"
-            ) {
-              if (applicationFields.includes(fieldId)) {
-                dynamicFields[fieldId] = value;
-              } else {
-                basicFields[fieldId] = value;
-              }
+              assignField(fieldId, value);
             }
           }
         }
@@ -559,11 +546,7 @@ export function ApplicationDetailDialog({
           return;
         }
 
-        if (applicationFields.includes(key)) {
-          dynamicFields[key] = value;
-        } else {
-          basicFields[key] = value;
-        }
+        assignField(key, value);
       });
     }
 

--- a/frontend/components/application-form-data-display.tsx
+++ b/frontend/components/application-form-data-display.tsx
@@ -9,6 +9,67 @@ import {
   formatFieldName,
   formatFieldValue,
 } from "@/lib/utils/application-helpers";
+import {
+  canonicalizeFieldId,
+  collectProfileOwnedFieldValues,
+} from "@/lib/utils/profile-owned-fields";
+
+interface ApplicationFormDataDisplayProps {
+  formData:
+    | Record<string, any>
+    | {
+        form_data?: Record<string, any>;
+        submitted_form_data?: Record<string, any>;
+        fields?: Record<string, any>;
+      };
+  locale: Locale;
+  fieldLabels?: { [key: string]: { zh?: string; en?: string } };
+}
+
+// Never rendered as form data: `files` is upload bookkeeping and `agree_terms`
+// has its own consent row in the dialog.
+const EXCLUDED_FIELD_IDS = new Set(["files", "agree_terms"]);
+
+/**
+ * The values to show for one application: the submitted dynamic fields (with the
+ * 郵局帳號 synonyms collapsed onto one id) plus the fixed fields that live on the
+ * student's UserProfile instead of `submitted_form_data`. Without the second
+ * source, 郵局帳號 renders twice (once filled, once「未填寫」) and the whole
+ * 指導教授 section renders as「未填寫」— see `profile-owned-fields.ts`.
+ */
+const collectDisplayValues = (
+  formData: ApplicationFormDataDisplayProps["formData"]
+): Record<string, unknown> => {
+  const values: Record<string, unknown> = {};
+  const fields =
+    (formData as { submitted_form_data?: { fields?: Record<string, unknown> } })
+      ?.submitted_form_data?.fields || {};
+
+  Object.entries(fields).forEach(([fieldId, fieldData]) => {
+    if (!fieldData || typeof fieldData !== "object" || !("value" in fieldData)) {
+      return;
+    }
+    const value = (fieldData as { value: unknown }).value;
+    if (value === null || value === undefined || value === "") return;
+    if (EXCLUDED_FIELD_IDS.has(fieldId)) return;
+
+    // Older submissions store the account under both synonyms; keep the first
+    // one so the rendered value doesn't depend on JSON key order.
+    const canonicalId = canonicalizeFieldId(fieldId);
+    if (canonicalId in values) return;
+    values[canonicalId] = value;
+  });
+
+  Object.entries(
+    collectProfileOwnedFieldValues(formData as Record<string, unknown>)
+  ).forEach(([fieldId, value]) => {
+    // A submitted snapshot wins over the current profile: it is what the
+    // student sent with this application.
+    if (!(fieldId in values)) values[fieldId] = value;
+  });
+
+  return values;
+};
 
 // 獲取欄位標籤（優先使用動態標籤，後備使用靜態標籤）
 const getFieldLabel = (
@@ -36,18 +97,6 @@ const getFieldLabel = (
   return fallbackLabel;
 };
 
-interface ApplicationFormDataDisplayProps {
-  formData:
-    | Record<string, any>
-    | {
-        form_data?: Record<string, any>;
-        submitted_form_data?: Record<string, any>;
-        fields?: Record<string, any>;
-      };
-  locale: Locale;
-  fieldLabels?: { [key: string]: { zh?: string; en?: string } };
-}
-
 export function ApplicationFormDataDisplay({
   formData,
   locale,
@@ -56,80 +105,29 @@ export function ApplicationFormDataDisplay({
   const [formattedData, setFormattedData] = useState<Record<string, any>>({});
   const [isLoading, setIsLoading] = useState(true);
 
-  // Debug logging
-
-    logger.debug(
-    "📋 fields 是物件:",
-    typeof formData?.submitted_form_data?.fields === "object"
-  );
-  logger.debug(
-    "📋 fields 鍵值:",
-    formData?.submitted_form_data?.fields
-      ? Object.keys(formData.submitted_form_data.fields)
-      : "N/A"
-  );
-  logger.debug(
-    "📋 原始 fields 物件:",
-    formData?.submitted_form_data?.fields
-  );
-  logger.debug("🏷️ 接收到的 fieldLabels:", fieldLabels);
   logger.debug(
     "🏷️ fieldLabels 鍵值:",
     fieldLabels ? Object.keys(fieldLabels) : "沒有標籤"
   );
 
-
-    if (formData?.submitted_form_data) {
-
-  }
-
   useEffect(() => {
     const formatData = async () => {
       setIsLoading(true);
-      const formatted: Record<string, any> = {};
+      const formatted = collectDisplayValues(formData);
 
-      // 只處理新格式：submitted_form_data.fields
-      const fields = formData?.submitted_form_data?.fields || {};
-
-
-      logger.debug("🔄 Processing fields:", fields);
-      logger.debug("🔄 Fields entries count:", Object.entries(fields).length);
-      logger.debug("🔄 All field keys:", Object.keys(fields));
-
-      for (const [fieldId, fieldData] of Object.entries(fields)) {
-        if (
-          fieldData &&
-          typeof fieldData === "object" &&
-          "value" in fieldData
-        ) {
-          const value = (fieldData as { value: unknown }).value;
-
-          // 跳過空值、files 欄位和 agree_terms
-          if (
-            value !== null &&
-            value !== undefined &&
-            value !== "" &&
-            fieldId !== "files" &&
-            fieldId !== "agree_terms"
-          ) {
-            if (fieldId === "scholarship_type") {
-              try {
-                formatted[fieldId] = await formatFieldValue(
-                  fieldId,
-                  value,
-                  locale
-                );
-              } catch (error) {
-                logger.warn(
-                  `Failed to format scholarship type: ${value}`,
-                  error
-                );
-                formatted[fieldId] = value;
-              }
-            } else {
-              formatted[fieldId] = value;
-            }
-          }
+      // scholarship_type stores the code — resolve it to the scholarship's name.
+      if (formatted.scholarship_type !== undefined) {
+        try {
+          formatted.scholarship_type = await formatFieldValue(
+            "scholarship_type",
+            formatted.scholarship_type,
+            locale
+          );
+        } catch (error) {
+          logger.warn(
+            `Failed to format scholarship type: ${formatted.scholarship_type}`,
+            error
+          );
         }
       }
 
@@ -142,24 +140,8 @@ export function ApplicationFormDataDisplay({
   }, [formData, locale]);
 
   if (isLoading) {
-    // 處理載入狀態的顯示
-    const dataToShow: Record<string, any> = {};
-    const fields = formData?.submitted_form_data?.fields || {};
-
-    Object.entries(fields).forEach(([fieldId, fieldData]: [string, any]) => {
-      if (fieldData && typeof fieldData === "object" && "value" in fieldData) {
-        const value = fieldData.value;
-        if (
-          value !== null &&
-          value !== undefined &&
-          value !== "" &&
-          fieldId !== "files" &&
-          fieldId !== "agree_terms"
-        ) {
-          dataToShow[fieldId] = value;
-        }
-      }
-    });
+    // 處理載入狀態的顯示（scholarship_type 尚未解析成名稱）
+    const dataToShow = collectDisplayValues(formData);
 
     // 如果沒有表單資料，顯示訊息
     if (Object.keys(dataToShow).length === 0) {
@@ -239,9 +221,9 @@ export function ApplicationFormDataDisplay({
       })}
 
       {/* 顯示 fieldLabels 中存在但 formattedData 中沒有值的字段 */}
-      {fieldLabels && Object.entries(fieldLabels).map(([fieldName, labels]) => {
-        // 如果這個字段已經在 formattedData 中，跳過
-        if (fieldName in formattedData) {
+      {fieldLabels && Object.entries(fieldLabels).map(([fieldName]) => {
+        // 如果這個字段已經在 formattedData 中，跳過（郵局帳號的同義 id 也算）
+        if (canonicalizeFieldId(fieldName) in formattedData) {
           return null;
         }
 

--- a/frontend/components/application-form-data-display.tsx
+++ b/frontend/components/application-form-data-display.tsx
@@ -30,14 +30,8 @@ interface ApplicationFormDataDisplayProps {
 // has its own consent row in the dialog.
 const EXCLUDED_FIELD_IDS = new Set(["files", "agree_terms"]);
 
-/**
- * The values to show for one application: the submitted dynamic fields (with the
- * 郵局帳號 synonyms collapsed onto one id) plus the fixed fields that live on the
- * student's UserProfile instead of `submitted_form_data`. Without the second
- * source, 郵局帳號 renders twice (once filled, once「未填寫」) and the whole
- * 指導教授 section renders as「未填寫」— see `profile-owned-fields.ts`.
- */
-const collectDisplayValues = (
+/** What the student actually submitted, with the 郵局帳號 synonyms collapsed. */
+const collectSubmittedValues = (
   formData: ApplicationFormDataDisplayProps["formData"]
 ): Record<string, unknown> => {
   const values: Record<string, unknown> = {};
@@ -60,12 +54,36 @@ const collectDisplayValues = (
     values[canonicalId] = value;
   });
 
+  return values;
+};
+
+/**
+ * The submitted values plus the fixed fields that live on the student's
+ * UserProfile instead of `submitted_form_data` — without them 郵局帳號 renders
+ * twice (once filled, once「未填寫」) and the 指導教授 block renders entirely as
+ * 「未填寫」. See `profile-owned-fields.ts`.
+ *
+ * Only fields the scholarship's own form config declares (`fieldLabels`) are
+ * merged: the backend injects the 指導教授 trio only when the scholarship
+ * requires professor review, and an application that never asked for those
+ * fields must not sprout them from a profile filled in for another scholarship.
+ */
+const withProfileOwnedFields = (
+  submittedValues: Record<string, unknown>,
+  formData: ApplicationFormDataDisplayProps["formData"],
+  fieldLabels?: ApplicationFormDataDisplayProps["fieldLabels"]
+): Record<string, unknown> => {
+  const values = { ...submittedValues };
+  if (!fieldLabels) return values;
+
   Object.entries(
     collectProfileOwnedFieldValues(formData as Record<string, unknown>)
   ).forEach(([fieldId, value]) => {
+    if (!(fieldId in fieldLabels)) return;
     // A submitted snapshot wins over the current profile: it is what the
     // student sent with this application.
-    if (!(fieldId in values)) values[fieldId] = value;
+    if (fieldId in values) return;
+    values[fieldId] = value;
   });
 
   return values;
@@ -113,7 +131,11 @@ export function ApplicationFormDataDisplay({
   useEffect(() => {
     const formatData = async () => {
       setIsLoading(true);
-      const formatted = collectDisplayValues(formData);
+      const formatted = withProfileOwnedFields(
+        collectSubmittedValues(formData),
+        formData,
+        fieldLabels
+      );
 
       // scholarship_type stores the code — resolve it to the scholarship's name.
       if (formatted.scholarship_type !== undefined) {
@@ -137,55 +159,13 @@ export function ApplicationFormDataDisplay({
     };
 
     formatData();
-  }, [formData, locale]);
+  }, [formData, locale, fieldLabels]);
 
-  if (isLoading) {
-    // 處理載入狀態的顯示（scholarship_type 尚未解析成名稱）
-    const dataToShow = collectDisplayValues(formData);
+  const submittedValues = collectSubmittedValues(formData);
 
-    // 如果沒有表單資料，顯示訊息
-    if (Object.keys(dataToShow).length === 0) {
-      return (
-        <div className="text-center py-8">
-          <p className="text-sm text-muted-foreground">
-            {locale === "zh" ? "無表單資料" : "No form data"}
-          </p>
-        </div>
-      );
-    }
-
-    return (
-      <div className="space-y-3">
-        {Object.entries(dataToShow).map(([key, value]) => {
-          return (
-            <div
-              key={key}
-              className="flex items-start justify-between p-3 bg-slate-50 rounded-lg"
-            >
-              <div className="flex-1">
-                <Label className="text-sm font-medium text-gray-700">
-                  {getFieldLabel(key, locale, fieldLabels)}
-                </Label>
-                <p className="text-sm text-gray-600 mt-1">
-                  {key === "scholarship_type"
-                    ? "載入中..."
-                    : (() => {
-                        const rendered = formatDisplayValue(value);
-                        return rendered.length > 100
-                          ? `${rendered.substring(0, 100)}...`
-                          : rendered;
-                      })()}
-                </p>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
-
-  // 如果沒有表單資料，顯示訊息
-  if (Object.keys(formattedData).length === 0) {
+  // 「無表單資料」只看學生送出的欄位：UserProfile 來源的固定欄位是補充資訊，
+  // 有 profile 不代表這份申請填過表單。
+  if (Object.keys(submittedValues).length === 0) {
     return (
       <div className="text-center py-8">
         <p className="text-sm text-muted-foreground">
@@ -195,9 +175,14 @@ export function ApplicationFormDataDisplay({
     );
   }
 
+  // 載入中時先顯示未解析的值（scholarship_type 仍在查名稱）。
+  const dataToShow = isLoading
+    ? withProfileOwnedFields(submittedValues, formData, fieldLabels)
+    : formattedData;
+
   return (
     <div className="space-y-3">
-      {Object.entries(formattedData).map(([key, value]) => {
+      {Object.entries(dataToShow).map(([key, value]) => {
         return (
           <div
             key={key}
@@ -208,22 +193,24 @@ export function ApplicationFormDataDisplay({
                 {getFieldLabel(key, locale, fieldLabels)}
               </Label>
               <p className="text-sm text-gray-600 mt-1">
-                {(() => {
-                  const rendered = formatDisplayValue(value);
-                  return rendered.length > 100
-                    ? `${rendered.substring(0, 100)}...`
-                    : rendered;
-                })()}
+                {isLoading && key === "scholarship_type"
+                  ? "載入中..."
+                  : (() => {
+                      const rendered = formatDisplayValue(value);
+                      return rendered.length > 100
+                        ? `${rendered.substring(0, 100)}...`
+                        : rendered;
+                    })()}
               </p>
             </div>
           </div>
         );
       })}
 
-      {/* 顯示 fieldLabels 中存在但 formattedData 中沒有值的字段 */}
+      {/* 顯示 fieldLabels 中存在但 dataToShow 中沒有值的字段 */}
       {fieldLabels && Object.entries(fieldLabels).map(([fieldName]) => {
-        // 如果這個字段已經在 formattedData 中，跳過（郵局帳號的同義 id 也算）
-        if (canonicalizeFieldId(fieldName) in formattedData) {
+        // 如果這個字段已經顯示過，跳過（郵局帳號的同義 id 也算）
+        if (canonicalizeFieldId(fieldName) in dataToShow) {
           return null;
         }
 

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -170,6 +170,10 @@ export interface Application {
   student_no?: string;
   /** 郵局帳號 (from the student's UserProfile.account_number, not submitted_form_data) */
   postal_account?: string | null;
+  /** 指導教授資訊 (from the student's UserProfile, not submitted_form_data) */
+  advisor_name?: string | null;
+  advisor_email?: string | null;
+  advisor_nycu_id?: string | null;
   student_termcount?: number;
   gpa?: number;
   department?: string;

--- a/frontend/lib/utils/application-helpers.ts
+++ b/frontend/lib/utils/application-helpers.ts
@@ -299,6 +299,13 @@ export const formatFieldName = (fieldName: string, locale: Locale) => {
     contact_address: locale === "zh" ? "通訊地址" : "Contact Address",
     bank_account: locale === "zh" ? "銀行帳戶" : "Bank Account",
     account_number: locale === "zh" ? "郵局帳號" : "Post Office Account",
+    // Fixed fields injected into every form config (see the backend's
+    // FIXED_FIELD_LABELS) — needed as a fallback when the config fails to load.
+    postal_account: locale === "zh" ? "郵局帳號" : "Post Office Account",
+    advisor_name: locale === "zh" ? "指導教授姓名" : "Advisor Name",
+    advisor_email: locale === "zh" ? "指導教授Email" : "Advisor Email",
+    advisor_nycu_id:
+      locale === "zh" ? "指導教授本校人事編號" : "Advisor NYCU ID",
     research_proposal: locale === "zh" ? "研究計畫" : "Research Proposal",
     budget_plan: locale === "zh" ? "預算規劃" : "Budget Plan",
     milestone_plan: locale === "zh" ? "里程碑規劃" : "Milestone Plan",

--- a/frontend/lib/utils/profile-owned-fields.ts
+++ b/frontend/lib/utils/profile-owned-fields.ts
@@ -1,0 +1,60 @@
+/**
+ * The form-config fields that are NOT stored in `submitted_form_data`.
+ *
+ * `ApplicationFieldService.inject_fixed_fields` adds 郵局帳號 (`postal_account`)
+ * and the 指導教授 trio (`advisor_*`) to every scholarship's form config, but the
+ * application wizard collects them in a dedicated section that writes to the
+ * student's UserProfile — they never become `submitted_form_data.fields` entries.
+ * A form-data view that only reads the submitted fields therefore renders all
+ * four as「未填寫」. The backend carries the authoritative values on the
+ * application detail response (see `ApplicationResponse.postal_account` /
+ * `.advisor_*`); this module maps them back onto their field ids.
+ */
+
+/** field id in the form config -> property on the application detail response. */
+export const PROFILE_OWNED_FIELD_SOURCES: Readonly<Record<string, string>> = {
+  postal_account: "postal_account",
+  advisor_name: "advisor_name",
+  advisor_email: "advisor_email",
+  advisor_nycu_id: "advisor_nycu_id",
+};
+
+/**
+ * The ids that carry the one 郵局帳號 a student typed — the form config calls it
+ * `postal_account`, while the wizard folds the same value into the submitted
+ * fields as `account_number` (for the bank-verification service). Both resolve
+ * to the label 郵局帳號, so rendering them separately shows the field twice.
+ * Mirrors `ACCOUNT_FIELD_SYNONYMS` in `backend/app/services/form_field_labels.py`.
+ */
+export const CANONICAL_ACCOUNT_FIELD_ID = "postal_account";
+const ACCOUNT_FIELD_SYNONYMS = new Set([
+  CANONICAL_ACCOUNT_FIELD_ID,
+  "account_number",
+]);
+
+/** Collapse the 郵局帳號 synonyms onto one id; every other id is unchanged. */
+export const canonicalizeFieldId = (fieldId: string): string =>
+  ACCOUNT_FIELD_SYNONYMS.has(fieldId) ? CANONICAL_ACCOUNT_FIELD_ID : fieldId;
+
+/**
+ * Pull the UserProfile-owned field values off an application detail payload.
+ * Empty/missing values are dropped so the caller still renders「未填寫」for a
+ * student who never filled the section in.
+ */
+export const collectProfileOwnedFieldValues = (
+  application: Record<string, unknown> | null | undefined
+): Record<string, string> => {
+  const values: Record<string, string> = {};
+  if (!application) return values;
+
+  Object.entries(PROFILE_OWNED_FIELD_SOURCES).forEach(
+    ([fieldId, sourceKey]) => {
+      const value = application[sourceKey];
+      if (typeof value === "string" && value.trim() !== "") {
+        values[fieldId] = value;
+      }
+    }
+  );
+
+  return values;
+};


### PR DESCRIPTION
## Problem

在學生送出申請後開啟「查看詳細」，申請欄位區塊出現：

- **郵局帳號 顯示兩次** — 一次有值、一次「未填寫」
- **指導教授姓名 / Email / 本校人事編號 全部顯示「未填寫」**（實際上學生已填過）

## Root cause

`ApplicationFieldService.inject_fixed_fields` 會把 `postal_account` 與
`advisor_name` / `advisor_email` / `advisor_nycu_id` 加進每個獎學金的表單設定，
但申請精靈的固定欄位區塊是把這些值寫進學生的 **UserProfile**，不會寫進
`submitted_form_data`。表單資料頁對「表單設定裡有、submitted_form_data 裡沒有」
的欄位一律顯示「未填寫」，於是：

- 精靈另外把帳號以同義 id `account_number` 折進送出的欄位（供銀行驗證使用），
  所以 `account_number` 有值、`postal_account`「未填寫」→ 郵局帳號重複。
- 指導教授三個欄位只存在於 UserProfile → 全部「未填寫」。

## Fix

**Backend** — `get_application_by_id` 除了既有的 `postal_account` 之外，一併回傳
UserProfile 上的指導教授資訊（新增 `_load_profile_owned_fields`，仍是同一次查詢）。

**Frontend** — 新增 `lib/utils/profile-owned-fields.ts`，把這些回應欄位對回它們的
表單欄位 id，並將郵局帳號的同義 id 收斂成一個（對應後端的 `ACCOUNT_FIELD_SYNONYMS`）。
`application-form-data-display.tsx` 合併這些權威值並消除重複列；
`application-detail-dialog.tsx` 的動態/基本欄位切分也做同樣收斂，避免郵局帳號在
「申請表單欄位」卡片再出現一次。

合併時只採用**該獎學金表單設定實際宣告的欄位**（指導教授欄位僅在需要教授審核時注入），
避免在沒有這些欄位的申請上憑其他獎學金留下的 profile 長出多餘欄位；
「無表單資料」也僅以學生送出的欄位判斷。已送出的快照優先於目前的 profile 值。

## Test plan

- [x] Backend：`app/tests` 中 `-k application` 共 752 passed，含兩個新測試
      （有/無 UserProfile 兩種情況的固定欄位回傳）
- [x] Backend lint：black + flake8 `B904,B014` clean
- [x] Frontend：`components/__tests__` 全數通過，新增 7 個案例
      （只有 alias、同時存在兩個同義 id、指導教授值、確實未填、未宣告欄位不合併、
      無送出欄位仍顯示無表單資料、快照優先於 profile）
- [x] Frontend：`tsc --noEmit` 與 eslint clean
- [x] 以 dev 資料庫實跑回應建構：`APP-114-0-00001`（即問題畫面的資料形狀）現在
      回傳 postal `12341234123412`、advisor `tes / professor@nycu.edu.tw / professor`，
      且 phd 表單設定確實宣告了這四個固定欄位
- [ ] 未在瀏覽器實測：dev stack 目前掛載於另一個 worktree（`feat-import-received-months`），
      未動它以免影響其他工作

註：這些端點回傳純 dict（無 `response_model`），`ApplicationResponse` 不在 OpenAPI
spec 內，因此 `schema.d.ts` 不需重新產生。

🤖 Generated with [Claude Code](https://claude.com/claude-code)