### PR TITLE
feat(roster): 新增「重新生成造冊」讓管理員不需人員異動也能重建名單

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -22,6 +22,7 @@ from app.core.path_security import validate_object_name_minio
 from app.core.security import check_user_roles
 from app.db.deps import get_db, get_sync_db
 from app.models.payment_roster import (
+    MANUAL_EXCLUSION_CATEGORY_LABELS,
     PaymentRoster,
     PaymentRosterItem,
     RosterStatus,
@@ -35,6 +36,8 @@ from app.schemas.payment_roster import (
     DistributionDiff,
     ReconcileRequest,
     ReconcileResult,
+    RegenerateRosterRequest,
+    RegenerateRosterResult,
     RemoveLockedItemRequest,
     RestoreItemRequest,
     RevokedSuspendedListResponse,
@@ -49,6 +52,7 @@ from app.schemas.roster import (
     RosterStatisticsResponse,
 )
 from app.services.excel_export_service import ExcelExportService
+from app.services.roster_regeneration_service import RosterRegenerationService
 from app.services.roster_service import RosterService
 from app.services.student_verification_service import StudentVerificationService
 from app.utils.academic_period import get_roster_period_dates
@@ -63,6 +67,23 @@ def _require_admin(user: User) -> None:
     """Raise 403 if user is not admin or super_admin."""
     if user.role not in (UserRole.admin, UserRole.super_admin):
         raise HTTPException(status_code=403, detail="Admin role required")
+
+
+def _roster_items_lock_key(roster_id: int) -> str:
+    """Shared distributed lock for the roster-id-scoped whole-roster mutations.
+
+    Reconcile mutates items by id while regenerate hard-deletes and rebuilds
+    all of them, so those two MUST be mutually exclusive — a shared key is what
+    makes that true. Do not give either its own key.
+
+    NOTE the batch path POST /manual-distribution/generate-rosters-from-distribution
+    (force_regenerate) resolves its roster ids inside the service, so it cannot
+    take this key and is NOT serialized against these two. It defends itself with
+    a `SELECT ... FOR UPDATE` on the roster row instead (see
+    `_generate_one_sub_type_roster`), which serializes batch-vs-batch rebuilds but
+    NOT batch-vs-regenerate — that gap is known and unguarded.
+    """
+    return f"roster:items:{roster_id}"
 
 
 # Large per-item JSON snapshots that only the 查看名單 detail view reads;
@@ -1963,7 +1984,7 @@ async def exclude_roster_item(
     """
     check_user_roles([UserRole.admin], current_user)
 
-    if reason_category not in {"returned", "declined", "other"}:
+    if reason_category not in MANUAL_EXCLUSION_CATEGORY_LABELS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="reason_category must be one of: returned / declined / other",
@@ -2009,12 +2030,10 @@ async def exclude_roster_item(
                 detail=(f"明細已被排除(原因:{item.exclusion_reason or '未填'})。" f"如需修改原因請先取消排除。"),
             )
 
-        # Build the human-readable reason string
-        category_label = {
-            "returned": "學生繳回",
-            "declined": "學生放棄",
-            "other": "其他",
-        }[reason_category]
+        # Build the human-readable reason string. The labels are shared with
+        # `is_manual_exclusion()` — regeneration keys off this exact prefix to
+        # know an exclusion was a human decision, so the two must not drift.
+        category_label = MANUAL_EXCLUSION_CATEGORY_LABELS[reason_category]
         full_reason = f"{category_label}: {reason_note}" if reason_note else category_label
 
         # Capture old/new for audit before mutation
@@ -2303,9 +2322,8 @@ def reconcile_roster_endpoint(
     sets excel_stale; audits each change. Presentation-layer only — does not
     touch quota."""
     _require_admin(current_user)
-    lock_key = f"roster:reconcile:{roster_id}"
     try:
-        with with_lock_sync(lock_key, ttl_seconds=300):
+        with with_lock_sync(_roster_items_lock_key(roster_id), ttl_seconds=300):
             svc = RosterService(db)
             result = svc.reconcile_roster(
                 roster_id=roster_id,
@@ -2320,3 +2338,94 @@ def reconcile_roster_endpoint(
         raise HTTPException(status_code=400, detail=str(e)) from e
     payload = ReconcileResult(**result).model_dump()
     return {"success": True, "message": "已更新造冊名單", "data": payload}
+
+
+def _build_regeneration_message(rebuilt: int, preserved: int, newly_excluded: int, dropped: int, failed: int) -> str:
+    """Honest summary of a roster regeneration.
+
+    Every way a student can leave the roster is named: preserved manual
+    exclusions, students the fresh verdicts newly excluded (which also undoes a
+    prior 回復), students who left the 名單 entirely, and applications that could
+    not be rebuilt. An admin must be able to tell from the message alone —
+    counting only `rebuilt` would let people disappear in silence. Pure function
+    so the wording stays under test.
+    """
+    message = f"已重新生成造冊：{rebuilt} 筆明細"
+    if preserved:
+        message += f"；保留 {preserved} 筆人為排除"
+    if newly_excluded:
+        message += f"；有 {newly_excluded} 筆先前納入的明細依當下資料改為排除"
+    if dropped:
+        message += f"；有 {dropped} 位先前納入的學生已不在分發名單中，已移出造冊"
+    if failed:
+        message += f"；有 {failed} 筆申請資料不全，未能重建"
+    return message
+
+
+@router.post("/{roster_id}/regenerate")
+def regenerate_roster_endpoint(
+    roster_id: int,
+    request: Optional[RegenerateRosterRequest] = None,
+    db: Session = Depends(get_sync_db),
+    current_user: User = Depends(get_current_user),
+):
+    """重新生成造冊：依當下的分發名單、學生資料、獎學金規則與配置重建全部明細。
+
+    不需要人員有異動即可執行——「比對分發名單」(reconcile) 只在名單有差異時
+    才有動作可做，本端點則刷新每一筆明細的內容（金額、計畫編號、學籍驗證、
+    規則判定、郵局帳號…）並重新匯出 Excel。
+
+    管理員的人為排除／移除與人工銀行覆核狀態會跨重建保留。已鎖定的造冊不可
+    重新生成（400），請先解鎖。
+    """
+    _require_admin(current_user)
+    try:
+        with with_lock_sync(_roster_items_lock_key(roster_id), ttl_seconds=300):
+            svc = RosterRegenerationService(db)
+            result = svc.regenerate_roster(
+                roster_id=roster_id,
+                admin_user_id=current_user.id,
+                student_verification_enabled=(request.student_verification_enabled if request else None),
+            )
+    except LockBusy as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="造冊處理中，請稍候再試") from exc
+    except RosterNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except (ValueError, RosterLockedError) as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except Exception as e:
+        db.rollback()
+        logger.exception(f"Failed to regenerate roster {roster_id}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="重新生成造冊失敗") from e
+
+    roster = result.roster
+    logger.info(f"Roster {roster.roster_code} regenerated by user {current_user.id}")
+    payload = RegenerateRosterResult(
+        roster_id=roster.id,
+        roster_code=roster.roster_code,
+        status=roster.status.value,
+        project_number=roster.project_number,
+        rebuilt_items=result.rebuilt_items,
+        failed_items=result.failed_items,
+        preserved_exclusions=result.preserved_exclusions,
+        newly_excluded=result.newly_excluded,
+        dropped_members=result.dropped_members,
+        qualified_count=roster.qualified_count or 0,
+        disqualified_count=roster.disqualified_count or 0,
+        total_applications=roster.total_applications or 0,
+        total_amount=float(roster.total_amount or 0),
+        excel_exported=result.excel_exported,
+        excel_stale=roster.excel_stale,
+    ).model_dump()
+    return {
+        "success": True,
+        "message": _build_regeneration_message(
+            result.rebuilt_items,
+            result.preserved_exclusions,
+            result.newly_excluded,
+            result.dropped_members,
+            result.failed_items,
+        ),
+        "data": payload,
+    }

--- a/backend/app/models/payment_roster.py
+++ b/backend/app/models/payment_roster.py
@@ -87,6 +87,31 @@ MANUAL_REMOVAL_PREFIX_LOCKED = "鎖定後移除"
 MANUAL_REMOVAL_PREFIX_RECONCILE = "比對分發移除"
 MANUAL_REMOVAL_PREFIXES = (MANUAL_REMOVAL_PREFIX_LOCKED, MANUAL_REMOVAL_PREFIX_RECONCILE)
 
+# 「排除造冊明細」(POST /{roster_id}/items/{item_id}/exclude) 的原因分類 →
+# 顯示標籤。寫入的 exclusion_reason 形如「學生繳回」或「其他: 補充說明」。
+MANUAL_EXCLUSION_CATEGORY_LABELS = {
+    "returned": "學生繳回",
+    "declined": "學生放棄",
+    "other": "其他",
+}
+
+# 「人為排除」= 管理員針對這位學生本身下的判斷（排除明細／鎖定後移除）。
+# 重建造冊時必須跨重建保留，否則已繳回／已放棄的學生會被重新納入造冊，
+# 並灌水該生的累計領取月份（博士 36 個月上限的依據）。
+#
+# 刻意「不」包含 MANUAL_REMOVAL_PREFIX_RECONCILE（比對分發移除）：那不是對學生的
+# 判斷，而是「不在分發名單」這個事實的推導結果，重建時會重新推導。一筆帶著該原因
+# 卻仍出現在重建名單中的申請，代表它已重新獲得分發——原因已然過期，保留它會讓
+# 學生卡在一個當下不成立的理由下。
+MANUAL_EXCLUSION_PREFIXES = (MANUAL_REMOVAL_PREFIX_LOCKED,) + tuple(MANUAL_EXCLUSION_CATEGORY_LABELS.values())
+
+
+def is_manual_exclusion(exclusion_reason: str | None) -> bool:
+    """該筆排除是否為管理員針對學生的人為決定，而非可重新推導的自動判定。"""
+    if not exclusion_reason:
+        return False
+    return exclusion_reason.startswith(MANUAL_EXCLUSION_PREFIXES)
+
 
 class PaymentRoster(Base):
     """造冊主檔"""

--- a/backend/app/schemas/payment_roster.py
+++ b/backend/app/schemas/payment_roster.py
@@ -418,3 +418,32 @@ class ReconcileResult(BaseModel):
     total_applications: int
     total_amount: float
     excel_stale: bool
+
+
+class RegenerateRosterRequest(BaseModel):
+    """Body for POST /payment-rosters/{roster_id}/regenerate."""
+
+    student_verification_enabled: Optional[bool] = Field(
+        None,
+        description="本次是否重新驗證學籍（單次覆寫，不會寫回造冊設定）；未提供則沿用造冊原本的設定",
+    )
+
+
+class RegenerateRosterResult(BaseModel):
+    """Response for POST /payment-rosters/{roster_id}/regenerate."""
+
+    roster_id: int
+    roster_code: str
+    status: str
+    project_number: Optional[str] = None
+    rebuilt_items: int  # 重建成功的明細數
+    failed_items: int  # 重建失敗（資料不全）的申請數
+    preserved_exclusions: int  # 跨重建保留的人為排除數
+    newly_excluded: int  # 先前納入、依當下資料重新被排除的明細數
+    dropped_members: int  # 先前納入、如今整筆不在名單中的學生數
+    qualified_count: int
+    disqualified_count: int
+    total_applications: int
+    total_amount: float
+    excel_exported: bool
+    excel_stale: bool

--- a/backend/app/services/roster_regeneration_service.py
+++ b/backend/app/services/roster_regeneration_service.py
@@ -1,0 +1,387 @@
+"""造冊重新生成服務
+
+「重新生成造冊」：以當前的分發名單、學生資料、獎學金規則與配置，重建一份**既有**
+造冊的全部明細。不需要人員有異動也能執行——這正是它與「比對分發名單」(reconcile)
+的分工：
+
+  * reconcile 只處理**名單成員**的增減，名單一致時無事可做；
+  * 重新生成則刷新**每一筆明細的內容**：金額、計畫編號、學籍驗證、獎學金規則
+    判定、分發子類型、備取資訊、郵局帳號等，全部依當下資料重算。
+
+跨重建保留的狀態（否則重建等同撤銷管理員的決定）：
+  * 人為排除／移除（學生繳回、學生放棄、鎖定後移除…）——若不保留，已排除的
+    學生會被重新納入造冊，並灌水該生的累計領取月份（博士 36 個月上限的依據）。
+  * 人工銀行帳戶覆核狀態——由銀行覆核流程寫入，重建不會重新推導。
+
+已鎖定的造冊不得重新生成（與 RosterService 的既有規則一致）；請先解鎖。
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Set
+
+from sqlalchemy import and_
+from sqlalchemy.orm import joinedload
+
+from app.core.exceptions import RosterLockedError, RosterNotFoundError
+from app.models.application import Application
+from app.models.payment_roster import (
+    PaymentRoster,
+    PaymentRosterItem,
+    RosterStatus,
+    RosterTriggerType,
+    StudentVerificationStatus,
+)
+from app.models.roster_audit import RosterAuditAction, RosterAuditLevel
+from app.models.scholarship import ScholarshipConfiguration
+from app.models.user import User
+from app.services.audit_service import audit_service
+from app.services.roster_service import PreservedItemState, RosterService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RosterRegenerationResult:
+    """重新生成造冊的結果摘要。"""
+
+    roster: PaymentRoster
+    rebuilt_items: int
+    failed_items: int
+    preserved_exclusions: int
+    #: 先前納入、依當下資料重新排除的明細數（例如學籍已變更、或規則調整後不再符合）。
+    #: 單獨回報，因為這也會撤銷管理員先前的「回復」動作——必須讓管理員看得見。
+    newly_excluded: int
+    #: 先前納入、如今整筆不在名單中的學生數（申請已撤回／改判／退出分發）。
+    #: 這些人不進入重建迴圈，既非 rebuilt 亦非 failed，不單獨回報就會無聲消失。
+    dropped_members: int
+    excel_exported: bool
+
+
+class RosterRegenerationService(RosterService):
+    """以 roster_id 為單位重新生成造冊明細（同步 Session）。
+
+    繼承 RosterService 以共用其名單解析、明細建立與人為狀態保留原語，確保
+    重新生成的成員判定與產生造冊完全一致，不會各自漂移。
+
+    已知的不對稱（刻意）：管理員的「排除」會跨重建保留，但管理員的「回復」
+    （把自動排除的學生手動納回）不會——自動判定本來就該依當下資料重算，否則
+    一位真的已畢業的學生會永遠留在造冊裡。重建因此可能撤銷一次回復，所以
+    `newly_excluded` 會單獨回報，讓管理員看得見而不是靜默發生。
+    """
+
+    def regenerate_roster(
+        self,
+        roster_id: int,
+        admin_user_id: int,
+        student_verification_enabled: Optional[bool] = None,
+    ) -> RosterRegenerationResult:
+        """重建造冊明細並提交。
+
+        Args:
+            roster_id: 造冊 ID
+            admin_user_id: 操作者
+            student_verification_enabled: 本次是否重新驗證學籍；None 代表沿用造冊原
+                設定。這是「單次」覆寫，不會寫回造冊——否則勾選一次之後就再也關不掉。
+
+        Raises:
+            RosterNotFoundError: 找不到造冊
+            RosterLockedError: 造冊已鎖定
+            ValueError: 造冊處理中、找不到配置、或目前沒有可造冊的名單
+        """
+        roster = self.db.get(PaymentRoster, roster_id)
+        if roster is None:
+            raise RosterNotFoundError(str(roster_id))
+        if roster.is_locked:
+            raise RosterLockedError(
+                f"無法重新生成已鎖定的造冊：{roster.roster_code}。請先解鎖再重新生成。",
+                roster=roster,
+            )
+        if roster.status == RosterStatus.PROCESSING:
+            raise ValueError(f"造冊 {roster.roster_code} 正在產生中，請稍候再試")
+
+        config = self.db.get(ScholarshipConfiguration, roster.scholarship_configuration_id)
+        if config is None:
+            raise ValueError(f"找不到獎學金配置：scholarship_configuration_id={roster.scholarship_configuration_id}")
+
+        # 名單必須在「刪除舊明細之前」解析完成並確認非空 —— 否則一份分發已被撤下的
+        # 造冊會被清空、標記完成、再匯出一份空白 Excel，訊息卻只說「0 筆明細」。
+        applications = self._load_rebuild_applications(roster, config)
+        if not applications:
+            raise ValueError(
+                "沒有可造冊的資料：目前的分發名單中找不到屬於本造冊的已核准學生。"
+                "請先完成矩陣分發（或匯入續領通過名單）後再重新生成。"
+            )
+
+        preserved = self._snapshot_manual_state(roster_id)
+        rebuild_ids = {application.id for application in applications}
+        # 先前納入、如今已不在名單中的學生（申請被撤回／改判、或已退出分發）。
+        # 這些人不會進入重建迴圈，因此既不算 rebuilt 也不算 failed —— 必須單獨回報。
+        dropped_members = sum(
+            1 for app_id, state in preserved.items() if state.was_included and app_id not in rebuild_ids
+        )
+
+        self._reset_roster_for_rebuild(roster, config)
+
+        counts = self._rebuild_items(roster, applications, preserved, student_verification_enabled)
+        rebuilt, failed, verification_failures, preserved_applied, newly_excluded = counts
+
+        self.db.flush()
+        roster.verification_api_failures = verification_failures
+        # 統計一律由明細列推導，不另外加計 failed —— 否則 total_applications 會與
+        # 實際明細筆數不符，並在下一次 reconcile/排除 重算時無聲地跳回去。
+        # failed 走 result / 訊息 / 稽核紀錄回報。
+        self._recompute_roster_totals_sync(roster_id)
+        roster.status = RosterStatus.COMPLETED
+        roster.completed_at = datetime.now(timezone.utc)
+        self.db.flush()
+
+        excel_exported = self._reexport_excel(roster)
+        # Excel 重新產生成功即與明細一致，可清除「需重新匯出」提示；失敗則保留提示。
+        roster.excel_stale = not excel_exported
+
+        self._log_regeneration(
+            roster=roster,
+            admin_user_id=admin_user_id,
+            rebuilt=rebuilt,
+            failed=failed,
+            preserved_exclusions=preserved_applied,
+            newly_excluded=newly_excluded,
+            dropped_members=dropped_members,
+            excel_exported=excel_exported,
+        )
+
+        self.db.commit()
+        logger.info(
+            "Roster %s regenerated: %s rebuilt, %s failed, %s manual exclusions preserved, "
+            "%s newly excluded, %s dropped",
+            roster.roster_code,
+            rebuilt,
+            failed,
+            preserved_applied,
+            newly_excluded,
+            dropped_members,
+        )
+        return RosterRegenerationResult(
+            roster=roster,
+            rebuilt_items=rebuilt,
+            failed_items=failed,
+            preserved_exclusions=preserved_applied,
+            newly_excluded=newly_excluded,
+            dropped_members=dropped_members,
+            excel_exported=excel_exported,
+        )
+
+    def _load_rebuild_applications(self, roster: PaymentRoster, config: ScholarshipConfiguration) -> List[Application]:
+        """本造冊要重建的已核准申請。
+
+        Eager-loads the to-one relationships `_create_roster_item` reads per row
+        (`scholarship_configuration.scholarship_type.name`) — the path this
+        mirrors does the same, and without it a few-hundred-row roster fires
+        hundreds of extra round-trips while holding the regenerate lock.
+        """
+        application_ids = self._resolve_membership(roster, config)
+        if not application_ids:
+            return []
+        return (
+            self.db.query(Application)
+            .options(
+                joinedload(Application.student),
+                joinedload(Application.scholarship_configuration).joinedload(ScholarshipConfiguration.scholarship_type),
+            )
+            .filter(and_(Application.id.in_(application_ids), Application.status == "approved"))
+            .all()
+        )
+
+    # ------------------------------------------------------------------
+    # 名單解析
+    # ------------------------------------------------------------------
+
+    def _resolve_membership(self, roster: PaymentRoster, config: ScholarshipConfiguration) -> Set[int]:
+        """本造冊應包含的申請 id 集合，沿用「產生造冊」既有的成員判定規則。"""
+        # 全期造冊（generate_roster 路徑）：sub_type / allocation_config_id 皆為 NULL，
+        # 名單即該路徑的申請篩選結果，不做分組切片。
+        if roster.sub_type is None and roster.allocation_config_id is None:
+            applications = self._get_eligible_applications(
+                roster.scholarship_configuration_id,
+                roster.period_label,
+                roster.academic_year,
+                roster.ranking_id,
+            )
+            return {application.id for application in applications}
+
+        # 分組造冊（矩陣分發路徑）：本分組的正取 + 本分組已核准的續領。
+        allocated_ids = set(self._resolve_distribution_for_roster(roster, config=config))
+        return allocated_ids | self._renewal_application_ids(roster, config)
+
+    def _renewal_application_ids(self, roster: PaymentRoster, config: ScholarshipConfiguration) -> Set[int]:
+        """本分組已核准的續領申請 id。
+
+        續領永遠不會產生 CollegeRankingItem（不參與配額分發），分發比對看不到
+        它們——分組 key 與 generate_rosters_from_distribution 一致。
+        """
+        semester = (
+            (config.semester.value if hasattr(config.semester, "value") else config.semester)
+            if config.semester
+            else None
+        )
+        renewals = (
+            self.db.query(Application)
+            .filter(
+                and_(
+                    Application.scholarship_type_id == config.scholarship_type_id,
+                    Application.academic_year == config.academic_year,
+                    Application.is_renewal.is_(True),
+                    Application.status == "approved",
+                    Application.deleted_at.is_(None),
+                    self._build_application_semester_filter(semester),
+                )
+            )
+            .all()
+        )
+        roster_key = (roster.allocation_config_id or config.id, roster.sub_type or "general")
+        return {
+            application.id
+            for application in renewals
+            if (
+                application.allocation_config_id or config.id,
+                application.sub_scholarship_type or "general",
+            )
+            == roster_key
+        }
+
+    # ------------------------------------------------------------------
+    # 重建
+    # ------------------------------------------------------------------
+
+    def _reset_roster_for_rebuild(self, roster: PaymentRoster, config: ScholarshipConfiguration) -> None:
+        """清空舊明細並把造冊主檔重設為「產生中」，同時刷新設定面的快照欄位。"""
+        # 計畫編號的真實來源是獎學金配置；管理員事後補填後，唯有重新生成才會生效。
+        if roster.sub_type:
+            consumed_config = (
+                self.db.get(ScholarshipConfiguration, roster.allocation_config_id)
+                if roster.allocation_config_id is not None
+                else config
+            ) or config
+            roster.project_number = (consumed_config.project_numbers or {}).get(roster.sub_type)
+
+        roster.status = RosterStatus.PROCESSING
+        roster.trigger_type = RosterTriggerType.MANUAL
+        roster.started_at = datetime.now(timezone.utc)
+        roster.completed_at = None
+        roster.total_applications = 0
+        roster.qualified_count = 0
+        roster.disqualified_count = 0
+        roster.total_amount = 0
+        roster.verification_api_failures = 0
+
+        self.db.query(PaymentRosterItem).filter(PaymentRosterItem.roster_id == roster.id).delete()
+        # flush + expire：Excel 匯出讀的是 roster.items 關聯集合，若不失效，
+        # 本 Session 先前載入的舊集合會讓匯出寫出過期名單。
+        self.db.flush()
+        self.db.expire(roster, ["items"])
+
+    def _rebuild_items(
+        self,
+        roster: PaymentRoster,
+        applications: List[Application],
+        preserved: Dict[int, PreservedItemState],
+        verification_enabled: Optional[bool],
+    ) -> tuple:
+        """逐筆重建明細。
+
+        Returns:
+            (rebuilt, failed, verification_failures, preserved_applied, newly_excluded)
+        """
+        rebuilt = 0
+        failed = 0
+        verification_failures = 0
+        preserved_applied = 0
+        newly_excluded = 0
+
+        for application in applications:
+            try:
+                item = self._verify_and_create_item(roster, application, verification_enabled=verification_enabled)
+            except Exception:
+                logger.exception(
+                    "Roster %s: failed to rebuild item for application %s", roster.roster_code, application.id
+                )
+                failed += 1
+                continue
+
+            if item.verification_status == StudentVerificationStatus.API_ERROR:
+                verification_failures += 1
+            state = preserved.get(application.id)
+            if self._apply_preserved_state(item, state):
+                preserved_applied += 1
+            elif state is not None and state.was_included and not item.is_included:
+                # 先前納入、現在被自動判定排除。這也會撤銷管理員先前的「回復」，
+                # 所以要計數回報，不能靜默發生。
+                newly_excluded += 1
+            rebuilt += 1
+
+        return rebuilt, failed, verification_failures, preserved_applied, newly_excluded
+
+    def _reexport_excel(self, roster: PaymentRoster) -> bool:
+        """依重建後的明細重新產生 Excel 並上傳。失敗僅記錄，不推翻整次重建。"""
+        from app.services.excel_export_service import ExcelExportService
+
+        try:
+            ExcelExportService().export_roster_to_excel(
+                roster=roster,
+                template_name="STD_UP_MIXLISTA",
+                include_header=True,
+                include_statistics=True,
+                include_excluded=False,
+            )
+            self.db.flush()  # 保存 minio_object_name / excel_filename
+            return True
+        except Exception:
+            logger.exception("Failed to regenerate Excel for roster %s", roster.roster_code)
+            return False
+
+    def _log_regeneration(
+        self,
+        roster: PaymentRoster,
+        admin_user_id: int,
+        rebuilt: int,
+        failed: int,
+        preserved_exclusions: int,
+        newly_excluded: int,
+        dropped_members: int,
+        excel_exported: bool,
+    ) -> None:
+        user = self.db.get(User, admin_user_id)
+        audit_service.log_roster_operation(
+            roster_id=roster.id,
+            action=RosterAuditAction.UPDATE,
+            title=f"重新生成造冊: {roster.roster_code} 納入造冊{roster.qualified_count}人",
+            user_id=admin_user_id,
+            user_name=user.name if user else "Unknown",
+            description=(
+                f"依當下分發名單與學生資料重建 {rebuilt} 筆明細"
+                f"（保留人為排除 {preserved_exclusions} 筆，新增排除 {newly_excluded} 筆，"
+                f"移出名單 {dropped_members} 筆，建立失敗 {failed} 筆）；"
+                f"計畫編號: {roster.project_number or '未設定'}，總金額: ${roster.total_amount}"
+            ),
+            old_values=None,
+            new_values=None,
+            level=(
+                RosterAuditLevel.WARNING if (failed or newly_excluded or dropped_members) else RosterAuditLevel.INFO
+            ),
+            affected_items_count=rebuilt,
+            metadata={
+                "rebuilt_items": rebuilt,
+                "failed_items": failed,
+                "preserved_exclusions": preserved_exclusions,
+                "newly_excluded": newly_excluded,
+                "dropped_members": dropped_members,
+                "excel_exported": excel_exported,
+                "qualified_count": roster.qualified_count,
+                "disqualified_count": roster.disqualified_count,
+                "total_amount": float(roster.total_amount or 0),
+            },
+            tags=["regenerate", roster.sub_type or "whole_period"],
+            db=self.db,
+        )

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -32,6 +32,7 @@ from app.models.payment_roster import (
     RosterStatus,
     RosterTriggerType,
     StudentVerificationStatus,
+    is_manual_exclusion,
     verification_status_label,
 )
 from app.models.roster_audit import RosterAuditAction, RosterAuditLevel, RosterAuditLog
@@ -63,12 +64,72 @@ class RosterGenerationResult:
     locked: List["PaymentRoster"] = field(default_factory=list)
 
 
+# 由人工覆核流程寫入、重建無法重新推導的明細欄位——必須跨重建搬運。
+PRESERVED_ITEM_FIELDS = (
+    "bank_account_number_status",
+    "bank_account_holder_status",
+    "bank_verification_details",
+    "bank_manual_review_notes",
+)
+
+
+@dataclass
+class PreservedItemState:
+    """一筆造冊明細中「不由重建推導」的狀態快照（以 application_id 為 key）。"""
+
+    is_manually_excluded: bool
+    was_included: bool
+    exclusion_reason: Optional[str]
+    review_fields: Dict[str, Any] = field(default_factory=dict)
+
+
 class RosterService:
     """造冊服務"""
 
     def __init__(self, db: Session):
         self.db = db
         self.student_verification_service = StudentVerificationService()
+
+    # ------------------------------------------------------------------
+    # 重建造冊明細時必須跨重建保留的人為狀態
+    # ------------------------------------------------------------------
+
+    def _snapshot_manual_state(self, roster_id: int) -> Dict[int, "PreservedItemState"]:
+        """重建前，以 application_id 為 key 快照「不由重建推導」的明細狀態。
+
+        EVERY path that wipes and rebuilds a roster's items must call this first
+        and re-apply it with `_apply_preserved_state` afterwards. Skipping it
+        silently re-includes students the admin excluded (學生繳回／放棄／鎖定後移除),
+        which inflates their cumulative received_months — the PhD 36-month cap.
+        """
+        items = self.db.query(PaymentRosterItem).filter(PaymentRosterItem.roster_id == roster_id).all()
+        return {
+            item.application_id: PreservedItemState(
+                is_manually_excluded=(not item.is_included and is_manual_exclusion(item.exclusion_reason)),
+                was_included=bool(item.is_included),
+                exclusion_reason=item.exclusion_reason,
+                review_fields={f: getattr(item, f) for f in PRESERVED_ITEM_FIELDS},
+            )
+            for item in items
+        }
+
+    @staticmethod
+    def _apply_preserved_state(item: PaymentRosterItem, state: Optional["PreservedItemState"]) -> bool:
+        """把快照的人為狀態套回新建的明細。回傳是否套用了人為排除。
+
+        人為排除優先於重建算出的納入判定；重建自己算出的排除原因不會消失——
+        它完整保存在 rule_validation_result / failed_rules / verification_status。
+        """
+        if state is None:
+            return False
+        for field_name, value in state.review_fields.items():
+            if value is not None:
+                setattr(item, field_name, value)
+        if not state.is_manually_excluded:
+            return False
+        item.is_included = False
+        item.exclusion_reason = state.exclusion_reason
+        return True
 
     def generate_roster(
         self,
@@ -165,10 +226,14 @@ class RosterService:
             # 產生造冊代碼
             roster_code = self._generate_roster_code(scholarship_configuration_id, period_label, academic_year)
 
+            # 人為排除／人工帳戶覆核在重建前先取快照，重建後套回（見 _snapshot_manual_state）。
+            preserved: Dict[int, PreservedItemState] = {}
+
             # 建立造冊主檔
             if existing_roster and force_regenerate:
                 # 更新現有造冊
                 roster = existing_roster
+                preserved = self._snapshot_manual_state(roster.id)
                 roster.status = RosterStatus.PROCESSING
                 roster.trigger_type = trigger_type
                 roster.student_verification_enabled = student_verification_enabled
@@ -367,6 +432,9 @@ class RosterService:
                     roster_item = self._create_roster_item(
                         roster, application, verification_result, verification_status, eligibility_result
                     )
+                    # 重建時把管理員的人為排除／人工帳戶覆核套回，且必須在統計之前——
+                    # 否則已排除的學生會被重新計入人數與總金額。
+                    self._apply_preserved_state(roster_item, preserved.get(application.id))
 
                     # 統計以「納入造冊」為準，與 Excel 的「納入造冊」欄、
                     # 造冊詳情的「納入造冊人數」及 _recompute_roster_totals_sync 同源
@@ -1729,6 +1797,11 @@ class RosterService:
 
         # 檢查是否已存在（unique key: scholarship_configuration_id + period_label
         # + allocation_config_id + sub_type）
+        #
+        # with_for_update：本批次路徑沒有分散式鎖，重建又是「先全刪再重插」。
+        # 兩個並行的重建若各自只看見自己快照裡的明細，會各刪各的、各插一份，
+        # 造冊最後帶著兩套明細與加倍金額。鎖住造冊主檔列即可把兩者序列化。
+        # （SQLite 測試環境會忽略 FOR UPDATE，不影響單執行緒測試。）
         existing_roster = (
             self.db.query(PaymentRoster)
             .filter(
@@ -1739,6 +1812,7 @@ class RosterService:
                     PaymentRoster.allocation_config_id == consumed_config.id,
                 )
             )
+            .with_for_update()
             .first()
         )
 
@@ -1757,8 +1831,12 @@ class RosterService:
         user = self.db.query(User).filter(User.id == created_by_user_id).first()
         user_name = user.name if user else "Unknown"
 
+        # 人為排除／人工帳戶覆核在重建前先取快照，重建後套回（見 _snapshot_manual_state）。
+        preserved: Dict[int, PreservedItemState] = {}
+
         if existing_roster and force_regenerate:
             roster = existing_roster
+            preserved = self._snapshot_manual_state(roster.id)
             roster.status = RosterStatus.PROCESSING
             roster.trigger_type = RosterTriggerType.MANUAL
             roster.student_verification_enabled = student_verification_enabled
@@ -1773,6 +1851,10 @@ class RosterService:
             roster.allocation_config_id = consumed_config.id
             roster.allocation_year = allocation_year
             self.db.query(PaymentRosterItem).filter(PaymentRosterItem.roster_id == roster.id).delete()
+            # flush + expire：Excel 匯出讀的是 roster.items 關聯集合，若不失效，
+            # 本 Session 先前載入的舊集合會讓匯出寫出過期名單。
+            self.db.flush()
+            self.db.expire(roster, ["items"])
             logger.info(f"Regenerating roster {roster_code}")
         else:
             roster = PaymentRoster(
@@ -1814,6 +1896,7 @@ class RosterService:
         disqualified_count = 0
         total_amount = 0
         verification_failures = 0
+        preserved_exclusions = 0
 
         for application in applications:
             try:
@@ -1847,6 +1930,10 @@ class RosterService:
                 roster_item = self._create_roster_item(
                     roster, application, verification_result, verification_status, eligibility_result
                 )
+                # 重建時把管理員的人為排除／人工帳戶覆核套回，且必須在統計之前——
+                # 否則已排除的學生會被重新計入人數與總金額。
+                if self._apply_preserved_state(roster_item, preserved.get(application.id)):
+                    preserved_exclusions += 1
 
                 # 同 generate_roster：統計以「納入造冊」為準
                 if roster_item.is_included:
@@ -1891,8 +1978,12 @@ class RosterService:
                 include_excluded=False,
             )
             self.db.flush()  # Persist minio_object_name and excel_filename
+            # 匯出成功 ⇒ 檔案與明細一致，清除「需重新匯出」提示（可能是先前的
+            # 移除／比對留下的）。失敗則標記為過期：MinIO 上那份已經對不上名單。
+            roster.excel_stale = False
             logger.info(f"Excel generated for roster {roster_code}: {roster.minio_object_name}")
         except Exception:
+            roster.excel_stale = True
             logger.exception(f"Failed to generate Excel for roster {roster_code}")
 
         audit_service.log_roster_operation(
@@ -1901,7 +1992,10 @@ class RosterService:
             title=f"批次造冊產生: {sub_type} {allocation_year}年度 納入造冊{qualified_count}人",
             user_id=created_by_user_id,
             user_name=user_name,
-            description=f"計畫編號: {project_number or '未設定'}，總金額: ${total_amount}",
+            description=(
+                f"計畫編號: {project_number or '未設定'}，總金額: ${total_amount}"
+                + (f"，保留人為排除 {preserved_exclusions} 筆" if preserved_exclusions else "")
+            ),
             old_values=None,
             new_values=None,
             level=RosterAuditLevel.INFO,
@@ -1912,6 +2006,7 @@ class RosterService:
                 "project_number": project_number,
                 "qualified_count": qualified_count,
                 "disqualified_count": disqualified_count,
+                "preserved_exclusions": preserved_exclusions,
                 "total_amount": float(total_amount),
             },
             tags=["batch_generation", sub_type],
@@ -2207,10 +2302,20 @@ class RosterService:
             "to_remove": to_remove,
         }
 
-    def _verify_and_create_item(self, roster: PaymentRoster, application: Application) -> PaymentRosterItem:
+    def _verify_and_create_item(
+        self,
+        roster: PaymentRoster,
+        application: Application,
+        verification_enabled: Optional[bool] = None,
+    ) -> PaymentRosterItem:
         """Verify (if enabled) + validate eligibility + build a PaymentRosterItem.
         Mirrors the generation per-application block. self.db.add()s the item
-        (does NOT flush/commit) and returns it."""
+        (does NOT flush/commit) and returns it.
+
+        `verification_enabled` overrides the roster's stored 學籍驗證 setting for
+        THIS call only — it is deliberately not written back to the roster, so a
+        one-off "also re-verify" run can never latch verification on permanently.
+        """
         sd = application.student_data or {}
         student_id_number = sd.get("std_stdcode")
         student_name = sd.get("std_cname")
@@ -2221,7 +2326,8 @@ class RosterService:
         verification_status = StudentVerificationStatus.VERIFIED
         fresh_student_data = None
 
-        if roster.student_verification_enabled:
+        verify = roster.student_verification_enabled if verification_enabled is None else verification_enabled
+        if verify:
             verification_result = self.student_verification_service.verify_student(
                 sd.get("std_stdcode"), sd.get("std_cname")
             )

--- a/backend/app/tests/test_roster_regenerate_api.py
+++ b/backend/app/tests/test_roster_regenerate_api.py
@@ -1,0 +1,163 @@
+"""Endpoint pin: POST /payment-rosters/{roster_id}/regenerate enforces admin,
+wraps the service in the {success,message,data} shape, and maps service errors
+to HTTP 400/404. Called as functions with a sync session to avoid the
+async/sync test-DB split and Redis.
+
+The route also fills a pre-existing hole: the frontend already shipped a
+`regenerateRoster()` client pointing at this path with no backend behind it.
+"""
+
+import contextlib
+
+import pytest
+from fastapi import HTTPException
+from unittest.mock import patch
+
+from app.api.v1.endpoints import payment_rosters as ep
+from app.api.v1.endpoints.payment_rosters import _build_regeneration_message
+from app.models.payment_roster import PaymentRosterItem, RosterStatus, StudentVerificationStatus
+from app.schemas.payment_roster import RegenerateRosterRequest
+from app.tests.test_roster_regeneration_service import (
+    EXPORT_TARGET,
+    _admin,
+    _allocate,
+    _application,
+    _config,
+    _generate,
+    _ranking,
+    _student,
+)
+from app.models.scholarship import ScholarshipType
+
+
+@contextlib.contextmanager
+def _passthrough_lock(*args, **kwargs):
+    yield "test-token"
+
+
+def _build_scenario(db_sync):
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="ep_regen", name="EpRegen", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    config = _config(db_sync, sch, code="EPREGEN-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "ep_regen_a"), sch, config, app_id="APP-EPR-A", std_code="115A")
+    _allocate(db_sync, ranking, app, config)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    db_sync.commit()
+    return admin, roster
+
+
+def test_regenerate_endpoint_returns_api_response(db_sync, monkeypatch):
+    monkeypatch.setattr(ep, "with_lock_sync", _passthrough_lock)
+    admin, roster = _build_scenario(db_sync)
+
+    with patch(EXPORT_TARGET):
+        resp = ep.regenerate_roster_endpoint(roster_id=roster.id, request=None, db=db_sync, current_user=admin)
+
+    assert resp["success"] is True
+    assert resp["data"]["roster_id"] == roster.id
+    assert resp["data"]["rebuilt_items"] == 1
+    assert resp["data"]["preserved_exclusions"] == 0
+    assert resp["data"]["status"] == RosterStatus.COMPLETED.value
+    assert resp["data"]["excel_stale"] is False
+
+
+def test_regenerate_endpoint_verification_override_is_per_run_not_sticky(db_sync, monkeypatch):
+    """「同時重新驗證學籍」is a one-off. It must NOT be written back to the roster —
+    otherwise ticking it once latches slow SIS verification on forever and
+    unticking it next time would silently do nothing."""
+    monkeypatch.setattr(ep, "with_lock_sync", _passthrough_lock)
+    admin, roster = _build_scenario(db_sync)
+    assert roster.student_verification_enabled is False
+
+    req = RegenerateRosterRequest(student_verification_enabled=True)
+    with patch(EXPORT_TARGET), patch("app.services.roster_service.StudentVerificationService") as svs:
+        # Return the ENUM member, not the "verified" string — _create_roster_item
+        # compares against StudentVerificationStatus.VERIFIED, so a string would
+        # silently exclude the student and mask what this test is asserting.
+        svs.return_value.verify_student.return_value = {
+            "status": StudentVerificationStatus.VERIFIED,
+            "student_info": {},
+        }
+        resp = ep.regenerate_roster_endpoint(roster_id=roster.id, request=req, db=db_sync, current_user=admin)
+
+    assert resp["success"] is True
+    # The override took effect for this run...
+    assert svs.return_value.verify_student.called
+    assert resp["data"]["newly_excluded"] == 0
+    # ...but the roster's own setting is untouched, so the next run is fast again.
+    assert roster.student_verification_enabled is False
+
+
+def test_regenerate_endpoint_requires_admin(db_sync, monkeypatch):
+    monkeypatch.setattr(ep, "with_lock_sync", _passthrough_lock)
+    _admin_user, roster = _build_scenario(db_sync)
+    student = _student(db_sync, "ep_regen_outsider")
+
+    with pytest.raises(HTTPException) as exc:
+        ep.regenerate_roster_endpoint(roster_id=roster.id, request=None, db=db_sync, current_user=student)
+    assert exc.value.status_code == 403
+
+
+def test_regenerate_endpoint_maps_missing_roster_to_404(db_sync, monkeypatch):
+    monkeypatch.setattr(ep, "with_lock_sync", _passthrough_lock)
+    admin, _roster = _build_scenario(db_sync)
+
+    with pytest.raises(HTTPException) as exc:
+        ep.regenerate_roster_endpoint(roster_id=999999, request=None, db=db_sync, current_user=admin)
+    assert exc.value.status_code == 404
+
+
+def test_regenerate_endpoint_maps_locked_roster_to_400(db_sync, monkeypatch):
+    """A locked roster must fail loudly with an actionable message, and its
+    items must survive the refused call."""
+    monkeypatch.setattr(ep, "with_lock_sync", _passthrough_lock)
+    admin, roster = _build_scenario(db_sync)
+    roster.status = RosterStatus.LOCKED
+    db_sync.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        ep.regenerate_roster_endpoint(roster_id=roster.id, request=None, db=db_sync, current_user=admin)
+    assert exc.value.status_code == 400
+    assert "解鎖" in exc.value.detail
+    assert db_sync.query(PaymentRosterItem).filter(PaymentRosterItem.roster_id == roster.id).count() == 1
+
+
+def test_regenerate_endpoint_maps_lock_busy_to_409(db_sync, monkeypatch):
+    admin, roster = _build_scenario(db_sync)
+
+    @contextlib.contextmanager
+    def _busy(*args, **kwargs):
+        raise ep.LockBusy("roster:regenerate:1")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(ep, "with_lock_sync", _busy)
+    with pytest.raises(HTTPException) as exc:
+        ep.regenerate_roster_endpoint(roster_id=roster.id, request=None, db=db_sync, current_user=admin)
+    assert exc.value.status_code == 409
+
+
+def test_build_regeneration_message_names_every_way_a_student_leaves():
+    assert _build_regeneration_message(5, 0, 0, 0, 0) == "已重新生成造冊：5 筆明細"
+
+    preserved = _build_regeneration_message(5, 2, 0, 0, 0)
+    assert "保留 2 筆人為排除" in preserved
+
+    newly_excluded = _build_regeneration_message(5, 0, 3, 0, 0)
+    assert "3 筆先前納入的明細依當下資料改為排除" in newly_excluded
+
+    dropped = _build_regeneration_message(5, 0, 0, 4, 0)
+    assert "4 位先前納入的學生已不在分發名單中" in dropped
+
+    failed = _build_regeneration_message(4, 0, 0, 0, 1)
+    assert "1 筆申請資料不全" in failed
+
+    everything = _build_regeneration_message(4, 2, 3, 4, 1)
+    assert "保留 2 筆人為排除" in everything
+    assert "3 筆先前納入的明細依當下資料改為排除" in everything
+    assert "4 位先前納入的學生已不在分發名單中" in everything
+    assert "1 筆申請資料不全" in everything

--- a/backend/app/tests/test_roster_regeneration_service.py
+++ b/backend/app/tests/test_roster_regeneration_service.py
@@ -1,0 +1,699 @@
+"""Pin the contract of 重新生成造冊 (RosterRegenerationService.regenerate_roster).
+
+The feature exists so an admin can rebuild a roster's 名單 at ANY time — it must
+NOT require 人員有異動 the way 比對分發名單 (reconcile) does. What it must and must
+not do:
+
+  * rebuild every item from the CURRENT distribution + config (fresh amount,
+    project_number, sub_type, 學生資料), even when membership is unchanged;
+  * carry approved 續領 students, which never own a CollegeRankingItem and are
+    therefore invisible to the distribution diff;
+  * PRESERVE the admin's manual exclusions (學生繳回 / 學生放棄 / 鎖定後移除…).
+    Resurrecting them would silently inflate the student's cumulative
+    received_months, which feeds the PhD 36-month cap;
+  * preserve human bank-verification review state, which a rebuild cannot
+    re-derive;
+  * refuse a LOCKED roster.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.exceptions import RosterLockedError, RosterNotFoundError
+from app.models.application import Application, ApplicationStatus
+from app.models.college_review import CollegeRanking, CollegeRankingItem
+from app.models.payment_roster import (
+    MANUAL_REMOVAL_PREFIX_RECONCILE,
+    PaymentRoster,
+    PaymentRosterItem,
+    RosterCycle,
+    RosterStatus,
+    StudentVerificationStatus,
+)
+from app.models.scholarship import (
+    ScholarshipConfiguration,
+    ScholarshipType,
+    SubTypeSelectionMode,
+)
+from app.models.user import User, UserRole, UserType
+from app.services.roster_regeneration_service import RosterRegenerationService
+from app.services.roster_service import RosterService
+
+EXPORT_TARGET = "app.services.excel_export_service.ExcelExportService"
+
+
+def _admin(db_sync):
+    u = User(
+        nycu_id="regen_admin",
+        email="regen_admin@nycu.edu.tw",
+        name="Regen Admin",
+        role=UserRole.admin,
+        user_type=UserType.employee,
+    )
+    db_sync.add(u)
+    db_sync.flush()
+    return u
+
+
+def _student(db_sync, nycu_id):
+    u = User(
+        nycu_id=nycu_id,
+        email=f"{nycu_id}@nycu.edu.tw",
+        name=f"Student {nycu_id}",
+        role=UserRole.student,
+        user_type=UserType.student,
+    )
+    db_sync.add(u)
+    db_sync.flush()
+    return u
+
+
+def _config(db_sync, scholarship, *, academic_year=115, code="REGEN-115", project_numbers=None, amount=50000):
+    c = ScholarshipConfiguration(
+        scholarship_type_id=scholarship.id,
+        config_code=code,
+        config_name=code,
+        academic_year=academic_year,
+        semester="first",
+        amount=amount,
+        has_quota_limit=False,
+        project_numbers=project_numbers,
+    )
+    db_sync.add(c)
+    db_sync.flush()
+    return c
+
+
+def _application(db_sync, user, scholarship, config, *, app_id, std_code, amount=50000, is_renewal=False):
+    a = Application(
+        user_id=user.id,
+        app_id=app_id,
+        scholarship_type_id=scholarship.id,
+        scholarship_configuration_id=config.id,
+        academic_year=config.academic_year,
+        semester="first",
+        status=ApplicationStatus.approved,
+        sub_type_selection_mode=SubTypeSelectionMode.single,
+        scholarship_subtype_list=[],
+        sub_scholarship_type="nstc",
+        allocation_config_id=config.id,
+        is_renewal=is_renewal,
+        student_data={
+            "std_stdcode": std_code,
+            "std_pid": f"A{std_code}",
+            "std_cname": f"學生{std_code}",
+        },
+        submitted_form_data={"fields": {"postal_account": {"value": "0001234567"}}},
+        amount=amount,
+    )
+    db_sync.add(a)
+    db_sync.flush()
+    return a
+
+
+def _ranking(db_sync, scholarship, *, academic_year=115):
+    r = CollegeRanking(
+        scholarship_type_id=scholarship.id,
+        sub_type_code="nstc",
+        academic_year=academic_year,
+        semester="first",
+        ranking_name="R",
+        is_finalized=True,
+        ranking_status="finalized",
+        distribution_executed=True,
+    )
+    db_sync.add(r)
+    db_sync.flush()
+    return r
+
+
+def _allocate(db_sync, ranking, application, config, *, rank_position=1):
+    item = CollegeRankingItem(
+        ranking_id=ranking.id,
+        application_id=application.id,
+        rank_position=rank_position,
+        is_allocated=True,
+        allocated_sub_type="nstc",
+        allocation_config_id=config.id,
+        status="allocated",
+    )
+    db_sync.add(item)
+    db_sync.flush()
+    return item
+
+
+def _generate(db_sync, scholarship, admin):
+    """Produce the initial roster through the real batch path."""
+    result = RosterService(db_sync).generate_rosters_from_distribution(
+        scholarship_type_id=scholarship.id,
+        academic_year=115,
+        semester="first",
+        created_by_user_id=admin.id,
+        student_verification_enabled=False,
+    )
+    assert len(result.created) == 1
+    return result.created[0]
+
+
+def _items(db_sync, roster_id):
+    return db_sync.query(PaymentRosterItem).filter(PaymentRosterItem.roster_id == roster_id).all()
+
+
+def test_regenerate_without_membership_change_refreshes_config_snapshots(db_sync):
+    """The core ask: regeneration must work with NO 人員異動 and pick up config
+    edits (計畫編號 / 金額) that were invisible to the already-generated roster."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_sch", name="Regen", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, project_numbers=None)
+    student = _student(db_sync, "regen_a")
+    app = _application(db_sync, student, sch, cfg, app_id="APP-REGEN-A", std_code="115A")
+    ranking = _ranking(db_sync, sch)
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    assert roster.project_number is None
+    roster_id = roster.id
+
+    # Admin fills in 計畫編號 and corrects the amount AFTER 生成造冊 — today the
+    # only way those reach the roster is a rebuild.
+    cfg.project_numbers = {"nstc": "115R000123"}
+    app.amount = 60000
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.rebuilt_items == 1
+    assert result.failed_items == 0
+    assert result.preserved_exclusions == 0
+    assert result.roster.project_number == "115R000123"
+    assert result.roster.status == RosterStatus.COMPLETED
+    assert result.roster.qualified_count == 1
+
+    items = _items(db_sync, roster_id)
+    assert len(items) == 1
+    assert int(items[0].scholarship_amount) == 60000
+
+
+def test_regenerate_picks_up_newly_allocated_student(db_sync):
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_add", name="RegenAdd", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENADD-115")
+    ranking = _ranking(db_sync, sch)
+
+    first_student = _student(db_sync, "add_a")
+    first_app = _application(db_sync, first_student, sch, cfg, app_id="APP-ADD-A", std_code="115A")
+    _allocate(db_sync, ranking, first_app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    late_student = _student(db_sync, "add_b")
+    late_app = _application(db_sync, late_student, sch, cfg, app_id="APP-ADD-B", std_code="115B")
+    _allocate(db_sync, ranking, late_app, cfg, rank_position=2)
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.rebuilt_items == 2
+    assert {i.student_number for i in _items(db_sync, roster_id)} == {"115A", "115B"}
+
+
+def test_regenerate_preserves_manual_exclusion(db_sync):
+    """A student the admin excluded (學生繳回) must NOT come back included —
+    that would inflate their cumulative received_months."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_excl", name="RegenExcl", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENEXCL-115")
+    ranking = _ranking(db_sync, sch)
+
+    kept = _application(db_sync, _student(db_sync, "ex_a"), sch, cfg, app_id="APP-EX-A", std_code="115A")
+    returned = _application(db_sync, _student(db_sync, "ex_b"), sch, cfg, app_id="APP-EX-B", std_code="115B")
+    _allocate(db_sync, ranking, kept, cfg)
+    _allocate(db_sync, ranking, returned, cfg, rank_position=2)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+    assert roster.qualified_count == 2
+
+    # Admin excludes one student the way POST /{roster_id}/items/{id}/exclude does.
+    excluded_item = next(i for i in _items(db_sync, roster_id) if i.application_id == returned.id)
+    excluded_item.is_included = False
+    excluded_item.exclusion_reason = "學生繳回: 已退款"
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.rebuilt_items == 2
+    assert result.preserved_exclusions == 1
+
+    by_app = {i.application_id: i for i in _items(db_sync, roster_id)}
+    assert by_app[kept.id].is_included is True
+    assert by_app[returned.id].is_included is False
+    assert by_app[returned.id].exclusion_reason == "學生繳回: 已退款"
+    # 人數/金額 must reflect the preserved exclusion, not the raw rebuild.
+    assert result.roster.qualified_count == 1
+    assert int(result.roster.total_amount) == 50000
+
+
+def test_batch_force_regenerate_also_preserves_manual_exclusion(db_sync):
+    """The batch 重新生成造冊 button (手動分發 panel) goes through
+    generate_rosters_from_distribution(force_regenerate=True), NOT through
+    RosterRegenerationService — so preservation must live in the shared base or
+    that button silently resurrects every 排除 while its dialog promises it won't."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="batch_excl", name="BatchExcl", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="BATCHEXCL-115")
+    ranking = _ranking(db_sync, sch)
+
+    kept = _application(db_sync, _student(db_sync, "bx_a"), sch, cfg, app_id="APP-BX-A", std_code="115A")
+    returned = _application(db_sync, _student(db_sync, "bx_b"), sch, cfg, app_id="APP-BX-B", std_code="115B")
+    _allocate(db_sync, ranking, kept, cfg)
+    _allocate(db_sync, ranking, returned, cfg, rank_position=2)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    excluded_item = next(i for i in _items(db_sync, roster_id) if i.application_id == returned.id)
+    excluded_item.is_included = False
+    excluded_item.exclusion_reason = "學生放棄"
+    excluded_item.bank_manual_review_notes = "人工核對無誤"
+    db_sync.commit()
+
+    forced = RosterService(db_sync).generate_rosters_from_distribution(
+        scholarship_type_id=sch.id,
+        academic_year=115,
+        semester="first",
+        created_by_user_id=admin.id,
+        student_verification_enabled=False,
+        force_regenerate=True,
+    )
+    assert len(forced.created) == 1
+
+    by_app = {i.application_id: i for i in _items(db_sync, roster_id)}
+    assert by_app[returned.id].is_included is False
+    assert by_app[returned.id].exclusion_reason == "學生放棄"
+    assert by_app[returned.id].bank_manual_review_notes == "人工核對無誤"
+    assert by_app[kept.id].is_included is True
+    # 人數/金額 must reflect the preserved exclusion.
+    assert forced.created[0].qualified_count == 1
+    # A successful rebuild + re-export leaves no stale-Excel hint behind.
+    assert forced.created[0].excel_stale is False
+
+
+def test_regenerate_reinstates_a_reconcile_removed_student_who_is_allocated_again(db_sync):
+    """比對分發移除 records「不在分發名單」— a derived fact, not a verdict about the
+    student. Once the student is allocated again the reason is false, so the
+    rebuild must re-include them rather than freeze them out."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_rec", name="RegenRec", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENREC-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "rc_a"), sch, cfg, app_id="APP-RC-A", std_code="115A")
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    item = _items(db_sync, roster_id)[0]
+    item.is_included = False
+    item.exclusion_reason = f"{MANUAL_REMOVAL_PREFIX_RECONCILE}：不在分發名單"
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.preserved_exclusions == 0
+    rebuilt = _items(db_sync, roster_id)[0]
+    assert rebuilt.is_included is True
+    assert rebuilt.exclusion_reason is None
+
+
+def test_regenerate_reports_newly_excluded_students(db_sync):
+    """A student who was included but fails today's verdicts must be counted and
+    reported — silently dropping them would also silently undo an admin 回復."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_new", name="RegenNew", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENNEW-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "nx_a"), sch, cfg, app_id="APP-NX-A", std_code="115A")
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+    assert _items(db_sync, roster_id)[0].is_included is True
+
+    # Re-verify against SIS, which now reports the student as graduated.
+    with patch(EXPORT_TARGET), patch("app.services.roster_service.StudentVerificationService") as svs:
+        svs.return_value.verify_student.return_value = {
+            "status": StudentVerificationStatus.GRADUATED,
+            "message": "已畢業",
+        }
+        result = RosterRegenerationService(db_sync).regenerate_roster(
+            roster_id=roster_id, admin_user_id=admin.id, student_verification_enabled=True
+        )
+
+    assert result.newly_excluded == 1
+    assert result.preserved_exclusions == 0
+    assert _items(db_sync, roster_id)[0].is_included is False
+
+
+def test_regenerate_does_not_preserve_automatic_exclusions(db_sync):
+    """Only HUMAN decisions survive. A rule/學籍 exclusion is a derived verdict and
+    must be recomputed — otherwise a student who has since become eligible could
+    never be re-included by a rebuild."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_auto", name="RegenAuto", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENAUTO-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "auto_a"), sch, cfg, app_id="APP-AUTO-A", std_code="115A")
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    item = _items(db_sync, roster_id)[0]
+    item.is_included = False
+    item.exclusion_reason = "學籍驗證未通過：已畢業"
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.preserved_exclusions == 0
+    rebuilt = _items(db_sync, roster_id)[0]
+    assert rebuilt.is_included is True
+    assert rebuilt.exclusion_reason is None
+
+
+def test_regenerate_preserves_bank_review_state(db_sync):
+    """Human bank-account review verdicts are not re-derivable by a rebuild."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_bank", name="RegenBank", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENBANK-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "bank_a"), sch, cfg, app_id="APP-BANK-A", std_code="115A")
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    item = _items(db_sync, roster_id)[0]
+    item.bank_account_number_status = "verified"
+    item.bank_manual_review_notes = "人工核對無誤"
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    rebuilt = _items(db_sync, roster_id)[0]
+    assert rebuilt.bank_account_number_status == "verified"
+    assert rebuilt.bank_manual_review_notes == "人工核對無誤"
+
+
+def test_regenerate_keeps_approved_renewals(db_sync):
+    """續領 students never own a CollegeRankingItem, so a distribution-only
+    rebuild would silently drop them from the roster."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_renew", name="RegenRenew", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENRENEW-115")
+    ranking = _ranking(db_sync, sch)
+
+    new_app = _application(db_sync, _student(db_sync, "rn_a"), sch, cfg, app_id="APP-RN-A", std_code="115A")
+    _allocate(db_sync, ranking, new_app, cfg)
+    renewal = _application(
+        db_sync, _student(db_sync, "rn_b"), sch, cfg, app_id="APP-RN-B", std_code="115B", is_renewal=True
+    )
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+    assert {i.application_id for i in _items(db_sync, roster_id)} == {new_app.id, renewal.id}
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.rebuilt_items == 2
+    assert {i.application_id for i in _items(db_sync, roster_id)} == {new_app.id, renewal.id}
+
+
+def test_regenerate_clears_excel_stale_on_successful_export(db_sync):
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_xls", name="RegenXls", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENXLS-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "xls_a"), sch, cfg, app_id="APP-XLS-A", std_code="115A")
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+    roster.excel_stale = True
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.excel_exported is True
+    assert result.roster.excel_stale is False
+
+
+def test_regenerate_marks_excel_stale_when_export_fails(db_sync):
+    """A failed re-export must not be swallowed as a clean roster: the file on
+    MinIO no longer matches the items, so the 需重新匯出 hint has to stay on."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_xfail", name="RegenXFail", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENXFAIL-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "xf_a"), sch, cfg, app_id="APP-XF-A", std_code="115A")
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    with patch(EXPORT_TARGET) as export_cls:
+        export_cls.return_value.export_roster_to_excel.side_effect = RuntimeError("minio down")
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    # The rebuild itself still succeeded — only the file is out of date.
+    assert result.excel_exported is False
+    assert result.roster.status == RosterStatus.COMPLETED
+    assert result.roster.excel_stale is True
+
+
+def test_regenerate_refuses_locked_roster(db_sync):
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_lock", name="RegenLock", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENLOCK-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "lk_a"), sch, cfg, app_id="APP-LK-A", std_code="115A")
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster.status = RosterStatus.LOCKED
+    db_sync.commit()
+
+    with pytest.raises(RosterLockedError) as exc:
+        RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster.id, admin_user_id=admin.id)
+    assert "已鎖定" in str(exc.value)
+    # Items must survive an refused regenerate untouched.
+    assert len(_items(db_sync, roster.id)) == 1
+
+
+def test_regenerate_unknown_roster_raises_not_found(db_sync):
+    admin = _admin(db_sync)
+    with pytest.raises(RosterNotFoundError):
+        RosterRegenerationService(db_sync).regenerate_roster(roster_id=999999, admin_user_id=admin.id)
+
+
+def test_regenerate_refuses_when_distribution_is_empty(db_sync):
+    """Never silently blank a roster: if the distribution no longer holds anyone
+    for this group, say so and leave the existing items alone."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_empty", name="RegenEmpty", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENEMPTY-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "em_a"), sch, cfg, app_id="APP-EM-A", std_code="115A")
+    ranking_item = _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    ranking_item.is_allocated = False
+    db_sync.commit()
+
+    with pytest.raises(ValueError) as exc:
+        RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+    assert "沒有可造冊的資料" in str(exc.value)
+    assert len(_items(db_sync, roster_id)) == 1
+    assert db_sync.get(PaymentRoster, roster_id).status == RosterStatus.COMPLETED
+
+
+def test_regenerate_refuses_when_every_member_is_no_longer_approved(db_sync):
+    """The emptiness guard must run against the APPROVED set, not the raw
+    distribution ids — an allocated-but-no-longer-approved application would
+    otherwise blank the roster, mark it COMPLETED and export an empty Excel."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_unappr", name="RegenUnappr", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENUNAPPR-115")
+    ranking = _ranking(db_sync, sch)
+    app = _application(db_sync, _student(db_sync, "ua_a"), sch, cfg, app_id="APP-UA-A", std_code="115A")
+    _allocate(db_sync, ranking, app, cfg)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    # Application reverted (回發) without the ranking item being de-allocated.
+    app.status = ApplicationStatus.under_review
+    db_sync.commit()
+
+    with pytest.raises(ValueError) as exc:
+        RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+    assert "沒有可造冊的資料" in str(exc.value)
+    assert len(_items(db_sync, roster_id)) == 1
+    assert db_sync.get(PaymentRoster, roster_id).status == RosterStatus.COMPLETED
+
+
+def test_regenerate_reports_students_dropped_from_the_distribution(db_sync):
+    """A student who left the 名單 entirely is in neither rebuilt_items nor
+    failed_items, so without its own counter they would vanish in silence."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_drop", name="RegenDrop", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENDROP-115")
+    ranking = _ranking(db_sync, sch)
+    kept = _application(db_sync, _student(db_sync, "dp_a"), sch, cfg, app_id="APP-DP-A", std_code="115A")
+    leaving = _application(db_sync, _student(db_sync, "dp_b"), sch, cfg, app_id="APP-DP-B", std_code="115B")
+    _allocate(db_sync, ranking, kept, cfg)
+    leaving_item = _allocate(db_sync, ranking, leaving, cfg, rank_position=2)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+    assert len(_items(db_sync, roster_id)) == 2
+
+    leaving_item.is_allocated = False
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.rebuilt_items == 1
+    assert result.dropped_members == 1
+    assert {i.application_id for i in _items(db_sync, roster_id)} == {kept.id}
+
+
+def test_totals_always_match_the_item_rows(db_sync):
+    """total_applications must equal count(items): folding a `failed` count into
+    the item-derived totals makes the roster's 人數 jump back on the next
+    reconcile/排除, which recomputes purely from the rows."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="regen_tot", name="RegenTot", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="REGENTOT-115")
+    ranking = _ranking(db_sync, sch)
+    good = _application(db_sync, _student(db_sync, "tt_a"), sch, cfg, app_id="APP-TT-A", std_code="115A")
+    broken = _application(db_sync, _student(db_sync, "tt_b"), sch, cfg, app_id="APP-TT-B", std_code="115B")
+    _allocate(db_sync, ranking, good, cfg)
+    _allocate(db_sync, ranking, broken, cfg, rank_position=2)
+    db_sync.commit()
+
+    roster = _generate(db_sync, sch, admin)
+    roster_id = roster.id
+
+    # Corrupt one snapshot so _verify_and_create_item raises for that row.
+    broken.student_data = {"std_stdcode": None, "std_cname": None}
+    db_sync.commit()
+
+    with patch(EXPORT_TARGET):
+        result = RosterRegenerationService(db_sync).regenerate_roster(roster_id=roster_id, admin_user_id=admin.id)
+
+    assert result.failed_items == 1
+    assert result.rebuilt_items == 1
+    rebuilt_roster = db_sync.get(PaymentRoster, roster_id)
+    assert rebuilt_roster.total_applications == len(_items(db_sync, roster_id))
+    assert rebuilt_roster.disqualified_count == (rebuilt_roster.total_applications - rebuilt_roster.qualified_count)
+
+
+def test_whole_period_force_regenerate_preserves_manual_exclusion(db_sync):
+    """generate_roster(force_regenerate=True) — the 立即產生/重新產生 path — wipes
+    items too, so it must honour the same preservation invariant."""
+    admin = _admin(db_sync)
+    sch = ScholarshipType(code="wp_excl", name="WholePeriodExcl", description="x")
+    db_sync.add(sch)
+    db_sync.flush()
+    cfg = _config(db_sync, sch, code="WPEXCL-115")
+    app = _application(db_sync, _student(db_sync, "wp_a"), sch, cfg, app_id="APP-WP-A", std_code="115A")
+    db_sync.commit()
+
+    svc = RosterService(db_sync)
+    kwargs = dict(
+        scholarship_configuration_id=cfg.id,
+        period_label="115",
+        roster_cycle=RosterCycle.YEARLY,
+        academic_year=115,
+        created_by_user_id=admin.id,
+        student_verification_enabled=False,
+    )
+    roster = svc.generate_roster(**kwargs)
+    roster_id = roster.id
+    assert len(_items(db_sync, roster_id)) == 1
+
+    item = _items(db_sync, roster_id)[0]
+    item.is_included = False
+    item.exclusion_reason = "學生繳回: 已退款"
+    item.bank_account_holder_status = "verified"
+    db_sync.commit()
+
+    svc.generate_roster(**kwargs, force_regenerate=True)
+
+    rebuilt = _items(db_sync, roster_id)[0]
+    assert rebuilt.application_id == app.id
+    assert rebuilt.is_included is False
+    assert rebuilt.exclusion_reason == "學生繳回: 已退款"
+    assert rebuilt.bank_account_holder_status == "verified"

--- a/frontend/components/__tests__/roster-list-table-regenerate.test.tsx
+++ b/frontend/components/__tests__/roster-list-table-regenerate.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Pins the 重新生成 action on the 造冊列表 row.
+ *
+ * The gating is subtle and was wrong once: the cycle-status endpoint collapses
+ * BOTH `COMPLETED` and `LOCKED` rosters into `period.status = "completed"`, and
+ * only `period.roster_status` carries the real state. A gate written against
+ * `period.status` therefore offers 重新生成 on a locked roster, which the backend
+ * refuses with 400「請先解鎖」.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { RosterListTable } from "../roster/RosterListTable";
+import { apiClient } from "@/lib/api";
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+const basePeriod = {
+  label: "115",
+  status: "completed" as const,
+  roster_id: 42,
+  roster_code: "ROSTER-115-nstc",
+  roster_status: "completed",
+  sub_type: "nstc",
+  allocation_year: 115,
+  qualified_count: 3,
+};
+
+function renderTable(
+  overrides: Partial<typeof basePeriod> = {},
+  onRosterGenerated = jest.fn()
+) {
+  render(
+    <RosterListTable
+      periods={[{ ...basePeriod, ...overrides }]}
+      configId={1}
+      rosterCycle="yearly"
+      onRosterGenerated={onRosterGenerated}
+    />
+  );
+  return { onRosterGenerated };
+}
+
+describe("RosterListTable 重新生成", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it("offers 重新生成 on a completed roster", () => {
+    renderTable();
+    expect(screen.getByRole("button", { name: /重新生成/ })).toBeInTheDocument();
+  });
+
+  it("hides 重新生成 on a LOCKED roster even though period.status says completed", () => {
+    // This exact shape is what /cycle-status returns for a locked roster.
+    renderTable({ status: "completed", roster_status: "locked" });
+    expect(screen.queryByRole("button", { name: /重新生成/ })).toBeNull();
+    expect(screen.getByText("已鎖定")).toBeInTheDocument();
+  });
+
+  it("regenerates by roster_id and refreshes the parent after confirmation", async () => {
+    const spy = jest
+      .spyOn(apiClient.paymentRosters, "regenerateRoster")
+      .mockResolvedValue({
+        success: true,
+        message: "已重新生成造冊：3 筆明細",
+        data: undefined,
+      } as never);
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+
+    const { onRosterGenerated } = renderTable();
+    fireEvent.click(screen.getByRole("button", { name: /重新生成/ }));
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith(42));
+    await waitFor(() => expect(onRosterGenerated).toHaveBeenCalled());
+  });
+
+  it("does not call the API when the admin cancels the confirmation", () => {
+    const spy = jest.spyOn(apiClient.paymentRosters, "regenerateRoster");
+    jest.spyOn(window, "confirm").mockReturnValue(false);
+
+    renderTable();
+    fireEvent.click(screen.getByRole("button", { name: /重新生成/ }));
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
+++ b/frontend/components/admin/manual-distribution/ManualDistributionPanel.tsx
@@ -864,7 +864,11 @@ export function ManualDistributionPanel({
     }
   };
 
-  const handleGenerateRosters = async () => {
+  /**
+   * 產生造冊。`forceRegenerate` 為 true 時會重建「已存在」的造冊——不需要人員有
+   * 異動也能以最新的分發／學生資料重新生成（已鎖定的造冊仍會被後端擋下）。
+   */
+  const handleGenerateRosters = async (forceRegenerate = false) => {
     if (!scholarshipTypeId || !selectedAcademicYear || !selectedSemester)
       return;
     setIsGeneratingRosters(true);
@@ -877,12 +881,15 @@ export function ManualDistributionPanel({
           academic_year: selectedAcademicYear,
           semester: selectedSemester,
           student_verification_enabled: false,
+          force_regenerate: forceRegenerate,
         });
       if (resp.success && resp.data) {
         setRosterResult(resp.data);
+        // 後端回傳的 message 會誠實交代「已存在未重新產生 / 已鎖定」的份數；
+        // 只印 rosters_created 會讓「0 個」看起來像失敗。
         setSaveMessage({
           type: "success",
-          text: `已產生 ${resp.data.rosters_created} 個造冊`,
+          text: resp.message || `已產生 ${resp.data.rosters_created} 個造冊`,
         });
       } else {
         setSaveMessage({ type: "error", text: resp.message || "造冊產生失敗" });
@@ -1359,12 +1366,49 @@ export function ManualDistributionPanel({
                     <AlertDialogDescription>
                       系統將依據已完成分發的結果，針對每個（子類型 ×
                       配額年度）組合各產生一份造冊。此操作需要分發已完成（已確認分發）。
+                      已存在的造冊會被略過——如需以最新的分發／學生資料重建，請改按「重新生成造冊」。
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>
                     <AlertDialogCancel>取消</AlertDialogCancel>
-                    <AlertDialogAction onClick={handleGenerateRosters}>
+                    <AlertDialogAction onClick={() => handleGenerateRosters()}>
                       確認產生
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={isGeneratingRosters || isLoading}
+                    title="重建已存在的造冊名單（不需人員有異動）"
+                  >
+                    {isGeneratingRosters ? (
+                      <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                    ) : (
+                      <RefreshCw className="h-4 w-4 mr-1" />
+                    )}
+                    重新生成造冊
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>確認重新生成造冊？</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      系統會依<strong>當下</strong>
+                      的分發名單與學生資料，重建每個（子類型 ×
+                      配額年度）組合的造冊名單——即使人員沒有異動也可以執行，並重新匯出
+                      Excel。您先前的人為排除／移除會保留；已鎖定的造冊不會被重建，需先解鎖。
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>取消</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => handleGenerateRosters(true)}
+                    >
+                      確認重新生成
                     </AlertDialogAction>
                   </AlertDialogFooter>
                 </AlertDialogContent>

--- a/frontend/components/roster/RosterDetailDialog.tsx
+++ b/frontend/components/roster/RosterDetailDialog.tsx
@@ -31,7 +31,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Loader2, Lock, LockOpen, X, AlertTriangle, RefreshCw, RotateCcw } from "lucide-react";
+import { Loader2, Lock, LockOpen, X, AlertTriangle, RefreshCw, RotateCcw, RefreshCcw } from "lucide-react";
 import { toast } from "sonner";
 import { apiClient } from "@/lib/api";
 import type { RevokedSuspendedList, DistributionDiff, DistributionDiffEntry } from "@/lib/api/modules/payment-rosters";
@@ -126,6 +126,11 @@ export function RosterDetailDialog({
 
   const [isLocking, setIsLocking] = useState(false);
   const [isUnlocking, setIsUnlocking] = useState(false);
+
+  // 重新生成造冊 — 不需要人員有異動即可重建整份名單
+  const [showRegenerateConfirm, setShowRegenerateConfirm] = useState(false);
+  const [regenerateVerify, setRegenerateVerify] = useState(false);
+  const [isRegenerating, setIsRegenerating] = useState(false);
 
   // 資格對比 detail dialog state
   const [eligibilityTarget, setEligibilityTarget] = useState<RosterItem | null>(null);
@@ -256,6 +261,41 @@ export function RosterDetailDialog({
       toast.error(e instanceof Error ? e.message : "解鎖失敗");
     } finally {
       setIsUnlocking(false);
+    }
+  };
+
+  const handleRegenerate = async () => {
+    if (!period.roster_id) return;
+    setIsRegenerating(true);
+    try {
+      // Additive only: ticked → force verification on for THIS run; unticked →
+      // send nothing and inherit the roster's own setting. Never send an
+      // explicit `false` — the box starts unticked every time, so doing so
+      // would silently DISABLE verification on a roster that was generated with
+      // it on, re-including 已畢業/已退學 students into a payment roster.
+      // The backend does not persist the override, so this cannot latch on.
+      const resp = await apiClient.paymentRosters.regenerateRoster(
+        period.roster_id,
+        regenerateVerify ? { student_verification_enabled: true } : undefined
+      );
+      if (resp.success) {
+        setShowRegenerateConfirm(false);
+        // Same post-mutation sequence as reconcile: refresh the dialog's own
+        // snapshot first (the `period` prop is frozen from when it opened),
+        // then let the parent refetch its list badges.
+        await Promise.all([loadRosterItems(), fetchAuditLogs()]);
+        setDiff(null);
+        setExcelStale(resp.data?.excel_stale ?? false);
+        onRosterChanged?.();
+        toast.success(resp.message || "造冊已重新生成");
+      } else {
+        toast.error(resp.message || "重新生成造冊失敗");
+      }
+    } catch (e) {
+      logger.error("regenerate roster failed", { error: e });
+      toast.error(e instanceof Error ? e.message : "重新生成造冊失敗");
+    } finally {
+      setIsRegenerating(false);
     }
   };
 
@@ -856,6 +896,25 @@ export function RosterDetailDialog({
 
           {period.roster_id && (
             <div className="mt-3 flex gap-2 justify-end">
+              {period.roster_status !== "locked" && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setRegenerateVerify(false);
+                    setShowRegenerateConfirm(true);
+                  }}
+                  disabled={isRegenerating || loading}
+                  title="依當下的分發名單與學生資料重建整份名單（不需人員有異動）"
+                >
+                  {isRegenerating ? (
+                    <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                  ) : (
+                    <RefreshCcw className="h-4 w-4 mr-1" />
+                  )}
+                  重新生成造冊
+                </Button>
+              )}
               {period.roster_status !== "locked" ? (
                 <Button
                   size="sm"
@@ -950,6 +1009,63 @@ export function RosterDetailDialog({
         item={eligibilityTarget}
         onClose={() => setEligibilityTarget(null)}
       />
+
+      {/* 重新生成造冊 — confirm + 學籍驗證 option */}
+      <Dialog
+        open={showRegenerateConfirm}
+        onOpenChange={open =>
+          !open && !isRegenerating && setShowRegenerateConfirm(false)
+        }
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>確認重新生成造冊？</DialogTitle>
+            <DialogDescription asChild>
+              <div className="space-y-2 text-left">
+                <p>
+                  系統會依<strong>當下</strong>
+                  的分發名單、學生資料與獎學金設定，重建本造冊的全部明細——
+                  即使名單人員沒有異動也可以執行。
+                </p>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>刷新金額、計畫編號、郵局帳號與規則資格判定</li>
+                  <li>補上已分發但不在造冊中的學生，移除已不在分發名單者</li>
+                  <li>
+                    <strong>保留</strong>
+                    您先前的人為排除／移除（學生繳回、放棄…）與人工帳戶覆核
+                  </li>
+                  <li>完成後會重新匯出 Excel</li>
+                </ul>
+              </div>
+            </DialogDescription>
+          </DialogHeader>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={regenerateVerify}
+              onChange={e => setRegenerateVerify(e.target.checked)}
+              disabled={isRegenerating}
+            />
+            同時重新驗證學籍（較慢，會排除已休學／退學／畢業的學生）。
+            不勾選則沿用本造冊原本的驗證設定。
+          </label>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowRegenerateConfirm(false)}
+              disabled={isRegenerating}
+            >
+              取消
+            </Button>
+            <Button onClick={handleRegenerate} disabled={isRegenerating}>
+              {isRegenerating ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : null}
+              確認重新生成
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* 比對分發名單 — single-row confirm */}
       <Dialog

--- a/frontend/components/roster/RosterListTable.tsx
+++ b/frontend/components/roster/RosterListTable.tsx
@@ -21,6 +21,8 @@ import {
   CheckCircle2,
   XCircle,
   Loader2,
+  RefreshCcw,
+  Lock,
 } from "lucide-react";
 import { RosterDetailDialog } from "./RosterDetailDialog";
 import { apiClient } from "@/lib/api";
@@ -74,6 +76,7 @@ export function RosterListTable({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [generating, setGenerating] = useState<string | null>(null);
   const [downloading, setDownloading] = useState<number | null>(null);
+  const [regenerating, setRegenerating] = useState<number | null>(null);
 
   const formatDate = (dateStr: string | null | undefined) => {
     if (!dateStr) return "-";
@@ -186,6 +189,45 @@ export function RosterListTable({
     }
   };
 
+  /**
+   * 重新生成一份既有造冊的名單。
+   *
+   * 以 roster_id 定位（不是 period_label）：矩陣分發下同一個 period_label 底下
+   * 會有多份 (子類型 × 配額年度) 造冊，走 handleGenerateNow 的 config+期間鍵
+   * 會打到別份造冊。
+   */
+  const handleRegenerate = async (period: Period) => {
+    if (!period.roster_id) return;
+    if (
+      !window.confirm(
+        `確認重新生成「${period.label}${period.sub_type ? ` · ${period.sub_type}` : ""}」的造冊名單？\n\n` +
+          "系統會依當下的分發名單與學生資料重建全部明細並重新匯出 Excel；" +
+          "您先前的人為排除／移除會保留。"
+      )
+    )
+      return;
+
+    setRegenerating(period.roster_id);
+    try {
+      const response = await apiClient.paymentRosters.regenerateRoster(
+        period.roster_id
+      );
+      if (response.success) {
+        toast.success(response.message || "造冊已重新生成");
+        onRosterGenerated?.();
+      } else {
+        throw new Error(response.message || "重新生成造冊失敗");
+      }
+    } catch (error: unknown) {
+      logger.error("Failed to regenerate roster", { error: error });
+      toast.error(
+        error instanceof Error ? error.message : "重新生成造冊失敗"
+      );
+    } finally {
+      setRegenerating(null);
+    }
+  };
+
   const getRowClassName = (status: string) => {
     switch (status) {
       case "completed":
@@ -285,15 +327,19 @@ export function RosterListTable({
 
                     {/* 狀態 */}
                     <TableCell className="whitespace-nowrap">
-                      {period.status === "completed" ? (
+                      {/* 已鎖定要先判斷：cycle-status 把 LOCKED 與 COMPLETED 都
+                          折成 status="completed"，只看 status 會讓「已鎖定」永遠
+                          顯示成「已完成」——管理員就看不出為何沒有「重新生成」。 */}
+                      {period.roster_status === "locked" ||
+                      period.status === "locked" ? (
+                        <Badge variant="default" className="bg-slate-600">
+                          <Lock className="mr-1 h-3 w-3" />
+                          已鎖定
+                        </Badge>
+                      ) : period.status === "completed" ? (
                         <Badge variant="default" className="bg-green-600">
                           <CheckCircle2 className="mr-1 h-3 w-3" />
                           已完成
-                        </Badge>
-                      ) : period.status === "locked" ? (
-                        <Badge variant="default" className="bg-green-600">
-                          <CheckCircle2 className="mr-1 h-3 w-3" />
-                          已鎖定
                         </Badge>
                       ) : period.status === "failed" ? (
                         <Badge variant="destructive">
@@ -373,6 +419,28 @@ export function RosterListTable({
                             <Eye className="mr-1 h-4 w-4" />
                             查看名單
                           </Button>
+                          {/* 已鎖定的造冊不可重建（後端會擋），需先解鎖。
+                              必須看 roster_status：cycle-status 把 LOCKED 與
+                              COMPLETED 都折成 period.status="completed"，只有
+                              roster_status 帶真正的造冊狀態。 */}
+                          {period.roster_status !== "locked" && period.roster_id && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleRegenerate(period)}
+                              disabled={regenerating === period.roster_id}
+                              title="依當下的分發名單與學生資料重建名單（不需人員有異動）"
+                            >
+                              {regenerating === period.roster_id ? (
+                                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                              ) : (
+                                <RefreshCcw className="mr-1 h-4 w-4" />
+                              )}
+                              {regenerating === period.roster_id
+                                ? "生成中..."
+                                : "重新生成"}
+                            </Button>
+                          )}
                           <Button
                             size="sm"
                             variant="default"

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -6734,6 +6734,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/payment-rosters/{roster_id}/regenerate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Regenerate Roster Endpoint
+         * @description 重新生成造冊：依當下的分發名單、學生資料、獎學金規則與配置重建全部明細。
+         *
+         *     不需要人員有異動即可執行——「比對分發名單」(reconcile) 只在名單有差異時
+         *     才有動作可做，本端點則刷新每一筆明細的內容（金額、計畫編號、學籍驗證、
+         *     規則判定、郵局帳號…）並重新匯出 Excel。
+         *
+         *     管理員的人為排除／移除與人工銀行覆核狀態會跨重建保留。已鎖定的造冊不可
+         *     重新生成（400），請先解鎖。
+         */
+        post: operations["regenerate_roster_endpoint_api_v1_payment_rosters__roster_id__regenerate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/roster-schedules": {
         parameters: {
             query?: never;
@@ -10019,6 +10046,17 @@ export interface components {
              * @description Roster code (if roster exists)
              */
             roster_code?: string | null;
+        };
+        /**
+         * RegenerateRosterRequest
+         * @description Body for POST /payment-rosters/{roster_id}/regenerate.
+         */
+        RegenerateRosterRequest: {
+            /**
+             * Student Verification Enabled
+             * @description 本次是否重新驗證學籍（單次覆寫，不會寫回造冊設定）；未提供則沿用造冊原本的設定
+             */
+            student_verification_enabled?: boolean | null;
         };
         /**
          * RemoveLockedItemRequest
@@ -22194,6 +22232,41 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["ReconcileRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    regenerate_roster_endpoint_api_v1_payment_rosters__roster_id__regenerate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                roster_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RegenerateRosterRequest"] | null;
             };
         };
         responses: {

--- a/frontend/lib/api/modules/__tests__/payment-rosters.test.ts
+++ b/frontend/lib/api/modules/__tests__/payment-rosters.test.ts
@@ -14,8 +14,11 @@
  *    false (conservative — don't overwrite existing)
  *  - Defaults applied via `??` so explicit false/false-y values
  *    pass through correctly
+ *  - regenerateRoster targets the roster-id-scoped path (a
+ *    period_label-keyed rebuild would hit the wrong roster when
+ *    one period holds several sub_type × 配額年度 rosters)
  *
- * 11 cases.
+ * 13 cases.
  */
 
 import { createPaymentRostersApi } from "../payment-rosters";
@@ -251,6 +254,38 @@ describe("reconcileRoster", () => {
       }
     );
     expect(res.success).toBe(true);
+  });
+});
+
+describe("regenerateRoster", () => {
+  it("POSTs to the roster-id-scoped regenerate path", async () => {
+    mockedRaw.POST.mockResolvedValueOnce(
+      _ok({ roster_id: 7, rebuilt_items: 3, preserved_exclusions: 1 })
+    );
+    const api = createPaymentRostersApi();
+
+    const res = await api.regenerateRoster(7);
+
+    expect(mockedRaw.POST).toHaveBeenCalledWith(
+      "/api/v1/payment-rosters/{roster_id}/regenerate",
+      {
+        params: { path: { roster_id: 7 } },
+        body: { student_verification_enabled: null },
+      }
+    );
+    expect(res.success).toBe(true);
+    expect(res.data?.preserved_exclusions).toBe(1);
+  });
+
+  it("forwards the 學籍驗證 override when supplied", async () => {
+    mockedRaw.POST.mockResolvedValueOnce(_ok({ roster_id: 7 }));
+    const api = createPaymentRostersApi();
+
+    await api.regenerateRoster(7, { student_verification_enabled: true });
+
+    expect(mockedRaw.POST.mock.calls[0][1].body).toEqual({
+      student_verification_enabled: true,
+    });
   });
 });
 

--- a/frontend/lib/api/modules/manual-distribution.ts
+++ b/frontend/lib/api/modules/manual-distribution.ts
@@ -372,6 +372,12 @@ export interface GenerateRostersRequest {
 export interface GenerateRostersResult {
   rosters_created: number;
   rosters: RosterSummary[];
+  /** 已存在、未重新產生（force_regenerate=false 時）的造冊 */
+  rosters_skipped?: number;
+  skipped_rosters?: RosterSummary[];
+  /** 已鎖定、force_regenerate 也無法重建的造冊 */
+  rosters_locked?: number;
+  locked_rosters?: RosterSummary[];
 }
 
 export interface DistributionSummaryStudent {

--- a/frontend/lib/api/modules/payment-rosters.ts
+++ b/frontend/lib/api/modules/payment-rosters.ts
@@ -52,6 +52,29 @@ export interface DistributionDiff {
   to_remove: DistributionDiffEntry[];
 }
 
+export interface RegenerateRosterResult {
+  roster_id: number;
+  roster_code: string;
+  status: string;
+  project_number: string | null;
+  /** 重建成功的明細數 */
+  rebuilt_items: number;
+  /** 資料不全、未能重建的申請數 */
+  failed_items: number;
+  /** 跨重建保留的人為排除（學生繳回／放棄／移除）數 */
+  preserved_exclusions: number;
+  /** 先前納入、依當下資料改為排除的明細數 */
+  newly_excluded: number;
+  /** 先前納入、如今已不在分發名單中的學生數 */
+  dropped_members: number;
+  qualified_count: number;
+  disqualified_count: number;
+  total_applications: number;
+  total_amount: number;
+  excel_exported: boolean;
+  excel_stale: boolean;
+}
+
 export interface ReconcileResult {
   added: { application_id: number | null; item_id: number | null; is_included: boolean | null; exclusion_reason: string | null }[];
   removed: { application_id: number | null; item_id: number | null }[];
@@ -354,17 +377,27 @@ export function createPaymentRostersApi() {
     },
 
     /**
-     * 重新產生造冊
-     * Note: POST /payment-rosters/{roster_id}/regenerate is not in the OpenAPI schema
-     * (orphan endpoint, see issue #665). Using `as any` to bypass typed routing.
+     * 重新生成造冊：依當下的分發名單、學生資料與設定重建全部明細
+     * POST /api/v1/payment-rosters/{roster_id}/regenerate
+     *
+     * 與 reconcileRoster 互補——reconcile 只增減名單成員（名單一致時無事可做），
+     * 本端點則刷新每一筆明細的內容並重新匯出 Excel。人為排除會跨重建保留。
      */
-    regenerateRoster: async (roster_id: number): Promise<ApiResponse<unknown>> => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = await (typedClient.raw.POST as any)(
+    regenerateRoster: async (
+      roster_id: number,
+      body?: { student_verification_enabled?: boolean }
+    ): Promise<ApiResponse<RegenerateRosterResult>> => {
+      const response = await typedClient.raw.POST(
         '/api/v1/payment-rosters/{roster_id}/regenerate',
-        { params: { path: { roster_id } } }
+        {
+          params: { path: { roster_id } },
+          body: {
+            student_verification_enabled:
+              body?.student_verification_enabled ?? null,
+          },
+        }
       );
-      return toApiResponse(response);
+      return toApiResponse(response) as ApiResponse<RegenerateRosterResult>;
     },
 
     /**


### PR DESCRIPTION
## 問題

管理員只能透過「比對分發名單」(reconcile) 更新造冊，而它**只有在名單成員真的有差異時**才有動作可做。名單一致時無事可做，於是：

- 生成造冊後才補填的**計畫編號**永遠上不了造冊
- 事後修正的**金額**、調整過的**獎學金規則**、學生補件的**郵局帳號**都不會反映
- 造冊實際上處於「除非有人員異動，否則永遠停在生成當下」的狀態

## 做法

新增「重新生成造冊」，兩個入口都不需要人員有異動：

- **單一造冊** — `POST /payment-rosters/{roster_id}/regenerate`（新的 `RosterRegenerationService`，繼承 `RosterService` 以共用名單解析與明細建立原語，確保與「生成造冊」不會各自漂移）。
  這同時補上一個既有破口：前端早就有 `regenerateRoster()` 指向這個路徑，但後端從來沒有這個路由（#665），呼叫必定 404。
- **批次** — 手動分發面板的「重新生成造冊」送出 `force_regenerate`。後端自 #1033 起就接受這個參數，但沒有任何 UI 送過；面板現在也改為顯示後端誠實的「已存在／已鎖定」訊息，而非只印 `rosters_created`（否則「0 個」看起來像失敗）。

### 保留人為決定（本 PR 最重要的部分）

重建會**整批刪除再重建**明細，因此把保留原語提升到 `RosterService`，**三條重建路徑**一致套用：

| 狀態 | 是否跨重建保留 | 理由 |
|---|---|---|
| 人為排除（學生繳回／放棄／鎖定後移除） | ✅ 保留 | 管理員對這位學生的判斷 |
| 人工銀行帳戶覆核狀態 | ✅ 保留 | 重建無法重新推導 |
| 比對分發移除 | ❌ 不保留 | 記錄的是「不在分發名單」這個事實，重建會重新推導；學生若重新獲得分發就該回來 |
| 學籍／規則自動排除 | ❌ 不保留 | 依當下資料重算，否則已恢復資格的學生永遠回不來 |

不保留人為排除的話，重建會**無聲地**把已排除的學生重新納入造冊，並灌水該生的累計領取月份 —— 那正是博士 36 個月上限的依據。

### 誠實回報

學生離開造冊的**每一種方式**都單獨計數並回報（`preserved` / `newly_excluded` / `dropped` / `failed`），不會摺疊成一個數字。名單也在**刪除之前**解析並檢查是否為空 —— 否則一份分發已被撤下的造冊會被清空、標記完成、匯出空白 Excel，訊息卻回報成功。

### 其他

- 已鎖定的造冊拒絕重建（需先解鎖）
- 「同時重新驗證學籍」是**單次**加購式覆寫，不寫回造冊設定：既不會勾一次就永久卡住，也不會反過來關掉原本開著驗證的造冊
- 重新匯出成功清除 `excel_stale`，失敗則設起來
- 批次重建對造冊主檔加 `SELECT ... FOR UPDATE`
- 造冊列表的「已鎖定」badge 與按鈕改看 `roster_status` —— `cycle-status` 會把 LOCKED 摺成 `status="completed"`，只看 `status` 會讓已鎖定造冊顯示成已完成並出現不該有的按鈕

## 測試

新增 25 個後端測試（`test_roster_regeneration_service.py`、`test_roster_regenerate_api.py`）與 4 個前端元件測試，釘住：無異動重建、續領學生不被丟掉、人為排除保留、比對分發移除**不**保留、`dropped`/`newly_excluded` 回報、總數恆等於明細列數、鎖定拒絕、批次路徑同樣保留、全期造冊路徑同樣保留。

本機驗證（rebase 到最新 main 之後）：

- backend unit lane **3398 passed**、integration lane **1752 passed**
- black + flake8 `B904,B014` clean
- `tsc --noEmit` clean、eslint clean、前端 jest 65 passed
- `schema.d.ts` 以 CI 相同環境（python:3.13-slim + pinned requirements）重新產生，與 rebase 合併後的檔案**完全一致**

## 測試計畫

- [ ] 造冊 → 到獎學金設定補填計畫編號 → 重新生成 → 確認計畫編號出現在造冊與 Excel
- [ ] 排除一位學生（學生繳回）→ 重新生成 → 確認該生仍為排除、人數未增加、訊息顯示「保留 1 筆人為排除」
- [ ] 鎖定造冊 → 確認「重新生成」按鈕消失、列表顯示「已鎖定」
- [ ] 手動分發面板「重新生成造冊」→ 確認已存在的造冊被重建而非略過

## 備註

無 migration。`POST /payment-rosters/{roster_id}/regenerate` 是新路由，`schema.d.ts` 為純新增（0 刪除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
