### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/backend/app/api/v1/endpoints/admin/dashboard.py
+++ b/backend/app/api/v1/endpoints/admin/dashboard.py
@@ -255,44 +255,50 @@ async def debug_nycu_employee_api(
         }
 
     except NYCUEmpAuthenticationError as e:
+        logger.warning("NYCU Employee API authentication error during debug request", exc_info=True)
         debug_info["test_results"] = {
             "status": "authentication_error",
-            "error": str(e),
+            "error": "Authentication with NYCU Employee API failed",
             "type": "NYCUEmpAuthenticationError",
             "suggestion": "Check NYCU_EMP_ACCOUNT and NYCU_EMP_KEY_HEX/NYCU_EMP_KEY_RAW",
         }
     except NYCUEmpConnectionError as e:
+        logger.warning("NYCU Employee API connection error during debug request", exc_info=True)
         debug_info["test_results"] = {
             "status": "connection_error",
-            "error": str(e),
+            "error": "Unable to connect to NYCU Employee API",
             "type": "NYCUEmpConnectionError",
             "suggestion": "Check NYCU_EMP_ENDPOINT and network connectivity",
         }
     except NYCUEmpTimeoutError as e:
+        logger.warning("NYCU Employee API timeout during debug request", exc_info=True)
         debug_info["test_results"] = {
             "status": "timeout_error",
-            "error": str(e),
+            "error": "NYCU Employee API request timed out",
             "type": "NYCUEmpTimeoutError",
             "suggestion": "Consider increasing NYCU_EMP_TIMEOUT value",
         }
     except NYCUEmpValidationError as e:
+        logger.warning("NYCU Employee API validation error during debug request", exc_info=True)
         debug_info["test_results"] = {
             "status": "validation_error",
-            "error": str(e),
+            "error": "Invalid NYCU Employee API request parameters",
             "type": "NYCUEmpValidationError",
             "suggestion": "Check page and status parameter values",
         }
     except NYCUEmpError as e:
+        logger.warning("NYCU Employee API error during debug request", exc_info=True)
         debug_info["test_results"] = {
             "status": "api_error",
-            "error": str(e),
+            "error": "NYCU Employee API returned an error",
             "type": type(e).__name__,
             "suggestion": "Check API endpoint and credentials",
         }
     except Exception as e:
+        logger.exception("Unexpected error during NYCU Employee API debug request")
         debug_info["test_results"] = {
             "status": "unexpected_error",
-            "error": str(e),
+            "error": "An unexpected error occurred while testing NYCU Employee API",
             "type": type(e).__name__,
             "suggestion": "Check system logs for more details",
         }


### PR DESCRIPTION
Potential fix for [https://github.com/anud18/scholarship-system/security/code-scanning/18](https://github.com/anud18/scholarship-system/security/code-scanning/18)

The best fix is to stop returning raw exception text to the client while still preserving diagnostics in server logs.  
In general: log the exception server-side (`logger.exception` / `logger.warning`) and return a generic, non-sensitive error string in API responses.

For this file (`backend/app/api/v1/endpoints/admin/dashboard.py`), update each `except ... as e` block in `debug_nycu_employee_api` so:

- Remove `"error": str(e)` from `debug_info["test_results"]`.
- Replace it with a safe generic message (for example, `"error": "Failed to ..."`).
- Add structured server-side logging in each `except` block:
  - `logger.warning(..., exc_info=True)` for expected integration errors.
  - `logger.exception(...)` for the final unexpected `Exception`.
  
This single change addresses all 6 alert variants because all taint flows originate from `str(e)` being placed into `debug_info` and returned at line 300.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
