### PR TITLE
feat(ui): 配額矩陣與核配表格補上完整 row/column 框線

### DIFF
--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -1684,7 +1684,7 @@ export function ManualDistributionPanel({
                     <tr>
                       <td
                         colSpan={14 + subTypeCols.length}
-                        className="px-4 py-10 text-center text-slate-500"
+                        className="px-4 py-10 border border-slate-200 text-center text-slate-500"
                       >
                         {students.length === 0
                           ? "尚無已確認排名的學生資料"
@@ -1706,7 +1706,7 @@ export function ManualDistributionPanel({
                           >
                             <td
                               colSpan={14 + subTypeCols.length}
-                              className="px-4 py-1.5 text-xs font-bold text-slate-600 border-y border-slate-300"
+                              className="px-4 py-1.5 text-xs font-bold text-slate-600 border border-slate-300"
                             >
                               {/* Left-aligned next to the college name: the row
                                   spans 14+N columns, so a right-aligned button
@@ -1786,7 +1786,7 @@ export function ManualDistributionPanel({
                             return (
                               <tr
                                 key={student.ranking_item_id}
-                                className={`border-b border-slate-100 transition-colors ${
+                                className={`transition-colors ${
                                   cancelStatus === "revoked"
                                     ? "bg-red-50/60 hover:bg-red-50"
                                     : cancelStatus === "suspended"
@@ -1796,14 +1796,14 @@ export function ManualDistributionPanel({
                                         : "hover:bg-slate-50"
                                 }`}
                               >
-                                <td className="px-1.5 py-1.5 border-r border-slate-100 text-center font-bold text-slate-700 text-[11px]">
+                                <td className="px-1.5 py-1.5 border border-slate-200 text-center font-bold text-slate-700 text-[11px]">
                                   {student.college_rejected ? (
                                     <span className="text-red-600">N</span>
                                   ) : (
                                     student.rank_position
                                   )}
                                 </td>
-                                <td className="px-1.5 py-1.5 border-r border-slate-100 leading-snug text-[10px]">
+                                <td className="px-1.5 py-1.5 border border-slate-200 leading-snug text-[10px]">
                                   {student.applied_sub_types.length > 0 ? (
                                     student.applied_sub_types.map((t, i) => {
                                       const displayName = getSubTypeShortName(
@@ -1825,7 +1825,7 @@ export function ManualDistributionPanel({
                                     </span>
                                   )}
                                 </td>
-                                <td className="px-1.5 py-1.5 border-r border-slate-100 leading-snug">
+                                <td className="px-1.5 py-1.5 border border-slate-200 leading-snug">
                                   {(student.professor_review_items || [])
                                     .length > 0 ||
                                   (student.requires_professor_recommendation &&
@@ -1865,7 +1865,7 @@ export function ManualDistributionPanel({
                                     </span>
                                   )}
                                 </td>
-                                <td className="px-1.5 py-1.5 border-r border-slate-100 leading-snug">
+                                <td className="px-1.5 py-1.5 border border-slate-200 leading-snug">
                                   <div className="flex flex-col gap-0.5">
                                     {/* The ranking IS the college's primary
                                         verdict: rows only exist once the
@@ -1987,7 +1987,7 @@ export function ManualDistributionPanel({
                                   return (
                                     <td
                                       key={col.key}
-                                      className={`px-0.5 py-1.5 border-r border-slate-100 text-center ${
+                                      className={`px-0.5 py-1.5 border border-slate-200 text-center ${
                                         isCancelled
                                           ? "opacity-40"
                                           : isRejected
@@ -2033,39 +2033,39 @@ export function ManualDistributionPanel({
                                     </td>
                                   );
                                 })}
-                                <td className="px-3 py-2.5 border-r border-slate-100 whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 whitespace-nowrap">
                                   {resolveCollegeName(
                                     collegeNames,
                                     student.college_code,
                                     student.college_name
                                   )}
                                 </td>
-                                <td className="px-3 py-2.5 border-r border-slate-100 whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 whitespace-nowrap">
                                   {student.department_name}
                                 </td>
-                                <td className="px-3 py-2.5 border-r border-slate-100 text-center whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 text-center whitespace-nowrap">
                                   {student.term_count ?? "-"}
                                 </td>
-                                <td className="px-3 py-2.5 border-r border-slate-100 text-center whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 text-center whitespace-nowrap">
                                   {/* 已領月份數 = 匯入 + 系統. The 匯 marker means an
                                       imported 國科會 baseline contributed to the total;
                                       see docs/received-months-calculation.md. */}
                                   <span className={student.received_months_source?.includes("imported") ? "text-blue-600 font-medium" : ""}>{student.received_months ?? "-"}</span>
                                   {student.received_months_source?.includes("imported") && <span className="ml-0.5 text-[9px] text-blue-400" title="含匯入的國科會已領月份數">匯</span>}
                                 </td>
-                                <td className="px-3 py-2.5 border-r border-slate-100 font-medium whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 font-medium whitespace-nowrap">
                                   {student.student_name}
                                 </td>
-                                <td className="px-3 py-2.5 border-r border-slate-100 text-slate-500 whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 text-slate-500 whitespace-nowrap">
                                   {student.nationality}
                                 </td>
-                                <td className="px-3 py-2.5 border-r border-slate-100 text-center tabular-nums whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 text-center tabular-nums whitespace-nowrap">
                                   {student.enrollment_date}
                                 </td>
-                                <td className="px-3 py-2.5 border-r border-slate-100 font-mono text-xs whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 font-mono text-xs whitespace-nowrap">
                                   {student.student_id}
                                 </td>
-                                <td className="px-3 py-2.5 text-xs font-semibold whitespace-nowrap">
+                                <td className="px-3 py-2.5 border border-slate-200 text-xs font-semibold whitespace-nowrap">
                                   {student.is_renewal ? (
                                     <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-300">
                                       {student.renewal_year || ""} 續領
@@ -2112,7 +2112,7 @@ export function ManualDistributionPanel({
                                     </div>
                                   )}
                                 </td>
-                                <td className="px-1.5 py-1.5 border-r border-slate-100 text-center">
+                                <td className="px-1.5 py-1.5 border border-slate-200 text-center">
                                   {/* Rendered for EVERY student, allocated or
                                       not — a 休學/退學/畢業 student must be
                                       markable before 確認分發 so the round

--- a/frontend/components/roster/MatrixQuotaDisplay.tsx
+++ b/frontend/components/roster/MatrixQuotaDisplay.tsx
@@ -48,7 +48,11 @@ export function MatrixQuotaDisplay({ quotas, hasMatrix }: MatrixQuotaDisplayProp
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <Table>
+        {/* Rule every cell. shadcn's Table only draws row separators (`border-b`
+            on TableRow), which leaves a dense 學院 × 子類型 numeric grid with no
+            column lines at all — the same full-border treatment as 各學院剩餘名額
+            (CollegeQuotaMatrix) on the 獎學金分發 screen. */}
+        <Table className="border-collapse border border-slate-300 [&_th]:border [&_th]:border-slate-300 [&_td]:border [&_td]:border-slate-300">
           <TableHeader>
             <TableRow>
               <TableHead className="font-semibold whitespace-nowrap">子類型</TableHead>


### PR DESCRIPTION
## Summary

兩個管理端表格補上完整框線。

### 1. 造冊管理 → 排程管理 → `配額矩陣`（主要修正）

該表格透過共用的 shadcn `Table` primitive 渲染，其 `TableRow` 只設了 `border-b`（`components/ui/table.tsx:61`），因此**只有橫向列分隔線、完全沒有直向欄框線**。在 13 個學院寬的 學院 × 子類型 數字矩陣下，欄與欄之間無法對齊閱讀。

改為每個 `th`/`td` 都上框線，與 獎學金分發 頁面的 `各學院剩餘名額`（`CollegeQuotaMatrix`，raw `<table>` + 每格 `border border-slate-300`）一致。

**刻意只作用於此元件**：`components/ui/table.tsx` 是全 app 所有表格的底層 primitive，若在該處加框線會連帶改動大量無關畫面。

### 2. 獎學金分發 → `學生申請名冊與核配作業`

原本每格只有一條淺色右框線 (`border-r border-slate-100`) 加上 row 的下框線，在 14+N 欄的密集資料下幾乎看不出格線。

- 所有 body cell 的 `border-r border-slate-100` → `border border-slate-200`，與 header `<th>` 既有樣式一致
- 補上 `身份` 欄位 cell 原本完全沒有的框線
- 移除 `<tr>` 已多餘的 `border-b`（`border-collapse` 下 cell 框線優先）
- 空資料提示 cell 與學院分組標題列一併補齊

## Changes

- `frontend/components/roster/MatrixQuotaDisplay.tsx`
- `frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx`

兩者皆為純樣式調整，無任何行為或資料邏輯變更。

## Test plan

- [x] `tsc --noEmit` 原始碼零錯誤
- [x] `jest components/admin/manual-distribution` 通過（2 suites / 13 tests）；`components/roster` 無對應測試
- [x] 於 dev stack 實際掛載該 worktree 熱重載確認編譯通過
- [ ] 手動確認：造冊管理 → 排程管理 → 配額矩陣 每列每欄皆有框線
- [ ] 手動確認：獎學金分發 學生名冊表格框線完整，且撤銷/停發/挑戰列底色與 hover 效果正常

## Notes

`prettier --check` 對這兩個檔案在 `main` 上即為 fail（既有格式問題，`MatrixQuotaDisplay.tsx` 全檔為 no-semicolon 風格），本 PR 未一併格式化以免產生大量無關 diff。