### PR TITLE
feat(ranking): 學院上傳排名錯誤訊息加註規則說明

### DIFF
--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -56,6 +56,10 @@ from ._helpers import (
 
 logger = logging.getLogger(__name__)
 
+# Appended to rank-sequence errors so the message states the rule that was
+# broken, not just the symptom. Mirrors the frontend (parse-ranking-sheet.ts).
+RANK_SEQUENCE_RULE = "，排名數字不可重複、不可跳號"
+
 router = APIRouter()
 
 
@@ -1108,7 +1112,7 @@ async def import_ranking_from_excel(
             rank_counts[r] = rank_counts.get(r, 0) + 1
         duplicates = [str(r) for r, count in sorted(rank_counts.items()) if count > 1]
         if duplicates:
-            errors.append(f"排名重複：{', '.join(duplicates)}")
+            errors.append(f"排名重複：{', '.join(duplicates)}{RANK_SEQUENCE_RULE}")
 
         # Check consecutive from 1
         if integer_ranks and not duplicates:
@@ -1116,7 +1120,9 @@ async def import_ranking_from_excel(
             actual = set(integer_ranks)
             missing_ranks = expected - actual
             if missing_ranks:
-                errors.append(f"排名不連續：缺少第 {', '.join(str(r) for r in sorted(missing_ranks))} 名")
+                errors.append(
+                    f"排名不連續：缺少第 {', '.join(str(r) for r in sorted(missing_ranks))} 名{RANK_SEQUENCE_RULE}"
+                )
 
         if errors:
             raise HTTPException(

--- a/frontend/lib/ranking/__tests__/parse-ranking-sheet.test.ts
+++ b/frontend/lib/ranking/__tests__/parse-ranking-sheet.test.ts
@@ -44,9 +44,7 @@ describe("parseRankingSheet", () => {
 
   it("errors when the rank cell is blank (data row = index + 3)", () => {
     const { errors } = parseRankingSheet([rowOf("310460099", "王小明", "")]);
-    expect(errors).toEqual([
-      "第 3 行排名欄位為空（學號：310460099）",
-    ]);
+    expect(errors).toEqual(["第 3 行排名欄位為空（學號：310460099）"]);
   });
 
   it("errors on a non-positive-integer rank", () => {
@@ -67,7 +65,9 @@ describe("parseRankingSheet", () => {
       rowOf("310460099", "王小明", 1),
       rowOf("310460100", "李小華", 1),
     ]);
-    expect(errors.some(e => e.includes("排名 1 重複出現"))).toBe(true);
+    expect(errors).toContain(
+      "排名 1 重複出現（2 次），排名數字不可重複、不可跳號"
+    );
   });
 
   it("errors when integer ranks are not consecutive from 1", () => {
@@ -75,7 +75,9 @@ describe("parseRankingSheet", () => {
       rowOf("310460099", "王小明", 1),
       rowOf("310460100", "李小華", 3),
     ]);
-    expect(errors.some(e => e.includes("排名不連續"))).toBe(true);
+    expect(errors).toContain(
+      "排名不連續：缺少第 2 名，排名數字不可重複、不可跳號"
+    );
   });
 
   it("does not treat N as a gap: ranks 1,2 + one N are consecutive", () => {

--- a/frontend/lib/ranking/parse-ranking-sheet.ts
+++ b/frontend/lib/ranking/parse-ranking-sheet.ts
@@ -18,6 +18,10 @@ const COL_RANK = "學院初審會議之學院排序";
 
 const FIRST_DATA_EXCEL_ROW = 3;
 
+// Appended to rank-sequence errors so the toast states the rule that was broken,
+// not just the symptom. Mirrors the backend (ranking_management.py).
+const RANK_SEQUENCE_RULE = "，排名數字不可重複、不可跳號";
+
 export interface ExcelRankingImportRow {
   student_id: string;
   student_name: string;
@@ -110,7 +114,7 @@ export function parseRankingSheet(
   countOccurrences(integerRanks).forEach((count, rank) => {
     if (count > 1) {
       hasDuplicateRanks = true;
-      errors.push(`排名 ${rank} 重複出現（${count} 次）`);
+      errors.push(`排名 ${rank} 重複出現（${count} 次）${RANK_SEQUENCE_RULE}`);
     }
   });
 
@@ -124,7 +128,9 @@ export function parseRankingSheet(
       if (!rankSet.has(i)) missing.push(i);
     }
     if (missing.length > 0) {
-      errors.push(`排名不連續：缺少第 ${missing.join(", ")} 名`);
+      errors.push(
+        `排名不連續：缺少第 ${missing.join(", ")} 名${RANK_SEQUENCE_RULE}`
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
學院上傳排名時，右下角跳出的驗證錯誤只說明症狀（例如「排名 1 重複出現（2 次）」），沒有說明違反了什麼規則。此 PR 在排名序列相關錯誤後面補上原因：

- `排名 1 重複出現（2 次），排名數字不可重複、不可跳號`
- `排名不連續：缺少第 2 名，排名數字不可重複、不可跳號`

前端預先解析（`parse-ranking-sheet.ts`）與後端匯入端點（`ranking_management.py`）兩邊都改，訊息一致（後端訊息會直接顯示在同一個 toast）。

## Test plan
- [x] `jest lib/ranking/__tests__/parse-ranking-sheet.test.ts`（11 passed，兩個排名序列測試改為完整字串斷言）
- [x] `tsc --noEmit`
- [ ] CI