### PR TITLE
feat(email): 將自動寄信收斂為三個時機

### DIFF
--- a/backend/alembic/versions/email_timing_three_triggers_001.py
+++ b/backend/alembic/versions/email_timing_three_triggers_001.py
@@ -1,7 +1,7 @@
 """Reduce automated email to the three agreed trigger points
 
 Revision ID: email_timing_three_triggers_001
-Revises: add_footer_links_001
+Revises: student_history_visibility_001
 Create Date: 2026-08-03 00:00:00.000000
 
 The system now mails exactly three events:
@@ -28,7 +28,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "email_timing_three_triggers_001"
-down_revision: Union[str, None] = "add_footer_links_001"
+down_revision: Union[str, None] = "student_history_visibility_001"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -47,6 +47,8 @@ CONDITION_QUERY = """
             """
 
 SUBJECT_TEMPLATE = "排名已送出 - {scholarship_name} {ranking_name}"
+
+RECIPIENT_OPTIONS_JSON = '[{"label": "學院承辦人", "value": "college"}]'
 
 BODY_TEMPLATE = """{college_name} 您好：
 
@@ -77,15 +79,22 @@ def upgrade() -> None:
             sa.text("SELECT id FROM email_templates WHERE key = :key"), {"key": TEMPLATE_KEY}
         ).first()
         if existing is None:
-            # requires_approval / sending_type carry Python-side defaults only,
-            # so a raw INSERT has to supply them explicitly.
+            # requires_approval / sending_type carry Python-side defaults only, so a
+            # raw INSERT has to supply them explicitly. recipient_options drives the
+            # 收件者選項 list in the admin manual-send UI — omitting it leaves an
+            # upgraded install with an empty picker where a seeded one has 學院承辦人.
             bind.execute(
                 sa.text(
                     "INSERT INTO email_templates "
-                    "(key, subject_template, body_template, sending_type, requires_approval) "
-                    "VALUES (:key, :subject, :body, 'single', false)"
+                    "(key, subject_template, body_template, sending_type, requires_approval, recipient_options) "
+                    "VALUES (:key, :subject, :body, 'single', false, CAST(:recipient_options AS JSON))"
                 ),
-                {"key": TEMPLATE_KEY, "subject": SUBJECT_TEMPLATE, "body": BODY_TEMPLATE},
+                {
+                    "key": TEMPLATE_KEY,
+                    "subject": SUBJECT_TEMPLATE,
+                    "body": BODY_TEMPLATE,
+                    "recipient_options": RECIPIENT_OPTIONS_JSON,
+                },
             )
 
     if "email_automation_rules" in tables:

--- a/backend/alembic/versions/email_timing_three_triggers_001.py
+++ b/backend/alembic/versions/email_timing_three_triggers_001.py
@@ -1,0 +1,160 @@
+"""Reduce automated email to the three agreed trigger points
+
+Revision ID: email_timing_three_triggers_001
+Revises: add_footer_links_001
+Create Date: 2026-08-03 00:00:00.000000
+
+The system now mails exactly three events:
+
+1. 學生送出申請       -> 學生 + 指導教授   (existing rules, untouched)
+2. 草稿 + 申請截止前三天 -> 學生            (deadline_checker, code-side)
+3. 學院送出（確認）排名 -> 該學院承辦人      (this migration wires it up)
+
+For (3) the dormant '學院審核通知' rule — bound to professor_review_submitted,
+which nothing ever emitted — is repointed at college_review_submitted, given a
+recipient query scoped by college_code, given its own template, and enabled.
+
+Existing installs seeded their automation rules once (the seed skips a
+non-empty table), so the change has to be applied here rather than in the seed
+alone. Content is snapshotted verbatim rather than imported from
+app.db.seed_scholarship_configs so that a later edit to the seed cannot
+retroactively change what this migration did.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "email_timing_three_triggers_001"
+down_revision: Union[str, None] = "add_footer_links_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+OLD_RULE_NAME = "學院審核通知"
+NEW_RULE_NAME = "學院排名送出通知"
+TEMPLATE_KEY = "college_ranking_submitted"
+
+CONDITION_QUERY = """
+                SELECT u.email
+                FROM users u
+                WHERE u.role = 'college'
+                AND u.college_code = {college_code}
+                AND u.email IS NOT NULL
+                AND u.email != ''
+            """
+
+SUBJECT_TEMPLATE = "排名已送出 - {scholarship_name} {ranking_name}"
+
+BODY_TEMPLATE = """{college_name} 您好：
+
+貴學院的 {scholarship_name} 推薦排名已完成送出並鎖定，後續將由承辦單位進行配額分發。
+
+排名資訊：
+- 排名名稱：{ranking_name}
+- 申請類別：{sub_type_code}
+- 學年度學期：{academic_year} 學年度 {semester}
+- 排名人數：{total_applications}
+- 送出時間：{finalized_at}（操作人：{finalized_by}）
+
+排名送出後即無法修改。若需調整，請聯繫承辦單位解除鎖定。
+
+請至系統查看：{system_url}/college/rankings
+
+國立陽明交通大學
+獎學金管理系統"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    if "email_templates" in tables:
+        existing = bind.execute(
+            sa.text("SELECT id FROM email_templates WHERE key = :key"), {"key": TEMPLATE_KEY}
+        ).first()
+        if existing is None:
+            # requires_approval / sending_type carry Python-side defaults only,
+            # so a raw INSERT has to supply them explicitly.
+            bind.execute(
+                sa.text(
+                    "INSERT INTO email_templates "
+                    "(key, subject_template, body_template, sending_type, requires_approval) "
+                    "VALUES (:key, :subject, :body, 'single', false)"
+                ),
+                {"key": TEMPLATE_KEY, "subject": SUBJECT_TEMPLATE, "body": BODY_TEMPLATE},
+            )
+
+    if "email_automation_rules" in tables:
+        params = {
+            "new_name": NEW_RULE_NAME,
+            "description": "當學院送出（確認）排名後，通知該學院承辦人排名已送出",
+            "template_key": TEMPLATE_KEY,
+            "condition_query": CONDITION_QUERY,
+            "old_name": OLD_RULE_NAME,
+        }
+        result = bind.execute(
+            sa.text(
+                "UPDATE email_automation_rules "
+                "SET name = :new_name, "
+                "    description = :description, "
+                "    trigger_event = 'college_review_submitted', "
+                "    template_key = :template_key, "
+                "    condition_query = :condition_query, "
+                "    delay_hours = 0, "
+                "    is_active = true "
+                "WHERE name = :old_name"
+            ),
+            params,
+        )
+
+        # An install whose seed predates the '學院審核通知' rule (or where it was
+        # deleted) still needs trigger point 3, so insert it rather than leaving
+        # the college with no mail at all.
+        if result.rowcount == 0:
+            already_present = bind.execute(
+                sa.text("SELECT id FROM email_automation_rules WHERE name = :new_name"),
+                {"new_name": NEW_RULE_NAME},
+            ).first()
+            if already_present is None:
+                bind.execute(
+                    sa.text(
+                        "INSERT INTO email_automation_rules "
+                        "(name, description, trigger_event, template_key, condition_query, "
+                        " delay_hours, is_active) "
+                        "VALUES (:new_name, :description, 'college_review_submitted', "
+                        "        :template_key, :condition_query, 0, true)"
+                    ),
+                    params,
+                )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+
+    if "email_automation_rules" in tables:
+        bind.execute(
+            sa.text(
+                "UPDATE email_automation_rules "
+                "SET name = :old_name, "
+                "    description = :description, "
+                "    trigger_event = 'professor_review_submitted', "
+                "    template_key = 'college_review_notification', "
+                "    condition_query = NULL, "
+                "    is_active = false "
+                "WHERE name = :new_name"
+            ),
+            {
+                "old_name": OLD_RULE_NAME,
+                "description": "當教授審核完成後，通知學院有新案件待審核",
+                "new_name": NEW_RULE_NAME,
+            },
+        )
+
+    if "email_templates" in tables:
+        bind.execute(sa.text("DELETE FROM email_templates WHERE key = :key"), {"key": TEMPLATE_KEY})

--- a/backend/app/api/v1/endpoints/admin/applications.py
+++ b/backend/app/api/v1/endpoints/admin/applications.py
@@ -576,7 +576,6 @@ async def bulk_approve_applications_endpoint(
         application_ids=payload.application_ids,
         approver_user_id=current_user.id,
         approval_notes=payload.comments,
-        send_notifications=payload.send_notifications,
     )
 
     return {"success": True, "message": "Bulk approval processed successfully", "data": result}

--- a/backend/app/api/v1/endpoints/college_review/ranking_management.py
+++ b/backend/app/api/v1/endpoints/college_review/ranking_management.py
@@ -19,6 +19,7 @@ from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.college_mappings import get_college_name
 from app.core.exceptions import AuthorizationError, NotFoundError
 from app.core.security import require_college, require_scholarship_manager
 from app.db.deps import get_db
@@ -26,7 +27,7 @@ from app.models.audit_log import AuditAction, AuditLog
 from app.models.college_review import CollegeRanking, CollegeRankingItem
 from app.models.enums import Semester
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
-from app.models.student import Department
+from app.models.student import Academy, Department
 from app.models.user import User, UserRole
 from app.schemas.college_review import RankingImportItem, RankingOrderUpdate, RankingUpdate
 from app.schemas.response import ApiResponse
@@ -41,6 +42,7 @@ from app.services.college_review_service import (
     RankingModificationError,
     RankingNotFoundError,
 )
+from app.services.email_automation_service import email_automation_service
 from app.services.review_service import ReviewService
 from app.utils.application_helpers import get_college_code_from_data
 from app.services.supplementary_import_service import SupplementaryImportService
@@ -749,6 +751,49 @@ async def update_ranking_order(
         ) from e
 
 
+async def _resolve_college_name(db: AsyncSession, college_code: Optional[str]) -> str:
+    """Resolve a college code to its display name, academies table first.
+
+    The static COLLEGE_MAPPINGS table lagged the real academy names for a long
+    time, so the DB is the authority and the static map is only a fallback.
+    """
+    if not college_code:
+        return ""
+
+    result = await db.execute(select(Academy.name).where(Academy.code == college_code))
+    name = result.scalar_one_or_none()
+    if name:
+        return name
+
+    return get_college_name(college_code) or college_code
+
+
+async def _notify_college_ranking_submitted(db: AsyncSession, ranking: CollegeRanking, finalizer: User) -> None:
+    """Emit the college_review_submitted trigger for a just-finalized ranking."""
+    scholarship_name = ""
+    if ranking.scholarship_type_id:
+        result = await db.execute(select(ScholarshipType.name).where(ScholarshipType.id == ranking.scholarship_type_id))
+        scholarship_name = result.scalar_one_or_none() or ""
+
+    await email_automation_service.trigger_college_ranking_submitted(
+        db=db,
+        ranking_data={
+            "ranking_id": ranking.id,
+            "college_code": ranking.college_code,
+            "college_name": await _resolve_college_name(db, ranking.college_code),
+            "ranking_name": ranking.ranking_name or f"排名 #{ranking.id}",
+            "scholarship_type": scholarship_name,
+            "scholarship_type_id": ranking.scholarship_type_id,
+            "sub_type_code": ranking.sub_type_code or "",
+            "academic_year": str(ranking.academic_year or ""),
+            "semester": normalize_semester_value(ranking.semester) or "全學年",
+            "total_applications": str(ranking.total_applications or 0),
+            "finalized_by": finalizer.name or finalizer.email or "",
+            "finalized_at": (ranking.finalized_at.strftime("%Y-%m-%d %H:%M") if ranking.finalized_at else ""),
+        },
+    )
+
+
 @router.post("/rankings/{ranking_id}/finalize")
 async def finalize_ranking(
     ranking_id: int,
@@ -808,6 +853,13 @@ async def finalize_ranking(
         )
         db.add(audit_log)
         await db.commit()
+
+        # Notify the owning college that its ranking has been sent. Wrapped so a
+        # mail failure can never turn a successful finalize into a 500.
+        try:
+            await _notify_college_ranking_submitted(db, ranking, current_user)
+        except Exception:
+            logger.exception("Failed to trigger college ranking submitted email for ranking %s", ranking.id)
 
         return ApiResponse(
             success=True,

--- a/backend/app/api/v1/endpoints/document_requests.py
+++ b/backend/app/api/v1/endpoints/document_requests.py
@@ -81,43 +81,8 @@ async def create_document_request(
         request=request,
     )
 
-    # 觸發補件要求事件（會觸發自動化郵件規則）
-    try:
-        from app.services.email_automation_service import email_automation_service
-
-        # Get student email from application
-        stmt_student = (
-            select(Application).options(joinedload(Application.student)).where(Application.id == application_id)
-        )
-        result_student = await db.execute(stmt_student)
-        app_with_user = result_student.scalar_one_or_none()
-
-        if app_with_user and app_with_user.student:
-            student_data = app_with_user.student_data or {}
-            student_email = student_data.get("email") or app_with_user.student.email
-            student_name = student_data.get("name") or app_with_user.student.name
-
-            await email_automation_service.trigger_supplement_requested(
-                db=db,
-                application_id=application.id,
-                request_data={
-                    "app_id": application.app_id,
-                    "student_name": student_name,
-                    "student_email": student_email,
-                    "requested_documents": request_data.requested_documents,
-                    "reason": request_data.reason,
-                    "notes": request_data.notes or "",
-                    "requester_name": current_user.name or current_user.email,
-                    "deadline": "",  # Add if deadline field exists in DocumentRequest model
-                    "scholarship_type": application.scholarship_name,
-                    "scholarship_type_id": application.scholarship_type_id,
-                    "request_date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-                },
-            )
-            logger.info(f"Document request automation triggered for {student_email}")
-    except Exception:
-        # Log error but don't fail the request creation
-        logger.exception("Failed to trigger supplement request automation")
+    # No email is sent for a supplementary-document request: students only ever
+    # receive mail on submission and on the 3-day draft deadline reminder.
 
     # Build response
     response_data = DocumentRequestResponse.model_validate(document_request)

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -894,13 +894,12 @@ async def seed_email_templates(session: AsyncSession) -> None:
     logger.info("Initializing email templates...")
     print("  📧 Initializing email templates...")
 
-    # Check if templates already exist
-    result = await session.execute(select(EmailTemplate))
-    existing_templates = result.scalars().all()
-
-    if existing_templates:
-        print(f"  ✓ Email templates already initialized ({len(existing_templates)} found)")
-        return
+    # Seed per key, NOT "skip if the table has any row". Migrations may legitimately
+    # insert a single template before this runs (alembic upgrade precedes seeding in
+    # scripts/reset_database.sh), and a table-level skip would then silently drop
+    # every other template — including the ones the submission emails depend on.
+    result = await session.execute(select(EmailTemplate.key).where(EmailTemplate.scholarship_type_id.is_(None)))
+    existing_keys = set(result.scalars().all())
 
     # Define default email templates
     default_templates = [
@@ -1057,13 +1056,14 @@ async def seed_email_templates(session: AsyncSession) -> None:
         },
     ]
 
-    for template_data in default_templates:
+    missing = [t for t in default_templates if t["key"] not in existing_keys]
+    for template_data in missing:
         template = EmailTemplate(**template_data)
         session.add(template)
 
     await session.commit()
     logger.info("Email templates initialized successfully!")
-    print(f"  📊 Inserted: {len(default_templates)} email templates")
+    print(f"  📊 Inserted: {len(missing)} email templates ({len(existing_keys)} already present)")
 
 
 async def seed_email_automation_rules(session: AsyncSession) -> None:
@@ -1073,13 +1073,12 @@ async def seed_email_automation_rules(session: AsyncSession) -> None:
     logger.info("Initializing email automation rules...")
     print("  🤖 Initializing email automation rules...")
 
-    # Check if automation rules already exist
-    result = await session.execute(select(EmailAutomationRule))
-    existing_rules = result.scalars().all()
-
-    if existing_rules:
-        print(f"  ✓ Email automation rules already initialized ({len(existing_rules)} found)")
-        return
+    # Seed per rule name, NOT "skip if the table has any row" — see the same note in
+    # seed_email_templates. email_timing_three_triggers_001 inserts 學院排名送出通知
+    # on a fresh DB, and a table-level skip would then drop the two submission rules,
+    # leaving trigger point 1 (student + professor) with no active rule at all.
+    result = await session.execute(select(EmailAutomationRule.name))
+    existing_names = set(result.scalars().all())
 
     # Define initial automation rules — these are the three trigger points the
     # system actually sends mail for (see docs: 送出申請 / 草稿截止前三天 / 送出排名).
@@ -1139,13 +1138,14 @@ async def seed_email_automation_rules(session: AsyncSession) -> None:
         },
     ]
 
-    for rule_data in initial_rules:
+    missing = [r for r in initial_rules if r["name"] not in existing_names]
+    for rule_data in missing:
         rule = EmailAutomationRule(**rule_data)
         session.add(rule)
 
     await session.commit()
     logger.info("Email automation rules initialized successfully!")
-    print(f"  📊 Inserted: {len(initial_rules)} email automation rules")
+    print(f"  📊 Inserted: {len(missing)} email automation rules ({len(existing_names)} already present)")
 
 
 async def init_all_scholarship_configs() -> None:

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -20,6 +20,41 @@ from app.models.system_setting import EmailTemplate, SendingType
 
 logger = logging.getLogger(__name__)
 
+# --- 學院送出排名通知 -------------------------------------------------------
+# The third and last automatic trigger point in the system: a college finalizes
+# ("送出") its ranking and its own reviewers get a confirmation. Recipients are
+# resolved by college_code, so the rule is ranking-scoped, not application-scoped.
+COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY = "college_ranking_submitted"
+
+COLLEGE_RANKING_SUBMITTED_SUBJECT = "排名已送出 - {scholarship_name} {ranking_name}"
+
+COLLEGE_RANKING_SUBMITTED_BODY = """{college_name} 您好：
+
+貴學院的 {scholarship_name} 推薦排名已完成送出並鎖定，後續將由承辦單位進行配額分發。
+
+排名資訊：
+- 排名名稱：{ranking_name}
+- 申請類別：{sub_type_code}
+- 學年度學期：{academic_year} 學年度 {semester}
+- 排名人數：{total_applications}
+- 送出時間：{finalized_at}（操作人：{finalized_by}）
+
+排名送出後即無法修改。若需調整，請聯繫承辦單位解除鎖定。
+
+請至系統查看：{system_url}/college/rankings
+
+國立陽明交通大學
+獎學金管理系統"""
+
+COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY = """
+                SELECT u.email
+                FROM users u
+                WHERE u.role = 'college'
+                AND u.college_code = {college_code}
+                AND u.email IS NOT NULL
+                AND u.email != ''
+            """
+
 
 async def seed_scholarship_configurations(session: AsyncSession) -> None:
     """Initialize scholarship configurations with quota and workflow settings"""
@@ -967,6 +1002,13 @@ async def seed_email_templates(session: AsyncSession) -> None:
             "sending_type": SendingType.single,
             "recipient_options": [{"label": "學院承辦人", "value": "college"}],
         },
+        {
+            "key": COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY,
+            "subject_template": COLLEGE_RANKING_SUBMITTED_SUBJECT,
+            "body_template": COLLEGE_RANKING_SUBMITTED_BODY,
+            "sending_type": SendingType.single,
+            "recipient_options": [{"label": "學院承辦人", "value": "college"}],
+        },
         # Bulk sending type templates
         {
             "key": "scholarship_announcement",
@@ -1039,7 +1081,8 @@ async def seed_email_automation_rules(session: AsyncSession) -> None:
         print(f"  ✓ Email automation rules already initialized ({len(existing_rules)} found)")
         return
 
-    # Define initial automation rules (disabled by default, admin must activate)
+    # Define initial automation rules — these are the three trigger points the
+    # system actually sends mail for (see docs: 送出申請 / 草稿截止前三天 / 送出排名).
     initial_rules = [
         {
             "name": "申請提交確認郵件",
@@ -1086,12 +1129,13 @@ async def seed_email_automation_rules(session: AsyncSession) -> None:
             """,
         },
         {
-            "name": "學院審核通知",
-            "description": "當教授審核完成後，通知學院有新案件待審核",
-            "trigger_event": TriggerEvent.professor_review_submitted,
-            "template_key": "college_review_notification",
+            "name": "學院排名送出通知",
+            "description": "當學院送出（確認）排名後，通知該學院承辦人排名已送出",
+            "trigger_event": TriggerEvent.college_review_submitted,
+            "template_key": COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY,
             "delay_hours": 0,
-            "is_active": False,
+            "is_active": True,
+            "condition_query": COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY,
         },
     ]
 
@@ -1101,7 +1145,7 @@ async def seed_email_automation_rules(session: AsyncSession) -> None:
 
     await session.commit()
     logger.info("Email automation rules initialized successfully!")
-    print(f"  📊 Inserted: {len(initial_rules)} email automation rules (disabled by default)")
+    print(f"  📊 Inserted: {len(initial_rules)} email automation rules")
 
 
 async def init_all_scholarship_configs() -> None:
@@ -1126,7 +1170,7 @@ async def init_all_scholarship_configs() -> None:
     print("- 3 scholarship configurations (114 academic year)")
     print("- 18 scholarship rules (114 academic year)")
     print("- 3 sub-type configurations (NSTC, MOE_1W, MOE_2W)")
-    print("- 6 email templates (single + bulk sending)")
+    print("- 7 email templates (single + bulk sending)")
 
 
 if __name__ == "__main__":

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -712,7 +712,6 @@ class BulkApproveRequest(BaseModel):
 
     application_ids: List[int] = Field(..., min_length=1, description="Application IDs to approve")
     comments: Optional[str] = Field(None, description="Optional approval notes")
-    send_notifications: bool = Field(True, description="Whether to notify applicants")
 
 
 class RevokeRequest(BaseModel):

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -3039,7 +3039,12 @@ class ApplicationService:
                     },
                     href=f"/professor/applications/{application.id}",
                     priority=NotificationPriority.high,
-                    channels=[NotificationChannel.in_app, NotificationChannel.email],
+                    # in_app ONLY. NotificationChannel.email here reaches
+                    # _send_email_notification -> FastMail directly, which bypasses the
+                    # scheduled_emails queue, the templates, email_history AND the
+                    # test-mode redirect — so it would both re-add assignment mail and
+                    # leak to real users while test mode is on.
+                    channels=[NotificationChannel.in_app],
                 )
                 logger.info(f"In-app notification created for professor {professor.nycu_id}")
             except Exception:

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -3016,43 +3016,9 @@ class ApplicationService:
             await self.db.commit()
             await self.db.refresh(application)
 
-            # Send email via React Email HTML system (scheduled_emails queue)
-            if professor.email:
-                try:
-                    from app.core.config import settings
-                    from app.services.frontend_email_renderer import render_email_via_frontend
-
-                    student_name = application.student_data.get("std_cname") if application.student_data else "Unknown"
-                    email_context = {
-                        "app_id": application.app_id,
-                        "student_name": student_name,
-                        "scholarship_type": application.scholarship_name or "獎學金",
-                        "professor_name": professor.name,
-                        "professor_email": professor.email,
-                        "submit_date": application.updated_at.strftime("%Y-%m-%d") if application.updated_at else "",
-                        "system_url": getattr(settings, "FRONTEND_URL", "https://scholarship.nycu.edu.tw"),
-                    }
-                    html = await render_email_via_frontend(
-                        frontend_url=getattr(settings, "INTERNAL_FRONTEND_URL", "http://frontend:3000"),
-                        template_name="professor-review-request",
-                        context=email_context,
-                    )
-                    email_service = EmailService()
-                    await email_service.schedule_email(
-                        db=self.db,
-                        to=professor.email,
-                        subject=f"審查通知 - {student_name} 的 {application.scholarship_name or '獎學金'} 申請",
-                        body=f"申請編號 {application.app_id} 已指派給您進行教授推薦審查。",
-                        scheduled_for=datetime.now(timezone.utc),
-                        html_content=html,
-                        template_key="professor_review_notification",
-                        application_id=application.id,
-                        scholarship_type_id=application.scholarship_type_id,
-                        created_by_user_id=assigned_by.id,
-                    )
-                    logger.info(f"Scheduled HTML email to professor {professor.nycu_id}")
-                except Exception:
-                    logger.exception(f"Failed to send email to professor {professor.nycu_id}")
+            # No email on assignment: professors are only mailed when a student
+            # they supervise submits an application. The in-app notification below
+            # remains the channel for an admin/college-initiated assignment.
 
             # Create in-app notification (use info type which exists in DB enum)
             try:

--- a/backend/app/services/bulk_approval_service.py
+++ b/backend/app/services/bulk_approval_service.py
@@ -32,16 +32,17 @@ class BulkApprovalService:
         application_ids: List[int],
         approver_user_id: int,
         approval_notes: Optional[str] = None,
-        send_notifications: bool = True,
     ) -> Dict[str, Any]:
-        """Bulk approve multiple applications"""
+        """Bulk approve multiple applications.
+
+        Students are NOT emailed about the outcome — the only mail a student
+        receives is the submission confirmation and the 3-day draft reminder.
+        """
 
         results = {
             "total_requested": len(application_ids),
             "successful_approvals": [],
             "failed_approvals": [],
-            "notifications_sent": 0,
-            "notifications_failed": 0,
         }
 
         try:
@@ -104,20 +105,6 @@ class BulkApprovalService:
                         }
                     )
 
-                    # Send notification if requested
-                    if send_notifications:
-                        try:
-                            notification_sent = await self.notification_service.send_status_change_notification(
-                                application, old_status, application.status
-                            )
-                            if notification_sent:
-                                results["notifications_sent"] += 1
-                            else:
-                                results["notifications_failed"] += 1
-                        except Exception:
-                            logger.exception(f"Failed to send notification for application {application.id}")
-                            results["notifications_failed"] += 1
-
                     logger.info(f"Bulk approved application {application.app_id}")
 
                 except Exception as e:
@@ -144,16 +131,16 @@ class BulkApprovalService:
         application_ids: List[int],
         rejector_user_id: int,
         rejection_reason: str,
-        send_notifications: bool = True,
     ) -> Dict[str, Any]:
-        """Bulk reject multiple applications"""
+        """Bulk reject multiple applications.
+
+        As with bulk approval, no outcome email is sent to the student.
+        """
 
         results = {
             "total_requested": len(application_ids),
             "successful_rejections": [],
             "failed_rejections": [],
-            "notifications_sent": 0,
-            "notifications_failed": 0,
         }
 
         try:
@@ -211,20 +198,6 @@ class BulkApprovalService:
                             "rejection_reason": rejection_reason,
                         }
                     )
-
-                    # Send notification
-                    if send_notifications:
-                        try:
-                            notification_sent = await self.notification_service.send_status_change_notification(
-                                application, old_status, application.status
-                            )
-                            if notification_sent:
-                                results["notifications_sent"] += 1
-                            else:
-                                results["notifications_failed"] += 1
-                        except Exception:
-                            logger.exception(f"Failed to send notification for application {application.id}")
-                            results["notifications_failed"] += 1
 
                     logger.info(f"Bulk rejected application {application.app_id}")
 
@@ -482,14 +455,12 @@ class BulkApprovalService:
                     application_ids,
                     operator_user_id,
                     operation_params.get("approval_notes"),
-                    operation_params.get("send_notifications", True),
                 )
             elif operation_type == "reject":
                 results = await self.bulk_reject_applications(
                     application_ids,
                     operator_user_id,
                     operation_params.get("rejection_reason", "Bulk rejection"),
-                    operation_params.get("send_notifications", True),
                 )
             elif operation_type == "update_status":
                 results = await self.bulk_status_update(

--- a/backend/app/services/email_automation_service.py
+++ b/backend/app/services/email_automation_service.py
@@ -413,6 +413,7 @@ class EmailAutomationService:
             "whitelist_notification": EmailCategory.application_whitelist,
             "deadline_reminder_draft": EmailCategory.application_student,
             "college_review_notification": EmailCategory.review_college,
+            "college_ranking_submitted": EmailCategory.review_college,
             "supplement_request": EmailCategory.supplement_student,
             "result_notification_student": EmailCategory.result_student,
             "result_notification_professor": EmailCategory.result_professor,
@@ -428,6 +429,7 @@ class EmailAutomationService:
             "application_submitted_student": "application-submitted",
             "professor_review_notification": "professor-review-request",
             "college_review_notification": "college-review-request",
+            "college_ranking_submitted": "college-ranking-submitted",
             "application_deadline_reminder": "deadline-reminder",
             "document_request_notification": "document-request",
             "result_notification_student": "result-notification",
@@ -495,107 +497,42 @@ class EmailAutomationService:
         await self.process_trigger(db, "application_submitted", context)
         logger.info(f"✓ Email automation trigger completed for application {application_id}")
 
-    async def trigger_professor_review_submitted(
-        self, db: AsyncSession, application_id: int, review_data: Dict[str, Any]
-    ):
-        """Trigger emails when professor submits review"""
+    async def trigger_college_ranking_submitted(self, db: AsyncSession, ranking_data: Dict[str, Any]):
+        """Trigger emails when a college submits (finalizes) its ranking.
+
+        Unlike the other triggers this one is ranking-scoped, not
+        application-scoped: one mail per finalized ranking, addressed to the
+        reviewers of the college that owns it. ``college_code`` is therefore the
+        key the rule's condition_query binds against — it is passed through even
+        when None so that a global (admin) ranking resolves to no recipients
+        rather than raising on an unknown placeholder.
+        """
         from app.core.config import settings
 
-        scholarship_type_value = review_data.get("scholarship_type", "")
+        scholarship_type_value = ranking_data.get("scholarship_type", "")
         context = {
-            "application_id": application_id,
-            "app_id": review_data.get("app_id", ""),
-            "student_name": review_data.get("student_name", ""),
-            "professor_name": review_data.get("professor_name", ""),
-            "professor_email": review_data.get("professor_email", ""),
+            "ranking_id": ranking_data.get("ranking_id"),
+            "college_code": ranking_data.get("college_code"),
+            "college_name": ranking_data.get("college_name", ""),
+            "ranking_name": ranking_data.get("ranking_name", ""),
             "scholarship_type": scholarship_type_value,
-            "scholarship_name": scholarship_type_value,  # Alias for backward compatibility with templates
-            "scholarship_type_id": review_data.get("scholarship_type_id"),
-            "review_result": review_data.get("review_result", ""),
-            "review_date": review_data.get("review_date", datetime.now().strftime("%Y-%m-%d")),
-            "professor_recommendation": review_data.get("professor_recommendation", ""),
-            "college_name": review_data.get("college_name", ""),
-            "review_deadline": review_data.get("review_deadline", ""),
+            "scholarship_name": scholarship_type_value,  # Alias for templates
+            "scholarship_type_id": ranking_data.get("scholarship_type_id"),
+            "sub_type_code": ranking_data.get("sub_type_code", ""),
+            "academic_year": ranking_data.get("academic_year", ""),
+            "semester": ranking_data.get("semester", ""),
+            "total_applications": ranking_data.get("total_applications", ""),
+            "finalized_by": ranking_data.get("finalized_by", ""),
+            "finalized_at": ranking_data.get("finalized_at", datetime.now().strftime("%Y-%m-%d %H:%M")),
             "system_url": settings.frontend_url,
         }
 
-        await self.process_trigger(db, "professor_review_submitted", context)
-
-    async def trigger_final_result_decided(self, db: AsyncSession, application_id: int, result_data: Dict[str, Any]):
-        """Trigger emails when final result is decided"""
-        from app.core.config import settings
-
-        scholarship_type_value = result_data.get("scholarship_type", "")
-        context = {
-            "application_id": application_id,
-            "app_id": result_data.get("app_id", ""),
-            "student_name": result_data.get("student_name", ""),
-            "student_email": result_data.get("student_email", ""),
-            "professor_name": result_data.get("professor_name", ""),
-            "professor_email": result_data.get("professor_email", ""),
-            "college_name": result_data.get("college_name", ""),
-            "scholarship_type": scholarship_type_value,
-            "scholarship_name": scholarship_type_value,  # Alias for backward compatibility with templates
-            "scholarship_type_id": result_data.get("scholarship_type_id"),
-            "result_status": result_data.get("result_status", ""),
-            "approved_amount": result_data.get("approved_amount", ""),
-            "result_message": result_data.get("result_message", ""),
-            "next_steps": result_data.get("next_steps", ""),
-            "system_url": settings.frontend_url,
-        }
-
-        await self.process_trigger(db, "final_result_decided", context)
-
-    async def trigger_college_review_submitted(
-        self, db: AsyncSession, application_id: int, review_data: Dict[str, Any]
-    ):
-        """Trigger emails when college submits review"""
-        from app.core.config import settings
-
-        scholarship_type_value = review_data.get("scholarship_type", "")
-        context = {
-            "application_id": application_id,
-            "app_id": review_data.get("app_id", ""),
-            "student_name": review_data.get("student_name", ""),
-            "student_email": review_data.get("student_email", ""),
-            "college_name": review_data.get("college_name", ""),
-            # Note: college_ranking_score removed - use final_rank instead
-            "college_final_rank": review_data.get("final_rank"),
-            "college_recommendation": review_data.get("recommendation", ""),
-            "college_comments": review_data.get("comments", ""),
-            "reviewer_name": review_data.get("reviewer_name", ""),
-            "scholarship_type": scholarship_type_value,
-            "scholarship_name": scholarship_type_value,  # Alias for backward compatibility with templates
-            "scholarship_type_id": review_data.get("scholarship_type_id"),
-            "review_date": review_data.get("review_date", datetime.now().strftime("%Y-%m-%d")),
-            "system_url": settings.frontend_url,
-        }
-
+        logger.info(
+            "🚀 EMAIL AUTOMATION TRIGGERED: college_review_submitted (ranking %s, college %s)",
+            context["ranking_id"],
+            context["college_code"],
+        )
         await self.process_trigger(db, "college_review_submitted", context)
-
-    async def trigger_supplement_requested(self, db: AsyncSession, application_id: int, request_data: Dict[str, Any]):
-        """Trigger emails when supplement documents are requested"""
-        from app.core.config import settings
-
-        scholarship_type_value = request_data.get("scholarship_type", "")
-        context = {
-            "application_id": application_id,
-            "app_id": request_data.get("app_id", ""),
-            "student_name": request_data.get("student_name", ""),
-            "student_email": request_data.get("student_email", ""),
-            "requested_documents": ", ".join(request_data.get("requested_documents", [])),
-            "reason": request_data.get("reason", ""),
-            "notes": request_data.get("notes", ""),
-            "requester_name": request_data.get("requester_name", ""),
-            "deadline": request_data.get("deadline", ""),
-            "scholarship_type": scholarship_type_value,
-            "scholarship_name": scholarship_type_value,  # Alias for backward compatibility with templates
-            "scholarship_type_id": request_data.get("scholarship_type_id"),
-            "request_date": request_data.get("request_date", datetime.now().strftime("%Y-%m-%d")),
-            "system_url": settings.frontend_url,
-        }
-
-        await self.process_trigger(db, "supplement_requested", context)
 
     async def trigger_deadline_approaching(self, db: AsyncSession, application_id: int, deadline_data: Dict[str, Any]):
         """Trigger emails when deadline is approaching"""

--- a/backend/app/tasks/deadline_checker.py
+++ b/backend/app/tasks/deadline_checker.py
@@ -1,7 +1,9 @@
 """
 Deadline Checker Task
 
-This task checks for approaching deadlines and triggers email notifications.
+Sends the one scheduled reminder the system still has: students whose
+application is still an unsubmitted draft, 3 days before the deadline
+they need to submit against.
 
 Integration:
     - Automatically runs via APScheduler (daily at 9 AM) when backend starts
@@ -18,23 +20,16 @@ Manual Usage:
 
 import asyncio
 import logging
-import math
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import and_, exists, or_, select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.core.config import settings
 from app.db.session import AsyncSessionLocal
 from app.models.application import Application, ApplicationStatus
-from app.models.document_request import DocumentRequest, DocumentRequestStatus
-from app.models.email_management import EmailCategory, ScheduledEmail
-from app.models.review import ApplicationReview
 from app.models.scholarship import ScholarshipConfiguration
 from app.services.email_automation_service import email_automation_service
-from app.services.email_service import EmailService
-from app.services.frontend_email_renderer import render_email_via_frontend
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +37,8 @@ logger = logging.getLogger(__name__)
 class DeadlineChecker:
     """Service for checking and notifying about approaching deadlines"""
 
-    # Warning thresholds (days before deadline)
-    WARNING_DAYS = [7, 3, 1]
+    # Students are reminded exactly once, this many days before the deadline.
+    REMINDER_DAYS_BEFORE = 3
 
     def __init__(self, db: AsyncSession):
         self.db = db
@@ -52,69 +47,53 @@ class DeadlineChecker:
         """Check all types of deadlines and trigger notifications"""
         logger.info("Starting deadline check...")
 
-        # Check different deadline types
         await self.check_submission_deadlines()
-        await self.check_document_request_deadlines()
-        await self.check_review_deadlines()
 
         logger.info("Deadline check completed")
 
     async def check_submission_deadlines(self):
-        """Check for approaching application submission deadlines"""
+        """Remind students whose application is still a draft 3 days before the deadline.
+
+        Renewal and general applications are matched against their own deadline
+        column, so a renewal draft is never reminded about the general deadline
+        (or vice versa).
+        """
         logger.info("Checking submission deadlines...")
 
-        for days_remaining in self.WARNING_DAYS:
-            target_date = datetime.now(timezone.utc) + timedelta(days=days_remaining)
-            target_date_start = target_date.replace(hour=0, minute=0, second=0, microsecond=0)
-            target_date_end = target_date.replace(hour=23, minute=59, second=59, microsecond=999999)
+        days_remaining = self.REMINDER_DAYS_BEFORE
+        target_date = datetime.now(timezone.utc) + timedelta(days=days_remaining)
+        target_date_start = target_date.replace(hour=0, minute=0, second=0, microsecond=0)
+        target_date_end = target_date.replace(hour=23, minute=59, second=59, microsecond=999999)
 
-            # Check renewal application deadlines
-            renewal_stmt = (
+        # (deadline column, deadline_type) — each pairs with its own draft population.
+        deadline_columns = (
+            (ScholarshipConfiguration.renewal_application_end_date, "renewal"),
+            (ScholarshipConfiguration.application_end_date, "general"),
+        )
+
+        for deadline_column, deadline_type in deadline_columns:
+            stmt = (
                 select(ScholarshipConfiguration)
                 .options(selectinload(ScholarshipConfiguration.scholarship_type))
                 .where(
                     and_(
                         ScholarshipConfiguration.is_active.is_(True),
-                        ScholarshipConfiguration.renewal_application_end_date.isnot(None),
-                        ScholarshipConfiguration.renewal_application_end_date >= target_date_start,
-                        ScholarshipConfiguration.renewal_application_end_date <= target_date_end,
+                        deadline_column.isnot(None),
+                        deadline_column >= target_date_start,
+                        deadline_column <= target_date_end,
                     )
                 )
             )
 
-            result = await self.db.execute(renewal_stmt)
-            renewal_configs = result.scalars().all()
+            result = await self.db.execute(stmt)
+            configs = result.scalars().all()
 
             logger.info(
-                f"Found {len(renewal_configs)} scholarship configurations with renewal deadline in {days_remaining} days"
+                f"Found {len(configs)} scholarship configurations with {deadline_type} deadline in {days_remaining} days"
             )
 
-            for config in renewal_configs:
-                await self._notify_submission_deadline(config, days_remaining, deadline_type="renewal")
-
-            # Check general application deadlines
-            general_stmt = (
-                select(ScholarshipConfiguration)
-                .options(selectinload(ScholarshipConfiguration.scholarship_type))
-                .where(
-                    and_(
-                        ScholarshipConfiguration.is_active.is_(True),
-                        ScholarshipConfiguration.application_end_date.isnot(None),
-                        ScholarshipConfiguration.application_end_date >= target_date_start,
-                        ScholarshipConfiguration.application_end_date <= target_date_end,
-                    )
-                )
-            )
-
-            result = await self.db.execute(general_stmt)
-            general_configs = result.scalars().all()
-
-            logger.info(
-                f"Found {len(general_configs)} scholarship configurations with general deadline in {days_remaining} days"
-            )
-
-            for config in general_configs:
-                await self._notify_submission_deadline(config, days_remaining, deadline_type="general")
+            for config in configs:
+                await self._notify_submission_deadline(config, days_remaining, deadline_type=deadline_type)
 
     async def _notify_submission_deadline(
         self, config: ScholarshipConfiguration, days_remaining: int, deadline_type: str = "general"
@@ -126,8 +105,9 @@ class DeadlineChecker:
             days_remaining: Days remaining until deadline
             deadline_type: Type of deadline - "renewal" or "general"
         """
-        # Determine which deadline to use
-        if deadline_type == "renewal":
+        # Determine which deadline to use, and which drafts it actually governs.
+        is_renewal_deadline = deadline_type == "renewal"
+        if is_renewal_deadline:
             deadline = config.renewal_application_end_date
             deadline_label = "renewal_submission"
         else:
@@ -138,7 +118,8 @@ class DeadlineChecker:
             logger.warning(f"No {deadline_type} deadline found for config {config.id}, skipping notification")
             return
 
-        # Find students who have draft applications for this scholarship
+        # Find students whose application for this scholarship is still an
+        # unsubmitted draft. Renewal drafts answer to the renewal deadline only.
         stmt = (
             select(Application)
             .options(
@@ -150,10 +131,8 @@ class DeadlineChecker:
                     Application.scholarship_type_id == config.scholarship_type_id,
                     Application.academic_year == config.academic_year,
                     Application.semester == config.semester,
-                    or_(
-                        Application.status == ApplicationStatus.draft.value,
-                        Application.status == ApplicationStatus.in_progress.value,
-                    ),
+                    Application.status == ApplicationStatus.draft.value,
+                    Application.is_renewal.is_(is_renewal_deadline),
                 )
             )
         )
@@ -162,7 +141,8 @@ class DeadlineChecker:
         draft_applications = result.scalars().all()
 
         logger.info(
-            f"Found {len(draft_applications)} draft applications for scholarship {config.scholarship_type.name if config.scholarship_type else config.scholarship_type_id}"
+            f"Found {len(draft_applications)} {deadline_type} draft applications for scholarship "
+            f"{config.scholarship_type.name if config.scholarship_type else config.scholarship_type_id}"
         )
 
         for application in draft_applications:
@@ -189,7 +169,8 @@ class DeadlineChecker:
                 )
 
                 logger.info(
-                    f"Triggered {deadline_type} deadline notification for application {application.id} (student: {application.student.email})"
+                    f"Triggered {deadline_type} deadline notification for application {application.id} "
+                    f"(student: {application.student.email})"
                 )
 
             except Exception as e:
@@ -198,248 +179,6 @@ class DeadlineChecker:
                     application.id,
                     e,
                 )
-
-    async def check_document_request_deadlines(self):
-        """Check for approaching document request deadlines.
-
-        For each warning threshold (7/3/1 days out), find pending
-        DocumentRequest rows whose deadline lands inside the day-long
-        window and fire a deadline-approaching notification scoped to
-        the document_request category. Mirrors check_submission_deadlines.
-        """
-        logger.info("Checking document request deadlines...")
-
-        for days_remaining in self.WARNING_DAYS:
-            target_date = datetime.now(timezone.utc) + timedelta(days=days_remaining)
-            target_date_start = target_date.replace(hour=0, minute=0, second=0, microsecond=0)
-            target_date_end = target_date.replace(hour=23, minute=59, second=59, microsecond=999999)
-
-            stmt = (
-                select(DocumentRequest)
-                .options(
-                    selectinload(DocumentRequest.application).selectinload(Application.student),
-                    selectinload(DocumentRequest.application).selectinload(Application.scholarship_type_ref),
-                )
-                .where(
-                    and_(
-                        DocumentRequest.status == DocumentRequestStatus.pending.value,
-                        DocumentRequest.deadline.isnot(None),
-                        DocumentRequest.deadline >= target_date_start,
-                        DocumentRequest.deadline <= target_date_end,
-                    )
-                )
-            )
-
-            result = await self.db.execute(stmt)
-            pending_requests = result.scalars().all()
-
-            logger.info(
-                "Found %d pending document requests with deadline in %d days",
-                len(pending_requests),
-                days_remaining,
-            )
-
-            for doc_request in pending_requests:
-                application = doc_request.application
-                if not application or not application.student:
-                    logger.warning(
-                        "DocumentRequest %s has no application/student, skipping notification",
-                        doc_request.id,
-                    )
-                    continue
-
-                student_data = application.student_data or {}
-                scholarship_name = (
-                    application.scholarship_type_ref.name if application.scholarship_type_ref else "Unknown"
-                )
-
-                try:
-                    await email_automation_service.trigger_deadline_approaching(
-                        db=self.db,
-                        application_id=application.id,
-                        deadline_data={
-                            "app_id": application.app_id,
-                            "student_name": student_data.get("name") or application.student.name,
-                            "student_email": student_data.get("email") or application.student.email,
-                            "deadline": doc_request.deadline.strftime("%Y-%m-%d %H:%M"),
-                            "days_remaining": str(days_remaining),
-                            "deadline_type": "document_request",
-                            "document_request_id": doc_request.id,
-                            "requested_documents": doc_request.requested_documents,
-                            "scholarship_name": scholarship_name,
-                        },
-                    )
-                    logger.info(
-                        "Triggered document-request deadline notification for request %s (app %s)",
-                        doc_request.id,
-                        application.id,
-                    )
-                except Exception as e:
-                    logger.exception(
-                        "Failed to trigger document-request deadline notification for request %s: %s",
-                        doc_request.id,
-                        e,
-                    )
-
-    async def check_review_deadlines(self):
-        """Check for approaching review deadlines"""
-        logger.info("Checking review deadlines...")
-        await self.send_professor_review_deadline_reminders()
-
-    async def send_professor_review_deadline_reminders(self):
-        """Send daily reminder emails to professors with pending reviews in the last 3 days before deadline"""
-        now = datetime.now(timezone.utc)
-        window_end = now + timedelta(days=3)
-        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-
-        # Find active configs with professor_review_end within next 3 days (not yet passed)
-        config_stmt = (
-            select(ScholarshipConfiguration)
-            .options(selectinload(ScholarshipConfiguration.scholarship_type))
-            .where(
-                and_(
-                    ScholarshipConfiguration.is_active.is_(True),
-                    ScholarshipConfiguration.professor_review_end.isnot(None),
-                    ScholarshipConfiguration.professor_review_end >= now,
-                    ScholarshipConfiguration.professor_review_end <= window_end,
-                )
-            )
-        )
-        result = await self.db.execute(config_stmt)
-        configs = result.scalars().all()
-
-        logger.info(f"Found {len(configs)} configs with professor review deadline in next 3 days")
-
-        for config in configs:
-            await self._send_professor_reminders_for_config(config, now, today_start)
-
-    async def _send_professor_reminders_for_config(
-        self, config: ScholarshipConfiguration, now: datetime, today_start: datetime
-    ):
-        """Find unreviewed applications for a config and schedule reminder emails"""
-        app_stmt = (
-            select(Application)
-            .options(
-                selectinload(Application.student),
-                selectinload(Application.professor),
-                selectinload(Application.scholarship_type_ref),
-            )
-            .where(
-                and_(
-                    Application.scholarship_configuration_id == config.id,
-                    Application.professor_id.isnot(None),
-                    or_(
-                        Application.status == ApplicationStatus.submitted.value,
-                        Application.status == ApplicationStatus.under_review.value,
-                    ),
-                    # Professor has not submitted a review yet
-                    ~exists(
-                        select(ApplicationReview.id).where(
-                            and_(
-                                ApplicationReview.application_id == Application.id,
-                                ApplicationReview.reviewer_id == Application.professor_id,
-                            )
-                        )
-                    ),
-                    # No reminder email sent today for this application
-                    ~exists(
-                        select(ScheduledEmail.id).where(
-                            and_(
-                                ScheduledEmail.application_id == Application.id,
-                                ScheduledEmail.template_key == "professor_review_notification",
-                                ScheduledEmail.created_at >= today_start,
-                            )
-                        )
-                    ),
-                )
-            )
-        )
-
-        result = await self.db.execute(app_stmt)
-        applications = result.scalars().all()
-
-        logger.info(f"Config {config.id}: scheduling {len(applications)} professor review deadline reminders")
-
-        for application in applications:
-            try:
-                await self._schedule_professor_deadline_reminder(application, config, now)
-            except Exception as e:
-                logger.exception(
-                    "Failed to schedule deadline reminder for application %s: %s",
-                    application.id,
-                    e,
-                )
-
-    async def _schedule_professor_deadline_reminder(
-        self, application: Application, config: ScholarshipConfiguration, now: datetime
-    ):
-        """Render and schedule one deadline reminder email for a professor"""
-        professor = application.professor
-        if not professor or not professor.email:
-            logger.warning(f"Application {application.id} has no professor email, skipping")
-            return
-
-        days_remaining = math.ceil((config.professor_review_end - now).total_seconds() / 86400)
-
-        student_data = application.student_data or {}
-        student_name = student_data.get("std_cname") or (application.student.name if application.student else "")
-        scholarship_name = config.scholarship_type.name if config.scholarship_type else ""
-        submit_date = application.submitted_at.strftime("%Y-%m-%d") if application.submitted_at else ""
-        app_id_str = application.app_id or str(application.id)
-
-        context = {
-            "professor_name": professor.name or "",
-            "student_name": student_name,
-            "app_id": app_id_str,
-            "application_id": application.id,
-            "scholarship_type": scholarship_name,
-            "scholarship_name": scholarship_name,
-            "submit_date": submit_date,
-            "submission_date": submit_date,
-            "system_url": settings.frontend_url,
-            "review_url": f"{settings.frontend_url}/applications/{app_id_str}",
-            "days_remaining": str(days_remaining),
-            "review_deadline": config.professor_review_end.strftime("%Y-%m-%d"),
-            "professor_email": professor.email,
-            "student_email": "",
-            "professor_recommendation": "",
-            "review_result": "",
-            "semester": "",
-            "scholarship_amount": "",
-        }
-
-        html_content = None
-        try:
-            html_content = await render_email_via_frontend(
-                frontend_url=settings.frontend_internal_url,
-                template_name="professor-review-request",
-                context=context,
-            )
-        except Exception as e:
-            logger.exception(
-                "Failed to render deadline reminder HTML for application %s: %s",
-                application.id,
-                e,
-            )
-
-        await EmailService().schedule_email(
-            db=self.db,
-            to=professor.email,
-            subject=f"[提醒] 尚有 {days_remaining} 天 — 請完成審核 {app_id_str}",
-            body=f"請完成審核：{app_id_str}（剩餘 {days_remaining} 天）",
-            scheduled_for=now,
-            html_content=html_content,
-            email_category=EmailCategory.recommendation_professor,
-            application_id=application.id,
-            scholarship_type_id=config.scholarship_type_id,
-            template_key="professor_review_notification",
-            created_by_user_id=1,
-        )
-
-        logger.info(
-            f"Scheduled deadline reminder → {professor.email} for application {app_id_str} "
-            f"({days_remaining} days remaining)"
-        )
 
 
 async def run_deadline_check():

--- a/backend/app/tests/test_application_bulk_approve_dashboard.py
+++ b/backend/app/tests/test_application_bulk_approve_dashboard.py
@@ -109,18 +109,15 @@ def test_bulk_approve_min_length_1():
         BulkApproveRequest(application_ids=[])
 
 
-def test_bulk_approve_send_notifications_defaults_true():
-    # Pin: send_notifications=True default. Admins expect approvals
-    # to notify the student by default. Flipping to False would
-    # silently approve applications without telling anyone.
+def test_bulk_approve_has_no_send_notifications_flag():
+    # Pin: bulk approval never emails the student, so there is no flag to set.
+    # Students receive mail on submission and on the 3-day draft reminder only.
+    assert "send_notifications" not in BulkApproveRequest.model_fields
+
+    # Extra keys are ignored rather than rejected, so assert on the model, not
+    # on a ValidationError: a stale caller still passing the flag gets no field.
     r = BulkApproveRequest(application_ids=[1, 2, 3])
-    assert r.send_notifications is True
-
-
-def test_bulk_approve_send_notifications_can_be_disabled():
-    # Pin: explicit opt-out works (silent bulk for migrations).
-    r = BulkApproveRequest(application_ids=[1], send_notifications=False)
-    assert r.send_notifications is False
+    assert not hasattr(r, "send_notifications")
 
 
 def test_bulk_approve_comments_optional():

--- a/backend/app/tests/test_assign_professor.py
+++ b/backend/app/tests/test_assign_professor.py
@@ -118,33 +118,36 @@ async def _seed_app(
 
 @pytest.fixture
 def silence_side_effects(monkeypatch):
-    """Stop EmailService.schedule_email + NotificationService.create_notification
-    from doing real work. The production code wraps both calls in try/except so
-    failures don't bubble — these tests assert the DB write happens regardless.
+    """Stop NotificationService.create_notification from doing real work.
+
+    EmailService.schedule_email is patched too, but only as a tripwire: assignment
+    must NOT send mail any more (professors are mailed on student submission only),
+    so a call here means the removed email path came back.
     """
 
     async def _noop(*args: Any, **kwargs: Any) -> Any:
         return None
 
+    async def _must_not_send(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("assign_professor must not schedule an email")
+
     from app.services.email_service import EmailService
     from app.services.notification_service import NotificationService
 
-    monkeypatch.setattr(EmailService, "schedule_email", _noop)
+    monkeypatch.setattr(EmailService, "schedule_email", _must_not_send)
     monkeypatch.setattr(NotificationService, "create_notification", _noop)
 
 
 @pytest.fixture
 def raise_side_effects(monkeypatch):
-    """Force both collaborators to raise — pins that assign_professor's
+    """Force the notification collaborator to raise — pins that assign_professor's
     try/except boundary keeps the DB write committed."""
 
     async def _boom(*args: Any, **kwargs: Any) -> Any:
         raise RuntimeError("collaborator down — must not bubble")
 
-    from app.services.email_service import EmailService
     from app.services.notification_service import NotificationService
 
-    monkeypatch.setattr(EmailService, "schedule_email", _boom)
     monkeypatch.setattr(NotificationService, "create_notification", _boom)
 
 
@@ -295,9 +298,8 @@ async def test_happy_path_admin_assigns_and_application_updated(db: AsyncSession
 
 @pytest.mark.asyncio
 async def test_collaborator_failures_do_not_block_db_write(db: AsyncSession, raise_side_effects):
-    """If EmailService / NotificationService both raise, the assignment must
-    still be persisted — they're best-effort side effects per the production
-    try/except boundaries.
+    """If NotificationService raises, the assignment must still be persisted —
+    it's a best-effort side effect per the production try/except boundary.
     """
     admin = await _seed_user(db, role=UserRole.admin, name="Admin", nycu_id="a_collab_fail")
     student = await _seed_user(db, role=UserRole.student, name="S", nycu_id="s_collab_fail")

--- a/backend/app/tests/test_bulk_approval_service.py
+++ b/backend/app/tests/test_bulk_approval_service.py
@@ -41,15 +41,14 @@ class TestBulkApprovalServiceApprove:
         with patch.object(
             service.notification_service,
             "send_status_change_notification",
-            return_value=True,
-        ):
-            results = await service.bulk_approve_applications(
-                application_ids=[1], approver_user_id=2, send_notifications=True
-            )
+            new_callable=AsyncMock,
+        ) as mock_notify:
+            results = await service.bulk_approve_applications(application_ids=[1], approver_user_id=2)
 
         assert results["total_requested"] == 1
         assert len(results["successful_approvals"]) == 1
-        assert results["notifications_sent"] == 1
+        # Bulk approval no longer emails the student.
+        mock_notify.assert_not_called()
         assert mock_application.status == ApplicationStatus.approved.value
 
     async def test_bulk_approve_invalid_status(self, service, mock_application):
@@ -60,9 +59,7 @@ class TestBulkApprovalServiceApprove:
         mock_result.scalars.return_value.all.return_value = [mock_application]
         service.db.execute = AsyncMock(return_value=mock_result)
 
-        results = await service.bulk_approve_applications(
-            application_ids=[1], approver_user_id=2, send_notifications=False
-        )
+        results = await service.bulk_approve_applications(application_ids=[1], approver_user_id=2)
 
         assert len(results["failed_approvals"]) == 1
         assert "Invalid status" in results["failed_approvals"][0]["reason"]

--- a/backend/app/tests/test_bulk_approval_service_unit.py
+++ b/backend/app/tests/test_bulk_approval_service_unit.py
@@ -120,8 +120,8 @@ async def test_bulk_approve_applications_success(monkeypatch):
 
     assert result["total_requested"] == 2
     assert len(result["successful_approvals"]) == 2
-    assert result["notifications_sent"] == 1
-    assert result["notifications_failed"] == 1
+    # Students are never emailed about a bulk outcome.
+    assert notification_stub.status_calls == []
     assert session.commits == 2
     # Note: priority_score calculation removed - no longer needed
     assert all(item["new_status"] == ApplicationStatus.approved.value for item in result["successful_approvals"])
@@ -141,29 +141,29 @@ async def test_bulk_approve_applications_handles_invalid_status():
 
 
 @pytest.mark.asyncio
-async def test_bulk_approve_handles_missing_ids_and_no_notifications():
+async def test_bulk_approve_handles_missing_ids():
     app = DummyApplication("APP-missing", ApplicationStatus.submitted.value)
     session = StubSession([StubResult([app])])
     service = make_service(session)
 
-    result = await service.bulk_approve_applications([app.id, 999], approver_user_id=2, send_notifications=False)
+    result = await service.bulk_approve_applications([app.id, 999], approver_user_id=2)
 
     assert result["total_requested"] == 2
     assert len(result["successful_approvals"]) == 1
-    assert result["notifications_sent"] == 0
-    assert result["notifications_failed"] == 0
 
 
 @pytest.mark.asyncio
-async def test_bulk_approve_records_notification_error(monkeypatch):
+async def test_bulk_approve_never_notifies_the_student():
+    """A notifier that would explode proves the approval path never calls it."""
     app = DummyApplication("APP-4", ApplicationStatus.under_review.value)
     session = StubSession([StubResult([app])])
-    notification_stub = StubNotificationService(responses=[RuntimeError("boom")])
+    notification_stub = StubNotificationService(responses=[RuntimeError("must not be sent")])
     service = make_service(session, notification_stub)
 
     result = await service.bulk_approve_applications([app.id], approver_user_id=5)
 
-    assert result["notifications_failed"] == 1
+    assert len(result["successful_approvals"]) == 1
+    assert notification_stub.status_calls == []
     assert session.commits == 1
     assert session.rollbacks == 0
 
@@ -214,7 +214,7 @@ async def test_bulk_reject_applications_success():
     result = await service.bulk_reject_applications([app.id], rejector_user_id=7, rejection_reason="missing docs")
 
     assert len(result["successful_rejections"]) == 1
-    assert result["notifications_sent"] == 1
+    assert notification_stub.status_calls == []
     # Note: rejection_reason moved to ApplicationReview model
     assert len(session.added_objects) == 1  # ApplicationReview record created
     assert session.added_objects[0].comments == "missing docs"
@@ -252,17 +252,16 @@ async def test_bulk_reject_commit_failure():
 
 
 @pytest.mark.asyncio
-async def test_bulk_reject_no_notifications():
+async def test_bulk_reject_never_notifies_the_student():
     app = DummyApplication("APP-reject2", ApplicationStatus.under_review.value)
     session = StubSession([StubResult([app])])
-    service = make_service(session)
+    notification_stub = StubNotificationService(responses=[RuntimeError("must not be sent")])
+    service = make_service(session, notification_stub)
 
-    result = await service.bulk_reject_applications(
-        [app.id], rejector_user_id=5, rejection_reason="late", send_notifications=False
-    )
+    result = await service.bulk_reject_applications([app.id], rejector_user_id=5, rejection_reason="late")
 
-    assert result["notifications_sent"] == 0
-    assert result["notifications_failed"] == 0
+    assert len(result["successful_rejections"]) == 1
+    assert notification_stub.status_calls == []
 
 
 @pytest.mark.asyncio

--- a/backend/app/tests/test_college_ranking_submitted_email.py
+++ b/backend/app/tests/test_college_ranking_submitted_email.py
@@ -1,0 +1,160 @@
+"""Tests for the third email trigger point: 學院送出排名 → 寄信給學院.
+
+The college finalizes ("送出") its ranking and the reviewers of that college get
+a confirmation. Unlike the other two trigger points this one is ranking-scoped,
+so the recipient query binds ``{college_code}`` rather than ``{application_id}``.
+
+Contract pinned here:
+- The trigger emits the ``college_review_submitted`` event with a context that
+  carries every placeholder the seeded rule and templates reference.
+- The seeded condition_query survives the read-only SQL guard and resolves to
+  exactly the college users of the ranking's own college.
+- The template key maps to the React template and the 學院 email category.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.seed_scholarship_configs import (
+    COLLEGE_RANKING_SUBMITTED_BODY,
+    COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY,
+    COLLEGE_RANKING_SUBMITTED_SUBJECT,
+    COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY,
+)
+from app.models.email_management import EmailAutomationRule, EmailCategory, TriggerEvent
+from app.models.user import User, UserRole, UserType
+from app.services.email_automation_service import email_automation_service
+
+RANKING_DATA = {
+    "ranking_id": 42,
+    "college_code": "C",
+    "college_name": "資訊學院",
+    "ranking_name": "114-1 博士生獎學金排名",
+    "scholarship_type": "博士生獎學金",
+    "scholarship_type_id": 7,
+    "sub_type_code": "nstc",
+    "academic_year": "114",
+    "semester": "first",
+    "total_applications": "12",
+    "finalized_by": "學院承辦人",
+    "finalized_at": "2026-08-03 10:00",
+}
+
+
+async def _seed_user(
+    db: AsyncSession,
+    *,
+    nycu_id: str,
+    role: UserRole,
+    college_code: str | None,
+    email: str | None = "unset",
+) -> User:
+    user = User(
+        nycu_id=nycu_id,
+        name=nycu_id,
+        email=f"{nycu_id}@u.edu" if email == "unset" else email,
+        user_type=UserType.employee if role != UserRole.student else UserType.student,
+        role=role,
+        college_code=college_code,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_trigger_emits_college_review_submitted_with_full_context(db: AsyncSession, monkeypatch):
+    captured = {}
+
+    async def _capture(_db, trigger_event, context):
+        captured["event"] = trigger_event
+        captured["context"] = context
+
+    monkeypatch.setattr(email_automation_service, "process_trigger", _capture)
+
+    await email_automation_service.trigger_college_ranking_submitted(db=db, ranking_data=RANKING_DATA)
+
+    assert captured["event"] == "college_review_submitted"
+    context = captured["context"]
+    assert context["ranking_id"] == 42
+    assert context["college_code"] == "C"
+    assert context["college_name"] == "資訊學院"
+    assert context["scholarship_name"] == "博士生獎學金"  # alias used by the templates
+    assert context["system_url"]
+
+
+@pytest.mark.asyncio
+async def test_seeded_templates_render_against_the_trigger_context(db: AsyncSession, monkeypatch):
+    """Every {placeholder} in the seeded subject/body must exist in the context.
+
+    _schedule_automated_email calls ``.format(**context)`` on both, so a missing
+    key is a KeyError at send time rather than a bad-looking email.
+    """
+    captured = {}
+
+    async def _capture(_db, trigger_event, context):
+        captured["context"] = context
+
+    monkeypatch.setattr(email_automation_service, "process_trigger", _capture)
+    await email_automation_service.trigger_college_ranking_submitted(db=db, ranking_data=RANKING_DATA)
+
+    context = captured["context"]
+    subject = COLLEGE_RANKING_SUBMITTED_SUBJECT.format(**context)
+    body = COLLEGE_RANKING_SUBMITTED_BODY.format(**context)
+
+    assert "博士生獎學金" in subject
+    assert "資訊學院" in body
+    assert "nstc" in body
+
+
+@pytest.mark.asyncio
+async def test_condition_query_resolves_only_that_colleges_reviewers(db: AsyncSession):
+    target = await _seed_user(db, nycu_id="col_c1", role=UserRole.college, college_code="C")
+    also_target = await _seed_user(db, nycu_id="col_c2", role=UserRole.college, college_code="C")
+    await _seed_user(db, nycu_id="col_e1", role=UserRole.college, college_code="E")  # other college
+    await _seed_user(db, nycu_id="prof_c", role=UserRole.professor, college_code="C")  # wrong role
+    await _seed_user(db, nycu_id="col_noemail", role=UserRole.college, college_code="C", email=None)
+
+    rule = EmailAutomationRule(
+        name="學院排名送出通知",
+        trigger_event=TriggerEvent.college_review_submitted,
+        template_key=COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY,
+        condition_query=COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY,
+        delay_hours=0,
+        is_active=True,
+    )
+
+    recipients = await email_automation_service._get_recipients(db, rule, {"college_code": "C"})
+
+    assert sorted(r["email"] for r in recipients) == sorted([target.email, also_target.email])
+
+
+@pytest.mark.asyncio
+async def test_global_admin_ranking_resolves_to_no_recipients(db: AsyncSession):
+    """A ranking with college_code NULL must not fan out to every college."""
+    await _seed_user(db, nycu_id="col_any", role=UserRole.college, college_code="C")
+
+    rule = EmailAutomationRule(
+        name="學院排名送出通知",
+        trigger_event=TriggerEvent.college_review_submitted,
+        template_key=COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY,
+        condition_query=COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY,
+        delay_hours=0,
+        is_active=True,
+    )
+
+    recipients = await email_automation_service._get_recipients(db, rule, {"college_code": None})
+
+    assert recipients == []
+
+
+def test_template_key_maps_to_react_template_and_college_category():
+    assert (
+        email_automation_service._get_react_email_template_name(COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY)
+        == "college-ranking-submitted"
+    )
+    assert (
+        email_automation_service._get_email_category_from_template_key(COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY)
+        == EmailCategory.review_college
+    )

--- a/backend/app/tests/test_critical_workflows.py
+++ b/backend/app/tests/test_critical_workflows.py
@@ -195,19 +195,13 @@ class TestCriticalAuthorizationPaths:
 
         bulk_service = BulkApprovalService(db)
 
-        # Admin can approve
-        with patch.object(
-            bulk_service.notification_service,
-            "send_status_change_notification",
-            return_value=True,
-        ):
-            result = await bulk_service.bulk_approve_applications(
-                application_ids=[app.id],
-                approver_user_id=test_admin.id,
-                send_notifications=False,
-            )
+        # Admin can approve (bulk approval sends no student email at all)
+        result = await bulk_service.bulk_approve_applications(
+            application_ids=[app.id],
+            approver_user_id=test_admin.id,
+        )
 
-            assert len(result["successful_approvals"]) == 1
+        assert len(result["successful_approvals"]) == 1
 
 
 @pytest.mark.integration
@@ -269,18 +263,12 @@ class TestCriticalBusinessLogic:
 
         # Approve first 2 - should succeed
         bulk_service = BulkApprovalService(db)
-        with patch.object(
-            bulk_service.notification_service,
-            "send_status_change_notification",
-            return_value=True,
-        ):
-            result = await bulk_service.bulk_approve_applications(
-                application_ids=[apps[0].id, apps[1].id],
-                approver_user_id=1,
-                send_notifications=False,
-            )
+        result = await bulk_service.bulk_approve_applications(
+            application_ids=[apps[0].id, apps[1].id],
+            approver_user_id=1,
+        )
 
-            assert len(result["successful_approvals"]) == 2
+        assert len(result["successful_approvals"]) == 2
 
         # Check quota availability - should show 0 available
         from app.services.scholarship_configuration_service import ScholarshipConfigurationService

--- a/backend/app/tests/test_deadline_checker_draft_reminder.py
+++ b/backend/app/tests/test_deadline_checker_draft_reminder.py
@@ -1,0 +1,220 @@
+"""Tests for the one surviving scheduled reminder: draft + 3 days before deadline.
+
+Pins the second of the system's three email trigger points:
+
+    學生：狀態在暫存未送出（draft）且在申請截止日前三天
+
+Contract pinned here:
+- Fires at exactly 3 days out, not at 7 or 1 (the old WARNING_DAYS ladder).
+- Only ``status = draft`` qualifies. The previous implementation also named
+  ``ApplicationStatus.in_progress``, which does not exist on the enum — that
+  raised AttributeError and took the whole daily job down, so a regression test
+  for "draft only" is also the regression test for that crash.
+- A renewal draft is matched against ``renewal_application_end_date`` and a
+  general draft against ``application_end_date`` — never crosswise.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application, ApplicationStatus
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.services.email_automation_service import email_automation_service
+from app.tasks.deadline_checker import DeadlineChecker
+
+NOW = datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def captured_triggers(monkeypatch) -> List[Dict[str, Any]]:
+    """Record trigger_deadline_approaching calls instead of queueing mail."""
+    calls: List[Dict[str, Any]] = []
+
+    async def _record(db, application_id: int, deadline_data: Dict[str, Any]) -> None:
+        calls.append({"application_id": application_id, **deadline_data})
+
+    monkeypatch.setattr(email_automation_service, "trigger_deadline_approaching", _record)
+    return calls
+
+
+async def _seed_student(db: AsyncSession, nycu_id: str) -> User:
+    user = User(
+        nycu_id=nycu_id,
+        name=f"Student {nycu_id}",
+        email=f"{nycu_id}@u.edu",
+        user_type=UserType.student,
+        role=UserRole.student,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _seed_config(
+    db: AsyncSession,
+    *,
+    suffix: str,
+    application_end_date: datetime | None = None,
+    renewal_application_end_date: datetime | None = None,
+) -> ScholarshipConfiguration:
+    st = ScholarshipType(code=f"dl_{suffix}", name=f"Deadline type {suffix}", status="active")
+    db.add(st)
+    await db.commit()
+    await db.refresh(st)
+
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=st.id,
+        config_code=f"dl_cfg_{suffix}",
+        config_name=f"Deadline cfg {suffix}",
+        academic_year=114,
+        application_start_date=NOW - timedelta(days=30),
+        application_end_date=application_end_date,
+        renewal_application_end_date=renewal_application_end_date,
+        amount=0,
+        is_active=True,
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+    return cfg
+
+
+async def _seed_app(
+    db: AsyncSession,
+    *,
+    student: User,
+    config: ScholarshipConfiguration,
+    suffix: str,
+    status: str = ApplicationStatus.draft.value,
+    is_renewal: bool = False,
+) -> Application:
+    app = Application(
+        app_id=f"APP-DL-{suffix}",
+        user_id=student.id,
+        scholarship_type_id=config.scholarship_type_id,
+        scholarship_configuration_id=config.id,
+        academic_year=config.academic_year,
+        semester=config.semester,
+        sub_type_selection_mode="single",
+        status=status,
+        is_renewal=is_renewal,
+        student_data={"std_cname": student.name},
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_draft_is_reminded_three_days_before_general_deadline(db: AsyncSession, captured_triggers):
+    student = await _seed_student(db, "dl_hit")
+    cfg = await _seed_config(db, suffix="hit", application_end_date=NOW + timedelta(days=3))
+    app = await _seed_app(db, student=student, config=cfg, suffix="hit")
+
+    await DeadlineChecker(db).check_submission_deadlines()
+
+    assert len(captured_triggers) == 1
+    call = captured_triggers[0]
+    assert call["application_id"] == app.id
+    assert call["deadline_type"] == "submission"
+    assert call["days_remaining"] == "3"
+
+
+@pytest.mark.asyncio
+async def test_no_reminder_seven_days_out(db: AsyncSession, captured_triggers):
+    student = await _seed_student(db, "dl_seven")
+    cfg = await _seed_config(db, suffix="seven", application_end_date=NOW + timedelta(days=7))
+    await _seed_app(db, student=student, config=cfg, suffix="seven")
+
+    await DeadlineChecker(db).check_submission_deadlines()
+
+    assert captured_triggers == []
+
+
+@pytest.mark.asyncio
+async def test_no_reminder_one_day_out(db: AsyncSession, captured_triggers):
+    student = await _seed_student(db, "dl_one")
+    cfg = await _seed_config(db, suffix="one", application_end_date=NOW + timedelta(days=1))
+    await _seed_app(db, student=student, config=cfg, suffix="one")
+
+    await DeadlineChecker(db).check_submission_deadlines()
+
+    assert captured_triggers == []
+
+
+@pytest.mark.asyncio
+async def test_submitted_application_is_not_reminded(db: AsyncSession, captured_triggers):
+    """Only 暫存未送出 qualifies — a submitted application already made it."""
+    student = await _seed_student(db, "dl_submitted")
+    cfg = await _seed_config(db, suffix="submitted", application_end_date=NOW + timedelta(days=3))
+    await _seed_app(
+        db,
+        student=student,
+        config=cfg,
+        suffix="submitted",
+        status=ApplicationStatus.submitted.value,
+    )
+
+    await DeadlineChecker(db).check_submission_deadlines()
+
+    assert captured_triggers == []
+
+
+@pytest.mark.asyncio
+async def test_renewal_draft_matches_renewal_deadline_only(db: AsyncSession, captured_triggers):
+    """A renewal draft answers to renewal_application_end_date, not the general one."""
+    renewal_student = await _seed_student(db, "dl_renewal")
+    general_student = await _seed_student(db, "dl_general")
+
+    # Renewal closes in 3 days; the general deadline is far away.
+    cfg = await _seed_config(
+        db,
+        suffix="split",
+        application_end_date=NOW + timedelta(days=30),
+        renewal_application_end_date=NOW + timedelta(days=3),
+    )
+    renewal_app = await _seed_app(db, student=renewal_student, config=cfg, suffix="renewal", is_renewal=True)
+    await _seed_app(db, student=general_student, config=cfg, suffix="general", is_renewal=False)
+
+    await DeadlineChecker(db).check_submission_deadlines()
+
+    assert len(captured_triggers) == 1
+    call = captured_triggers[0]
+    assert call["application_id"] == renewal_app.id
+    assert call["deadline_type"] == "renewal_submission"
+
+
+@pytest.mark.asyncio
+async def test_general_draft_not_reminded_by_renewal_deadline(db: AsyncSession, captured_triggers):
+    student = await _seed_student(db, "dl_cross")
+    cfg = await _seed_config(
+        db,
+        suffix="cross",
+        application_end_date=NOW + timedelta(days=30),
+        renewal_application_end_date=NOW + timedelta(days=3),
+    )
+    await _seed_app(db, student=student, config=cfg, suffix="cross", is_renewal=False)
+
+    await DeadlineChecker(db).check_submission_deadlines()
+
+    assert captured_triggers == []
+
+
+@pytest.mark.asyncio
+async def test_check_all_deadlines_runs_clean_with_a_matching_config(db: AsyncSession, captured_triggers):
+    """Regression: the old ApplicationStatus.in_progress reference raised
+    AttributeError as soon as any config's deadline landed on a boundary,
+    which aborted the whole daily job."""
+    student = await _seed_student(db, "dl_all")
+    cfg = await _seed_config(db, suffix="all", application_end_date=NOW + timedelta(days=3))
+    await _seed_app(db, student=student, config=cfg, suffix="all")
+
+    await DeadlineChecker(db).check_all_deadlines()
+
+    assert len(captured_triggers) == 1

--- a/backend/app/tests/test_deadline_checker_draft_reminder.py
+++ b/backend/app/tests/test_deadline_checker_draft_reminder.py
@@ -26,7 +26,17 @@ from app.models.user import User, UserRole, UserType
 from app.services.email_automation_service import email_automation_service
 from app.tasks.deadline_checker import DeadlineChecker
 
-NOW = datetime.now(timezone.utc)
+
+def _deadline_in(days: int) -> datetime:
+    """A deadline `days` out, anchored at NOON of that day.
+
+    The checker builds a window covering the whole UTC day that is N days from
+    *its own* now(). Anchoring at noon — and computing it per call rather than
+    once at import — keeps the value well inside that window no matter when in
+    the day the suite runs or how long it takes to reach this test.
+    """
+    target = datetime.now(timezone.utc) + timedelta(days=days)
+    return target.replace(hour=12, minute=0, second=0, microsecond=0)
 
 
 @pytest.fixture
@@ -39,6 +49,16 @@ def captured_triggers(monkeypatch) -> List[Dict[str, Any]]:
 
     monkeypatch.setattr(email_automation_service, "trigger_deadline_approaching", _record)
     return calls
+
+
+def _for_app(calls: List[Dict[str, Any]], application: Application) -> List[Dict[str, Any]]:
+    """Only the reminders for *application*.
+
+    Scoped rather than asserting on the total: check_submission_deadlines scans
+    every active config in the database, so a global count would couple this
+    test to whatever else happens to be seeded.
+    """
+    return [c for c in calls if c["application_id"] == application.id]
 
 
 async def _seed_student(db: AsyncSession, nycu_id: str) -> User:
@@ -72,7 +92,7 @@ async def _seed_config(
         config_code=f"dl_cfg_{suffix}",
         config_name=f"Deadline cfg {suffix}",
         academic_year=114,
-        application_start_date=NOW - timedelta(days=30),
+        application_start_date=datetime.now(timezone.utc) - timedelta(days=30),
         application_end_date=application_end_date,
         renewal_application_end_date=renewal_application_end_date,
         amount=0,
@@ -114,46 +134,45 @@ async def _seed_app(
 @pytest.mark.asyncio
 async def test_draft_is_reminded_three_days_before_general_deadline(db: AsyncSession, captured_triggers):
     student = await _seed_student(db, "dl_hit")
-    cfg = await _seed_config(db, suffix="hit", application_end_date=NOW + timedelta(days=3))
+    cfg = await _seed_config(db, suffix="hit", application_end_date=_deadline_in(3))
     app = await _seed_app(db, student=student, config=cfg, suffix="hit")
 
     await DeadlineChecker(db).check_submission_deadlines()
 
-    assert len(captured_triggers) == 1
-    call = captured_triggers[0]
-    assert call["application_id"] == app.id
-    assert call["deadline_type"] == "submission"
-    assert call["days_remaining"] == "3"
+    mine = _for_app(captured_triggers, app)
+    assert len(mine) == 1
+    assert mine[0]["deadline_type"] == "submission"
+    assert mine[0]["days_remaining"] == "3"
 
 
 @pytest.mark.asyncio
 async def test_no_reminder_seven_days_out(db: AsyncSession, captured_triggers):
     student = await _seed_student(db, "dl_seven")
-    cfg = await _seed_config(db, suffix="seven", application_end_date=NOW + timedelta(days=7))
-    await _seed_app(db, student=student, config=cfg, suffix="seven")
+    cfg = await _seed_config(db, suffix="seven", application_end_date=_deadline_in(7))
+    app = await _seed_app(db, student=student, config=cfg, suffix="seven")
 
     await DeadlineChecker(db).check_submission_deadlines()
 
-    assert captured_triggers == []
+    assert _for_app(captured_triggers, app) == []
 
 
 @pytest.mark.asyncio
 async def test_no_reminder_one_day_out(db: AsyncSession, captured_triggers):
     student = await _seed_student(db, "dl_one")
-    cfg = await _seed_config(db, suffix="one", application_end_date=NOW + timedelta(days=1))
-    await _seed_app(db, student=student, config=cfg, suffix="one")
+    cfg = await _seed_config(db, suffix="one", application_end_date=_deadline_in(1))
+    app = await _seed_app(db, student=student, config=cfg, suffix="one")
 
     await DeadlineChecker(db).check_submission_deadlines()
 
-    assert captured_triggers == []
+    assert _for_app(captured_triggers, app) == []
 
 
 @pytest.mark.asyncio
 async def test_submitted_application_is_not_reminded(db: AsyncSession, captured_triggers):
     """Only 暫存未送出 qualifies — a submitted application already made it."""
     student = await _seed_student(db, "dl_submitted")
-    cfg = await _seed_config(db, suffix="submitted", application_end_date=NOW + timedelta(days=3))
-    await _seed_app(
+    cfg = await _seed_config(db, suffix="submitted", application_end_date=_deadline_in(3))
+    app = await _seed_app(
         db,
         student=student,
         config=cfg,
@@ -163,7 +182,7 @@ async def test_submitted_application_is_not_reminded(db: AsyncSession, captured_
 
     await DeadlineChecker(db).check_submission_deadlines()
 
-    assert captured_triggers == []
+    assert _for_app(captured_triggers, app) == []
 
 
 @pytest.mark.asyncio
@@ -176,18 +195,19 @@ async def test_renewal_draft_matches_renewal_deadline_only(db: AsyncSession, cap
     cfg = await _seed_config(
         db,
         suffix="split",
-        application_end_date=NOW + timedelta(days=30),
-        renewal_application_end_date=NOW + timedelta(days=3),
+        application_end_date=_deadline_in(30),
+        renewal_application_end_date=_deadline_in(3),
     )
     renewal_app = await _seed_app(db, student=renewal_student, config=cfg, suffix="renewal", is_renewal=True)
-    await _seed_app(db, student=general_student, config=cfg, suffix="general", is_renewal=False)
+    general_app = await _seed_app(db, student=general_student, config=cfg, suffix="general", is_renewal=False)
 
     await DeadlineChecker(db).check_submission_deadlines()
 
-    assert len(captured_triggers) == 1
-    call = captured_triggers[0]
-    assert call["application_id"] == renewal_app.id
-    assert call["deadline_type"] == "renewal_submission"
+    mine = _for_app(captured_triggers, renewal_app)
+    assert len(mine) == 1
+    assert mine[0]["deadline_type"] == "renewal_submission"
+    # The general draft under the same config must NOT be pulled in.
+    assert _for_app(captured_triggers, general_app) == []
 
 
 @pytest.mark.asyncio
@@ -196,14 +216,14 @@ async def test_general_draft_not_reminded_by_renewal_deadline(db: AsyncSession, 
     cfg = await _seed_config(
         db,
         suffix="cross",
-        application_end_date=NOW + timedelta(days=30),
-        renewal_application_end_date=NOW + timedelta(days=3),
+        application_end_date=_deadline_in(30),
+        renewal_application_end_date=_deadline_in(3),
     )
-    await _seed_app(db, student=student, config=cfg, suffix="cross", is_renewal=False)
+    app = await _seed_app(db, student=student, config=cfg, suffix="cross", is_renewal=False)
 
     await DeadlineChecker(db).check_submission_deadlines()
 
-    assert captured_triggers == []
+    assert _for_app(captured_triggers, app) == []
 
 
 @pytest.mark.asyncio
@@ -212,9 +232,9 @@ async def test_check_all_deadlines_runs_clean_with_a_matching_config(db: AsyncSe
     AttributeError as soon as any config's deadline landed on a boundary,
     which aborted the whole daily job."""
     student = await _seed_student(db, "dl_all")
-    cfg = await _seed_config(db, suffix="all", application_end_date=NOW + timedelta(days=3))
-    await _seed_app(db, student=student, config=cfg, suffix="all")
+    cfg = await _seed_config(db, suffix="all", application_end_date=_deadline_in(3))
+    app = await _seed_app(db, student=student, config=cfg, suffix="all")
 
     await DeadlineChecker(db).check_all_deadlines()
 
-    assert len(captured_triggers) == 1
+    assert len(_for_app(captured_triggers, app)) == 1

--- a/backend/app/tests/test_email_seed_idempotency.py
+++ b/backend/app/tests/test_email_seed_idempotency.py
@@ -1,0 +1,131 @@
+"""The email seeders must merge per row, never skip on a non-empty table.
+
+``scripts/reset_database.sh`` runs ``alembic upgrade head`` BEFORE ``python -m
+app.seed``, and ``email_timing_three_triggers_001`` inserts the 學院排名送出通知
+rule and its template. With the old table-level guard
+(``if existing: return``) that single pre-existing row made both seeders bail
+out, so a fresh database ended up with the college rule and nothing else —
+trigger point 1 (學生送出申請 → 學生 + 教授) had no active rule and silently
+sent no mail at all.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from app.db.seed_scholarship_configs import (
+    COLLEGE_RANKING_SUBMITTED_BODY,
+    COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY,
+    COLLEGE_RANKING_SUBMITTED_SUBJECT,
+    COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY,
+    seed_email_automation_rules,
+    seed_email_templates,
+)
+from app.models.email_management import EmailAutomationRule, TriggerEvent
+from app.models.system_setting import EmailTemplate, SendingType
+
+# The rules the two submission emails depend on — the ones the old guard dropped.
+SUBMISSION_RULE_NAMES = {"申請提交確認郵件", "教授審核通知"}
+SUBMISSION_TEMPLATE_KEYS = {"application_submitted_student", "professor_review_notification"}
+
+
+async def _template_keys(db) -> set[str]:
+    result = await db.execute(select(EmailTemplate.key))
+    return set(result.scalars().all())
+
+
+async def _rule_names(db) -> set[str]:
+    result = await db.execute(select(EmailAutomationRule.name))
+    return set(result.scalars().all())
+
+
+async def _insert_migration_rows(db) -> None:
+    """Recreate exactly what the alembic migration leaves behind."""
+    db.add(
+        EmailTemplate(
+            key=COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY,
+            subject_template=COLLEGE_RANKING_SUBMITTED_SUBJECT,
+            body_template=COLLEGE_RANKING_SUBMITTED_BODY,
+            sending_type=SendingType.single,
+            requires_approval=False,
+            recipient_options=[{"label": "學院承辦人", "value": "college"}],
+        )
+    )
+    db.add(
+        EmailAutomationRule(
+            name="學院排名送出通知",
+            description="當學院送出（確認）排名後，通知該學院承辦人排名已送出",
+            trigger_event=TriggerEvent.college_review_submitted,
+            template_key=COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY,
+            condition_query=COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY,
+            delay_hours=0,
+            is_active=True,
+        )
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_seed_still_creates_submission_rows_after_migration_inserted_one(db):
+    """Migration-then-seed must end with all three trigger points wired."""
+    await _insert_migration_rows(db)
+
+    await seed_email_templates(db)
+    await seed_email_automation_rules(db)
+
+    keys = await _template_keys(db)
+    names = await _rule_names(db)
+
+    # The pre-existing row survives...
+    assert COLLEGE_RANKING_SUBMITTED_TEMPLATE_KEY in keys
+    assert "學院排名送出通知" in names
+    # ...and the rows the old table-level guard would have skipped are created.
+    assert SUBMISSION_TEMPLATE_KEYS <= keys
+    assert SUBMISSION_RULE_NAMES <= names
+
+
+@pytest.mark.asyncio
+async def test_all_seeded_rules_reference_a_seeded_template(db):
+    """A rule whose template_key has no row is silently dropped at send time."""
+    await _insert_migration_rows(db)
+    await seed_email_templates(db)
+    await seed_email_automation_rules(db)
+
+    keys = await _template_keys(db)
+    result = await db.execute(select(EmailAutomationRule.name, EmailAutomationRule.template_key))
+    for name, template_key in result.all():
+        assert template_key in keys, f"rule {name} points at missing template {template_key}"
+
+
+@pytest.mark.asyncio
+async def test_seeders_are_idempotent(db):
+    """Re-running the seed must not duplicate rows."""
+    await seed_email_templates(db)
+    await seed_email_automation_rules(db)
+    first_keys = await _template_keys(db)
+    first_names = await _rule_names(db)
+
+    await seed_email_templates(db)
+    await seed_email_automation_rules(db)
+
+    result = await db.execute(select(EmailTemplate.key))
+    all_keys = list(result.scalars().all())
+    result = await db.execute(select(EmailAutomationRule.name))
+    all_names = list(result.scalars().all())
+
+    assert len(all_keys) == len(first_keys), "seeding twice duplicated email templates"
+    assert len(all_names) == len(first_names), "seeding twice duplicated automation rules"
+
+
+@pytest.mark.asyncio
+async def test_seed_on_empty_database_wires_all_three_trigger_points(db):
+    """No migration rows present — the seed alone must still be complete."""
+    await seed_email_templates(db)
+    await seed_email_automation_rules(db)
+
+    names = await _rule_names(db)
+    assert SUBMISSION_RULE_NAMES <= names
+    assert "學院排名送出通知" in names
+
+    result = await db.execute(select(EmailAutomationRule.trigger_event).where(EmailAutomationRule.is_active))
+    events = {e.value if hasattr(e, "value") else e for e in result.scalars().all()}
+    assert events == {"application_submitted", "college_review_submitted"}

--- a/frontend/app/api/email/render/route.ts
+++ b/frontend/app/api/email/render/route.ts
@@ -22,6 +22,7 @@ const VALID_TEMPLATES: EmailTemplate[] = [
   'application-submitted',
   'professor-review-request',
   'college-review-request',
+  'college-ranking-submitted',
   'deadline-reminder',
   'document-request',
   'result-notification',

--- a/frontend/e2e/specs/admin-bulk-approve.spec.ts
+++ b/frontend/e2e/specs/admin-bulk-approve.spec.ts
@@ -13,11 +13,11 @@
  *   stuphd001 (student) → POST /applications?is_draft=false
  *                          → DB applications.status = 'submitted'
  *   admin               → POST /admin/applications/bulk-approve
- *                          { application_ids: [appDbId], send_notifications: false }
+ *                          { application_ids: [appDbId] }
  *                          → HTTP 200, data.successful_approvals.length = 1
  *                          → DB applications.status = 'approved'
  *   admin               → POST /admin/applications/bulk-approve  (second call)
- *                          { application_ids: [appDbId], send_notifications: false }
+ *                          { application_ids: [appDbId] }
  *                          → HTTP 200 (bulk-approve never returns 4xx for individual failures)
  *                          → data.failed_approvals contains the application
  *                            (status 'approved' is not in allowed set)
@@ -135,7 +135,8 @@ test.describe("Admin bulk-approves a submitted application", () => {
     // 2. Admin bulk-approves the application.
     //    POST /admin/applications/bulk-approve requires require_admin.
     //    The service checks status ∈ {submitted, under_review} before approving.
-    //    send_notifications=false avoids triggering email side-effects in test.
+    //    Bulk approve/reject no longer emails the student at all — the only
+    //    student mail is submission confirmation + the 3-day draft reminder.
     const adminLogin = await loginAs(browser, "admin");
     pushTrace(runState, adminLogin.traceId);
 
@@ -145,12 +146,9 @@ test.describe("Admin bulk-approves a submitted application", () => {
         total_requested: number;
         successful_approvals: Array<{ application_id: number; app_id: string }>;
         failed_approvals: Array<{ application_id: number; reason: string }>;
-        notifications_sent: number;
-        notifications_failed: number;
       };
     }>(adminLogin.token, "POST", "/admin/applications/bulk-approve", {
       application_ids: [appDbId],
-      send_notifications: false,
     });
     pushTrace(runState, bulkApproveRes.traceId);
     expect(
@@ -182,7 +180,6 @@ test.describe("Admin bulk-approves a submitted application", () => {
       };
     }>(adminLogin.token, "POST", "/admin/applications/bulk-approve", {
       application_ids: [appDbId],
-      send_notifications: false,
     });
     pushTrace(runState, secondBulkRes.traceId);
     expect(

--- a/frontend/emails/college-ranking-submitted.tsx
+++ b/frontend/emails/college-ranking-submitted.tsx
@@ -1,0 +1,78 @@
+import { Heading, Text, Hr } from '@react-email/components';
+import * as React from 'react';
+import { BaseTemplate } from './_components/BaseTemplate';
+import { NYCUButton } from './_components/NYCUButton';
+import { InfoBox } from './_components/InfoBox';
+
+interface CollegeRankingSubmittedProps {
+  college_name?: string;
+  ranking_name?: string;
+  scholarship_type?: string;
+  sub_type_code?: string;
+  academic_year?: string;
+  semester?: string;
+  total_applications?: string;
+  finalized_by?: string;
+  finalized_at?: string;
+  system_url?: string;
+}
+
+export default function CollegeRankingSubmitted({
+  college_name = '{{college_name}}',
+  ranking_name = '{{ranking_name}}',
+  scholarship_type = '{{scholarship_type}}',
+  sub_type_code = '{{sub_type_code}}',
+  academic_year = '{{academic_year}}',
+  semester = '{{semester}}',
+  total_applications = '{{total_applications}}',
+  finalized_by = '{{finalized_by}}',
+  finalized_at = '{{finalized_at}}',
+  system_url = '{{system_url}}',
+}: CollegeRankingSubmittedProps) {
+  return (
+    <BaseTemplate previewText={`排名已送出 - ${scholarship_type}`}>
+      <Heading className="text-2xl font-bold text-gray-900 mb-4 mt-0">
+        排名已送出 ✓
+      </Heading>
+
+      <Text className="text-gray-700 mb-4">{college_name} 您好：</Text>
+
+      <Text className="text-gray-700 mb-4">
+        貴學院的獎學金推薦排名已完成送出並鎖定，後續將由承辦單位進行配額分發。
+      </Text>
+
+      <InfoBox>
+        <Text className="font-semibold text-gray-900 m-0 mb-2">
+          📋 排名名稱：{ranking_name}
+        </Text>
+        <Text className="text-gray-700 m-0 mb-2">
+          🎓 獎學金類型：{scholarship_type}
+        </Text>
+        <Text className="text-gray-700 m-0 mb-2">
+          🏷️ 申請類別：{sub_type_code}
+        </Text>
+        <Text className="text-gray-700 m-0 mb-2">
+          📅 學年度學期：{academic_year} 學年度 {semester}
+        </Text>
+        <Text className="text-gray-700 m-0 mb-2">
+          👥 排名人數：{total_applications}
+        </Text>
+        <Text className="text-gray-700 m-0">
+          🕒 送出時間：{finalized_at}（操作人：{finalized_by}）
+        </Text>
+      </InfoBox>
+
+      <Text className="text-gray-700 mb-4">
+        排名送出後即無法修改。若需調整，請聯繫承辦單位解除鎖定。
+      </Text>
+
+      <NYCUButton href={`${system_url}/college/rankings`} text="查看排名" />
+
+      <Hr className="border-gray-200 my-6" />
+
+      <Text className="text-gray-500 text-sm m-0">
+        本信件由系統自動發送，請勿直接回覆。
+      </Text>
+    </BaseTemplate>
+  );
+}

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -9128,12 +9128,6 @@ export interface components {
              * @description Optional approval notes
              */
             comments?: string | null;
-            /**
-             * Send Notifications
-             * @description Whether to notify applicants
-             * @default true
-             */
-            send_notifications: boolean;
         };
         /**
          * BulkRuleOperation

--- a/frontend/lib/api/modules/admin.ts
+++ b/frontend/lib/api/modules/admin.ts
@@ -1078,28 +1078,22 @@ export function createAdminApi() {
       applicationIds: number[],
       options?: {
         comments?: string;
-        sendNotifications?: boolean;
       }
     ): Promise<ApiResponse<{
       total_requested: number;
       successful_approvals: Array<{ application_id: number; app_id: string }>;
       failed_approvals: Array<{ application_id: number; reason: string; current_status?: string }>;
-      notifications_sent: number;
-      notifications_failed: number;
     }>> => {
       const response = await typedClient.raw.POST('/api/v1/admin/applications/bulk-approve', {
         body: {
           application_ids: applicationIds,
           ...(options?.comments !== undefined && { comments: options.comments }),
-          send_notifications: options?.sendNotifications ?? true,
         },
       });
       return toApiResponse(response) as ApiResponse<{
         total_requested: number;
         successful_approvals: Array<{ application_id: number; app_id: string }>;
         failed_approvals: Array<{ application_id: number; reason: string; current_status?: string }>;
-        notifications_sent: number;
-        notifications_failed: number;
       }>;
     },
   };

--- a/frontend/lib/email-renderer.tsx
+++ b/frontend/lib/email-renderer.tsx
@@ -20,6 +20,7 @@ import { logger } from '@/lib/utils/logger';
 import ApplicationSubmitted from '@/emails/application-submitted';
 import ProfessorReviewRequest from '@/emails/professor-review-request';
 import CollegeReviewRequest from '@/emails/college-review-request';
+import CollegeRankingSubmitted from '@/emails/college-ranking-submitted';
 import DeadlineReminder from '@/emails/deadline-reminder';
 import DocumentRequest from '@/emails/document-request';
 import ResultNotification from '@/emails/result-notification';
@@ -33,6 +34,7 @@ export type EmailTemplate =
   | 'application-submitted'
   | 'professor-review-request'
   | 'college-review-request'
+  | 'college-ranking-submitted'
   | 'deadline-reminder'
   | 'document-request'
   | 'result-notification'
@@ -46,6 +48,7 @@ const templateMap: Record<EmailTemplate, React.ComponentType<any>> = {
   'application-submitted': ApplicationSubmitted,
   'professor-review-request': ProfessorReviewRequest,
   'college-review-request': CollegeReviewRequest,
+  'college-ranking-submitted': CollegeRankingSubmitted,
   'deadline-reminder': DeadlineReminder,
   'document-request': DocumentRequest,
   'result-notification': ResultNotification,


### PR DESCRIPTION
## 目的

調整寄信時機，讓「學生／教授／學院」三個角色只在下列三個時機收到信：

| # | 時機 | 收件人 |
|---|---|---|
| 1 | 學生送出申請 | 學生 + 指導教授 |
| 2 | 申請狀態為暫存未送出（draft）且距申請截止日 3 天 | 學生 |
| 3 | 學院送出（確認）排名 | 該學院承辦人 |

寄給**管理員**的信不在此限，維持原狀：撤銷／停發存證信、批次作業完成通知、後台「寄送測試信」。

現有寄信機制的盤點可參考 #1246。

## 主要變更

### 時機 1 — 未變更
`application_submitted` 的兩條規則（申請提交確認郵件 / 教授審核通知）原本就正常運作。

### 時機 2 — 修好一個原本就壞掉的功能

這個提醒**在 main 上根本不會運作**。`deadline_checker.py` 用 `ApplicationStatus.in_progress` 過濾，但這個值不存在於 enum，所以只要有任何設定的截止日落在 7/3/1 天的邊界，每日 09:00 排程就會拋 `AttributeError`，並且連帶讓後面的截止日檢查全部不執行。

修正後：
- 只在**截止前 3 天**寄（移除 7 天與 1 天）
- 只針對 `status = draft`
- 續領草稿比對 `renewal_application_end_date`、一般草稿比對 `application_end_date`（原本兩種截止日都會通知**全部**草稿）

### 時機 3 — 新增

學院按下「確認排名」（`POST /college-review/rankings/{id}/finalize`）後，寄確認信給該 `college_code` 底下的 college 角色使用者。

沿用既有的自動化規則管線：原本休眠的「學院審核通知」規則（綁在 `professor_review_submitted`，但這個事件從來沒有任何程式發出）改綁 `college_review_submitted`，加上收件人查詢與專屬版型後啟用。`college_code` 為 NULL 的全域（admin）排名會解析出零個收件人，不會擴散到所有學院。

新增 `frontend/emails/college-ranking-submitted.tsx` 版型。

### 移除的寄信點

以下都會寄給三個角色之一，但不在指定時機內：

- 指派教授通知（站內通知保留）
- 補件要求通知
- 7 天／1 天截止提醒，以及補件截止檢查
- 教授審核截止前 3 天提醒
- 批次核准／退件通知學生 — 連同 `send_notifications` 參數與 `notifications_sent` / `notifications_failed` 回傳欄位一併移除（schema、endpoint、前端 client、e2e、`schema.d.ts`）

## Review 修正（第二個 commit）

第一版有三個真實缺陷，已修正並補上迴歸測試：

1. **Migration 會讓時機 1 在全新資料庫上靜默失效。** `reset_database.sh` 是先 `alembic upgrade head` 再 `python -m app.seed`，而兩個 email seeder 原本只要資料表非空就整段跳過。Migration 插入 1 筆 template + 1 筆 rule 之後，seeder 就把其他全部略過 —— 兩條送出申請的規則從未建立，學生送出申請後沒有任何人收到信。改為**逐 key／逐 rule name 合併**，順帶讓重複 seed 變成冪等。
2. **指派教授的信其實沒被移除。** 拿掉 `EmailService` 呼叫後，下方的 `create_notification(channels=[in_app, email])` 仍在，而該路徑會直接走 `_send_email_notification` → FastMail。更麻煩的是它繞過 `scheduled_emails` 佇列、版型、`email_history` 與**測試模式攔截**，測試模式開著時會外洩到真實使用者。已改為 `in_app` only。
3. Migration 的 template INSERT 漏了 `recipient_options`，升級的環境在後台手動寄信的「收件者選項」會是空的。

另外把新增的 deadline 測試從 module-level `now()` 改為每次呼叫計算（錨在目標日中午），斷言也改為只看自己建立的申請 —— 原本會隨執行時間與其他測試資料而偶發失敗。

## 測試

- **後端全套測試連跑兩次，皆 5140 passed / 0 failed**（新增 16 個測試，分佈於 3 個新檔案）
- Migration 在 Postgres clone 上驗證 upgrade → downgrade → 再 upgrade，冪等
- 在全新 Postgres 上重現 `reset_database.sh` 的「先 migrate 再 seed」順序：修正後為 8 templates / 3 rules（修正前是 1 / 1）
- 新增的 seed 迴歸測試對舊的 table-level guard 會失敗、對修正版會通過（雙向驗證過）
- `schema.d.ts` 以 CI 相同方式（乾淨的 `python:3.13-slim` + `requirements.txt`）重新產生，僅 6 行刪除、無 generator drift
- 前端 `tsc --noEmit` 通過；`black --check` 與 `flake8 --select=B904,B014` 通過

## 需要留意

- **補件要求現在完全不寄信，包含截止提醒。** 這是本次規格的直接結果（移除補件通知 + 補件截止檢查）。`DocumentRequest.deadline` 與 `pending` 狀態目前沒有任何通知管道，學生可能在不知情的狀況下讓補件期限過期。若要保留這條，需要另外討論。
- `ScholarshipNotificationService.send_status_change_notification` 現在已無生產程式碼呼叫，加入該檔案原本就有的三個孤兒方法行列。此 PR 未一併刪除（該類別仍需提供管理員的批次完成通知）。
- #1246 的 `docs/features/email-triggers.md` 尚未合併進 main，因此本 PR 沒有動到它。該文件合併後需要更新 §3、§4.4、§5.2、§8。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
