### PR TITLE
feat(student-history): open award-history lookup to college and student roles

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -32,6 +32,7 @@ from app.api.v1.endpoints import (
     scholarship_rules,
     scholarships,
     student_bank_accounts,
+    student_history,
     system_settings,
     user_profiles,
     users,
@@ -77,6 +78,7 @@ api_router.include_router(payment_rosters.router, prefix="/payment-rosters", tag
 api_router.include_router(roster_schedules.router, prefix="/roster-schedules", tags=["Roster Schedules"])
 api_router.include_router(system_settings.router, prefix="/system-settings", tags=["System Settings"])
 api_router.include_router(student_bank_accounts.router, prefix="/student-bank-accounts", tags=["Student Bank Accounts"])
+api_router.include_router(student_history.router, prefix="/student-history", tags=["Student History"])
 api_router.include_router(csp_report.router, prefix="", tags=["Security"])
 api_router.include_router(renewal.router, prefix="/renewals", tags=["Renewals"])
 api_router.include_router(manual_distribution_router)

--- a/backend/app/api/v1/endpoints/admin/student_history.py
+++ b/backend/app/api/v1/endpoints/admin/student_history.py
@@ -1,7 +1,6 @@
 """Admin endpoint: GET /admin/student-history/{student_number}."""
 
 import logging
-import re
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import require_admin
 from app.db.deps import get_db
 from app.models.user import User
+from app.schemas.student_scholarship_history import STUDENT_NUMBER_PATTERN
 from app.services.student_scholarship_history_service import (
     StudentScholarshipHistoryService,
 )
@@ -16,8 +16,6 @@ from app.services.student_scholarship_history_service import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-_STUDENT_NUMBER_PATTERN = re.compile(r"^[A-Za-z0-9]{4,15}$")
 
 
 @router.get("/{student_number}")
@@ -31,7 +29,7 @@ async def get_student_scholarship_history(
     NotFoundError (and any ScholarshipException) is mapped to its HTTP status by
     the global handler in app.main; no per-endpoint try/except needed.
     """
-    if not _STUDENT_NUMBER_PATTERN.match(student_number):
+    if not STUDENT_NUMBER_PATTERN.match(student_number):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="學號格式不正確",

--- a/backend/app/api/v1/endpoints/student_history.py
+++ b/backend/app/api/v1/endpoints/student_history.py
@@ -1,0 +1,150 @@
+"""Shared student scholarship history endpoints (non-admin roles).
+
+- POST /student-history/batch — multi-student lookup for admin, super_admin and
+  college users. College users only see students of their own college: the SIS
+  ``std_academyno`` must equal the user's ``college_code``.
+- GET /student-history/me/months — a student's own 總領月份數. Students get the
+  total months only, never amounts or payment details.
+
+The admin single-student lookup lives at /admin/student-history/{student_number}.
+"""
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import ScholarshipException
+from app.core.security import require_scholarship_manager, require_student
+from app.db.deps import get_db
+from app.models.user import User
+from app.schemas.student_scholarship_history import (
+    BatchStudentHistoryRequest,
+    StudentScholarshipHistoryData,
+)
+from app.services.student_scholarship_history_service import (
+    StudentScholarshipHistoryService,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_STUDENT_NUMBER_PATTERN = re.compile(r"^[A-Za-z0-9]{4,15}$")
+MAX_BATCH_SIZE = 50
+
+
+def _college_scope_error(user: User, data: StudentScholarshipHistoryData) -> Optional[str]:
+    """Per-student authorization for college users.
+
+    Returns an error message when the college user may not view this student,
+    None when access is allowed. Admin/super_admin are never scoped. A student
+    whose college cannot be determined (SIS unavailable) is denied — access
+    control must not fail open on an upstream outage.
+    """
+    if not user.is_college():
+        return None
+    basic_info = data.academic_info.basic_info if data.academic_info else None
+    academy_no = basic_info.std_academyno if basic_info else None
+    if not academy_no:
+        return "無法確認學生所屬學院，暫時無法查詢此學生"
+    if str(academy_no) != str(user.college_code):
+        return "僅能查詢本學院學生"
+    return None
+
+
+def _error_result(student_number: str, error: str) -> Dict[str, Any]:
+    return {"student_number": student_number, "success": False, "error": error, "data": None}
+
+
+@router.post("/batch")
+async def batch_student_scholarship_history(
+    request: BatchStudentHistoryRequest,
+    current_user: User = Depends(require_scholarship_manager),
+    db: AsyncSession = Depends(get_db),
+):
+    """Multi-student history lookup. Per-student failures (not found, out of
+    college scope) are reported inside data.results, not as an HTTP error, so
+    one bad 學號 doesn't sink the rest of the batch."""
+    student_numbers = list(dict.fromkeys(number.strip() for number in request.student_numbers if number.strip()))
+    if not student_numbers:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="請輸入至少一個學號")
+    if len(student_numbers) > MAX_BATCH_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"一次最多查詢 {MAX_BATCH_SIZE} 位學生",
+        )
+    invalid = [number for number in student_numbers if not _STUDENT_NUMBER_PATTERN.match(number)]
+    if invalid:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"學號格式不正確: {', '.join(invalid)}",
+        )
+    if current_user.is_college() and not current_user.college_code:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="帳號未設定學院代碼，無法查詢學生領獎紀錄",
+        )
+
+    service = StudentScholarshipHistoryService()
+    results = []
+    # Sequential on purpose: every lookup shares this request's AsyncSession,
+    # which does not support concurrent statements on one connection.
+    for student_number in student_numbers:
+        try:
+            data = await service.get_history(db, student_number)
+        except ScholarshipException as exc:
+            if exc.status_code != status.HTTP_404_NOT_FOUND:
+                raise
+            results.append(_error_result(student_number, exc.message))
+            continue
+
+        scope_error = _college_scope_error(current_user, data)
+        if scope_error:
+            results.append(_error_result(student_number, scope_error))
+            continue
+
+        results.append(
+            {
+                "student_number": student_number,
+                "success": True,
+                "error": None,
+                "data": data.model_dump(mode="json"),
+            }
+        )
+
+    return {
+        "success": True,
+        "message": "Student histories retrieved",
+        "data": {"results": results},
+    }
+
+
+@router.get("/me/months")
+async def get_my_received_months(
+    current_user: User = Depends(require_student),
+    db: AsyncSession = Depends(get_db),
+):
+    """A student's own 總領月份數 (匯入 + 系統, summed across every scholarship
+    type). No SIS data and no payment records is a valid "0 months" state for a
+    student viewing their own history, not a 404."""
+    student_number = current_user.nycu_id
+    service = StudentScholarshipHistoryService()
+    try:
+        data = await service.get_history(db, student_number)
+        total_received_months = data.summary.total_received_months
+    except ScholarshipException as exc:
+        if exc.status_code != status.HTTP_404_NOT_FOUND:
+            raise
+        total_received_months = 0
+
+    return {
+        "success": True,
+        "message": "Received months retrieved",
+        "data": {
+            "student_number": student_number,
+            "total_received_months": total_received_months,
+        },
+    }

--- a/backend/app/api/v1/endpoints/student_history.py
+++ b/backend/app/api/v1/endpoints/student_history.py
@@ -1,8 +1,10 @@
 """Shared student scholarship history endpoints (non-admin roles).
 
 - POST /student-history/batch — multi-student lookup for admin, super_admin and
-  college users. College users only see students of their own college: the SIS
-  ``std_academyno`` must equal the user's ``college_code``.
+  college users. College users only see students of their own college; scope is
+  decided snapshot-first (application ``student_data.std_academyno``) with live
+  SIS as a secondary signal, so a SIS outage cannot lock colleges out of their
+  own students' records.
 - GET /student-history/me/months — a student's own 總領月份數. Students get the
   total months only, never amounts or payment details.
 
@@ -10,8 +12,7 @@ The admin single-student lookup lives at /admin/student-history/{student_number}
 """
 
 import logging
-import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,8 +20,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.exceptions import ScholarshipException
 from app.core.security import require_scholarship_manager, require_student
 from app.db.deps import get_db
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.user import User
 from app.schemas.student_scholarship_history import (
+    STUDENT_NUMBER_PATTERN,
     BatchStudentHistoryRequest,
     StudentScholarshipHistoryData,
 )
@@ -32,27 +35,56 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-_STUDENT_NUMBER_PATTERN = re.compile(r"^[A-Za-z0-9]{4,15}$")
-MAX_BATCH_SIZE = 50
+MAX_BATCH_SIZE = 20
+
+# One message for BOTH "student does not exist" and "student is outside your
+# college": distinguishable errors would let a college account enumerate which
+# student numbers exist university-wide (existence oracle).
+_COLLEGE_NOT_VISIBLE = "查無符合條件的學生資料"
+
+# Admin-authored content that must not reach college users: free-text
+# revocation/suspension notes, and the verbatim rows/provenance of the
+# admin-uploaded 已領月份數 import file.
+_COLLEGE_HIDDEN_RECORD_FIELDS = ("revoke_reason", "suspend_reason")
+_COLLEGE_HIDDEN_MONTHS_FIELDS = ("raw_row", "file_name", "imported_at")
 
 
-def _college_scope_error(user: User, data: StudentScholarshipHistoryData) -> Optional[str]:
-    """Per-student authorization for college users.
+async def _is_college_visible(
+    db: AsyncSession,
+    service: StudentScholarshipHistoryService,
+    college_code: str,
+    data: StudentScholarshipHistoryData,
+) -> bool:
+    """May a college user with ``college_code`` view this student?
 
-    Returns an error message when the college user may not view this student,
-    None when access is allowed. Admin/super_admin are never scoped. A student
-    whose college cannot be determined (SIS unavailable) is denied — access
-    control must not fail open on an upstream outage.
+    Snapshot-first: the frozen application ``std_academyno`` is the same
+    source every other college gate in the repo scopes by, and it keeps the
+    awarding college's access alive through SIS outages and student
+    transfers. Live SIS additionally admits the student's *current* college
+    (e.g. record-less students, post-transfer college). Both sides are
+    stripped — ``users.college_code`` is stored unvalidated.
     """
-    if not user.is_college():
-        return None
+    code = (college_code or "").strip()
     basic_info = data.academic_info.basic_info if data.academic_info else None
-    academy_no = basic_info.std_academyno if basic_info else None
-    if not academy_no:
-        return "無法確認學生所屬學院，暫時無法查詢此學生"
-    if str(academy_no) != str(user.college_code):
-        return "僅能查詢本學院學生"
-    return None
+    sis_code = str(basic_info.std_academyno).strip() if basic_info and basic_info.std_academyno is not None else ""
+    if code and sis_code == code:
+        return True
+    snapshot_codes = await service.get_snapshot_academy_codes(db, data.student_number)
+    return code in snapshot_codes
+
+
+def _project_payload(data: StudentScholarshipHistoryData, for_college: bool) -> Dict[str, Any]:
+    """Serialize history; for college users, blank out admin-only fields."""
+    payload = data.model_dump(mode="json")
+    if not for_college:
+        return payload
+    for record in payload["payment_records"]:
+        for field in _COLLEGE_HIDDEN_RECORD_FIELDS:
+            record[field] = None
+    for breakdown in payload["received_months"]:
+        for field in _COLLEGE_HIDDEN_MONTHS_FIELDS:
+            breakdown[field] = None
+    return payload
 
 
 def _error_result(student_number: str, error: str) -> Dict[str, Any]:
@@ -65,9 +97,9 @@ async def batch_student_scholarship_history(
     current_user: User = Depends(require_scholarship_manager),
     db: AsyncSession = Depends(get_db),
 ):
-    """Multi-student history lookup. Per-student failures (not found, out of
-    college scope) are reported inside data.results, not as an HTTP error, so
-    one bad 學號 doesn't sink the rest of the batch."""
+    """Multi-student history lookup. Failures are strictly per-student
+    (not found, out of college scope, lookup error) inside data.results —
+    one bad 學號 or one failed lookup never sinks the rest of the batch."""
     student_numbers = list(dict.fromkeys(number.strip() for number in request.student_numbers if number.strip()))
     if not student_numbers:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="請輸入至少一個學號")
@@ -76,34 +108,41 @@ async def batch_student_scholarship_history(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"一次最多查詢 {MAX_BATCH_SIZE} 位學生",
         )
-    invalid = [number for number in student_numbers if not _STUDENT_NUMBER_PATTERN.match(number)]
+    invalid = [number for number in student_numbers if not STUDENT_NUMBER_PATTERN.match(number)]
     if invalid:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"學號格式不正確: {', '.join(invalid)}",
         )
-    if current_user.is_college() and not current_user.college_code:
+    is_college = current_user.is_college()
+    if is_college and not (current_user.college_code or "").strip():
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="帳號未設定學院代碼，無法查詢學生領獎紀錄",
         )
 
     service = StudentScholarshipHistoryService()
+    # SIS lookups run as one concurrent wave up front; the per-student loop
+    # below stays sequential because every DB statement shares this request's
+    # AsyncSession, which does not support concurrent use.
+    sis_lookups = await service.fetch_sis_lookups(student_numbers)
+
     results = []
-    # Sequential on purpose: every lookup shares this request's AsyncSession,
-    # which does not support concurrent statements on one connection.
     for student_number in student_numbers:
         try:
-            data = await service.get_history(db, student_number)
-        except ScholarshipException as exc:
-            if exc.status_code != status.HTTP_404_NOT_FOUND:
-                raise
-            results.append(_error_result(student_number, exc.message))
-            continue
-
-        scope_error = _college_scope_error(current_user, data)
-        if scope_error:
-            results.append(_error_result(student_number, scope_error))
+            data = await service.get_history(db, student_number, prefetched_sis=sis_lookups.get(student_number))
+            if is_college and not await _is_college_visible(db, service, current_user.college_code, data):
+                results.append(_error_result(student_number, _COLLEGE_NOT_VISIBLE))
+                continue
+        except Exception as exc:
+            if isinstance(exc, ScholarshipException) and exc.status_code == status.HTTP_404_NOT_FOUND:
+                results.append(_error_result(student_number, _COLLEGE_NOT_VISIBLE if is_college else exc.message))
+                continue
+            # Per-student contract: report and move on. Roll back so the
+            # shared session is usable for the remaining students.
+            await db.rollback()
+            logger.error("Student history lookup failed for %s", student_number, exc_info=True)
+            results.append(_error_result(student_number, "查詢失敗，請稍後再試"))
             continue
 
         results.append(
@@ -111,9 +150,25 @@ async def batch_student_scholarship_history(
                 "student_number": student_number,
                 "success": True,
                 "error": None,
-                "data": data.model_dump(mode="json"),
+                "data": _project_payload(data, for_college=is_college),
             }
         )
+
+    # Privileged bulk read of payment data — leave an audit trail of who
+    # queried whom (the admin single-lookup predates this and has none).
+    db.add(
+        AuditLog.create_log(
+            user_id=current_user.id,
+            action=AuditAction.view.value,
+            resource_type="student_history",
+            description=f"student history batch lookup ({len(student_numbers)} students)",
+            new_values={
+                "student_numbers": student_numbers,
+                "returned": [r["student_number"] for r in results if r["success"]],
+            },
+        )
+    )
+    await db.commit()
 
     return {
         "success": True,
@@ -128,17 +183,11 @@ async def get_my_received_months(
     db: AsyncSession = Depends(get_db),
 ):
     """A student's own 總領月份數 (匯入 + 系統, summed across every scholarship
-    type). No SIS data and no payment records is a valid "0 months" state for a
-    student viewing their own history, not a 404."""
+    type). DB-only — no SIS round trip — and an empty history is a valid
+    0-month state, not an error."""
     student_number = current_user.nycu_id
     service = StudentScholarshipHistoryService()
-    try:
-        data = await service.get_history(db, student_number)
-        total_received_months = data.summary.total_received_months
-    except ScholarshipException as exc:
-        if exc.status_code != status.HTTP_404_NOT_FOUND:
-            raise
-        total_received_months = 0
+    total_received_months = await service.get_total_received_months(db, student_number)
 
     return {
         "success": True,

--- a/backend/app/schemas/student_scholarship_history.py
+++ b/backend/app/schemas/student_scholarship_history.py
@@ -127,3 +127,13 @@ class StudentScholarshipHistoryData(BaseModel):
         default_factory=list,
         description="已領月份數 per scholarship type (匯入 + 系統)",
     )
+
+
+class BatchStudentHistoryRequest(BaseModel):
+    """Multi-student lookup request body for POST /student-history/batch.
+
+    Size and per-number format limits are enforced in the endpoint (uniform
+    400s with zh-TW messages) rather than as Field constraints (422s).
+    """
+
+    student_numbers: List[str]

--- a/backend/app/schemas/student_scholarship_history.py
+++ b/backend/app/schemas/student_scholarship_history.py
@@ -1,10 +1,15 @@
 """Response schemas for admin student scholarship history endpoint."""
 
+import re
 from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
+
+# Shared by the admin single-lookup and the batch endpoints; mirrored client-side
+# in frontend/components/admin/student-history/parse-student-numbers.ts.
+STUDENT_NUMBER_PATTERN = re.compile(r"^[A-Za-z0-9]{4,15}$")
 
 
 class AcademicBasicInfo(BaseModel):

--- a/backend/app/services/student_scholarship_history_service.py
+++ b/backend/app/services/student_scholarship_history_service.py
@@ -12,6 +12,7 @@ from app.core.exceptions import ScholarshipException
 from app.models.application import Application
 from app.models.payment_roster import PaymentRoster, PaymentRosterItem, RosterStatus
 from app.models.scholarship import ScholarshipConfiguration
+from app.models.user import User
 from app.schemas.student_scholarship_history import (
     AcademicBasicInfo,
     AcademicInfo,
@@ -206,40 +207,106 @@ class StudentScholarshipHistoryService:
             total_received_months=sum(b.total_months for b in received_months),
         )
 
+    async def fetch_sis_lookups(
+        self,
+        student_numbers: List[str],
+        concurrency: int = 10,
+    ) -> Dict[str, Tuple[Optional[Dict[str, Any]], Optional[str]]]:
+        """Concurrent SIS lookups for a batch, capped by ``concurrency``.
+
+        Returns {student_number: (sis_data, error_message)}. Failures never
+        raise — a degraded SIS costs at most one timeout window per wave
+        instead of one per student, and each student degrades independently
+        to the SIS-unavailable display state.
+        """
+        semaphore = asyncio.Semaphore(concurrency)
+        service = StudentService()
+
+        async def lookup(number: str) -> Tuple[str, Tuple[Optional[Dict[str, Any]], Optional[str]]]:
+            async with semaphore:
+                try:
+                    return number, (await service.get_student_basic_info(number), None)
+                except Exception as exc:
+                    logger.warning("SIS lookup failed for student %s", number, exc_info=True)
+                    return number, (None, str(exc))
+
+        pairs = await asyncio.gather(*(lookup(number) for number in student_numbers))
+        return dict(pairs)
+
+    async def get_total_received_months(self, db: AsyncSession, student_number: str) -> int:
+        """總領月份數 (匯入 + 系統) from DB records only — no SIS round trip.
+
+        An unknown student simply has no records and totals 0; there is no
+        404 concept here (student self-service treats empty history as a
+        valid zero-month state)."""
+        records, _ = await self._fetch_paid_payments(db, student_number)
+        imported_records = await get_student_imported_records(db, student_number)
+        breakdowns = self._build_received_months(records, imported_records)
+        return sum(b.total_months for b in breakdowns)
+
+    async def get_snapshot_academy_codes(self, db: AsyncSession, student_number: str) -> set:
+        """College codes (std_academyno) frozen in the student's application
+        snapshots, for college-scope checks that must not depend on live SIS.
+
+        Applications are matched through User.nycu_id (== 學號 for student
+        accounts, including batch-imported ones). JSON is parsed in Python,
+        not SQL — SQLite (tests) lacks json_extract_path_text."""
+        stmt = (
+            select(Application.student_data)
+            .join(User, Application.user_id == User.id)
+            .where(User.nycu_id == student_number, Application.deleted_at.is_(None))
+        )
+        result = await db.execute(stmt)
+        codes = set()
+        for student_data in result.scalars():
+            if not isinstance(student_data, dict):
+                continue
+            code = student_data.get("std_academyno")
+            if code is not None and str(code).strip():
+                codes.add(str(code).strip())
+        return codes
+
     async def get_history(
         self,
         db: AsyncSession,
         student_number: str,
+        prefetched_sis: Optional[Tuple[Optional[Dict[str, Any]], Optional[str]]] = None,
     ) -> StudentScholarshipHistoryData:
         """Orchestrate SIS lookup + paid-payment retrieval. Raises
         ScholarshipException(404) when both sources are empty.
 
-        SIS and DB are queried concurrently: SIS calls can take up to
-        ``student_api_timeout`` seconds, while the DB query is local — running
-        them in parallel keeps the worst-case latency at max(sis, db) rather
-        than sis + db."""
-        sis_task = asyncio.create_task(StudentService().get_student_basic_info(student_number))
-        db_task = asyncio.create_task(self._fetch_paid_payments(db, student_number))
+        Without ``prefetched_sis``, SIS and DB are queried concurrently: SIS
+        calls can take up to ``student_api_timeout`` seconds, while the DB
+        query is local — running them in parallel keeps the worst-case latency
+        at max(sis, db) rather than sis + db. Batch callers pass
+        ``prefetched_sis`` (from :meth:`fetch_sis_lookups`) so N students cost
+        one concurrent SIS wave, not N serialized calls."""
+        sis_error: Optional[str] = None
+        sis_data: Optional[Dict[str, Any]] = None
+        if prefetched_sis is None:
+            sis_task = asyncio.create_task(StudentService().get_student_basic_info(student_number))
+            db_task = asyncio.create_task(self._fetch_paid_payments(db, student_number))
 
-        sis_result, db_result = await asyncio.gather(sis_task, db_task, return_exceptions=True)
+            sis_result, db_result = await asyncio.gather(sis_task, db_task, return_exceptions=True)
+
+            if isinstance(sis_result, BaseException):
+                logger.warning("SIS lookup failed for student %s: %s", student_number, sis_result)
+                sis_error = str(sis_result)
+            else:
+                sis_data = sis_result
+
+            if isinstance(db_result, BaseException):
+                # DB failures are not user-recoverable — re-raise so the global
+                # handler can produce a 500 with trace_id.
+                raise db_result
+            records, snapshot_name = db_result
+        else:
+            sis_data, sis_error = prefetched_sis
+            records, snapshot_name = await self._fetch_paid_payments(db, student_number)
 
         # Sequential, not gathered with the above: both use `db`, and an
         # AsyncSession does not support concurrent statements on one connection.
         imported_records = await get_student_imported_records(db, student_number)
-
-        sis_error: Optional[str] = None
-        sis_data: Optional[Dict[str, Any]] = None
-        if isinstance(sis_result, BaseException):
-            logger.warning("SIS lookup failed for student %s: %s", student_number, sis_result)
-            sis_error = str(sis_result)
-        else:
-            sis_data = sis_result
-
-        if isinstance(db_result, BaseException):
-            # DB failures are not user-recoverable — re-raise so the global
-            # handler can produce a 500 with trace_id.
-            raise db_result
-        records, snapshot_name = db_result
 
         academic_info = self._build_academic_info(sis_data, error_message=sis_error)
 

--- a/backend/app/tests/test_student_history_shared_endpoint.py
+++ b/backend/app/tests/test_student_history_shared_endpoint.py
@@ -1,0 +1,221 @@
+"""Integration tests for the shared /api/v1/student-history endpoints.
+
+- POST /student-history/batch (admin/super_admin/college, college scoped to
+  its own college via SIS std_academyno)
+- GET /student-history/me/months (student, months total only)
+
+Auth pattern: override get_current_user with a configured Mock so the REAL
+role-dependency checks (require_scholarship_manager / require_student) still
+run. Mock(spec=User) alone is not enough — un-configured is_admin()/is_college()
+return truthy Mocks and every role check would pass.
+"""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import pytest_asyncio
+
+from app.models.user import User, UserRole
+
+SERVICE_PATH = "app.api.v1.endpoints.student_history.StudentScholarshipHistoryService"
+
+
+def _mock_user(role: UserRole, nycu_id: str = "tester01", college_code=None) -> Mock:
+    user = Mock(spec=User)
+    user.id = 1
+    user.nycu_id = nycu_id
+    user.role = role
+    user.college_code = college_code
+    user.is_admin.return_value = role == UserRole.admin
+    user.is_super_admin.return_value = role == UserRole.super_admin
+    user.is_college.return_value = role == UserRole.college
+    user.is_student.return_value = role == UserRole.student
+    user.is_professor.return_value = role == UserRole.professor
+    return user
+
+
+def _history_data(student_number: str = "S001", academy_no=None, available: bool = True, total_months: int = 5):
+    from app.schemas.student_scholarship_history import (
+        AcademicBasicInfo,
+        AcademicInfo,
+        HistorySummary,
+        StudentScholarshipHistoryData,
+    )
+
+    academic_info = (
+        AcademicInfo(available=True, basic_info=AcademicBasicInfo(std_academyno=academy_no))
+        if available
+        else AcademicInfo(available=False, error="SIS down", basic_info=None)
+    )
+    return StudentScholarshipHistoryData(
+        student_number=student_number,
+        academic_info=academic_info,
+        summary=HistorySummary(
+            total_records=0,
+            total_amount=Decimal("0"),
+            scholarship_type_count=0,
+            snapshot_name=None,
+            total_received_months=total_months,
+        ),
+        payment_records=[],
+    )
+
+
+@pytest_asyncio.fixture
+async def client_as():
+    """Factory: yield an AsyncClient authenticated as the given mock user."""
+    from app.core.security import get_current_user
+    from app.main import app
+
+    created = []
+
+    def _make(client, user):
+        async def override():
+            return user
+
+        app.dependency_overrides[get_current_user] = override
+        created.append(get_current_user)
+        return client
+
+    yield _make
+    for dep in created:
+        app.dependency_overrides.pop(dep, None)
+
+
+# ---------------------------------------------------------------------------
+# POST /student-history/batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_batch_mixed_found_and_not_found(client, client_as):
+    """Per-student results: a 404 for one 學號 doesn't sink the batch. Duplicate
+    numbers are deduped before lookup."""
+    from app.core.exceptions import NotFoundError
+
+    authed = client_as(client, _mock_user(UserRole.admin))
+    with patch(SERVICE_PATH) as MockSvc:
+        MockSvc.return_value.get_history = AsyncMock(
+            side_effect=[_history_data("S001"), NotFoundError("查無此學生資料", "GHOST1")]
+        )
+        response = await authed.post(
+            "/api/v1/student-history/batch",
+            json={"student_numbers": ["S001", "GHOST1", "S001"]},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    results = body["data"]["results"]
+    assert len(results) == 2
+    assert results[0]["student_number"] == "S001"
+    assert results[0]["success"] is True
+    assert results[0]["data"]["student_number"] == "S001"
+    assert results[1]["student_number"] == "GHOST1"
+    assert results[1]["success"] is False
+    assert "查無" in results[1]["error"]
+
+
+@pytest.mark.asyncio
+async def test_college_batch_scoped_to_own_college(client, client_as):
+    """College sees own-college students; other colleges and SIS-unverifiable
+    students are denied per-student."""
+    authed = client_as(client, _mock_user(UserRole.college, college_code="E"))
+    with patch(SERVICE_PATH) as MockSvc:
+        MockSvc.return_value.get_history = AsyncMock(
+            side_effect=[
+                _history_data("S001", academy_no="E"),
+                _history_data("S002", academy_no="C"),
+                _history_data("S003", available=False),
+            ]
+        )
+        response = await authed.post(
+            "/api/v1/student-history/batch",
+            json={"student_numbers": ["S001", "S002", "S003"]},
+        )
+
+    assert response.status_code == 200
+    results = response.json()["data"]["results"]
+    assert results[0]["success"] is True
+    assert results[1]["success"] is False
+    assert "本學院" in results[1]["error"]
+    assert results[1]["data"] is None
+    assert results[2]["success"] is False
+    assert "無法確認" in results[2]["error"]
+
+
+@pytest.mark.asyncio
+async def test_college_without_college_code_rejected(client, client_as):
+    authed = client_as(client, _mock_user(UserRole.college, college_code=None))
+    response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_batch_validation_errors(client, client_as):
+    """Empty list, oversized batch and malformed 學號 all yield 400."""
+    authed = client_as(client, _mock_user(UserRole.admin))
+
+    response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["  "]})
+    assert response.status_code == 400
+
+    response = await authed.post(
+        "/api/v1/student-history/batch",
+        json={"student_numbers": [f"S{i:05d}" for i in range(51)]},
+    )
+    assert response.status_code == 400
+
+    response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["bad@@chars"]})
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_batch_rejects_student_and_professor_roles(client, client_as):
+    authed = client_as(client, _mock_user(UserRole.student))
+    response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_batch_unauthenticated(client):
+    response = await client.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+    assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# GET /student-history/me/months
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_me_months_returns_total_only(client, client_as):
+    """Students get their 學號 and 總月數 — no payment records, no amounts."""
+    authed = client_as(client, _mock_user(UserRole.student, nycu_id="stuphd001"))
+    with patch(SERVICE_PATH) as MockSvc:
+        MockSvc.return_value.get_history = AsyncMock(return_value=_history_data("stuphd001", total_months=12))
+        response = await authed.get("/api/v1/student-history/me/months")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data == {"student_number": "stuphd001", "total_received_months": 12}
+
+
+@pytest.mark.asyncio
+async def test_me_months_no_history_is_zero_not_404(client, client_as):
+    from app.core.exceptions import NotFoundError
+
+    authed = client_as(client, _mock_user(UserRole.student, nycu_id="stunew001"))
+    with patch(SERVICE_PATH) as MockSvc:
+        MockSvc.return_value.get_history = AsyncMock(side_effect=NotFoundError("查無此學生資料", "stunew001"))
+        response = await authed.get("/api/v1/student-history/me/months")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["total_received_months"] == 0
+
+
+@pytest.mark.asyncio
+async def test_me_months_rejects_non_students(client, client_as):
+    authed = client_as(client, _mock_user(UserRole.admin))
+    response = await authed.get("/api/v1/student-history/me/months")
+    assert response.status_code == 403

--- a/backend/app/tests/test_student_history_shared_endpoint.py
+++ b/backend/app/tests/test_student_history_shared_endpoint.py
@@ -1,7 +1,7 @@
 """Integration tests for the shared /api/v1/student-history endpoints.
 
-- POST /student-history/batch (admin/super_admin/college, college scoped to
-  its own college via SIS std_academyno)
+- POST /student-history/batch (admin/super_admin/college; college scoped to
+  its own college, snapshot-first with live SIS as a secondary signal)
 - GET /student-history/me/months (student, months total only)
 
 Auth pattern: override get_current_user with a configured Mock so the REAL
@@ -19,6 +19,7 @@ import pytest_asyncio
 from app.models.user import User, UserRole
 
 SERVICE_PATH = "app.api.v1.endpoints.student_history.StudentScholarshipHistoryService"
+COLLEGE_NOT_VISIBLE = "查無符合條件的學生資料"
 
 
 def _mock_user(role: UserRole, nycu_id: str = "tester01", college_code=None) -> Mock:
@@ -35,11 +36,29 @@ def _mock_user(role: UserRole, nycu_id: str = "tester01", college_code=None) -> 
     return user
 
 
-def _history_data(student_number: str = "S001", academy_no=None, available: bool = True, total_months: int = 5):
+def _mock_service(MockSvc, get_history=None):
+    """Configure the mocked service with batch-endpoint defaults."""
+    svc = MockSvc.return_value
+    svc.fetch_sis_lookups = AsyncMock(return_value={})
+    svc.get_snapshot_academy_codes = AsyncMock(return_value=set())
+    if get_history is not None:
+        svc.get_history = AsyncMock(side_effect=get_history)
+    return svc
+
+
+def _history_data(
+    student_number: str = "S001",
+    academy_no=None,
+    available: bool = True,
+    total_months: int = 5,
+    with_sensitive_fields: bool = False,
+):
     from app.schemas.student_scholarship_history import (
         AcademicBasicInfo,
         AcademicInfo,
         HistorySummary,
+        PaymentRecord,
+        ReceivedMonthsBreakdown,
         StudentScholarshipHistoryData,
     )
 
@@ -48,17 +67,46 @@ def _history_data(student_number: str = "S001", academy_no=None, available: bool
         if available
         else AcademicInfo(available=False, error="SIS down", basic_info=None)
     )
+    payment_records = []
+    received_months = []
+    if with_sensitive_fields:
+        payment_records = [
+            PaymentRecord(
+                roster_id=1,
+                roster_code="R",
+                period_label="114-10",
+                academic_year=114,
+                roster_cycle="monthly",
+                scholarship_name="A",
+                scholarship_amount=Decimal("1000"),
+                revoke_reason="admin-only note",
+                suspend_reason="admin-only note",
+            )
+        ]
+        received_months = [
+            ReceivedMonthsBreakdown(
+                scholarship_type_id=1,
+                scholarship_name="A",
+                total_months=total_months,
+                imported_months=total_months,
+                system_months=0,
+                raw_row={"隱藏欄": "imported cell"},
+                file_name="import.xlsx",
+                imported_at="2026-01-01T00:00:00",
+            )
+        ]
     return StudentScholarshipHistoryData(
         student_number=student_number,
         academic_info=academic_info,
         summary=HistorySummary(
-            total_records=0,
+            total_records=len(payment_records),
             total_amount=Decimal("0"),
-            scholarship_type_count=0,
+            scholarship_type_count=len(payment_records),
             snapshot_name=None,
             total_received_months=total_months,
         ),
-        payment_records=[],
+        payment_records=payment_records,
+        received_months=received_months,
     )
 
 
@@ -89,15 +137,16 @@ async def client_as():
 
 
 @pytest.mark.asyncio
-async def test_admin_batch_mixed_found_and_not_found(client, client_as):
+async def test_admin_batch_mixed_found_and_not_found(client, client_as, db):
     """Per-student results: a 404 for one 學號 doesn't sink the batch. Duplicate
-    numbers are deduped before lookup."""
+    numbers are deduped before lookup, and the batch leaves an audit trail."""
     from app.core.exceptions import NotFoundError
 
     authed = client_as(client, _mock_user(UserRole.admin))
     with patch(SERVICE_PATH) as MockSvc:
-        MockSvc.return_value.get_history = AsyncMock(
-            side_effect=[_history_data("S001"), NotFoundError("查無此學生資料", "GHOST1")]
+        _mock_service(
+            MockSvc,
+            get_history=[_history_data("S001"), NotFoundError("查無此學生資料", "GHOST1")],
         )
         response = await authed.post(
             "/api/v1/student-history/batch",
@@ -116,19 +165,123 @@ async def test_admin_batch_mixed_found_and_not_found(client, client_as):
     assert results[1]["success"] is False
     assert "查無" in results[1]["error"]
 
+    from sqlalchemy import select
+
+    from app.models.audit_log import AuditLog
+
+    logs = (await db.execute(select(AuditLog).where(AuditLog.resource_type == "student_history"))).scalars().all()
+    assert len(logs) == 1
+    assert logs[0].new_values["student_numbers"] == ["S001", "GHOST1"]
+    assert logs[0].new_values["returned"] == ["S001"]
+
 
 @pytest.mark.asyncio
-async def test_college_batch_scoped_to_own_college(client, client_as):
-    """College sees own-college students; other colleges and SIS-unverifiable
-    students are denied per-student."""
+async def test_college_batch_scoped_without_existence_oracle(client, client_as):
+    """College sees own-college students (via live SIS); other-college and
+    nonexistent students get the SAME error message, so responses cannot be
+    used to probe which student numbers exist."""
+    from app.core.exceptions import NotFoundError
+
     authed = client_as(client, _mock_user(UserRole.college, college_code="E"))
     with patch(SERVICE_PATH) as MockSvc:
-        MockSvc.return_value.get_history = AsyncMock(
-            side_effect=[
+        _mock_service(
+            MockSvc,
+            get_history=[
                 _history_data("S001", academy_no="E"),
                 _history_data("S002", academy_no="C"),
-                _history_data("S003", available=False),
-            ]
+                NotFoundError("查無此學生資料", "GHOST1"),
+            ],
+        )
+        response = await authed.post(
+            "/api/v1/student-history/batch",
+            json={"student_numbers": ["S001", "S002", "GHOST1"]},
+        )
+
+    assert response.status_code == 200
+    results = response.json()["data"]["results"]
+    assert results[0]["success"] is True
+    assert results[1]["success"] is False
+    assert results[2]["success"] is False
+    # Existence oracle closed: out-of-college and not-found are identical.
+    assert results[1]["error"] == COLLEGE_NOT_VISIBLE
+    assert results[2]["error"] == COLLEGE_NOT_VISIBLE
+    assert results[1]["data"] is None
+
+
+@pytest.mark.asyncio
+async def test_college_snapshot_grants_access_when_sis_down(client, client_as):
+    """SIS unavailability must not lock a college out of its own students:
+    the frozen application snapshot (std_academyno) grants access alone."""
+    authed = client_as(client, _mock_user(UserRole.college, college_code="E"))
+    with patch(SERVICE_PATH) as MockSvc:
+        svc = _mock_service(MockSvc, get_history=[_history_data("S001", available=False)])
+        svc.get_snapshot_academy_codes = AsyncMock(return_value={"E"})
+        response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+
+    assert response.status_code == 200
+    result = response.json()["data"]["results"][0]
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_college_denied_when_neither_sis_nor_snapshot_match(client, client_as):
+    """No SIS data and no matching snapshot → denied (fail closed), with the
+    oracle-safe message."""
+    authed = client_as(client, _mock_user(UserRole.college, college_code="E"))
+    with patch(SERVICE_PATH) as MockSvc:
+        _mock_service(MockSvc, get_history=[_history_data("S001", available=False)])
+        response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+
+    result = response.json()["data"]["results"][0]
+    assert result["success"] is False
+    assert result["error"] == COLLEGE_NOT_VISIBLE
+
+
+@pytest.mark.asyncio
+async def test_college_payload_hides_admin_only_fields(client, client_as):
+    """College results must not carry admin-authored content: revocation and
+    suspension free-text, and the raw imported-file rows/provenance."""
+    authed = client_as(client, _mock_user(UserRole.college, college_code="E"))
+    with patch(SERVICE_PATH) as MockSvc:
+        _mock_service(
+            MockSvc,
+            get_history=[_history_data("S001", academy_no="E", with_sensitive_fields=True)],
+        )
+        response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+
+    data = response.json()["data"]["results"][0]["data"]
+    record = data["payment_records"][0]
+    assert record["revoke_reason"] is None
+    assert record["suspend_reason"] is None
+    breakdown = data["received_months"][0]
+    assert breakdown["raw_row"] is None
+    assert breakdown["file_name"] is None
+    assert breakdown["imported_at"] is None
+    # Months themselves remain visible.
+    assert breakdown["total_months"] == 5
+
+
+@pytest.mark.asyncio
+async def test_admin_payload_keeps_admin_fields(client, client_as):
+    authed = client_as(client, _mock_user(UserRole.admin))
+    with patch(SERVICE_PATH) as MockSvc:
+        _mock_service(MockSvc, get_history=[_history_data("S001", with_sensitive_fields=True)])
+        response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+
+    data = response.json()["data"]["results"][0]["data"]
+    assert data["payment_records"][0]["revoke_reason"] == "admin-only note"
+    assert data["received_months"][0]["raw_row"] == {"隱藏欄": "imported cell"}
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_mid_batch_reports_per_student(client, client_as):
+    """A DB/lookup crash for one student must not 500 the batch nor discard
+    the other results (per-student contract)."""
+    authed = client_as(client, _mock_user(UserRole.admin))
+    with patch(SERVICE_PATH) as MockSvc:
+        _mock_service(
+            MockSvc,
+            get_history=[_history_data("S001"), RuntimeError("db exploded"), _history_data("S003")],
         )
         response = await authed.post(
             "/api/v1/student-history/batch",
@@ -137,12 +290,8 @@ async def test_college_batch_scoped_to_own_college(client, client_as):
 
     assert response.status_code == 200
     results = response.json()["data"]["results"]
-    assert results[0]["success"] is True
-    assert results[1]["success"] is False
-    assert "本學院" in results[1]["error"]
-    assert results[1]["data"] is None
-    assert results[2]["success"] is False
-    assert "無法確認" in results[2]["error"]
+    assert [r["success"] for r in results] == [True, False, True]
+    assert "查詢失敗" in results[1]["error"]
 
 
 @pytest.mark.asyncio
@@ -162,7 +311,7 @@ async def test_batch_validation_errors(client, client_as):
 
     response = await authed.post(
         "/api/v1/student-history/batch",
-        json={"student_numbers": [f"S{i:05d}" for i in range(51)]},
+        json={"student_numbers": [f"S{i:05d}" for i in range(21)]},
     )
     assert response.status_code == 400
 
@@ -172,9 +321,13 @@ async def test_batch_validation_errors(client, client_as):
 
 @pytest.mark.asyncio
 async def test_batch_rejects_student_and_professor_roles(client, client_as):
-    authed = client_as(client, _mock_user(UserRole.student))
-    response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
-    assert response.status_code == 403
+    """Both non-staff-manager roles are rejected. The professor case guards
+    against a future require_staff swap — require_staff includes professors,
+    and the college scope gate does not apply to non-college users."""
+    for role in (UserRole.student, UserRole.professor):
+        authed = client_as(client, _mock_user(role))
+        response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+        assert response.status_code == 403, f"role {role.value} must be rejected"
 
 
 @pytest.mark.asyncio
@@ -193,7 +346,7 @@ async def test_me_months_returns_total_only(client, client_as):
     """Students get their 學號 and 總月數 — no payment records, no amounts."""
     authed = client_as(client, _mock_user(UserRole.student, nycu_id="stuphd001"))
     with patch(SERVICE_PATH) as MockSvc:
-        MockSvc.return_value.get_history = AsyncMock(return_value=_history_data("stuphd001", total_months=12))
+        MockSvc.return_value.get_total_received_months = AsyncMock(return_value=12)
         response = await authed.get("/api/v1/student-history/me/months")
 
     assert response.status_code == 200
@@ -202,12 +355,10 @@ async def test_me_months_returns_total_only(client, client_as):
 
 
 @pytest.mark.asyncio
-async def test_me_months_no_history_is_zero_not_404(client, client_as):
-    from app.core.exceptions import NotFoundError
-
+async def test_me_months_empty_history_is_zero(client, client_as):
     authed = client_as(client, _mock_user(UserRole.student, nycu_id="stunew001"))
     with patch(SERVICE_PATH) as MockSvc:
-        MockSvc.return_value.get_history = AsyncMock(side_effect=NotFoundError("查無此學生資料", "stunew001"))
+        MockSvc.return_value.get_total_received_months = AsyncMock(return_value=0)
         response = await authed.get("/api/v1/student-history/me/months")
 
     assert response.status_code == 200

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -27,6 +27,7 @@ import {
   FileSpreadsheet,
   Upload,
   UserCheck,
+  History,
 } from "lucide-react";
 import { EnhancedStudentPortal } from "@/components/enhanced-student-portal";
 import { AdminScholarshipDashboard } from "@/components/admin-scholarship-dashboard";
@@ -36,6 +37,7 @@ import { CollegeDashboard } from "@/components/college/CollegeManagementShell";
 import { AdminDashboard } from "@/components/admin-dashboard";
 import { RosterManagementDashboard } from "@/components/roster-management-dashboard";
 import { BatchImportPanel } from "@/components/batch-import-panel";
+import { StudentHistoryPanel } from "@/components/admin/student-history/StudentHistoryPanel";
 import { RenewalImportPanel } from "@/components/renewal-import-panel";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
@@ -272,7 +274,7 @@ export default function ScholarshipManagementSystem() {
 
     if (user.role === "college") {
       return (
-        <TabsList className="grid w-full grid-cols-2 bg-nycu-blue-50 border border-nycu-blue-200">
+        <TabsList className="grid w-full grid-cols-3 bg-nycu-blue-50 border border-nycu-blue-200">
           <TabsTrigger
             value="main"
             className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
@@ -286,6 +288,13 @@ export default function ScholarshipManagementSystem() {
           >
             <Upload className="h-4 w-4" />
             批次匯入
+          </TabsTrigger>
+          <TabsTrigger
+            value="student-history"
+            className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
+          >
+            <History className="h-4 w-4" />
+            領獎紀錄查詢
           </TabsTrigger>
         </TabsList>
       );
@@ -562,6 +571,13 @@ export default function ScholarshipManagementSystem() {
           {(user.role === "college" || user.role === "admin" || user.role === "super_admin") && (
             <TabsContent value="batch-import" className="space-y-4">
               <BatchImportPanel locale={locale} />
+            </TabsContent>
+          )}
+
+          {/* 領獎紀錄查詢 - college 角色；查詢範圍由後端限制在本學院學生 */}
+          {user.role === "college" && (
+            <TabsContent value="student-history" className="space-y-4">
+              <StudentHistoryPanel variant="college" />
             </TabsContent>
           )}
 

--- a/frontend/components/__tests__/enhanced-student-portal.test.tsx
+++ b/frontend/components/__tests__/enhanced-student-portal.test.tsx
@@ -26,7 +26,8 @@ jest.mock("../student-wizard/StudentApplicationWizard", () => ({
   ),
 }));
 
-// Mock the API client
+// Mock the API client. TotalReceivedMonthsCard imports the NAMED `apiClient`
+// export, so the factory must provide it alongside the default export.
 jest.mock("../../lib/api", () => ({
   __esModule: true,
   default: {
@@ -42,6 +43,14 @@ jest.mock("../../lib/api", () => ({
     documentRequests: {
       getMyDocumentRequests: jest.fn(),
       fulfillDocumentRequest: jest.fn(),
+    },
+  },
+  apiClient: {
+    studentHistory: {
+      getMyMonths: jest.fn().mockResolvedValue({
+        success: true,
+        data: { student_number: "test", total_received_months: 0 },
+      }),
     },
   },
 }));

--- a/frontend/components/admin/student-history/StudentHistoryPanel.tsx
+++ b/frontend/components/admin/student-history/StudentHistoryPanel.tsx
@@ -114,9 +114,13 @@ export function StudentHistoryPanel({ variant = "admin" }: StudentHistoryPanelPr
     if (validationError) {
       setInputError(validationError);
       // Clear previous result so it doesn't render under the validation error.
+      // loading must be reset here too: setting `submitted` to null makes the
+      // effect early-return, so an in-flight request's .finally (cancelled)
+      // would otherwise leave the spinner stranded on.
       setSubmitted(null);
       setResults(null);
       setError(null);
+      setLoading(false);
       return;
     }
     setInputError(null);
@@ -145,7 +149,8 @@ export function StudentHistoryPanel({ variant = "admin" }: StudentHistoryPanelPr
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSubmit();
+                  // Same gate as the 查詢 button's disabled={loading}.
+                  if (e.key === "Enter" && !loading) handleSubmit();
                 }}
                 placeholder="例: 310460031, 310460032 (可一次查詢多位，以逗號或空白分隔)"
                 autoFocus

--- a/frontend/components/admin/student-history/StudentHistoryPanel.tsx
+++ b/frontend/components/admin/student-history/StudentHistoryPanel.tsx
@@ -1,31 +1,70 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Search, Loader2, Upload } from "lucide-react";
+import { Search, Loader2, Upload, User as UserIcon } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { apiClient } from "@/lib/api";
-import type { StudentScholarshipHistoryData } from "@/lib/api/modules/student-history";
+import type { StudentHistoryBatchResult } from "@/lib/api/modules/student-history";
 
 import { AcademicInfoCard } from "./AcademicInfoCard";
 import { SummaryCards } from "./SummaryCards";
 import { PaymentHistoryTable } from "./PaymentHistoryTable";
 import { ReceivedMonthsCard } from "./ReceivedMonthsCard";
 import { ImportReceivedMonthsDialog } from "./ImportReceivedMonthsDialog";
+import { MAX_BATCH_SIZE, parseStudentNumbers } from "./parse-student-numbers";
 
-const STUDENT_NUMBER_REGEX = /^[A-Za-z0-9]{4,15}$/;
+interface StudentHistoryPanelProps {
+  /**
+   * "admin" (default) shows the 匯入已領月份數 action; "college" hides it —
+   * the import endpoint is admin-only, and the backend scopes college
+   * queries to the user's own college.
+   */
+  variant?: "admin" | "college";
+}
 
-export function StudentHistoryPanel() {
+function StudentHistoryResult({ result }: { result: StudentHistoryBatchResult }) {
+  if (!result.success || !result.data) {
+    const isNotFound = /查無/.test(result.error ?? "");
+    return (
+      <Card className="border-destructive">
+        <CardContent className="pt-6">
+          <p className="font-medium text-destructive">
+            {isNotFound ? "查無此學生資料" : "查詢失敗"}
+          </p>
+          <p className="text-sm text-muted-foreground mt-1">
+            學號 <span className="font-mono">{result.student_number}</span>
+            {isNotFound ? " 既無學籍資料也無領取記錄。" : `：${result.error}`}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const data = result.data;
+  return (
+    <div className="space-y-4">
+      <AcademicInfoCard
+        academicInfo={data.academic_info}
+        snapshotName={data.summary.snapshot_name}
+      />
+      <SummaryCards summary={data.summary} />
+      <ReceivedMonthsCard breakdowns={data.received_months} />
+      <PaymentHistoryTable records={data.payment_records} />
+    </div>
+  );
+}
+
+export function StudentHistoryPanel({ variant = "admin" }: StudentHistoryPanelProps) {
   const [input, setInput] = useState("");
-  const [submitted, setSubmitted] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState<string[] | null>(null);
   const [fetchToken, setFetchToken] = useState(0);
   const [inputError, setInputError] = useState<string | null>(null);
-  const [data, setData] = useState<StudentScholarshipHistoryData | null>(null);
+  const [results, setResults] = useState<StudentHistoryBatchResult[] | null>(null);
   const [loading, setLoading] = useState(false);
-  const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [importOpen, setImportOpen] = useState(false);
 
@@ -34,33 +73,22 @@ export function StudentHistoryPanel() {
 
     let cancelled = false;
     setLoading(true);
-    setData(null);
-    setNotFound(false);
+    setResults(null);
     setError(null);
 
     apiClient.studentHistory
-      .getByNumber(submitted)
+      .getBatch(submitted)
       .then((response) => {
         if (cancelled) return;
         if (response.success && response.data) {
-          setData(response.data);
+          setResults(response.data.results);
         } else {
-          const msg = response.message ?? "查詢失敗";
-          if (/404|查無/.test(msg)) {
-            setNotFound(true);
-          } else {
-            setError(msg);
-          }
+          setError(response.message ?? "查詢失敗");
         }
       })
       .catch((err) => {
         if (cancelled) return;
-        const msg = err instanceof Error ? err.message : "網路錯誤";
-        if (/404|查無/.test(msg)) {
-          setNotFound(true);
-        } else {
-          setError(msg);
-        }
+        setError(err instanceof Error ? err.message : "網路錯誤");
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -69,22 +97,30 @@ export function StudentHistoryPanel() {
     return () => {
       cancelled = true;
     };
-    // fetchToken forces refetch when the user retries with the same student number
+    // fetchToken forces refetch when the user retries with the same student numbers
   }, [submitted, fetchToken]);
 
   const handleSubmit = () => {
-    const trimmed = input.trim();
-    if (!STUDENT_NUMBER_REGEX.test(trimmed)) {
-      setInputError("請輸入有效的學號 (4-15 位英數字)");
+    const { valid, invalid } = parseStudentNumbers(input);
+    let validationError: string | null = null;
+    if (invalid.length > 0) {
+      validationError = `請輸入有效的學號 (4-15 位英數字)：${invalid.join("、")}`;
+    } else if (valid.length === 0) {
+      validationError = "請輸入有效的學號 (4-15 位英數字)";
+    } else if (valid.length > MAX_BATCH_SIZE) {
+      validationError = `一次最多查詢 ${MAX_BATCH_SIZE} 位學生`;
+    }
+
+    if (validationError) {
+      setInputError(validationError);
       // Clear previous result so it doesn't render under the validation error.
       setSubmitted(null);
-      setData(null);
-      setNotFound(false);
+      setResults(null);
       setError(null);
       return;
     }
     setInputError(null);
-    setSubmitted(trimmed);
+    setSubmitted(valid);
     setFetchToken((n) => n + 1);
   };
 
@@ -93,10 +129,12 @@ export function StudentHistoryPanel() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <CardTitle>學生領獎紀錄查詢</CardTitle>
-          <Button variant="outline" size="sm" onClick={() => setImportOpen(true)}>
-            <Upload className="h-4 w-4 mr-2" />
-            匯入已領月份數
-          </Button>
+          {variant === "admin" && (
+            <Button variant="outline" size="sm" onClick={() => setImportOpen(true)}>
+              <Upload className="h-4 w-4 mr-2" />
+              匯入已領月份數
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           <div className="flex items-end gap-3">
@@ -109,10 +147,15 @@ export function StudentHistoryPanel() {
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handleSubmit();
                 }}
-                placeholder="例: 310460031"
+                placeholder="例: 310460031, 310460032 (可一次查詢多位，以逗號或空白分隔)"
                 autoFocus
               />
               {inputError && <p className="text-sm text-destructive mt-1">{inputError}</p>}
+              {variant === "college" && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  僅能查詢本學院學生的領獎紀錄。
+                </p>
+              )}
             </div>
             <Button onClick={handleSubmit} disabled={loading}>
               {loading ? (
@@ -135,17 +178,6 @@ export function StudentHistoryPanel() {
         </Card>
       )}
 
-      {!loading && notFound && (
-        <Card className="border-destructive">
-          <CardContent className="pt-6">
-            <p className="font-medium text-destructive">查無此學生資料</p>
-            <p className="text-sm text-muted-foreground mt-1">
-              學號 <span className="font-mono">{submitted}</span> 既無學籍資料也無領取記錄。
-            </p>
-          </CardContent>
-        </Card>
-      )}
-
       {!loading && error && (
         <Card className="border-destructive">
           <CardContent className="pt-6">
@@ -155,26 +187,37 @@ export function StudentHistoryPanel() {
         </Card>
       )}
 
-      {!loading && data && (
-        <>
-          <AcademicInfoCard
-            academicInfo={data.academic_info}
-            snapshotName={data.summary.snapshot_name}
-          />
-          <SummaryCards summary={data.summary} />
-          <ReceivedMonthsCard breakdowns={data.received_months} />
-          <PaymentHistoryTable records={data.payment_records} />
-        </>
-      )}
+      {!loading &&
+        results &&
+        (results.length === 1 ? (
+          <StudentHistoryResult result={results[0]} />
+        ) : (
+          results.map((result) => (
+            <section key={result.student_number} className="space-y-4">
+              <h3 className="flex items-center gap-2 text-lg font-semibold border-b pb-2">
+                <UserIcon className="h-5 w-5 text-muted-foreground" />
+                <span className="font-mono">{result.student_number}</span>
+                {result.data?.summary.snapshot_name && (
+                  <span className="text-muted-foreground font-normal">
+                    {result.data.summary.snapshot_name}
+                  </span>
+                )}
+              </h3>
+              <StudentHistoryResult result={result} />
+            </section>
+          ))
+        ))}
 
-      <ImportReceivedMonthsDialog
-        open={importOpen}
-        onOpenChange={setImportOpen}
-        onImported={() => {
-          // Re-run the current lookup so a just-imported baseline shows up.
-          if (submitted !== null) setFetchToken((n) => n + 1);
-        }}
-      />
+      {variant === "admin" && (
+        <ImportReceivedMonthsDialog
+          open={importOpen}
+          onOpenChange={setImportOpen}
+          onImported={() => {
+            // Re-run the current lookup so a just-imported baseline shows up.
+            if (submitted !== null) setFetchToken((n) => n + 1);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/components/admin/student-history/__tests__/parse-student-numbers.test.ts
+++ b/frontend/components/admin/student-history/__tests__/parse-student-numbers.test.ts
@@ -1,0 +1,37 @@
+import { parseStudentNumbers } from "../parse-student-numbers";
+
+describe("parseStudentNumbers", () => {
+  it("parses a single student number", () => {
+    expect(parseStudentNumbers(" 310460031 ")).toEqual({
+      valid: ["310460031"],
+      invalid: [],
+    });
+  });
+
+  it("splits on commas, 頓號, semicolons and whitespace", () => {
+    expect(
+      parseStudentNumbers("S001,S002，S003、S004;S005；S006 S007\nS008"),
+    ).toEqual({
+      valid: ["S001", "S002", "S003", "S004", "S005", "S006", "S007", "S008"],
+      invalid: [],
+    });
+  });
+
+  it("dedupes preserving first-seen order", () => {
+    expect(parseStudentNumbers("S002, S001, S002")).toEqual({
+      valid: ["S002", "S001"],
+      invalid: [],
+    });
+  });
+
+  it("separates invalid tokens", () => {
+    expect(parseStudentNumbers("S001, bad@@chars, ab")).toEqual({
+      valid: ["S001"],
+      invalid: ["bad@@chars", "ab"],
+    });
+  });
+
+  it("returns empty lists for blank input", () => {
+    expect(parseStudentNumbers("  \n ,, ")).toEqual({ valid: [], invalid: [] });
+  });
+});

--- a/frontend/components/admin/student-history/parse-student-numbers.ts
+++ b/frontend/components/admin/student-history/parse-student-numbers.ts
@@ -1,0 +1,27 @@
+/**
+ * Multi-學號 input parsing for the student history lookup.
+ *
+ * Accepts comma / 頓號 / semicolon / whitespace (incl. newline) separators,
+ * trims, dedupes preserving order, and splits into valid / invalid tokens.
+ * Mirrors the backend rules: `^[A-Za-z0-9]{4,15}$`, max 50 per batch.
+ */
+
+export const STUDENT_NUMBER_REGEX = /^[A-Za-z0-9]{4,15}$/;
+export const MAX_BATCH_SIZE = 50;
+
+export interface ParsedStudentNumbers {
+  valid: string[];
+  invalid: string[];
+}
+
+export function parseStudentNumbers(input: string): ParsedStudentNumbers {
+  const tokens = input
+    .split(/[\s,，、;；]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+  const deduped = [...new Set(tokens)];
+  return {
+    valid: deduped.filter((token) => STUDENT_NUMBER_REGEX.test(token)),
+    invalid: deduped.filter((token) => !STUDENT_NUMBER_REGEX.test(token)),
+  };
+}

--- a/frontend/components/admin/student-history/parse-student-numbers.ts
+++ b/frontend/components/admin/student-history/parse-student-numbers.ts
@@ -7,7 +7,7 @@
  */
 
 export const STUDENT_NUMBER_REGEX = /^[A-Za-z0-9]{4,15}$/;
-export const MAX_BATCH_SIZE = 50;
+export const MAX_BATCH_SIZE = 20;
 
 export interface ParsedStudentNumbers {
   valid: string[];
@@ -15,13 +15,11 @@ export interface ParsedStudentNumbers {
 }
 
 export function parseStudentNumbers(input: string): ParsedStudentNumbers {
-  const tokens = input
-    .split(/[\s,，、;；]+/)
-    .map((token) => token.trim())
-    .filter(Boolean);
-  const deduped = [...new Set(tokens)];
-  return {
-    valid: deduped.filter((token) => STUDENT_NUMBER_REGEX.test(token)),
-    invalid: deduped.filter((token) => !STUDENT_NUMBER_REGEX.test(token)),
-  };
+  const tokens = input.split(/[\s,，、;；]+/).filter(Boolean);
+  const valid: string[] = [];
+  const invalid: string[] = [];
+  for (const token of new Set(tokens)) {
+    (STUDENT_NUMBER_REGEX.test(token) ? valid : invalid).push(token);
+  }
+  return { valid, invalid };
 }

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -1166,9 +1166,8 @@ export function EnhancedStudentPortal({
 
       {/* Conditional rendering based on activeTab */}
       {activeTab === "applications" && (
+        <>
         <TotalReceivedMonthsCard locale={locale} />
-      )}
-      {activeTab === "applications" && (
         <Card>
           <CardHeader>
             <CardTitle>{t("portal.application_records")}</CardTitle>
@@ -1345,6 +1344,7 @@ export function EnhancedStudentPortal({
             )}
           </CardContent>
         </Card>
+        </>
       )}
 
       {activeTab === "new-application" &&

--- a/frontend/components/enhanced-student-portal.tsx
+++ b/frontend/components/enhanced-student-portal.tsx
@@ -31,6 +31,7 @@ import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { StudentApplicationWizard } from "@/components/student-wizard/StudentApplicationWizard";
 import { DocumentRequestAlert } from "@/components/document-request-alert";
 import { RenewalApplicationCard } from "@/components/student/RenewalApplicationCard";
+import { TotalReceivedMonthsCard } from "@/components/student/TotalReceivedMonthsCard";
 import { ChallengeApplicationCard } from "@/components/student/ChallengeApplicationCard";
 import type { StudentDocumentRequest } from "@/lib/api/modules/document-requests";
 import {
@@ -1164,6 +1165,9 @@ export function EnhancedStudentPortal({
       })}
 
       {/* Conditional rendering based on activeTab */}
+      {activeTab === "applications" && (
+        <TotalReceivedMonthsCard locale={locale} />
+      )}
       {activeTab === "applications" && (
         <Card>
           <CardHeader>

--- a/frontend/components/student/TotalReceivedMonthsCard.tsx
+++ b/frontend/components/student/TotalReceivedMonthsCard.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CalendarClock } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { apiClient } from "@/lib/api";
+import { logger } from "@/lib/utils/logger";
+
+interface TotalReceivedMonthsCardProps {
+  locale?: "zh" | "en";
+}
+
+/**
+ * Student self-service view of their 已領獎學金總月數 (匯入 + 系統, all
+ * scholarship types combined). Students see the months total only — never
+ * amounts or per-roster payment details. Renders nothing while loading or
+ * when the lookup fails, so it can't block the surrounding page.
+ */
+export function TotalReceivedMonthsCard({ locale = "zh" }: TotalReceivedMonthsCardProps) {
+  const [totalMonths, setTotalMonths] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiClient.studentHistory
+      .getMyMonths()
+      .then((response) => {
+        if (cancelled) return;
+        if (response.success && response.data) {
+          setTotalMonths(response.data.total_received_months);
+        } else {
+          logger.error("Failed to fetch my received months", {
+            message: response.message,
+          });
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          logger.error("Failed to fetch my received months", { error });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (totalMonths === null) return null;
+
+  return (
+    <Card data-testid="total-received-months-card">
+      <CardContent className="flex items-center gap-4 py-4">
+        <div className="rounded-full bg-nycu-blue-50 p-3">
+          <CalendarClock className="h-6 w-6 text-nycu-blue-600" />
+        </div>
+        <div>
+          <p className="text-sm text-muted-foreground">
+            {locale === "zh" ? "已領獎學金總月數" : "Total Scholarship Months Received"}
+          </p>
+          <p className="text-2xl font-bold">
+            {totalMonths}
+            <span className="ml-1 text-base font-normal text-muted-foreground">
+              {locale === "zh" ? "個月" : "months"}
+            </span>
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/e2e/specs/admin-student-history.spec.ts
+++ b/frontend/e2e/specs/admin-student-history.spec.ts
@@ -40,6 +40,20 @@ test.describe("Admin student scholarship history", () => {
     await context.close();
   });
 
+  test("multi-student query renders a block per 學號", async ({ browser }) => {
+    const { context } = await loginAs(browser, "admin");
+    const page = await context.newPage();
+    await page.goto("/");
+    await page.getByRole("tab", { name: "系統管理" }).click();
+    await page.getByRole("tab", { name: "學生領獎紀錄查詢" }).click();
+    await page.getByLabel("學號").fill("GHOST00001 GHOST00002");
+    await page.getByRole("button", { name: "查詢" }).click();
+    await expect(page.getByText("查無此學生資料")).toHaveCount(2, {
+      timeout: 15000,
+    });
+    await context.close();
+  });
+
   // NOTE: This test uses seeded `stuphd001` (see backend/app/seed.py). The
   // dev DB may or may not have paid (COMPLETED or LOCKED) rosters for them
   // by default. If not, the table will show the "尚無領取記錄" empty state —

--- a/frontend/e2e/specs/student-history-access.spec.ts
+++ b/frontend/e2e/specs/student-history-access.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * E2E: student scholarship history access for college and student roles.
+ *
+ * - College: top-level "領獎紀錄查詢" tab renders StudentHistoryPanel in the
+ *   college variant (no admin-only 匯入已領月份數 button); backend scopes
+ *   lookups to the user's own college (college_code, seeded "C").
+ * - Student: 我的申請 tab shows the 已領獎學金總月數 card fed by
+ *   GET /student-history/me/months (0 個月 is a valid state on a fresh seed).
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../helpers/auth";
+
+test.describe("College student history lookup", () => {
+  test("college tab renders panel without admin import action", async ({
+    browser,
+  }) => {
+    const { context } = await loginAs(browser, "cs_college");
+    const page = await context.newPage();
+    await page.goto("/");
+    await page.getByRole("tab", { name: "領獎紀錄查詢" }).click();
+    await expect(page.getByLabel("學號")).toBeVisible();
+    await expect(page.getByText("僅能查詢本學院學生的領獎紀錄。")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "匯入已領月份數" }),
+    ).toHaveCount(0);
+    await context.close();
+  });
+
+  test("college multi-student query shows one result block per 學號", async ({
+    browser,
+  }) => {
+    const { context } = await loginAs(browser, "cs_college");
+    const page = await context.newPage();
+    await page.goto("/");
+    await page.getByRole("tab", { name: "領獎紀錄查詢" }).click();
+    // Unknown 學號s keep the assertion seed-independent: each yields its own
+    // per-student "查無此學生資料" block from the batch endpoint.
+    await page.getByLabel("學號").fill("GHOST00001, GHOST00002");
+    await page.getByRole("button", { name: "查詢" }).click();
+    await expect(page.getByText("查無此學生資料")).toHaveCount(2, {
+      timeout: 15000,
+    });
+    await context.close();
+  });
+});
+
+test.describe("Student total received months", () => {
+  test("我的申請 tab shows the 總月數 card", async ({ browser }) => {
+    const { context } = await loginAs(browser, "stuphd001");
+    const page = await context.newPage();
+    await page.goto("/");
+    await page.getByRole("tab", { name: "我的申請" }).click();
+    const card = page.getByTestId("total-received-months-card");
+    await expect(card).toBeVisible({ timeout: 15000 });
+    await expect(card).toContainText("已領獎學金總月數");
+    await expect(card).toContainText("個月");
+    await context.close();
+  });
+});

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7206,9 +7206,9 @@ export interface paths {
         put?: never;
         /**
          * Batch Student Scholarship History
-         * @description Multi-student history lookup. Per-student failures (not found, out of
-         *     college scope) are reported inside data.results, not as an HTTP error, so
-         *     one bad 學號 doesn't sink the rest of the batch.
+         * @description Multi-student history lookup. Failures are strictly per-student
+         *     (not found, out of college scope, lookup error) inside data.results —
+         *     one bad 學號 or one failed lookup never sinks the rest of the batch.
          */
         post: operations["batch_student_scholarship_history_api_v1_student_history_batch_post"];
         delete?: never;
@@ -7227,8 +7227,8 @@ export interface paths {
         /**
          * Get My Received Months
          * @description A student's own 總領月份數 (匯入 + 系統, summed across every scholarship
-         *     type). No SIS data and no payment records is a valid "0 months" state for a
-         *     student viewing their own history, not a 404.
+         *     type). DB-only — no SIS round trip — and an empty history is a valid
+         *     0-month state, not an error.
          */
         get: operations["get_my_received_months_api_v1_student_history_me_months_get"];
         put?: never;

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7195,6 +7195,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/student-history/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Batch Student Scholarship History
+         * @description Multi-student history lookup. Per-student failures (not found, out of
+         *     college scope) are reported inside data.results, not as an HTTP error, so
+         *     one bad 學號 doesn't sink the rest of the batch.
+         */
+        post: operations["batch_student_scholarship_history_api_v1_student_history_batch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/student-history/me/months": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get My Received Months
+         * @description A student's own 總領月份數 (匯入 + 系統, summed across every scholarship
+         *     type). No SIS data and no payment records is a valid "0 months" state for a
+         *     student viewing their own history, not a 404.
+         */
+        get: operations["get_my_received_months_api_v1_student_history_me_months_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/csp-report": {
         parameters: {
             query?: never;
@@ -8662,6 +8706,17 @@ export interface components {
             updates: {
                 [key: string]: unknown;
             };
+        };
+        /**
+         * BatchStudentHistoryRequest
+         * @description Multi-student lookup request body for POST /student-history/batch.
+         *
+         *     Size and per-number format limits are enforced in the endpoint (uniform
+         *     400s with zh-TW messages) rather than as Field constraints (422s).
+         */
+        BatchStudentHistoryRequest: {
+            /** Student Numbers */
+            student_numbers: string[];
         };
         /** Body_create_ranking_api_v1_college_review_rankings_post */
         Body_create_ranking_api_v1_college_review_rankings_post: {
@@ -22847,6 +22902,59 @@ export interface operations {
         };
     };
     get_my_verified_account_api_v1_student_bank_accounts_my_verified_account_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    batch_student_scholarship_history_api_v1_student_history_batch_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchStudentHistoryRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_my_received_months_api_v1_student_history_me_months_get: {
         parameters: {
             query?: never;
             header?: never;

--- a/frontend/lib/api/modules/student-history.ts
+++ b/frontend/lib/api/modules/student-history.ts
@@ -1,10 +1,10 @@
 /**
  * Student Scholarship History API Module
  *
- * - Admin single-student lookup by 學號 (academic info + paid-roster payment
- *   records; rosters in COMPLETED or LOCKED state).
- * - Batch lookup for admin/college (college is server-scoped to its own
- *   college via SIS std_academyno).
+ * - Batch lookup by 學號 for admin/college (academic info + paid-roster
+ *   payment records; rosters in COMPLETED or LOCKED state). College users are
+ *   server-scoped to their own college and receive a projected payload
+ *   without admin-only fields.
  * - Student self-service 總領月份數 (months total only).
  */
 
@@ -118,18 +118,6 @@ export interface MyReceivedMonthsData {
 
 export function createStudentHistoryApi() {
   return {
-    async getByNumber(
-      studentNumber: string,
-    ): Promise<ApiResponse<StudentScholarshipHistoryData>> {
-      const response = await typedClient.raw.GET(
-        "/api/v1/admin/student-history/{student_number}",
-        {
-          params: { path: { student_number: studentNumber } },
-        },
-      );
-      return toApiResponse<StudentScholarshipHistoryData>(response);
-    },
-
     async getBatch(
       studentNumbers: string[],
     ): Promise<ApiResponse<StudentHistoryBatchData>> {

--- a/frontend/lib/api/modules/student-history.ts
+++ b/frontend/lib/api/modules/student-history.ts
@@ -1,8 +1,11 @@
 /**
- * Admin Student Scholarship History API Module
+ * Student Scholarship History API Module
  *
- * Single-student lookup by 學號 — returns academic info + paid-roster payment
- * records (rosters in COMPLETED or LOCKED state).
+ * - Admin single-student lookup by 學號 (academic info + paid-roster payment
+ *   records; rosters in COMPLETED or LOCKED state).
+ * - Batch lookup for admin/college (college is server-scoped to its own
+ *   college via SIS std_academyno).
+ * - Student self-service 總領月份數 (months total only).
  */
 
 import { typedClient } from "../typed-client";
@@ -91,6 +94,28 @@ export interface StudentScholarshipHistoryData {
   received_months: ReceivedMonthsBreakdown[];
 }
 
+/**
+ * One entry of POST /student-history/batch. Per-student failures (查無資料,
+ * out-of-college scope) arrive here with success=false — the HTTP call itself
+ * still succeeds.
+ */
+export interface StudentHistoryBatchResult {
+  student_number: string;
+  success: boolean;
+  error: string | null;
+  data: StudentScholarshipHistoryData | null;
+}
+
+export interface StudentHistoryBatchData {
+  results: StudentHistoryBatchResult[];
+}
+
+/** Student self-service payload — 總月數 only, no amounts or payment details. */
+export interface MyReceivedMonthsData {
+  student_number: string;
+  total_received_months: number;
+}
+
 export function createStudentHistoryApi() {
   return {
     async getByNumber(
@@ -103,6 +128,26 @@ export function createStudentHistoryApi() {
         },
       );
       return toApiResponse<StudentScholarshipHistoryData>(response);
+    },
+
+    async getBatch(
+      studentNumbers: string[],
+    ): Promise<ApiResponse<StudentHistoryBatchData>> {
+      const response = await typedClient.raw.POST(
+        "/api/v1/student-history/batch",
+        {
+          body: { student_numbers: studentNumbers },
+        },
+      );
+      return toApiResponse<StudentHistoryBatchData>(response);
+    },
+
+    async getMyMonths(): Promise<ApiResponse<MyReceivedMonthsData>> {
+      const response = await typedClient.raw.GET(
+        "/api/v1/student-history/me/months",
+        {},
+      );
+      return toApiResponse<MyReceivedMonthsData>(response);
     },
   };
 }


### PR DESCRIPTION
## Summary

Opens the 學生領獎紀錄查詢 feature (previously admin-only) to college and student roles, and adds multi-student querying.

### New endpoints
- `POST /api/v1/student-history/batch` — multi-學號 lookup (max 20) for admin / super_admin / college. Failures are strictly per-student (`results[].success/error`); one bad 學號 or one crashed lookup never sinks the batch (per-student rollback keeps the shared session usable).
- `GET /api/v1/student-history/me/months` — student self-service; returns **only** `total_received_months` (no amounts, no payment details). DB-only, no SIS round trip; empty history is a valid 0-month state.
- The admin single lookup `GET /admin/student-history/{student_number}` is unchanged (still used by admin-revoke-suspend e2e).

### College scoping (server-side, fail-safe)
- Snapshot-first: a student is visible to a college if any application snapshot `student_data.std_academyno` matches the user's `college_code` (same source as every other college gate in the repo), with live SIS as a secondary signal — SIS outages can't lock a college out of its own students, and the awarding college keeps access after a student transfers.
- Out-of-college and nonexistent students return the **identical** error message (no student-existence oracle).
- College payloads are projected: `revoke_reason` / `suspend_reason` free-text and imported-file `raw_row` / `file_name` / `imported_at` are admin-only.
- Every batch lookup writes an `AuditLog` entry recording who queried whom.

### Performance
- Batch SIS lookups run as one semaphore-capped (10) concurrent wave instead of N serialized calls; `MAX_BATCH_SIZE=20` keeps the worst case (fully degraded SIS ≈ 20s) inside the 30s/60s proxy budgets.

### Frontend
- `StudentHistoryPanel` accepts multiple 學號 (comma/頓號/semicolon/whitespace separated, deduped) and renders one result block per student; new `variant="college"` hides the admin-only 匯入已領月份數 action.
- New top-level 領獎紀錄查詢 tab for the college role.
- Student portal 我的申請 tab shows a 已領獎學金總月數 card.
- `schema.d.ts` regenerated from a CI-faithful spec (pinned requirements under python:3.13 — local host/container deps are stale and produce phantom drift).

An adversarial `/code-review high` pass ran over the branch; all 10 confirmed findings were fixed in the second commit (snapshot-first college gate, oracle closure + audit trail, payload projection, concurrent SIS wave, per-student error isolation, DB-only `/me/months`, stranded-loading UI fix, portal jest mock fix, professor-rejection test, dead-code cleanups).

## Test plan
- [x] Backend: 23 tests across the new shared endpoints + existing admin history suites (batch scoping/oracle/projection/mid-batch failure/audit, me/months, role gating) — pass on in-mem SQLite
- [x] Lint: black, flake8 B904/B014, logger-traceback AST invariants — clean
- [x] Frontend: full jest suite 1444/1444 (incl. fixed enhanced-student-portal suite and new parse-helper tests); `tsc --noEmit` clean
- [x] E2E (live dev stack): 7/7 — admin single + multi lookup, college tab without import action, college multi-student per-學號 blocks, student 總月數 card
- [ ] CI: api-types-check (schema.d.ts generated CI-faithfully), backend unit/integration/smoke lanes