### PR TITLE
feat(manual-distribution): gridlines + 總名額 column on the college quota matrix

### DIFF
--- a/frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
+++ b/frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
@@ -126,12 +126,12 @@ export function CollegeQuotaMatrix({
         </span>
       </div>
       <div className="p-3 overflow-x-auto">
-        <table className="w-full text-xs">
+        <table className="w-full text-xs border-collapse border border-slate-300">
           <thead>
-            <tr className="text-slate-500">
+            <tr className="text-slate-500 bg-slate-50">
               <th
                 scope="col"
-                className="text-left font-medium py-1.5 pr-3 whitespace-nowrap"
+                className="text-left font-medium py-1.5 px-2 whitespace-nowrap border border-slate-300"
               >
                 學院
               </th>
@@ -139,7 +139,7 @@ export function CollegeQuotaMatrix({
                 <th
                   key={col.key}
                   scope="col"
-                  className="text-center font-medium py-1.5 px-2 whitespace-nowrap"
+                  className="text-center font-medium py-1.5 px-2 whitespace-nowrap border border-slate-300"
                 >
                   {col.display_name}
                   {!col.is_own && (
@@ -149,53 +149,88 @@ export function CollegeQuotaMatrix({
                   )}
                 </th>
               ))}
+              <th
+                scope="col"
+                className="text-center font-medium py-1.5 px-2 whitespace-nowrap border border-slate-300 bg-slate-100 text-slate-600"
+              >
+                總名額
+              </th>
             </tr>
           </thead>
           <tbody>
-            {collegeRows.map(code => (
-              <tr key={code || "__unknown__"} className="border-t border-slate-100">
-                <th
-                  scope="row"
-                  className="text-left py-1.5 pr-3 font-medium text-slate-700 whitespace-nowrap"
-                >
-                  {resolveCollegeName(collegeNames, code)}
-                </th>
-                {cols.map(col => {
-                  const colColleges = byColKey[col.key];
-                  const delta = localDelta[cellKey(code, col.key)] ?? 0;
-                  // Synthesize a 0/0 cell when a matrix column only has
-                  // staged allocations for this college (no server entry).
-                  const entry =
-                    colColleges?.[code] ??
-                    (colColleges != null && delta !== 0
-                      ? ZERO_QUOTA_CELL
-                      : undefined);
-                  if (!entry) {
+            {collegeRows.map(code => {
+              const rowCells = cols.map(col => {
+                const colColleges = byColKey[col.key];
+                const delta = localDelta[cellKey(code, col.key)] ?? 0;
+                // Synthesize a 0/0 cell when a matrix column only has
+                // staged allocations for this college (no server entry).
+                const entry =
+                  colColleges?.[code] ??
+                  (colColleges != null && delta !== 0
+                    ? ZERO_QUOTA_CELL
+                    : undefined);
+                return { col, entry, delta };
+              });
+              const rowTotal = rowCells.reduce(
+                (acc, { entry }) => acc + (entry?.total ?? 0),
+                0
+              );
+              const rowRemaining = rowCells.reduce(
+                (acc, { entry, delta }) =>
+                  acc + (entry ? entry.remaining - delta : 0),
+                0
+              );
+              return (
+                <tr key={code || "__unknown__"}>
+                  <th
+                    scope="row"
+                    className="text-left py-1.5 px-2 font-medium text-slate-700 whitespace-nowrap border border-slate-300"
+                  >
+                    {resolveCollegeName(collegeNames, code)}
+                  </th>
+                  {rowCells.map(({ col, entry, delta }) => {
+                    if (!entry) {
+                      return (
+                        <td
+                          key={col.key}
+                          className="py-1.5 px-2 text-center text-slate-300 border border-slate-300"
+                        >
+                          —
+                        </td>
+                      );
+                    }
+                    const liveRemaining = entry.remaining - delta;
+                    const tone =
+                      liveRemaining < 0
+                        ? "text-red-600 font-bold"
+                        : liveRemaining === 0
+                          ? "text-slate-400"
+                          : "text-[#003d7a] font-semibold";
                     return (
-                      <td key={col.key} className="py-1.5 px-2 text-center text-slate-300">
-                        —
+                      <td
+                        key={col.key}
+                        className={`py-1.5 px-2 text-center font-mono tabular-nums border border-slate-300 ${tone}`}
+                        title={`總額 ${entry.total}・已儲存核配 ${entry.allocated}`}
+                      >
+                        {liveRemaining}/{entry.total}
                       </td>
                     );
-                  }
-                  const liveRemaining = entry.remaining - delta;
-                  const tone =
-                    liveRemaining < 0
-                      ? "text-red-600 font-bold"
-                      : liveRemaining === 0
-                        ? "text-slate-400"
-                        : "text-[#003d7a] font-semibold";
-                  return (
-                    <td
-                      key={col.key}
-                      className={`py-1.5 px-2 text-center font-mono tabular-nums ${tone}`}
-                      title={`總額 ${entry.total}・已儲存核配 ${entry.allocated}`}
-                    >
-                      {liveRemaining}/{entry.total}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
+                  })}
+                  <td
+                    className={`py-1.5 px-2 text-center font-mono tabular-nums border border-slate-300 bg-slate-50 ${
+                      rowRemaining < 0
+                        ? "text-red-600 font-bold"
+                        : rowRemaining === 0
+                          ? "text-slate-400"
+                          : "text-[#003d7a] font-bold"
+                    }`}
+                    title={`本學院各欄位加總：剩餘 ${rowRemaining}・總額 ${rowTotal}`}
+                  >
+                    {rowRemaining}/{rowTotal}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary

Two display-only changes to the **各學院剩餘名額** matrix on 獎學金分發 (admin manual distribution):

- **Gridlines on every column and row.** The table previously drew only row separators, so with several sub-type × config columns visible it was easy to lose track of which column a number belonged to. Every `<th>`/`<td>` now carries a border (`border-collapse` on the table), and the header row gets a light fill.
- **New trailing `總名額` column.** Shows the per-college row total in the same `剩餘/總額` form as the other cells — it sums each visible column's `total` and its *live* remaining (server remaining minus the unsaved staged delta), so it reacts to checkbox changes exactly like the individual cells. Same tone rules apply (red when over-allocated, grey at 0), bolded and tinted so it reads as a summary, with a tooltip spelling out the aggregate.

Cells with no quota entry still render `—` and contribute 0 to the total, so a college present in only one column totals correctly.

No API, schema, or quota-logic changes — `CollegeQuotaMatrix.tsx` only.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Dev stack (main checkout) → 獎學金分發 → confirm the matrix renders as a full grid and `總名額` matches the sum of the row's columns
- [ ] Toggle allocation checkboxes → `總名額` moves in step with the individual cells
- [ ] Over-allocate a college → both the offending cell and `總名額` turn red
- [ ] A college with quota in only one column → `—` cells ignored, total equals that one column