### PR TITLE
feat(mirror): auto-update pristine stale workflows from templates

### DIFF
--- a/.github/PRODUCTION_SYNC_GUIDE.md
+++ b/.github/PRODUCTION_SYNC_GUIDE.md
@@ -46,6 +46,9 @@ This workflow automatically mirrors the development repository to a separate pri
    - **Expiration**: 90 days (recommended) or based on your security policy
    - **Select scopes**:
      - ✅ **`repo`** (Full control of private repositories)
+     - ✅ **`workflow`** (Update GitHub Action workflows — required: the mirror
+       installs and auto-updates `.github/workflows/**` in the production repo,
+       and GitHub rejects such pushes from a PAT without this scope)
 
 4. Click **"Generate token"**
 
@@ -343,7 +346,7 @@ git log --oneline -5
 
 ### 1. Token Security
 
-- ✅ Use tokens with **minimum required permissions** (`repo` scope only)
+- ✅ Use tokens with **minimum required permissions** (`repo` + `workflow` scopes — the mirror pushes `.github/workflows/**`)
 - ✅ Set **expiration dates** on tokens
 - ✅ **Rotate tokens regularly** (every 90 days recommended)
 - ✅ **Delete tokens** when no longer needed

--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -9,8 +9,14 @@
 `.github/workflows/`：
 
 - prod repo **還沒有**的檔案 → 自動安裝（首次 mirror 即完成 CI/CD bootstrap）
-- prod repo **已有**的檔案 → 一律不覆寫（prod 端客製優先）；若範本與 prod 版本
-  不同，mirror log 會以 notice 提示，由人工決定是否移植
+- prod repo 已有、且內容與**某個歷史版範本逐字節相同**的檔案（= 從未被 prod
+  端客製，只是舊版範本）→ **自動更新**到現行範本，讓範本修正（如 #1282 的
+  permissions 區塊）能經由 mirror 送達 prod。release notes 會列出
+  「Workflows updated from templates」清單;若 prod 端剛刻意 rollback 某個
+  workflow、暫時不想被升回來，dispatch mirror 時勾選 `freeze_workflows`
+- prod repo 已有、但**比對不到任何歷史版範本**的檔案（= prod 端有客製,
+  如 `auto-tag-on-merge.yml`）→ 一律不覆寫;mirror log 會以 notice 提示,
+  由人工決定是否移植
 
 > 📦 **只帶必要的可執行 CI/CD（.yml workflows）過去。** prod repo 資安掃描嚴格，
 > 因此本目錄的設定指南（`SECRETS-SETUP-GUIDE.md` 等含大量 example secret 值與

--- a/.github/workflows/mirror-to-production.yml
+++ b/.github/workflows/mirror-to-production.yml
@@ -18,6 +18,12 @@ on:
         required: false
         type: string
 
+      freeze_workflows:
+        description: '凍結 prod repo 的 workflows：跳過「pristine 舊模板自動更新」（例如 prod 端剛刻意 rollback 某個 workflow 時使用）'
+        required: false
+        type: boolean
+        default: false
+
 # SECURITY: Limit GITHUB_TOKEN permissions to minimum required
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -57,6 +63,22 @@ jobs:
             echo "::error::PRODUCTION_REPO secret not configured"
             echo "::error::Please set PRODUCTION_REPO to format: owner/repo-name"
             exit 1
+          fi
+
+          # The mirror pushes .github/workflows/** whenever a template is
+          # installed or a pristine-stale prod copy is auto-updated — a classic
+          # PAT must carry the `workflow` scope or the final push is rejected
+          # with "refusing to allow a Personal Access Token to create or
+          # update workflow". Fail fast HERE with an actionable message.
+          # Fine-grained PATs do not expose x-oauth-scopes; warn instead.
+          SCOPES=$(curl -sI -H "Authorization: token ${{ secrets.GH_PAT }}" https://api.github.com/user | tr -d '\r' | grep -i '^x-oauth-scopes:' || true)
+          if [ -n "$SCOPES" ] && ! echo "$SCOPES" | grep -qw "workflow"; then
+            echo "::error::GH_PAT lacks the 'workflow' scope — pushing .github/workflows/** to the production repo will be rejected."
+            echo "::error::Re-issue the PAT with 'repo' + 'workflow' scopes (see .github/PRODUCTION_SYNC_GUIDE.md)."
+            exit 1
+          fi
+          if [ -z "$SCOPES" ]; then
+            echo "::warning::Could not read x-oauth-scopes (fine-grained PAT?) — ensure the token has the 'Workflows' repository permission (read and write) on the production repo."
           fi
 
           echo "configured=true" >> $GITHUB_OUTPUT
@@ -510,29 +532,37 @@ jobs:
         id: install-workflows
         env:
           PRESERVED_COUNT: ${{ steps.preserve-workflows.outputs.preserved_count }}
+          FREEZE_WORKFLOWS: ${{ inputs.freeze_workflows }}
         run: |
           echo "::group::Installing production workflows from templates"
 
           # Bootstrap + drift policy:
-          #   - A workflow file the prod repo ALREADY has (just preserved from
-          #     prod-repo/main) wins — prod-side customizations are never
-          #     overwritten by the mirror.
           #   - A workflow file the prod repo does NOT have yet is installed
           #     from the staged templates (first mirror seeds the whole CI/CD).
-          #   - When a template differs from the preserved prod copy we only
-          #     surface a notice so the diff can be ported deliberately.
+          #   - A preserved prod copy that is byte-identical to SOME historical
+          #     revision of its template (checked against the dev history at
+          #     GITHUB_SHA) was never customized on the prod side — it is just
+          #     a stale template, so it IS updated to the current template.
+          #     This is what lets template fixes (e.g. the permissions blocks
+          #     from #1282) actually reach production through the mirror.
+          #   - A preserved prod copy matching NO template revision carries
+          #     prod-side customizations — never overwritten; we only surface
+          #     a notice so the diff can be ported deliberately.
           #
           # NOTE: pushing .github/workflows/** to the prod repo requires the
           # GH_PAT to carry the `workflow` scope — without it the push step
           # fails with "refusing to allow a Personal Access Token to create or
           # update workflow".
           INSTALLED=""
+          UPDATED=""
           SKIPPED=""
           DIFFERS=""
 
           if [ ! -d /tmp/prod-workflow-templates ]; then
             echo "::warning::No staged templates — skipping install"
             echo "installed=" >> $GITHUB_OUTPUT
+            echo "updated=" >> $GITHUB_OUTPUT
+            echo "customized=" >> $GITHUB_OUTPUT
             echo "::endgroup::"
             exit 0
           fi
@@ -554,8 +584,35 @@ jobs:
               if cmp -s "$src" "$dest"; then
                 SKIPPED="$SKIPPED $f"
               else
-                DIFFERS="$DIFFERS $f"
-                echo "::notice::$f: prod repo has a customized copy — template differs, NOT overwriting (port changes manually if intended)"
+                # Provenance check: does the preserved prod copy match ANY
+                # historical revision of the template? Byte-identical to one
+                # → never customized on the prod side → safe to update.
+                # CAVEAT: a deliberate prod-side rollback TO a historical
+                # template revision is indistinguishable from staleness — it
+                # would be re-upgraded here. Dispatch with
+                # freeze_workflows=true to hold workflows back in that window.
+                tpl=".github/production-workflows-examples/$f"
+                dest_blob=$(git hash-object "$dest" 2>/dev/null || true)
+                pristine=""
+                if [ -n "$dest_blob" ]; then
+                  for c in $(git rev-list "$GITHUB_SHA" -- "$tpl"); do
+                    if [ "$(git rev-parse --verify --quiet "$c:$tpl" || true)" = "$dest_blob" ]; then
+                      pristine="$c"
+                      break
+                    fi
+                  done
+                fi
+                if [ -n "$pristine" ] && [ "$FREEZE_WORKFLOWS" != "true" ]; then
+                  cp "$src" "$dest"
+                  UPDATED="$UPDATED $f"
+                  echo "::notice::$f: prod copy is a pristine template from ${pristine:0:8} — updated to current template"
+                elif [ -n "$pristine" ]; then
+                  DIFFERS="$DIFFERS $f"
+                  echo "::notice::$f: pristine stale template, but freeze_workflows=true — NOT updating this run"
+                else
+                  DIFFERS="$DIFFERS $f"
+                  echo "::notice::$f: prod repo has a customized copy — template differs, NOT overwriting (port changes manually if intended)"
+                fi
               fi
             else
               cp "$src" "$dest"
@@ -569,8 +626,9 @@ jobs:
             git commit -m "chore: install/update production CI-CD from templates
 
           Installed:${INSTALLED:- (none)}
+          Updated (pristine stale template):${UPDATED:- (none)}
           Already present (identical):${SKIPPED:- (none)}
-          Present but template differs (NOT overwritten):${DIFFERS:- (none)}
+          Customized on prod side (NOT overwritten):${DIFFERS:- (none)}
 
           Seeded from dev-repo .github/production-workflows-examples/ — this
           mirror is the only channel into this repository, so its CI/CD is
@@ -585,10 +643,13 @@ jobs:
           {
             echo "## Production CI/CD install"
             echo "- Installed:${INSTALLED:- (none)}"
+            echo "- Updated (pristine stale template):${UPDATED:- (none)}"
             echo "- Already present:${SKIPPED:- (none)}"
-            echo "- Differs (not overwritten):${DIFFERS:- (none)}"
+            echo "- Customized (not overwritten):${DIFFERS:- (none)}"
           } >> $GITHUB_STEP_SUMMARY
           echo "installed=${INSTALLED}" >> $GITHUB_OUTPUT
+          echo "updated=${UPDATED}" >> $GITHUB_OUTPUT
+          echo "customized=${DIFFERS}" >> $GITHUB_OUTPUT
           echo "::endgroup::"
 
       - name: Calculate next version
@@ -726,7 +787,9 @@ jobs:
 
           - This is a production-ready snapshot with development files excluded or removed
           - Test files remain in development repository but are excluded from production sync
-          - Production workflows have been preserved: ${{ steps.preserve-workflows.outputs.preserved_count || '0' }} workflow(s)
+          - Production workflows preserved: ${{ steps.preserve-workflows.outputs.preserved_count || '0' }} workflow(s)
+          - Workflows updated from templates (pristine stale copies):${{ steps.install-workflows.outputs.updated || ' (none)' }}
+          - Workflows customized on prod side (NOT overwritten):${{ steps.install-workflows.outputs.customized || ' (none)' }}
           - All changes squashed into a single clean commit for production
 
           ___


### PR DESCRIPTION
## Summary

**Problem**: the mirror preserved every workflow the prod repo already had, so template fixes never reached production. Today's `production-sync-20260805` (naass v1.0.1) correctly preserved naass's stale workflow copies — leaving its 7 CodeQL `actions/missing-workflow-permissions` alerts open even though #1282 fixed the templates. (NYCUITSC/naass#38 ports today's fix manually; this PR makes the mirror deliver future ones itself.)

**New install policy** (three-way, was two-way):

| Prod copy | Action |
|---|---|
| missing | installed from templates *(unchanged)* |
| byte-identical to **some historical template revision** (`git hash-object` vs `rev-list` blob ids) → never customized, just stale | **auto-updated to the current template** ✨ |
| matches **no** template revision → prod-side customization | preserved, notice only *(unchanged)* |

Provenance audit of naass's real workflows validates the classifier: `deploy.yml`@a5b56765, `backup.yml`@e0cf4f12, `setting-env.yml`@29f67906 (all pristine → would auto-update), `auto-tag-on-merge.yml` matches no revision (genuinely customized → stays protected), `health-check.yml` current (skipped).

## Supporting changes (from adversarial review findings)

- **`freeze_workflows` dispatch input** — escape hatch for the one ambiguous case: a deliberate prod-side rollback *to a historical template revision* is byte-indistinguishable from staleness; dispatch with the box checked to hold workflows back that run
- **GH_PAT scope preflight** in check-secrets — the auto-update path makes pushing `.github/workflows/**` load-bearing, which classic PATs reject without the `workflow` scope; the run now fails fast with an actionable error (fine-grained PATs, which expose no `x-oauth-scopes` header, get a warning instead)
- **Audit trail** — the install step exports `updated=`/`customized=` outputs; the release notes (→ squashed prod commit message → prod PR body) list both, so an auto-update is never silent
- **Docs** — `PRODUCTION_SYNC_GUIDE.md` now instructs `repo` + `workflow` scopes (it said `repo` only, contradicting reality); `production-workflows-examples/README.md` describes the new policy
- **Hardened bash** — guarded `hash-object`, `rev-parse --verify --quiet`

## Test plan

- [x] Real-data simulation (naass copies + full dev history): classification exactly as the table above; `freeze=true` freezes only pristine files; absent input ≡ false
- [x] Two adversarial review rounds — round 1 executed the extracted step under `bash -e` against a synthetic repo (errexit, quoting, empty rev-list, CRLF, chmod-000 all fail toward *preserve*); round 2 independently re-simulated and confirmed all 5 round-1 findings fixed
- [x] `yaml.safe_load` parses; no other step consumes the changed outputs
- [ ] After merge: dispatch `mirror-to-production` → naass PR should list deploy/backup/setting-env under "Workflows updated from templates" (if #38 is merged first, they'll show as "Already present" instead — both correct)

## Known-safe limitations

`rev-list` without `--follow`/`--full-history`: a template revision existing only mid-feature-branch, or a future rename of the templates directory, would classify as "customized" — i.e. fail toward **not overwriting**, the safe direction.