### PR TITLE
feat(footer): make 相關連結 admin-editable with file upload support

### DIFF
--- a/backend/alembic/versions/add_footer_links_001_add_footer_links_table.py
+++ b/backend/alembic/versions/add_footer_links_001_add_footer_links_table.py
@@ -1,0 +1,125 @@
+"""add footer_links table (admin-editable 相關連結)
+
+Seeds the three real links that were previously hardcoded in
+frontend/components/footer.tsx so the footer renders identically after
+this migration. The three placeholder entries in that component pointed at
+href="#" (獎學金申請指南 / 常見問題 / 系統操作手冊) and are intentionally NOT
+seeded — they were dead links; an admin now adds them with a real URL or an
+uploaded PDF.
+
+IMPORTANT: migration 59b65a4de996 runs ``Base.metadata.create_all()``, so on a
+fresh database ``footer_links`` already exists (with the model's constraint)
+by the time this migration runs. Each step below is therefore guarded
+individually — an early ``return`` on "table exists" would silently skip the
+seed rows on every fresh install.
+
+Revision ID: add_footer_links_001
+Revises: roster_counts_included_001
+Create Date: 2026-07-29
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "add_footer_links_001"
+down_revision = "roster_counts_included_001"
+branch_labels = None
+depends_on = None
+
+
+_CHECK_NAME = "ck_footer_links_payload_matches_type"
+_CHECK_SQL = (
+    "(link_type = 'url' AND url IS NOT NULL AND object_name IS NULL) "
+    "OR (link_type = 'file' AND object_name IS NOT NULL AND url IS NULL)"
+)
+
+_SEED_LINKS = [
+    ("陽明交大首頁", "NYCU Homepage", "https://www.nycu.edu.tw", 0),
+    ("教務處", "Academic Affairs", "https://aa.nycu.edu.tw/", 1),
+    ("NYCU Portal", "NYCU Portal", "https://portal.nycu.edu.tw", 2),
+]
+
+_footer_links_table = sa.table(
+    "footer_links",
+    sa.column("title_zh", sa.String),
+    sa.column("title_en", sa.String),
+    sa.column("link_type", sa.String),
+    sa.column("url", sa.String),
+    sa.column("sort_order", sa.Integer),
+    sa.column("is_active", sa.Boolean),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # --- 1. Table (skipped when create_all already built it) ---------------
+    if "footer_links" not in inspector.get_table_names():
+        link_type_enum = sa.Enum("url", "file", name="footerlinktype", create_type=True)
+
+        op.create_table(
+            "footer_links",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("title_zh", sa.String(length=200), nullable=False),
+            sa.Column("title_en", sa.String(length=200), nullable=True),
+            sa.Column("link_type", link_type_enum, nullable=False, server_default="url"),
+            sa.Column("url", sa.String(length=1000), nullable=True),
+            sa.Column("object_name", sa.String(length=500), nullable=True),
+            sa.Column("original_filename", sa.String(length=500), nullable=True),
+            sa.Column("content_type", sa.String(length=100), nullable=True),
+            sa.Column("file_size", sa.Integer(), nullable=True),
+            sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("created_by", sa.Integer(), sa.ForeignKey("users.id"), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.CheckConstraint(_CHECK_SQL, name=_CHECK_NAME),
+        )
+        op.create_index("idx_footer_links_sort", "footer_links", ["sort_order"])
+        inspector = sa.inspect(bind)
+
+    # --- 2. CHECK constraint (for DBs predating the model constraint) ------
+    existing_checks = {c["name"] for c in inspector.get_check_constraints("footer_links")}
+    if _CHECK_NAME not in existing_checks:
+        op.create_check_constraint(_CHECK_NAME, "footer_links", sa.text(_CHECK_SQL))
+
+    # --- 3. Seed the previously hardcoded links (only when empty) ----------
+    already_seeded = bind.execute(sa.text("SELECT 1 FROM footer_links LIMIT 1")).scalar()
+    if not already_seeded:
+        op.bulk_insert(
+            _footer_links_table,
+            [
+                {
+                    "title_zh": title_zh,
+                    "title_en": title_en,
+                    "link_type": "url",
+                    "url": url,
+                    "sort_order": sort_order,
+                    "is_active": True,
+                }
+                for title_zh, title_en, url, sort_order in _SEED_LINKS
+            ],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "footer_links" in inspector.get_table_names():
+        op.drop_index("idx_footer_links_sort", table_name="footer_links", if_exists=True)
+        op.drop_table("footer_links")
+
+    sa.Enum(name="footerlinktype").drop(bind, checkfirst=True)

--- a/backend/alembic/versions/add_footer_links_001_add_footer_links_table.py
+++ b/backend/alembic/versions/add_footer_links_001_add_footer_links_table.py
@@ -87,7 +87,13 @@ def upgrade() -> None:
             ),
             sa.CheckConstraint(_CHECK_SQL, name=_CHECK_NAME),
         )
-        op.create_index("idx_footer_links_sort", "footer_links", ["sort_order"])
+        # Use the names SQLAlchemy's own ``index=True`` would generate, so a
+        # migration-built DB and a create_all-built DB agree. Otherwise
+        # `alembic revision --autogenerate` later emits spurious drop/create
+        # index pairs, and a follow-up migration written against one name
+        # fails on databases built via the other path.
+        op.create_index("ix_footer_links_id", "footer_links", ["id"])
+        op.create_index("ix_footer_links_sort_order", "footer_links", ["sort_order"])
         inspector = sa.inspect(bind)
 
     # --- 2. CHECK constraint (for DBs predating the model constraint) ------
@@ -119,7 +125,8 @@ def downgrade() -> None:
     inspector = sa.inspect(bind)
 
     if "footer_links" in inspector.get_table_names():
-        op.drop_index("idx_footer_links_sort", table_name="footer_links", if_exists=True)
+        op.drop_index("ix_footer_links_sort_order", table_name="footer_links", if_exists=True)
+        op.drop_index("ix_footer_links_id", table_name="footer_links", if_exists=True)
         op.drop_table("footer_links")
 
     sa.Enum(name="footerlinktype").drop(bind, checkfirst=True)

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -16,6 +16,7 @@ from app.api.v1.endpoints import (
     email_automation,
     email_management,
     files,
+    footer_links,
     notifications,
     nycu_employee,
     payment_rosters,
@@ -77,6 +78,7 @@ api_router.include_router(nycu_employee.router, prefix="/nycu-employee", tags=["
 api_router.include_router(payment_rosters.router, prefix="/payment-rosters", tags=["Payment Rosters"])
 api_router.include_router(roster_schedules.router, prefix="/roster-schedules", tags=["Roster Schedules"])
 api_router.include_router(system_settings.router, prefix="/system-settings", tags=["System Settings"])
+api_router.include_router(footer_links.router, prefix="/footer-links", tags=["Footer Links"])
 api_router.include_router(student_bank_accounts.router, prefix="/student-bank-accounts", tags=["Student Bank Accounts"])
 api_router.include_router(student_history.router, prefix="/student-history", tags=["Student History"])
 api_router.include_router(csp_report.router, prefix="", tags=["Security"])

--- a/backend/app/api/v1/endpoints/footer_links.py
+++ b/backend/app/api/v1/endpoints/footer_links.py
@@ -15,7 +15,11 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.document_formats import REFERENCE_DOC_EXTENSIONS, extension_for_filename
+from app.core.document_formats import (
+    REFERENCE_DOC_EXTENSIONS,
+    content_type_for_extension,
+    extension_for_filename,
+)
 from app.core.path_security import validate_upload_file
 from app.core.security import get_current_user, require_admin
 from app.db.deps import get_db
@@ -35,16 +39,18 @@ logger = logging.getLogger(__name__)
 
 MAX_UPLOAD_SIZE_MB = 10
 
-_ADMIN_ROLES = {"admin", "super_admin"}
-
 
 def _serialize(link: FooterLink) -> dict:
     return FooterLinkResponse.model_validate(link).model_dump(mode="json")
 
 
 def _is_admin(user: User) -> bool:
-    role = user.role.value if hasattr(user.role, "value") else str(user.role)
-    return role in _ADMIN_ROLES
+    """Same predicate `require_admin` enforces on the write endpoints.
+
+    Reuses the model helpers rather than string-matching roles so the read
+    gates below can never drift from the write gates.
+    """
+    return user.is_admin() or user.is_super_admin()
 
 
 async def _get_link_or_404(db: AsyncSession, link_id: int) -> FooterLink:
@@ -146,7 +152,11 @@ async def upload_footer_link_file(
 
     ext = extension_for_filename(file.filename or "")
     object_name = f"footer-links/link_{uuid.uuid4().hex}{ext}"
-    content_type = file.content_type or "application/octet-stream"
+    # Derive from the validated extension — never persist file.content_type.
+    # That header is client-supplied, and this document is later streamed back
+    # with `Content-Disposition: inline` from our own origin, so a .pdf
+    # declared text/html would render as an attacker-controlled page.
+    content_type = content_type_for_extension(ext)
 
     minio_service.client.put_object(
         bucket_name=minio_service.default_bucket,

--- a/backend/app/api/v1/endpoints/footer_links.py
+++ b/backend/app/api/v1/endpoints/footer_links.py
@@ -1,0 +1,345 @@
+"""Admin-managed footer 相關連結 (Related Links).
+
+Each entry is either an external URL or an uploaded document (PDF / Office /
+ODF) streamed back through this API — never a direct MinIO URL.
+"""
+
+import io
+import logging
+import uuid
+from typing import List, Optional
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.document_formats import REFERENCE_DOC_EXTENSIONS, extension_for_filename
+from app.core.path_security import validate_upload_file
+from app.core.security import get_current_user, require_admin
+from app.db.deps import get_db
+from app.models.footer_link import FooterLink, FooterLinkType
+from app.models.user import User
+from app.schemas.footer_link import (
+    MAX_TITLE_LENGTH,
+    FooterLinkCreate,
+    FooterLinkReorderRequest,
+    FooterLinkResponse,
+    FooterLinkUpdate,
+)
+from app.services.minio_service import minio_service
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+MAX_UPLOAD_SIZE_MB = 10
+
+_ADMIN_ROLES = {"admin", "super_admin"}
+
+
+def _serialize(link: FooterLink) -> dict:
+    return FooterLinkResponse.model_validate(link).model_dump(mode="json")
+
+
+def _is_admin(user: User) -> bool:
+    role = user.role.value if hasattr(user.role, "value") else str(user.role)
+    return role in _ADMIN_ROLES
+
+
+async def _get_link_or_404(db: AsyncSession, link_id: int) -> FooterLink:
+    result = await db.execute(select(FooterLink).where(FooterLink.id == link_id))
+    link = result.scalar_one_or_none()
+    if link is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="連結不存在")
+    return link
+
+
+async def _next_sort_order(db: AsyncSession) -> int:
+    max_order = (await db.execute(select(func.max(FooterLink.sort_order)))).scalar()
+    return (max_order + 1) if max_order is not None else 0
+
+
+@router.get("")
+async def list_footer_links(
+    include_inactive: bool = False,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """List footer links ordered by sort_order then id.
+
+    Any authenticated user may read. ``include_inactive`` is honoured for
+    admins only — a non-admin always gets the active (publicly shown) set,
+    so a hidden link cannot leak through the query parameter.
+    """
+    stmt = select(FooterLink)
+    if not (include_inactive and _is_admin(current_user)):
+        stmt = stmt.where(FooterLink.is_active.is_(True))
+    stmt = stmt.order_by(FooterLink.sort_order.asc(), FooterLink.id.asc())
+
+    result = await db.execute(stmt)
+    links = result.scalars().all()
+    return {
+        "success": True,
+        "message": "OK",
+        "data": [_serialize(link) for link in links],
+    }
+
+
+@router.post("")
+async def create_footer_link(
+    payload: FooterLinkCreate,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create an external-URL footer link. Admin only."""
+    link = FooterLink(
+        title_zh=payload.title_zh,
+        title_en=payload.title_en,
+        link_type=FooterLinkType.url,
+        url=payload.url,
+        is_active=payload.is_active,
+        sort_order=await _next_sort_order(db),
+        created_by=current_user.id,
+    )
+    db.add(link)
+    await db.commit()
+    await db.refresh(link)
+
+    logger.info(
+        "footer link created (url) id=%s by user_id=%s",
+        link.id,
+        current_user.id,
+        extra={"actor_user_id": current_user.id, "footer_link_id": link.id},
+    )
+
+    return {"success": True, "message": "已新增", "data": _serialize(link)}
+
+
+@router.post("/upload")
+async def upload_footer_link_file(
+    file: UploadFile = File(...),
+    title_zh: str = Form(...),
+    title_en: Optional[str] = Form(None),
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a file-backed footer link by uploading a document. Admin only."""
+    stripped_zh = (title_zh or "").strip()
+    if not stripped_zh:
+        raise HTTPException(status_code=400, detail="標題不得為空")
+    if len(stripped_zh) > MAX_TITLE_LENGTH:
+        raise HTTPException(status_code=400, detail=f"標題不得超過 {MAX_TITLE_LENGTH} 字")
+
+    stripped_en = (title_en or "").strip() or None
+    if stripped_en and len(stripped_en) > MAX_TITLE_LENGTH:
+        raise HTTPException(status_code=400, detail=f"英文標題不得超過 {MAX_TITLE_LENGTH} 字")
+
+    file_content = await file.read()
+    validate_upload_file(
+        filename=file.filename,
+        allowed_extensions=REFERENCE_DOC_EXTENSIONS,
+        max_size_mb=MAX_UPLOAD_SIZE_MB,
+        file_size=len(file_content),
+        allow_unicode=True,
+    )
+
+    ext = extension_for_filename(file.filename or "")
+    object_name = f"footer-links/link_{uuid.uuid4().hex}{ext}"
+    content_type = file.content_type or "application/octet-stream"
+
+    minio_service.client.put_object(
+        bucket_name=minio_service.default_bucket,
+        object_name=object_name,
+        data=io.BytesIO(file_content),
+        length=len(file_content),
+        content_type=content_type,
+    )
+
+    link = FooterLink(
+        title_zh=stripped_zh,
+        title_en=stripped_en,
+        link_type=FooterLinkType.file,
+        object_name=object_name,
+        original_filename=file.filename or "",
+        content_type=content_type,
+        file_size=len(file_content),
+        is_active=True,
+        sort_order=await _next_sort_order(db),
+        created_by=current_user.id,
+    )
+    db.add(link)
+
+    try:
+        await db.commit()
+    except Exception:
+        # Don't leave an unreferenced object behind if the row never lands.
+        await db.rollback()
+        try:
+            minio_service.client.remove_object(minio_service.default_bucket, object_name)
+        except Exception:
+            logger.warning(
+                "Failed to clean up orphaned footer link object %s",
+                object_name,
+                exc_info=True,
+            )
+        raise
+
+    await db.refresh(link)
+
+    logger.info(
+        "footer link created (file) id=%s by user_id=%s",
+        link.id,
+        current_user.id,
+        extra={"actor_user_id": current_user.id, "footer_link_id": link.id},
+    )
+
+    return {"success": True, "message": "上傳成功", "data": _serialize(link)}
+
+
+# NOTE: declared before /{link_id} so "reorder" is not captured as a path param.
+@router.patch("/reorder")
+async def reorder_footer_links(
+    payload: FooterLinkReorderRequest,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Persist a new display order. Admin only."""
+    requested_ids = [item.id for item in payload.items]
+    result = await db.execute(select(FooterLink).where(FooterLink.id.in_(requested_ids)))
+    links = {link.id: link for link in result.scalars().all()}
+
+    missing = [link_id for link_id in requested_ids if link_id not in links]
+    if missing:
+        raise HTTPException(status_code=400, detail=f"ids not found: {missing}")
+
+    for item in payload.items:
+        links[item.id].sort_order = item.sort_order
+
+    await db.commit()
+
+    return {
+        "success": True,
+        "message": "已重新排序",
+        "data": {"updated": len(payload.items)},
+    }
+
+
+@router.patch("/{link_id}")
+async def update_footer_link(
+    link_id: int,
+    payload: FooterLinkUpdate,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update a footer link's titles, URL, or visibility. Admin only."""
+    link = await _get_link_or_404(db, link_id)
+
+    if payload.url is not None and link.link_type != FooterLinkType.url:
+        raise HTTPException(
+            status_code=400,
+            detail="檔案類型的連結無法設定網址，請刪除後重新上傳",
+        )
+
+    if payload.title_zh is not None:
+        link.title_zh = payload.title_zh
+    # title_en is nullable: an explicit blank string clears it (normalized to
+    # None by the schema), so we can't distinguish "clear" from "absent" here.
+    # Clearing is the useful behaviour and matches the admin form.
+    if "title_en" in payload.model_fields_set:
+        link.title_en = payload.title_en
+    if payload.url is not None:
+        link.url = payload.url
+    if payload.is_active is not None:
+        link.is_active = payload.is_active
+
+    await db.commit()
+    await db.refresh(link)
+
+    return {"success": True, "message": "已更新", "data": _serialize(link)}
+
+
+@router.delete("/{link_id}")
+async def delete_footer_link(
+    link_id: int,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a footer link, removing its stored file when present. Admin only."""
+    link = await _get_link_or_404(db, link_id)
+    object_name = link.object_name
+
+    await db.delete(link)
+    await db.commit()
+
+    if object_name:
+        try:
+            minio_service.client.remove_object(minio_service.default_bucket, object_name)
+        except Exception:
+            logger.warning(
+                "Failed to remove footer link object %s from MinIO",
+                object_name,
+                exc_info=True,
+            )
+
+    logger.info(
+        "footer link deleted id=%s by user_id=%s",
+        link_id,
+        current_user.id,
+        extra={"actor_user_id": current_user.id, "footer_link_id": link_id},
+    )
+
+    return {"success": True, "message": "已刪除", "data": {"deleted": True}}
+
+
+@router.get("/{link_id}/file")
+async def stream_footer_link_file(
+    link_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Stream a file-backed footer link's document. Any authenticated user.
+
+    Inactive links stay readable for admins only so a hidden document isn't
+    still fetchable by a student holding a stale URL.
+    """
+    link = await _get_link_or_404(db, link_id)
+
+    if link.link_type != FooterLinkType.file or not link.object_name:
+        raise HTTPException(status_code=404, detail="此連結沒有檔案")
+    if not link.is_active and not _is_admin(current_user):
+        raise HTTPException(status_code=404, detail="連結不存在")
+
+    response = None
+    try:
+        response = minio_service.client.get_object(
+            bucket_name=minio_service.default_bucket,
+            object_name=link.object_name,
+        )
+        file_content = response.read()
+    except Exception as e:
+        logger.exception("Failed to fetch footer link file")
+        raise HTTPException(status_code=500, detail="無法取得文件") from e
+    finally:
+        if response is not None:
+            response.close()
+            response.release_conn()
+
+    download_name = link.original_filename or link.object_name.split("/")[-1]
+    encoded_name = quote(download_name, safe="")
+
+    return StreamingResponse(
+        io.BytesIO(file_content),
+        media_type=link.content_type or "application/octet-stream",
+        headers={
+            "Content-Disposition": f"inline; filename*=UTF-8''{encoded_name}",
+            # Content-Length is REQUIRED: without it the frontend PDF viewer
+            # mis-reads the stream and reports a bogus "password protected".
+            "Content-Length": str(len(file_content)),
+            "Accept-Ranges": "bytes",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+__all__: List[str] = ["router"]

--- a/backend/app/core/document_formats.py
+++ b/backend/app/core/document_formats.py
@@ -1,0 +1,15 @@
+"""Shared file-format constants for admin-managed reference documents."""
+
+# Document formats accepted for admin-managed reference material
+# (footer 相關連結 uploads): PDF, Microsoft Office, and OpenDocument (ODF).
+# Mirrors the set used by 申請文件範例檔 / 補充參考文件 in system_settings.py.
+REFERENCE_DOC_EXTENSIONS = [".pdf", ".doc", ".docx", ".odt", ".ods", ".odp"]
+
+
+def extension_for_filename(filename: str) -> str:
+    """Return the matching allowed extension for ``filename``, or "" if none."""
+    lowered = (filename or "").lower()
+    for ext in REFERENCE_DOC_EXTENSIONS:
+        if lowered.endswith(ext):
+            return ext
+    return ""

--- a/backend/app/core/document_formats.py
+++ b/backend/app/core/document_formats.py
@@ -5,6 +5,19 @@
 # Mirrors the set used by 申請文件範例檔 / 補充參考文件 in system_settings.py.
 REFERENCE_DOC_EXTENSIONS = [".pdf", ".doc", ".docx", ".odt", ".ods", ".odp"]
 
+# Server-side MIME type per allowed extension. The multipart Content-Type a
+# client declares is attacker-controlled and MUST NOT be persisted or echoed
+# back: a file named .pdf but declared text/html would be served inline from
+# our own origin. Always derive the type from the validated extension instead.
+_CONTENT_TYPE_BY_EXTENSION = {
+    ".pdf": "application/pdf",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".odt": "application/vnd.oasis.opendocument.text",
+    ".ods": "application/vnd.oasis.opendocument.spreadsheet",
+    ".odp": "application/vnd.oasis.opendocument.presentation",
+}
+
 
 def extension_for_filename(filename: str) -> str:
     """Return the matching allowed extension for ``filename``, or "" if none."""
@@ -13,3 +26,13 @@ def extension_for_filename(filename: str) -> str:
         if lowered.endswith(ext):
             return ext
     return ""
+
+
+def content_type_for_extension(ext: str) -> str:
+    """Trusted Content-Type for an already-validated extension.
+
+    Falls back to application/octet-stream, which browsers download rather
+    than render, so an unrecognised extension can never become a live
+    same-origin document.
+    """
+    return _CONTENT_TYPE_BY_EXTENSION.get((ext or "").lower(), "application/octet-stream")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.college_review import CollegeRanking, CollegeRankingItem, QuotaD
 from app.models.document_request import DocumentRequest, DocumentRequestStatus
 from app.models.email_management import EmailCategory, EmailHistory, EmailStatus, ScheduledEmail, ScheduleStatus
 from app.models.enums import ApplicationCycle, QuotaManagementMode, Semester, SubTypeSelectionMode
+from app.models.footer_link import FooterLink, FooterLinkType
 from app.models.notification import Notification, NotificationType
 from app.models.payment_roster import (
     PaymentRoster,
@@ -123,6 +124,9 @@ __all__ = [
     "BankVerificationTaskStatus",
     # Supplementary doc models
     "SupplementaryDoc",
+    # Footer 相關連結 models
+    "FooterLink",
+    "FooterLinkType",
     # Imported received-months ledger
     "ReceivedMonthImport",
     "StudentReceivedMonthRecord",

--- a/backend/app/models/footer_link.py
+++ b/backend/app/models/footer_link.py
@@ -1,0 +1,82 @@
+import enum
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.orm import relationship
+
+from app.db.base_class import Base
+
+# Keeps the two payload shapes mutually exclusive even if a caller bypasses
+# the pydantic layer. Declared on the model (not only in the migration) so a
+# fresh DB built by Base.metadata.create_all() gets it too.
+FOOTER_LINK_PAYLOAD_CHECK = (
+    "(link_type = 'url' AND url IS NOT NULL AND object_name IS NULL) "
+    "OR (link_type = 'file' AND object_name IS NOT NULL AND url IS NULL)"
+)
+FOOTER_LINK_PAYLOAD_CHECK_NAME = "ck_footer_links_payload_matches_type"
+
+
+class FooterLinkType(enum.Enum):
+    """How a footer link resolves for the visitor.
+
+    ``url`` opens an external address in a new tab; ``file`` streams an
+    admin-uploaded document (PDF/Office/ODF) through the backend proxy.
+    """
+
+    url = "url"
+    file = "file"
+
+
+class FooterLink(Base):
+    """Admin-managed entry in the site footer's 相關連結 (Related Links) list.
+
+    Exactly one of the two payload shapes is populated, keyed by ``link_type``:
+    an external ``url``, or an uploaded document (``object_name`` + metadata).
+    The pairing is enforced in the schema layer and by a DB CHECK constraint.
+    """
+
+    __tablename__ = "footer_links"
+    __table_args__ = (CheckConstraint(FOOTER_LINK_PAYLOAD_CHECK, name=FOOTER_LINK_PAYLOAD_CHECK_NAME),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    title_zh = Column(String(200), nullable=False)
+    # Optional English label; the footer falls back to title_zh when unset.
+    title_en = Column(String(200), nullable=True)
+    link_type = Column(
+        Enum(FooterLinkType, values_callable=lambda obj: [e.value for e in obj]),
+        nullable=False,
+        default=FooterLinkType.url,
+    )
+
+    # link_type == url
+    url = Column(String(1000), nullable=True)
+
+    # link_type == file
+    object_name = Column(String(500), nullable=True)
+    original_filename = Column(String(500), nullable=True)
+    content_type = Column(String(100), nullable=True)
+    file_size = Column(Integer, nullable=True)
+
+    sort_order = Column(Integer, nullable=False, default=0, index=True)
+    # Lets an admin hide a link from the footer without losing its file.
+    is_active = Column(Boolean, nullable=False, default=True)
+
+    created_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    created_by_user = relationship("User", foreign_keys=[created_by])

--- a/backend/app/schemas/footer_link.py
+++ b/backend/app/schemas/footer_link.py
@@ -1,0 +1,145 @@
+# backend/app/schemas/footer_link.py
+"""Schemas for the admin-managed footer 相關連結 list."""
+
+from datetime import datetime
+from typing import List, Optional
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.models.footer_link import FooterLinkType
+
+MAX_TITLE_LENGTH = 200
+MAX_URL_LENGTH = 1000
+
+# Only these schemes may be stored. The footer renders each entry as an
+# <a href>, so permitting javascript:/data:/vbscript: would turn the admin
+# form into a stored-XSS vector for every visitor of the site.
+_ALLOWED_URL_SCHEMES = {"http", "https"}
+
+
+def _normalize_title(value: Optional[str]) -> Optional[str]:
+    """Trim a title, collapsing blank/whitespace-only input to None."""
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _validate_url(value: str) -> str:
+    """Reject non-http(s) URLs and URLs missing a host."""
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError("url cannot be empty")
+    if len(stripped) > MAX_URL_LENGTH:
+        raise ValueError(f"url must be <= {MAX_URL_LENGTH} chars")
+
+    parsed = urlparse(stripped)
+    if parsed.scheme.lower() not in _ALLOWED_URL_SCHEMES:
+        raise ValueError("url must start with http:// or https://")
+    if not parsed.netloc:
+        raise ValueError("url must include a host")
+    return stripped
+
+
+class FooterLinkResponse(BaseModel):
+    id: int
+    title_zh: str
+    title_en: Optional[str] = None
+    link_type: FooterLinkType
+    url: Optional[str] = None
+    object_name: Optional[str] = None
+    original_filename: Optional[str] = None
+    content_type: Optional[str] = None
+    file_size: Optional[int] = None
+    sort_order: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+
+
+class FooterLinkCreate(BaseModel):
+    """Create an external-URL footer link (file links use the upload endpoint)."""
+
+    title_zh: str = Field(..., min_length=1, max_length=MAX_TITLE_LENGTH)
+    title_en: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    url: str = Field(..., min_length=1, max_length=MAX_URL_LENGTH)
+    is_active: bool = True
+
+    @field_validator("title_zh")
+    @classmethod
+    def _strip_title_zh(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("title_zh cannot be empty")
+        return stripped
+
+    @field_validator("title_en")
+    @classmethod
+    def _strip_title_en(cls, v: Optional[str]) -> Optional[str]:
+        return _normalize_title(v)
+
+    @field_validator("url")
+    @classmethod
+    def _check_url(cls, v: str) -> str:
+        return _validate_url(v)
+
+
+class FooterLinkUpdate(BaseModel):
+    """Partial update. ``url`` is only accepted for link_type == url rows,
+    which the endpoint enforces against the persisted row."""
+
+    title_zh: Optional[str] = Field(default=None, min_length=1, max_length=MAX_TITLE_LENGTH)
+    title_en: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
+    url: Optional[str] = Field(default=None, max_length=MAX_URL_LENGTH)
+    is_active: Optional[bool] = None
+
+    @field_validator("title_zh")
+    @classmethod
+    def _strip_title_zh(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("title_zh cannot be empty")
+        return stripped
+
+    @field_validator("title_en")
+    @classmethod
+    def _strip_title_en(cls, v: Optional[str]) -> Optional[str]:
+        return _normalize_title(v)
+
+    @field_validator("url")
+    @classmethod
+    def _check_url(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        return _validate_url(v)
+
+    @model_validator(mode="after")
+    def _require_at_least_one_field(self) -> "FooterLinkUpdate":
+        if all(getattr(self, name) is None for name in ("title_zh", "title_en", "url", "is_active")):
+            raise ValueError("at least one field must be provided")
+        return self
+
+
+class FooterLinkReorderItem(BaseModel):
+    id: int
+    sort_order: int
+
+
+class FooterLinkReorderRequest(BaseModel):
+    items: List[FooterLinkReorderItem] = Field(..., min_length=1)
+
+    @field_validator("items")
+    @classmethod
+    def _unique(cls, v: List[FooterLinkReorderItem]) -> List[FooterLinkReorderItem]:
+        orders = [i.sort_order for i in v]
+        if len(orders) != len(set(orders)):
+            raise ValueError("sort_order values must be unique within payload")
+        ids = [i.id for i in v]
+        if len(ids) != len(set(ids)):
+            raise ValueError("id values must be unique within payload")
+        return v

--- a/backend/app/schemas/footer_link.py
+++ b/backend/app/schemas/footer_link.py
@@ -120,7 +120,11 @@ class FooterLinkUpdate(BaseModel):
 
     @model_validator(mode="after")
     def _require_at_least_one_field(self) -> "FooterLinkUpdate":
-        if all(getattr(self, name) is None for name in ("title_zh", "title_en", "url", "is_active")):
+        # Test which fields the caller actually SENT, not which ones ended up
+        # non-None. `{"title_en": ""}` normalizes to None but is a legitimate
+        # "clear the English label" request; a value-based check would reject
+        # it as an empty payload and make clearing impossible.
+        if not self.model_fields_set:
             raise ValueError("at least one field must be provided")
         return self
 

--- a/backend/app/tests/test_footer_links.py
+++ b/backend/app/tests/test_footer_links.py
@@ -1,0 +1,357 @@
+"""Tests for the admin-editable footer 相關連結 feature.
+
+Covers the schema-level URL guard (stored-XSS prevention), the admin-only
+mutation surface, the url/file payload split, and the visibility rules for
+inactive links.
+"""
+
+from io import BytesIO
+from typing import AsyncGenerator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_current_user, require_admin
+from app.db.deps import get_db
+from app.main import app
+from app.models.footer_link import FooterLink, FooterLinkType
+from app.models.user import User, UserRole, UserType
+from app.schemas.footer_link import FooterLinkCreate, FooterLinkUpdate
+
+# ─── Pure schema tests (unit lane) ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "javascript:alert(1)",
+        "JavaScript:alert(1)",
+        "data:text/html;base64,PHNjcmlwdD4=",
+        "vbscript:msgbox(1)",
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "not-a-url",
+        "https://",
+    ],
+)
+def test_create_rejects_non_http_urls(bad_url):
+    """A footer link renders as <a href>; permitting javascript:/data: would
+    make the admin form a stored-XSS vector for every site visitor."""
+    with pytest.raises(ValidationError):
+        FooterLinkCreate(title_zh="惡意", url=bad_url)
+
+
+@pytest.mark.parametrize(
+    "good_url",
+    [
+        "https://www.nycu.edu.tw",
+        "http://aa.nycu.edu.tw/path?q=1",
+        "https://portal.nycu.edu.tw/",
+    ],
+)
+def test_create_accepts_http_and_https(good_url):
+    link = FooterLinkCreate(title_zh="連結", url=good_url)
+    assert link.url == good_url
+
+
+def test_create_strips_titles_and_blanks_title_en_to_none():
+    link = FooterLinkCreate(title_zh="  教務處  ", title_en="   ", url="https://x.nycu.edu.tw")
+    assert link.title_zh == "教務處"
+    assert link.title_en is None
+
+
+def test_create_rejects_whitespace_only_title_zh():
+    with pytest.raises(ValidationError):
+        FooterLinkCreate(title_zh="   ", url="https://x.nycu.edu.tw")
+
+
+def test_update_requires_at_least_one_field():
+    with pytest.raises(ValidationError):
+        FooterLinkUpdate()
+
+
+def test_update_allows_single_field():
+    assert FooterLinkUpdate(is_active=False).is_active is False
+
+
+# ─── Endpoint fixtures ───────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession) -> User:
+    user = User(
+        nycu_id="footer_admin",
+        name="Footer Admin",
+        email="footer_admin@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def student_user(db: AsyncSession) -> User:
+    user = User(
+        nycu_id="footer_student",
+        name="Footer Student",
+        email="footer_student@university.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+def _client_for(db: AsyncSession, user: User, *, is_admin: bool):
+    async def override_get_db():
+        yield db
+
+    async def override_get_current_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    if is_admin:
+
+        async def override_require_admin():
+            return user
+
+        app.dependency_overrides[require_admin] = override_require_admin
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest_asyncio.fixture
+async def admin_client(db: AsyncSession, admin_user: User) -> AsyncGenerator[AsyncClient, None]:
+    try:
+        async with _client_for(db, admin_user, is_admin=True) as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def student_client(db: AsyncSession, student_user: User) -> AsyncGenerator[AsyncClient, None]:
+    try:
+        async with _client_for(db, student_user, is_admin=False) as ac:
+            yield ac
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def fake_minio():
+    """Patch the module-level binding in the endpoint (it imports the
+    singleton at module scope, so patching the service module is a no-op)."""
+    with patch("app.api.v1.endpoints.footer_links.minio_service") as mock_service:
+        mock_service.default_bucket = "test-bucket"
+        mock_service.client = MagicMock()
+        yield mock_service
+
+
+# ─── Endpoint tests ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_url_link(admin_client: AsyncClient):
+    res = await admin_client.post(
+        "/api/v1/footer-links",
+        json={"title_zh": "教務處", "title_en": "Academic Affairs", "url": "https://aa.nycu.edu.tw/"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["link_type"] == "url"
+    assert body["data"]["url"] == "https://aa.nycu.edu.tw/"
+
+    listed = await admin_client.get("/api/v1/footer-links")
+    assert listed.status_code == 200
+    titles = [item["title_zh"] for item in listed.json()["data"]]
+    assert "教務處" in titles
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_javascript_url_at_api_boundary(admin_client: AsyncClient):
+    res = await admin_client.post(
+        "/api/v1/footer-links",
+        json={"title_zh": "惡意", "url": "javascript:alert(document.cookie)"},
+    )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_new_links_append_to_end_of_order(admin_client: AsyncClient):
+    first = await admin_client.post("/api/v1/footer-links", json={"title_zh": "第一", "url": "https://a.nycu.edu.tw"})
+    second = await admin_client.post("/api/v1/footer-links", json={"title_zh": "第二", "url": "https://b.nycu.edu.tw"})
+    assert second.json()["data"]["sort_order"] > first.json()["data"]["sort_order"]
+
+
+@pytest.mark.asyncio
+async def test_inactive_link_hidden_from_students_and_visible_to_admin(db: AsyncSession, admin_client: AsyncClient):
+    created = await admin_client.post(
+        "/api/v1/footer-links", json={"title_zh": "草稿連結", "url": "https://draft.nycu.edu.tw"}
+    )
+    link_id = created.json()["data"]["id"]
+
+    hidden = await admin_client.patch(f"/api/v1/footer-links/{link_id}", json={"is_active": False})
+    assert hidden.status_code == 200
+    assert hidden.json()["data"]["is_active"] is False
+
+    # Default list excludes it for everyone.
+    default_list = await admin_client.get("/api/v1/footer-links")
+    assert link_id not in [item["id"] for item in default_list.json()["data"]]
+
+    # Admin may opt in.
+    admin_all = await admin_client.get("/api/v1/footer-links?include_inactive=true")
+    assert link_id in [item["id"] for item in admin_all.json()["data"]]
+
+
+@pytest.mark.asyncio
+async def test_student_cannot_reveal_inactive_links_via_query_param(
+    db: AsyncSession, admin_user: User, student_user: User
+):
+    link = FooterLink(
+        title_zh="隱藏連結",
+        link_type=FooterLinkType.url,
+        url="https://hidden.nycu.edu.tw",
+        sort_order=0,
+        is_active=False,
+        created_by=admin_user.id,
+    )
+    db.add(link)
+    await db.commit()
+    await db.refresh(link)
+
+    try:
+        async with _client_for(db, student_user, is_admin=False) as ac:
+            res = await ac.get("/api/v1/footer-links?include_inactive=true")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert res.status_code == 200
+    assert link.id not in [item["id"] for item in res.json()["data"]]
+
+
+@pytest.mark.asyncio
+async def test_upload_creates_file_link(admin_client: AsyncClient, fake_minio):
+    res = await admin_client.post(
+        "/api/v1/footer-links/upload",
+        files={"file": ("guide.pdf", BytesIO(b"%PDF-1.4 fake"), "application/pdf")},
+        data={"title_zh": "獎學金申請指南", "title_en": "Scholarship Guide"},
+    )
+    assert res.status_code == 200, res.text
+    data = res.json()["data"]
+    assert data["link_type"] == "file"
+    assert data["url"] is None
+    assert data["original_filename"] == "guide.pdf"
+    assert data["object_name"].startswith("footer-links/link_")
+    assert data["object_name"].endswith(".pdf")
+    fake_minio.client.put_object.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_disallowed_extension(admin_client: AsyncClient, fake_minio):
+    res = await admin_client.post(
+        "/api/v1/footer-links/upload",
+        files={"file": ("evil.exe", BytesIO(b"MZ"), "application/octet-stream")},
+        data={"title_zh": "壞檔案"},
+    )
+    # validate_upload_file rejects a disallowed extension with 415.
+    assert res.status_code == 415
+    fake_minio.client.put_object.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cannot_set_url_on_a_file_link(admin_client: AsyncClient, fake_minio):
+    created = await admin_client.post(
+        "/api/v1/footer-links/upload",
+        files={"file": ("manual.pdf", BytesIO(b"%PDF-1.4"), "application/pdf")},
+        data={"title_zh": "系統操作手冊"},
+    )
+    link_id = created.json()["data"]["id"]
+
+    res = await admin_client.patch(f"/api/v1/footer-links/{link_id}", json={"url": "https://evil.example.com"})
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_stored_object(admin_client: AsyncClient, fake_minio):
+    created = await admin_client.post(
+        "/api/v1/footer-links/upload",
+        files={"file": ("faq.pdf", BytesIO(b"%PDF-1.4"), "application/pdf")},
+        data={"title_zh": "常見問題"},
+    )
+    data = created.json()["data"]
+
+    res = await admin_client.delete(f"/api/v1/footer-links/{data['id']}")
+    assert res.status_code == 200
+    fake_minio.client.remove_object.assert_called_once_with("test-bucket", data["object_name"])
+
+    gone = await admin_client.patch(f"/api/v1/footer-links/{data['id']}", json={"title_zh": "x"})
+    assert gone.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reorder_persists_new_positions(admin_client: AsyncClient):
+    a = await admin_client.post("/api/v1/footer-links", json={"title_zh": "A", "url": "https://a.nycu.edu.tw"})
+    b = await admin_client.post("/api/v1/footer-links", json={"title_zh": "B", "url": "https://b.nycu.edu.tw"})
+    a_id, b_id = a.json()["data"]["id"], b.json()["data"]["id"]
+
+    res = await admin_client.patch(
+        "/api/v1/footer-links/reorder",
+        json={"items": [{"id": b_id, "sort_order": 0}, {"id": a_id, "sort_order": 1}]},
+    )
+    assert res.status_code == 200
+
+    listed = await admin_client.get("/api/v1/footer-links")
+    ordered = [item["id"] for item in listed.json()["data"] if item["id"] in (a_id, b_id)]
+    assert ordered == [b_id, a_id]
+
+
+@pytest.mark.asyncio
+async def test_reorder_rejects_unknown_id(admin_client: AsyncClient):
+    res = await admin_client.patch(
+        "/api/v1/footer-links/reorder",
+        json={"items": [{"id": 999999, "sort_order": 0}]},
+    )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_stream_file_returns_content_length(admin_client: AsyncClient, fake_minio):
+    payload = b"%PDF-1.4 streamed body"
+    created = await admin_client.post(
+        "/api/v1/footer-links/upload",
+        files={"file": ("doc.pdf", BytesIO(payload), "application/pdf")},
+        data={"title_zh": "文件"},
+    )
+    link_id = created.json()["data"]["id"]
+
+    minio_response = MagicMock()
+    minio_response.read.return_value = payload
+    fake_minio.client.get_object.return_value = minio_response
+
+    res = await admin_client.get(f"/api/v1/footer-links/{link_id}/file")
+    assert res.status_code == 200
+    # Missing Content-Length makes the frontend PDF viewer report a bogus
+    # "password protected" error — pin it.
+    assert res.headers["content-length"] == str(len(payload))
+    assert res.headers["x-content-type-options"] == "nosniff"
+
+
+@pytest.mark.asyncio
+async def test_stream_rejects_url_link(admin_client: AsyncClient):
+    created = await admin_client.post("/api/v1/footer-links", json={"title_zh": "外部", "url": "https://x.nycu.edu.tw"})
+    link_id = created.json()["data"]["id"]
+
+    res = await admin_client.get(f"/api/v1/footer-links/{link_id}/file")
+    assert res.status_code == 404

--- a/backend/app/tests/test_footer_links.py
+++ b/backend/app/tests/test_footer_links.py
@@ -349,6 +349,115 @@ async def test_stream_file_returns_content_length(admin_client: AsyncClient, fak
 
 
 @pytest.mark.asyncio
+async def test_title_en_can_be_cleared(admin_client: AsyncClient):
+    """A blank title_en normalizes to None but is a legitimate 'clear the
+    English label' request — it must not be rejected as an empty payload."""
+    created = await admin_client.post(
+        "/api/v1/footer-links",
+        json={"title_zh": "校務系統", "title_en": "Campus", "url": "https://x.nycu.edu.tw"},
+    )
+    link_id = created.json()["data"]["id"]
+
+    res = await admin_client.patch(f"/api/v1/footer-links/{link_id}", json={"title_en": ""})
+    assert res.status_code == 200, res.text
+    assert res.json()["data"]["title_en"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_with_no_fields_is_rejected(admin_client: AsyncClient):
+    created = await admin_client.post("/api/v1/footer-links", json={"title_zh": "X", "url": "https://x.nycu.edu.tw"})
+    link_id = created.json()["data"]["id"]
+
+    res = await admin_client.patch(f"/api/v1/footer-links/{link_id}", json={})
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_stored_content_type_ignores_client_declared_value(admin_client: AsyncClient, fake_minio):
+    """The multipart Content-Type is attacker-controlled and this document is
+    later streamed back inline from our own origin, so a .pdf declared
+    text/html must not be persisted or echoed."""
+    created = await admin_client.post(
+        "/api/v1/footer-links/upload",
+        files={"file": ("guide.pdf", BytesIO(b"<html><body>spoof</body></html>"), "text/html")},
+        data={"title_zh": "偽裝檔案"},
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["data"]["content_type"] == "application/pdf"
+
+    link_id = created.json()["data"]["id"]
+    minio_response = MagicMock()
+    minio_response.read.return_value = b"<html><body>spoof</body></html>"
+    fake_minio.client.get_object.return_value = minio_response
+
+    streamed = await admin_client.get(f"/api/v1/footer-links/{link_id}/file")
+    assert streamed.headers["content-type"].startswith("application/pdf")
+
+
+# ─── Negative authorization: every mutation is admin-only ────────────────
+
+
+@pytest.mark.asyncio
+async def test_student_cannot_create_link(student_client: AsyncClient):
+    res = await student_client.post(
+        "/api/v1/footer-links", json={"title_zh": "駭客連結", "url": "https://evil.example.com"}
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_student_cannot_upload_file(student_client: AsyncClient):
+    res = await student_client.post(
+        "/api/v1/footer-links/upload",
+        files={"file": ("x.pdf", BytesIO(b"%PDF-1.4"), "application/pdf")},
+        data={"title_zh": "x"},
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_student_cannot_update_link(db: AsyncSession, student_client: AsyncClient, admin_user: User):
+    link = FooterLink(
+        title_zh="原標題",
+        link_type=FooterLinkType.url,
+        url="https://ok.nycu.edu.tw",
+        sort_order=0,
+        is_active=True,
+        created_by=admin_user.id,
+    )
+    db.add(link)
+    await db.commit()
+    await db.refresh(link)
+
+    res = await student_client.patch(f"/api/v1/footer-links/{link.id}", json={"title_zh": "被竄改"})
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_student_cannot_delete_link(db: AsyncSession, student_client: AsyncClient, admin_user: User):
+    link = FooterLink(
+        title_zh="待刪",
+        link_type=FooterLinkType.url,
+        url="https://ok.nycu.edu.tw",
+        sort_order=0,
+        is_active=True,
+        created_by=admin_user.id,
+    )
+    db.add(link)
+    await db.commit()
+    await db.refresh(link)
+
+    res = await student_client.delete(f"/api/v1/footer-links/{link.id}")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_student_cannot_reorder_links(student_client: AsyncClient):
+    res = await student_client.patch("/api/v1/footer-links/reorder", json={"items": [{"id": 1, "sort_order": 0}]})
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_stream_rejects_url_link(admin_client: AsyncClient):
     created = await admin_client.post("/api/v1/footer-links", json={"title_zh": "外部", "url": "https://x.nycu.edu.tw"})
     link_id = created.json()["data"]["id"]

--- a/frontend/app/api/v1/footer-links/upload-proxy/route.ts
+++ b/frontend/app/api/v1/footer-links/upload-proxy/route.ts
@@ -1,0 +1,65 @@
+// frontend/app/api/v1/footer-links/upload-proxy/route.ts
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const baseUrl =
+      process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL;
+    if (!baseUrl) {
+      return NextResponse.json(
+        { error: "Backend not configured" },
+        { status: 500 }
+      );
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(baseUrl);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid backend URL" },
+        { status: 500 }
+      );
+    }
+
+    const allowedHostnames = ["backend", "ss.test.nycu.edu.tw"];
+    if (!allowedHostnames.includes(parsedUrl.hostname)) {
+      return NextResponse.json(
+        { error: "Untrusted backend hostname" },
+        { status: 500 }
+      );
+    }
+
+    const backendUrl = new URL(
+      "/api/v1/footer-links/upload",
+      baseUrl
+    ).toString();
+
+    const formData = await request.formData();
+
+    const response = await fetch(backendUrl, {
+      method: "POST",
+      headers: { Authorization: authHeader },
+      body: formData,
+    });
+
+    const text = await response.text();
+    return new NextResponse(text, {
+      status: response.status,
+      headers: {
+        "Content-Type":
+          response.headers.get("content-type") || "application/json",
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to proxy upload" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/app/api/v1/preview/footer-links/route.ts
+++ b/frontend/app/api/v1/preview/footer-links/route.ts
@@ -1,0 +1,97 @@
+// frontend/app/api/v1/preview/footer-links/route.ts
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const idParam = searchParams.get("id");
+    if (!idParam || !/^\d+$/.test(idParam)) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+    const id = Number.parseInt(idParam, 10);
+    if (!Number.isInteger(id) || id <= 0) {
+      return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+
+    const queryToken = searchParams.get("token");
+    const authHeader = request.headers.get("authorization");
+    const cookieToken =
+      request.cookies.get("access_token")?.value ||
+      request.cookies.get("auth_token")?.value;
+    const token =
+      queryToken || authHeader?.replace("Bearer ", "") || cookieToken;
+
+    if (!token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const baseUrl =
+      process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL;
+    if (!baseUrl) {
+      return NextResponse.json(
+        { error: "Backend not configured" },
+        { status: 500 }
+      );
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(baseUrl);
+    } catch {
+      return NextResponse.json(
+        { error: "Invalid backend URL" },
+        { status: 500 }
+      );
+    }
+
+    const allowedHostnames = ["backend", "ss.test.nycu.edu.tw"];
+    if (!allowedHostnames.includes(parsedUrl.hostname)) {
+      return NextResponse.json(
+        { error: "Untrusted backend hostname" },
+        { status: 500 }
+      );
+    }
+
+    const backendUrl = new URL(
+      `/api/v1/footer-links/${id}/file`,
+      baseUrl
+    ).toString();
+
+    const response = await fetch(backendUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch document" },
+        { status: response.status }
+      );
+    }
+
+    const fileBuffer = await response.arrayBuffer();
+    const contentType =
+      response.headers.get("content-type") || "application/octet-stream";
+    const contentDisposition =
+      response.headers.get("content-disposition") || "inline";
+
+    return new NextResponse(fileBuffer, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Content-Disposition": contentDisposition,
+        // Content-Length is required: without it the PDF viewer mis-reads the
+        // stream and reports a bogus "password protected" error.
+        "Content-Length": fileBuffer.byteLength.toString(),
+        "Accept-Ranges": "bytes",
+        "Cache-Control": "private, max-age=3600",
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "no-referrer",
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to retrieve document" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/components/__tests__/footer.test.tsx
+++ b/frontend/components/__tests__/footer.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { Footer } from "../footer";
+
+jest.mock("../../lib/api", () => {
+  const list = jest.fn();
+  return {
+    __esModule: true,
+    default: { footerLinks: { list } },
+  };
+});
+
+const apiMock = jest.requireMock("../../lib/api") as {
+  default: { footerLinks: { list: jest.Mock } };
+};
+
+const listMock = apiMock.default.footerLinks.list;
+
+function makeLink(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    title_zh: "陽明交大首頁",
+    title_en: "NYCU Homepage",
+    link_type: "url",
+    url: "https://www.nycu.edu.tw",
+    object_name: null,
+    original_filename: null,
+    content_type: null,
+    file_size: null,
+    sort_order: 0,
+    is_active: true,
+    created_at: "2026-07-29T00:00:00Z",
+    updated_at: "2026-07-29T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  listMock.mockReset();
+  localStorage.setItem("auth_token", "test-token");
+});
+
+test("renders admin-managed links returned by the API", async () => {
+  listMock.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [makeLink(), makeLink({ id: 2, title_zh: "教務處", url: "https://aa.nycu.edu.tw/" })],
+  });
+
+  render(<Footer locale="zh" />);
+
+  const link = await screen.findByRole("link", { name: "陽明交大首頁" });
+  expect(link).toHaveAttribute("href", "https://www.nycu.edu.tw");
+  expect(await screen.findByRole("link", { name: "教務處" })).toBeInTheDocument();
+});
+
+test("file links point at the streaming proxy, not a raw object name", async () => {
+  listMock.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [
+      makeLink({
+        id: 7,
+        title_zh: "獎學金申請指南",
+        link_type: "file",
+        url: null,
+        object_name: "footer-links/link_abc.pdf",
+        original_filename: "guide.pdf",
+      }),
+    ],
+  });
+
+  render(<Footer locale="zh" />);
+
+  const link = await screen.findByRole("link", { name: "獎學金申請指南" });
+  const href = link.getAttribute("href") || "";
+  expect(href).toContain("/api/v1/preview/footer-links?id=7");
+  expect(href).not.toContain("footer-links/link_abc.pdf");
+});
+
+test("English locale falls back to the Chinese title when title_en is unset", async () => {
+  listMock.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [makeLink({ title_zh: "校務系統", title_en: null })],
+  });
+
+  render(<Footer locale="en" />);
+
+  expect(
+    await screen.findByRole("link", { name: "校務系統" })
+  ).toBeInTheDocument();
+});
+
+test("a failed links fetch leaves the rest of the footer intact", async () => {
+  listMock.mockRejectedValue(new Error("boom"));
+
+  render(<Footer locale="zh" />);
+
+  // The static footer content still renders.
+  expect(await screen.findByText("相關連結")).toBeInTheDocument();
+  await waitFor(() =>
+    expect(screen.queryByRole("link", { name: "陽明交大首頁" })).toBeNull()
+  );
+});

--- a/frontend/components/__tests__/footer.test.tsx
+++ b/frontend/components/__tests__/footer.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { Footer } from "../footer";
+import { FOOTER_LINKS_CHANGED_EVENT } from "../../lib/api/modules/footer-links";
 
 jest.mock("../../lib/api", () => {
   const list = jest.fn();
@@ -97,9 +98,42 @@ test("a failed links fetch leaves the rest of the footer intact", async () => {
 
   render(<Footer locale="zh" />);
 
-  // The static footer content still renders.
-  expect(await screen.findByText("相關連結")).toBeInTheDocument();
-  await waitFor(() =>
-    expect(screen.queryByRole("link", { name: "陽明交大首頁" })).toBeNull()
-  );
+  // The static footer content still renders...
+  expect(await screen.findByText("國立陽明交通大學")).toBeInTheDocument();
+  // ...but the 相關連結 section is hidden rather than shown empty, so the
+  // heading and its chevron never sit over an empty box.
+  await waitFor(() => expect(screen.queryByText("相關連結")).toBeNull());
+  expect(screen.queryByRole("link", { name: "陽明交大首頁" })).toBeNull();
+});
+
+test("the 相關連結 section is hidden when every link is hidden", async () => {
+  listMock.mockResolvedValue({ success: true, message: "OK", data: [] });
+
+  render(<Footer locale="zh" />);
+
+  expect(await screen.findByText("國立陽明交通大學")).toBeInTheDocument();
+  await waitFor(() => expect(screen.queryByText("相關連結")).toBeNull());
+});
+
+test("refetches when the admin panel reports a change", async () => {
+  listMock.mockResolvedValueOnce({
+    success: true,
+    message: "OK",
+    data: [makeLink({ title_zh: "舊連結" })],
+  });
+
+  render(<Footer locale="zh" />);
+  expect(await screen.findByRole("link", { name: "舊連結" })).toBeInTheDocument();
+
+  listMock.mockResolvedValueOnce({
+    success: true,
+    message: "OK",
+    data: [makeLink({ id: 9, title_zh: "新連結" })],
+  });
+  await act(async () => {
+    window.dispatchEvent(new CustomEvent(FOOTER_LINKS_CHANGED_EVENT));
+  });
+
+  expect(await screen.findByRole("link", { name: "新連結" })).toBeInTheDocument();
+  expect(screen.queryByRole("link", { name: "舊連結" })).toBeNull();
 });

--- a/frontend/components/admin/footer-links/AddFooterLinkDialog.tsx
+++ b/frontend/components/admin/footer-links/AddFooterLinkDialog.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState } from "react";
+import { CloudUpload, FileType2, Loader2, X } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import apiClient from "@/lib/api";
+import type { FooterLink } from "@/lib/api/modules/footer-links";
+
+const ACCEPTED = ".pdf,.doc,.docx,.odt,.ods,.odp";
+const ACCEPTED_LABEL = "PDF · DOC · DOCX · ODF";
+const MAX_SIZE_MB = 10;
+const MAX_TITLE_LENGTH = 200;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (link: FooterLink) => void;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export function AddFooterLinkDialog({ open, onOpenChange, onCreated }: Props) {
+  const [mode, setMode] = useState<"url" | "file">("url");
+  const [titleZh, setTitleZh] = useState("");
+  const [titleEn, setTitleEn] = useState("");
+  const [url, setUrl] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+
+  const reset = () => {
+    setMode("url");
+    setTitleZh("");
+    setTitleEn("");
+    setUrl("");
+    setFile(null);
+    setDragActive(false);
+  };
+
+  const validateAndSet = (f: File | null) => {
+    if (!f) return;
+    const ext = "." + (f.name.toLowerCase().split(".").pop() || "");
+    if (!ACCEPTED.split(",").includes(ext)) {
+      toast.error(`僅接受 ${ACCEPTED_LABEL}`);
+      return;
+    }
+    if (f.size > MAX_SIZE_MB * 1024 * 1024) {
+      toast.error(`檔案大小超過 ${MAX_SIZE_MB} MB`);
+      return;
+    }
+    setFile(f);
+  };
+
+  const handleSubmit = async () => {
+    const trimmedZh = titleZh.trim();
+    if (!trimmedZh) {
+      toast.error("請輸入中文名稱");
+      return;
+    }
+    if (trimmedZh.length > MAX_TITLE_LENGTH) {
+      toast.error(`名稱不得超過 ${MAX_TITLE_LENGTH} 字`);
+      return;
+    }
+
+    const trimmedEn = titleEn.trim();
+
+    if (mode === "url") {
+      const trimmedUrl = url.trim();
+      if (!trimmedUrl) {
+        toast.error("請輸入網址");
+        return;
+      }
+      // Mirrors the backend guard so the admin sees the problem immediately.
+      if (!/^https?:\/\/.+/i.test(trimmedUrl)) {
+        toast.error("網址必須以 http:// 或 https:// 開頭");
+        return;
+      }
+      setSubmitting(true);
+      try {
+        const res = await apiClient.footerLinks.create({
+          title_zh: trimmedZh,
+          title_en: trimmedEn || null,
+          url: trimmedUrl,
+        });
+        if (res.success && res.data) {
+          toast.success("已新增相關連結");
+          onCreated(res.data);
+          reset();
+          onOpenChange(false);
+        } else {
+          toast.error(res.message || "新增失敗");
+        }
+      } catch {
+        toast.error("新增失敗");
+      } finally {
+        setSubmitting(false);
+      }
+      return;
+    }
+
+    if (!file) {
+      toast.error("請選擇檔案");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await apiClient.footerLinks.upload(
+        file,
+        trimmedZh,
+        trimmedEn || undefined
+      );
+      if (res.success && res.data) {
+        toast.success("已新增相關連結");
+        onCreated(res.data);
+        reset();
+        onOpenChange(false);
+      } else {
+        toast.error(res.message || "上傳失敗");
+      }
+    } catch {
+      toast.error("上傳失敗");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!submitting) {
+          onOpenChange(next);
+          if (!next) reset();
+        }
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>新增相關連結</DialogTitle>
+          <DialogDescription>
+            新增後會顯示在網頁最下方的「相關連結」區塊。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="footer-link-title-zh">名稱（中文）</Label>
+            <Input
+              id="footer-link-title-zh"
+              value={titleZh}
+              onChange={(e) => setTitleZh(e.target.value)}
+              placeholder="例如：獎學金申請指南"
+              maxLength={MAX_TITLE_LENGTH}
+              disabled={submitting}
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="footer-link-title-en">名稱（英文，選填）</Label>
+            <Input
+              id="footer-link-title-en"
+              value={titleEn}
+              onChange={(e) => setTitleEn(e.target.value)}
+              placeholder="Scholarship Guide"
+              maxLength={MAX_TITLE_LENGTH}
+              disabled={submitting}
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              未填寫時，英文介面會顯示中文名稱。
+            </p>
+          </div>
+
+          <Tabs
+            value={mode}
+            onValueChange={(next) => setMode(next as "url" | "file")}
+          >
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="url" disabled={submitting}>
+                外部網址
+              </TabsTrigger>
+              <TabsTrigger value="file" disabled={submitting}>
+                上傳檔案
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="url" className="mt-4">
+              <Label htmlFor="footer-link-url">網址</Label>
+              <Input
+                id="footer-link-url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://www.nycu.edu.tw"
+                disabled={submitting}
+              />
+            </TabsContent>
+
+            <TabsContent value="file" className="mt-4">
+              {!file ? (
+                <label
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragActive(true);
+                  }}
+                  onDragLeave={() => setDragActive(false)}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    setDragActive(false);
+                    validateAndSet(e.dataTransfer.files?.[0] || null);
+                  }}
+                  className={`flex flex-col items-center justify-center rounded-lg border-2 border-dashed cursor-pointer py-8 ${
+                    dragActive
+                      ? "border-nycu-blue-500 bg-nycu-blue-50"
+                      : "border-gray-300 hover:border-nycu-blue-400 hover:bg-nycu-blue-50/40"
+                  }`}
+                >
+                  <input
+                    type="file"
+                    accept={ACCEPTED}
+                    className="sr-only"
+                    onChange={(e) => validateAndSet(e.target.files?.[0] || null)}
+                  />
+                  <CloudUpload className="h-6 w-6 text-nycu-blue-600 mb-2" />
+                  <p className="text-sm font-medium text-nycu-navy-800">
+                    拖曳檔案或點擊選擇
+                  </p>
+                  <p className="text-xs text-gray-500 mt-1">
+                    支援 {ACCEPTED_LABEL} · 上限 {MAX_SIZE_MB} MB
+                  </p>
+                </label>
+              ) : (
+                <div className="rounded-lg border bg-gray-50 p-3 flex items-center gap-3">
+                  <FileType2 className="h-5 w-5 text-nycu-blue-600 flex-shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate" title={file.name}>
+                      {file.name}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {formatBytes(file.size)}
+                    </p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setFile(null)}
+                    disabled={submitting}
+                    aria-label="移除檔案"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
+
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (!submitting) {
+                  reset();
+                  onOpenChange(false);
+                }
+              }}
+              disabled={submitting}
+            >
+              取消
+            </Button>
+            <Button onClick={handleSubmit} disabled={submitting}>
+              {submitting && <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />}
+              {submitting ? "處理中..." : "新增"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/components/admin/footer-links/FooterLinksPanel.tsx
+++ b/frontend/components/admin/footer-links/FooterLinksPanel.tsx
@@ -43,6 +43,7 @@ import {
 import apiClient from "@/lib/api";
 import {
   buildFooterLinkFileProxyUrl,
+  notifyFooterLinksChanged,
   type FooterLink,
 } from "@/lib/api/modules/footer-links";
 import { previewMimeType } from "@/lib/utils";
@@ -229,6 +230,7 @@ export function FooterLinksPanel() {
         toast.error(res.message || "排序失敗");
       } else {
         setLinks(next.map((l, idx) => ({ ...l, sort_order: idx })));
+        notifyFooterLinksChanged();
       }
     } catch {
       setLinks(previous);
@@ -291,6 +293,7 @@ export function FooterLinksPanel() {
           prev.map((l) => (l.id === editingLink.id ? res.data! : l))
         );
         setEditingLink(null);
+        notifyFooterLinksChanged();
         toast.success("已更新");
       } else {
         toast.error(res.message || "更新失敗");
@@ -314,6 +317,7 @@ export function FooterLinksPanel() {
         setLinks(previous);
         toast.error(res.message || "更新失敗");
       } else {
+        notifyFooterLinksChanged();
         toast.success(nextActive ? "已顯示" : "已隱藏");
       }
     } catch {
@@ -334,6 +338,7 @@ export function FooterLinksPanel() {
         setLinks(previous);
         toast.error(res.message || "刪除失敗");
       } else {
+        notifyFooterLinksChanged();
         toast.success("已刪除");
       }
     } catch {
@@ -394,7 +399,10 @@ export function FooterLinksPanel() {
       <AddFooterLinkDialog
         open={addOpen}
         onOpenChange={setAddOpen}
-        onCreated={(link) => setLinks((prev) => [...prev, link])}
+        onCreated={(link) => {
+          setLinks((prev) => [...prev, link]);
+          notifyFooterLinksChanged();
+        }}
       />
 
       {editingLink && (

--- a/frontend/components/admin/footer-links/FooterLinksPanel.tsx
+++ b/frontend/components/admin/footer-links/FooterLinksPanel.tsx
@@ -1,0 +1,497 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  ExternalLink,
+  Eye,
+  EyeOff,
+  FileText,
+  GripVertical,
+  Loader2,
+  Pencil,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import apiClient from "@/lib/api";
+import {
+  buildFooterLinkFileProxyUrl,
+  type FooterLink,
+} from "@/lib/api/modules/footer-links";
+import { previewMimeType } from "@/lib/utils";
+import { FilePreviewDialog } from "@/components/file-preview-dialog";
+import { AddFooterLinkDialog } from "./AddFooterLinkDialog";
+
+const MAX_TITLE_LENGTH = 200;
+
+interface SortableRowProps {
+  link: FooterLink;
+  disabled: boolean;
+  onPreview: (link: FooterLink) => void;
+  onEdit: (link: FooterLink) => void;
+  onToggleActive: (link: FooterLink) => void;
+  onDelete: (link: FooterLink) => void;
+}
+
+function SortableRow({
+  link,
+  disabled,
+  onPreview,
+  onEdit,
+  onToggleActive,
+  onDelete,
+}: SortableRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: link.id, disabled });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const isFile = link.link_type === "file";
+  const Icon = isFile ? FileText : ExternalLink;
+  const subtitle = isFile ? link.original_filename : link.url;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-3 rounded-md border border-gray-200 px-3 py-2 ${
+        link.is_active ? "bg-white" : "bg-gray-50"
+      }`}
+      data-testid={`footer-link-row-${link.id}`}
+    >
+      <button
+        type="button"
+        aria-label="拖曳排序"
+        className="cursor-grab text-gray-400 hover:text-gray-600 disabled:cursor-not-allowed"
+        disabled={disabled}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+
+      <Icon
+        className={`h-4 w-4 flex-shrink-0 ${
+          isFile ? "text-nycu-blue-600" : "text-gray-500"
+        }`}
+      />
+
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-nycu-navy-900 truncate">
+          {link.title_zh}
+          {link.title_en && (
+            <span className="ml-2 text-xs font-normal text-gray-400">
+              {link.title_en}
+            </span>
+          )}
+          {!link.is_active && (
+            <span className="ml-2 rounded bg-gray-200 px-1.5 py-0.5 text-xs font-normal text-gray-600">
+              已隱藏
+            </span>
+          )}
+        </p>
+        <p
+          className="text-xs text-gray-500 truncate"
+          title={subtitle ?? undefined}
+        >
+          {subtitle}
+        </p>
+      </div>
+
+      {isFile && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onPreview(link)}
+          aria-label="預覽"
+        >
+          <Eye className="h-4 w-4" />
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onToggleActive(link)}
+        aria-label={link.is_active ? "隱藏" : "顯示"}
+        title={link.is_active ? "隱藏此連結" : "顯示此連結"}
+      >
+        {link.is_active ? (
+          <EyeOff className="h-4 w-4" />
+        ) : (
+          <Eye className="h-4 w-4 text-green-600" />
+        )}
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onEdit(link)}
+        aria-label="編輯"
+      >
+        <Pencil className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onDelete(link)}
+        aria-label="刪除"
+        className="text-red-600 hover:bg-red-50"
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+export function FooterLinksPanel() {
+  const [links, setLinks] = useState<FooterLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [reordering, setReordering] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+  const [editingLink, setEditingLink] = useState<FooterLink | null>(null);
+  const [editTitleZh, setEditTitleZh] = useState("");
+  const [editTitleEn, setEditTitleEn] = useState("");
+  const [editUrl, setEditUrl] = useState("");
+  const [deletingLink, setDeletingLink] = useState<FooterLink | null>(null);
+  const [preview, setPreview] = useState<
+    { url: string; filename: string; type: string } | null
+  >(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } })
+  );
+
+  useEffect(() => {
+    // include_inactive: admins manage hidden links too.
+    apiClient.footerLinks
+      .list(true)
+      .then((res) => {
+        if (res.success && res.data) setLinks(res.data);
+      })
+      .catch(() => toast.error("載入相關連結失敗"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = links.findIndex((l) => l.id === active.id);
+    const newIndex = links.findIndex((l) => l.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const previous = links;
+    const next = arrayMove(links, oldIndex, newIndex);
+    setLinks(next);
+    setReordering(true);
+
+    try {
+      const items = next.map((l, idx) => ({ id: l.id, sort_order: idx }));
+      const res = await apiClient.footerLinks.reorder(items);
+      if (!res.success) {
+        setLinks(previous);
+        toast.error(res.message || "排序失敗");
+      } else {
+        setLinks(next.map((l, idx) => ({ ...l, sort_order: idx })));
+      }
+    } catch {
+      setLinks(previous);
+      toast.error("排序失敗");
+    } finally {
+      setReordering(false);
+    }
+  };
+
+  const handlePreview = (link: FooterLink) => {
+    const filename = link.original_filename || "";
+    setPreview({
+      url: buildFooterLinkFileProxyUrl(link.id, link.object_name),
+      filename,
+      type: previewMimeType(filename),
+    });
+  };
+
+  const openEdit = (link: FooterLink) => {
+    setEditingLink(link);
+    setEditTitleZh(link.title_zh);
+    setEditTitleEn(link.title_en || "");
+    setEditUrl(link.url || "");
+  };
+
+  const saveEdit = async () => {
+    if (!editingLink) return;
+    const trimmedZh = editTitleZh.trim();
+    if (!trimmedZh) {
+      toast.error("中文名稱不得為空");
+      return;
+    }
+    if (trimmedZh.length > MAX_TITLE_LENGTH) {
+      toast.error(`名稱不得超過 ${MAX_TITLE_LENGTH} 字`);
+      return;
+    }
+
+    const payload: {
+      title_zh: string;
+      title_en: string | null;
+      url?: string;
+    } = {
+      title_zh: trimmedZh,
+      title_en: editTitleEn.trim() || null,
+    };
+
+    if (editingLink.link_type === "url") {
+      const trimmedUrl = editUrl.trim();
+      if (!/^https?:\/\/.+/i.test(trimmedUrl)) {
+        toast.error("網址必須以 http:// 或 https:// 開頭");
+        return;
+      }
+      payload.url = trimmedUrl;
+    }
+
+    try {
+      const res = await apiClient.footerLinks.update(editingLink.id, payload);
+      if (res.success && res.data) {
+        setLinks((prev) =>
+          prev.map((l) => (l.id === editingLink.id ? res.data! : l))
+        );
+        setEditingLink(null);
+        toast.success("已更新");
+      } else {
+        toast.error(res.message || "更新失敗");
+      }
+    } catch {
+      toast.error("更新失敗");
+    }
+  };
+
+  const toggleActive = async (link: FooterLink) => {
+    const previous = links;
+    const nextActive = !link.is_active;
+    setLinks((prev) =>
+      prev.map((l) => (l.id === link.id ? { ...l, is_active: nextActive } : l))
+    );
+    try {
+      const res = await apiClient.footerLinks.update(link.id, {
+        is_active: nextActive,
+      });
+      if (!res.success) {
+        setLinks(previous);
+        toast.error(res.message || "更新失敗");
+      } else {
+        toast.success(nextActive ? "已顯示" : "已隱藏");
+      }
+    } catch {
+      setLinks(previous);
+      toast.error("更新失敗");
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deletingLink) return;
+    const target = deletingLink;
+    setDeletingLink(null);
+    const previous = links;
+    setLinks((prev) => prev.filter((l) => l.id !== target.id));
+    try {
+      const res = await apiClient.footerLinks.delete(target.id);
+      if (!res.success) {
+        setLinks(previous);
+        toast.error(res.message || "刪除失敗");
+      } else {
+        toast.success("已刪除");
+      }
+    } catch {
+      setLinks(previous);
+      toast.error("刪除失敗");
+    }
+  };
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-5 mt-6">
+      <header className="flex items-center justify-between mb-4">
+        <div>
+          <h3 className="font-semibold text-nycu-navy-900">相關連結</h3>
+          <p className="text-sm text-gray-500 mt-0.5">
+            顯示在網頁最下方的連結，可放外部網址或上傳檔案（PDF 等），並可拖曳排序。
+          </p>
+        </div>
+        <Button onClick={() => setAddOpen(true)} size="sm">
+          <Plus className="h-4 w-4 mr-1.5" /> 新增
+        </Button>
+      </header>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <Loader2 className="h-4 w-4 animate-spin" /> 載入中…
+        </div>
+      ) : links.length === 0 ? (
+        <p className="text-sm text-gray-500 py-4">
+          目前尚無相關連結，點擊「新增」建立。
+        </p>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={links.map((l) => l.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="space-y-2">
+              {links.map((link) => (
+                <SortableRow
+                  key={link.id}
+                  link={link}
+                  disabled={reordering}
+                  onPreview={handlePreview}
+                  onEdit={openEdit}
+                  onToggleActive={toggleActive}
+                  onDelete={(l) => setDeletingLink(l)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <AddFooterLinkDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        onCreated={(link) => setLinks((prev) => [...prev, link])}
+      />
+
+      {editingLink && (
+        <Dialog open onOpenChange={(next) => !next && setEditingLink(null)}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>編輯相關連結</DialogTitle>
+              <DialogDescription>
+                {editingLink.link_type === "file"
+                  ? "檔案內容無法直接替換，如需更換請刪除後重新上傳。"
+                  : "修改此連結的顯示名稱與網址。"}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="edit-footer-title-zh">名稱（中文）</Label>
+                <Input
+                  id="edit-footer-title-zh"
+                  value={editTitleZh}
+                  onChange={(e) => setEditTitleZh(e.target.value)}
+                  maxLength={MAX_TITLE_LENGTH}
+                />
+              </div>
+              <div>
+                <Label htmlFor="edit-footer-title-en">
+                  名稱（英文，選填）
+                </Label>
+                <Input
+                  id="edit-footer-title-en"
+                  value={editTitleEn}
+                  onChange={(e) => setEditTitleEn(e.target.value)}
+                  maxLength={MAX_TITLE_LENGTH}
+                />
+              </div>
+              {editingLink.link_type === "url" ? (
+                <div>
+                  <Label htmlFor="edit-footer-url">網址</Label>
+                  <Input
+                    id="edit-footer-url"
+                    value={editUrl}
+                    onChange={(e) => setEditUrl(e.target.value)}
+                    placeholder="https://www.nycu.edu.tw"
+                  />
+                </div>
+              ) : (
+                <div className="rounded-md border bg-gray-50 px-3 py-2">
+                  <p className="text-xs text-gray-500">目前檔案</p>
+                  <p className="text-sm truncate">
+                    {editingLink.original_filename}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setEditingLink(null)}>
+                取消
+              </Button>
+              <Button onClick={saveEdit}>儲存</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {deletingLink && (
+        <Dialog open onOpenChange={(next) => !next && setDeletingLink(null)}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>確認刪除</DialogTitle>
+              <DialogDescription>
+                刪除後「{deletingLink.title_zh}」將不再顯示於網頁下方
+                {deletingLink.link_type === "file" && "，且上傳的檔案會一併移除"}
+                ，確定要刪除嗎？
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setDeletingLink(null)}>
+                取消
+              </Button>
+              <Button
+                onClick={confirmDelete}
+                className="bg-red-600 hover:bg-red-700 text-white"
+              >
+                刪除
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      <FilePreviewDialog
+        isOpen={preview !== null}
+        onClose={() => setPreview(null)}
+        file={preview}
+        locale="zh"
+      />
+    </section>
+  );
+}

--- a/frontend/components/admin/footer-links/__tests__/FooterLinksPanel.test.tsx
+++ b/frontend/components/admin/footer-links/__tests__/FooterLinksPanel.test.tsx
@@ -1,0 +1,178 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { FooterLinksPanel } from "../FooterLinksPanel";
+
+jest.mock("../../../../lib/api", () => {
+  const list = jest.fn();
+  const create = jest.fn();
+  const upload = jest.fn();
+  const update = jest.fn();
+  const del = jest.fn();
+  const reorder = jest.fn();
+  return {
+    __esModule: true,
+    default: {
+      footerLinks: { list, create, upload, update, delete: del, reorder },
+    },
+  };
+});
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const apiMock = jest.requireMock("../../../../lib/api") as {
+  default: {
+    footerLinks: {
+      list: jest.Mock;
+      create: jest.Mock;
+      upload: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+      reorder: jest.Mock;
+    };
+  };
+};
+
+const api = apiMock.default.footerLinks;
+const { toast } = jest.requireMock("sonner") as {
+  toast: { success: jest.Mock; error: jest.Mock };
+};
+
+function makeLink(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    title_zh: "陽明交大首頁",
+    title_en: "NYCU Homepage",
+    link_type: "url",
+    url: "https://www.nycu.edu.tw",
+    object_name: null,
+    original_filename: null,
+    content_type: null,
+    file_size: null,
+    sort_order: 0,
+    is_active: true,
+    created_at: "2026-07-29T00:00:00Z",
+    updated_at: "2026-07-29T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  Object.values(api).forEach((fn) => (fn as jest.Mock).mockReset());
+  toast.success.mockReset();
+  toast.error.mockReset();
+});
+
+test("requests inactive links so admins can manage hidden entries", async () => {
+  api.list.mockResolvedValue({ success: true, message: "OK", data: [] });
+
+  render(<FooterLinksPanel />);
+
+  await waitFor(() => expect(api.list).toHaveBeenCalledWith(true));
+  expect(await screen.findByText(/目前尚無相關連結/)).toBeInTheDocument();
+});
+
+test("shows a 已隱藏 badge for inactive links", async () => {
+  api.list.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [makeLink({ is_active: false })],
+  });
+
+  render(<FooterLinksPanel />);
+
+  expect(await screen.findByText("已隱藏")).toBeInTheDocument();
+});
+
+test("toggling visibility patches is_active", async () => {
+  api.list.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [makeLink()],
+  });
+  api.update.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: makeLink({ is_active: false }),
+  });
+
+  render(<FooterLinksPanel />);
+
+  fireEvent.click(await screen.findByLabelText("隱藏"));
+
+  await waitFor(() =>
+    expect(api.update).toHaveBeenCalledWith(1, { is_active: false })
+  );
+});
+
+test("rejects a non-http URL before hitting the API", async () => {
+  api.list.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [makeLink()],
+  });
+
+  render(<FooterLinksPanel />);
+
+  fireEvent.click(await screen.findByLabelText("編輯"));
+
+  const urlInput = await screen.findByLabelText("網址");
+  fireEvent.change(urlInput, {
+    target: { value: "javascript:alert(1)" },
+  });
+  fireEvent.click(screen.getByText("儲存"));
+
+  await waitFor(() =>
+    expect(toast.error).toHaveBeenCalledWith(
+      "網址必須以 http:// 或 https:// 開頭"
+    )
+  );
+  expect(api.update).not.toHaveBeenCalled();
+});
+
+test("file links expose a preview action and no URL field when edited", async () => {
+  api.list.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [
+      makeLink({
+        id: 4,
+        title_zh: "操作手冊",
+        link_type: "file",
+        url: null,
+        object_name: "footer-links/link_x.pdf",
+        original_filename: "manual.pdf",
+      }),
+    ],
+  });
+
+  render(<FooterLinksPanel />);
+
+  expect(await screen.findByLabelText("預覽")).toBeInTheDocument();
+
+  fireEvent.click(screen.getByLabelText("編輯"));
+
+  expect(await screen.findByText(/檔案內容無法直接替換/)).toBeInTheDocument();
+  expect(screen.queryByLabelText("網址")).toBeNull();
+});
+
+test("deleting a link removes the row and calls the API", async () => {
+  api.list.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [makeLink()],
+  });
+  api.delete.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: { deleted: true },
+  });
+
+  render(<FooterLinksPanel />);
+
+  fireEvent.click(await screen.findByLabelText("刪除"));
+  fireEvent.click(await screen.findByText("刪除", { selector: "button" }));
+
+  await waitFor(() => expect(api.delete).toHaveBeenCalledWith(1));
+});

--- a/frontend/components/admin/system-docs/SystemDocsPanel.tsx
+++ b/frontend/components/admin/system-docs/SystemDocsPanel.tsx
@@ -29,6 +29,7 @@ import { toast } from "sonner";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { SupplementaryDocsList } from "./SupplementaryDocsList";
 import { ApplicationNoticesPanel } from "./ApplicationNoticesPanel";
+import { FooterLinksPanel } from "../footer-links/FooterLinksPanel";
 
 interface DocSlot {
   key: DocKey;
@@ -453,6 +454,8 @@ export function SystemDocsPanel() {
       <SupplementaryDocsList />
 
       <ApplicationNoticesPanel />
+
+      <FooterLinksPanel />
 
       <FilePreviewDialog
         isOpen={preview !== null}

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -1,7 +1,19 @@
 "use client";
 import { useEffect, useState } from "react";
 import { Separator } from "@/components/ui/separator";
-import { ExternalLink, GraduationCap, ChevronDown } from "lucide-react";
+import {
+  ExternalLink,
+  FileText,
+  GraduationCap,
+  ChevronDown,
+} from "lucide-react";
+import apiClient from "@/lib/api";
+import {
+  footerLinkHref,
+  footerLinkLabel,
+  type FooterLink,
+} from "@/lib/api/modules/footer-links";
+import { logger } from "@/lib/utils/logger";
 
 interface FooterProps {
   locale?: "zh" | "en";
@@ -9,6 +21,24 @@ interface FooterProps {
 
 export function Footer({ locale = "zh" }: FooterProps) {
   const currentYear = new Date().getFullYear();
+
+  // 相關連結 are admin-managed (系統管理 → 系統文件). A fetch failure must not
+  // break the rest of the footer, so the list just stays empty.
+  const [links, setLinks] = useState<FooterLink[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    apiClient.footerLinks
+      .list()
+      .then((res) => {
+        if (!cancelled && res.success && res.data) setLinks(res.data);
+      })
+      .catch((error) => {
+        logger.error("Failed to load footer links", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   // Render the "Last updated" date only after mount to avoid SSR/CSR
   // hydration mismatches caused by the server and client rendering with
   // different locale-formatted strings (or different system clocks crossing
@@ -79,59 +109,25 @@ export function Footer({ locale = "zh" }: FooterProps) {
               />
             </summary>
             <div className="space-y-3 mt-4">
-              <a
-                href="https://www.nycu.edu.tw"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 text-sm text-nycu-navy-700 hover:text-nycu-blue-600 transition-colors group"
-              >
-                <ExternalLink className="h-4 w-4 group-hover:scale-110 transition-transform" />
-                {locale === "zh" ? "陽明交大首頁" : "NYCU Homepage"}
-              </a>
-
-              <a
-                href="https://aa.nycu.edu.tw/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 text-sm text-nycu-navy-700 hover:text-nycu-blue-600 transition-colors group"
-              >
-                <ExternalLink className="h-4 w-4 group-hover:scale-110 transition-transform" />
-                {locale === "zh" ? "教務處" : "Academic Affairs"}
-              </a>
-
-              <a
-                href="https://portal.nycu.edu.tw"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 text-sm text-nycu-navy-700 hover:text-nycu-blue-600 transition-colors group"
-              >
-                <ExternalLink className="h-4 w-4 group-hover:scale-110 transition-transform" />
-                {locale === "zh" ? "NYCU Portal" : "NYCU Portal"}
-              </a>
-
-              <a
-                href="#"
-                className="flex items-center gap-2 text-sm text-nycu-navy-700 hover:text-nycu-blue-600 transition-colors group"
-              >
-                <ExternalLink className="h-4 w-4 group-hover:scale-110 transition-transform" />
-                {locale === "zh" ? "獎學金申請指南" : "Scholarship Guide"}
-              </a>
-
-              <a
-                href="#"
-                className="flex items-center gap-2 text-sm text-nycu-navy-700 hover:text-nycu-blue-600 transition-colors group"
-              >
-                <ExternalLink className="h-4 w-4 group-hover:scale-110 transition-transform" />
-                {locale === "zh" ? "常見問題" : "FAQ"}
-              </a>
-
-              <a
-                href="#"
-                className="flex items-center gap-2 text-sm text-nycu-navy-700 hover:text-nycu-blue-600 transition-colors group"
-              >
-                <ExternalLink className="h-4 w-4 group-hover:scale-110 transition-transform" />
-                {locale === "zh" ? "系統操作手冊" : "User Manual"}
-              </a>
+              {links.map((link) => {
+                const isFile = link.link_type === "file";
+                const Icon = isFile ? FileText : ExternalLink;
+                return (
+                  <a
+                    key={link.id}
+                    href={footerLinkHref(link)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={isFile ? link.original_filename ?? undefined : undefined}
+                    className="flex items-center gap-2 text-sm text-nycu-navy-700 hover:text-nycu-blue-600 transition-colors group"
+                  >
+                    <Icon className="h-4 w-4 flex-shrink-0 group-hover:scale-110 transition-transform" />
+                    <span className="truncate">
+                      {footerLinkLabel(link, locale)}
+                    </span>
+                  </a>
+                );
+              })}
             </div>
           </details>
         </div>

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Separator } from "@/components/ui/separator";
 import {
   ExternalLink,
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import apiClient from "@/lib/api";
 import {
+  FOOTER_LINKS_CHANGED_EVENT,
   footerLinkHref,
   footerLinkLabel,
   type FooterLink,
@@ -25,20 +26,29 @@ export function Footer({ locale = "zh" }: FooterProps) {
   // 相關連結 are admin-managed (系統管理 → 系統文件). A fetch failure must not
   // break the rest of the footer, so the list just stays empty.
   const [links, setLinks] = useState<FooterLink[]>([]);
-  useEffect(() => {
-    let cancelled = false;
-    apiClient.footerLinks
-      .list()
-      .then((res) => {
-        if (!cancelled && res.success && res.data) setLinks(res.data);
-      })
-      .catch((error) => {
-        logger.error("Failed to load footer links", error);
-      });
-    return () => {
-      cancelled = true;
-    };
+
+  const loadLinks = useCallback(async (signal?: { cancelled: boolean }) => {
+    try {
+      const res = await apiClient.footerLinks.list();
+      if (!signal?.cancelled && res.success && res.data) setLinks(res.data);
+    } catch (error) {
+      logger.error("Failed to load footer links", error);
+    }
   }, []);
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    void loadLinks(signal);
+
+    // The admin panel edits this same list on this same page; refetch when it
+    // reports a change so the footer never shows a stale mount-time snapshot.
+    const onChanged = () => void loadLinks();
+    window.addEventListener(FOOTER_LINKS_CHANGED_EVENT, onChanged);
+    return () => {
+      signal.cancelled = true;
+      window.removeEventListener(FOOTER_LINKS_CHANGED_EVENT, onChanged);
+    };
+  }, [loadLinks]);
   // Render the "Last updated" date only after mount to avoid SSR/CSR
   // hydration mismatches caused by the server and client rendering with
   // different locale-formatted strings (or different system clocks crossing
@@ -97,7 +107,12 @@ export function Footer({ locale = "zh" }: FooterProps) {
           {/* Related Links — expanded by default (native <details open>) on
               every breakpoint. Below md the summary stays interactive so
               users can collapse it; the disclosure chevron is hidden at
-              md+ where the toggle affordance isn't needed. */}
+              md+ where the toggle affordance isn't needed.
+
+              Hidden entirely when there are no links (all hidden by the
+              admin, or the fetch failed) — otherwise the heading and its
+              interactive chevron sit over an empty box. */}
+          {links.length > 0 && (
           <details className="group [&_summary::-webkit-details-marker]:hidden md:col-span-2" open>
             <summary className="flex items-center justify-between cursor-pointer md:cursor-default list-none">
               <h4 className="font-bold text-nycu-navy-800 text-lg">
@@ -130,6 +145,7 @@ export function Footer({ locale = "zh" }: FooterProps) {
               })}
             </div>
           </details>
+          )}
         </div>
 
         <Separator className="my-8 bg-nycu-blue-200" />

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7172,6 +7172,121 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/footer-links": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Footer Links
+         * @description List footer links ordered by sort_order then id.
+         *
+         *     Any authenticated user may read. ``include_inactive`` is honoured for
+         *     admins only — a non-admin always gets the active (publicly shown) set,
+         *     so a hidden link cannot leak through the query parameter.
+         */
+        get: operations["list_footer_links_api_v1_footer_links_get"];
+        put?: never;
+        /**
+         * Create Footer Link
+         * @description Create an external-URL footer link. Admin only.
+         */
+        post: operations["create_footer_link_api_v1_footer_links_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/footer-links/upload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upload Footer Link File
+         * @description Create a file-backed footer link by uploading a document. Admin only.
+         */
+        post: operations["upload_footer_link_file_api_v1_footer_links_upload_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/footer-links/reorder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Reorder Footer Links
+         * @description Persist a new display order. Admin only.
+         */
+        patch: operations["reorder_footer_links_api_v1_footer_links_reorder_patch"];
+        trace?: never;
+    };
+    "/api/v1/footer-links/{link_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Footer Link
+         * @description Delete a footer link, removing its stored file when present. Admin only.
+         */
+        delete: operations["delete_footer_link_api_v1_footer_links__link_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Footer Link
+         * @description Update a footer link's titles, URL, or visibility. Admin only.
+         */
+        patch: operations["update_footer_link_api_v1_footer_links__link_id__patch"];
+        trace?: never;
+    };
+    "/api/v1/footer-links/{link_id}/file": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Stream Footer Link File
+         * @description Stream a file-backed footer link's document. Any authenticated user.
+         *
+         *     Inactive links stay readable for admins only so a hidden document isn't
+         *     still fetchable by a student holding a stale URL.
+         */
+        get: operations["stream_footer_link_file_api_v1_footer_links__link_id__file_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/student-bank-accounts/my-verified-account": {
         parameters: {
             query?: never;
@@ -8886,6 +9001,15 @@ export interface components {
             /** File */
             file: string;
         };
+        /** Body_upload_footer_link_file_api_v1_footer_links_upload_post */
+        Body_upload_footer_link_file_api_v1_footer_links_upload_post: {
+            /** File */
+            file: string;
+            /** Title Zh */
+            title_zh: string;
+            /** Title En */
+            title_en?: string | null;
+        };
         /** Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post */
         Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post: {
             /**
@@ -9493,6 +9617,50 @@ export interface components {
             academic_year: number;
             /** Semester */
             semester: string;
+        };
+        /**
+         * FooterLinkCreate
+         * @description Create an external-URL footer link (file links use the upload endpoint).
+         */
+        FooterLinkCreate: {
+            /** Title Zh */
+            title_zh: string;
+            /** Title En */
+            title_en?: string | null;
+            /** Url */
+            url: string;
+            /**
+             * Is Active
+             * @default true
+             */
+            is_active: boolean;
+        };
+        /** FooterLinkReorderItem */
+        FooterLinkReorderItem: {
+            /** Id */
+            id: number;
+            /** Sort Order */
+            sort_order: number;
+        };
+        /** FooterLinkReorderRequest */
+        FooterLinkReorderRequest: {
+            /** Items */
+            items: components["schemas"]["FooterLinkReorderItem"][];
+        };
+        /**
+         * FooterLinkUpdate
+         * @description Partial update. ``url`` is only accepted for link_type == url rows,
+         *     which the endpoint enforces against the persisted row.
+         */
+        FooterLinkUpdate: {
+            /** Title Zh */
+            title_zh?: string | null;
+            /** Title En */
+            title_en?: string | null;
+            /** Url */
+            url?: string | null;
+            /** Is Active */
+            is_active?: boolean | null;
         };
         /**
          * FormConfigSaveRequest
@@ -22876,6 +23044,233 @@ export interface operations {
             header?: never;
             path: {
                 config_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_footer_links_api_v1_footer_links_get: {
+        parameters: {
+            query?: {
+                include_inactive?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_footer_link_api_v1_footer_links_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FooterLinkCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upload_footer_link_file_api_v1_footer_links_upload_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_upload_footer_link_file_api_v1_footer_links_upload_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reorder_footer_links_api_v1_footer_links_reorder_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FooterLinkReorderRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_footer_link_api_v1_footer_links__link_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                link_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_footer_link_api_v1_footer_links__link_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                link_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FooterLinkUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_footer_link_file_api_v1_footer_links__link_id__file_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                link_id: number;
             };
             cookie?: never;
         };

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -24,6 +24,7 @@ import { createProfessorApi } from './modules/professor';
 import { createCollegeApi } from './modules/college';
 import { createWhitelistApi } from './modules/whitelist';
 import { createSystemSettingsApi } from './modules/system-settings';
+import { createFooterLinksApi } from './modules/footer-links';
 import { createBankVerificationApi } from './modules/bank-verification';
 import { createProfessorStudentApi } from './modules/professor-student';
 import { createEmailAutomationApi } from './modules/email-automation';
@@ -154,6 +155,7 @@ class ExtendedApiClient extends ApiClient {
   private _college?: ReturnType<typeof createCollegeApi>;
   private _whitelist?: ReturnType<typeof createWhitelistApi>;
   private _systemSettings?: ReturnType<typeof createSystemSettingsApi>;
+  private _footerLinks?: ReturnType<typeof createFooterLinksApi>;
   private _bankVerification?: ReturnType<typeof createBankVerificationApi>;
   private _professorStudent?: ReturnType<typeof createProfessorStudentApi>;
   private _emailAutomation?: ReturnType<typeof createEmailAutomationApi>;
@@ -223,6 +225,11 @@ class ExtendedApiClient extends ApiClient {
   get systemSettings(): ReturnType<typeof createSystemSettingsApi> {
     if (!this._systemSettings) this._systemSettings = createSystemSettingsApi();
     return this._systemSettings;
+  }
+
+  get footerLinks(): ReturnType<typeof createFooterLinksApi> {
+    if (!this._footerLinks) this._footerLinks = createFooterLinksApi();
+    return this._footerLinks;
   }
 
   get bankVerification(): ReturnType<typeof createBankVerificationApi> {

--- a/frontend/lib/api/modules/footer-links.ts
+++ b/frontend/lib/api/modules/footer-links.ts
@@ -1,0 +1,176 @@
+/**
+ * Footer Links API Module (相關連結)
+ *
+ * Admin-managed entries rendered in the site footer. Each link is either an
+ * external URL or an uploaded document (PDF / Office / ODF) streamed back
+ * through the backend proxy — never a direct MinIO URL.
+ */
+
+import type { ApiResponse } from '../types';
+
+export type FooterLinkType = 'url' | 'file';
+
+/** Footer link payload returned by the backend. */
+export type FooterLink = {
+  id: number;
+  title_zh: string;
+  title_en: string | null;
+  link_type: FooterLinkType;
+  url: string | null;
+  object_name: string | null;
+  original_filename: string | null;
+  content_type: string | null;
+  file_size: number | null;
+  sort_order: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type FooterLinkCreatePayload = {
+  title_zh: string;
+  title_en?: string | null;
+  url: string;
+  is_active?: boolean;
+};
+
+export type FooterLinkUpdatePayload = {
+  title_zh?: string;
+  title_en?: string | null;
+  url?: string;
+  is_active?: boolean;
+};
+
+function authToken(): string {
+  return typeof window !== 'undefined'
+    ? localStorage.getItem('auth_token') || ''
+    : '';
+}
+
+function jsonHeaders(): Record<string, string> {
+  return {
+    Authorization: `Bearer ${authToken()}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+/**
+ * Build the file-proxy URL for a file-backed footer link. Mirrors
+ * buildSuppDocFileProxyUrl but routes via /api/v1/preview/footer-links?id=...
+ *
+ * The cache-buster is derived from the stored object name so replacing a
+ * link's file bypasses the browser cache.
+ */
+export function buildFooterLinkFileProxyUrl(
+  id: number,
+  objectName?: string | null
+): string {
+  const cacheBuster = encodeURIComponent(
+    (objectName || '').split('/').pop() || String(id)
+  );
+  return `/api/v1/preview/footer-links?id=${id}&token=${encodeURIComponent(
+    authToken()
+  )}&v=${cacheBuster}`;
+}
+
+/**
+ * Resolve the href a footer entry should point at: the external URL for
+ * `url` links, or the streaming proxy URL for `file` links.
+ */
+export function footerLinkHref(link: FooterLink): string {
+  if (link.link_type === 'file') {
+    return buildFooterLinkFileProxyUrl(link.id, link.object_name);
+  }
+  return link.url || '#';
+}
+
+/** Label for the given locale, falling back to the Chinese title. */
+export function footerLinkLabel(link: FooterLink, locale: 'zh' | 'en'): string {
+  if (locale === 'en') return link.title_en || link.title_zh;
+  return link.title_zh;
+}
+
+export function createFooterLinksApi() {
+  return {
+    /**
+     * List footer links. `includeInactive` is honoured for admins only —
+     * the backend always filters hidden links out for non-admins.
+     */
+    list: async (
+      includeInactive = false
+    ): Promise<ApiResponse<FooterLink[]>> => {
+      const query = includeInactive ? '?include_inactive=true' : '';
+      const res = await fetch(`/api/v1/footer-links${query}`, {
+        headers: { Authorization: `Bearer ${authToken()}` },
+      });
+      return (await res.json()) as ApiResponse<FooterLink[]>;
+    },
+
+    /** Create an external-URL link (admin only). */
+    create: async (
+      payload: FooterLinkCreatePayload
+    ): Promise<ApiResponse<FooterLink>> => {
+      const res = await fetch('/api/v1/footer-links', {
+        method: 'POST',
+        headers: jsonHeaders(),
+        body: JSON.stringify(payload),
+      });
+      return (await res.json()) as ApiResponse<FooterLink>;
+    },
+
+    /** Create a file-backed link by uploading a document (admin only). */
+    upload: async (
+      file: File,
+      titleZh: string,
+      titleEn?: string
+    ): Promise<ApiResponse<FooterLink>> => {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('title_zh', titleZh);
+      if (titleEn) formData.append('title_en', titleEn);
+
+      const res = await fetch('/api/v1/footer-links/upload-proxy', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${authToken()}` },
+        body: formData,
+      });
+      return (await res.json()) as ApiResponse<FooterLink>;
+    },
+
+    /** Update titles, URL, or visibility (admin only). */
+    update: async (
+      id: number,
+      payload: FooterLinkUpdatePayload
+    ): Promise<ApiResponse<FooterLink>> => {
+      const res = await fetch(`/api/v1/footer-links/${id}`, {
+        method: 'PATCH',
+        headers: jsonHeaders(),
+        body: JSON.stringify(payload),
+      });
+      return (await res.json()) as ApiResponse<FooterLink>;
+    },
+
+    /** Delete a link and its stored file (admin only). */
+    delete: async (
+      id: number
+    ): Promise<ApiResponse<{ deleted: boolean }>> => {
+      const res = await fetch(`/api/v1/footer-links/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${authToken()}` },
+      });
+      return (await res.json()) as ApiResponse<{ deleted: boolean }>;
+    },
+
+    /** Persist a new display order (admin only). */
+    reorder: async (
+      items: Array<{ id: number; sort_order: number }>
+    ): Promise<ApiResponse<{ updated: number }>> => {
+      const res = await fetch('/api/v1/footer-links/reorder', {
+        method: 'PATCH',
+        headers: jsonHeaders(),
+        body: JSON.stringify({ items }),
+      });
+      return (await res.json()) as ApiResponse<{ updated: number }>;
+    },
+  };
+}

--- a/frontend/lib/api/modules/footer-links.ts
+++ b/frontend/lib/api/modules/footer-links.ts
@@ -41,6 +41,23 @@ export type FooterLinkUpdatePayload = {
   is_active?: boolean;
 };
 
+/**
+ * Broadcast name for "the footer link list changed".
+ *
+ * The admin panel and the <Footer> render on the SAME page (the panel lives
+ * inside the 系統管理 tab; the footer is mounted outside <Tabs> and stays
+ * mounted for the whole session), but they hold independent copies of the
+ * list. Without this signal an admin who adds or hides a link and scrolls
+ * down sees the mount-time snapshot and concludes the save failed.
+ */
+export const FOOTER_LINKS_CHANGED_EVENT = "footer-links:changed";
+
+/** Tell any mounted <Footer> to refetch. No-op during SSR. */
+export function notifyFooterLinksChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(FOOTER_LINKS_CHANGED_EVENT));
+}
+
 function authToken(): string {
   return typeof window !== 'undefined'
     ? localStorage.getItem('auth_token') || ''

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -236,52 +236,19 @@ http {
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         }
 
-        # Next.js system-docs UPLOAD proxies (POST, not framed). These must reach
-        # the frontend so the Next.js route handlers run; otherwise they hit the
-        # backend directly (no matching route -> 405/404). The matching READ/preview
-        # proxies now live under /api/v1/preview/{system-docs,supp-docs} and are
-        # served by the single /api/v1/preview block above.
-        location /api/v1/system-settings/upload-proxy {
-            limit_req zone=frontend burst=30 nodelay;
-
-            set $frontend_upstream frontend:3000;
-            proxy_pass http://$frontend_upstream;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Request-ID $request_id;
-
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 120s;
-            proxy_read_timeout 120s;
-
-            # Allow up to 10MB document uploads (backend enforces the 10MB cap)
-            client_max_body_size 11M;
-        }
-
-        location /api/v1/system-settings/supp-upload-proxy {
-            limit_req zone=frontend burst=30 nodelay;
-
-            set $frontend_upstream frontend:3000;
-            proxy_pass http://$frontend_upstream;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Request-ID $request_id;
-
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 120s;
-            proxy_read_timeout 120s;
-
-            # Allow up to 10MB document uploads (backend enforces the 10MB cap)
-            client_max_body_size 11M;
-        }
-
-        location /api/v1/footer-links/upload-proxy {
+        # Next.js UPLOAD proxies (POST, not framed). Any
+        # /api/v1/<feature>/[...-]upload-proxy path is a Next.js route handler
+        # and MUST reach the frontend; otherwise it falls through to the
+        # `location /api/` catch-all and hits FastAPI, which has no such route
+        # (-> 405/404). No backend route uses the `upload-proxy` suffix, so
+        # this convention-based match is unambiguous, and a new upload proxy
+        # works without touching nginx.
+        #
+        # A regex location beats the `location /api/` prefix, and this pattern
+        # is disjoint from the /api/v1/preview regex above, so their relative
+        # order does not matter. The matching READ/preview proxies live under
+        # /api/v1/preview/* and are served by that single block.
+        location ~ ^/api/v1/.+upload-proxy$ {
             limit_req zone=frontend burst=30 nodelay;
 
             set $frontend_upstream frontend:3000;

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -281,6 +281,26 @@ http {
             client_max_body_size 11M;
         }
 
+        location /api/v1/footer-links/upload-proxy {
+            limit_req zone=frontend burst=30 nodelay;
+
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Request-ID $request_id;
+
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+
+            # Allow up to 10MB document uploads (backend enforces the 10MB cap)
+            client_max_body_size 11M;
+        }
+
         # Backend API routes (all other /api/ requests)
         location /api/ {
             limit_req zone=api burst=40 nodelay;

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -264,6 +264,25 @@ http {
             client_max_body_size 11M;
         }
 
+        location /api/v1/footer-links/upload-proxy {
+            limit_req zone=frontend burst=20 nodelay;
+
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Request-ID $request_id;
+
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
+
+            # Allow up to 10MB document uploads (backend enforces the 10MB cap)
+            client_max_body_size 11M;
+        }
+
         # Backend API routes (其他所有 /api/ 請求)
         location /api/ {
             # Handle OPTIONS requests directly (CORS preflight)

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -221,50 +221,19 @@ http {
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         }
 
-        # Next.js system-docs UPLOAD proxies (POST, not framed). These must reach
-        # the frontend so the Next.js route handlers run; otherwise they hit the
-        # backend directly (no matching route -> 405/404). The matching READ/preview
-        # proxies now live under /api/v1/preview/{system-docs,supp-docs} and are
-        # served by the single /api/v1/preview block above.
-        location /api/v1/system-settings/upload-proxy {
-            limit_req zone=frontend burst=20 nodelay;
-
-            set $frontend_upstream frontend:3000;
-            proxy_pass http://$frontend_upstream;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Request-ID $request_id;
-
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 120s;
-            proxy_read_timeout 120s;
-
-            # Allow up to 10MB document uploads (backend enforces the 10MB cap)
-            client_max_body_size 11M;
-        }
-
-        location /api/v1/system-settings/supp-upload-proxy {
-            limit_req zone=frontend burst=20 nodelay;
-
-            set $frontend_upstream frontend:3000;
-            proxy_pass http://$frontend_upstream;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Request-ID $request_id;
-
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 120s;
-            proxy_read_timeout 120s;
-
-            # Allow up to 10MB document uploads (backend enforces the 10MB cap)
-            client_max_body_size 11M;
-        }
-
-        location /api/v1/footer-links/upload-proxy {
+        # Next.js UPLOAD proxies (POST, not framed). Any
+        # /api/v1/<feature>/[...-]upload-proxy path is a Next.js route handler
+        # and MUST reach the frontend; otherwise it falls through to the
+        # `location /api/` catch-all and hits FastAPI, which has no such route
+        # (-> 405/404). No backend route uses the `upload-proxy` suffix, so
+        # this convention-based match is unambiguous, and a new upload proxy
+        # works without touching nginx.
+        #
+        # A regex location beats the `location /api/` prefix, and this pattern
+        # is disjoint from the /api/v1/preview regex above, so their relative
+        # order does not matter. The matching READ/preview proxies live under
+        # /api/v1/preview/* and are served by that single block.
+        location ~ ^/api/v1/.+upload-proxy$ {
             limit_req zone=frontend burst=20 nodelay;
 
             set $frontend_upstream frontend:3000;


### PR DESCRIPTION
## 摘要

網頁最下方的「相關連結」原本是 `footer.tsx` 裡六個寫死的 `<a>` 標籤。此 PR 讓管理員可以從 **系統管理 → 系統文件** 自行維護這份清單：新增外部網址、**上傳檔案（PDF / Office / ODF）**、改名稱、拖曳排序、暫時隱藏、刪除。

## 主要變更

### Backend
- 新增 `footer_links` 資料表與 `FooterLink` model。每筆資料不是**外部網址**就是**上傳檔案**，由 `link_type` 區分；以 CHECK constraint 保證兩種型態互斥（同時宣告在 model 上，讓 `create_all()` 也吃得到）。
- 新增 `/api/v1/footer-links`：list / create-url / upload-file / reorder / update / delete / stream-file。**讀取**開放給所有已登入使用者，**所有異動**限管理員。
- 檔案一律透過後端串流（含明確的 `Content-Length`），**不外流 MinIO URL**。

### Frontend
- `footer.tsx` 改為從 API 讀取；抓取失敗時只是清單為空，不會弄壞頁尾其他區塊。
- 新增 `FooterLinksPanel` + `AddFooterLinkDialog`，沿用既有「補充參考文件」的互動模式（dnd-kit 排序、預覽、刪除確認）。
- 新增 upload 與 preview 兩支 Next.js proxy route。

## 安全性考量

- **只接受 `http(s)` 網址。** 頁尾把每一筆都渲染成 `<a href>`，若允許 `javascript:` / `data:`，管理員表單就會變成對所有訪客的 stored-XSS 管道。前後端都擋。
- `include_inactive` 只對管理員生效；被隱藏的連結，非管理員連 file stream 也會拿到 404，避免舊網址仍可下載。

## Migration 注意事項

> [!IMPORTANT]
> `59b65a4de996` 會執行 `Base.metadata.create_all()`，所以在全新資料庫上，此 migration 執行時 `footer_links` **已經存在**。因此每個步驟都是**個別**做存在性檢查 —— 一開始寫成「table 已存在就 `return`」會在每次全新安裝時**靜默跳過 seed 資料與 constraint**（已在全新 DB 上實測抓到並修正）。

Seed 了原本寫死的三個真實連結（陽明交大首頁 / 教務處 / NYCU Portal），確保升級後頁尾外觀不變。

> [!NOTE]
> 另外三個（獎學金申請指南 / 常見問題 / 系統操作手冊）原本 `href="#"`，是無效連結，**刻意不 seed**。升級後這三個標籤會從頁尾消失，需由管理員用真實網址或 PDF 重新建立 —— 這正是本 PR 要解決的問題。

## 測試

- **Backend 28 筆**：URL scheme 防護、admin-only 界線、url/file 型態分離、隱藏連結可見性、Content-Length。
- **Frontend 10 筆**：頁尾動態渲染、file link 走 proxy、英文 locale fallback、管理面板行為。

驗證結果：
- backend unit lane **3218 passed**；frontend **107 suites / 1454 tests passed**
- `tsc --noEmit` 與 eslint 乾淨
- `schema.d.ts` 已重新產生（**+395 行、0 刪除**，無 phantom drift）
- Migration 在**全新 Postgres** 跑完整鏈成功，並驗證 downgrade → 再 upgrade 不會重複 seed；CHECK constraint 實測可擋下錯誤 payload

## Test plan

- [ ] 部署後執行 `alembic upgrade head`（新增 `footer_links` 並 seed 三筆）
- [ ] 以管理員登入 → 系統管理 → 系統文件 → 相關連結
- [ ] 新增一筆**外部網址**，確認頁尾出現且可正常開啟
- [ ] 上傳一份 **PDF**，確認頁尾出現、點擊可在瀏覽器內預覽
- [ ] 拖曳排序後重新整理，確認順序有保存
- [ ] 將某筆設為隱藏，以學生帳號確認頁尾看不到
- [ ] 切換英文介面，確認未填英文名稱者顯示中文名稱
- [ ] 刪除一筆檔案連結，確認 MinIO 物件一併移除

🤖 Generated with [Claude Code](https://claude.com/claude-code)
