### PR TITLE
fix(csp): remove unsafe-inline from production style-src (#1273)

### DIFF
--- a/docs/CSP_IMPLEMENTATION.md
+++ b/docs/CSP_IMPLEMENTATION.md
@@ -79,6 +79,7 @@ Content-Security-Policy:
   default-src 'self';
   script-src 'self' 'nonce-{RANDOM}' 'strict-dynamic';
   style-src 'self' 'nonce-{RANDOM}';
+  style-src-attr 'unsafe-inline';                   /* Radix inline positioning — see below */
   img-src 'self' data: blob:;
   font-src 'self';
   connect-src 'self' https://*.nycu.edu.tw;
@@ -92,8 +93,56 @@ Content-Security-Policy:
 **Key Security Features:**
 - **Nonce-based loading**: Unique cryptographic nonce per request
 - **`'strict-dynamic'`**: Allows webpack-bundled scripts without explicit whitelisting
-- **No `'unsafe-*'` directives**: Eliminates inline script/eval risks
+- **No `'unsafe-*'` for scripts**: Eliminates inline script/eval risks
 - **NYCU domain whitelist**: Only allows connections to `*.nycu.edu.tw` (SSO, SIS API)
+
+**Why `style-src` and `style-src-attr` are split (issue #1273)**
+
+The original policy was `style-src 'self' 'nonce-{RANDOM}'`, which commit `bc2019f0`
+widened to `style-src 'self' 'unsafe-inline'` because shadcn/ui broke: Radix +
+floating-ui write inline style **attributes** at runtime (Popover/Dropdown/Dialog
+positioning, animation variables), and a nonce cannot be attached to a `style=`
+attribute. That single keyword also re-permitted injected `<style>` **elements**,
+which nothing in this app needs — and ZAP flags it as Medium (rule 10055).
+
+CSP Level 3 separates the two targets, so only the half the UI needs is allowed:
+
+| Directive | Covers | Policy |
+|---|---|---|
+| `style-src` | `<style>` elements, `<link rel=stylesheet>` | nonce-gated |
+| `style-src-attr` | `style="…"` attributes | `'unsafe-inline'` (Radix requirement) |
+
+**Accepted residual risk**: an HTML-injection point can still set a `style=`
+attribute. Removing that would require replacing Radix's positioning engine, which
+is disproportionate to the risk. Injected `<style>` blocks are blocked by the browser.
+
+Pinned by `frontend/__tests__/middleware-csp.test.ts` — both that `style-src` carries
+no `'unsafe-inline'` and that `style-src-attr` still does (dropping it re-breaks every
+Popover/Dropdown/Dialog, which is exactly what `bc2019f0` was reacting to).
+
+**Getting the nonce to every `<style>` that needs it**
+
+Nonce-gating `style-src` is only half the work: three separate mechanisms inject
+`<style>` elements at runtime, and each takes the nonce from a different place.
+All three are wired in `frontend/components/providers/csp-nonce.tsx`, rendered as
+the outermost provider in `app/layout.tsx`:
+
+| Injector | How it gets the nonce |
+|---|---|
+| `react-remove-scroll` → `react-style-singleton` (used by every Radix scroll-locking primitive: Select, DropdownMenu, Dialog, Popover) | `__webpack_nonce__`, read by the `get-nonce` package — the only hook these packages expose |
+| `Select.Viewport`, `ScrollArea.Viewport` (render their own `<style>` in JSX) | `useCspNonce()` passed as the `nonce` prop in `components/ui/select.tsx` / `scroll-area.tsx` |
+| `sonner` (the `<Toaster />`) | Neither — it has no nonce hook in 1.7.4 *or* 2.0.7, so its stylesheet is allowed by **content hash** (`SONNER_STYLE_HASH` in `lib/security-headers.ts`) |
+
+The `__webpack_nonce__` assignment is wrapped in try/catch on purpose: outside a
+webpack bundle (jest, Turbopack `next dev`) the identifier is undeclared and the
+strict-mode assignment would throw and take down the whole React tree.
+
+Missing any one of these is a **silent visual break** — the browser drops the
+stylesheet and only logs a `style-src-elem` violation. Dev never reproduces it,
+because the dev CSP still carries `'unsafe-inline'`. Guarded by
+`__tests__/csp-nonce-wiring.test.tsx` (prop plumbing) and
+`__tests__/csp-sonner-hash.test.ts` (hash freshness). For an end-to-end check
+against a real production build, run `frontend/e2e/csp-violation-check.js`.
 
 ## Files Modified
 

--- a/docs/CSP_IMPLEMENTATION.md
+++ b/docs/CSP_IMPLEMENTATION.md
@@ -116,6 +116,15 @@ CSP Level 3 separates the two targets, so only the half the UI needs is allowed:
 attribute. Removing that would require replacing Radix's positioning engine, which
 is disproportionate to the risk. Injected `<style>` blocks are blocked by the browser.
 
+**Browser-support caveat**: `style-src-attr` is CSP Level 3 — Chrome/Edge 75+,
+Firefox 74+, Safari 15.4+ (iOS 15.4+, March 2022). A browser that does **not**
+implement it ignores the directive and falls back to `style-src`, which no longer
+carries `'unsafe-inline'`, so every runtime `style="…"` attribute Radix writes is
+blocked and floating content (Popover/Dropdown/Select/Dialog) renders unpositioned.
+This is a deliberate trade: the affected cohort is iOS ≤ 15.3 / Safari ≤ 15.3, which
+NYCU's supported-browser baseline does not cover. Revisit if analytics show real
+traffic from it.
+
 Pinned by `frontend/__tests__/middleware-csp.test.ts` — both that `style-src` carries
 no `'unsafe-inline'` and that `style-src-attr` still does (dropping it re-breaks every
 Popover/Dropdown/Dialog, which is exactly what `bc2019f0` was reacting to).
@@ -132,6 +141,9 @@ the outermost provider in `app/layout.tsx`:
 | `react-remove-scroll` → `react-style-singleton` (used by every Radix scroll-locking primitive: Select, DropdownMenu, Dialog, Popover) | `__webpack_nonce__`, read by the `get-nonce` package — the only hook these packages expose |
 | `Select.Viewport`, `ScrollArea.Viewport` (render their own `<style>` in JSX) | `useCspNonce()` passed as the `nonce` prop in `components/ui/select.tsx` / `scroll-area.tsx` |
 | `sonner` (the `<Toaster />`) | Neither — it has no nonce hook in 1.7.4 *or* 2.0.7, so its stylesheet is allowed by **content hash** (`SONNER_STYLE_HASH` in `lib/security-headers.ts`) |
+| `react-diff-viewer-continued` (audit-trail JSON diff) — its own `@emotion/css` instance | its `nonce` prop, threaded straight into that emotion instance — `components/audit-trail/JsonDiffViewer.tsx` |
+| `Select.Viewport` / `ScrollArea.Viewport` / `ChartStyle` (`components/ui/chart.tsx`) | `nonce` prop from `useCspNonce()` |
+| The 查看源碼 popup in `react-email-template-viewer.tsx` | writes `<style nonce="…">` — an `about:blank` window inherits the opener's CSP |
 
 The `__webpack_nonce__` assignment is wrapped in try/catch on purpose: outside a
 webpack bundle (jest, Turbopack `next dev`) the identifier is undeclared and the
@@ -139,7 +151,17 @@ strict-mode assignment would throw and take down the whole React tree.
 
 Missing any one of these is a **silent visual break** — the browser drops the
 stylesheet and only logs a `style-src-elem` violation. Dev never reproduces it,
-because the dev CSP still carries `'unsafe-inline'`. Guarded by
+because the dev CSP still carries `'unsafe-inline'`.
+
+> **Known gap — no violation reporting.** The policy carries no `report-to` /
+> `report-uri`, so in production the only detection path for a missed injector is
+> a user noticing broken styling. Adding a reporting group (backed by a backend
+> endpoint that just logs) would turn these into diagnosable signals and would
+> allow a `Content-Security-Policy-Report-Only` soak before future tightening.
+> Not done here to keep this change scoped; **when adding a new dependency that
+> injects styles, check it against the table above.**
+
+Guarded by
 `__tests__/csp-nonce-wiring.test.tsx` (prop plumbing) and
 `__tests__/csp-sonner-hash.test.ts` (hash freshness). For an end-to-end check
 against a real production build, run `frontend/e2e/csp-violation-check.js`.

--- a/frontend/__tests__/csp-nonce-wiring.test.tsx
+++ b/frontend/__tests__/csp-nonce-wiring.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Wiring guard for the CSP nonce (issue #1273).
+ *
+ * Under the nonce-gated production `style-src`, any Radix primitive that renders
+ * its own `<style>` must receive the nonce or the browser drops the stylesheet —
+ * a silent visual break (hidden scrollbars stop being hidden) that no type check
+ * or lint catches, and that dev never reproduces because the dev CSP still
+ * carries 'unsafe-inline'.
+ *
+ * `@radix-ui/react-select` and `@radix-ui/react-scroll-area` are the only two
+ * packages in the tree that render a `<style>` in JSX (verified by grepping
+ * `dangerouslySetInnerHTML` across @radix-ui/*), and both accept a `nonce` prop.
+ * These tests pin that our ui/ wrappers actually pass it through.
+ */
+import { render, screen } from "@testing-library/react";
+import { CspNonceProvider } from "@/components/providers/csp-nonce";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+const NONCE = "test-nonce-abc123";
+
+// Radix Select drives real layout APIs jsdom does not implement.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+  Element.prototype.hasPointerCapture = jest.fn(() => false);
+  Element.prototype.releasePointerCapture = jest.fn();
+  global.ResizeObserver =
+    global.ResizeObserver ||
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+});
+
+function styleNonces(): (string | null)[] {
+  return [...document.querySelectorAll("style")].map((s) => s.getAttribute("nonce"));
+}
+
+describe("CSP nonce wiring", () => {
+  it("ScrollArea forwards the nonce to the Radix viewport <style>", () => {
+    render(
+      <CspNonceProvider nonce={NONCE}>
+        <ScrollArea>
+          <div>content</div>
+        </ScrollArea>
+      </CspNonceProvider>
+    );
+    const nonces = styleNonces();
+    expect(nonces.length).toBeGreaterThan(0);
+    expect(nonces).toContain(NONCE);
+  });
+
+  it("Select forwards the nonce to the Radix viewport <style> when open", async () => {
+    render(
+      <CspNonceProvider nonce={NONCE}>
+        <Select open>
+          <SelectTrigger>
+            <SelectValue placeholder="pick" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="a">A</SelectItem>
+          </SelectContent>
+        </Select>
+      </CspNonceProvider>
+    );
+    // The content renders in a portal; wait for the item to confirm it mounted.
+    expect(await screen.findByText("A")).toBeInTheDocument();
+    expect(styleNonces()).toContain(NONCE);
+  });
+
+  it("renders without a nonce outside the provider (dev CSP path)", () => {
+    render(
+      <ScrollArea>
+        <div>content</div>
+      </ScrollArea>
+    );
+    // No provider -> undefined nonce -> no crash, no nonce attribute.
+    expect(styleNonces().filter((n) => n === NONCE)).toHaveLength(0);
+  });
+});

--- a/frontend/__tests__/csp-nonce-wiring.test.tsx
+++ b/frontend/__tests__/csp-nonce-wiring.test.tsx
@@ -69,13 +69,34 @@ describe("CSP nonce wiring", () => {
     expect(styleNonces()).toContain(NONCE);
   });
 
+  it("JsonDiffViewer nonces the stylesheets @emotion/css injects", async () => {
+    // react-diff-viewer-continued styles itself with @emotion/css, whose default
+    // cache carries no nonce — the audit-trail diff would render unstyled in
+    // production. Assert on emotion's own tags (data-emotion), not just any
+    // <style>, so the test cannot pass on some other component's element.
+    const { JsonDiffViewer } = await import("@/components/audit-trail/JsonDiffViewer");
+    render(
+      <CspNonceProvider nonce={NONCE}>
+        <JsonDiffViewer oldValue={{ a: 1 }} newValue={{ a: 2 }} />
+      </CspNonceProvider>
+    );
+    const emotionTags = [...document.querySelectorAll("style[data-emotion]")];
+    expect(emotionTags.length).toBeGreaterThan(0);
+    expect(emotionTags.every((t) => t.getAttribute("nonce") === NONCE)).toBe(true);
+  });
+
   it("renders without a nonce outside the provider (dev CSP path)", () => {
+    // Scope to the styles THIS render adds: emotion leaves its <head> tags
+    // behind after the earlier test (testing-library only unmounts containers).
+    const before = new Set(document.querySelectorAll("style"));
     render(
       <ScrollArea>
         <div>content</div>
       </ScrollArea>
     );
+    const added = [...document.querySelectorAll("style")].filter((s) => !before.has(s));
     // No provider -> undefined nonce -> no crash, no nonce attribute.
-    expect(styleNonces().filter((n) => n === NONCE)).toHaveLength(0);
+    expect(added.length).toBeGreaterThan(0);
+    expect(added.filter((s) => s.getAttribute("nonce") === NONCE)).toHaveLength(0);
   });
 });

--- a/frontend/__tests__/csp-sonner-hash.test.ts
+++ b/frontend/__tests__/csp-sonner-hash.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Drift guard for the sonner CSP style hash (issue #1273).
+ *
+ * The production `style-src` is nonce-gated, and sonner injects its stylesheet
+ * imperatively with no nonce hook (see lib/security-headers.ts). The only way to
+ * allow it is a content hash — which silently goes stale on every sonner upgrade,
+ * and the failure mode is invisible in dev (the dev CSP still carries
+ * 'unsafe-inline'): toasts simply lose ALL styling in production.
+ *
+ * This test recomputes the hash from the INSTALLED sonner bundle so an upgrade
+ * fails CI loudly, with the replacement value printed in the diff.
+ */
+import { createHash } from "crypto";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { SONNER_EMPTY_STYLE_HASH, SONNER_STYLE_HASH } from "@/lib/security-headers";
+
+function sha256Csp(content: string): string {
+  return `'sha256-${createHash("sha256").update(content, "utf8").digest("base64")}'`;
+}
+
+describe("sonner CSP style hash", () => {
+  it("matches the CSS in the installed sonner bundle", () => {
+    // Read the file directly rather than require.resolve(): sonner's package
+    // "exports" map does not expose the dist path, and jest's resolver honours it.
+    const bundlePath = join(process.cwd(), "node_modules/sonner/dist/index.mjs");
+    expect(existsSync(bundlePath)).toBe(true);
+    const bundle = readFileSync(bundlePath, "utf8");
+
+    // sonner's injector is `function wt(n,{insertAt:e}={}){...}` called once with
+    // the whole stylesheet as a template literal: wt(`:where(html[dir="ltr"])...`).
+    // Match the call that carries the stylesheet, identified by its first selector
+    // rather than by the (minifier-generated, unstable) function name.
+    const match = bundle.match(/\(`(:where\(html\[dir="ltr"\][\s\S]*?)`\)/);
+    expect(match).not.toBeNull();
+
+    const css = match![1];
+    expect(css.length).toBeGreaterThan(1000);
+    expect(css).toContain("data-sonner-toaster");
+
+    // If this fails after a sonner upgrade, copy the RECEIVED value into
+    // lib/security-headers.ts (SONNER_STYLE_HASH) — do NOT relax style-src.
+    expect(sha256Csp(css)).toBe(SONNER_STYLE_HASH);
+  });
+
+  it("pins the empty-element hash sonner's two-step injection requires", () => {
+    // sonner appends the <style> element BEFORE filling it, so the browser
+    // hash-checks an empty element first. This hash is content-independent.
+    expect(sha256Csp("")).toBe(SONNER_EMPTY_STYLE_HASH);
+  });
+});

--- a/frontend/__tests__/middleware-csp.test.ts
+++ b/frontend/__tests__/middleware-csp.test.ts
@@ -10,6 +10,7 @@
  * clickjacking protections were not loosened in the process.
  */
 import { middleware } from "@/middleware";
+import { SONNER_EMPTY_STYLE_HASH, SONNER_STYLE_HASH } from "@/lib/security-headers";
 
 // The middleware only reads request.headers and request.nextUrl.hostname, so a
 // minimal stand-in is enough (NextResponse is the real one from next/server).
@@ -55,6 +56,63 @@ describe("middleware Content-Security-Policy", () => {
     expect(csp).toContain("frame-ancestors 'none'");
     expect(csp).toContain("object-src 'none'");
     expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #1273 (ZAP 10055 "CSP: style-src unsafe-inline", Medium).
+  // `style-src 'self' 'unsafe-inline'` was commit bc2019f0's blunt fix for
+  // shadcn/ui. The narrow form keeps `'unsafe-inline'` for style ATTRIBUTES only
+  // (Radix/floating-ui positioning) while ELEMENT styles stay nonce-gated.
+  // `toContain` would not catch a regression that appends ' unsafe-inline' back
+  // onto style-src, so assert on the PARSED directive.
+  // ---------------------------------------------------------------------------
+
+  function directiveOf(csp: string, name: string): string {
+    return csp.split("; ").find((d) => d === name || d.startsWith(`${name} `)) ?? "";
+  }
+
+  it("prod style-src is nonce-gated with NO unsafe-inline", () => {
+    setNodeEnv("production");
+    const res = middleware(mockRequest("https://ss.test.nycu.edu.tw/student/apply"));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    const nonce = res.headers.get("X-CSP-Nonce");
+
+    expect(directiveOf(csp, "style-src")).toBe(
+      `style-src 'self' 'nonce-${nonce}' ${SONNER_STYLE_HASH} ${SONNER_EMPTY_STYLE_HASH}`,
+    );
+    // the regression this test exists for
+    expect(directiveOf(csp, "style-src")).not.toContain("unsafe-inline");
+    // and no unsafe-* survives anywhere in the production policy
+    expect(csp).not.toContain("'unsafe-eval'");
+  });
+
+  it("prod keeps style-src-attr 'unsafe-inline' so Radix inline positioning still works", () => {
+    setNodeEnv("production");
+    const res = middleware(mockRequest("https://ss.test.nycu.edu.tw/student/apply"));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    // Dropping this re-breaks every Popover/Dropdown/Dialog (bc2019f0's symptom).
+    expect(directiveOf(csp, "style-src-attr")).toBe("style-src-attr 'unsafe-inline'");
+  });
+
+  it("the framable-preview branch does not fork a stale style-src", () => {
+    setNodeEnv("production");
+    const res = middleware(mockRequest("https://ss.test.nycu.edu.tw/api/v1/preview?fileId=1&type=pdf"));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    const nonce = res.headers.get("X-CSP-Nonce");
+    expect(directiveOf(csp, "style-src")).toBe(
+      `style-src 'self' 'nonce-${nonce}' ${SONNER_STYLE_HASH} ${SONNER_EMPTY_STYLE_HASH}`,
+    );
+    expect(directiveOf(csp, "style-src-attr")).toBe("style-src-attr 'unsafe-inline'");
+  });
+
+  it("dev style-src stays relaxed (React Fast Refresh injects unnonced styles)", () => {
+    setNodeEnv("development");
+    const csp = middleware(mockRequest("http://localhost:3000/student/apply")).headers.get(
+      "Content-Security-Policy",
+    ) ?? "";
+    // Deliberate dev/prod split: nonce-gating styles locally buys nothing and
+    // fights HMR. The prod branch is the one under test above.
+    expect(directiveOf(csp, "style-src")).toBe("style-src 'self' 'unsafe-inline'");
   });
 
   it("emits a per-request nonce and exposes it for nginx", () => {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,6 +6,7 @@ import { DebugPanelWrapper } from "@/components/debug-panel-wrapper";
 import { AppProvider } from "@/components/providers/app-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { getNonce } from "./NonceProvider";
+import { CspNonceProvider } from "@/components/providers/csp-nonce";
 
 export const metadata: Metadata = {
   title: "獎學金申請與審核系統 | 國立陽明交通大學教務處",
@@ -46,13 +47,17 @@ export default async function RootLayout({
         {/* Next.js will automatically apply nonce to all injected scripts */}
       </head>
       <body className="antialiased" nonce={nonce}>
-        <AppProvider>
-          <SessionExpiredProvider>
-            {children}
-            <DebugPanelWrapper />
-            <Toaster />
-          </SessionExpiredProvider>
-        </AppProvider>
+        {/* Outermost: sets __webpack_nonce__ and serves useCspNonce() to every
+            Radix primitive that renders its own <style> — see csp-nonce.tsx */}
+        <CspNonceProvider nonce={nonce}>
+          <AppProvider>
+            <SessionExpiredProvider>
+              {children}
+              <DebugPanelWrapper />
+              <Toaster />
+            </SessionExpiredProvider>
+          </AppProvider>
+        </CspNonceProvider>
       </body>
     </html>
   );

--- a/frontend/components/audit-trail/JsonDiffViewer.tsx
+++ b/frontend/components/audit-trail/JsonDiffViewer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
+import { useCspNonce } from "@/components/providers/csp-nonce";
 
 interface JsonDiffViewerProps {
   // Audit-log diffs ship arbitrary JSON payloads (rows from many tables),
@@ -16,6 +17,14 @@ export function JsonDiffViewer({
   newValue,
   locale = "zh",
 }: JsonDiffViewerProps) {
+  // react-diff-viewer-continued styles itself with its OWN @emotion/css instance
+  // (create-instance, not the global cache), so the nonce-gated production
+  // style-src would drop the entire diff stylesheet — the audit-trail diff would
+  // render as unstyled text (#1273). The library threads a `nonce` prop straight
+  // into that instance (lib/src/index.js: computeStyles(styles, dark, nonce)),
+  // so passing it is the whole fix; no emotion cache surgery is needed.
+  const nonce = useCspNonce();
+
   const oldString = useMemo(() => {
     if (!oldValue) return "";
     return typeof oldValue === "string"
@@ -90,6 +99,7 @@ export function JsonDiffViewer({
         newValue={newString}
         splitView={false}
         compareMethod={DiffMethod.WORDS}
+        nonce={nonce}
         useDarkTheme={false}
         hideLineNumbers={false}
         showDiffOnly={true}

--- a/frontend/components/providers/csp-nonce.tsx
+++ b/frontend/components/providers/csp-nonce.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/**
+ * Client-side plumbing for the per-request CSP nonce. Issue #1273.
+ *
+ * With production `style-src` nonce-gated (no 'unsafe-inline'), EVERY <style>
+ * element that reaches the DOM needs the nonce. Three different mechanisms need
+ * it, and they each take it from a different place:
+ *
+ *  1. `__webpack_nonce__` — read by `get-nonce`, which `react-style-singleton`
+ *     (via `react-remove-scroll`, used by every Radix scroll-locking primitive:
+ *     Select, DropdownMenu, Dialog, Popover) uses to stamp its injected
+ *     `.with-scroll-bars-hidden` stylesheet. Setting the webpack runtime nonce
+ *     is the ONLY hook those packages expose.
+ *  2. `useCspNonce()` — Radix components that render their own `<style>` in JSX
+ *     and accept a `nonce` prop: `Select.Viewport`, `ScrollArea.Viewport`.
+ *     See components/ui/select.tsx and components/ui/scroll-area.tsx.
+ *  3. Hashes in the CSP itself — for libraries with no nonce hook at all
+ *     (sonner). See lib/security-headers.ts.
+ *
+ * The nonce originates in middleware.ts, travels on the `x-nonce` REQUEST header,
+ * and is read by app/layout.tsx (getNonce) which renders this provider.
+ */
+
+const CspNonceContext = createContext<string | undefined>(undefined);
+
+declare let __webpack_nonce__: string;
+
+export function CspNonceProvider({
+  nonce,
+  children,
+}: {
+  nonce?: string;
+  children: React.ReactNode;
+}) {
+  if (nonce) {
+    // webpack rewrites this identifier to `__webpack_require__.nc`, which its
+    // runtime stamps onto every style/script element it injects. Assigned during
+    // render (not in an effect) so it is set before any child mounts a portal.
+    //
+    // The try/catch is NOT defensive padding: outside a webpack bundle the
+    // identifier is undeclared, and ES module code is strict-mode, so the bare
+    // assignment throws ReferenceError and takes the whole tree down. That is
+    // every non-webpack runtime — jest (caught by __tests__/csp-nonce-wiring)
+    // and Turbopack `next dev`. Only the production webpack build needs it, and
+    // only production has a nonce-gated style-src.
+    try {
+      __webpack_nonce__ = nonce;
+    } catch {
+      /* not a webpack runtime — nothing to publish the nonce to */
+    }
+  }
+  return <CspNonceContext.Provider value={nonce}>{children}</CspNonceContext.Provider>;
+}
+
+/**
+ * The active CSP nonce, or undefined when rendered outside the provider.
+ * Pass to any Radix primitive that renders its own <style> (see above).
+ */
+export function useCspNonce(): string | undefined {
+  return useContext(CspNonceContext);
+}

--- a/frontend/components/react-email-template-viewer.tsx
+++ b/frontend/components/react-email-template-viewer.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Eye, Mail, Code, FileText, AlertCircle, Loader2 } from "lucide-react";
 import { api } from "@/lib/api";
+import { useCspNonce } from "@/components/providers/csp-nonce";
 
 interface TemplateVariable {
   name: string;
@@ -252,6 +253,9 @@ function PreviewDialog({ template, open, onClose }: PreviewDialogProps) {
 }
 
 export function ReactEmailTemplateViewer() {
+  // The 查看源碼 popup is an about:blank window, which INHERITS this document's
+  // CSP — so the <style> it writes needs the nonce like any other (#1273).
+  const nonce = useCspNonce();
   const [templates, setTemplates] = useState<ReactEmailTemplate[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -306,7 +310,7 @@ export function ReactEmailTemplateViewer() {
           <html>
             <head>
               <title>${template.display_name} - 源碼</title>
-              <style>
+              <style${nonce ? ` nonce="${nonce}"` : ""}>
                 body { margin: 0; font-family: monospace; }
                 pre { margin: 0; padding: 20px; background: #1e1e1e; color: #d4d4d4; overflow: auto; }
               </style>

--- a/frontend/components/ui/chart.tsx
+++ b/frontend/components/ui/chart.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import * as RechartsPrimitive from "recharts";
 
 import { cn } from "@/lib/utils";
+import { useCspNonce } from "@/components/providers/csp-nonce";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
@@ -68,6 +69,11 @@ const ChartContainer = React.forwardRef<
 ChartContainer.displayName = "Chart";
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  // Nonce-gated production style-src drops any un-nonced <style> (#1273).
+  // Nothing imports ChartContainer today, so this is pre-emptive: without it the
+  // first chart added to the app would lose all CSS-variable theming, and only
+  // in production.
+  const nonce = useCspNonce();
   const colorConfig = Object.entries(config).filter(
     ([_, config]) => config.theme || config.color
   );
@@ -78,6 +84,7 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 
   return (
     <style
+      nonce={nonce}
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(

--- a/frontend/components/ui/scroll-area.tsx
+++ b/frontend/components/ui/scroll-area.tsx
@@ -4,23 +4,32 @@ import * as React from "react";
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 
 import { cn } from "@/lib/utils";
+import { useCspNonce } from "@/components/providers/csp-nonce";
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
-    ref={ref}
-    className={cn("relative overflow-hidden", className)}
-    {...props}
-  >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
-      {children}
-    </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
-    <ScrollAreaPrimitive.Corner />
-  </ScrollAreaPrimitive.Root>
-));
+>(({ className, children, ...props }, ref) => {
+  // Viewport renders its own <style>; nonce it or the nonce-gated production
+  // style-src blocks it — issue #1273.
+  const nonce = useCspNonce();
+  return (
+    <ScrollAreaPrimitive.Root
+      ref={ref}
+      className={cn("relative overflow-hidden", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        className="h-full w-full rounded-[inherit]"
+        nonce={nonce}
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+});
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 const ScrollBar = React.forwardRef<

--- a/frontend/components/ui/select.tsx
+++ b/frontend/components/ui/select.tsx
@@ -5,6 +5,7 @@ import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { useCspNonce } from "@/components/providers/csp-nonce";
 
 const Select = SelectPrimitive.Root;
 
@@ -70,24 +71,29 @@ SelectScrollDownButton.displayName =
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      className={cn(
-        "overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md z-50 min-w-[8rem] max-h-96",
-        className
-      )}
-      {...props}
-    >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport className="p-1">
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
+>(({ className, children, ...props }, ref) => {
+  // Viewport renders its own <style> (scrollbar hiding). Under the nonce-gated
+  // production style-src it is blocked without this — issue #1273.
+  const nonce = useCspNonce();
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
+        className={cn(
+          "overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md z-50 min-w-[8rem] max-h-96",
+          className
+        )}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport className="p-1" nonce={nonce}>
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+});
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<

--- a/frontend/e2e/csp-violation-check.js
+++ b/frontend/e2e/csp-violation-check.js
@@ -1,0 +1,236 @@
+/**
+ * Manual CSP verification driver for issue #1273.
+ *
+ * Runs against a PRODUCTION build (`next build && next start`) — the dev CSP
+ * branch is deliberately relaxed, so only a production server exercises the
+ * nonce-gated `style-src` + `style-src-attr 'unsafe-inline'` split.
+ *
+ * Captures every `securitypolicyviolation` event (the only reliable signal —
+ * some blocked styles never reach console) plus console errors, across the
+ * public login page and authenticated pages that render Radix
+ * Dialog/Dropdown/Select portals (the primitives commit bc2019f0 broke).
+ *
+ * Usage: node e2e/csp-violation-check.js <frontendUrl> <backendUrl> <outDir>
+ */
+const { chromium } = require("playwright");
+const fs = require("fs");
+const path = require("path");
+
+const FRONTEND = process.argv[2] || "http://localhost:3100";
+const BACKEND = process.argv[3] || "http://localhost:8000";
+const OUT_DIR = process.argv[4] || "test-results/screenshots";
+
+const violations = [];
+const consoleErrors = [];
+
+async function mockSsoLogin(nycuId) {
+  const r = await fetch(`${BACKEND}/api/v1/auth/mock-sso/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ nycu_id: nycuId }),
+  });
+  const body = await r.json();
+  if (!r.ok || !body.success) {
+    throw new Error(`mock-sso login failed for ${nycuId}: HTTP ${r.status}`);
+  }
+  return { token: body.data.access_token, user: body.data.user };
+}
+
+async function visit(page, label, urlPath, interact) {
+  console.log(`\n--- ${label} (${urlPath}) ---`);
+  await page.goto(`${FRONTEND}${urlPath}`, { waitUntil: "networkidle" }).catch((e) => {
+    console.log(`  nav warning: ${e.message.split("\n")[0]}`);
+  });
+  await page.waitForTimeout(1500);
+  if (interact) {
+    try {
+      await interact(page);
+    } catch (e) {
+      console.log(`  interact warning: ${e.message.split("\n")[0]}`);
+    }
+  }
+  await page.waitForTimeout(800);
+  await page
+    .screenshot({ path: path.join(OUT_DIR, `csp-${label}.png`), fullPage: false })
+    .catch(() => {});
+  console.log(`  violations so far: ${violations.length}`);
+}
+
+(async () => {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ locale: "zh-TW" });
+  context.setDefaultTimeout(8000);
+
+  // Record CSP violations from the page itself — console-only capture misses
+  // style-src blocks in some Chromium versions.
+  await context.addInitScript(() => {
+    window.__cspViolations = [];
+    document.addEventListener("securitypolicyviolation", (e) => {
+      window.__cspViolations.push({
+        directive: e.effectiveDirective || e.violatedDirective,
+        blockedURI: e.blockedURI,
+        sample: (e.sample || "").slice(0, 120),
+        source: `${e.sourceFile || ""}:${e.lineNumber || ""}`,
+      });
+    });
+  });
+
+  const page = await context.newPage();
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text().slice(0, 200));
+  });
+
+  async function drain(label) {
+    const v = await page.evaluate(() => {
+      const out = window.__cspViolations || [];
+      window.__cspViolations = [];
+      return out;
+    }).catch(() => []);
+    v.forEach((x) => violations.push({ page: label, ...x }));
+  }
+
+  // 1. Public login page (unauthenticated)
+  await visit(page, "login", "/");
+  await drain("login");
+
+  // 2. Authenticate as admin, then exercise Radix-heavy pages
+  const { token, user } = await mockSsoLogin("admin");
+  console.log(`\nlogged in as: ${user.email || user.username}`);
+  await context.addInitScript(
+    ({ t, u }) => {
+      localStorage.setItem("auth_token", t);
+      localStorage.setItem("user", u);
+    },
+    { t: token, u: JSON.stringify(user) }
+  );
+
+  // The app is a single authenticated route ("/"), rendered by role.
+  await visit(page, "admin-home", "/", async (p) => {
+    const els = await p.$$eval('button,[role],a', (ns) =>
+      ns
+        .map((n) => ({
+          role: n.getAttribute("role") || n.tagName.toLowerCase(),
+          t: (n.innerText || "").trim().slice(0, 20),
+        }))
+        .filter((x) => x.t)
+        .slice(0, 30)
+    );
+    console.log(`  roles: ${JSON.stringify(els)}`);
+  });
+  await drain("admin-home");
+
+  // Radix Tabs — navigates the admin shell without a reload
+  await visit(page, "admin-tabs", "/", async (p) => {
+    const tabs = p.locator('[role="tab"]');
+    const n = await tabs.count();
+    console.log(`  tabs: ${n}`);
+    for (let i = 1; i < Math.min(n, 5); i++) {
+      await tabs.nth(i).click().catch(() => {});
+      await p.waitForTimeout(900);
+    }
+  });
+  await drain("admin-tabs");
+
+  // Radix Select/Combobox — its floating panel is positioned with INLINE STYLE
+  // ATTRIBUTES, the exact thing style-src-attr must keep allowing.
+  await visit(page, "admin-dropdown", "/", async (p) => {
+    const combo = p.locator('button[role="combobox"]').first();
+    if (await combo.count()) {
+      await combo.click();
+      await p.waitForTimeout(800);
+      const opened = await p.locator('[role="listbox"],[role="option"]').count();
+      console.log(`  combobox opened, options visible: ${opened}`);
+      await p.keyboard.press("ArrowDown");
+      await p.keyboard.press("Escape");
+    } else {
+      console.log("  no combobox on this page");
+    }
+  });
+  await drain("admin-dropdown");
+
+  // Radix Dialog — the heaviest style injector (react-remove-scroll scroll-lock
+  // + portal animation). Walk the admin tabs until a trigger actually opens one.
+  await visit(page, "admin-dialog", "/", async (p) => {
+    const tabs = p.locator('[role="tab"]');
+    const tabCount = await tabs.count();
+    let opened = false;
+    for (let t = 0; t < tabCount && !opened; t++) {
+      await tabs.nth(t).click().catch(() => {});
+      await p.waitForTimeout(1200);
+      const triggers = p
+        .locator("button")
+        .filter({ hasText: /新增|建立|設定|編輯|查看|詳情|上傳|匯入|產生|管理/ });
+      const n = Math.min(await triggers.count(), 6);
+      for (let i = 0; i < n && !opened; i++) {
+        await triggers.nth(i).click({ timeout: 3000 }).catch(() => {});
+        await p.waitForTimeout(1200);
+        opened = (await p.locator('[role="dialog"]').count()) > 0;
+        if (opened) {
+          const tabName = (await tabs.nth(t).innerText().catch(() => "?")).trim();
+          console.log(`  dialog opened from tab "${tabName}" trigger #${i}`);
+          // scroll-lock proof: react-remove-scroll's stylesheet must have applied
+          const locked = await p.evaluate(
+            () => getComputedStyle(document.body).overflow
+          );
+          console.log(`  body overflow while dialog open: ${locked} (expect hidden)`);
+        }
+      }
+    }
+    if (!opened) console.log("  WARNING: no dialog could be opened");
+  });
+  await drain("admin-dialog");
+
+  // Force a toast so sonner's hashed stylesheet is proven to APPLY, not merely
+  // to stop violating. Rendering unstyled toasts is the silent failure mode.
+  await visit(page, "toast", "/", async (p) => {
+    await p.evaluate(() => {
+      // sonner exposes no global; trigger via a real API failure instead —
+      // an unauthenticated fetch the app surfaces as an error toast.
+      window.dispatchEvent(new Event("offline"));
+    });
+    const anyTrigger = p.locator("button").filter({ hasText: /重新整理|重整|更新|重載/ }).first();
+    if (await anyTrigger.count()) await anyTrigger.click().catch(() => {});
+    await p.waitForTimeout(2000);
+    const state = await p.evaluate(() => {
+      const el = document.querySelector("[data-sonner-toaster]");
+      if (!el) return { present: false };
+      const cs = getComputedStyle(el);
+      return { present: true, position: cs.position, zIndex: cs.zIndex };
+    });
+    console.log(`  sonner toaster: ${JSON.stringify(state)}`);
+    // Independent of any toast firing: the stylesheet itself must be live.
+    const sheetApplied = await p.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule.cssText && rule.cssText.includes("data-sonner-toaster")) return true;
+          }
+        } catch {
+          /* cross-origin sheet */
+        }
+      }
+      return false;
+    });
+    console.log(`  sonner CSS rules live in document.styleSheets: ${sheetApplied}`);
+    if (!sheetApplied) throw new Error("sonner stylesheet was NOT applied");
+  });
+  await drain("toast");
+
+  await visit(page, "admin-renewal", "/admin/renewal");
+  await drain("admin-renewal");
+
+  await browser.close();
+
+  console.log("\n================ RESULT ================");
+  console.log(`CSP violations: ${violations.length}`);
+  violations.forEach((v) =>
+    console.log(`  [${v.page}] ${v.directive} blocked=${v.blockedURI} sample="${v.sample}"`)
+  );
+  console.log(`\nconsole errors: ${consoleErrors.length}`);
+  consoleErrors.slice(0, 15).forEach((e) => console.log(`  ${e}`));
+
+  const styleViolations = violations.filter((v) => (v.directive || "").startsWith("style-src"));
+  console.log(`\nstyle-src violations: ${styleViolations.length}`);
+  process.exit(styleViolations.length > 0 ? 1 : 0);
+})();

--- a/frontend/e2e/csp-violation-check.js
+++ b/frontend/e2e/csp-violation-check.js
@@ -22,6 +22,13 @@ const OUT_DIR = process.argv[4] || "test-results/screenshots";
 
 const violations = [];
 const consoleErrors = [];
+/**
+ * Hard failures raised from inside a `visit()` interaction. `visit` deliberately
+ * swallows interaction errors (a missing button must not abort the sweep), so an
+ * assertion thrown in there would otherwise be downgraded to a log line and the
+ * run would still exit 0. Push here instead; the exit code reads this.
+ */
+const assertionFailures = [];
 
 async function mockSsoLogin(nycuId) {
   const r = await fetch(`${BACKEND}/api/v1/auth/mock-sso/login`, {
@@ -213,7 +220,11 @@ async function visit(page, label, urlPath, interact) {
       return false;
     });
     console.log(`  sonner CSS rules live in document.styleSheets: ${sheetApplied}`);
-    if (!sheetApplied) throw new Error("sonner stylesheet was NOT applied");
+    if (!sheetApplied) {
+      assertionFailures.push(
+        "sonner stylesheet was NOT applied — SONNER_STYLE_HASH is stale (toasts render unstyled)"
+      );
+    }
   });
   await drain("toast");
 
@@ -232,5 +243,7 @@ async function visit(page, label, urlPath, interact) {
 
   const styleViolations = violations.filter((v) => (v.directive || "").startsWith("style-src"));
   console.log(`\nstyle-src violations: ${styleViolations.length}`);
-  process.exit(styleViolations.length > 0 ? 1 : 0);
+  console.log(`assertion failures: ${assertionFailures.length}`);
+  assertionFailures.forEach((f) => console.log(`  FAIL: ${f}`));
+  process.exit(styleViolations.length > 0 || assertionFailures.length > 0 ? 1 : 0);
 })();

--- a/frontend/lib/security-headers.ts
+++ b/frontend/lib/security-headers.ts
@@ -113,3 +113,30 @@ export const CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups";
  * uses no SharedArrayBuffer and never needs `crossOriginIsolated`.
  */
 export const CROSS_ORIGIN_RESOURCE_POLICY = "same-origin";
+
+/**
+ * CSP hashes for the two `<style>` elements sonner (the `<Toaster />` in
+ * app/layout.tsx) injects into `<head>` at module-import time. Issue #1273.
+ *
+ * WHY THIS EXISTS: the production `style-src` is nonce-gated (no
+ * `'unsafe-inline'`). sonner 1.7.4 injects its stylesheet imperatively —
+ *
+ *   let a = document.createElement("style");
+ *   t.appendChild(a);                        // (1) EMPTY element -> hash of ""
+ *   a.appendChild(document.createTextNode(n)) // (2) fills it -> hash of the CSS
+ *
+ * — with no nonce, no element id, and no opt-out, so a nonce cannot reach it and
+ * both steps are separately hash-checked by the browser. Without these two
+ * hashes every page logs two `style-src-elem` violations and ALL toast styling
+ * is dropped (unstyled toasts, verified in a production build).
+ *
+ * WHY NOT UPGRADE: sonner 2.0.7 (latest as of 2026-08-03) has no `nonce`
+ * support either — `grep -c nonce dist/index.mjs` is 0 in both versions.
+ *
+ * DRIFT GUARD: `__tests__/csp-sonner-hash.test.ts` recomputes the CSS hash from
+ * the INSTALLED sonner bundle and fails if it differs from the constant below.
+ * A sonner upgrade therefore breaks CI loudly instead of silently un-styling
+ * every toast in production. When that test fails, copy the hash it prints here.
+ */
+export const SONNER_EMPTY_STYLE_HASH = "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='";
+export const SONNER_STYLE_HASH = "'sha256-Od9mHMH7x2G6QuoV3hsPkDCwIyqbg2DX3F5nLeCYQBc='";

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -4,6 +4,8 @@ import {
   CROSS_ORIGIN_OPENER_POLICY,
   CROSS_ORIGIN_RESOURCE_POLICY,
   PERMISSIONS_POLICY,
+  SONNER_EMPTY_STYLE_HASH,
+  SONNER_STYLE_HASH,
 } from "@/lib/security-headers";
 
 /**
@@ -16,17 +18,6 @@ export function middleware(request: NextRequest) {
   const nonceArray = new Uint8Array(16);
   crypto.getRandomValues(nonceArray);
   const nonce = Buffer.from(nonceArray).toString("base64");
-
-  // Clone the request headers
-  const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-nonce", nonce);
-
-  // Create response with updated headers
-  const response = NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
-  });
 
   // Determine environment-specific CSP policy
   const isDevelopment = process.env.NODE_ENV === "development";
@@ -60,9 +51,11 @@ export function middleware(request: NextRequest) {
     pathname === "/api/v1/preview" || pathname.startsWith("/api/v1/preview/");
   const frameAncestors = isFramablePreview ? "frame-ancestors 'self'" : "frame-ancestors 'none'";
 
+  let csp: string;
+
   if (isDevelopment) {
     // Development CSP: Relaxed for HMR and debugging
-    const csp = [
+    csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-eval' 'unsafe-inline'", // HMR requires unsafe-eval
       "style-src 'self' 'unsafe-inline'",
@@ -78,8 +71,6 @@ export function middleware(request: NextRequest) {
       "base-uri 'self'",
       "form-action 'self'",
     ].join("; ");
-
-    response.headers.set("Content-Security-Policy", csp);
   } else {
     // Production CSP: Strict with nonce-based script/style loading
     const portalHost =
@@ -87,10 +78,28 @@ export function middleware(request: NextRequest) {
       request.nextUrl.hostname.includes("staging")
         ? "https://portal.test.nycu.edu.tw"
         : "https://portal.nycu.edu.tw";
-    const csp = [
+    csp = [
       "default-src 'self'",
       `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`, // strict-dynamic for bundled scripts
-      "style-src 'self' 'unsafe-inline'",
+      // Issue #1273 / ZAP 10055. `style-src 'self' 'unsafe-inline'` (commit bc2019f0)
+      // was the blunt fix for shadcn/ui: Radix + floating-ui write inline style
+      // ATTRIBUTES at runtime (Popover/Dropdown/Dialog positioning, animation vars)
+      // and a nonce cannot be attached to a `style=` attribute. But that one keyword
+      // also re-permitted injected `<style>` ELEMENTS, which nothing in this app needs.
+      //
+      // CSP Level 3 splits the two. Keep the half the UI actually requires and drop
+      // the half that only helps an attacker:
+      //   style-src      -> ELEMENTS (<style>, <link rel=stylesheet>): nonce-gated
+      //   style-src-attr -> ATTRIBUTES (style="..."): 'unsafe-inline', for Radix
+      //
+      // ACCEPTED RESIDUAL RISK: an HTML-injection point can still set a `style=`
+      // attribute. Closing that would mean replacing Radix's positioning engine —
+      // disproportionate. Injected <style> blocks are now blocked by the browser.
+      //
+      // The two sonner hashes cover the <Toaster/> stylesheet, which the library
+      // injects imperatively with no nonce hook — see lib/security-headers.ts.
+      `style-src 'self' 'nonce-${nonce}' ${SONNER_STYLE_HASH} ${SONNER_EMPTY_STYLE_HASH}`,
+      "style-src-attr 'unsafe-inline'",
       // NO bare `https:` — that allowed images from ANY HTTPS origin (issue #1223
       // finding B, flagged by ZAP) and nothing in the app needs it. Every <img>
       // render site uses a same-origin or blob: source:
@@ -109,9 +118,31 @@ export function middleware(request: NextRequest) {
       "object-src 'none'",
       "upgrade-insecure-requests",
     ].join("; ");
-
-    response.headers.set("Content-Security-Policy", csp);
   }
+
+  // Clone the request headers.
+  //
+  // BOTH of these must be forwarded on the REQUEST, not just the response:
+  //   x-nonce                  -> read by app/layout.tsx via getNonce()
+  //   Content-Security-Policy  -> read by Next.js itself
+  //
+  // Next.js only auto-attaches the nonce to the <style>/<script> tags it injects
+  // when it can parse a nonce out of the REQUEST's CSP header. With the header set
+  // on the response only (the pre-#1273 shape), Next emitted two un-nonced inline
+  // <style> elements on every page — invisible while `style-src` still carried
+  // 'unsafe-inline', but an instant style-src-elem block the moment it was removed.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", csp);
+
+  // Create response with updated headers
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
+  response.headers.set("Content-Security-Policy", csp);
 
   // Additional security headers (defense in depth). Same-origin preview proxies
   // must stay framable by the app itself, so SAMEORIGIN (not DENY) for those —


### PR DESCRIPTION
Closes #1273

## 問題

正式環境 CSP 的 `style-src` 帶 `'unsafe-inline'`，ZAP baseline 標記 Medium（規則 10055）。這是上線前掃描中**唯一會在正式環境重現**的 Medium — 其餘 Medium 都是開發模式 CSP 專屬。

該關鍵字來自 `bc2019f0`（"allow shadcn/ui inline styles"）：Radix + floating-ui 在執行期寫 inline style **屬性**，而 nonce 無法附加到 `style=` 屬性上。但整條放寬也順帶放行了注入的 `<style>` **元素**，超出實際需求。

## 修法

用 CSP Level 3 把元素與屬性拆開：

```
style-src      'self' 'nonce-<per-request>' <sonner hashes>   # 元素：nonce 管制
style-src-attr 'unsafe-inline'                                # 屬性：Radix 需要
```

要讓這件事真的成立，必須把 nonce 送到**每一個**執行期注入樣式的地方，而三者各自從不同管道取得：

| 注入者 | 取得 nonce 的方式 |
|---|---|
| `react-remove-scroll` → `react-style-singleton`（所有 Radix scroll-lock 元件：Select / DropdownMenu / Dialog / Popover） | `__webpack_nonce__`（`get-nonce` 套件讀取）— 這些套件唯一暴露的掛鉤 |
| `Select.Viewport`、`ScrollArea.Viewport`（自行在 JSX render `<style>`） | 新增的 `CspNonceProvider` → `useCspNonce()` 傳入 `nonce` prop |
| `sonner`（`<Toaster />`） | 兩者皆無 — 1.7.4 與最新的 2.0.7 都不支援 nonce，只能用**內容 hash** 允許 |

另外把 CSP 一併放到 **request** header（原本只設在 response），Next.js 才會替它自己注入的標籤加上 nonce。

`__webpack_nonce__` 的賦值包在 try/catch：在非 webpack 環境（jest、Turbopack `next dev`）該識別字未宣告，strict mode 下裸賦值會 ReferenceError 並讓整棵 React tree 掛掉（此問題由新增的測試抓到）。

## 接受的殘留風險

`style-src-attr 'unsafe-inline'` 仍允許注入 `style=` 屬性。要完全消除必須替換 Radix 的定位機制，成本與效益不成比例。已記載於 `docs/CSP_IMPLEMENTATION.md`。

## 驗證

**Production build 實測**（`next build && next start`，非 dev — dev CSP 仍帶 `unsafe-inline`，不會重現）：

- 登入頁、admin 首頁、切換 10 個 tab、開啟 Radix Select 下拉、續領管理頁 → **CSP violations: 0**
- sonner CSS 確認實際生效（`document.styleSheets` 中找得到 `data-sonner-toaster` 規則），不只是「沒報錯」

過程中實測抓到三個若只改 header 就會**靜默壞掉**的地方（樣式被瀏覽器丟棄、畫面壞掉但只有 console 有訊息）：Next.js 自身注入的兩個 `<style>`、sonner 的 14KB 樣式表、Radix viewport 樣式。

**ZAP baseline 對 production build 重掃**：0 High、0 Medium，`CSP: style-src unsafe-inline` 已消失（報告：`zap-reports/after-fix/`）。

**測試**：前端全套 116 suites / 1534 tests 通過，含三個新的防迴歸鎖：
- `middleware-csp.test.ts` — prod `style-src` 不得含 `unsafe-inline`、`style-src-attr` 必須保留（拿掉會重現 bc2019f0 的災情）
- `csp-sonner-hash.test.ts` — 從安裝的 sonner bundle 重算 hash，升版時 CI 會擋下（否則 toast 會在正式環境靜默失去樣式）
- `csp-nonce-wiring.test.tsx` — 驗證兩個 Radix wrapper 確實把 nonce 傳下去

`frontend/e2e/csp-violation-check.js` 保留為可重複執行的 production-build 檢查腳本。

## 未涵蓋

Radix **Dialog** 未能在實測中開啟（測試環境資料不足，找不到可觸發的入口）。其 scroll-lock 樣式與已驗證的 Select 走同一個 `react-remove-scroll` 機制，且 Dialog 本身不 render 自己的 `<style>`（已對 `@radix-ui/*` grep `dangerouslySetInnerHTML` 確認只有 Select 與 ScrollArea），風險低但未經瀏覽器實證。ScrollArea 同理，僅以單元測試驗證 prop 佈線。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
