### PR TITLE
feat(manual-distribution): 各學院子類別名額改為硬性上限

### DIFF
--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -22,6 +22,7 @@ from app.models.enums import ApplicationStatus, ReviewStage
 from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.payment_roster import PaymentRoster, PaymentRosterItem, RosterStatus
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipSubTypeConfig
+from app.models.student import Academy
 from app.models.user import User, UserRole
 from app.services.received_months_service import (
     calculate_received_months_bulk_async,
@@ -941,13 +942,14 @@ class ManualDistributionService:
         cfg: ScholarshipConfiguration | None,
         sub_type: str,
     ) -> dict[str, dict[str, int]] | None:
-        """Per-college quota grid for one (config, sub_type) column (advisory).
+        """Per-college quota grid for one (config, sub_type) column.
 
         None for non-matrix configs (no per-college split exists). Colleges
         appear when they have quota > 0 in the matrix OR live consumers;
-        remaining is NOT clamped — negative flags over-allocation in the UI.
-        The enforced gate stays the global per-(config, sub_type) recount in
-        _assert_round_not_oversubscribed.
+        remaining is NOT clamped — a negative value means the college is
+        already over its cell, which _assert_round_not_oversubscribed rejects
+        on the next allocate/finalize/restore (per-college quota is a hard cap,
+        not a display hint).
         """
         if cfg is None or not cfg.has_college_quota:
             return None
@@ -1519,7 +1521,8 @@ class ManualDistributionService:
         # Server-side quota enforcement is net-new (spec §10): the lock gate in
         # allocate/finalize (_assert_round_not_oversubscribed) recounts remaining
         # under SELECT FOR UPDATE on the consumed config rows and rejects
-        # oversubscription. The frontend remaining counts are advisory.
+        # oversubscription — both the global pool AND each college's own cell of
+        # quotas[sub_type]. The frontend counts only mirror it; the gate decides.
 
     async def _resolve_allocating_apps(
         self, allocations: list[dict[str, Any]]
@@ -2413,6 +2416,12 @@ class ManualDistributionService:
         round (own + every linked source across every sub_type), recount remaining
         via §6.2, and reject if any consumed config is oversubscribed.
 
+        Two caps are enforced, both hard:
+          1. the GLOBAL per-(config, sub_type) pool, and
+          2. for matrix configs (has_college_quota), the PER-COLLEGE cell of that
+             sub_type — 每個學院的子類別名額 is its own ceiling, so a college may
+             not be over-filled even while the global pool still has slots left.
+
         Flushes pending allocation writes FIRST so the recount sees them (autoflush
         is off on this session, so the just-written items would otherwise be
         invisible to the count queries)."""
@@ -2438,8 +2447,62 @@ class ManualDistributionService:
 
         for cfg in locked_rows:
             for sub_type in (cfg.quotas or {}).keys():
-                if await self.remaining(cfg, sub_type) < 0:
+                if not cfg.has_college_quota:
+                    # No per-college split exists — the global pool is the only cap.
+                    if await self.remaining(cfg, sub_type) < 0:
+                        raise ValueError(f"配額超額：{cfg.config_code} / {sub_type} 的核配數已超過總配額，請調整分發")
+                    continue
+                # One pass for BOTH caps. sum(by_college) == consumers_count is a
+                # tripwire-tested invariant (the two share _winner_filters /
+                # _renewal_filters), so the global recount is derivable from the
+                # per-college split — no second pair of count queries on the hot
+                # 儲存 path just to ask the same question at a coarser grain.
+                consumers = await self.consumers_by_college(cfg.id, sub_type)
+                if self.pool_total(cfg, sub_type) - sum(consumers.values()) < 0:
                     raise ValueError(f"配額超額：{cfg.config_code} / {sub_type} 的核配數已超過總配額，請調整分發")
+                await self._assert_college_quotas_not_exceeded(cfg, sub_type, consumers)
+
+    async def _assert_college_quotas_not_exceeded(
+        self, cfg: ScholarshipConfiguration, sub_type: str, consumers: dict[str, int]
+    ) -> None:
+        """Per-college half of the §10 gate: no college may exceed its own cell of
+        `quotas[sub_type]` — the same numbers the 各學院剩餘名額 grid renders.
+
+        `consumers` is the caller's consumers_by_college result (the SAME two-half
+        partition as the global recount, so the two gates can never disagree about
+        who consumes what). A college that is absent from the matrix — an unmapped
+        學院代碼, or a student whose snapshot carries no std_academyno — has a cell
+        of 0, so allocating into it is over-allocation too; that is the allocation
+        auto-分發 already refuses to make (UNALLOCATED_NO_COLLEGE_QUOTA).
+        """
+        matrix = self._matrix_row(cfg, sub_type)
+        over = [
+            (code, count, matrix.get(code, 0))
+            for code, count in sorted(consumers.items())
+            if count > matrix.get(code, 0)
+        ]
+        if not over:
+            return
+
+        names = await self._college_display_names([code for code, _, _ in over])
+        detail = "；".join(
+            f"{names.get(code) or code or '未知學院（學生資料缺少學院代碼）'} 已核配 {count} 人，"
+            f"超過該學院名額 {total}"
+            for code, count, total in over
+        )
+        raise ValueError(
+            f"學院名額超額：{cfg.config_code} / {sub_type} — {detail}。"
+            f"請取消該學院的部分核配，或於名額設定調整該學院的名額"
+        )
+
+    async def _college_display_names(self, codes: Sequence[str]) -> dict[str, str]:
+        """學院代碼 → 學院名稱, for error messages only. Codes with no academies row
+        are simply absent, and the caller falls back to the raw code."""
+        real = [code for code in codes if code]
+        if not real:
+            return {}
+        rows = await self.db.execute(select(Academy.code, Academy.name).where(Academy.code.in_(real)))
+        return {code: name for code, name in rows.all()}
 
     async def execute_general_distribution(
         self,

--- a/backend/app/tests/test_college_quota_gate.py
+++ b/backend/app/tests/test_college_quota_gate.py
@@ -1,0 +1,186 @@
+"""§10 per-college half of the quota gate.
+
+Each college's cell of `quotas[sub_type]` is a HARD cap: allocate/finalize must
+reject a round that over-fills one college even while the GLOBAL pool for that
+(config, sub_type) still has slots free. Complements
+test_allocate_config_id.py::test_allocate_gate_rejects_oversubscription, which
+covers the global half.
+"""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import ApplicationStatus, ReviewStage, SubTypeSelectionMode
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.student import Academy
+from app.models.user import User, UserRole, UserType
+from app.services.manual_distribution_service import ManualDistributionService
+
+
+async def _make_round(db: AsyncSession, *, code: str, quotas: dict, has_college_quota: bool, colleges: list[str]):
+    """One finalized ranking with a ranked item per entry in `colleges`
+    (the college code lands in the application's std_academyno snapshot)."""
+    sch = ScholarshipType(code=code, name=code, description="x")
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        academic_year=115,
+        semester=None,
+        config_name=f"{code}115",
+        config_code=f"{code}_115",
+        amount=30000,
+        currency="TWD",
+        is_active=True,
+        has_college_quota=has_college_quota,
+        quotas=quotas,
+    )
+    db.add(config)
+    ranking = CollegeRanking(
+        scholarship_type_id=sch.id,
+        sub_type_code="nstc",
+        academic_year=115,
+        semester=None,
+        is_finalized=True,
+        ranking_status="finalized",
+    )
+    db.add(ranking)
+    await db.commit()
+    await db.refresh(config)
+    await db.refresh(ranking)
+
+    items = []
+    for idx, college in enumerate(colleges):
+        user = User(
+            nycu_id=f"{code}_s{idx}",
+            name=f"S{idx}",
+            email=f"{code}_s{idx}@u.edu",
+            user_type=UserType.student,
+            role=UserRole.student,
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+        application = Application(
+            app_id=f"APP-115-0-{code}{idx}",
+            user_id=user.id,
+            scholarship_type_id=sch.id,
+            scholarship_subtype_list=["nstc"],
+            sub_type_selection_mode=SubTypeSelectionMode.single,
+            sub_scholarship_type="nstc",
+            academic_year=115,
+            semester=None,
+            status=ApplicationStatus.under_review,
+            review_stage=ReviewStage.college_ranked,
+            is_renewal=False,
+            agree_terms=True,
+            student_data={"std_academyno": college},
+        )
+        db.add(application)
+        await db.commit()
+        await db.refresh(application)
+        item = CollegeRankingItem(
+            ranking_id=ranking.id,
+            application_id=application.id,
+            rank_position=idx + 1,
+            is_allocated=False,
+            status="ranked",
+        )
+        db.add(item)
+        await db.commit()
+        await db.refresh(item)
+        items.append(item)
+
+    return {"sch": sch, "config": config, "items": items}
+
+
+def _allocations(items) -> list[dict]:
+    return [{"ranking_item_id": item.id, "sub_type_code": "nstc"} for item in items]
+
+
+@pytest_asyncio.fixture
+async def matrix_round(db: AsyncSession):
+    """A=1, B=2 → global pool 3, so two A students fit the pool but not the cell."""
+    db.add(Academy(code="A", name="工學院"))
+    await db.commit()
+    return await _make_round(
+        db,
+        code="cq_matrix",
+        quotas={"nstc": {"A": 1, "B": 2}},
+        has_college_quota=True,
+        colleges=["A", "A", "B"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_allocate_rejects_college_over_cap_while_pool_has_room(db: AsyncSession, matrix_round):
+    svc = ManualDistributionService(db)
+    a_items = matrix_round["items"][:2]
+
+    with pytest.raises(ValueError, match="學院名額超額"):
+        await svc.allocate(matrix_round["sch"].id, 115, "yearly", _allocations(a_items))
+
+    # The global pool was never the problem: 2 of 3 slots used.
+    assert await svc.remaining(matrix_round["config"], "nstc") == 1
+
+
+@pytest.mark.asyncio
+async def test_college_over_cap_message_names_the_college(db: AsyncSession, matrix_round):
+    svc = ManualDistributionService(db)
+    with pytest.raises(ValueError, match="工學院 已核配 2 人，超過該學院名額 1"):
+        await svc.allocate(matrix_round["sch"].id, 115, "yearly", _allocations(matrix_round["items"][:2]))
+
+
+@pytest.mark.asyncio
+async def test_allocate_allows_one_per_college_cell(db: AsyncSession, matrix_round):
+    svc = ManualDistributionService(db)
+    one_a, _, one_b = matrix_round["items"]
+
+    await svc.allocate(matrix_round["sch"].id, 115, "yearly", _allocations([one_a, one_b]))
+
+    allocated = (
+        (await db.execute(select(CollegeRankingItem).where(CollegeRankingItem.id.in_([one_a.id, one_b.id]))))
+        .scalars()
+        .all()
+    )
+    assert [item.is_allocated for item in allocated] == [True, True]
+
+
+@pytest.mark.asyncio
+async def test_allocate_rejects_college_absent_from_the_matrix(db: AsyncSession):
+    """An unmapped 學院代碼 (or a snapshot with no std_academyno) has a cell of 0 —
+    the same allocation auto-分發 refuses to make."""
+    round_ = await _make_round(
+        db,
+        code="cq_unmapped",
+        quotas={"nstc": {"A": 5}},
+        has_college_quota=True,
+        colleges=["ZZ"],
+    )
+    svc = ManualDistributionService(db)
+
+    with pytest.raises(ValueError, match="學院名額超額"):
+        await svc.allocate(round_["sch"].id, 115, "yearly", _allocations(round_["items"]))
+
+
+@pytest.mark.asyncio
+async def test_non_matrix_config_has_no_per_college_cap(db: AsyncSession):
+    """simple/none configs carry a scalar pool only — the global gate is the only one."""
+    round_ = await _make_round(
+        db,
+        code="cq_scalar",
+        quotas={"nstc": 5},
+        has_college_quota=False,
+        colleges=["A", "A", "A"],
+    )
+    svc = ManualDistributionService(db)
+
+    await svc.allocate(round_["sch"].id, 115, "yearly", _allocations(round_["items"]))
+
+    assert await svc.remaining(round_["config"], "nstc") == 2

--- a/backend/app/tests/test_finalize_lock_gate.py
+++ b/backend/app/tests/test_finalize_lock_gate.py
@@ -92,6 +92,11 @@ async def _new_app(db, *, user, sch_id):
         review_stage=ReviewStage.college_ranked,
         is_renewal=False,
         agree_terms=True,
+        # College "A" is the only cell in `base`'s quota matrix. Without it the
+        # snapshot has no std_academyno, the student lands in the "" bucket
+        # (quota 0) and the per-college half of the §10 gate rejects the round —
+        # which is not what either test here is about.
+        student_data={"std_academyno": "A"},
     )
     db.add(a)
     await db.commit()

--- a/frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
+++ b/frontend/components/admin/manual-distribution/CollegeQuotaMatrix.tsx
@@ -3,7 +3,6 @@
 import { useMemo } from "react";
 import { Building2 } from "lucide-react";
 import type {
-  CollegeQuota,
   DistributionStudent,
   LocalAlloc,
   QuotaStatus,
@@ -11,10 +10,9 @@ import type {
 } from "@/lib/api/modules/manual-distribution";
 import {
   buildCollegeNameMap,
-  getSavedAllocation,
-  makeColKey,
   resolveCollegeName,
 } from "@/lib/api/modules/manual-distribution";
+import { buildCollegeQuotaGrid } from "@/lib/api/modules/college-quota-grid";
 
 interface CollegeQuotaMatrixProps {
   cols: SubTypeConfigCol[];
@@ -25,25 +23,13 @@ interface CollegeQuotaMatrixProps {
   academies: Array<{ code: string; name: string }>;
 }
 
-function cellKey(collegeCode: string, colKey: string) {
-  return `${collegeCode}|${colKey}`;
-}
-
-/** A cell for a college the matrix has no quota/consumers for (staged-only). */
-const ZERO_QUOTA_CELL: CollegeQuota = { total: 0, allocated: 0, remaining: 0 };
-
 /**
- * College × (sub_type × config) remaining-quota matrix (advisory display).
+ * College × (sub_type × config) remaining-quota matrix.
  *
- * liveRemaining = serverRemaining − Δlocal, where Δlocal counts the UNSAVED
- * difference between each student's current local allocation and their
- * server-saved allocation. The delta form avoids double-counting: server
- * `allocated` already includes saved allocations, and `localAllocations` is
- * seeded from them (plus auto-preview suggestions).
- *
- * Renewal students are excluded from the delta: the backend counts a
- * renewal's consumption via its approved Application, not its ranking item,
- * so checkbox changes on a renewal row don't move quota server-side.
+ * Each cell is `liveRemaining/total`, where liveRemaining already nets out the
+ * UNSAVED checkbox changes (see buildCollegeQuotaGrid). A red (negative) cell is
+ * not a warning to weigh — it blocks 儲存/確認分發, both on this screen and in the
+ * server's own quota gate.
  */
 export function CollegeQuotaMatrix({
   cols,
@@ -52,67 +38,17 @@ export function CollegeQuotaMatrix({
   localAllocations,
   academies,
 }: CollegeQuotaMatrixProps) {
-  const localDelta = useMemo(() => {
-    const delta: Record<string, number> = {};
-    const bump = (college: string, colKey: string, amount: number) => {
-      const k = cellKey(college, colKey);
-      delta[k] = (delta[k] ?? 0) + amount;
-    };
-    for (const s of students) {
-      if (s.is_renewal) continue;
-      const college = s.college_code || "";
-      const saved = getSavedAllocation(s);
-      if (saved) {
-        bump(college, makeColKey(saved.sub_type, saved.config_id), -1);
-      }
-      const local = localAllocations.get(s.ranking_item_id);
-      if (local) {
-        bump(college, makeColKey(local.sub_type, local.config_id), +1);
-      }
-    }
-    return delta;
-  }, [students, localAllocations]);
-
-  // Per visible column: the server's per-college grid (null = non-matrix config).
-  const byColKey = useMemo(() => {
-    const map: Record<string, Record<string, CollegeQuota> | null> = {};
-    for (const col of cols) {
-      const cData = (quotaStatus[col.sub_type]?.by_config ?? []).find(
-        c => c.config_id === col.config_id
-      );
-      map[col.key] = cData?.by_college ?? null;
-    }
-    return map;
-  }, [cols, quotaStatus]);
-
-  // Rows: colleges known to the server, plus colleges that only exist as
-  // staged (unsaved) allocations into a matrix column — those must surface
-  // so over-allocating a zero-quota college warns BEFORE saving.
-  const collegeRows = useMemo(() => {
-    const codes = new Set<string>();
-    for (const col of cols) {
-      for (const code of Object.keys(byColKey[col.key] ?? {})) {
-        codes.add(code);
-      }
-    }
-    for (const [key, delta] of Object.entries(localDelta)) {
-      if (delta === 0) continue;
-      const sep = key.indexOf("|");
-      const college = key.slice(0, sep);
-      const colKey = key.slice(sep + 1);
-      if (byColKey[colKey] != null) {
-        codes.add(college);
-      }
-    }
-    return Array.from(codes).sort((a, b) => a.localeCompare(b));
-  }, [cols, byColKey, localDelta]);
+  const grid = useMemo(
+    () => buildCollegeQuotaGrid({ cols, quotaStatus, students, localAllocations }),
+    [cols, quotaStatus, students, localAllocations]
+  );
 
   const collegeNames = useMemo(
     () => buildCollegeNameMap(academies, students),
     [academies, students]
   );
 
-  if (cols.length === 0 || collegeRows.length === 0) return null;
+  if (cols.length === 0 || grid.collegeCodes.length === 0) return null;
 
   return (
     <div className="bg-white rounded-xl border border-slate-200 shadow-sm mb-3">
@@ -122,7 +58,7 @@ export function CollegeQuotaMatrix({
           各學院剩餘名額
         </h3>
         <span className="text-[10px] text-slate-400">
-          剩餘/總額；已即時扣除未儲存的勾選；超額僅供參考，鎖定時以全域名額檢查為準
+          剩餘/總額；已即時扣除未儲存的勾選；紅字表示超過該學院名額，須調整後才能儲存
         </span>
       </div>
       <div className="p-3 overflow-x-auto">
@@ -158,26 +94,17 @@ export function CollegeQuotaMatrix({
             </tr>
           </thead>
           <tbody>
-            {collegeRows.map(code => {
-              const rowCells = cols.map(col => {
-                const colColleges = byColKey[col.key];
-                const delta = localDelta[cellKey(code, col.key)] ?? 0;
-                // Synthesize a 0/0 cell when a matrix column only has
-                // staged allocations for this college (no server entry).
-                const entry =
-                  colColleges?.[code] ??
-                  (colColleges != null && delta !== 0
-                    ? ZERO_QUOTA_CELL
-                    : undefined);
-                return { col, entry, delta };
-              });
+            {grid.collegeCodes.map(code => {
+              const rowCells = cols.map(col => ({
+                col,
+                entry: grid.cell(code, col.key),
+              }));
               const rowTotal = rowCells.reduce(
                 (acc, { entry }) => acc + (entry?.total ?? 0),
                 0
               );
               const rowRemaining = rowCells.reduce(
-                (acc, { entry, delta }) =>
-                  acc + (entry ? entry.remaining - delta : 0),
+                (acc, { entry }) => acc + (entry?.remaining ?? 0),
                 0
               );
               return (
@@ -188,7 +115,7 @@ export function CollegeQuotaMatrix({
                   >
                     {resolveCollegeName(collegeNames, code)}
                   </th>
-                  {rowCells.map(({ col, entry, delta }) => {
+                  {rowCells.map(({ col, entry }) => {
                     if (!entry) {
                       return (
                         <td
@@ -199,11 +126,10 @@ export function CollegeQuotaMatrix({
                         </td>
                       );
                     }
-                    const liveRemaining = entry.remaining - delta;
                     const tone =
-                      liveRemaining < 0
+                      entry.remaining < 0
                         ? "text-red-600 font-bold"
-                        : liveRemaining === 0
+                        : entry.remaining === 0
                           ? "text-slate-400"
                           : "text-[#003d7a] font-semibold";
                     return (
@@ -212,7 +138,7 @@ export function CollegeQuotaMatrix({
                         className={`py-1.5 px-2 text-center font-mono tabular-nums border border-slate-300 ${tone}`}
                         title={`總額 ${entry.total}・已儲存核配 ${entry.allocated}`}
                       >
-                        {liveRemaining}/{entry.total}
+                        {entry.remaining}/{entry.total}
                       </td>
                     );
                   })}

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -33,6 +33,7 @@ import {
   unallocatedReasonLabel,
   type UnallocatedReason,
 } from "@/lib/api/modules/manual-distribution";
+import { buildCollegeQuotaGrid } from "@/lib/api/modules/college-quota-grid";
 import { User } from "@/types/user";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -90,6 +91,12 @@ const ALL_ACADEMIES_SYSTEM = "__all__";
 
 /** In-flight marker for the whole-page 預設分發 run; no college_code collides. */
 const ALL_COLLEGES = "__all_colleges__";
+
+/** Refusals when a college is over its own cell of quotas[sub_type] — the
+ * offending cells are listed in the banner, so these only say why nothing ran. */
+const OVERFLOW_BLOCKED_SAVE = "有學院超過名額上限，無法儲存（詳見上方紅色提示）";
+const OVERFLOW_BLOCKED_FINALIZE =
+  "有學院超過名額上限，無法確認分發（詳見上方紅色提示）";
 
 /** Seed local allocation state from the server snapshot (null = 未決). */
 function seedAllocations(
@@ -411,6 +418,71 @@ export function ManualDistributionPanel({
     return counts;
   }, [localAllocations, subTypeCols]);
 
+  // Academies-first code→name map, shared with the quota matrix so every
+  // college label on this screen resolves identically (see buildCollegeNameMap).
+  const collegeNames = useMemo(
+    () => buildCollegeNameMap(academies, students),
+    [academies, students]
+  );
+
+  const studentByItemId = useMemo(
+    () => new Map(students.map(s => [s.ranking_item_id, s])),
+    [students]
+  );
+
+  // Each college's cell of quotas[sub_type] is a HARD cap, enforced server-side
+  // in _assert_round_not_oversubscribed. This is the SAME live grid the
+  // 各學院剩餘名額 matrix renders, so a tick that would overfill a college is
+  // refused on the spot (see collegeQuotaRefusal) and 儲存/確認分發 have a
+  // backstop for states the ticks can't produce (auto-preview, stale snapshot).
+  const collegeQuotaGrid = useMemo(
+    () =>
+      buildCollegeQuotaGrid({
+        cols: subTypeCols,
+        quotaStatus,
+        students,
+        localAllocations,
+      }),
+    [subTypeCols, quotaStatus, students, localAllocations]
+  );
+
+  /**
+   * Why assigning `rankingItemId` to `col` must be refused, or null when it fits.
+   *
+   * Renewal rows are exempt: the backend counts a renewal's consumption via its
+   * approved Application, not its ranking item, so it never moves this grid.
+   */
+  const collegeQuotaRefusal = useCallback(
+    (rankingItemId: number, col: SubTypeConfigCol): string | null => {
+      const student = studentByItemId.get(rankingItemId);
+      if (!student || student.is_renewal) return null;
+      // A non-matrix column has no per-college split at all — only the global
+      // pool caps it, and that is the `atCapacity` disable on the checkbox.
+      if (!collegeQuotaGrid.hasCollegeSplit(col.key)) return null;
+      const code = student.college_code || "";
+      const cell = collegeQuotaGrid.cell(code, col.key);
+      if (!cell || cell.remaining > 0) return null;
+      const college = resolveCollegeName(collegeNames, code, student.college_name);
+      if (cell.total <= 0) {
+        return `${college} 在「${col.display_name}」沒有名額，無法核配`;
+      }
+      return `${college}「${col.display_name}」名額已用完（${cell.total - cell.remaining}/${cell.total}），無法再核配`;
+    },
+    [studentByItemId, collegeQuotaGrid, collegeNames]
+  );
+
+  const collegeOverflowMessage = useMemo(() => {
+    const { overflows } = collegeQuotaGrid;
+    if (overflows.length === 0) return null;
+    const detail = overflows
+      .map(
+        o =>
+          `${resolveCollegeName(collegeNames, o.collegeCode)}／${o.col.display_name} ${o.used}/${o.total}`
+      )
+      .join("；");
+    return `超過各學院名額（已核配/該學院名額）：${detail}。請調整分發後再儲存。`;
+  }, [collegeQuotaGrid, collegeNames]);
+
   const fetchData = useCallback(async () => {
     if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
       return;
@@ -664,11 +736,24 @@ export function ManualDistributionPanel({
     hasStagedChallenge,
   ]);
 
-  const handleCheckbox = (
-    rankingItemId: number,
-    sub_type: string,
-    config_id: number
-  ) => {
+  const handleCheckbox = (rankingItemId: number, col: SubTypeConfigCol) => {
+    const { sub_type, config_id } = col;
+    const current = localAllocations.get(rankingItemId);
+    const isUncheck =
+      current?.sub_type === sub_type && current?.config_id === config_id;
+
+    // A tick that would push this student's college past its own cell of
+    // quotas[sub_type] is a no-op: the controlled checkbox snaps back to its
+    // previous state and the reason surfaces as a toast. Unticking is always
+    // allowed — it can only free a slot.
+    if (!isUncheck) {
+      const refusal = collegeQuotaRefusal(rankingItemId, col);
+      if (refusal) {
+        toast.error(refusal);
+        return;
+      }
+    }
+
     // Unticking returns the row to 未決 — nothing else is remembered about it.
     // A 未決 row is open to 預設分發 again and its slot is free for someone
     // else; to keep a student out of the round entirely, use 撤銷/停發.
@@ -697,6 +782,12 @@ export function ManualDistributionPanel({
   const handleSave = async () => {
     if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
       return;
+    if (collegeOverflowMessage) {
+      // The offending cells are already named in the banner above — don't repeat
+      // the whole list here, just say why the click did nothing.
+      setSaveMessage({ type: "error", text: OVERFLOW_BLOCKED_SAVE });
+      return;
+    }
     setIsSaving(true);
     setSaveMessage(null);
     try {
@@ -727,7 +818,12 @@ export function ManualDistributionPanel({
       }
     } catch (error) {
       logger.error("Save error", { error: error });
-      setSaveMessage({ type: "error", text: "儲存時發生錯誤" });
+      // The quota gates (global pool / per-college cell) come back as a 400 whose
+      // detail names the offending config or college — echo it, never bury it.
+      setSaveMessage({
+        type: "error",
+        text: (error as Error)?.message || "儲存時發生錯誤",
+      });
     } finally {
       setIsSaving(false);
     }
@@ -736,6 +832,10 @@ export function ManualDistributionPanel({
   const handleFinalize = async () => {
     if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
       return;
+    if (collegeOverflowMessage) {
+      setSaveMessage({ type: "error", text: OVERFLOW_BLOCKED_FINALIZE });
+      return;
+    }
     setIsFinalizing(true);
     setSaveMessage(null);
     try {
@@ -755,7 +855,10 @@ export function ManualDistributionPanel({
       }
     } catch (error) {
       logger.error("Finalize error", { error: error });
-      setSaveMessage({ type: "error", text: "確認分發時發生錯誤" });
+      setSaveMessage({
+        type: "error",
+        text: (error as Error)?.message || "確認分發時發生錯誤",
+      });
     } finally {
       setIsFinalizing(false);
     }
@@ -1025,13 +1128,6 @@ export function ManualDistributionPanel({
       return true;
     });
   }, [students, collegeFilter, searchQuery]);
-
-  // Academies-first code→name map, shared with the quota matrix so every
-  // college label on this screen resolves identically (see buildCollegeNameMap).
-  const collegeNames = useMemo(
-    () => buildCollegeNameMap(academies, students),
-    [academies, students]
-  );
 
   // Group students by college
   const studentsByCollege = useMemo(() => {
@@ -1359,6 +1455,14 @@ export function ManualDistributionPanel({
             </div>
           </div>
         </div>
+
+        {/* Per-college quota overflow — 儲存/確認分發 stay blocked until it clears */}
+        {collegeOverflowMessage && (
+          <div className="px-4 py-2 rounded text-sm bg-red-50 text-red-700 border border-red-200 flex items-start gap-2">
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+            <span>{collegeOverflowMessage}</span>
+          </div>
+        )}
 
         {/* Save message */}
         {saveMessage && (
@@ -1828,6 +1932,20 @@ export function ManualDistributionPanel({
                                     col.total > 0 &&
                                     localUsed >= col.total &&
                                     !isChecked;
+                                  // Per-college cell full (hard cap) — tooltip
+                                  // only. The cell is NOT tinted: "exactly
+                                  // consumed" is the healthy end state of a
+                                  // finished college, and painting it red would
+                                  // be indistinguishable from real overflow.
+                                  // Kept clickable on purpose too: the click is
+                                  // a no-op that toasts the reason, which reads
+                                  // better than a silently greyed-out box.
+                                  const collegeFull = isChecked
+                                    ? null
+                                    : collegeQuotaRefusal(
+                                        student.ranking_item_id,
+                                        col
+                                      );
                                   // Phase 8.2: for a challenge candidate the
                                   // sub_type they already hold a renewal in is
                                   // their "safety net" — they must not be
@@ -1845,9 +1963,9 @@ export function ManualDistributionPanel({
                                   // up and merges the reply back into it, so a
                                   // tick landing in between is both lost AND
                                   // uncounted — the server would hand out a slot
-                                  // it does not know was just taken, and nothing
-                                  // downstream re-checks the per-college matrix
-                                  // (the save gate only recounts the global pool).
+                                  // it does not know was just taken. The save
+                                  // gate would reject the result rather than
+                                  // over-allocate, but only after the fact.
                                   const isMutating =
                                     isSaving ||
                                     isFinalizing ||
@@ -1899,15 +2017,16 @@ export function ManualDistributionPanel({
                                                   : `審核不同意（不推薦）${col.display_name}`
                                                 : atCapacity
                                                   ? `${col.display_name} 名額已滿`
-                                                  : isChecked
-                                                    ? "點擊取消分配"
-                                                    : `分配至 ${col.display_name}`
+                                                  : collegeFull
+                                                    ? collegeFull
+                                                    : isChecked
+                                                      ? "點擊取消分配"
+                                                      : `分配至 ${col.display_name}`
                                         }
                                         onChange={() =>
                                           handleCheckbox(
                                             student.ranking_item_id,
-                                            col.sub_type,
-                                            col.config_id
+                                            col
                                           )
                                         }
                                       />

--- a/frontend/lib/api/__tests__/college-quota-grid.test.ts
+++ b/frontend/lib/api/__tests__/college-quota-grid.test.ts
@@ -1,0 +1,211 @@
+/**
+ * buildCollegeQuotaGrid — the live 各學院剩餘名額 grid shared by the matrix and
+ * the panel's save gate. Per-college quota is a hard cap, so `overflows` is what
+ * blocks 儲存/確認分發; these tests pin the delta math that produces it.
+ */
+
+import { buildCollegeQuotaGrid } from "../modules/college-quota-grid";
+import type {
+  DistributionStudent,
+  LocalAlloc,
+  QuotaStatus,
+  SubTypeConfigCol,
+} from "../modules/manual-distribution";
+import { makeColKey } from "../modules/manual-distribution";
+
+const COL: SubTypeConfigCol = {
+  sub_type: "nstc",
+  config_id: 7,
+  config_code: "phd_115",
+  academic_year: 115,
+  is_own: true,
+  display_name: "國科會",
+  total: 3,
+  remaining: 3,
+  key: makeColKey("nstc", 7),
+};
+
+function quotaStatus(
+  byCollege: Record<string, { total: number; allocated: number }> | null
+): QuotaStatus {
+  return {
+    nstc: {
+      display_name: "國科會",
+      by_config: [
+        {
+          config_id: 7,
+          config_code: "phd_115",
+          academic_year: 115,
+          is_own: true,
+          total: 3,
+          remaining: 3,
+          by_college:
+            byCollege &&
+            Object.fromEntries(
+              Object.entries(byCollege).map(([code, cell]) => [
+                code,
+                { ...cell, remaining: cell.total - cell.allocated },
+              ])
+            ),
+        },
+      ],
+    },
+  };
+}
+
+function student(over: Partial<DistributionStudent>): DistributionStudent {
+  return {
+    ranking_item_id: 1,
+    application_id: 1,
+    rank_position: 1,
+    applied_sub_types: ["nstc"],
+    rejected_sub_types: [],
+    professor_review_items: [],
+    college_review_items: [],
+    requires_professor_recommendation: false,
+    allocated_sub_type: null,
+    allocation_config_id: null,
+    is_allocated: false,
+    status: "ranked",
+    quota_allocation_status: null,
+    holds_award: false,
+    revoke_reason: null,
+    suspend_reason: null,
+    college_rejected: false,
+    college_code: "A",
+    college_name: "工學院",
+    department_name: "資工系",
+    term_count: null,
+    student_name: "S",
+    nationality: "TW",
+    enrollment_date: "2025-09-01",
+    student_id: "111550001",
+    application_identity: "phd",
+    is_renewal: false,
+    renewal_year: null,
+    renewal_sub_type: null,
+    received_months: null,
+    received_months_source: null,
+    is_supplementary: false,
+    ...over,
+  };
+}
+
+const staged = (entries: Array<[number, LocalAlloc | null]>) =>
+  new Map<number, LocalAlloc | null>(entries);
+
+describe("buildCollegeQuotaGrid", () => {
+  it("nets unsaved checkboxes out of the college's remaining", () => {
+    const grid = buildCollegeQuotaGrid({
+      cols: [COL],
+      quotaStatus: quotaStatus({ A: { total: 2, allocated: 0 } }),
+      students: [student({ ranking_item_id: 1 })],
+      localAllocations: staged([[1, { sub_type: "nstc", config_id: 7 }]]),
+    });
+
+    expect(grid.cell("A", COL.key)).toEqual({
+      total: 2,
+      allocated: 0,
+      remaining: 1,
+    });
+    expect(grid.overflows).toEqual([]);
+  });
+
+  it("does not double-count an allocation that is already saved", () => {
+    const grid = buildCollegeQuotaGrid({
+      cols: [COL],
+      quotaStatus: quotaStatus({ A: { total: 2, allocated: 1 } }),
+      students: [
+        student({
+          ranking_item_id: 1,
+          is_allocated: true,
+          allocated_sub_type: "nstc",
+          allocation_config_id: 7,
+        }),
+      ],
+      localAllocations: staged([[1, { sub_type: "nstc", config_id: 7 }]]),
+    });
+
+    expect(grid.cell("A", COL.key)?.remaining).toBe(1);
+  });
+
+  it("reports an overflow when staged checkboxes exceed the college's cell", () => {
+    const grid = buildCollegeQuotaGrid({
+      cols: [COL],
+      quotaStatus: quotaStatus({ A: { total: 1, allocated: 0 } }),
+      students: [
+        student({ ranking_item_id: 1 }),
+        student({ ranking_item_id: 2, application_id: 2 }),
+      ],
+      localAllocations: staged([
+        [1, { sub_type: "nstc", config_id: 7 }],
+        [2, { sub_type: "nstc", config_id: 7 }],
+      ]),
+    });
+
+    expect(grid.cell("A", COL.key)?.remaining).toBe(-1);
+    expect(grid.overflows).toEqual([
+      { collegeCode: "A", col: COL, total: 1, used: 2 },
+    ]);
+  });
+
+  it("surfaces a college that only exists as a staged allocation (zero quota)", () => {
+    const grid = buildCollegeQuotaGrid({
+      cols: [COL],
+      quotaStatus: quotaStatus({ A: { total: 1, allocated: 0 } }),
+      students: [student({ ranking_item_id: 1, college_code: "ZZ" })],
+      localAllocations: staged([[1, { sub_type: "nstc", config_id: 7 }]]),
+    });
+
+    expect(grid.collegeCodes).toEqual(["A", "ZZ"]);
+    expect(grid.overflows).toEqual([
+      { collegeCode: "ZZ", col: COL, total: 0, used: 1 },
+    ]);
+  });
+
+  it("reads a college with NO cell in a matrix column as 0 quota, not unconstrained", () => {
+    // The tick-time guard asks for the cell BEFORE staging anything, so a
+    // missing entry must already read as full — otherwise the first tick into a
+    // zero-quota college is accepted and only the second one is refused.
+    const grid = buildCollegeQuotaGrid({
+      cols: [COL],
+      quotaStatus: quotaStatus({ A: { total: 1, allocated: 0 } }),
+      students: [student({ ranking_item_id: 1, college_code: "ZZ" })],
+      localAllocations: staged([[1, null]]),
+    });
+
+    expect(grid.hasCollegeSplit(COL.key)).toBe(true);
+    expect(grid.cell("ZZ", COL.key)).toEqual({
+      total: 0,
+      allocated: 0,
+      remaining: 0,
+    });
+    expect(grid.overflows).toEqual([]);
+  });
+
+  it("ignores renewal rows — their consumption is counted server-side", () => {
+    const grid = buildCollegeQuotaGrid({
+      cols: [COL],
+      quotaStatus: quotaStatus({ A: { total: 1, allocated: 1 } }),
+      students: [student({ ranking_item_id: 1, is_renewal: true })],
+      localAllocations: staged([[1, { sub_type: "nstc", config_id: 7 }]]),
+    });
+
+    expect(grid.cell("A", COL.key)?.remaining).toBe(0);
+    expect(grid.overflows).toEqual([]);
+  });
+
+  it("has no cell for a non-matrix column", () => {
+    const grid = buildCollegeQuotaGrid({
+      cols: [COL],
+      quotaStatus: quotaStatus(null),
+      students: [student({ ranking_item_id: 1 })],
+      localAllocations: staged([[1, { sub_type: "nstc", config_id: 7 }]]),
+    });
+
+    expect(grid.collegeCodes).toEqual([]);
+    expect(grid.hasCollegeSplit(COL.key)).toBe(false);
+    expect(grid.cell("A", COL.key)).toBeNull();
+    expect(grid.overflows).toEqual([]);
+  });
+});

--- a/frontend/lib/api/modules/college-quota-grid.ts
+++ b/frontend/lib/api/modules/college-quota-grid.ts
@@ -1,0 +1,176 @@
+/**
+ * Live college × (sub_type × config) quota grid for manual distribution.
+ *
+ * Pure — no React, no API. Shared by the 各學院剩餘名額 matrix (which renders it)
+ * and the distribution panel (which blocks 儲存/確認分發 on overflow), so the
+ * numbers an admin sees and the numbers the save gate applies can never drift.
+ *
+ * The server enforces the same rule authoritatively in
+ * `_assert_round_not_oversubscribed` (per-college cell of `quotas[sub_type]` is a
+ * hard cap, not a hint); this module only stops the round-trip early and points
+ * at the offending cells.
+ */
+
+import type {
+  CollegeQuota,
+  DistributionStudent,
+  LocalAlloc,
+  QuotaStatus,
+  SubTypeConfigCol,
+} from "./manual-distribution";
+import { getSavedAllocation, makeColKey } from "./manual-distribution";
+
+export interface CollegeQuotaCell {
+  /** The college's cell of `quotas[sub_type]` for this column. */
+  total: number;
+  /** Server `allocated` for this cell (saved allocations + approved renewals). */
+  allocated: number;
+  /** total − allocated − unsaved staged delta. NOT clamped: < 0 = over-allocated. */
+  remaining: number;
+}
+
+export interface CollegeQuotaOverflow {
+  collegeCode: string;
+  col: SubTypeConfigCol;
+  total: number;
+  /** Allocated once the staged changes are saved (total − remaining). */
+  used: number;
+}
+
+export interface CollegeQuotaGrid {
+  /** Colleges with a quota cell or a (saved or staged) consumer, sorted by code. */
+  collegeCodes: string[];
+  /**
+   * Whether this column is quota'd per college at all. False for a non-matrix
+   * config, whose only ceiling is the global pool — the caller MUST check this
+   * before reading a null `cell` as "no cap": a matrix column with no cell for a
+   * college means that college has NO quota there, which is the opposite.
+   */
+  hasCollegeSplit(colKey: string): boolean;
+  /** The cell, or null when the college has no cell in this column. */
+  cell(collegeCode: string, colKey: string): CollegeQuotaCell | null;
+  /** Every cell the staged state would push past its per-college quota. */
+  overflows: CollegeQuotaOverflow[];
+}
+
+interface BuildArgs {
+  cols: SubTypeConfigCol[];
+  quotaStatus: QuotaStatus;
+  students: DistributionStudent[];
+  /** ranking_item_id → current local allocation (null = unallocated). */
+  localAllocations: Map<number, LocalAlloc | null>;
+}
+
+function cellKey(collegeCode: string, colKey: string): string {
+  return `${collegeCode}|${colKey}`;
+}
+
+/** A college the grid has no server quota/consumers for (staged-only). */
+const ZERO_QUOTA_CELL = { total: 0, allocated: 0, remaining: 0 } as const;
+
+/**
+ * Unsaved delta per (college, column): +1 for each student's current local
+ * allocation, −1 for their server-saved one. The delta form avoids double
+ * counting — the server's `allocated` already includes saved allocations, and
+ * `localAllocations` is seeded from them (plus auto-preview suggestions).
+ *
+ * Renewal students are excluded: the backend counts a renewal's consumption via
+ * its approved Application, not its ranking item, so checkbox changes on a
+ * renewal row don't move quota server-side.
+ */
+function buildLocalDelta(
+  students: DistributionStudent[],
+  localAllocations: Map<number, LocalAlloc | null>
+): Record<string, number> {
+  const delta: Record<string, number> = {};
+  const bump = (college: string, colKey: string, amount: number) => {
+    const k = cellKey(college, colKey);
+    delta[k] = (delta[k] ?? 0) + amount;
+  };
+  for (const s of students) {
+    if (s.is_renewal) continue;
+    const college = s.college_code || "";
+    const saved = getSavedAllocation(s);
+    if (saved) {
+      bump(college, makeColKey(saved.sub_type, saved.config_id), -1);
+    }
+    const local = localAllocations.get(s.ranking_item_id);
+    if (local) {
+      bump(college, makeColKey(local.sub_type, local.config_id), +1);
+    }
+  }
+  return delta;
+}
+
+export function buildCollegeQuotaGrid({
+  cols,
+  quotaStatus,
+  students,
+  localAllocations,
+}: BuildArgs): CollegeQuotaGrid {
+  const localDelta = buildLocalDelta(students, localAllocations);
+
+  // Per visible column: the server's per-college grid (null = non-matrix config).
+  const byColKey: Record<string, Record<string, CollegeQuota> | null> = {};
+  for (const col of cols) {
+    const cData = (quotaStatus[col.sub_type]?.by_config ?? []).find(
+      c => c.config_id === col.config_id
+    );
+    byColKey[col.key] = cData?.by_college ?? null;
+  }
+
+  // Rows: colleges known to the server, plus colleges that only exist as staged
+  // (unsaved) allocations into a matrix column — those must surface so
+  // over-allocating a zero-quota college warns BEFORE saving.
+  const codes = new Set<string>();
+  for (const col of cols) {
+    for (const code of Object.keys(byColKey[col.key] ?? {})) {
+      codes.add(code);
+    }
+  }
+  for (const [key, delta] of Object.entries(localDelta)) {
+    if (delta === 0) continue;
+    const sep = key.indexOf("|");
+    const college = key.slice(0, sep);
+    const colKey = key.slice(sep + 1);
+    if (byColKey[colKey] != null) {
+      codes.add(college);
+    }
+  }
+  const collegeCodes = Array.from(codes).sort((a, b) => a.localeCompare(b));
+
+  const hasCollegeSplit = (colKey: string): boolean => byColKey[colKey] != null;
+
+  const cell = (collegeCode: string, colKey: string): CollegeQuotaCell | null => {
+    const colColleges = byColKey[colKey];
+    if (colColleges == null) return null;
+    const entry = colColleges[collegeCode];
+    // _college_breakdown omits a college with neither quota nor consumers, so a
+    // missing entry in a MATRIX column means a cell of 0 — not "unconstrained".
+    // Reading it as 0/0 is what makes the very first tick into a zero-quota
+    // college refusable; treating it as absent let one slip through.
+    const delta = localDelta[cellKey(collegeCode, colKey)] ?? 0;
+    const base = entry ?? ZERO_QUOTA_CELL;
+    return {
+      total: base.total,
+      allocated: base.allocated,
+      remaining: base.remaining - delta,
+    };
+  };
+
+  const overflows: CollegeQuotaOverflow[] = [];
+  for (const collegeCode of collegeCodes) {
+    for (const col of cols) {
+      const entry = cell(collegeCode, col.key);
+      if (!entry || entry.remaining >= 0) continue;
+      overflows.push({
+        collegeCode,
+        col,
+        total: entry.total,
+        used: entry.total - entry.remaining,
+      });
+    }
+  }
+
+  return { collegeCodes, hasCollegeSplit, cell, overflows };
+}

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -63,7 +63,8 @@ export interface DistributionStudent {
 export interface CollegeQuota {
   total: number;
   allocated: number;
-  /** total − allocated; NOT clamped — negative means over-allocated (advisory). */
+  /** total − allocated; NOT clamped — negative means the college is over its
+   * cell of quotas[sub_type], which the server rejects on allocate/finalize. */
   remaining: number;
 }
 


### PR DESCRIPTION
## 問題

各學院的子類別名額（`quotas[sub_type]` 的每個學院格子）只是「參考值」：
各學院剩餘名額 矩陣會把超額的格子標紅，但沒有任何機制阻止儲存。唯一真正
被強制的是 **全域** per-(config, sub_type) 名額池，所以只要整輪總數還沒爆，
某個學院就可以吃掉別的學院的名額。

## 改動

### 後端：§10 鎖定閘門同時檢查兩個上限

- `_assert_college_quotas_not_exceeded()` 對每個矩陣設定檔，用
  `consumers_by_college` 比對矩陣列，超過就丟出點名學院、已核配人數與名額的
  錯誤。它跑在原本 `SELECT ... FOR UPDATE` 的同一段裡，所以
  **allocate（儲存）／finalize（確認分發）／restore_allocation（復發）** 三個
  寫入點都涵蓋到。
- 兩個檢查共用同一次 by-college 掃描。`sum(by_college) == consumers_count`
  是既有 tripwire 測試保證的不變量，所以全域餘額直接由學院分佈推導，不再為了
  同一個問題在 儲存 熱路徑上多跑一組 count 查詢。
- 矩陣中沒有該學院（未對應的 `學院代碼`，或快照缺 `std_academyno`）＝名額 0，
  因此同樣被擋 —— 這正是 預設分發 早就拒絕做的配置
  （`UNALLOCATED_NO_COLLEGE_QUOTA`）。
- 錯誤訊息附上解法：取消該學院的部分核配，或於名額設定調整該學院名額。

### 前端：在管理員動作的當下套用規則

- 勾選會讓該生所屬學院超過名額時，**點擊沒有效果**：受控 checkbox 彈回原狀態，
  原因以 toast 顯示在右下角。取消勾選永遠允許；續領生豁免（後端是用已核准的
  Application 計算其消耗，不走 ranking item）。
- 儲存/確認分發 保留擋門，涵蓋不是靠點擊產生的狀態（預設分發、還原快照），
  紅色橫幅列出所有超額格子；後端 400 的 `detail` 現在會原樣顯示，不再被吞成
  「儲存時發生錯誤」。
- 矩陣的即時餘額計算抽成 `buildCollegeQuotaGrid()`，渲染數字、點擊擋門、儲存
  擋門三者用同一份計算，不會各自飄移。矩陣欄位中缺格的學院讀成「名額 0」而非
  「無上限」—— 這是讓**第一次**點進零名額學院就能被擋下的關鍵。

### 另含：矩陣可讀性（先前的 commit）

各學院剩餘名額 加上完整格線與表頭底色，並新增 `總名額` 欄位，以相同的
`剩餘/總額` 形式顯示該學院各欄位的橫向加總。

## 測試計畫

- [x] `backend/app/tests/test_college_quota_gate.py`（新增 5 項）：全域池還有
      餘額但學院已滿 → 擋；錯誤訊息帶學院名稱；剛好用滿 → 放行；矩陣中沒有的
      學院 → 擋；非矩陣設定不受影響
- [x] `frontend/lib/api/__tests__/college-quota-grid.test.ts`（新增 7 項）：
      未儲存勾選即時扣除、已儲存不重複扣、超額偵測、僅存在於暫存的學院、
      缺格讀成 0 名額（第一次點擊回歸測試）、續領生排除、非矩陣欄位
- [x] `pytest -k "distribution or quota or allocat or roster"` → 875 passed
- [x] `tsc --noEmit`、eslint、`jest components/admin/manual-distribution
      lib/api/__tests__` → 194 passed
- [x] black + flake8 (B904, B014)
- [x] 以服務層方法盤點 dev DB 既有資料：0 個超額格子
- [ ] 上線前建議對 staging/prod 跑同一份盤點，確認沒有舊資料會一開始就卡住
      儲存（若有，調整該學院名額設定即可）

## 待確認的取捨

借用 **共用往年** 名額時，檢查的是「來源年度設定檔中該學生學院的格子」。因此
若 113 年度 工學院 已用完、電機還有剩，工學院的學生不能借電機的剩餘。這是
「不可以超過各個學院該獎學金子類別」的字面解讀；若補發應只受全域池限制，
per-college 檢查可改為只套用在本年度自己的設定檔。
