### PR TITLE
fix(production-workflows): add least-privilege GITHUB_TOKEN permissions to templates

### DIFF
--- a/.github/production-workflows-examples/backup.yml
+++ b/.github/production-workflows-examples/backup.yml
@@ -53,6 +53,10 @@ env:
   # Must match the server major version or pg_dump refuses to run.
   PG_IMAGE: postgres:15-alpine
 
+# Least privilege: no step in this workflow uses GITHUB_TOKEN at all (backups
+# stay on the AP VM disk for IT collection) — grant the token zero scopes.
+permissions: {}
+
 jobs:
   backup-database:
     name: Backup PostgreSQL Database

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -46,6 +46,11 @@ concurrency:
   group: production-deploy
   cancel-in-progress: false
 
+# Least privilege: nothing in this workflow writes via GITHUB_TOKEN. Jobs that
+# pull images from ghcr.io elevate to packages: read individually below.
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
 
@@ -141,6 +146,8 @@ jobs:
     name: Resolve Upstream Images
     runs-on: ubuntu-latest
     needs: validate-secrets
+    permissions:
+      packages: read # ghcr.io login + docker manifest inspect (GITHUB_TOKEN fallback when GH_PAT is unset)
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -200,6 +207,11 @@ jobs:
     # runners cannot reach it. Register with: [self-hosted, linux].
     runs-on: [self-hosted, linux]
     needs: [validate-secrets, resolve-images]
+    # Job-level permissions REPLACE the workflow-level block, so contents: read
+    # must be restated alongside the packages elevation.
+    permissions:
+      contents: read # actions/checkout
+      packages: read # docker/login-action + docker pull (GITHUB_TOKEN fallback when GH_PAT is unset)
     environment:
       name: production
       url: ${{ vars.PRODUCTION_URL }}

--- a/.github/production-workflows-examples/setting-env.yml
+++ b/.github/production-workflows-examples/setting-env.yml
@@ -25,6 +25,10 @@ on:
           - full-check
         default: 'validate'
 
+# Least privilege: the only token consumer in this workflow is actions/checkout.
+permissions:
+  contents: read
+
 jobs:
   setup-environment:
     name: ${{ github.event.inputs.action == 'validate' && 'Validate Environment' || github.event.inputs.action == 'setup' && 'Setup Environment' || 'Full Check & Setup' }}


### PR DESCRIPTION
## Summary

CodeQL (`actions/missing-workflow-permissions`) raised 7 Medium alerts on the production repo because none of the seeded workflows declare a `permissions:` block, so every job inherits the potentially permissive repo-default token scopes — on self-hosted runners sitting on the production AP VM. This PR adds explicit least-privilege blocks to the three affected templates in `.github/production-workflows-examples/`, keeping them in sync with the fix already pushed to the production repo (`anud18/naass-prod-test` @ `fa8859f`).

Per-file rationale (from a full per-job token-usage audit):

| Template | Workflow-level | Job elevation | Why |
|---|---|---|---|
| `deploy.yml` | `contents: read` | `resolve-images`: `packages: read`; `deploy`: `contents: read` + `packages: read` | Both jobs authenticate to ghcr.io with `secrets.GH_PAT \|\| secrets.GITHUB_TOKEN` — under a bare `contents: read` the GITHUB_TOKEN fallback path would fail the image gate and block the whole deploy. Job-level `permissions:` **replaces** the workflow block, so `deploy` restates `contents: read` for its checkout. |
| `backup.yml` | `permissions: {}` | none | Zero token consumers — no `uses:` steps at all; backups stay on the AP VM disk for IT collection. Zero scopes = one less credential on that box. |
| `setting-env.yml` | `contents: read` | none | The only token consumer in ~1500 lines is `actions/checkout`. All VM work uses the `DB_VM_SSH_KEY` secret or anonymous Docker Hub pulls. |

Deliberately **not** granted: `packages: write` (this pipeline only promotes upstream images, never pushes), `deployments: write` (the `environment:` key is recorded by the Actions service, not the token), `issues:`/`contents: write` (no gh CLI, releases, tags, or pushes exist in these files).

Note: `auto-tag-on-merge.yml` and `health-check.yml` templates already carry explicit permissions blocks — only these three lacked them, matching the 7 CodeQL alerts exactly.

## Test plan

- [x] `yaml.safe_load` parses all three edited templates (also under a strict duplicate-key-rejecting loader)
- [x] Adversarial per-job audit of all 7 jobs: every job covered by an explicit or inherited block; no step needs a scope that is not granted (ghcr.io fallback path exercised in the audit)
- [x] Edited templates verified byte-identical to the workflows pushed to the production repo
- [x] Production repo push accepted; CodeQL rescan on the production repo expected to close alerts #1–#7
- [ ] Next `mirror-to-production` run seeds the updated templates into a fresh production repo without conflict (prod-side copies already match, so the installer will report "already present")