### PR TITLE
fix(production): repair the production deploy path — logrotate, monitoring wiring, sudo dependency

### DIFF
--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -245,9 +245,34 @@ jobs:
           # ~/scholarship-production/nginx/ssl/prod by the operator must
           # survive, since the repo ships nginx configs but no keys.
           if [ -d nginx ]; then cp -r nginx ~/scholarship-production/; fi
+          # Everything below is copied as the runner user and therefore owned by
+          # it, so a plain rm is enough to replace it. sudo -n is only a fallback
+          # for hosts that ran an earlier, broken version of this workflow and
+          # were left with root-owned leftovers; -n so a VM WITHOUT passwordless
+          # sudo fails immediately with the message below instead of blocking on
+          # a password prompt no one can answer.
+          replace_dir() {
+            rm -rf "$HOME/scholarship-production/$1" 2>/dev/null && return 0
+            sudo -n rm -rf "$HOME/scholarship-production/$1" 2>/dev/null && return 0
+            echo "::error::Cannot replace ~/scholarship-production/$1 — it is owned by root"
+            echo "::error::from an earlier deploy and this runner has no passwordless sudo."
+            echo "::error::Clear it once on the AP VM: sudo rm -rf ~/scholarship-production/$1"
+            return 1
+          }
           if [ -d monitoring ]; then
-            sudo rm -rf ~/scholarship-production/monitoring
+            replace_dir monitoring
             cp -r monitoring ~/scholarship-production/
+          fi
+          # scripts/logrotate.conf is bind-mounted as the logrotate service's
+          # config. This copy was missing, so Docker materialised the mount
+          # source as a root-owned DIRECTORY and logrotate rotated nothing
+          # ("Handling 0 logs", exit 0) while the container stayed Up — the
+          # nginx access log grew unbounded with no signal anything was wrong.
+          # No chown here: logrotate ignores configs it does not own, so the
+          # container makes its own root-owned copy (docker-compose.prod.yml).
+          if [ -d scripts ]; then
+            replace_dir scripts
+            cp -r scripts ~/scholarship-production/
           fi
 
       # Two supported ways to configure the stack, chosen by the ENV_FILE

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -464,15 +464,24 @@ jobs:
       - name: Start new containers
         run: |
           cd ~/scholarship-production
-          # scholarship_prod_network is declared external so it keeps a stable,
-          # unprefixed name that the monitoring stack can join — compose never
-          # creates an external network, so make sure it exists first. The
-          # subnet is the one this stack has always used.
-          docker network inspect scholarship_prod_network >/dev/null 2>&1 || \
-            docker network create --subnet 172.24.0.0/16 scholarship_prod_network
           # --env-file is the single source of interpolation values; TAG and
           # IMAGE_OWNER come from the job env and intentionally take precedence.
           docker compose --env-file "${ENV_FILE}" down || true
+
+          # scholarship_prod_network is declared external so it keeps a stable,
+          # unprefixed name the monitoring stack can join — compose never
+          # creates an external network, so it has to exist before `up`.
+          #
+          # Order matters: this runs AFTER `down`. Revisions before the external
+          # switch declared the network inline, so it exists under the compose
+          # project prefix holding this very subnet, and creating the new one
+          # first fails with "Pool overlaps with other one on this address
+          # space". `down` detaches the containers; removing the legacy network
+          # then frees the address space. Both lines are no-ops once migrated.
+          docker network rm scholarship-production_scholarship_prod_network 2>/dev/null || true
+          docker network inspect scholarship_prod_network >/dev/null 2>&1 || \
+            docker network create --subnet 172.24.0.0/16 scholarship_prod_network
+
           docker compose --env-file "${ENV_FILE}" up -d
 
       - name: Validate and reload nginx config

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -464,6 +464,12 @@ jobs:
       - name: Start new containers
         run: |
           cd ~/scholarship-production
+          # scholarship_prod_network is declared external so it keeps a stable,
+          # unprefixed name that the monitoring stack can join — compose never
+          # creates an external network, so make sure it exists first. The
+          # subnet is the one this stack has always used.
+          docker network inspect scholarship_prod_network >/dev/null 2>&1 || \
+            docker network create --subnet 172.24.0.0/16 scholarship_prod_network
           # --env-file is the single source of interpolation values; TAG and
           # IMAGE_OWNER come from the job env and intentionally take precedence.
           docker compose --env-file "${ENV_FILE}" down || true

--- a/.github/workflows/deploy-monitoring-stack.yml
+++ b/.github/workflows/deploy-monitoring-stack.yml
@@ -93,20 +93,30 @@ jobs:
 
           # Required env vars; unset values fail-fast below
           export APP_NETWORK_NAME="scholarship_staging_network"
+          # The stack serves both environments. Grafana/Loki/Prometheus join
+          # this second app network too, so production's alloy can push and
+          # prod nginx can proxy /monitoring to Grafana. Without it the prod
+          # side resolved nothing and silently dropped every batch.
+          export PROD_APP_NETWORK_NAME="scholarship_prod_network"
           export GRAFANA_ADMIN_USER="${{ secrets.GRAFANA_ADMIN_USER }}"
           export GRAFANA_ADMIN_PASSWORD="${{ secrets.GRAFANA_ADMIN_PASSWORD }}"
           export GRAFANA_ROOT_URL="${{ secrets.GRAFANA_ROOT_URL }}"
 
-          for var in APP_NETWORK_NAME GRAFANA_ADMIN_USER GRAFANA_ADMIN_PASSWORD GRAFANA_ROOT_URL; do
+          for var in APP_NETWORK_NAME PROD_APP_NETWORK_NAME GRAFANA_ADMIN_USER GRAFANA_ADMIN_PASSWORD GRAFANA_ROOT_URL; do
             if [ -z "${!var}" ]; then
               echo "::error::Required env var $var is unset"
               exit 1
             fi
           done
 
-          # Verify the named external network exists; create if missing
+          # Verify the named external networks exist; create if missing.
+          # docker-compose.prod.yml declares scholarship_prod_network external
+          # with this exact subnet, so create it the same way here — whichever
+          # side runs first wins and the other simply finds it.
           docker network inspect "$APP_NETWORK_NAME" >/dev/null 2>&1 || \
             docker network create "$APP_NETWORK_NAME"
+          docker network inspect "$PROD_APP_NETWORK_NAME" >/dev/null 2>&1 || \
+            docker network create --subnet 172.24.0.0/16 "$PROD_APP_NETWORK_NAME"
 
           # Write GH_PAT to a secrets file Grafana can mount via $__file{}
           sudo mkdir -p /opt/scholarship/secrets

--- a/.github/workflows/deploy-pipeline.yml
+++ b/.github/workflows/deploy-pipeline.yml
@@ -186,11 +186,31 @@ jobs:
             cp -r nginx ~/scholarship-staging/
             echo "Nginx config copied"
           fi
+          # These trees are copied as the runner user and are therefore owned by
+          # it, so a plain rm replaces them. sudo -n is only a fallback for hosts
+          # left with root-owned copies by an earlier deploy; -n so a VM WITHOUT
+          # passwordless sudo fails with the message below instead of blocking on
+          # a password prompt no one can answer.
+          replace_dir() {
+            rm -rf "$HOME/scholarship-staging/$1" 2>/dev/null && return 0
+            sudo -n rm -rf "$HOME/scholarship-staging/$1" 2>/dev/null && return 0
+            echo "::error::Cannot replace ~/scholarship-staging/$1 — it is owned by root"
+            echo "::error::and this runner has no passwordless sudo. Clear it once on the VM:"
+            echo "::error::  sudo rm -rf ~/scholarship-staging/$1"
+            return 1
+          }
           if [ -d monitoring ]; then
-            # Remove old monitoring directory if it exists (may have wrong permissions)
-            sudo rm -rf ~/scholarship-staging/monitoring
+            replace_dir monitoring
             cp -r monitoring ~/scholarship-staging/
             echo "Monitoring config copied"
+          fi
+          # scripts/logrotate.conf is the logrotate service's config. Without
+          # this copy Docker materialises the mount source as a directory and
+          # logrotate reports "Handling 0 logs" while rotating nothing.
+          if [ -d scripts ]; then
+            replace_dir scripts
+            cp -r scripts ~/scholarship-staging/
+            echo "Scripts copied"
           fi
           cd ~/scholarship-staging
           echo "Deployment files prepared"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -213,7 +213,15 @@ services:
       sh -c '
         apk add --no-cache logrotate
         while true; do
-          logrotate /etc/logrotate.conf
+          # logrotate silently ignores any config file it does not own (uid 0)
+          # or that is group/world-writable. The bind-mounted file belongs to
+          # the deploy user on the host, so re-materialise it as a root-owned
+          # copy in here — this container already runs as root — instead of
+          # making the deploy depend on passwordless sudo on the AP VM.
+          cp /etc/logrotate.conf /run/logrotate.conf
+          chown root:root /run/logrotate.conf
+          chmod 644 /run/logrotate.conf
+          logrotate /run/logrotate.conf
           sleep 3600
         done
       '

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -238,7 +238,9 @@ services:
     volumes:
       - ./monitoring/config/alloy/prod-ap-vm.alloy:/etc/alloy/config.alloy:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./logs/nginx:/var/log/nginx:ro
+      # ./logs/nginx was mounted here but never read: the config's only log
+      # source is loki.source.docker. nginx now logs to stdout, which that
+      # source already collects, so the mount is gone rather than misleading.
     networks:
       - scholarship_prod_network
     command: run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy
@@ -362,9 +364,12 @@ volumes:
       device: /opt/scholarship/app/redis/data
 
 networks:
+  # Declared external, like staging's, so the name is exactly
+  # `scholarship_prod_network`. Inline-declared networks get the compose project
+  # prefix (`scholarship-production_…`), and the monitoring stack joins an app
+  # network BY NAME — with the prefix, Loki and Prometheus could never be
+  # attached, alloy's DNS lookups failed, and every log batch was dropped.
+  # deploy.yml creates it (with the 172.24.0.0/16 subnet) if it does not exist.
   scholarship_prod_network:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.24.0.0/16
+    external: true
+    name: scholarship_prod_network

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -102,6 +102,41 @@ services:
       timeout: 10s
       retries: 3
 
+  # Log Management
+  # Staging had no rotation at all, so nginx's access.log reached 1.4G on a
+  # 92%-full disk. Container stdout is capped by the json-file driver, but the
+  # bind-mounted files below are not — nothing else truncates them.
+  logrotate:
+    image: alpine:latest
+    container_name: scholarship_logrotate_staging
+    volumes:
+      - ./logs:/logs
+      - ./scripts/logrotate.conf:/etc/logrotate.conf:ro
+    networks:
+      - scholarship_staging_network
+    command: |
+      sh -c '
+        apk add --no-cache logrotate
+        while true; do
+          # logrotate silently ignores any config file it does not own (uid 0)
+          # or that is group/world-writable. The bind-mounted file belongs to
+          # the deploy user on the host, so re-materialise it as a root-owned
+          # copy in here — this container already runs as root — instead of
+          # making the deploy depend on passwordless sudo on the VM.
+          cp /etc/logrotate.conf /run/logrotate.conf
+          chown root:root /run/logrotate.conf
+          chmod 644 /run/logrotate.conf
+          logrotate /run/logrotate.conf
+          sleep 3600
+        done
+      '
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "5m"
+        max-file: "3"
+
   # Next.js Frontend
   frontend:
     image: ghcr.io/anud18/scholarship-system-frontend:${TAG:-latest}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -166,7 +166,9 @@ services:
     volumes:
       - ./monitoring/config/alloy/staging-ap-vm.alloy:/etc/alloy/config.alloy:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./logs/nginx:/var/log/nginx:ro
+      # ./logs/nginx was mounted here but never read: the config's only log
+      # source is loki.source.docker. nginx now logs to stdout, which that
+      # source already collects, so the mount is gone rather than misleading.
     networks:
       - scholarship_staging_network
     command: run --server.http.listen-addr=0.0.0.0:12345 /etc/alloy/config.alloy

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -45,6 +45,7 @@ services:
     networks:
       - monitoring_network
       - app_network
+      - prod_app_network
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
@@ -74,6 +75,7 @@ services:
     networks:
       - monitoring_network
       - app_network
+      - prod_app_network
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3100/ready"]
@@ -117,6 +119,7 @@ services:
     networks:
       - monitoring_network
       - app_network
+      - prod_app_network
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]
@@ -197,3 +200,11 @@ networks:
   app_network:
     external: true
     name: ${APP_NETWORK_NAME}
+  # The stack serves BOTH environments, but only ever joined one app network,
+  # hardcoded to staging in deploy-monitoring-stack.yml. Production's alloy sat
+  # on a network Loki and Prometheus were not attached to, so its DNS lookups
+  # failed and every batch was dropped ("no retries left, dropping data"), and
+  # prod nginx could not reach Grafana for the /monitoring proxy either.
+  prod_app_network:
+    external: true
+    name: ${PROD_APP_NETWORK_NAME:-scholarship_prod_network}

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -61,8 +61,13 @@ http {
         server_name ss.aa.nycu.edu.tw localhost _;
 
         # Access log with JSON format
-        access_log /var/log/nginx/access.log json_combined;
-        error_log /var/log/nginx/error.log warn;
+        # Logs go to the container's stdout/stderr, NOT to a file. Alloy's only
+        # log source is loki.source.docker (the Docker socket), so file-based
+        # logs never reached Loki — the alloy config even carries a stage.json
+        # written to parse these very json_combined fields, for data that never
+        # arrived. Docker's json-file driver caps and rotates this stream.
+        access_log /dev/stdout json_combined;
+        error_log /dev/stderr warn;
 
         # SSL Configuration
         ssl_certificate /etc/nginx/ssl/fullchain.pem;
@@ -344,6 +349,40 @@ http {
             proxy_hide_header Server;
 
             add_header X-Content-Type-Options "nosniff";
+        }
+
+        # Grafana monitoring dashboard (subpath serving)
+        # Grafana publishes no host port — this proxy is the ONLY way to reach
+        # it. Production shipped without this block, so the dashboard was
+        # unreachable whenever the production stack held :443.
+        # Using ^~ to prevent regex matching for static assets.
+        location ^~ /monitoring {
+            # Rate limiting for monitoring access
+            limit_req zone=api burst=100 nodelay;
+
+            set $grafana_upstream monitoring_grafana:3000;
+
+            proxy_pass http://$grafana_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Request-ID $request_id;
+
+            # WebSocket support for Grafana Live
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            # Grafana specific timeouts
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+
+            # Buffer settings
+            proxy_buffering off;
+            proxy_buffer_size 16k;
+            proxy_buffers 8 16k;
         }
 
         # Frontend routes (all other requests)

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -64,8 +64,13 @@ http {
         server_name ss.test.nycu.edu.tw 140.113.7.148 localhost;
 
         # Access log with JSON format
-        access_log /var/log/nginx/access.log json_combined;
-        error_log /var/log/nginx/error.log warn;
+        # Logs go to the container's stdout/stderr, NOT to a file. Alloy's only
+        # log source is loki.source.docker (the Docker socket), so file-based
+        # logs never reached Loki — the alloy config even carries a stage.json
+        # written to parse these very json_combined fields, for data that never
+        # arrived. Docker's json-file driver caps and rotates this stream.
+        access_log /dev/stdout json_combined;
+        error_log /dev/stderr warn;
 
         # SSL Configuration (real certificates)
         ssl_certificate /etc/nginx/ssl/test.nycu.cer;

--- a/scripts/logrotate.conf
+++ b/scripts/logrotate.conf
@@ -1,0 +1,45 @@
+# Rotation policy for the bind-mounted file logs.
+#
+# docker-compose.prod.yml's `logrotate` service mounts ./logs as /logs and this
+# file as /etc/logrotate.conf, then runs `logrotate /etc/logrotate.conf` once an
+# hour. Without this file the mount source does not exist, Docker materialises it
+# as a directory, and logrotate reports "Handling 0 logs" and exits 0 forever —
+# a healthy-looking container that rotates nothing while the AP VM's disk fills.
+#
+# Scope: only the bind-mounted FILE logs below. Container stdout is capped
+# separately by each service's json-file max-size/max-file options.
+#
+# Two requirements logrotate enforces on this file itself, both handled by
+# deploy.yml's "Prepare deployment files" step: it must be owned by uid 0, and
+# it must not be group- or world-writable. Otherwise logrotate ignores it.
+
+# The log files are written by root inside the nginx container, but their parent
+# directory is owned by the deploy user and is group-writable, which logrotate
+# refuses to touch by default ("insecure permissions"). `su` names the identity
+# to rotate as and satisfies that check.
+su root root
+
+compress
+delaycompress
+notifempty
+missingok
+
+# nginx holds its access/error log file descriptors open and cannot be sent USR1
+# from the logrotate container, so the files are truncated in place instead of
+# renamed — a rename would leave nginx writing to the rotated inode and the live
+# log would look frozen.
+/logs/nginx/*.log {
+    daily
+    rotate 14
+    maxsize 100M
+    copytruncate
+}
+
+# The backend logs to stdout today; this covers /app/logs should file logging be
+# enabled later. missingok keeps it quiet while the directory is empty.
+/logs/backend/*.log {
+    daily
+    rotate 14
+    maxsize 50M
+    copytruncate
+}


### PR DESCRIPTION
Repairs the production deployment path end-to-end. Everything below was verified by actually running the workflows — private production repo `anud18/naass-prod-test`, its self-hosted runner on the AP VM, real GHCR images, real DB VM — not by reading YAML.

## Verification

| Workflow | Result |
|---|---|
| Deploy to Production | ✅ all 15 steps, migrations to head, `seed --prod`, health + smoke |
| Production Health Check | ✅ backend / frontend / DB / Redis |
| Backup Production Data | ✅ database + files + verify |

Backups were checked independently rather than trusted: gzip intact, sha256 matching, 112 `CREATE TABLE`/`COPY` statements, dump not truncated.

## What was broken

### 1. logrotate never rotated anything

`docker-compose.prod.yml` bind-mounts `./scripts/logrotate.conf`, but that file has never existed in this repo and the deploy step copied only `nginx/` and `monitoring/`. Docker materialised the mount source as a root-owned **directory**, and logrotate read a directory as its config: `Handling 0 logs`, exit 0, container permanently `Up`. Confirmed on the live deploy — `~/scholarship-production/scripts/logrotate.conf` was a directory.

A second trap surfaced after adding the file: logrotate ignores any config it does not own (uid 0) or that is group/world-writable, which a copy made by the runner user always is. Rather than `chown` on the host — which would make every deploy depend on passwordless sudo a production VM is not guaranteed to have — the logrotate container re-materialises the config as a root-owned copy before each run. It already runs as root.

Staging had no logrotate service at all. Its `access.log` had reached **1.4G** and `error.log` 62M on a 92%-full disk.

### 2. Production was invisible to the monitoring stack

Three independent gaps, all confirmed live:

- **alloy could not reach Loki or Prometheus.** The monitoring stack joins exactly one app network, hardcoded to staging, while production's alloy sat elsewhere. Every batch was dropped — `final error sending batch, no retries left, dropping data` — and metrics retried forever, with the container reporting `Up` throughout. `docker-compose.prod.yml` also declared its network inline, so compose prefixed the real name and nothing could join it by name; it is now external with a fixed name, as staging already was.
- **nginx logs never reached Loki.** They went to files, but alloy's only source is `loki.source.docker`, and the `./logs/nginx` mount on alloy was read by nothing. The alloy config even carries a `stage.json` written to parse the `json_combined` fields those files hold — a pipeline built for data that never arrived. nginx now logs to stdout/stderr; the dead mount is gone.
- **Grafana was unreachable in production.** It publishes no host port and is served only through nginx at `/monitoring`, a location `nginx.prod.conf` never had. Ported verbatim from `nginx.staging.conf`.

After the fix, Loki's `prod` tenant carries 22 container streams including `/scholarship_nginx_prod` with its JSON access log, and `https://<domain>/monitoring` serves Grafana (302 → login, `/api/health` → `database: ok`).

### 3. Deploy depended on passwordless sudo

Directory replacement in both deploy paths used unconditional `sudo rm -rf` on trees the runner itself owns. Reworked to a plain `rm`, with `sudo -n` only as a fallback for root-owned leftovers — `-n` so a VM without NOPASSWD fails immediately with an actionable message instead of blocking on a password prompt no one can answer.

## Migration note

Switching the production network to external needs the address space the old project-prefixed network still holds. Creating it before `docker compose down` fails with `Pool overlaps with other one on this address space` — this happened on the first deploy after the switch and is fixed by ordering (`down` → drop legacy network → create → `up`). Both cleanup lines are no-ops once a host has migrated. The failed deploy caused no outage: the previous stack kept serving throughout.

`nginx.staging.conf` also switches to stdout logging, so staging's access logs reach Loki too — effective on the first staging deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
