### PR TITLE
fix(api): 修正 ZAP 主動掃描發現的 4,950 個 HTTP 500,並將誤報判定進版控

### DIFF
--- a/backend/app/api/v1/endpoints/admin/bank_verification.py
+++ b/backend/app/api/v1/endpoints/admin/bank_verification.py
@@ -9,7 +9,7 @@ Handles bank account verification operations including:
 import logging
 from typing import Any, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -534,7 +534,11 @@ async def get_verification_task_status(
 
 @router.get("/bank-verification/tasks")
 async def list_verification_tasks(
-    status: Optional[str] = None,
+    # NOT named `status`: that shadowed the `fastapi.status` module inside this
+    # function, so every `status.HTTP_*` lookup below raised AttributeError and
+    # returned 500 — including the 400 meant to reject a bad filter value.
+    # `alias` keeps the query-string name `?status=` unchanged for callers.
+    status_value: Optional[str] = Query(None, alias="status"),
     limit: int = 50,
     offset: int = 0,
     current_user: User = Depends(require_admin),
@@ -550,13 +554,13 @@ async def list_verification_tasks(
 
         # Parse status filter
         status_filter = None
-        if status:
+        if status_value:
             try:
-                status_filter = BankVerificationTaskStatus(status)
+                status_filter = BankVerificationTaskStatus(status_value)
             except ValueError as exc:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"無效的狀態值: {status}",
+                    detail=f"無效的狀態值: {status_value}",
                 ) from exc
 
         tasks = await task_service.list_tasks(

--- a/backend/app/api/v1/endpoints/csp_report.py
+++ b/backend/app/api/v1/endpoints/csp_report.py
@@ -9,7 +9,7 @@ import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Request, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import Response
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -76,8 +76,11 @@ async def report_csp_violation(request: Request):
             extra={"violation_data": violation_data},
         )
 
-        # Return 204 No Content (standard for CSP reports)
-        return JSONResponse(content="", status_code=status.HTTP_204_NO_CONTENT)
+        # Return 204 No Content (standard for CSP reports).
+        # Must be a bare Response: a 204 carries no body, but JSONResponse
+        # serialises even "" to two bytes, which tripped Starlette's
+        # "Response content longer than Content-Length" RuntimeError -> 500.
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     except Exception:
         # logger.exception preserves the traceback so 5xx-style failures from
@@ -87,7 +90,7 @@ async def report_csp_violation(request: Request):
             extra={"ip": client_ip, "user_agent": user_agent},
         )
         # Still return 204 to prevent browser errors
-        return JSONResponse(content="", status_code=status.HTTP_204_NO_CONTENT)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/csp-report")

--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -234,6 +234,11 @@ async def createSystemAnnouncement(
         )
         raise HTTPException(status_code=403, detail="需要管理員權限")
 
+    # Captured before the try: the error path rolls the session back, which
+    # expires `current_user`, and reading an attribute off an expired instance
+    # afterwards raises MissingGreenlet instead of logging the real failure.
+    actor_user_id = current_user.id
+
     try:
         notification_service = NotificationService(db)
 
@@ -295,7 +300,9 @@ async def createSystemAnnouncement(
 
     except Exception as e:
         await db.rollback()
-        logger.exception("Failed to create system announcement by user_id=%s", current_user.id)
+        # `actor_user_id` was captured before the rollback: reading
+        # current_user.id here would raise MissingGreenlet (see below).
+        logger.exception("Failed to create system announcement by user_id=%s", actor_user_id)
         raise HTTPException(status_code=500, detail="創建系統公告失敗") from e
 
 
@@ -315,6 +322,11 @@ async def createTestNotifications(current_user: User = Depends(get_current_user)
             },
         )
         raise HTTPException(status_code=403, detail="需要管理員權限")
+
+    # Captured before the try: the error path rolls the session back, which
+    # expires `current_user`, and reading an attribute off an expired instance
+    # afterwards raises MissingGreenlet instead of logging the real failure.
+    actor_user_id = current_user.id
 
     try:
         notification_service = NotificationService(db)
@@ -382,5 +394,5 @@ async def createTestNotifications(current_user: User = Depends(get_current_user)
 
     except Exception as e:
         await db.rollback()
-        logger.exception("Failed to create test notifications by user_id=%s", current_user.id)
+        logger.exception("Failed to create test notifications by user_id=%s", actor_user_id)
         raise HTTPException(status_code=500, detail="創建測試通知失敗") from e

--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -363,7 +363,10 @@ async def createTestNotifications(current_user: User = Depends(get_current_user)
             message="2024春季獎學金申請將於本月底截止，請尚未提交申請的同學把握時間完成申請程序。",
             message_en="The 2024 Spring Scholarship application deadline is at the end of this month. Students who have not yet submitted their applications should complete the process soon.",
             notification_type=NotificationType.reminder.value,
-            priority=NotificationPriority.URGENT.value,
+            # Lowercase member name: Python enums in this codebase mirror the
+            # database values exactly (see .claude/CLAUDE.md §4). `URGENT` does
+            # not exist, so this raised AttributeError -> 500 on every call.
+            priority=NotificationPriority.urgent.value,
             action_url="/scholarships",
         )
         created_notifications.append(urgent_notification.id)

--- a/backend/app/api/v1/endpoints/reference_data.py
+++ b/backend/app/api/v1/endpoints/reference_data.py
@@ -417,7 +417,11 @@ async def get_scholarship_periods(
     taiwan_year = current_year - 1911
     current_semester = Semester.first.value if current_month >= 8 else Semester.second.value
 
-    # Get scholarship info if specified
+    # Get scholarship info if specified.
+    # `scholarship` must be initialised here, not only inside the branch below:
+    # it is read unconditionally further down, so calling this endpoint with
+    # neither scholarship_id nor scholarship_code raised UnboundLocalError -> 500.
+    scholarship = None
     scholarship_cycle = None
     scholarship_name = None
 

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -769,7 +769,13 @@ async def get_quota_overview(
                         Application.scholarship_type_id == stype.id,
                         Application.config_code == config.config_code,
                         Application.sub_type == sub_type_code,
-                        Application.status.in_([ApplicationStatus.approved, ApplicationStatus.FUNDED]),
+                        # ApplicationStatus has no `funded` member — the old
+                        # `ApplicationStatus.FUNDED` here raised AttributeError
+                        # (uppercase is the TypeScript spelling; Python members
+                        # are lowercase, CLAUDE.md §4), so this query 500'd
+                        # whenever it ran. `approved` is the status that
+                        # consumes quota.
+                        Application.status.in_([ApplicationStatus.approved]),
                     )
                 )
                 used_quota_result = await db.execute(quota_query)

--- a/backend/app/core/db_error_mapping.py
+++ b/backend/app/core/db_error_mapping.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from app.core.exception_chain import iter_cause_chain
+
 # SQLSTATE class → (HTTP status, user-facing message).
 # Messages are deliberately generic: they must not echo the driver's text back
 # to the caller, which can contain column names, SQL fragments or the offending
@@ -67,10 +69,6 @@ def map_db_exception(exc: BaseException) -> Optional[tuple[int, str]]:
     return _SQLSTATE_CLASS_MAP.get(sqlstate[:2])
 
 
-# Walking further than this is pointless and risks pathological chains.
-_MAX_CAUSE_DEPTH = 10
-
-
 def map_db_exception_chain(exc: BaseException) -> Optional[tuple[int, str]]:
     """Like `map_db_exception`, but follows the `__cause__`/`__context__` chain.
 
@@ -80,24 +78,9 @@ def map_db_exception_chain(exc: BaseException) -> Optional[tuple[int, str]]:
     one of those sites uses `from exc`, so the original driver error is still
     reachable via `__cause__`. Following the chain lets a single handler
     reclassify all of them instead of editing 161 call sites.
-
-    Cycle-guarded by identity: `__context__` chains can loop when an exception
-    is raised while handling itself.
     """
-    seen: set[int] = set()
-    current: Optional[BaseException] = exc
-
-    for _ in range(_MAX_CAUSE_DEPTH):
-        if current is None or id(current) in seen:
-            return None
-        seen.add(id(current))
-
+    for current in iter_cause_chain(exc):
         mapped = map_db_exception(current)
         if mapped is not None:
             return mapped
-
-        # __cause__ is the explicit `raise ... from exc`; __context__ is the
-        # implicit "raised while handling" link. Prefer the explicit one.
-        current = current.__cause__ or current.__context__
-
     return None

--- a/backend/app/core/db_error_mapping.py
+++ b/backend/app/core/db_error_mapping.py
@@ -1,0 +1,67 @@
+"""Map database driver errors onto the HTTP status they actually deserve.
+
+Context: an authenticated OWASP ZAP active scan (2026-08-06, `main` @ e79d8f33)
+produced 4,950 HTTP 500s across 54 production-reachable endpoints. Almost all of
+them were the database rejecting *caller input* — an invalid enum literal, a
+string longer than the column, a NUL byte — surfacing as an unhandled
+`DBAPIError` and falling through to the generic 500 handler.
+
+A 500 says "the server is broken". These are the client sending something the
+schema cannot represent, which is a 4xx. Mapping them correctly also stops the
+noise from burying real faults in monitoring.
+
+Rather than enumerate driver exception classes (asyncpg and psycopg2 raise
+different types for the same condition), match on the SQLSTATE code, which is
+defined by the SQL standard and identical across drivers. The two-character
+prefix is the "class" and is all we need:
+
+    class 22 — data exception            → 400 Bad Request
+    class 23 — integrity constraint      → 409 Conflict
+
+Deliberately NOT mapped: class 08 (connection), 53 (insufficient resources),
+57 (operator intervention) and friends are genuine server-side faults and must
+keep returning 5xx. `main.py` already routes `OperationalError`/`TimeoutError`
+to 503 ahead of this.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# SQLSTATE class → (HTTP status, user-facing message).
+# Messages are deliberately generic: they must not echo the driver's text back
+# to the caller, which can contain column names, SQL fragments or the offending
+# value.
+_SQLSTATE_CLASS_MAP: dict[str, tuple[int, str]] = {
+    "22": (400, "輸入資料格式不正確"),
+    "23": (409, "資料衝突：違反唯一性或關聯限制"),
+}
+
+
+def _extract_sqlstate(exc: BaseException) -> Optional[str]:
+    """Pull the SQLSTATE off a SQLAlchemy wrapper or a raw driver error.
+
+    SQLAlchemy wraps driver errors and exposes the original on `.orig`. asyncpg
+    spells the code `sqlstate`; psycopg2 spells it `pgcode`. Check the wrapper
+    itself too, so a bare driver exception still resolves.
+    """
+    for candidate in (getattr(exc, "orig", None), exc):
+        if candidate is None:
+            continue
+        for attr in ("sqlstate", "pgcode"):
+            code = getattr(candidate, attr, None)
+            if isinstance(code, str) and len(code) >= 2:
+                return code
+    return None
+
+
+def map_db_exception(exc: BaseException) -> Optional[tuple[int, str]]:
+    """Return `(status_code, message)` for a caller-input DB error, else None.
+
+    None means "not a client-input problem" — the caller should fall through to
+    its existing 5xx handling.
+    """
+    sqlstate = _extract_sqlstate(exc)
+    if not sqlstate:
+        return None
+    return _SQLSTATE_CLASS_MAP.get(sqlstate[:2])

--- a/backend/app/core/db_error_mapping.py
+++ b/backend/app/core/db_error_mapping.py
@@ -65,3 +65,39 @@ def map_db_exception(exc: BaseException) -> Optional[tuple[int, str]]:
     if not sqlstate:
         return None
     return _SQLSTATE_CLASS_MAP.get(sqlstate[:2])
+
+
+# Walking further than this is pointless and risks pathological chains.
+_MAX_CAUSE_DEPTH = 10
+
+
+def map_db_exception_chain(exc: BaseException) -> Optional[tuple[int, str]]:
+    """Like `map_db_exception`, but follows the `__cause__`/`__context__` chain.
+
+    161 endpoints in this codebase catch broadly and re-raise as
+    `HTTPException(status_code=500, ...) from exc`. The HTTPException itself
+    carries no SQLSTATE, so `map_db_exception` alone sees nothing — but every
+    one of those sites uses `from exc`, so the original driver error is still
+    reachable via `__cause__`. Following the chain lets a single handler
+    reclassify all of them instead of editing 161 call sites.
+
+    Cycle-guarded by identity: `__context__` chains can loop when an exception
+    is raised while handling itself.
+    """
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+
+    for _ in range(_MAX_CAUSE_DEPTH):
+        if current is None or id(current) in seen:
+            return None
+        seen.add(id(current))
+
+        mapped = map_db_exception(current)
+        if mapped is not None:
+            return mapped
+
+        # __cause__ is the explicit `raise ... from exc`; __context__ is the
+        # implicit "raised while handling" link. Prefer the explicit one.
+        current = current.__cause__ or current.__context__
+
+    return None

--- a/backend/app/core/exception_chain.py
+++ b/backend/app/core/exception_chain.py
@@ -1,0 +1,43 @@
+"""Walk an exception's `__cause__`/`__context__` chain safely.
+
+Shared by the DB-error mapping and the HTTP exception handler, both of which
+need to look past a wrapper exception to find what actually went wrong.
+
+Two hazards this exists to contain:
+  * `__context__` chains can be cyclic when an exception is raised while
+    handling itself, so the walk is identity-guarded.
+  * Chains can be arbitrarily deep, so the walk is depth-capped.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Optional
+
+# Deeper than this and we are almost certainly in a pathological chain; the
+# useful cause is always near the top in this codebase.
+DEFAULT_MAX_DEPTH = 10
+
+
+def iter_cause_chain(
+    exc: Optional[BaseException],
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    include_self: bool = True,
+) -> Iterator[BaseException]:
+    """Yield `exc` and its causes, outermost first.
+
+    `__cause__` (an explicit `raise ... from exc`) is preferred over
+    `__context__` (the implicit "raised while handling" link).
+    """
+    seen: set[int] = set()
+    current = exc
+
+    if not include_self and current is not None:
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+
+    for _ in range(max_depth):
+        if current is None or id(current) in seen:
+            return
+        seen.add(id(current))
+        yield current
+        current = current.__cause__ or current.__context__

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,12 +14,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+from sqlalchemy.orm.exc import StaleDataError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 # Import routers
 from app.api.v1.api import api_router
 from app.core.config import settings
 from app.core.database_health import check_database_health
+from app.core.db_error_mapping import map_db_exception
 from app.core.exceptions import ScholarshipException, scholarship_exception_handler
 from app.core.security import require_admin
 from app.models.user import User
@@ -284,6 +286,33 @@ async def general_exception_handler(request: Request, exc: Exception):  # pylint
             content={
                 "success": False,
                 "message": "Service temporarily unavailable - database connection issue",
+                "trace_id": trace_id,
+            },
+        )
+
+    # A row the caller asked us to update vanished (or was changed) underneath
+    # the flush. That is a concurrency conflict, not a server fault.
+    if isinstance(exc, StaleDataError):
+        return JSONResponse(
+            status_code=409,
+            content={
+                "success": False,
+                "message": "資料已被其他操作變更，請重新載入後再試",
+                "trace_id": trace_id,
+            },
+        )
+
+    # The database rejected the caller's input (bad enum literal, over-long
+    # string, NUL byte, constraint violation). Answer 4xx instead of 500 — see
+    # app/core/db_error_mapping.py for why this matches on SQLSTATE.
+    db_mapped = map_db_exception(exc)
+    if db_mapped is not None:
+        status_code, message = db_mapped
+        return JSONResponse(
+            status_code=status_code,
+            content={
+                "success": False,
+                "message": message,
                 "trace_id": trace_id,
             },
         )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.api.v1.api import api_router
 from app.core.config import settings
 from app.core.database_health import check_database_health
-from app.core.db_error_mapping import map_db_exception
+from app.core.db_error_mapping import map_db_exception, map_db_exception_chain
 from app.core.exceptions import ScholarshipException, scholarship_exception_handler
 from app.core.security import require_admin
 from app.models.user import User
@@ -189,11 +189,23 @@ app.add_exception_handler(ScholarshipException, scholarship_exception_handler)
 @app.exception_handler(StarletteHTTPException)
 async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     """Handle HTTP exceptions"""
+    status_code = exc.status_code
+    message = exc.detail
+
+    # Many endpoints catch broadly and re-raise as HTTPException(500) `from exc`.
+    # When the preserved cause turns out to be the database rejecting caller
+    # input, the honest answer is 4xx: the server is fine, the request was not.
+    # Doing it here covers every such site at once — see db_error_mapping.py.
+    if status_code == 500:
+        mapped = map_db_exception_chain(exc)
+        if mapped is not None:
+            status_code, message = mapped
+
     return JSONResponse(
-        status_code=exc.status_code,
+        status_code=status_code,
         content={
             "success": False,
-            "message": exc.detail,
+            "message": message,
             "trace_id": getattr(request.state, "trace_id", None),
         },
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.api.v1.api import api_router
 from app.core.config import settings
 from app.core.database_health import check_database_health
 from app.core.db_error_mapping import map_db_exception, map_db_exception_chain
+from app.core.exception_chain import iter_cause_chain
 from app.core.exceptions import ScholarshipException, scholarship_exception_handler
 from app.core.security import require_admin
 from app.models.user import User
@@ -186,20 +187,52 @@ async def add_trace_id_middleware(request: Request, call_next):
 app.add_exception_handler(ScholarshipException, scholarship_exception_handler)
 
 
+def _unwrap_client_http_error(exc: BaseException):
+    """Find a deliberate 4xx buried in `exc`'s cause chain.
+
+    Two shapes of the same mistake, both common here:
+      * a `try` that raises HTTPException(404) with an `except Exception` that
+        does not re-raise HTTPException first (6 sites), and
+      * a service raising a domain error (NotFoundError, ConflictError, …)
+        into an endpoint whose blanket handler only re-raises HTTPException,
+        so the domain error's status is lost.
+
+    Both use `raise ... from exc`, so the intended status is still reachable.
+    Recovering it here covers every site at once, including future ones —
+    "scholarship configuration not found" is a 404, not a server fault.
+
+    Only 4xx is recovered: a nested 5xx (FileStorageError, OCRError, …) is a
+    genuine server fault and must stay a 500.
+    """
+    for cause in iter_cause_chain(exc, include_self=False):
+        if isinstance(cause, StarletteHTTPException) and 400 <= cause.status_code < 500:
+            return cause.status_code, cause.detail
+        if isinstance(cause, ScholarshipException) and 400 <= cause.status_code < 500:
+            return cause.status_code, cause.message
+    return None
+
+
 @app.exception_handler(StarletteHTTPException)
 async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     """Handle HTTP exceptions"""
     status_code = exc.status_code
     message = exc.detail
 
-    # Many endpoints catch broadly and re-raise as HTTPException(500) `from exc`.
-    # When the preserved cause turns out to be the database rejecting caller
-    # input, the honest answer is 4xx: the server is fine, the request was not.
-    # Doing it here covers every such site at once — see db_error_mapping.py.
     if status_code == 500:
-        mapped = map_db_exception_chain(exc)
-        if mapped is not None:
-            status_code, message = mapped
+        # An endpoint raised a deliberate 4xx inside its `try`, and its own
+        # `except Exception` swallowed it and re-raised as 500. The intended
+        # status is still in the cause chain, and it is the honest answer —
+        # "no active configuration found" is a 404, not a server fault.
+        client_error = _unwrap_client_http_error(exc)
+        if client_error is not None:
+            status_code, message = client_error
+        else:
+            # Otherwise: if the preserved cause turns out to be the database
+            # rejecting caller input, answer 4xx. The server is fine, the
+            # request was not. See db_error_mapping.py.
+            mapped = map_db_exception_chain(exc)
+            if mapped is not None:
+                status_code, message = mapped
 
     return JSONResponse(
         status_code=status_code,

--- a/backend/app/services/roster_service.py
+++ b/backend/app/services/roster_service.py
@@ -18,6 +18,7 @@ from app.core.exceptions import (
     RosterGenerationError,
     RosterLockedError,
     RosterNotFoundError,
+    ScholarshipException,
 )
 from app.core.metrics import payment_rosters_total
 from app.core.pii_crypto import redact_dict_pii
@@ -1411,7 +1412,11 @@ class RosterService:
             )
 
             if not scholarship_config:
-                raise ValueError(f"找不到獎學金配置: ID {scholarship_configuration_id}")
+                # NotFoundError, not ValueError: the caller asked for an id that
+                # does not exist, which is a 404. Raised as a plain ValueError it
+                # was caught by the blanket handler at the end of this method,
+                # re-wrapped as "預演失敗" and reported as 500.
+                raise NotFoundError("獎學金配置", f"ID {scholarship_configuration_id}")
 
             # 2. 檢查重複造冊
             existing_roster = self.check_roster_exists(scholarship_configuration_id, period_label)
@@ -1538,6 +1543,11 @@ class RosterService:
 
             return result
 
+        except ScholarshipException:
+            # Domain errors already carry the right status (404/409/422) and are
+            # handled by scholarship_exception_handler. Re-wrapping them as a
+            # generic failure below would turn a 404 into a 500.
+            raise
         except Exception as e:
             logger.exception("Dry run failed")
             raise ValueError("預演失敗") from e

--- a/backend/app/tests/test_admin_endpoints.py
+++ b/backend/app/tests/test_admin_endpoints.py
@@ -239,9 +239,13 @@ class TestAdminEndpoints:
         )
 
         # Assert
-        # May get 500 if scholarship doesn't allow professor review
-        # This test validates the endpoint works, not the business logic
-        assert response.status_code in [200, 500]
+        # 422 if this scholarship doesn't allow professor review: the service
+        # raises ValidationError, and the endpoint's blanket `except Exception`
+        # re-raises it as HTTPException(500) `from e`. The global handler now
+        # recovers the intended 422 from the cause chain instead of reporting a
+        # server fault for a business-rule violation.
+        # This test validates the endpoint works, not the business logic.
+        assert response.status_code in [200, 422]
 
     @pytest.mark.asyncio
     async def test_assign_professor_application_not_found(self, admin_client):

--- a/backend/app/tests/test_db_error_mapping.py
+++ b/backend/app/tests/test_db_error_mapping.py
@@ -6,7 +6,7 @@ ZAP active scan turned into an HTTP 500. See docs/security/zap-active-2026-08-06
 
 import pytest
 
-from app.core.db_error_mapping import map_db_exception
+from app.core.db_error_mapping import map_db_exception, map_db_exception_chain
 
 
 class _FakeDriverError(Exception):
@@ -87,6 +87,65 @@ def test_unrelated_exception_returns_none():
 
 def test_missing_sqlstate_returns_none():
     assert map_db_exception(_FakeWrapper(Exception("no code attribute"))) is None
+
+
+def test_chain_follows_explicit_cause():
+    """The 161 `raise HTTPException(500) from exc` sites must be reclassified."""
+    driver = _FakeDriverError("23505")
+    wrapper = _FakeWrapper(driver)
+    try:
+        try:
+            raise wrapper
+        except _FakeWrapper as exc:
+            raise RuntimeError("endpoint wrapped it") from exc
+    except RuntimeError as outer:
+        result = map_db_exception_chain(outer)
+
+    assert result is not None
+    assert result[0] == 409
+
+
+def test_chain_follows_implicit_context():
+    driver = _FakeDriverError("22P02")
+    try:
+        try:
+            raise driver
+        except _FakeDriverError:
+            raise RuntimeError("raised while handling")  # noqa: B904 - deliberate
+    except RuntimeError as outer:
+        result = map_db_exception_chain(outer)
+
+    assert result is not None
+    assert result[0] == 400
+
+
+def test_chain_stops_on_unrelated_exception():
+    try:
+        try:
+            raise ValueError("business rule violated")
+        except ValueError as exc:
+            raise RuntimeError("wrapped") from exc
+    except RuntimeError as outer:
+        assert map_db_exception_chain(outer) is None
+
+
+def test_chain_survives_a_self_referential_context():
+    """A cycle must terminate rather than hang."""
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__context__ = b
+    b.__context__ = a
+    assert map_db_exception_chain(a) is None
+
+
+def test_chain_gives_up_past_the_depth_cap():
+    deepest = _FakeWrapper(_FakeDriverError("23505"))
+    current = deepest
+    for _ in range(20):
+        wrapper = RuntimeError("layer")
+        wrapper.__cause__ = current
+        current = wrapper
+    assert map_db_exception_chain(current) is None
 
 
 def test_message_does_not_leak_driver_text():

--- a/backend/app/tests/test_db_error_mapping.py
+++ b/backend/app/tests/test_db_error_mapping.py
@@ -1,0 +1,103 @@
+"""Regression tests for db_error_mapping.
+
+Every case here corresponds to a driver error that the 2026-08-06 authenticated
+ZAP active scan turned into an HTTP 500. See docs/security/zap-active-2026-08-06/.
+"""
+
+import pytest
+
+from app.core.db_error_mapping import map_db_exception
+
+
+class _FakeDriverError(Exception):
+    """Stands in for an asyncpg exception (which carries `sqlstate`)."""
+
+    def __init__(self, sqlstate):
+        super().__init__(f"driver error {sqlstate}")
+        self.sqlstate = sqlstate
+
+
+class _FakePsycopgError(Exception):
+    """Stands in for a psycopg2 exception (which spells it `pgcode`)."""
+
+    def __init__(self, pgcode):
+        super().__init__(f"driver error {pgcode}")
+        self.pgcode = pgcode
+
+
+class _FakeWrapper(Exception):
+    """Stands in for sqlalchemy.exc.DBAPIError, which exposes `.orig`."""
+
+    def __init__(self, orig):
+        super().__init__("wrapped")
+        self.orig = orig
+
+
+@pytest.mark.parametrize(
+    "sqlstate,expected_status",
+    [
+        ("22P02", 400),  # InvalidTextRepresentation - bad enum/int literal
+        ("22001", 400),  # StringDataRightTruncation - value longer than column
+        ("22021", 400),  # CharacterNotInRepertoire - NUL byte in text
+        ("22000", 400),  # generic data exception
+        ("23505", 409),  # UniqueViolation
+        ("23503", 409),  # ForeignKeyViolation
+        ("23502", 409),  # NotNullViolation
+    ],
+)
+def test_client_input_errors_map_to_4xx(sqlstate, expected_status):
+    """Caller-input errors must not surface as 500."""
+    result = map_db_exception(_FakeWrapper(_FakeDriverError(sqlstate)))
+    assert result is not None, f"{sqlstate} should be mapped"
+    assert result[0] == expected_status
+
+
+@pytest.mark.parametrize(
+    "sqlstate",
+    [
+        "08006",  # connection_failure
+        "53300",  # too_many_connections
+        "57014",  # query_canceled
+        "42P01",  # undefined_table - our bug, not the caller's
+        "XX000",  # internal_error
+    ],
+)
+def test_server_side_faults_are_not_mapped(sqlstate):
+    """Genuine server faults must keep returning 5xx, not be laundered into 4xx."""
+    assert map_db_exception(_FakeWrapper(_FakeDriverError(sqlstate))) is None
+
+
+def test_psycopg_pgcode_is_read():
+    """The sync engine's driver spells the code differently."""
+    result = map_db_exception(_FakeWrapper(_FakePsycopgError("23505")))
+    assert result is not None
+    assert result[0] == 409
+
+
+def test_bare_driver_exception_without_wrapper():
+    """A driver error raised outside a SQLAlchemy wrapper still resolves."""
+    result = map_db_exception(_FakeDriverError("22P02"))
+    assert result is not None
+    assert result[0] == 400
+
+
+def test_unrelated_exception_returns_none():
+    assert map_db_exception(ValueError("nothing to do with the database")) is None
+
+
+def test_missing_sqlstate_returns_none():
+    assert map_db_exception(_FakeWrapper(Exception("no code attribute"))) is None
+
+
+def test_message_does_not_leak_driver_text():
+    """The user-facing message must never echo the driver's error string.
+
+    Driver text can contain column names, SQL fragments, or the offending value.
+    """
+    driver = _FakeDriverError("23505")
+    driver.args = ('duplicate key value violates unique constraint "uq_secret_col"',)
+    result = map_db_exception(_FakeWrapper(driver))
+    assert result is not None
+    _, message = result
+    assert "uq_secret_col" not in message
+    assert "duplicate key" not in message.lower()

--- a/backend/app/tests/test_db_error_mapping.py
+++ b/backend/app/tests/test_db_error_mapping.py
@@ -160,3 +160,19 @@ def test_message_does_not_leak_driver_text():
     _, message = result
     assert "uq_secret_col" not in message
     assert "duplicate key" not in message.lower()
+
+
+def test_iter_cause_chain_is_shared_and_cycle_safe():
+    """The chain walker is shared by the DB mapping and the HTTP unwrap."""
+    from app.core.exception_chain import iter_cause_chain
+
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__context__ = b
+    b.__context__ = a
+    assert len(list(iter_cause_chain(a))) == 2
+
+    outer = RuntimeError("outer")
+    inner = RuntimeError("inner")
+    outer.__cause__ = inner
+    assert list(iter_cause_chain(outer, include_self=False)) == [inner]

--- a/backend/app/tests/test_enum_member_access.py
+++ b/backend/app/tests/test_enum_member_access.py
@@ -1,0 +1,116 @@
+"""AST invariant: never reference an enum member that does not exist.
+
+`.claude/CLAUDE.md` §4 requires Python enum member names to be **lowercase**,
+matching the PostgreSQL values exactly. Writing the TypeScript spelling
+(`NotificationPriority.URGENT`) is an easy slip, and Python only notices at
+runtime — the attribute lookup raises AttributeError the moment that branch
+executes.
+
+`notifications.py` shipped exactly that: `NotificationPriority.URGENT.value`
+where the member is `urgent`. Every call to the endpoint 500'd, and the ZAP
+active scan hit it 17 times.
+
+This walks the AST rather than importing, so it stays fast and has no
+side effects. It only checks attribute access on a bare `Name` that matches a
+known enum class, which keeps it conservative: aliased or dynamically-resolved
+enums are simply not checked rather than guessed at.
+"""
+
+import ast
+import pathlib
+
+APP_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# Attributes every Enum exposes, plus the ones our code adds by convention.
+_ENUM_BUILTINS = {
+    "value",
+    "name",
+    "_name_",
+    "_value_",
+    "__members__",
+    "__class__",
+    "__doc__",
+    "mro",
+}
+
+
+def _collect_enum_definitions():
+    """Map enum class name -> set of legal attribute names."""
+    enums: dict[str, set[str]] = {}
+
+    for path in APP_ROOT.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+
+            base_names = set()
+            for base in node.bases:
+                base_names.add(getattr(base, "id", None) or getattr(base, "attr", None))
+            if not base_names & {"Enum", "IntEnum", "StrEnum"}:
+                continue
+
+            legal = set(_ENUM_BUILTINS)
+            for stmt in node.body:
+                # Members: `low = "low"`
+                if isinstance(stmt, ast.Assign):
+                    for target in stmt.targets:
+                        if isinstance(target, ast.Name):
+                            legal.add(target.id)
+                elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                    legal.add(stmt.target.id)
+                # Methods and classmethods are legal attributes too.
+                elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    legal.add(stmt.name)
+
+            # A name defined twice (rare) should accept either member set.
+            enums.setdefault(node.name, set()).update(legal)
+
+    return enums
+
+
+def _find_bad_accesses(enums):
+    violations = []
+
+    for path in APP_ROOT.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Attribute):
+                continue
+            if not isinstance(node.value, ast.Name):
+                continue
+
+            enum_name = node.value.id
+            if enum_name not in enums:
+                continue
+            if node.attr in enums[enum_name]:
+                continue
+
+            violations.append(
+                f"{path.relative_to(APP_ROOT.parent)}:{node.lineno} "
+                f"{enum_name}.{node.attr} does not exist. "
+                f"Members are lowercase (CLAUDE.md §4); did you mean "
+                f"{enum_name}.{node.attr.lower()}?"
+            )
+
+    return violations
+
+
+def test_no_reference_to_a_nonexistent_enum_member():
+    enums = _collect_enum_definitions()
+    assert enums, "found no enum definitions - the collector is broken"
+
+    violations = _find_bad_accesses(enums)
+    assert not violations, "nonexistent enum member referenced:\n" + "\n".join(violations)

--- a/backend/app/tests/test_no_status_module_shadowing.py
+++ b/backend/app/tests/test_no_status_module_shadowing.py
@@ -1,0 +1,71 @@
+"""AST invariant: never shadow the `status` module with a parameter named `status`.
+
+`from fastapi import status` is the project-wide idiom for HTTP constants. An
+endpoint that also declares a parameter named `status` (a very natural name for
+a filter) rebinds the name locally, so every `status.HTTP_*` lookup in that
+function raises AttributeError at runtime.
+
+This is not hypothetical. `admin/bank_verification.py::list_verification_tasks`
+shipped with exactly this bug: passing an invalid `?status=` value tried to
+raise a 400, hit `'str' object has no attribute 'HTTP_400_BAD_REQUEST'`, and
+returned 500 instead. The 2026-08-06 ZAP active scan hit it 212 times.
+
+The fix is `Query(None, alias="status")` on a differently-named parameter, which
+keeps the wire contract while freeing the module name.
+
+Sibling invariants: test_no_logger_warning_traceback_loss.py,
+test_no_logger_error_traceback_loss.py.
+"""
+
+import ast
+import pathlib
+
+APP_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _iter_python_files():
+    for path in APP_ROOT.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        yield path
+
+
+def _shadowing_violations(tree, path):
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        arg_names = {a.arg for a in node.args.args + node.args.kwonlyargs + node.args.posonlyargs}
+        if "status" not in arg_names:
+            continue
+
+        # The parameter shadows the module only if the body actually reads
+        # `status.HTTP_*`; a handler that never touches the constants is fine.
+        for inner in ast.walk(node):
+            if (
+                isinstance(inner, ast.Attribute)
+                and isinstance(inner.value, ast.Name)
+                and inner.value.id == "status"
+                and inner.attr.startswith("HTTP_")
+            ):
+                violations.append(
+                    f"{path.relative_to(APP_ROOT.parent)}:{inner.lineno} "
+                    f"in {node.name}(): parameter 'status' shadows the fastapi "
+                    f"status module, so 'status.{inner.attr}' raises AttributeError. "
+                    f"Rename the parameter and use Query(..., alias='status')."
+                )
+                break
+    return violations
+
+
+def test_no_endpoint_shadows_the_status_module():
+    violations = []
+    for path in _iter_python_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        violations.extend(_shadowing_violations(tree, path))
+
+    assert not violations, "status-module shadowing detected:\n" + "\n".join(violations)

--- a/security/zap/README.md
+++ b/security/zap/README.md
@@ -1,0 +1,88 @@
+# ZAP 掃描設定
+
+檢查進版控的 ZAP 掃描設定，讓主動掃描可重現、誤報判定可追溯。
+
+| 檔案 | 用途 |
+|---|---|
+| `active-scan-plan.yaml` | 已認證主動掃描的 Automation Framework 計畫 |
+| `alert-filters.yaml` | 已驗證的誤報清單（含逐項證據），是 plan 裡 `alertFilter` job 的來源 |
+
+歷次掃描報告在 `docs/security/`。
+
+## ⚠️ 絕對不要對開發資料庫跑主動掃描
+
+主動掃描會對每個發現的端點送出帶攻擊 payload 的 `POST`/`PUT`/`DELETE`，
+會刪資料、改狀態、觸發寄信。**一定要先複製一份可拋棄的資料庫。**
+
+## 完整流程
+
+```bash
+# 1) 複製資料庫（來源庫全程不被寫入）
+docker exec scholarship_postgres_dev psql -U scholarship_user -d postgres \
+  -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+      WHERE datname='scholarship_db' AND pid<>pg_backend_pid();"
+docker exec scholarship_postgres_dev psql -U scholarship_user -d postgres \
+  -c "CREATE DATABASE scholarship_zap TEMPLATE scholarship_db;"
+
+# 2) 起一個指向複本的獨立後端（:8100），與開發用 :8000 並存
+#    隔離重點：獨立 bucket、獨立 Redis index、SMTP 指向關閉的埠
+docker run -d --name scholarship_backend_zap \
+  --network scholarship-system_scholarship_dev_network -p 8100:8000 \
+  -e DATABASE_URL="postgresql+asyncpg://scholarship_user:scholarship_pass@postgres:5432/scholarship_zap" \
+  -e DATABASE_URL_SYNC="postgresql://scholarship_user:scholarship_pass@postgres:5432/scholarship_zap" \
+  -e REDIS_URL="redis://redis:6379/9" \
+  -e MINIO_BUCKET="scholarship-zap-scan" \
+  -e SMTP_HOST="127.0.0.1" -e SMTP_PORT="2525" \
+  -e DEBUG="false" -e ENVIRONMENT="development" \
+  -e ACCESS_TOKEN_EXPIRE_MINUTES="2880" \
+  -e SECRET_KEY="dev-secret-key-for-development-only" \
+  -e ENABLE_MOCK_SSO="true" \
+  ghcr.io/anud18/scholarship-system-backend:latest \
+  uvicorn app.main:app --host 0.0.0.0 --port 8000
+  # （其餘 env 比照 docker-compose.dev.yml 的 backend）
+
+# 3) 取 token 與 OpenAPI spec
+mkdir -p /tmp/zapwrk
+export ZAP_BEARER_TOKEN=$(curl -s -X POST http://localhost:8100/api/v1/auth/login \
+  -H 'Content-Type: application/json' -d '{"username":"admin@nycu.edu.tw"}' \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["data"]["access_token"])')
+curl -s http://localhost:8100/api/v1/openapi.json -o /tmp/zapwrk/openapi.json
+
+# 4) 展開 plan 並執行
+envsubst < security/zap/active-scan-plan.yaml > /tmp/zapwrk/plan.yaml
+docker run --rm --network host -v /tmp/zapwrk:/zap/wrk/:rw \
+  ghcr.io/zaproxy/zaproxy:stable zap.sh -cmd -port 8999 -autorun /zap/wrk/plan.yaml
+
+# 5) 收尾（務必執行）
+docker rm -f scholarship_backend_zap
+docker exec scholarship_postgres_dev psql -U scholarship_user -d postgres \
+  -c "DROP DATABASE IF EXISTS scholarship_zap;"
+```
+
+## 三個會讓掃描結果騙人的坑
+
+**1. `-port 8999` 不能省。** ZAP proxy 預設 8080，而 mock student API 佔著這個埠。
+綁定失敗時 **ZAP 會 exit 0**，看起來和掃描成功一模一樣，只有讀 log 才看得出
+`Failed to start the main proxy: Address already in use`。
+
+**2. 一定要餵 OpenAPI spec。** 未認證的爬蟲在後端只爬得到 3 個 URL（`/` 與兩個 404），
+spec 匯入則有 416 個。少了這步會得到一份「乾淨但幾乎什麼都沒測」的報告 ——
+**那比不掃更危險**，因為它會被當成保證。
+
+**3. `outputSummary` 不含主動掃描告警。** console 最後那行
+`FAIL-NEW: 0  WARN-NEW: 4` 只涵蓋被動規則。主動掃描的 High/Medium 只出現在
+**報告檔**裡。判讀請一律以 `zap-active-api-report.json` 為準。
+
+## 誤報處理原則
+
+看 `alert-filters.yaml` 開頭的四條規則。摘要：**沒有書面重現證據就不准加**，
+而且用 `newRisk: "False Positive"` 重新標記而非刪除 —— 稽核者仍看得到該筆並可提出異議。
+
+## 已知限制（報告請一併揭露）
+
+- **僅單一 admin 身分** → 越權存取（IDOR / 水平提權）未被系統性測試
+- **業務資料稀疏**：`applications` 為空時，以申請案 ID 為主的端點多半走到 404，
+  未觸及背後商業邏輯 —— 這些端點的「無發現」是**未充分測試**，不是已測試且乾淨
+- **僅後端 API**，前端未做主動掃描
+- **認證走開發專屬端點**（`/auth/login` 僅需 username，硬性擋在 `enable_mock_sso` 之後，
+  prod/staging 皆為 false）。正式環境要做等效掃描需改用真實 Portal SSO token

--- a/security/zap/active-scan-plan.yaml
+++ b/security/zap/active-scan-plan.yaml
@@ -33,6 +33,24 @@ env:
         # Logging out mid-scan would invalidate the session for every
         # subsequent request.
         - "http://localhost:8100/api/v1/auth/logout.*"
+
+        # Dev-only surface. These are hard-gated behind `enable_mock_sso`,
+        # which docker-compose.prod.yml and docker-compose.staging.yml both set
+        # to false, and config.py refuses to boot a production environment with
+        # it enabled. They return 404 in production, so any finding here
+        # describes an attack surface that does not exist there.
+        #
+        # Scoping them out is deliberately preferred over suppressing the rules
+        # they trip: a rule-level filter would hide the same class of finding on
+        # real endpoints too. Excluding non-existent surface does not.
+        #
+        # These endpoints generated every Path Traversal instance, the SQL
+        # Injection alert, and the data behind the OS-command false positive.
+        # All were verified non-exploitable (docs/security/), but they are noise
+        # against production risk either way.
+        - "http://localhost:8100/api/v1/auth/dev-profiles.*"
+        - "http://localhost:8100/api/v1/auth/mock-sso.*"
+        - "http://localhost:8100/api/v1/auth/login.*"
   parameters:
     failOnError: false
     failOnWarning: false
@@ -81,16 +99,16 @@ jobs:
         newRisk: "False Positive"
         context: api
         evidence: " Get-Help"
-      - ruleId: 6
-        newRisk: "False Positive"
-        context: api
-        url: "http://localhost:8100/api/v1/auth/dev-profiles.*"
       - ruleId: 30002
         newRisk: "False Positive"
         context: api
       - ruleId: 40014
         newRisk: "False Positive"
         context: api
+      # NOTE: no filter for rule 6 (Path Traversal) or 40018 (SQL Injection).
+      # Both only ever fired on the dev-only endpoints now excluded above.
+      # Deliberately left unfiltered so that if either ever fires on a
+      # production-reachable endpoint, it is reported at full risk.
 
   - type: activeScan
     parameters:

--- a/security/zap/active-scan-plan.yaml
+++ b/security/zap/active-scan-plan.yaml
@@ -1,0 +1,123 @@
+# ZAP Automation Framework plan — authenticated active scan of the backend API.
+#
+# Run it:
+#   export ZAP_BEARER_TOKEN=...        # admin JWT, see security/zap/README.md
+#   envsubst < security/zap/active-scan-plan.yaml > /tmp/zapwrk/plan.yaml
+#   docker run --network host -v /tmp/zapwrk:/zap/wrk/:rw \
+#     ghcr.io/zaproxy/zaproxy:stable zap.sh -cmd -port 8999 -autorun /zap/wrk/plan.yaml
+#
+# NEVER point this at the shared dev database. It sends destructive payloads
+# (POST/PUT/DELETE with attack strings). Stand up a throwaway clone first —
+# security/zap/README.md has the full recipe.
+#
+# Two settings that are load-bearing and easy to get wrong:
+#   * -port 8999   : ZAP's proxy defaults to 8080, which the mock student API
+#                    already holds. Without this ZAP exits 0 after failing to
+#                    bind, which looks exactly like a successful scan.
+#   * openapi job  : the URL tree comes from the spec, not a spider. Unauthenticated
+#                    crawling reaches 3 URLs; the spec supplies 416. Skipping this
+#                    produces a clean report that tested almost nothing.
+
+env:
+  contexts:
+    - name: api
+      urls:
+        - http://localhost:8100
+      includePaths:
+        - "http://localhost:8100/api/v1/.*"
+        - "http://localhost:8100/health"
+        - "http://localhost:8100/metrics"
+        - "http://localhost:8100/debug/.*"
+        - "http://localhost:8100/"
+      excludePaths:
+        # Logging out mid-scan would invalidate the session for every
+        # subsequent request.
+        - "http://localhost:8100/api/v1/auth/logout.*"
+  parameters:
+    failOnError: false
+    failOnWarning: false
+    progressToStdout: true
+
+jobs:
+  - type: passiveScan-config
+    parameters:
+      maxAlertsPerRule: 20
+      enableTags: false
+
+  # Inject the admin bearer token on every request. ZAP's session-management
+  # options can re-authenticate, but this API mints tokens with a configurable
+  # lifetime, so a single long-lived token is simpler and avoids a login storm.
+  - type: replacer
+    parameters:
+      deleteAllRules: true
+    rules:
+      - description: inject-admin-bearer
+        enabled: true
+        matchType: req_header
+        matchString: Authorization
+        matchRegex: false
+        replacementString: "Bearer ${ZAP_BEARER_TOKEN}"
+
+  - type: openapi
+    parameters:
+      apiFile: /zap/wrk/openapi.json
+      targetUrl: http://localhost:8100
+      context: api
+
+  - type: activeScan
+    parameters:
+      context: api
+      maxScanDurationInMins: 120
+      maxRuleDurationInMins: 10
+      threadPerHost: 5
+    policyDefinition:
+      defaultStrength: medium
+      defaultThreshold: medium
+
+  # Re-label findings already investigated and refuted. Entries and their
+  # evidence live in security/zap/alert-filters.yaml — read the rules at the top
+  # of that file before adding anything here.
+  - type: alertFilter
+    alertFilters:
+      - ruleId: 90020
+        newRisk: "False Positive"
+        context: api
+        evidence: "Get-Help"
+      - ruleId: 6
+        newRisk: "False Positive"
+        context: api
+        url: "http://localhost:8100/api/v1/auth/dev-profiles.*"
+      - ruleId: 30002
+        newRisk: "False Positive"
+        context: api
+      - ruleId: 40014
+        newRisk: "False Positive"
+        context: api
+
+  - type: passiveScan-wait
+    parameters:
+      maxDuration: 10
+
+  - type: outputSummary
+    parameters:
+      format: Long
+      summaryFile: /zap/wrk/summary.json
+
+  - type: report
+    parameters:
+      template: traditional-html
+      reportDir: /zap/wrk/
+      reportFile: zap-active-api-report.html
+      reportTitle: ZAP Authenticated Active Scan Report - Backend API
+  - type: report
+    parameters:
+      template: traditional-json
+      reportDir: /zap/wrk/
+      reportFile: zap-active-api-report.json
+      reportTitle: ZAP Authenticated Active Scan Report - Backend API
+  - type: report
+    parameters:
+      template: traditional-md
+      reportDir: /zap/wrk/
+      reportFile: zap-active-api-report.md
+      reportTitle: ZAP Authenticated Active Scan Report - Backend API

--- a/security/zap/active-scan-plan.yaml
+++ b/security/zap/active-scan-plan.yaml
@@ -64,25 +64,23 @@ jobs:
       targetUrl: http://localhost:8100
       context: api
 
-  - type: activeScan
-    parameters:
-      context: api
-      maxScanDurationInMins: 120
-      maxRuleDurationInMins: 10
-      threadPerHost: 5
-    policyDefinition:
-      defaultStrength: medium
-      defaultThreshold: medium
-
-  # Re-label findings already investigated and refuted. Entries and their
-  # evidence live in security/zap/alert-filters.yaml — read the rules at the top
-  # of that file before adding anything here.
+  # MUST come before the scanning jobs. Filters are applied as alerts are
+  # raised, not retroactively — placing this after activeScan installs them
+  # too late and every filtered finding still appears at full risk, with no
+  # error to tell you the suppression did nothing.
+  #
+  # Entries and their evidence live in security/zap/alert-filters.yaml. Read
+  # the rules at the top of that file before adding anything here.
   - type: alertFilter
     alertFilters:
+      # Evidence string is matched literally and ZAP records it with a leading
+      # space. Scoping by evidence rather than blanket-suppressing rule 90020
+      # keeps a genuine command-injection finding (whose evidence would be real
+      # command output) visible.
       - ruleId: 90020
         newRisk: "False Positive"
         context: api
-        evidence: "Get-Help"
+        evidence: " Get-Help"
       - ruleId: 6
         newRisk: "False Positive"
         context: api
@@ -93,6 +91,16 @@ jobs:
       - ruleId: 40014
         newRisk: "False Positive"
         context: api
+
+  - type: activeScan
+    parameters:
+      context: api
+      maxScanDurationInMins: 120
+      maxRuleDurationInMins: 10
+      threadPerHost: 5
+    policyDefinition:
+      defaultStrength: medium
+      defaultThreshold: medium
 
   - type: passiveScan-wait
     parameters:

--- a/security/zap/alert-filters.yaml
+++ b/security/zap/alert-filters.yaml
@@ -14,6 +14,11 @@
 #      correct against one implementation can mask a real bug in the next.
 #   4. `newRisk: "False Positive"` keeps the finding visible in the report,
 #      re-labelled. It is NOT deleted. Auditors can still see it and disagree.
+#   5. The `alertFilter` job must run BEFORE the scanning jobs. Filters apply as
+#      alerts are raised, not retroactively, and ZAP reports no error when they
+#      arrive too late — the findings simply appear at full risk as if the
+#      filters were never configured. After changing this file, re-run and
+#      confirm the risk really flipped; do not assume it worked.
 #
 # Evidence for every entry below: docs/security/zap-active-2026-08-06/README.md §3
 # Verified against `main` @ e79d8f33 on 2026-08-06.
@@ -33,10 +38,12 @@ alertFilters:
   #
   # No shell is invoked anywhere on this path. Additionally the dev-profiles
   # endpoints are hard-gated behind enable_mock_sso and 404 in production.
+  # NOTE the leading space in `evidence`: ZAP records it as " Get-Help" and the
+  # match is literal. Without it the filter silently matches nothing.
   - ruleId: 90020
     newRisk: "False Positive"
     context: api
-    evidence: "Get-Help"
+    evidence: " Get-Help"
     reason: >-
       Scanner-generated data echoed back by a search endpoint. The "Get-Help"
       string is a dev profile the scan itself created via

--- a/security/zap/alert-filters.yaml
+++ b/security/zap/alert-filters.yaml
@@ -1,0 +1,101 @@
+# ZAP alert filters — verified false positives
+#
+# Drop this into an Automation Framework plan as an `alertFilter` job (see
+# active-scan-plan.yaml) so a scan does not keep re-raising findings that were
+# already investigated and refuted.
+#
+# RULES FOR THIS FILE
+#   1. Nothing goes in here without a written reproduction proving it is a false
+#      positive. "Looks wrong" is not a reason; "here is the request and the
+#      response showing why ZAP is mistaken" is.
+#   2. Scope every entry with `url` where possible. A blanket rule-id suppression
+#      hides real instances of the same class elsewhere.
+#   3. Re-check on every major dependency or endpoint change — a filter that was
+#      correct against one implementation can mask a real bug in the next.
+#   4. `newRisk: "False Positive"` keeps the finding visible in the report,
+#      re-labelled. It is NOT deleted. Auditors can still see it and disagree.
+#
+# Evidence for every entry below: docs/security/zap-active-2026-08-06/README.md §3
+# Verified against `main` @ e79d8f33 on 2026-08-06.
+
+alertFilters:
+  # ---------------------------------------------------------------------------
+  # 90020 — Remote OS Command Injection (reported High)
+  # ---------------------------------------------------------------------------
+  # ZAP sends the PowerShell payload `get-help` and concludes success when the
+  # response contains "Get-Help". The scanner had, earlier in the same run,
+  # POSTed to /auth/dev-profiles/get-help/quick-setup, which creates a dev user
+  # literally named "Prof. Get-Help". The search endpoint then echoes that
+  # stored name back. ZAP is matching data it created itself.
+  #
+  #   GET /api/v1/admin/professors?search=get-help
+  #   {"data":[{"name":"Prof. Get-Help","nycu_id":"dev_get-help_professor"}]}
+  #
+  # No shell is invoked anywhere on this path. Additionally the dev-profiles
+  # endpoints are hard-gated behind enable_mock_sso and 404 in production.
+  - ruleId: 90020
+    newRisk: "False Positive"
+    context: api
+    evidence: "Get-Help"
+    reason: >-
+      Scanner-generated data echoed back by a search endpoint. The "Get-Help"
+      string is a dev profile the scan itself created via
+      /auth/dev-profiles/{id}/quick-setup. No command execution occurs.
+
+  # ---------------------------------------------------------------------------
+  # 6 — Path Traversal (reported High, Low confidence)
+  # ---------------------------------------------------------------------------
+  # Flagged on /auth/dev-profiles/{developer_id}/quick-setup because swapping the
+  # path parameter for an adjacent path segment still returned 200. ZAP's
+  # evidence field is empty — no file content was ever returned.
+  #
+  #   GET /api/v1/auth/dev-profiles/..%2F..%2F..%2Fetc%2Fpasswd  -> 404
+  #   response contains no "root:x:" and no file content
+  #
+  # The handler uses the parameter as a database lookup key and never touches
+  # the filesystem.
+  - ruleId: 6
+    newRisk: "False Positive"
+    context: api
+    url: "http://localhost:8100/api/v1/auth/dev-profiles.*"
+    reason: >-
+      Parameter is a DB lookup key, not a path. Traversal payloads return 404
+      with no file content; ZAP's evidence field is empty (inferred from a
+      200 on a sibling path segment).
+
+  # ---------------------------------------------------------------------------
+  # 30002 — Format String Error (reported Medium)
+  # ---------------------------------------------------------------------------
+  # Inferred from response differences after sending %n/%s/%x payloads, with an
+  # empty evidence field. Those differences are the 500s tracked separately as
+  # IntegrityError/DBAPIError, now mapped to 4xx.
+  #
+  # CPython has no C-style varargs format-string vulnerability class: there is
+  # no printf family reading a caller-supplied format off the stack.
+  - ruleId: 30002
+    newRisk: "False Positive"
+    context: api
+    reason: >-
+      Not applicable to CPython — no printf-family varargs parsing. Alert was
+      inferred from response deltas caused by unrelated DB errors, with no
+      supporting evidence string.
+
+  # ---------------------------------------------------------------------------
+  # 40014 — Cross Site Scripting (Persistent in JSON Response)
+  # ---------------------------------------------------------------------------
+  # The payload is returned inside an application/json document, which browsers
+  # do not parse as HTML, and the frontend renders everything through React's
+  # escaping. Not reflected into any HTML context.
+  #
+  #   GET /api/v1/users?search=<script>alert(1)</script>
+  #   content-type: application/json
+  #
+  # NOTE: this filter is scoped to the JSON API only. If any endpoint ever
+  # returns text/html, this must be revisited — that is a real XSS surface.
+  - ruleId: 40014
+    newRisk: "False Positive"
+    context: api
+    reason: >-
+      Payload echoed inside application/json, never an HTML context. Browsers
+      do not script-parse JSON responses and the frontend escapes via React.
+      Revisit if any API endpoint starts returning text/html.

--- a/security/zap/alert-filters.yaml
+++ b/security/zap/alert-filters.yaml
@@ -22,6 +22,24 @@
 #
 # Evidence for every entry below: docs/security/zap-active-2026-08-06/README.md §3
 # Verified against `main` @ e79d8f33 on 2026-08-06.
+#
+# PREFER SCOPE OVER SUPPRESSION. Two findings that used to be listed here —
+# Path Traversal (rule 6) and SQL Injection (rule 40018) — are no longer
+# filtered at all. Both only ever fired on `/auth/dev-profiles/*`, which is
+# hard-gated behind `enable_mock_sso` and returns 404 in production. The scan
+# plan now excludes that surface instead, so those rules stay armed: if either
+# ever fires on a real endpoint it is reported at full risk. A rule-level
+# filter would have hidden that.
+#
+# WATCH OUT: fixing 500s can surface NEW false positives. Several ZAP rules
+# (boolean-based SQL injection especially) work by diffing responses. While
+# every malformed request returned an identical 500, those rules had nothing to
+# compare and stayed silent. Once responses became informative 4xx/2xx, rule
+# 40018 fired on a stateful POST whose responses vary for reasons unrelated to
+# the payload. It was refuted three ways — identical bodies for '1'='1' vs
+# '1'='2', no delay from pg_sleep(5) payloads, and no raw SQL in the code path
+# (SQLAlchemy parameterises) — but expect this pattern after any error-handling
+# change, and re-verify rather than assuming a new alert is a real regression.
 
 alertFilters:
   # ---------------------------------------------------------------------------
@@ -48,27 +66,6 @@ alertFilters:
       Scanner-generated data echoed back by a search endpoint. The "Get-Help"
       string is a dev profile the scan itself created via
       /auth/dev-profiles/{id}/quick-setup. No command execution occurs.
-
-  # ---------------------------------------------------------------------------
-  # 6 — Path Traversal (reported High, Low confidence)
-  # ---------------------------------------------------------------------------
-  # Flagged on /auth/dev-profiles/{developer_id}/quick-setup because swapping the
-  # path parameter for an adjacent path segment still returned 200. ZAP's
-  # evidence field is empty — no file content was ever returned.
-  #
-  #   GET /api/v1/auth/dev-profiles/..%2F..%2F..%2Fetc%2Fpasswd  -> 404
-  #   response contains no "root:x:" and no file content
-  #
-  # The handler uses the parameter as a database lookup key and never touches
-  # the filesystem.
-  - ruleId: 6
-    newRisk: "False Positive"
-    context: api
-    url: "http://localhost:8100/api/v1/auth/dev-profiles.*"
-    reason: >-
-      Parameter is a DB lookup key, not a path. Traversal payloads return 404
-      with no file content; ZAP's evidence field is empty (inferred from a
-      200 on a sibling path segment).
 
   # ---------------------------------------------------------------------------
   # 30002 — Format String Error (reported Medium)


### PR DESCRIPTION
修正 2026-08-06 已認證 OWASP ZAP 主動掃描（`main` @ `e79d8f33`）發現的問題，並把已驗證的誤報判定寫進版控。

Related: #1280

## 結果

| | 修正前 | 修正後 |
|---|---:|---:|
| 正式環境可達的 HTTP 500 | **4,950** | **0** |
| 受影響端點 | **54** | **0** |
| ZAP High / Medium 告警 | 2 類 / 1 類（全為誤報） | **0 / 0** |

同一份掃描計畫、同一份複製資料庫、~20 萬次請求下量測。狀態碼由 500 改判為正確的 4xx：400 由 6,271 → 8,068，409 由 4 → 1,461。

## 三種不同的問題（不是同一種）

每一輪修完都重跑掃描，才發現後面兩種——只靠前一輪的 curl 驗證會誤以為已經修完。

| 輪次 | 問題類型 | 修完後剩餘 500 |
|---|---|---:|
| `71d94ce0` | 資料庫拒絕呼叫端輸入（SQLSTATE 22/23） | 1,086 / 19 端點 |
| `d414511a` | DB 錯誤被包成 `HTTPException(500) from exc` | 649 / 4 端點 |
| `1c233668` | 程式已決定好的 4xx 被 blanket `except` 吞掉 | 18 / 2 端點 |
| `77da4f93` | 參照不存在的 enum 成員 | **0** |

### 1. 資料庫拒絕呼叫端輸入（約 4,700 筆）

不列舉 driver 例外類別，改用 **SQLSTATE class** 判斷——asyncpg 與 psycopg2 對同一種情況會丟出不同類別，SQLSTATE 則是標準且一致的：

- class 22（data exception）→ **400**：非法列舉值、字串超長、NUL byte
- class 23（integrity constraint）→ **409**：唯一鍵重複、外鍵違反

連線類（08）、資源耗盡類（53）、內部錯誤類（XX）**刻意不對應**，仍然回 5xx——那些是真的伺服器故障，不該被洗成 4xx。

### 2. 被包成 500 的 DB 錯誤（1,086 → 649）

161 個端點會 `raise HTTPException(500, ...) from exc`，這些不會經過通用例外處理器。全部都用了 `from exc`，所以原始錯誤還在 `__cause__` 裡——走 cause chain 一次涵蓋全部，不必改 161 個地方。

### 3. 被吞掉的 4xx（649 → 18）

這一類最值得注意：**根本不是 DB 錯誤**。程式早就決定好要回 404 了，卻被自己的錯誤處理丟掉：

- 6 個端點在 `try` 裡 `raise HTTPException(404)`，而 `except Exception` 沒有先 re-raise HTTPException → 變成 500（「No active configuration found for PhD scholarship」）
- service 丟出 domain error（`NotFoundError`、`ConflictError`…），端點的 blanket handler 只 re-raise `HTTPException`，domain 的狀態碼就消失了（「找不到獎學金配置」→ 500「預演失敗」）

兩種都用 `raise ... from exc`，所以一律從 cause chain 還原。**只還原 4xx**：巢狀的 5xx（`FileStorageError`、`OCRError`）是真故障，維持 500。

### 4. 不存在的 enum 成員（18 → 0）

`NotificationPriority.URGENT` 與 `ApplicationStatus.FUNDED` 都不存在（大寫是 TypeScript 的寫法，Python 成員是小寫，見 CLAUDE.md §4），執行到就 AttributeError。

## 誤報處理：優先縮小範圍，而不是壓制規則

原本打算把 4 條規則都加進 alert filter，改掃之後改變作法：

**`/auth/dev-profiles/*`、`/auth/mock-sso/*`、`/auth/login` 直接排除在掃描範圍外**，而不是壓制規則。這些端點硬性擋在 `enable_mock_sso` 之後，prod/staging 皆為 `false`，且 `config.py` 在 production 且旗標為真時直接拒絕啟動——**在正式環境根本不存在**，findings 描述的是不存在的攻擊面。

這讓 **Path Traversal（rule 6）與 SQL Injection（rule 40018）的 filter 可以完全移除**，兩條規則維持啟用：日後只要在真實端點上觸發，就會以完整風險等級回報。若當初用 rule-level 壓制，就會連真的一起蓋掉。

只剩 30002（CPython 無此弱點類別）與 40014（API 全站 JSON）仍在 filter，兩者本質上就是全站適用，理由都寫在 `security/zap/alert-filters.yaml`。

### 修好 500 之後反而冒出新的（假）警報

最後一次掃描出現一筆前幾次都沒有的 **SQL Injection (High)**。三種方式獨立否證：

1. `'1'='1'` 與 `'1'='2'` 兩個 payload 回應 **byte-identical**（皆 199 bytes）——boolean-based SQLi 的前提就是兩者要不同
2. 所有 `pg_sleep(5)` payload 皆在 **~7ms** 回應，無延遲
3. 該路徑無任何 raw SQL，是 ORM 物件建構，SQLAlchemy 會參數化

成因是**我自己的修正造成的**：ZAP 的 boolean 偵測靠比對回應差異，先前所有畸形請求都回一模一樣的 500，偵測器無從比較；一旦回應變成有區別的 4xx/2xx，就在一個「有副作用的 POST」上誤判（該端點回應本來就會因先建立後衝突而不同）。已寫進 `alert-filters.yaml`，提醒任何錯誤處理改動之後都要預期這個模式，並重新驗證而不是當成真的迴歸。

## 測試

- **`test_db_error_mapping.py`**：涵蓋各 SQLSTATE、兩種 driver 寫法（`sqlstate`／`pgcode`）、cause chain（顯式 `__cause__`／隱式 `__context__`／循環／深度上限），並斷言**伺服器端故障不會被洗成 4xx**、**driver 原文不會出現在回應**（可能含欄位名、SQL 片段、原始值）
- **`test_no_status_module_shadowing.py`**：AST invariant。已驗證它在修正前的程式碼上**會失敗**、修正後通過——是真的迴歸測試，不是恆真式
- **`test_enum_member_access.py`**：AST invariant，解析所有 enum 類別後檢查每一處成員存取。**它找出了掃描沒碰到的 `ApplicationStatus.FUNDED`**（該路徑需要特定設定資料才會走到）

`test_assign_professor_to_application_success` 原本斷言 `status_code in [200, 500]`，註解寫「May get 500 if scholarship doesn't allow professor review」——那個 500 正是本 PR 要修的問題（`ValidationError` 應為 422），已改為 `[200, 422]`。

3,421 unit + 1,804 integration 全數通過；black、flake8 `B904,B014` 乾淨；**OpenAPI spec 與修改前 byte-identical**（`status` 參數用 `alias` 保住 wire contract），`api-types-check` 不會有 drift。

## 順帶修掉的真實 bug

| 檔案 | 問題 |
|---|---|
| `admin/bank_verification.py` | 參數名 `status` 遮蔽了 `fastapi.status` 模組，所有 `status.HTTP_*` 都 AttributeError——連要擋掉非法值的那個 400 也一起壞掉（掃描中 212 次） |
| `notifications.py` ×2 | `logger.exception(..., current_user.id)` 在 `db.rollback()` 之後執行，實例已 expire，讀取屬性觸發 MissingGreenlet，把「已處理的失敗」變成 500 |
| `csp_report.py` | 204 回應帶 `JSONResponse(content="")`，兩個 byte 對上 Content-Length 0，觸發 Starlette 的 "Response content longer than Content-Length" |
| `reference_data.py` | `scholarship` 只在條件式內綁定卻被無條件讀取，不帶篩選條件呼叫 `/scholarship-periods` 就 UnboundLocalError |

## 掃描設定進版控

`security/zap/` 新增掃描計畫、誤報清單與完整重現步驟，並記錄三個**會讓掃描結果騙人**的坑：

1. **`-port 8999` 不能省**：ZAP proxy 預設 8080 已被 mock student API 佔用，綁定失敗時 **ZAP 仍 exit 0**，看起來和成功完全一樣
2. **`alertFilter` 必須排在掃描 job 之前**：filter 是在 alert 產生時套用，不會回溯。放在後面不會報錯，findings 就是照原風險等級出現，像是從沒設定過（本 PR 第一版就踩到）
3. **`outputSummary` 不含主動掃描告警**：console 最後那行 `FAIL-NEW: 0 WARN-NEW: 4` 只涵蓋被動規則，主動掃描的 High/Medium 只在報告檔裡

另外 rule 90020 的 evidence 是 `" Get-Help"`（**開頭有空格**）且為字面比對，少一個空格就完全比不到。

## 測試計畫

- [x] 4,950 → 0 個 500（同一份掃描計畫、複製資料庫實測）
- [x] 每一類根因逐一驗證：非法列舉值 → 400、NUL byte → 400、唯一鍵重複 → 409、`?status=BOGUS` → 400、`/scholarship-periods` → 200、`/csp-report` → 204、dry-run 不存在的 config → 404、matrix-quota 無 active config → 404
- [x] 正常請求不受影響（合法 `?status=completed` 仍 200、有效 dry-run 仍 200、新增不重複的 field 仍 200）
- [x] 3,421 unit + 1,804 integration
- [x] black / flake8 / OpenAPI spec 無 drift
- [ ] Reviewer 確認：`ApplicationStatus.FUNDED` 移除後，配額使用量只計 `approved`。若 `partial_approved` 也該計入請告知——原本的程式碼一執行就 crash，沒有可參考的既有行為

## 已知未涵蓋（與 #1280 報告一致）

- **僅 admin 單一身分掃描** → 越權存取（IDOR／水平提權）未被系統性測試
- **業務資料稀疏**：掃描時 `applications` 為 0 筆，以申請案 ID 為主的端點多半走到 404，未觸及背後商業邏輯；這些端點的「無發現」應理解為**未充分測試**
- **僅後端 API**，前端未做主動掃描

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjWMHqES2xjo6WRAMraXKc
