### PR TITLE
fix(security): drop fastapi-mail, bump cryptography to 50.0.0

### DIFF
--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -3040,10 +3040,10 @@ class ApplicationService:
                     href=f"/professor/applications/{application.id}",
                     priority=NotificationPriority.high,
                     # in_app ONLY. NotificationChannel.email here reaches
-                    # _send_email_notification -> FastMail directly, which bypasses the
-                    # scheduled_emails queue, the templates, email_history AND the
-                    # test-mode redirect — so it would both re-add assignment mail and
-                    # leak to real users while test mode is on.
+                    # _send_email_notification -> EmailService immediately, which
+                    # bypasses the scheduled_emails queue and the assignment
+                    # templates — so it would re-add assignment mail on top of the
+                    # scheduled one.
                     channels=[NotificationChannel.in_app],
                 )
                 logger.info(f"In-app notification created for professor {professor.nycu_id}")

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -365,7 +365,7 @@ class NotificationService:
                 self._websocket_connections[user_id].remove(ws)
 
     async def _send_email_notification(self, notification: Notification):
-        """Send notification via email"""
+        """Send notification via email through EmailService (test-mode + history aware)"""
         from app.core.config import settings
 
         # Check required SMTP configuration (host and from address)
@@ -382,46 +382,37 @@ class NotificationService:
             return
 
         try:
-            from fastapi_mail import ConnectionConfig, FastMail, MessageSchema
+            from app.db.session import AsyncSessionLocal
+            from app.models.email_management import EmailCategory
+            from app.services.email_service import EmailService
 
-            # Configure email connection
-            conf = ConnectionConfig(
-                MAIL_USERNAME=settings.smtp_user,
-                MAIL_PASSWORD=settings.smtp_password,
-                MAIL_FROM=settings.email_from,
-                MAIL_FROM_NAME=settings.email_from_name,
-                MAIL_PORT=settings.smtp_port,
-                MAIL_SERVER=settings.smtp_host,
-                MAIL_STARTTLS=settings.smtp_use_tls,
-                MAIL_SSL_TLS=False,
-                USE_CREDENTIALS=True,
-                VALIDATE_CERTS=True,
-            )
+            html_content = f"""
+            <html>
+            <body>
+                <h2>{notification.title or 'Notification'}</h2>
+                <p>{notification.message}</p>
 
-            # Create email message
-            message = MessageSchema(
-                subject=notification.title or "NYCU Scholarship System Notification",
-                recipients=[notification.user.email],
-                body=f"""
-                <html>
-                <body>
-                    <h2>{notification.title or 'Notification'}</h2>
-                    <p>{notification.message}</p>
+                <hr>
+                <p style="color: gray; font-size: 12px;">
+                    This is an automated message from NYCU Scholarship System.<br>
+                    Please do not reply to this email.
+                </p>
+            </body>
+            </html>
+            """
 
-                    <hr>
-                    <p style="color: gray; font-size: 12px;">
-                        This is an automated message from NYCU Scholarship System.<br>
-                        Please do not reply to this email.
-                    </p>
-                </body>
-                </html>
-                """,
-                subtype="html",
-            )
-
-            # Send email
-            fm = FastMail(conf)
-            await fm.send_message(message)
+            # Dedicated session: EmailService commits/rolls back its session in
+            # its test-mode handling, which must never touch the notification
+            # flow's transaction.
+            async with AsyncSessionLocal() as email_db:
+                email_service = EmailService(email_db)
+                await email_service.send_email(
+                    to=notification.user.email,
+                    subject=notification.title or "NYCU Scholarship System Notification",
+                    html_content=html_content,
+                    db=email_db,
+                    email_category=EmailCategory.system,
+                )
 
             logger.info(f"Email notification sent to {notification.user.email} for notification {notification.id}")
 

--- a/backend/app/tests/test_notification_service_unit.py
+++ b/backend/app/tests/test_notification_service_unit.py
@@ -322,3 +322,107 @@ async def test_add_and_remove_websocket(dummy_service):
 
     await dummy_service.remove_websocket_connection(user_id=1, websocket=connection)
     assert dummy_service._websocket_connections[1] == []
+
+
+class _FakeSessionCM:
+    """Async context manager standing in for AsyncSessionLocal()."""
+
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def email_notification():
+    from types import SimpleNamespace
+
+    from app.models.notification import Notification
+
+    notification = Notification(user_id=1, title="Test Title", message="Test Message")
+    notification.__dict__["user"] = SimpleNamespace(email="student@nycu.edu.tw")
+    return notification
+
+
+@pytest.fixture
+def email_env(monkeypatch):
+    from types import SimpleNamespace
+
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "smtp_host", "smtp.test.nycu.edu.tw")
+    monkeypatch.setattr(settings, "email_from", "noreply@nycu.edu.tw")
+
+    fake_db = object()
+    monkeypatch.setattr("app.db.session.AsyncSessionLocal", lambda: _FakeSessionCM(fake_db))
+
+    class FakeEmailService:
+        instances = []
+
+        def __init__(self, db):
+            self.db = db
+            self.send_email = AsyncMock()
+            FakeEmailService.instances.append(self)
+
+    monkeypatch.setattr("app.services.email_service.EmailService", FakeEmailService)
+    return SimpleNamespace(fake_db=fake_db, service_cls=FakeEmailService)
+
+
+@pytest.mark.asyncio
+async def test_send_email_notification_routes_through_email_service(dummy_service, email_notification, email_env):
+    from app.models.email_management import EmailCategory
+
+    await dummy_service._send_email_notification(email_notification)
+
+    assert len(email_env.service_cls.instances) == 1
+    instance = email_env.service_cls.instances[0]
+    # EmailService must run on the dedicated session, never the notification session
+    assert instance.db is email_env.fake_db
+    assert instance.db is not dummy_service.db
+
+    instance.send_email.assert_awaited_once()
+    kwargs = instance.send_email.await_args.kwargs
+    assert kwargs["to"] == "student@nycu.edu.tw"
+    assert kwargs["subject"] == "Test Title"
+    assert "Test Message" in kwargs["html_content"]
+    assert kwargs["db"] is email_env.fake_db
+    assert kwargs["email_category"] == EmailCategory.system
+
+
+@pytest.mark.asyncio
+async def test_send_email_notification_skips_without_smtp_config(
+    dummy_service, email_notification, email_env, monkeypatch
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "smtp_host", "")
+
+    await dummy_service._send_email_notification(email_notification)
+
+    assert email_env.service_cls.instances == []
+
+
+@pytest.mark.asyncio
+async def test_send_email_notification_skips_without_user_email(dummy_service, email_notification, email_env):
+    email_notification.user.email = None
+
+    await dummy_service._send_email_notification(email_notification)
+
+    assert email_env.service_cls.instances == []
+
+
+@pytest.mark.asyncio
+async def test_send_email_notification_swallows_send_errors(dummy_service, email_notification, email_env, monkeypatch):
+    class FailingEmailService(email_env.service_cls):
+        def __init__(self, db):
+            super().__init__(db)
+            self.send_email = AsyncMock(side_effect=RuntimeError("SMTP down"))
+
+    monkeypatch.setattr("app.services.email_service.EmailService", FailingEmailService)
+
+    # Must not raise — email failures never break the notification flow
+    await dummy_service._send_email_notification(email_notification)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -125,7 +125,7 @@ dependencies = [
     "PyJWT[crypto]==2.13.0",
     "passlib[bcrypt]==1.7.4",
     "bcrypt==4.2.1",
-    "cryptography==49.0.0",
+    "cryptography==50.0.0",
     "python-decouple==3.8",
     
     # Data validation and serialization
@@ -149,7 +149,7 @@ dependencies = [
     "croniter==1.4.1",
     
     # Email services
-    "fastapi-mail==1.6.5",
+    "aiosmtplib==5.1.2",
     "jinja2==3.1.6",
     
     # File processing and OCR

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,14 +15,14 @@ greenlet>=3.0,<4  # Required by SQLAlchemy sync engine (used by health check + A
 PyJWT[crypto]==2.13.0  # Security update: patched CVEs PYSEC-2026-175/176/177/178/179
 passlib[bcrypt]==1.7.4
 bcrypt==4.2.1  # Updated for Python 3.13 compatibility
-cryptography==49.0.0  # PINNED BY CEILING: fastapi-mail 1.6.5 requires >=49,<50. GHSA-g6cj-pr64-35w5 (PKCS#7 EnvelopedData decrypt oracle, >=44,<50) is unreachable here (app uses only AESGCM/Fernet/PyJWT) — bump to >=50.0.0 once fastapi-mail lifts its cap
+cryptography==50.0.0  # Security: GHSA-g6cj-pr64-35w5 (PKCS#7 EnvelopedData Bleichenbacher oracle, >=44,<50); unblocked by dropping fastapi-mail (capped <50)
 python-decouple==3.8
 
 # Data validation and serialization
-pydantic==2.13.4  # >=2.12.5 required by fastapi-mail 1.6.3+
-pydantic[email]==2.13.4  # >=2.12.5 required by fastapi-mail 1.6.3+
+pydantic==2.13.4
+pydantic[email]==2.13.4
 pydantic-settings==2.14.2  # Updated to match pydantic version
-email-validator==2.3.0  # >=2.3.0 required by fastapi-mail 1.6.5
+email-validator==2.3.0
 
 # HTTP client and utilities
 httpx==0.28.1  # Updated for Python 3.13 compatibility
@@ -39,7 +39,7 @@ apscheduler==3.10.4
 croniter==1.4.1
 
 # Email services
-fastapi-mail==1.6.5  # 1.6.3+ required for starlette>=1.0 compatibility
+aiosmtplib==5.1.2  # Direct SMTP sending (EmailService); declared explicitly after dropping fastapi-mail
 jinja2==3.1.6  # Security: Fixed sandbox escape vulnerability (GHSA-cpwx-vrp4-4pq7)
 
 # File processing and OCR


### PR DESCRIPTION
## Summary

Follow-up completing #1283 — this commit was pushed after that PR merged, so it needs its own PR. Closes the remaining **3 cryptography Dependabot alerts** (#154/#155/#156 on NYCUITSC/naass) with a real version bump.

GHSA-g6cj-pr64-35w5 (PKCS#7 EnvelopedData Bleichenbacher oracle) is fixed in cryptography 50.0.0, but `fastapi-mail==1.6.5` (latest release; cap unchanged upstream) hard-pins `cryptography<50.0.0` — a naive bump fails `ResolutionImpossible` in both pip (CI) and uv (Docker build).

fastapi-mail's **only call site** was `notification_service._send_email_notification` — a parallel FastMail path that bypassed `EmailService`: no `email_history` row, no scheduled-queue awareness, and **no test-mode redirect** (it would leak mail to real users while test mode is on, exactly as the warning comment in `application_service.py` said). The method now sends through `EmailService` with `EmailCategory.system`, on a **dedicated session** so EmailService's test-mode commit/rollback can never touch the notification flow's transaction. New unit tests pin the contract (the email channel is dormant today — zero `notification_preferences` rows — and had zero coverage).

Dependency changes:
- `cryptography==50.0.0` (requirements.txt + pyproject.toml) — the alert's patched version, actually installed
- `fastapi-mail` removed from both manifests
- `aiosmtplib==5.1.2` declared explicitly — `email_service.py` imports it at module top but it was only installed transitively via fastapi-mail (latent undeclared dependency)

## Verification

- ✅ pip resolution (`python:3.13-slim`) and uv resolution (the actual Docker build image `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`) both clean at cryptography 50.0.0
- ✅ Import graph verified cycle-free in both orders inside the backend image; `fastapi_mail` absent from `sys.modules`
- ✅ 284 backend email/notification tests pass (+4 new contract tests); `validate_manifest_sync.py`, black, flake8 B904/B014 all clean
- ✅ Backend cryptography consumers audited: only AESGCM (`pii_crypto.py`), Fernet (`config_management_service.py`), PyJWT — all stable APIs in 50.x

## After merge

Dispatch **Mirror to Production** and merge the naass sync PR — the 3 cryptography alerts close when the production manifests show 50.0.0. (The 88 npm alerts are handled by the already-merged #1283.)

## Known pre-existing issue (not fixed here)

`docker-compose.prod.yml` never passes `SMTP_USE_TLS` (docs claim `SMTP_USE_TLS=true`), so all production system mail does plaintext SMTP AUTH on port 587 — predates this PR. Fix needs the compose env var **plus** an UPDATE of the seeded `system_settings.smtp_use_tls` row (seeder is skip-if-exists; the DB row wins over env).