### PR TITLE
fix(test): 修正續領測試的學年度凍結失效（main integration lane 因跨學年度而失敗）

### DIFF
--- a/backend/app/tests/test_renewal_application_creation.py
+++ b/backend/app/tests/test_renewal_application_creation.py
@@ -152,13 +152,29 @@ async def authed_client(client: AsyncClient, test_user: User):
 
 @pytest.fixture(autouse=True)
 def freeze_current_academic_year(monkeypatch):
-    """Force `get_current_academic_period()` to return AY114 so tests are stable."""
+    """Force `get_current_academic_period()` to return AY114 so tests are stable.
+
+    Patched where it is LOOKED UP, not only where it is defined. ``renewal.py``
+    does ``from app.utils.academic_period import get_current_academic_period``,
+    which binds the function object into that module's namespace at import time —
+    so patching only ``academic_period.get_current_academic_period`` leaves the
+    endpoint calling the real one. That made this fixture a silent no-op: the
+    tests passed only while the wall-clock ROC academic year happened to be 114,
+    and broke the moment it rolled over to 115 on 2026-08-01 (the calendar rolls
+    in August, see calculate_academic_period_from_date).
+    """
+    from app.api.v1.endpoints import renewal
     from app.utils import academic_period
 
     def _fake_current_period():
-        return {"academic_year": CURRENT_ACADEMIC_YEAR, "semester": "first", "western_year": 2025}
+        return {
+            "academic_year": CURRENT_ACADEMIC_YEAR,
+            "semester": "first",
+            "western_year": CURRENT_ACADEMIC_YEAR + 1911,
+        }
 
     monkeypatch.setattr(academic_period, "get_current_academic_period", _fake_current_period)
+    monkeypatch.setattr(renewal, "get_current_academic_period", _fake_current_period)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## 問題

`main` 的 **Backend Tests (integration)** 從 2026-08-01 起失敗（run [30757489735](https://github.com/anud18/scholarship-system/actions/runs/30757489735)）：

```
FAILED test_create_renewal_application_success  - assert 400 == 201
FAILED test_create_renewal_rejects_duplicate    - assert 400 == 201
  {"success":false,"message":"目前不在續領申請期間"}
2 failed, 1750 passed
```

## 根因：學年度跨年 + monkeypatch 打錯命名空間

`calculate_academic_period_from_date` 在 **8 月**跨學年度：

| 日期 | 月 | 計算出的 ROC 學年度 |
|---|---|---|
| 2026-07-29 | 7 | **114** |
| 2026-08-01 | 8 | **115** |
| 2026-08-02 | 8 | **115** |

測試把 `CURRENT_ACADEMIC_YEAR = 114` 寫死，並且**已經有**一個 autouse fixture 想把學年度凍結在 114。但它只 patch 了定義處：

```python
monkeypatch.setattr(academic_period, "get_current_academic_period", ...)
```

而 `renewal.py:40` 是直接 import 進自己的命名空間：

```python
from app.utils.academic_period import get_current_academic_period
```

`from X import Y` 在 **import 當下**就把函式物件綁進 `renewal` 模組，之後改 `academic_period` 的屬性完全不會影響它。

**所以這個 fixture 一直是無效的** —— 測試能過只是因為真實時鐘剛好等於寫死的 114。8/1 一跨到 115，endpoint 就去找 AY115 的 config、找不到，於是回 400。

## 修正

同時 patch「查找處」與「定義處」：

```python
monkeypatch.setattr(academic_period, "get_current_academic_period", _fake_current_period)
monkeypatch.setattr(renewal, "get_current_academic_period", _fake_current_period)
```

順手把 `western_year` 改成從 `CURRENT_ACADEMIC_YEAR + 1911` 導出，不再另外寫死 2025。

## 驗證

**目前真實時鐘仍是 AY115** —— 也就是 `main` 上失敗的那個情境。修正後這兩個測試在同樣條件下通過，證明凍結真的生效了（不是靠日期剛好對上）：

```
app/tests/test_renewal_application_creation.py .......           7 passed
+ test_renewal_distribution_result.py + test_academic_period_utils.py
                                                                34 passed
```

完整 integration lane（本機、在此分支上）：`1731 passed, 2 skipped, 0 failed`。
`black --check` 與 `flake8 --select=B904,B014` 皆通過。

## 不是誰的 regression

最後一次綠燈的 main 是 2026-07-29（AY114），PR #1258 的檢查跑在 2026-07-30（AY114、全綠）。跨年之後的**第一次** main 執行就是這次失敗 —— 不論當時合併的是什麼都會炸。

## 附帶說明

`test_renewal_distribution_result.py` 有同樣寫法的 fixture，但**無害**：`GET /renewals/distribution-result` 的 `academic_year` 是必填參數，不會呼叫該 helper，所以今天在 AY115 下仍然通過。維持原狀未動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
