### PR TITLE
feat(student-history): 學生領獎紀錄查詢開放對象由管理者分別決定

### DIFF
--- a/backend/alembic/versions/student_history_visibility_001.py
+++ b/backend/alembic/versions/student_history_visibility_001.py
@@ -1,0 +1,78 @@
+"""Seed the 學生領獎紀錄查詢 visibility switches
+
+Revision ID: student_history_visibility_001
+Revises: add_footer_links_001
+Create Date: 2026-08-02 00:00:00.000000
+
+Adds two `features` system settings so an admin can open/close 領獎紀錄查詢 for
+students and for colleges independently:
+
+- student_history_visible_to_student
+- student_history_visible_to_college
+
+Both are seeded to 'true', which is the behaviour the feature shipped with.
+The application also treats a MISSING row as open, so this migration only
+makes the setting visible/editable in 系統設定 on databases that predate it.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "student_history_visibility_001"
+down_revision: Union[str, None] = "add_footer_links_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SETTINGS = (
+    (
+        "student_history_visible_to_student",
+        "開放學生查詢自己的獎學金領獎紀錄（已領總月數）",
+    ),
+    (
+        "student_history_visible_to_college",
+        "開放學院查詢本學院學生的獎學金領獎紀錄",
+    ),
+)
+
+INSERT_SQL = sa.text("""
+    INSERT INTO system_settings (
+        key, value, category, data_type,
+        is_sensitive, is_readonly, allow_empty,
+        description, default_value, created_at, updated_at
+    )
+    SELECT
+        :key, 'true', 'features'::configcategory, 'boolean'::configdatatype,
+        false, false, false,
+        :description, 'true', NOW(), NOW()
+    WHERE NOT EXISTS (SELECT 1 FROM system_settings WHERE key = :key)
+    """)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "system_settings" not in inspector.get_table_names():
+        return
+
+    for key, description in SETTINGS:
+        bind.execute(INSERT_SQL, {"key": key, "description": description})
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "system_settings" not in inspector.get_table_names():
+        return
+
+    # configuration_audit_logs rows are left in place: setting_key is a plain
+    # string (no FK), and the change history of a since-removed key is still
+    # legitimate audit trail.
+    bind.execute(
+        sa.text("DELETE FROM system_settings WHERE key = ANY(:keys)"),
+        {"keys": [key for key, _ in SETTINGS]},
+    )

--- a/backend/app/api/v1/endpoints/student_history.py
+++ b/backend/app/api/v1/endpoints/student_history.py
@@ -7,6 +7,8 @@
   own students' records.
 - GET /student-history/me/months — a student's own 總領月份數. Students get the
   total months only, never amounts or payment details.
+- GET/PUT /student-history/visibility — the two admin switches that decide
+  whether the student and college views above are open at all.
 
 The admin single-student lookup lives at /admin/student-history/{student_number}.
 """
@@ -18,14 +20,21 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import ScholarshipException
-from app.core.security import require_scholarship_manager, require_student
+from app.core.security import get_current_user, require_admin, require_scholarship_manager, require_student
 from app.db.deps import get_db
 from app.models.audit_log import AuditAction, AuditLog
 from app.models.user import User
 from app.schemas.student_scholarship_history import (
     STUDENT_NUMBER_PATTERN,
     BatchStudentHistoryRequest,
+    StudentHistoryVisibilityUpdate,
     StudentScholarshipHistoryData,
+)
+from app.services.student_history_visibility import (
+    COLLEGE_DISABLED_MESSAGE,
+    STUDENT_DISABLED_MESSAGE,
+    get_student_history_visibility,
+    set_student_history_visibility,
 )
 from app.services.student_scholarship_history_service import (
     StudentScholarshipHistoryService,
@@ -115,11 +124,17 @@ async def batch_student_scholarship_history(
             detail=f"學號格式不正確: {', '.join(invalid)}",
         )
     is_college = current_user.is_college()
-    if is_college and not (current_user.college_code or "").strip():
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="帳號未設定學院代碼，無法查詢學生領獎紀錄",
-        )
+    if is_college:
+        # Admin switch, checked before any lookup work: when 學院查詢 is closed
+        # a college account has no access at all, not a narrower one.
+        visibility = await get_student_history_visibility(db)
+        if not visibility.college_enabled:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=COLLEGE_DISABLED_MESSAGE)
+        if not (current_user.college_code or "").strip():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="帳號未設定學院代碼，無法查詢學生領獎紀錄",
+            )
 
     service = StudentScholarshipHistoryService()
     # SIS lookups run as one concurrent wave up front; the per-student loop
@@ -185,6 +200,10 @@ async def get_my_received_months(
     """A student's own 總領月份數 (匯入 + 系統, summed across every scholarship
     type). DB-only — no SIS round trip — and an empty history is a valid
     0-month state, not an error."""
+    visibility = await get_student_history_visibility(db)
+    if not visibility.student_enabled:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=STUDENT_DISABLED_MESSAGE)
+
     student_number = current_user.nycu_id
     service = StudentScholarshipHistoryService()
     total_received_months = await service.get_total_received_months(db, student_number)
@@ -196,4 +215,42 @@ async def get_my_received_months(
             "student_number": student_number,
             "total_received_months": total_received_months,
         },
+    }
+
+
+@router.get("/visibility")
+async def get_visibility(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Read both switches. Open to any authenticated user on purpose: the
+    student card and the college tab hide themselves when their switch is off,
+    which needs the flag BEFORE the gated request is attempted. The payload is
+    two booleans about the system, never about a person."""
+    visibility = await get_student_history_visibility(db)
+    return {
+        "success": True,
+        "message": "Student history visibility retrieved",
+        "data": visibility.to_dict(),
+    }
+
+
+@router.put("/visibility")
+async def update_visibility(
+    request: StudentHistoryVisibilityUpdate,
+    current_user: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Admin-only. Each audience is decided separately — an omitted field keeps
+    its current value rather than being reset."""
+    visibility = await set_student_history_visibility(
+        db,
+        user_id=current_user.id,
+        student_enabled=request.student_enabled,
+        college_enabled=request.college_enabled,
+    )
+    return {
+        "success": True,
+        "message": "Student history visibility updated",
+        "data": visibility.to_dict(),
     }

--- a/backend/app/api/v1/endpoints/student_history.py
+++ b/backend/app/api/v1/endpoints/student_history.py
@@ -243,12 +243,17 @@ async def update_visibility(
 ):
     """Admin-only. Each audience is decided separately — an omitted field keeps
     its current value rather than being reset."""
-    visibility = await set_student_history_visibility(
-        db,
-        user_id=current_user.id,
-        student_enabled=request.student_enabled,
-        college_enabled=request.college_enabled,
-    )
+    try:
+        visibility = await set_student_history_visibility(
+            db,
+            user_id=current_user.id,
+            student_enabled=request.student_enabled,
+            college_enabled=request.college_enabled,
+        )
+    except ValueError as exc:
+        # Rejected before anything was written (readonly row) — a 400 with the
+        # reason, not an opaque 500 from the catch-all handler.
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     return {
         "success": True,
         "message": "Student history visibility updated",

--- a/backend/app/db/seed_system_settings.py
+++ b/backend/app/db/seed_system_settings.py
@@ -8,6 +8,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.models.system_setting import ConfigCategory, ConfigDataType
 from app.services.config_management_service import ConfigurationService
+from app.services.student_history_visibility import (
+    COLLEGE_VISIBILITY_DESCRIPTION,
+    COLLEGE_VISIBILITY_KEY,
+    DEFAULT_ENABLED,
+    STUDENT_VISIBILITY_DESCRIPTION,
+    STUDENT_VISIBILITY_KEY,
+)
 
 
 async def seed_system_settings(db: AsyncSession, system_user_id: int = 1):
@@ -188,6 +195,24 @@ async def seed_system_settings(db: AsyncSession, system_user_id: int = 1):
             "category": ConfigCategory.security,
             "data_type": ConfigDataType.integer,
             "description": "重新整理權杖過期時間（天）",
+            "is_sensitive": False,
+        },
+        # Feature Visibility Settings — 學生領獎紀錄查詢 開放對象
+        # (two independent switches; admin access is never gated by them)
+        {
+            "key": STUDENT_VISIBILITY_KEY,
+            "value": str(DEFAULT_ENABLED).lower(),
+            "category": ConfigCategory.features,
+            "data_type": ConfigDataType.boolean,
+            "description": STUDENT_VISIBILITY_DESCRIPTION,
+            "is_sensitive": False,
+        },
+        {
+            "key": COLLEGE_VISIBILITY_KEY,
+            "value": str(DEFAULT_ENABLED).lower(),
+            "category": ConfigCategory.features,
+            "data_type": ConfigDataType.boolean,
+            "description": COLLEGE_VISIBILITY_DESCRIPTION,
             "is_sensitive": False,
         },
     ]

--- a/backend/app/schemas/student_scholarship_history.py
+++ b/backend/app/schemas/student_scholarship_history.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # Shared by the admin single-lookup and the batch endpoints; mirrored client-side
 # in frontend/components/admin/student-history/parse-student-numbers.ts.
@@ -142,3 +142,29 @@ class BatchStudentHistoryRequest(BaseModel):
     """
 
     student_numbers: List[str]
+
+
+class StudentHistoryVisibilityResponse(BaseModel):
+    """Who the admin has opened 領獎紀錄查詢 to. Readable by any logged-in user
+    so the UI can hide an entry point instead of letting it 403."""
+
+    student_enabled: bool = Field(..., description="學生可否查詢自己的領獎紀錄")
+    college_enabled: bool = Field(..., description="學院可否查詢本學院學生的領獎紀錄")
+
+
+class StudentHistoryVisibilityUpdate(BaseModel):
+    """Admin toggle body for PUT /student-history/visibility.
+
+    Both fields are optional and applied independently: omitting one leaves
+    that audience's setting untouched, so the two switches never clobber each
+    other. Sending neither is a 400 (nothing to do).
+    """
+
+    student_enabled: Optional[bool] = None
+    college_enabled: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self) -> "StudentHistoryVisibilityUpdate":
+        if self.student_enabled is None and self.college_enabled is None:
+            raise ValueError("請至少指定一項開放設定")
+        return self

--- a/backend/app/schemas/student_scholarship_history.py
+++ b/backend/app/schemas/student_scholarship_history.py
@@ -144,20 +144,16 @@ class BatchStudentHistoryRequest(BaseModel):
     student_numbers: List[str]
 
 
-class StudentHistoryVisibilityResponse(BaseModel):
-    """Who the admin has opened 領獎紀錄查詢 to. Readable by any logged-in user
-    so the UI can hide an entry point instead of letting it 403."""
-
-    student_enabled: bool = Field(..., description="學生可否查詢自己的領獎紀錄")
-    college_enabled: bool = Field(..., description="學院可否查詢本學院學生的領獎紀錄")
-
-
 class StudentHistoryVisibilityUpdate(BaseModel):
     """Admin toggle body for PUT /student-history/visibility.
 
     Both fields are optional and applied independently: omitting one leaves
     that audience's setting untouched, so the two switches never clobber each
-    other. Sending neither is a 400 (nothing to do).
+    other. Sending neither is a 422 (nothing to do).
+
+    The response shape (both switches) is produced by
+    ``StudentHistoryVisibility.to_dict()`` in the service layer; endpoints in
+    this project return plain ApiResponse dicts, never a ``response_model``.
     """
 
     student_enabled: Optional[bool] = None

--- a/backend/app/services/student_history_visibility.py
+++ b/backend/app/services/student_history_visibility.py
@@ -1,0 +1,116 @@
+"""Admin-controlled visibility of 學生領獎紀錄查詢.
+
+Two INDEPENDENT switches, stored as ``system_settings`` rows so they are
+editable at runtime (no redeploy) and audited by ``ConfigurationAuditLog``:
+
+- ``student_history_visible_to_student`` — a student may see their own
+  已領獎學金總月數.
+- ``student_history_visible_to_college`` — a college account may look up the
+  領獎紀錄 of students in its own college.
+
+Admin/super_admin access is never gated by these switches; they are what the
+admin uses to open or close the feature for everyone else.
+
+A missing row reads as **open**: the feature shipped unrestricted, so a
+database that predates these keys keeps behaving as it does today until an
+admin closes it.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.system_setting import ConfigCategory, ConfigDataType, SystemSetting
+from app.services.config_management_service import ConfigurationService
+
+logger = logging.getLogger(__name__)
+
+STUDENT_VISIBILITY_KEY = "student_history_visible_to_student"
+COLLEGE_VISIBILITY_KEY = "student_history_visible_to_college"
+
+STUDENT_VISIBILITY_DESCRIPTION = "開放學生查詢自己的獎學金領獎紀錄（已領總月數）"
+COLLEGE_VISIBILITY_DESCRIPTION = "開放學院查詢本學院學生的獎學金領獎紀錄"
+
+DEFAULT_ENABLED = True
+
+# Same truthy set ConfigurationService.get_decrypted_value uses, so a value
+# written through the generic 系統設定 editor reads back identically here.
+_TRUTHY_VALUES = frozenset({"true", "1", "yes", "on"})
+
+STUDENT_DISABLED_MESSAGE = "管理者已關閉學生查詢領獎紀錄功能"
+COLLEGE_DISABLED_MESSAGE = "管理者已關閉學院查詢學生領獎紀錄功能"
+
+
+@dataclass(frozen=True)
+class StudentHistoryVisibility:
+    """Resolved state of both switches."""
+
+    student_enabled: bool
+    college_enabled: bool
+
+    def to_dict(self) -> Dict[str, bool]:
+        return {
+            "student_enabled": self.student_enabled,
+            "college_enabled": self.college_enabled,
+        }
+
+
+def _to_bool(raw: Optional[str]) -> bool:
+    if raw is None:
+        return DEFAULT_ENABLED
+    return raw.strip().lower() in _TRUTHY_VALUES
+
+
+async def get_student_history_visibility(db: AsyncSession) -> StudentHistoryVisibility:
+    """Read both switches in a single statement."""
+    stmt = select(SystemSetting.key, SystemSetting.value).where(
+        SystemSetting.key.in_((STUDENT_VISIBILITY_KEY, COLLEGE_VISIBILITY_KEY))
+    )
+    rows = (await db.execute(stmt)).all()
+    values = {key: value for key, value in rows}
+    return StudentHistoryVisibility(
+        student_enabled=_to_bool(values.get(STUDENT_VISIBILITY_KEY)),
+        college_enabled=_to_bool(values.get(COLLEGE_VISIBILITY_KEY)),
+    )
+
+
+async def set_student_history_visibility(
+    db: AsyncSession,
+    user_id: int,
+    student_enabled: Optional[bool] = None,
+    college_enabled: Optional[bool] = None,
+) -> StudentHistoryVisibility:
+    """Write the switches an admin actually changed.
+
+    ``None`` means "leave this one alone" — the two audiences are decided
+    separately, so toggling 學生 must never overwrite a concurrent 學院 change.
+    Rows are created on first write (the seed may predate this feature).
+    """
+    config_service = ConfigurationService(db)
+    updates = (
+        (STUDENT_VISIBILITY_KEY, student_enabled, STUDENT_VISIBILITY_DESCRIPTION),
+        (COLLEGE_VISIBILITY_KEY, college_enabled, COLLEGE_VISIBILITY_DESCRIPTION),
+    )
+
+    for key, value, description in updates:
+        if value is None:
+            continue
+        await config_service.set_configuration(
+            key=key,
+            value=value,
+            user_id=user_id,
+            category=ConfigCategory.features,
+            data_type=ConfigDataType.boolean,
+            description=description,
+            default_value=str(DEFAULT_ENABLED).lower(),
+            change_reason="學生領獎紀錄查詢開放設定",
+        )
+        logger.info(
+            "Student history visibility updated",
+            extra={"config_key": key, "new_value": value, "changed_by": user_id},
+        )
+
+    return await get_student_history_visibility(db)

--- a/backend/app/services/student_history_visibility.py
+++ b/backend/app/services/student_history_visibility.py
@@ -39,6 +39,9 @@ DEFAULT_ENABLED = True
 # Same truthy set ConfigurationService.get_decrypted_value uses, so a value
 # written through the generic 系統設定 editor reads back identically here.
 _TRUTHY_VALUES = frozenset({"true", "1", "yes", "on"})
+# Not the complement of the above — only these read as a deliberate "closed";
+# anything else is a mangled row and gets logged (see _to_bool).
+_FALSY_VALUES = frozenset({"false", "0", "no", "off", ""})
 
 STUDENT_DISABLED_MESSAGE = "管理者已關閉學生查詢領獎紀錄功能"
 COLLEGE_DISABLED_MESSAGE = "管理者已關閉學院查詢學生領獎紀錄功能"
@@ -58,10 +61,22 @@ class StudentHistoryVisibility:
         }
 
 
-def _to_bool(raw: Optional[str]) -> bool:
+def _to_bool(key: str, raw: Optional[str]) -> bool:
     if raw is None:
         return DEFAULT_ENABLED
-    return raw.strip().lower() in _TRUTHY_VALUES
+    normalized = raw.strip().lower()
+    if normalized in _TRUTHY_VALUES:
+        return True
+    if normalized not in _FALSY_VALUES:
+        # Anything else means the row was mangled outside this service — most
+        # plausibly by flipping is_sensitive in the generic 系統設定 editor,
+        # which leaves a Fernet ciphertext in `value`. We still fail closed,
+        # but the feature must not go dark without a diagnosable reason.
+        logger.warning(
+            "Unrecognised student history visibility value; treating the switch as closed",
+            extra={"config_key": key},
+        )
+    return False
 
 
 async def get_student_history_visibility(db: AsyncSession) -> StudentHistoryVisibility:
@@ -72,8 +87,8 @@ async def get_student_history_visibility(db: AsyncSession) -> StudentHistoryVisi
     rows = (await db.execute(stmt)).all()
     values = {key: value for key, value in rows}
     return StudentHistoryVisibility(
-        student_enabled=_to_bool(values.get(STUDENT_VISIBILITY_KEY)),
-        college_enabled=_to_bool(values.get(COLLEGE_VISIBILITY_KEY)),
+        student_enabled=_to_bool(STUDENT_VISIBILITY_KEY, values.get(STUDENT_VISIBILITY_KEY)),
+        college_enabled=_to_bool(COLLEGE_VISIBILITY_KEY, values.get(COLLEGE_VISIBILITY_KEY)),
     )
 
 
@@ -88,12 +103,25 @@ async def set_student_history_visibility(
     ``None`` means "leave this one alone" — the two audiences are decided
     separately, so toggling 學生 must never overwrite a concurrent 學院 change.
     Rows are created on first write (the seed may predate this feature).
+
+    Raises ``ValueError`` (mapped to 400 by the endpoint) when a target row is
+    readonly.
     """
     config_service = ConfigurationService(db)
     updates = (
         (STUDENT_VISIBILITY_KEY, student_enabled, STUDENT_VISIBILITY_DESCRIPTION),
         (COLLEGE_VISIBILITY_KEY, college_enabled, COLLEGE_VISIBILITY_DESCRIPTION),
     )
+
+    # Pre-flight both keys before writing either. set_configuration commits per
+    # key, so a readonly row discovered mid-loop would leave a two-switch update
+    # half applied — with the caller told only that it failed.
+    for key, value, _ in updates:
+        if value is None:
+            continue
+        existing = await config_service.get_configuration(key)
+        if existing is not None and existing.is_readonly:
+            raise ValueError(f"設定 {key} 為唯讀，無法變更")
 
     for key, value, description in updates:
         if value is None:

--- a/backend/app/tests/test_student_history_visibility.py
+++ b/backend/app/tests/test_student_history_visibility.py
@@ -1,0 +1,276 @@
+"""Tests for the admin switches gating 學生領獎紀錄查詢.
+
+Two independent settings decide whether students may see their own 總月數 and
+whether colleges may look up their students' 領獎紀錄. Admin access is never
+gated by them.
+
+Auth pattern mirrors test_student_history_shared_endpoint.py: override
+get_current_user with a fully configured Mock so the REAL role dependencies
+still run.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import pytest_asyncio
+
+from app.models.user import User, UserRole
+from app.services.student_history_visibility import (
+    COLLEGE_VISIBILITY_KEY,
+    STUDENT_VISIBILITY_KEY,
+    get_student_history_visibility,
+    set_student_history_visibility,
+)
+
+SERVICE_PATH = "app.api.v1.endpoints.student_history.StudentScholarshipHistoryService"
+
+
+def _mock_user(role: UserRole, nycu_id: str = "tester01", college_code=None) -> Mock:
+    user = Mock(spec=User)
+    user.id = 1
+    user.nycu_id = nycu_id
+    user.role = role
+    user.college_code = college_code
+    user.is_admin.return_value = role == UserRole.admin
+    user.is_super_admin.return_value = role == UserRole.super_admin
+    user.is_college.return_value = role == UserRole.college
+    user.is_student.return_value = role == UserRole.student
+    user.is_professor.return_value = role == UserRole.professor
+    return user
+
+
+@pytest_asyncio.fixture
+async def client_as():
+    """Factory: yield an AsyncClient authenticated as the given mock user."""
+    from app.core.security import get_current_user
+    from app.main import app
+
+    created = []
+
+    def _make(client, user):
+        async def override():
+            return user
+
+        app.dependency_overrides[get_current_user] = override
+        created.append(get_current_user)
+        return client
+
+    yield _make
+    for dep in created:
+        app.dependency_overrides.pop(dep, None)
+
+
+# ---------------------------------------------------------------------------
+# Service layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_rows_read_as_open(db):
+    """A database that predates the feature keeps behaving as it did."""
+    visibility = await get_student_history_visibility(db)
+    assert visibility.student_enabled is True
+    assert visibility.college_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_switches_are_independent(db):
+    """Writing one audience must never touch the other — they are decided
+    separately, and a concurrent toggle must not be clobbered."""
+    await set_student_history_visibility(db, user_id=1, student_enabled=False, college_enabled=True)
+    visibility = await get_student_history_visibility(db)
+    assert visibility.student_enabled is False
+    assert visibility.college_enabled is True
+
+    # Only the college switch is sent this time.
+    await set_student_history_visibility(db, user_id=1, college_enabled=False)
+    visibility = await get_student_history_visibility(db)
+    assert visibility.student_enabled is False, "student switch must survive a college-only update"
+    assert visibility.college_enabled is False
+
+    await set_student_history_visibility(db, user_id=1, student_enabled=True)
+    visibility = await get_student_history_visibility(db)
+    assert visibility.student_enabled is True
+    assert visibility.college_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_updates_are_audited(db):
+    """Changes go through ConfigurationService, so 系統設定 audit history sees
+    them like any other setting change."""
+    from sqlalchemy import select
+
+    from app.models.system_setting import ConfigurationAuditLog
+
+    await set_student_history_visibility(db, user_id=7, college_enabled=False)
+
+    logs = (
+        (
+            await db.execute(
+                select(ConfigurationAuditLog).where(ConfigurationAuditLog.setting_key == COLLEGE_VISIBILITY_KEY)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(logs) == 1
+    assert logs[0].new_value == "false"
+    assert logs[0].changed_by == 7
+
+
+@pytest.mark.asyncio
+async def test_stored_values_are_boolean_typed(db):
+    """Stored as a real boolean setting so the generic 系統設定 editor renders
+    and round-trips it correctly."""
+    from sqlalchemy import select
+
+    from app.models.system_setting import ConfigCategory, ConfigDataType, SystemSetting
+
+    await set_student_history_visibility(db, user_id=1, student_enabled=False)
+    setting = (
+        (await db.execute(select(SystemSetting).where(SystemSetting.key == STUDENT_VISIBILITY_KEY))).scalars().one()
+    )
+    assert setting.value == "false"
+    assert setting.data_type == ConfigDataType.boolean
+    assert setting.category == ConfigCategory.features
+
+
+# ---------------------------------------------------------------------------
+# GET/PUT /student-history/visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_visibility_open_to_any_authenticated_role(client, client_as, db):
+    """The student card and college tab need the flags before making a gated
+    request, so every logged-in role may read them."""
+    await set_student_history_visibility(db, user_id=1, student_enabled=False, college_enabled=True)
+
+    for role in (UserRole.student, UserRole.college, UserRole.professor, UserRole.admin):
+        authed = client_as(client, _mock_user(role))
+        response = await authed.get("/api/v1/student-history/visibility")
+        assert response.status_code == 200, f"role {role.value} must be able to read the flags"
+        assert response.json()["data"] == {"student_enabled": False, "college_enabled": True}
+
+
+@pytest.mark.asyncio
+async def test_get_visibility_unauthenticated(client):
+    response = await client.get("/api/v1/student-history/visibility")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_admin_updates_one_switch_at_a_time(client, client_as, db):
+    authed = client_as(client, _mock_user(UserRole.admin))
+
+    response = await authed.put("/api/v1/student-history/visibility", json={"college_enabled": False})
+    assert response.status_code == 200
+    # The response carries BOTH switches so the UI never guesses the other.
+    assert response.json()["data"] == {"student_enabled": True, "college_enabled": False}
+
+    response = await authed.put("/api/v1/student-history/visibility", json={"student_enabled": False})
+    assert response.status_code == 200
+    assert response.json()["data"] == {"student_enabled": False, "college_enabled": False}
+
+    visibility = await get_student_history_visibility(db)
+    assert visibility.student_enabled is False
+    assert visibility.college_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_update_visibility_rejects_non_admin_roles(client, client_as):
+    for role in (UserRole.student, UserRole.college, UserRole.professor):
+        authed = client_as(client, _mock_user(role, college_code="E"))
+        response = await authed.put("/api/v1/student-history/visibility", json={"college_enabled": True})
+        assert response.status_code == 403, f"role {role.value} must not change the switches"
+
+
+@pytest.mark.asyncio
+async def test_update_visibility_requires_a_field(client, client_as):
+    authed = client_as(client, _mock_user(UserRole.admin))
+    response = await authed.put("/api/v1/student-history/visibility", json={})
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Enforcement on the gated endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_college_batch_blocked_when_closed(client, client_as, db):
+    await set_student_history_visibility(db, user_id=1, college_enabled=False)
+
+    authed = client_as(client, _mock_user(UserRole.college, college_code="E"))
+    with patch(SERVICE_PATH) as MockSvc:
+        MockSvc.return_value.fetch_sis_lookups = AsyncMock(return_value={})
+        response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+
+    assert response.status_code == 403
+    # No lookup work is done once the feature is closed to colleges.
+    MockSvc.return_value.fetch_sis_lookups.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_admin_batch_unaffected_by_switches(client, client_as, db):
+    """The switches open the feature to OTHERS; admins always keep access."""
+    from decimal import Decimal
+
+    from app.schemas.student_scholarship_history import (
+        AcademicInfo,
+        HistorySummary,
+        StudentScholarshipHistoryData,
+    )
+
+    await set_student_history_visibility(db, user_id=1, student_enabled=False, college_enabled=False)
+
+    authed = client_as(client, _mock_user(UserRole.admin))
+    with patch(SERVICE_PATH) as MockSvc:
+        svc = MockSvc.return_value
+        svc.fetch_sis_lookups = AsyncMock(return_value={})
+        svc.get_snapshot_academy_codes = AsyncMock(return_value=set())
+        svc.get_history = AsyncMock(
+            return_value=StudentScholarshipHistoryData(
+                student_number="S001",
+                academic_info=AcademicInfo(available=False, error="SIS down", basic_info=None),
+                summary=HistorySummary(
+                    total_records=0,
+                    total_amount=Decimal("0"),
+                    scholarship_type_count=0,
+                    total_received_months=0,
+                ),
+                payment_records=[],
+                received_months=[],
+            )
+        )
+        response = await authed.post("/api/v1/student-history/batch", json={"student_numbers": ["S001"]})
+
+    assert response.status_code == 200
+    assert response.json()["data"]["results"][0]["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_me_months_blocked_when_closed(client, client_as, db):
+    await set_student_history_visibility(db, user_id=1, student_enabled=False)
+
+    authed = client_as(client, _mock_user(UserRole.student, nycu_id="stuphd001"))
+    with patch(SERVICE_PATH) as MockSvc:
+        MockSvc.return_value.get_total_received_months = AsyncMock(return_value=12)
+        response = await authed.get("/api/v1/student-history/me/months")
+
+    assert response.status_code == 403
+    MockSvc.return_value.get_total_received_months.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_me_months_allowed_when_open(client, client_as, db):
+    """Closing 學院查詢 must not close the student's own view."""
+    await set_student_history_visibility(db, user_id=1, student_enabled=True, college_enabled=False)
+
+    authed = client_as(client, _mock_user(UserRole.student, nycu_id="stuphd001"))
+    with patch(SERVICE_PATH) as MockSvc:
+        MockSvc.return_value.get_total_received_months = AsyncMock(return_value=12)
+        response = await authed.get("/api/v1/student-history/me/months")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["total_received_months"] == 12

--- a/backend/app/tests/test_student_history_visibility.py
+++ b/backend/app/tests/test_student_history_visibility.py
@@ -119,6 +119,66 @@ async def test_updates_are_audited(db):
 
 
 @pytest.mark.asyncio
+async def test_mangled_value_fails_closed_with_a_warning(db, caplog):
+    """A value that is neither truthy nor a recognised falsy token (e.g. a
+    Fernet ciphertext left by flipping is_sensitive in the generic 系統設定
+    editor) must not close the feature silently."""
+    from app.models.system_setting import ConfigCategory, ConfigDataType, SystemSetting
+
+    db.add(
+        SystemSetting(
+            key=COLLEGE_VISIBILITY_KEY,
+            value="gAAAAABm-not-a-boolean",
+            category=ConfigCategory.features,
+            data_type=ConfigDataType.boolean,
+            is_sensitive=False,
+            is_readonly=False,
+            allow_empty=False,
+        )
+    )
+    await db.commit()
+
+    with caplog.at_level("WARNING"):
+        visibility = await get_student_history_visibility(db)
+
+    assert visibility.college_enabled is False
+    assert visibility.student_enabled is True, "the other switch is unaffected"
+    assert any("Unrecognised student history visibility value" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_readonly_row_rejected_before_any_write(db):
+    """A two-switch update must not half-apply: the readonly row is detected
+    up front, so the other switch is left untouched."""
+    from sqlalchemy import select
+
+    from app.models.system_setting import ConfigCategory, ConfigDataType, SystemSetting
+
+    db.add(
+        SystemSetting(
+            key=COLLEGE_VISIBILITY_KEY,
+            value="true",
+            category=ConfigCategory.features,
+            data_type=ConfigDataType.boolean,
+            is_sensitive=False,
+            is_readonly=True,
+            allow_empty=False,
+        )
+    )
+    await db.commit()
+
+    with pytest.raises(ValueError):
+        await set_student_history_visibility(db, user_id=1, student_enabled=False, college_enabled=False)
+
+    assert (
+        await db.execute(select(SystemSetting).where(SystemSetting.key == STUDENT_VISIBILITY_KEY))
+    ).scalar_one_or_none() is None
+    visibility = await get_student_history_visibility(db)
+    assert visibility.student_enabled is True
+    assert visibility.college_enabled is True
+
+
+@pytest.mark.asyncio
 async def test_stored_values_are_boolean_typed(db):
     """Stored as a real boolean setting so the generic 系統設定 editor renders
     and round-trips it correctly."""
@@ -190,6 +250,31 @@ async def test_update_visibility_requires_a_field(client, client_as):
     authed = client_as(client, _mock_user(UserRole.admin))
     response = await authed.put("/api/v1/student-history/visibility", json={})
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_visibility_readonly_row_is_a_400(client, client_as, db):
+    """Not an opaque 500 from the catch-all handler."""
+    from app.models.system_setting import ConfigCategory, ConfigDataType, SystemSetting
+
+    db.add(
+        SystemSetting(
+            key=STUDENT_VISIBILITY_KEY,
+            value="true",
+            category=ConfigCategory.features,
+            data_type=ConfigDataType.boolean,
+            is_sensitive=False,
+            is_readonly=True,
+            allow_empty=False,
+        )
+    )
+    await db.commit()
+
+    authed = client_as(client, _mock_user(UserRole.admin))
+    response = await authed.put("/api/v1/student-history/visibility", json={"student_enabled": False})
+    assert response.status_code == 400
+    # The global handler renders HTTPException.detail as ApiResponse.message.
+    assert "唯讀" in response.json()["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -46,6 +46,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { DevLoginPage } from "@/components/dev-login-page";
 import { SSOLoginPage } from "@/components/sso-login-page";
 import { useAdminDashboard } from "@/hooks/use-admin";
+import { useStudentHistoryVisibility } from "@/hooks/use-student-history-visibility";
 import { User } from "@/types/user";
 import { verifySsoToken } from "@/lib/auth/verify-sso-token";
 import { logger } from "@/lib/utils/logger";
@@ -122,6 +123,11 @@ export default function ScholarshipManagementSystem() {
   // 使用語言偏好 Hook
   const { locale, changeLocale, isLanguageSwitchEnabled } =
     useLanguagePreference(user?.role || "student", "zh");
+
+  // 領獎紀錄查詢開放設定（管理者可分別關閉學生與學院的查詢入口）
+  const { visibility: studentHistoryVisibility } = useStudentHistoryVisibility(
+    isAuthenticated,
+  );
 
   // 使用 admin dashboard hook
   const {
@@ -258,8 +264,12 @@ export default function ScholarshipManagementSystem() {
     }
 
     if (user.role === "college") {
+      // 領獎紀錄查詢 is admin-gated; without it the college keeps two tabs.
+      const canQueryStudentHistory = studentHistoryVisibility.college_enabled;
       return (
-        <TabsList className="grid w-full grid-cols-3 bg-nycu-blue-50 border border-nycu-blue-200">
+        <TabsList
+          className={`grid w-full ${canQueryStudentHistory ? "grid-cols-3" : "grid-cols-2"} bg-nycu-blue-50 border border-nycu-blue-200`}
+        >
           <TabsTrigger
             value="main"
             className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
@@ -274,13 +284,15 @@ export default function ScholarshipManagementSystem() {
             <Upload className="h-4 w-4" />
             批次匯入
           </TabsTrigger>
-          <TabsTrigger
-            value="student-history"
-            className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
-          >
-            <History className="h-4 w-4" />
-            領獎紀錄查詢
-          </TabsTrigger>
+          {canQueryStudentHistory && (
+            <TabsTrigger
+              value="student-history"
+              className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
+            >
+              <History className="h-4 w-4" />
+              領獎紀錄查詢
+            </TabsTrigger>
+          )}
         </TabsList>
       );
     }
@@ -559,8 +571,8 @@ export default function ScholarshipManagementSystem() {
             </TabsContent>
           )}
 
-          {/* 領獎紀錄查詢 - college 角色；查詢範圍由後端限制在本學院學生 */}
-          {user.role === "college" && (
+          {/* 領獎紀錄查詢 - college 角色；需管理者開放，查詢範圍由後端限制在本學院學生 */}
+          {user.role === "college" && studentHistoryVisibility.college_enabled && (
             <TabsContent value="student-history" className="space-y-4">
               <StudentHistoryPanel variant="college" />
             </TabsContent>

--- a/frontend/components/__tests__/enhanced-student-portal.test.tsx
+++ b/frontend/components/__tests__/enhanced-student-portal.test.tsx
@@ -51,6 +51,12 @@ jest.mock("../../lib/api", () => ({
         success: true,
         data: { student_number: "test", total_received_months: 0 },
       }),
+      // The card is admin-gated; without this the visibility hook errors and
+      // the card silently hides.
+      getVisibility: jest.fn().mockResolvedValue({
+        success: true,
+        data: { student_enabled: true, college_enabled: true },
+      }),
     },
   },
 }));

--- a/frontend/components/admin/student-history/HistoryVisibilityCard.tsx
+++ b/frontend/components/admin/student-history/HistoryVisibilityCard.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { apiClient } from "@/lib/api";
+import { useStudentHistoryVisibility } from "@/hooks/use-student-history-visibility";
+import type { StudentHistoryVisibilityUpdate } from "@/lib/api/modules/student-history";
+import { logger } from "@/lib/utils/logger";
+
+type Audience = "student" | "college";
+
+const AUDIENCES: Array<{
+  audience: Audience;
+  field: keyof StudentHistoryVisibilityUpdate;
+  label: string;
+  description: string;
+}> = [
+  {
+    audience: "student",
+    field: "student_enabled",
+    label: "開放學生查詢",
+    description: "學生可在「我的申請」看到自己的已領獎學金總月數（不含金額與造冊明細）。",
+  },
+  {
+    audience: "college",
+    field: "college_enabled",
+    label: "開放學院查詢",
+    description: "學院可查詢本學院學生的領獎紀錄；查詢範圍仍由後端限制在該學院。",
+  },
+];
+
+/**
+ * Admin control for who 領獎紀錄查詢 is open to. The two audiences are decided
+ * separately — each switch sends only its own field, so toggling one never
+ * overwrites the other. Admin access itself is never gated by these switches.
+ */
+export function HistoryVisibilityCard() {
+  const { visibility, isLoaded, error, mutate } = useStudentHistoryVisibility();
+  const [pendingAudience, setPendingAudience] = useState<Audience | null>(null);
+
+  const handleToggle = async (
+    audience: Audience,
+    field: keyof StudentHistoryVisibilityUpdate,
+    checked: boolean,
+  ) => {
+    setPendingAudience(audience);
+    try {
+      const response = await apiClient.studentHistory.updateVisibility({
+        [field]: checked,
+      });
+      if (response.success && response.data) {
+        // Server response is authoritative — it carries BOTH switches back.
+        await mutate(response.data, { revalidate: false });
+        toast.success(checked ? "已開放查詢" : "已關閉查詢");
+      } else {
+        toast.error(response.message || "更新開放設定失敗");
+      }
+    } catch (err) {
+      logger.error("Failed to update student history visibility", { err });
+      toast.error(err instanceof Error ? err.message : "更新開放設定失敗");
+    } finally {
+      setPendingAudience(null);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Eye className="h-5 w-5 text-muted-foreground" />
+          查詢開放設定
+        </CardTitle>
+        <CardDescription>
+          決定學生與學院是否能查詢領獎紀錄，兩者可分別開放；管理者不受此設定限制。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <p className="text-sm text-destructive">
+            無法載入開放設定，請重新整理頁面。
+          </p>
+        )}
+        {AUDIENCES.map(({ audience, field, label, description }) => {
+          const switchId = `student-history-visible-${audience}`;
+          return (
+            <div
+              key={audience}
+              className="flex items-start justify-between gap-4 rounded-md border p-3"
+            >
+              <div className="space-y-1">
+                <Label htmlFor={switchId} className="text-sm font-medium">
+                  {label}
+                </Label>
+                <p className="text-xs text-muted-foreground">{description}</p>
+              </div>
+              <div className="flex items-center gap-2 pt-1">
+                {pendingAudience === audience && (
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                )}
+                <Switch
+                  id={switchId}
+                  checked={visibility[field]}
+                  disabled={!isLoaded || pendingAudience !== null}
+                  onCheckedChange={(checked) => handleToggle(audience, field, checked)}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/admin/student-history/HistoryVisibilityCard.tsx
+++ b/frontend/components/admin/student-history/HistoryVisibilityCard.tsx
@@ -65,10 +65,15 @@ export function HistoryVisibilityCard() {
         toast.success(checked ? "已開放查詢" : "已關閉查詢");
       } else {
         toast.error(response.message || "更新開放設定失敗");
+        await mutate();
       }
     } catch (err) {
       logger.error("Failed to update student history visibility", { err });
       toast.error(err instanceof Error ? err.message : "更新開放設定失敗");
+      // Refetch rather than assume nothing changed: the switches are written
+      // one row at a time server-side, so a failure leaves the real state
+      // uncertain.
+      await mutate();
     } finally {
       setPendingAudience(null);
     }

--- a/frontend/components/admin/student-history/HistoryVisibilityCard.tsx
+++ b/frontend/components/admin/student-history/HistoryVisibilityCard.tsx
@@ -80,7 +80,7 @@ export function HistoryVisibilityCard() {
   };
 
   return (
-    <Card>
+    <Card data-testid="history-visibility-card">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Eye className="h-5 w-5 text-muted-foreground" />

--- a/frontend/components/admin/student-history/StudentHistoryPanel.tsx
+++ b/frontend/components/admin/student-history/StudentHistoryPanel.tsx
@@ -15,6 +15,7 @@ import { SummaryCards } from "./SummaryCards";
 import { PaymentHistoryTable } from "./PaymentHistoryTable";
 import { ReceivedMonthsCard } from "./ReceivedMonthsCard";
 import { ImportReceivedMonthsDialog } from "./ImportReceivedMonthsDialog";
+import { HistoryVisibilityCard } from "./HistoryVisibilityCard";
 import { MAX_BATCH_SIZE, parseStudentNumbers } from "./parse-student-numbers";
 
 interface StudentHistoryPanelProps {
@@ -130,6 +131,8 @@ export function StudentHistoryPanel({ variant = "admin" }: StudentHistoryPanelPr
 
   return (
     <div className="space-y-4">
+      {variant === "admin" && <HistoryVisibilityCard />}
+
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0">
           <CardTitle>學生領獎紀錄查詢</CardTitle>

--- a/frontend/components/admin/student-history/__tests__/HistoryVisibilityCard.test.tsx
+++ b/frontend/components/admin/student-history/__tests__/HistoryVisibilityCard.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { HistoryVisibilityCard } from "../HistoryVisibilityCard";
+import { useStudentHistoryVisibility } from "@/hooks/use-student-history-visibility";
+import { apiClient } from "@/lib/api";
+
+jest.mock("@/hooks/use-student-history-visibility");
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const mockUseVisibility = useStudentHistoryVisibility as jest.MockedFunction<
+  typeof useStudentHistoryVisibility
+>;
+
+const mutate = jest.fn();
+
+function mockVisibility(studentEnabled: boolean, collegeEnabled: boolean) {
+  mockUseVisibility.mockReturnValue({
+    visibility: {
+      student_enabled: studentEnabled,
+      college_enabled: collegeEnabled,
+    },
+    isLoaded: true,
+    isLoading: false,
+    error: undefined,
+    mutate,
+  } as unknown as ReturnType<typeof useStudentHistoryVisibility>);
+}
+
+describe("HistoryVisibilityCard", () => {
+  let updateVisibility: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    updateVisibility = jest
+      .spyOn(apiClient.studentHistory, "updateVisibility")
+      .mockResolvedValue({
+        success: true,
+        message: "ok",
+        data: { student_enabled: true, college_enabled: false },
+      });
+  });
+
+  afterEach(() => {
+    updateVisibility.mockRestore();
+  });
+
+  it("reflects the stored state of both switches", () => {
+    mockVisibility(true, false);
+    render(<HistoryVisibilityCard />);
+
+    expect(screen.getByLabelText("開放學生查詢")).toBeChecked();
+    expect(screen.getByLabelText("開放學院查詢")).not.toBeChecked();
+  });
+
+  it("sends only the toggled audience so the other switch is untouched", async () => {
+    mockVisibility(true, true);
+    render(<HistoryVisibilityCard />);
+
+    await userEvent.click(screen.getByLabelText("開放學院查詢"));
+
+    await waitFor(() =>
+      expect(updateVisibility).toHaveBeenCalledWith({ college_enabled: false }),
+    );
+    // The server response (both switches) is what refreshes the cache.
+    expect(mutate).toHaveBeenCalledWith(
+      { student_enabled: true, college_enabled: false },
+      { revalidate: false },
+    );
+  });
+});

--- a/frontend/components/student/TotalReceivedMonthsCard.tsx
+++ b/frontend/components/student/TotalReceivedMonthsCard.tsx
@@ -5,6 +5,7 @@ import { CalendarClock } from "lucide-react";
 
 import { Card, CardContent } from "@/components/ui/card";
 import { apiClient } from "@/lib/api";
+import { useStudentHistoryVisibility } from "@/hooks/use-student-history-visibility";
 import { logger } from "@/lib/utils/logger";
 
 interface TotalReceivedMonthsCardProps {
@@ -16,11 +17,22 @@ interface TotalReceivedMonthsCardProps {
  * scholarship types combined). Students see the months total only — never
  * amounts or per-roster payment details. Renders nothing while loading or
  * when the lookup fails, so it can't block the surrounding page.
+ *
+ * The whole card is admin-gated: when 開放學生查詢 is off the months request is
+ * never made (the endpoint would 403 anyway) and nothing renders.
  */
 export function TotalReceivedMonthsCard({ locale = "zh" }: TotalReceivedMonthsCardProps) {
   const [totalMonths, setTotalMonths] = useState<number | null>(null);
+  const { visibility } = useStudentHistoryVisibility();
+  const isEnabled = visibility.student_enabled;
 
   useEffect(() => {
+    if (!isEnabled) {
+      // Drop a previously fetched total if the admin closes the feature.
+      setTotalMonths(null);
+      return;
+    }
+
     let cancelled = false;
     apiClient.studentHistory
       .getMyMonths()
@@ -42,9 +54,9 @@ export function TotalReceivedMonthsCard({ locale = "zh" }: TotalReceivedMonthsCa
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isEnabled]);
 
-  if (totalMonths === null) return null;
+  if (!isEnabled || totalMonths === null) return null;
 
   return (
     <Card data-testid="total-received-months-card">

--- a/frontend/components/student/__tests__/TotalReceivedMonthsCard.test.tsx
+++ b/frontend/components/student/__tests__/TotalReceivedMonthsCard.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { TotalReceivedMonthsCard } from "../TotalReceivedMonthsCard";
+import { useStudentHistoryVisibility } from "@/hooks/use-student-history-visibility";
+import { apiClient } from "@/lib/api";
+
+jest.mock("@/hooks/use-student-history-visibility");
+
+const mockUseVisibility = useStudentHistoryVisibility as jest.MockedFunction<
+  typeof useStudentHistoryVisibility
+>;
+
+function mockVisibility(studentEnabled: boolean) {
+  mockUseVisibility.mockReturnValue({
+    visibility: { student_enabled: studentEnabled, college_enabled: true },
+    isLoaded: true,
+    isLoading: false,
+    error: undefined,
+    mutate: jest.fn(),
+  } as unknown as ReturnType<typeof useStudentHistoryVisibility>);
+}
+
+describe("TotalReceivedMonthsCard", () => {
+  let getMyMonths: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // spyOn the real client: a jest.mock factory for "@/lib/api" does not
+    // intercept the module's own top-level import graph in this setup.
+    getMyMonths = jest
+      .spyOn(apiClient.studentHistory, "getMyMonths")
+      .mockResolvedValue({
+        success: true,
+        message: "ok",
+        data: { student_number: "stuphd001", total_received_months: 7 },
+      });
+  });
+
+  afterEach(() => {
+    getMyMonths.mockRestore();
+  });
+
+  it("renders the total once the admin has opened 學生查詢", async () => {
+    mockVisibility(true);
+    render(<TotalReceivedMonthsCard />);
+
+    expect(
+      await screen.findByTestId("total-received-months-card"),
+    ).toHaveTextContent("7");
+    expect(getMyMonths).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing and skips the request when 學生查詢 is closed", async () => {
+    mockVisibility(false);
+    render(<TotalReceivedMonthsCard />);
+
+    await waitFor(() => expect(getMyMonths).not.toHaveBeenCalled());
+    expect(
+      screen.queryByTestId("total-received-months-card"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/e2e/specs/admin-student-history.spec.ts
+++ b/frontend/e2e/specs/admin-student-history.spec.ts
@@ -23,9 +23,10 @@ test.describe("Admin student scholarship history", () => {
     await page.getByRole("tab", { name: "學生領獎紀錄查詢" }).click();
     // Read-only assertion on purpose: flipping a system-wide switch here would
     // leak into every other spec sharing the seeded database.
-    await expect(page.getByText("查詢開放設定")).toBeVisible();
-    const studentSwitch = page.getByLabel("開放學生查詢");
-    const collegeSwitch = page.getByLabel("開放學院查詢");
+    const card = page.getByTestId("history-visibility-card");
+    await expect(card).toBeVisible();
+    const studentSwitch = card.getByLabel("開放學生查詢");
+    const collegeSwitch = card.getByLabel("開放學院查詢");
     await expect(studentSwitch).toBeVisible();
     await expect(collegeSwitch).toBeVisible();
     // Seeded default: both audiences open, and the switches are enabled once

--- a/frontend/e2e/specs/admin-student-history.spec.ts
+++ b/frontend/e2e/specs/admin-student-history.spec.ts
@@ -13,6 +13,29 @@ import { test, expect } from "@playwright/test";
 import { loginAs } from "../helpers/auth";
 
 test.describe("Admin student scholarship history", () => {
+  test("shows the 查詢開放設定 switches for 學生 and 學院", async ({
+    browser,
+  }) => {
+    const { context } = await loginAs(browser, "admin");
+    const page = await context.newPage();
+    await page.goto("/");
+    await page.getByRole("tab", { name: "系統管理" }).click();
+    await page.getByRole("tab", { name: "學生領獎紀錄查詢" }).click();
+    // Read-only assertion on purpose: flipping a system-wide switch here would
+    // leak into every other spec sharing the seeded database.
+    await expect(page.getByText("查詢開放設定")).toBeVisible();
+    const studentSwitch = page.getByLabel("開放學生查詢");
+    const collegeSwitch = page.getByLabel("開放學院查詢");
+    await expect(studentSwitch).toBeVisible();
+    await expect(collegeSwitch).toBeVisible();
+    // Seeded default: both audiences open, and the switches are enabled once
+    // the visibility request resolves.
+    await expect(studentSwitch).toBeEnabled({ timeout: 10000 });
+    await expect(studentSwitch).toBeChecked();
+    await expect(collegeSwitch).toBeChecked();
+    await context.close();
+  });
+
   test("rejects invalid student number client-side", async ({ browser }) => {
     const { context } = await loginAs(browser, "admin");
     const page = await context.newPage();

--- a/frontend/hooks/__tests__/use-student-history-visibility.test.tsx
+++ b/frontend/hooks/__tests__/use-student-history-visibility.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import { useStudentHistoryVisibility } from "../use-student-history-visibility";
+import { apiClient } from "@/lib/api";
+
+// Fresh cache per test, and no retries so the error branch settles fast.
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig
+    value={{
+      provider: () => new Map(),
+      dedupingInterval: 0,
+      shouldRetryOnError: false,
+    }}
+  >
+    {children}
+  </SWRConfig>
+);
+
+describe("useStudentHistoryVisibility", () => {
+  let getVisibility: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getVisibility = jest.spyOn(apiClient.studentHistory, "getVisibility");
+  });
+
+  afterEach(() => {
+    getVisibility.mockRestore();
+  });
+
+  it("reports the stored switches", async () => {
+    getVisibility.mockResolvedValue({
+      success: true,
+      message: "ok",
+      data: { student_enabled: false, college_enabled: true },
+    });
+
+    const { result } = renderHook(() => useStudentHistoryVisibility(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(result.current.visibility).toEqual({
+      student_enabled: false,
+      college_enabled: true,
+    });
+  });
+
+  it("starts closed so a gated entry point never flashes", () => {
+    getVisibility.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useStudentHistoryVisibility(), {
+      wrapper,
+    });
+
+    expect(result.current.isLoaded).toBe(false);
+    expect(result.current.visibility).toEqual({
+      student_enabled: false,
+      college_enabled: false,
+    });
+  });
+
+  it("falls back to open when the lookup fails, matching the backend default", async () => {
+    getVisibility.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useStudentHistoryVisibility(), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    // The endpoints behind the entry point enforce the same switches, so a
+    // blip costs an error message rather than removing a college's tab.
+    expect(result.current.visibility).toEqual({
+      student_enabled: true,
+      college_enabled: true,
+    });
+    expect(result.current.isLoaded).toBe(false);
+  });
+
+  it("makes no request when disabled", () => {
+    renderHook(() => useStudentHistoryVisibility(false), { wrapper });
+    expect(getVisibility).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/hooks/use-student-history-visibility.ts
+++ b/frontend/hooks/use-student-history-visibility.ts
@@ -7,13 +7,24 @@ import type { StudentHistoryVisibility } from "@/lib/api/modules/student-history
 const VISIBILITY_KEY = "/student-history/visibility";
 
 /**
- * Closed until proven open: while the request is in flight (or if it fails) no
- * gated entry point renders, so a 領獎紀錄 tab/card can never flash into view
- * for an audience the admin has shut out.
+ * Closed while the request is in flight, so a 領獎紀錄 tab/card never flashes
+ * into view for an audience the admin has shut out.
  */
 const CLOSED: StudentHistoryVisibility = {
   student_enabled: false,
   college_enabled: false,
+};
+
+/**
+ * ...but OPEN if the request itself failed. This mirrors the backend, which
+ * reads an unknown setting as open, and keeps a network blip from silently
+ * removing a college's tab. The entry point only leads to endpoints that
+ * enforce the same switches server-side, so a wrong guess here costs an error
+ * message, never access.
+ */
+const OPEN_ON_ERROR: StudentHistoryVisibility = {
+  student_enabled: true,
+  college_enabled: true,
 };
 
 /**
@@ -35,7 +46,9 @@ export function useStudentHistoryVisibility(isEnabled: boolean = true) {
   );
 
   return {
-    visibility: data ?? CLOSED,
+    // SWR keeps the last good `data` across a failed revalidation, so the
+    // error fallback only applies when nothing was ever fetched.
+    visibility: data ?? (error ? OPEN_ON_ERROR : CLOSED),
     /** True only once a real answer has arrived. */
     isLoaded: !!data,
     isLoading,

--- a/frontend/hooks/use-student-history-visibility.ts
+++ b/frontend/hooks/use-student-history-visibility.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import useSWR from "swr";
+import { apiClient } from "@/lib/api";
+import type { StudentHistoryVisibility } from "@/lib/api/modules/student-history";
+
+const VISIBILITY_KEY = "/student-history/visibility";
+
+/**
+ * Closed until proven open: while the request is in flight (or if it fails) no
+ * gated entry point renders, so a 領獎紀錄 tab/card can never flash into view
+ * for an audience the admin has shut out.
+ */
+const CLOSED: StudentHistoryVisibility = {
+  student_enabled: false,
+  college_enabled: false,
+};
+
+/**
+ * Reads the admin switches controlling who may use 領獎紀錄查詢. The SWR key is
+ * shared, so the college tab list, the student card and the admin toggle panel
+ * all ride on a single request.
+ */
+export function useStudentHistoryVisibility(isEnabled: boolean = true) {
+  const { data, error, isLoading, mutate } = useSWR<StudentHistoryVisibility>(
+    isEnabled ? VISIBILITY_KEY : null,
+    async () => {
+      const response = await apiClient.studentHistory.getVisibility();
+      if (!response.success || !response.data) {
+        throw new Error(response.message || "無法取得領獎紀錄查詢開放設定");
+      }
+      return response.data;
+    },
+    { revalidateOnFocus: false },
+  );
+
+  return {
+    visibility: data ?? CLOSED,
+    /** True only once a real answer has arrived. */
+    isLoaded: !!data,
+    isLoading,
+    error,
+    mutate,
+  };
+}
+
+export const studentHistoryVisibilityKeys = {
+  visibility: VISIBILITY_KEY,
+};

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -10872,7 +10872,11 @@ export interface components {
          *
          *     Both fields are optional and applied independently: omitting one leaves
          *     that audience's setting untouched, so the two switches never clobber each
-         *     other. Sending neither is a 400 (nothing to do).
+         *     other. Sending neither is a 422 (nothing to do).
+         *
+         *     The response shape (both switches) is produced by
+         *     ``StudentHistoryVisibility.to_dict()`` in the service layer; endpoints in
+         *     this project return plain ApiResponse dicts, never a ``response_model``.
          */
         StudentHistoryVisibilityUpdate: {
             /** Student Enabled */

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7354,6 +7354,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/student-history/visibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Visibility
+         * @description Read both switches. Open to any authenticated user on purpose: the
+         *     student card and the college tab hide themselves when their switch is off,
+         *     which needs the flag BEFORE the gated request is attempted. The payload is
+         *     two booleans about the system, never about a person.
+         */
+        get: operations["get_visibility_api_v1_student_history_visibility_get"];
+        /**
+         * Update Visibility
+         * @description Admin-only. Each audience is decided separately — an omitted field keeps
+         *     its current value rather than being reset.
+         */
+        put: operations["update_visibility_api_v1_student_history_visibility_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/csp-report": {
         parameters: {
             query?: never;
@@ -10837,6 +10865,20 @@ export interface components {
              * @description 帳戶戶名
              */
             account_holder_name?: string | null;
+        };
+        /**
+         * StudentHistoryVisibilityUpdate
+         * @description Admin toggle body for PUT /student-history/visibility.
+         *
+         *     Both fields are optional and applied independently: omitting one leaves
+         *     that audience's setting untouched, so the two switches never clobber each
+         *     other. Sending neither is a 400 (nothing to do).
+         */
+        StudentHistoryVisibilityUpdate: {
+            /** Student Enabled */
+            student_enabled?: boolean | null;
+            /** College Enabled */
+            college_enabled?: boolean | null;
         };
         /**
          * StudentVerificationStatus
@@ -23365,6 +23407,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_visibility_api_v1_student_history_visibility_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    update_visibility_api_v1_student_history_visibility_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StudentHistoryVisibilityUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/lib/api/modules/student-history.ts
+++ b/frontend/lib/api/modules/student-history.ts
@@ -116,6 +116,22 @@ export interface MyReceivedMonthsData {
   total_received_months: number;
 }
 
+/**
+ * The two admin switches deciding who 領獎紀錄查詢 is open to. Readable by any
+ * authenticated user so the student card and the college tab can hide
+ * themselves instead of rendering an entry point that 403s.
+ */
+export interface StudentHistoryVisibility {
+  student_enabled: boolean;
+  college_enabled: boolean;
+}
+
+/** Admin toggle payload — omit a field to leave that audience untouched. */
+export interface StudentHistoryVisibilityUpdate {
+  student_enabled?: boolean;
+  college_enabled?: boolean;
+}
+
 export function createStudentHistoryApi() {
   return {
     async getBatch(
@@ -136,6 +152,24 @@ export function createStudentHistoryApi() {
         {},
       );
       return toApiResponse<MyReceivedMonthsData>(response);
+    },
+
+    async getVisibility(): Promise<ApiResponse<StudentHistoryVisibility>> {
+      const response = await typedClient.raw.GET(
+        "/api/v1/student-history/visibility",
+        {},
+      );
+      return toApiResponse<StudentHistoryVisibility>(response);
+    },
+
+    async updateVisibility(
+      update: StudentHistoryVisibilityUpdate,
+    ): Promise<ApiResponse<StudentHistoryVisibility>> {
+      const response = await typedClient.raw.PUT(
+        "/api/v1/student-history/visibility",
+        { body: update },
+      );
+      return toApiResponse<StudentHistoryVisibility>(response);
     },
   };
 }


### PR DESCRIPTION
## 摘要

學生領獎紀錄查詢原本對學生（自己的已領總月數）與學院（本學院學生的領獎紀錄）**無條件開放**。此 PR 讓管理者可以**分別**決定要不要開放給這兩種對象。

管理者本身永遠不受此設定限制 —— 這兩個開關是管理者用來開放/關閉其他人的。

| system_settings key | 控制對象 |
| --- | --- |
| `student_history_visible_to_student` | 學生查看自己的「已領獎學金總月數」 |
| `student_history_visible_to_college` | 學院查詢本學院學生的領獎紀錄 |

## Backend

- `app/services/student_history_visibility.py` — 一次查詢讀取兩個開關；寫入走 `ConfigurationService`，因此每次變更都會進入 `configuration_audit_logs`（與其他系統設定一致）。
- **兩個開關互不干擾**：`None` 代表「不動這一項」，切換學生不會覆寫同時發生的學院變更。
- **列缺失 = 開放**：功能上線時本來就是開放的，因此既有資料庫在管理者主動關閉前維持現狀。
- Enforcement：`POST /student-history/batch` 對學院使用者在關閉時回 403（在任何 SIS/DB 查詢之前）；`GET /student-history/me/months` 對學生在關閉時回 403。
- 新增 `GET /student-history/visibility`（任何已登入者可讀 —— UI 需要在送出被守門的請求「之前」就知道旗標，才能隱藏入口而不是讓它 403）與 `PUT`（僅管理者，部分更新，空 body 為 422）。
- `PUT` 會**先**檢查兩個 key 是否 readonly 才寫入任何一列：`set_configuration` 是逐 key commit 的，中途才發現 readonly 會讓雙開關更新只做一半。
- Migration `student_history_visibility_001` 為既有資料庫補上兩列（`true`）；`seed_system_settings` 涵蓋全新資料庫。

## Frontend

- `hooks/use-student-history-visibility.ts` —— 共用 SWR key。載入中視為關閉（不會閃現），**但查詢本身失敗時 fallback 為開放**，與後端「未知設定 = 開放」一致；入口背後的 endpoint 一樣有守門，因此猜錯只會換到一則錯誤訊息，不會換到存取權。
- 學院「領獎紀錄查詢」分頁（及其內容）在關閉時隱藏，分頁 grid 由 3 欄縮為 2 欄。
- `TotalReceivedMonthsCard` 在關閉時直接不發請求、不渲染。
- 管理者面板最上方新增「查詢開放設定」卡片，兩個獨立開關。

## 測試

- Backend：15 個新測試（service 預設值/獨立性/稽核/唯讀前置檢查/異常值告警 + endpoint 三種角色的守門），既有相關測試 153 個全數通過。
- Frontend：8 個新 jest 測試（卡片、管理者開關、hook 的載入/錯誤/停用分支），相關套件共 188 個通過。
- Migration 於 throwaway Postgres 實際 upgrade + downgrade 驗證。
- `schema.d.ts` 以 CI 對齊的 python:3.13-slim + pinned requirements 重新產生。
- black / flake8 / tsc / eslint 全部乾淨。

## Test plan

- [ ] 管理者 → 系統管理 → 學生領獎紀錄查詢：看到「查詢開放設定」兩個開關，預設皆開啟
- [ ] 關閉「開放學院查詢」→ 學院帳號的「領獎紀錄查詢」分頁消失；直接打 API 回 403
- [ ] 關閉「開放學生查詢」→ 學生「我的申請」的總月數卡片消失；`/me/months` 回 403
- [ ] 只切換其中一個開關，另一個維持原狀
- [ ] 管理者自身查詢在兩個開關都關閉時仍可正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)
