### PR TITLE
fix(authz): superadmin 補齊 admin 的所有權限

### DIFF
--- a/backend/app/api/v1/endpoints/payment_rosters.py
+++ b/backend/app/api/v1/endpoints/payment_rosters.py
@@ -1425,7 +1425,7 @@ async def lock_roster(
     Lock roster
     """
     # 檢查權限：只有管理員可以鎖定造冊
-    check_user_roles([UserRole.admin], current_user)
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
 
     try:
         stmt = select(PaymentRoster).where(PaymentRoster.id == roster_id)
@@ -1471,7 +1471,7 @@ async def unlock_roster(
     Unlock roster
     """
     # 檢查權限：只有管理員可以解鎖造冊
-    check_user_roles([UserRole.admin], current_user)
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
 
     try:
         stmt = select(PaymentRoster).where(PaymentRoster.id == roster_id)
@@ -1975,14 +1975,14 @@ async def exclude_roster_item(
     metadata, rather than being hard-deleted (#66).
 
     Notes:
-      - Only admins may exclude items. Roster must NOT be LOCKED.
+      - Only admins / super admins may exclude items. Roster must NOT be LOCKED.
       - This does NOT decrement the student's cumulative received_months;
         if the funds are actually being returned, the admin should adjust
         received_months separately (it lives on CollegeRankingItem and the
         update path is intentionally manual).
       - A RosterAuditLog row is created with action=ITEM_REMOVE.
     """
-    check_user_roles([UserRole.admin], current_user)
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
 
     if reason_category not in MANUAL_EXCLUSION_CATEGORY_LABELS:
         raise HTTPException(
@@ -2114,7 +2114,7 @@ async def delete_roster(
     Delete roster (only unlocked rosters)
     """
     # 檢查權限：只有管理員可以刪除造冊
-    check_user_roles([UserRole.admin], current_user)
+    check_user_roles([UserRole.admin, UserRole.super_admin], current_user)
 
     try:
         stmt = select(PaymentRoster).where(PaymentRoster.id == roster_id)

--- a/backend/app/services/roster_notification_service.py
+++ b/backend/app/services/roster_notification_service.py
@@ -174,7 +174,7 @@ class RosterNotificationService:
             List[int]: 已發送通知的使用者ID清單
         """
         if notify_roles is None:
-            notify_roles = [UserRole.admin]
+            notify_roles = [UserRole.admin, UserRole.super_admin]
 
         try:
             target_users = self._get_users_by_roles(notify_roles)
@@ -336,7 +336,7 @@ class RosterNotificationService:
             List[int]: 已發送通知的使用者ID清單
         """
         if notify_roles is None:
-            notify_roles = [UserRole.admin]
+            notify_roles = [UserRole.admin, UserRole.super_admin]
 
         try:
             target_users = self._get_users_by_roles(notify_roles)

--- a/backend/app/tests/test_payment_rosters_api.py
+++ b/backend/app/tests/test_payment_rosters_api.py
@@ -77,6 +77,20 @@ def _make_mock_admin() -> Mock:
     return u
 
 
+def _make_mock_super_admin() -> Mock:
+    """Mock super_admin. Anything a plain admin can do, a super_admin can do
+    too — these endpoints must not gate on `[UserRole.admin]` alone."""
+    u = Mock(spec=User)
+    u.id = 2
+    u.role = UserRole.super_admin
+    u.name = "Super Admin EP"
+    u.email = "super_admin_pr@nycu.edu.tw"
+    u.has_role.side_effect = lambda role: u.role == role
+    u.is_admin.side_effect = lambda: u.role == UserRole.admin
+    u.is_super_admin.side_effect = lambda: u.role == UserRole.super_admin
+    return u
+
+
 def _make_mock_student() -> Mock:
     """Mock student. `has_role` must return False for admin/super_admin so
     `check_user_roles([admin, super_admin], ...)` raises 403."""
@@ -122,6 +136,30 @@ async def client_admin(client: AsyncClient, sync_db_for_rosters):
 
     def override_user():
         return admin
+
+    def override_sync_db():
+        yield sync_db_for_rosters
+
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_sync_db] = override_sync_db
+    yield client
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_sync_db, None)
+
+
+@pytest_asyncio.fixture
+async def client_super_admin(client: AsyncClient, sync_db_for_rosters):
+    """Same wiring as `client_admin` but with a super_admin
+    `get_current_user`, so the admin-tier handlers can be asserted to admit
+    super_admin as well."""
+    from app.core.deps import get_current_user
+    from app.db.deps import get_sync_db
+    from app.main import app
+
+    super_admin = _make_mock_super_admin()
+
+    def override_user():
+        return super_admin
 
     def override_sync_db():
         yield sync_db_for_rosters
@@ -789,3 +827,60 @@ async def test_list_filters_by_scholarship_type_id(client_admin: AsyncClient, ro
     assert resp2.status_code == 200, resp2.text
     codes2 = {it["roster_code"] for it in resp2.json()["data"]["items"]}
     assert "ROSTER-PR-CFG" not in codes2
+
+
+# ===========================================================================
+# super_admin parity with admin
+#
+# lock / unlock / exclude / DELETE used to gate on `[UserRole.admin]` alone
+# while every other roster endpoint accepted `[admin, super_admin]`. A
+# super_admin therefore got a 403 on the four most destructive operations.
+# These pin the parity so the narrower list can't come back.
+#
+# NOTE: `User.has_permission`'s map declares `roster_delete` as super_admin
+# ONLY, which these gates do NOT match (they also admit plain admin). That
+# map is currently aspirational — `User.has_permission` has no production
+# caller, the roster handlers gate via `check_user_roles` instead — and the
+# divergence predates this change (the old `[admin]` gate contradicted the
+# map in BOTH directions). Narrowing the gate to super_admin would remove a
+# capability admins have today, so it is left alone deliberately; reconciling
+# the two is a separate product decision.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_lock_allows_super_admin(client_super_admin: AsyncClient, completed_roster: PaymentRoster):
+    resp = await client_super_admin.post(f"/api/v1/payment-rosters/{completed_roster.id}/lock")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    _assert_api_response_envelope(body)
+    assert body["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_unlock_allows_super_admin(client_super_admin: AsyncClient, locked_roster_with_item: PaymentRoster):
+    resp = await client_super_admin.post(f"/api/v1/payment-rosters/{locked_roster_with_item.id}/unlock")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    _assert_api_response_envelope(body)
+    assert body["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_exclude_allows_super_admin(client_super_admin: AsyncClient, draft_roster_with_item: PaymentRoster):
+    item_id = draft_roster_with_item._test_item_id
+    resp = await client_super_admin.post(
+        f"/api/v1/payment-rosters/{draft_roster_with_item.id}/items/{item_id}/exclude",
+        json={"reason_category": "returned", "reason_note": "退回"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    _assert_api_response_envelope(body)
+    assert body["data"]["is_included"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_allows_super_admin(client_super_admin: AsyncClient, draft_roster: PaymentRoster):
+    resp = await client_super_admin.delete(f"/api/v1/payment-rosters/{draft_roster.id}")
+    assert resp.status_code == 200, resp.text
+    _assert_api_response_envelope(resp.json())

--- a/backend/app/tests/test_roster_notification_defaults.py
+++ b/backend/app/tests/test_roster_notification_defaults.py
@@ -137,17 +137,27 @@ class TestNotifyRosterGeneratedDefaults:
 
 
 class TestNotifyRosterErrorDefaults:
-    """Pin: notify_roster_error defaults to admin-ONLY (NOT processor).
+    """Pin: notify_roster_error defaults to the admin tier (NOT processor).
 
-    SECURITY: error notifications go to admin alone because they
-    require human intervention. Processors handling roster ops
+    SECURITY: error notifications go to the admin tier alone because
+    they require human intervention. Processors handling roster ops
     shouldn't get spammed with errors from outside their scope.
+
+    super_admin is part of that tier: anything a plain admin can do or
+    be notified about, a super_admin can too — matching the other three
+    notify_* methods, which already default to both roles.
+
+    NOTE: this is a consistency fix, not a live bug fix.
+    `RosterNotificationService` currently has no production caller (only
+    this test file), so no notification is being missed today. It is
+    aligned here so the default is already correct whenever the service
+    does get wired up.
     """
 
     @pytest.mark.asyncio
-    async def test_error_default_role_is_admin_only(self):
-        # Pin SECURITY: error notifications go to admin ONLY (NOT
-        # admin + processor). Pin so refactor adding processor
+    async def test_error_default_role_is_admin_tier_only(self):
+        # Pin SECURITY: error notifications go to admin + super_admin
+        # ONLY (NOT processor). Pin so refactor adding processor
         # silently spams the team with errors they can't act on.
         service = RosterNotificationService(db=MagicMock())
         service._get_users_by_roles = MagicMock(return_value=[_stub_user(1)])
@@ -157,7 +167,7 @@ class TestNotifyRosterErrorDefaults:
         await service.notify_roster_error(error_data={"config_name": "nstc-114-1", "error": "missing quota"})
 
         called_roles = service._get_users_by_roles.call_args.args[0]
-        assert called_roles == [UserRole.admin]
+        assert called_roles == [UserRole.admin, UserRole.super_admin]
         # Per CLAUDE.md §4: UserRole has admin/student/professor/college/super_admin.
         # No `processor` exists.
         assert not any(r.value == "processor" for r in called_roles if hasattr(r, "value"))

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -6590,7 +6590,7 @@ export interface paths {
          *     metadata, rather than being hard-deleted (#66).
          *
          *     Notes:
-         *       - Only admins may exclude items. Roster must NOT be LOCKED.
+         *       - Only admins / super admins may exclude items. Roster must NOT be LOCKED.
          *       - This does NOT decrement the student's cumulative received_months;
          *         if the funds are actually being returned, the admin should adjust
          *         received_months separately (it lives on CollegeRankingItem and the


### PR DESCRIPTION
## 問題

`payment_rosters.py` 有四個端點只認 `[UserRole.admin]`，而同一檔案其餘所有造冊端點都接受 `[admin, super_admin]`。super_admin 因此在四個破壞性最強的操作上拿到 403：

| 端點 | 說明 |
|---|---|
| `POST /payment-rosters/{id}/lock` | 鎖定造冊 |
| `POST /payment-rosters/{id}/unlock` | 解鎖造冊 |
| `POST /payment-rosters/{id}/items/{item_id}/exclude` | 排除造冊明細 |
| `DELETE /payment-rosters/{id}` | 刪除造冊 |

## 修改

1. 四個 gate 改為 `[UserRole.admin, UserRole.super_admin]`，與同檔案其餘 13 個 `check_user_roles` 及 6 個 `_require_admin` 一致。
2. `roster_notification_service.py` 兩個仍指向 `[UserRole.admin]` 的通知預設對象（roster error、scheduled summary）對齊其餘三個 `notify_*` method。**這是一致性修正，不是線上 bug 修正**：`RosterNotificationService` 目前沒有 production caller，所以現在並沒有漏掉任何通知，只是讓預設值在它被接上時就是對的。

## 全庫盤查結果

已在 rebase 後的 main（含 #1265）重新掃過一次：

- `check_user_roles([UserRole.admin])` / `require_roles(UserRole.admin)` 單獨出現：**0 處**
- `require_admin`、`require_staff`、`get_allowed_scholarship_ids`、college-review helpers、`files.py`、`batch_import.py`、`application_service.py`、`scholarship_configurations.py`、`reviews.py` 皆已把 super_admin 視為 >= admin
- 前端 `use-admin.ts`、`page.tsx`、`quota-management.tsx`、`user-permission-management.tsx`、`college-management-context.tsx` 等角色分支皆已正確處理 super_admin
- #1265 新增的 `POST /{roster_id}/regenerate` 使用 `_require_admin()`（`payment_rosters.py:66`，已接受兩種角色），新增的 `roster_regeneration_service.py` 與前端 roster 元件都沒有角色判斷 — **無新增缺口**

## 刻意未處理

`User.has_permission` 把 `roster_delete` 宣告為 super_admin ONLY，但 DELETE gate 也放行一般 admin。這個 map 目前是**宣告性質**的（`User.has_permission` 沒有 production caller，造冊 handler 走 `check_user_roles`），而且這個分歧早於本 PR — 舊的 `[admin]` gate 在兩個方向上都與 map 矛盾。把 gate 收緊到 super_admin 會拿掉 admin 現有的能力，與本 PR 的目的相反，因此留作獨立決策。

## 測試

- 新增 `client_super_admin` fixture 與四個 parity 測試，pin 住四個端點
- 更新 `notify_roster_error` 的 pin（其原始意圖是排除不存在的 `processor` role，該意圖仍成立）
- 後端全套：**5154 passed, 0 failed**
- `black --check --line-length=120 app`：653 files unchanged
- `flake8 app --select=B904,B014`：clean

無 migration。

`schema.d.ts` 有一行變更：exclude-item 的 docstring 被 FastAPI 當作端點的 OpenAPI description，因此把它從「Only admins」改成「Only admins / super admins」會連帶改到產生出來的 JSDoc。已套用 CI 算出的那一行 hunk，無其他 drift。

🤖 Generated with [Claude Code](https://claude.com/claude-code)