### PR TITLE
feat(mirror): production sync 自動產生該版本的 ZAP 與 CodeQL 報告

### DIFF
--- a/.github/PRODUCTION_SYNC_GUIDE.md
+++ b/.github/PRODUCTION_SYNC_GUIDE.md
@@ -157,6 +157,39 @@ Trigger a sync manually from GitHub UI:
    - Force push: ☐ (usually not needed)
 5. Click **"Run workflow"**
 
+## 🔐 版本資安報告（ZAP + CodeQL）
+
+每次同步預設會為**本次要上線的 commit** 產生兩份報告，並把摘要留言到 production PR 上。
+由 `security_reports` 這個 input 控制（預設開啟；不需要時取消勾選即可）。
+
+| 報告 | 產生方式 | 內容 |
+|---|---|---|
+| **OWASP ZAP (baseline)** | `.github/workflows/zap-report.yml` | 在 runner 內啟動整套 stack，掃描**正式環境組態的前端**（`frontend/Dockerfile` → `next start`，:3100）與**後端 API**（:8000） |
+| **CodeQL** | `.github/workflows/sarif-to-pdf.yml` | 取用該 commit 的 CodeQL run SARIF，產生 PDF |
+
+兩者皆輸出 PDF（另含 HTML/JSON/MD），存放於**來源 repo** 該次 workflow run 的 artifacts，
+保留 90 天。production PR 上的留言會帶上各風險等級的數量與下載連結。
+
+**設計上的幾個取捨：**
+
+- **不阻擋發布**：兩個掃描與 `sync-to-production` **並行**執行，且刻意不被 `needs` 依賴。
+  掃描要跑數十分鐘，拿它擋住 mirror 只會讓發布變慢而不會更安全——這些報告是給人看的佐證，
+  不是 merge gate。掃描失敗或被略過時，留言會**明確寫出來**（不會靜默省略，
+  以免被誤讀成「掃過了而且沒問題」）。
+- **報告以 commit SHA 命名**，不是版本號：版本號是在 `sync-to-production` 內部算出來的，
+  並行的掃描 job 拿不到。SHA 不會有歧義，版本號則會出現在 PR 留言裡。
+- **CodeQL 對不上該 commit 時會警告**：若找不到該 SHA 的成功 CodeQL run，
+  會退回最近一次成功的 run，並在留言中標明「此報告並非本 commit」。
+- **ZAP 只掃正式組態前端 + 後端**：開發模式前端的 CSP 是為了 Turbopack HMR 刻意放寬的
+  （`unsafe-eval` / `unsafe-inline`），掃它只會產生正式環境不可能出現的 Medium 告警。
+
+⚠️ **ZAP baseline 是被動掃描**：不送攻擊 payload、未認證，因此**不涵蓋 SQLi / XSS / 指令注入**，
+也不涵蓋登入後的功能。**「0 findings」代表「被動掃描未發現」，不等於「已完整測試且安全」。**
+完整限制寫在 PDF 內。需要認證後的主動掃描時，見 `security/zap/`（需可拋棄的測試資料庫）。
+
+兩個 workflow 也都可以單獨手動執行（Actions → 選擇該 workflow → Run workflow），
+用於重新產生某個版本的報告。
+
 ## 💾 Squash Commits 機制
 
 ### 概述

--- a/.github/workflows/mirror-to-production.yml
+++ b/.github/workflows/mirror-to-production.yml
@@ -24,6 +24,12 @@ on:
         type: boolean
         default: false
 
+      security_reports:
+        description: '產生本次版本的資安報告（ZAP baseline + CodeQL PDF）並附到 production PR'
+        required: false
+        type: boolean
+        default: true
+
 # SECURITY: Limit GITHUB_TOKEN permissions to minimum required
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -32,11 +38,49 @@ permissions:
   contents: write  # Need write for creating/updating production branch
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Security evidence for the exact commit being shipped.
+  #
+  # These run IN PARALLEL with sync-to-production rather than gating it: a scan
+  # takes tens of minutes, and blocking the mirror on it would make releases
+  # slow without making them safer (nothing here is a merge gate — the reports
+  # are evidence attached to the PR for a human to read).
+  #
+  # They are also deliberately NOT `needs`-ed by the sync job, so a scanner
+  # hiccup can never block a release. attach-security-reports below runs with
+  # `always()` and reports honestly if a scan failed or was skipped.
+  # ---------------------------------------------------------------------------
+  zap-report:
+    name: ZAP baseline report
+    if: github.event_name == 'workflow_dispatch' && inputs.security_reports
+    uses: ./.github/workflows/zap-report.yml
+    with:
+      ref: ${{ github.sha }}
+    permissions:
+      contents: read
+
+  codeql-report:
+    name: CodeQL PDF report
+    if: github.event_name == 'workflow_dispatch' && inputs.security_reports
+    uses: ./.github/workflows/sarif-to-pdf.yml
+    with:
+      # Report on the commit being mirrored, not merely the newest scan.
+      sha: ${{ github.sha }}
+    permissions:
+      actions: read
+      contents: read
+
   sync-to-production:
     name: Sync to Production Repository
     runs-on: ubuntu-latest
     # Only run if secrets are configured
     if: github.event_name == 'workflow_dispatch'
+    # Consumed by attach-security-reports so it can comment the evidence onto
+    # the PR this job created.
+    outputs:
+      pr_url: ${{ steps.create-pr.outputs.pr_url }}
+      version: ${{ steps.version.outputs.version }}
+      temp_branch: ${{ steps.push-temp.outputs.temp_branch }}
 
     steps:
       - name: Checkout repository
@@ -1080,3 +1124,102 @@ jobs:
           git remote remove prod-repo 2>/dev/null || true
 
           echo "::notice::Cleanup completed"
+
+  # ---------------------------------------------------------------------------
+  # Attach the security evidence to the production PR.
+  #
+  # `always()` on purpose: if a scan failed, timed out or was skipped, the PR
+  # should say so explicitly. Silence would read as "scanned and clean", which
+  # is the one outcome we must never imply by accident.
+  # ---------------------------------------------------------------------------
+  attach-security-reports:
+    name: Attach security reports to production PR
+    runs-on: ubuntu-latest
+    needs: [sync-to-production, zap-report, codeql-report]
+    if: always() && needs.sync-to-production.result == 'success' && inputs.security_reports
+    permissions:
+      contents: read
+
+    steps:
+      - name: Compose and post report comment
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          PR_URL: ${{ needs.sync-to-production.outputs.pr_url }}
+          VERSION: ${{ needs.sync-to-production.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+
+          ZAP_RESULT: ${{ needs.zap-report.result }}
+          ZAP_HIGH: ${{ needs.zap-report.outputs.high }}
+          ZAP_MEDIUM: ${{ needs.zap-report.outputs.medium }}
+          ZAP_LOW: ${{ needs.zap-report.outputs.low }}
+          ZAP_ARTIFACT: ${{ needs.zap-report.outputs.artifact }}
+
+          CODEQL_RESULT: ${{ needs.codeql-report.result }}
+          CODEQL_TOTAL: ${{ needs.codeql-report.outputs.total }}
+          CODEQL_CRITICAL: ${{ needs.codeql-report.outputs.critical }}
+          CODEQL_HIGH: ${{ needs.codeql-report.outputs.high }}
+          CODEQL_MEDIUM: ${{ needs.codeql-report.outputs.medium }}
+          CODEQL_ARTIFACT: ${{ needs.codeql-report.outputs.artifact }}
+          CODEQL_SHA_MATCHED: ${{ needs.codeql-report.outputs.sha_matched }}
+          CODEQL_RESOLVED_SHA: ${{ needs.codeql-report.outputs.resolved_sha }}
+        run: |
+          set -euo pipefail
+
+          # Renders one row per scanner. A non-success result becomes a visible
+          # "未產出" row rather than a missing row.
+          row() {  # $1 name, $2 result, $3 detail
+            case "$2" in
+              success) echo "| $1 | ✅ 已產出 | $3 |" ;;
+              skipped) echo "| $1 | ⏭️ 已略過 | 本次未執行 |" ;;
+              *)       echo "| $1 | ❌ 未產出（\`$2\`）| 請查看 workflow run |" ;;
+            esac
+          }
+
+          {
+            echo "## 🔐 本版本資安報告 (${VERSION})"
+            echo ""
+            echo "受測 commit：\`${COMMIT_SHA}\`"
+            echo ""
+            echo "| 報告 | 狀態 | 結果 |"
+            echo "|---|---|---|"
+            row "OWASP ZAP (baseline)" "${ZAP_RESULT}" \
+                "High **${ZAP_HIGH:-?}** / Medium **${ZAP_MEDIUM:-?}** / Low ${ZAP_LOW:-?}"
+            row "CodeQL" "${CODEQL_RESULT}" \
+                "Critical **${CODEQL_CRITICAL:-?}** / High **${CODEQL_HIGH:-?}** / Medium ${CODEQL_MEDIUM:-?}（共 ${CODEQL_TOTAL:-?}）"
+            echo ""
+            echo "📥 **下載**（於來源 repo 的 workflow run artifacts）："
+            echo "- [${RUN_URL}](${RUN_URL})"
+            if [ "${ZAP_RESULT}" = "success" ]; then
+              echo "  - ZAP：\`${ZAP_ARTIFACT}\`（PDF / HTML / JSON / MD）"
+            fi
+            if [ "${CODEQL_RESULT}" = "success" ]; then
+              echo "  - CodeQL：\`${CODEQL_ARTIFACT}\`（PDF）"
+            fi
+            echo ""
+
+            if [ "${CODEQL_RESULT}" = "success" ] && [ "${CODEQL_SHA_MATCHED}" != "true" ]; then
+              echo "> ⚠️ **CodeQL 報告並非本 commit**：找不到 \`${COMMIT_SHA}\` 的成功 CodeQL run，"
+              echo "> 報告內容對應的是 \`${CODEQL_RESOLVED_SHA}\`。合併前請確認差異。"
+              echo ""
+            fi
+
+            echo "### 判讀須知"
+            echo ""
+            echo "ZAP 為 **baseline（被動）** 掃描：**不送攻擊 payload、未認證**，"
+            echo "因此不涵蓋 SQLi／XSS／指令注入，也未涵蓋登入後的功能。"
+            echo "**「0 findings」代表「被動掃描未發現」，不等於「已完整測試且安全」。**"
+            echo "完整限制說明在 PDF 內；認證後的主動掃描見來源 repo 的 \`security/zap/\`。"
+          } > /tmp/security-comment.md
+
+          cat /tmp/security-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "${PR_URL}" ]; then
+            echo "::warning::No production PR URL available; security summary written to the job summary only."
+            exit 0
+          fi
+
+          # The URL fully identifies the target repo; passing --repo as well is
+          # redundant and gh treats the two as competing selectors.
+          gh pr comment "${PR_URL}" --body-file /tmp/security-comment.md
+          echo "::notice::✅ Security report summary posted to ${PR_URL}"

--- a/.github/workflows/sarif-to-pdf.yml
+++ b/.github/workflows/sarif-to-pdf.yml
@@ -7,6 +7,51 @@ on:
         description: "GitHub Actions run ID that produced SARIF artifacts (leave empty for latest)"
         required: false
         type: string
+      sha:
+        description: "Commit SHA to report on (resolves the CodeQL run for exactly that commit; overrides 'latest')"
+        required: false
+        type: string
+      label:
+        description: "Label shown in the report header and appended to artifact names (e.g. v1.2.3)"
+        required: false
+        type: string
+
+  # Callable from other workflows (mirror-to-production.yml uses this to
+  # produce a per-release report) so the ~300-line SARIF parser below lives
+  # in exactly one place.
+  workflow_call:
+    inputs:
+      run_id:
+        required: false
+        type: string
+      sha:
+        required: false
+        type: string
+      label:
+        required: false
+        type: string
+    outputs:
+      total:
+        description: "Total number of CodeQL findings"
+        value: ${{ jobs.generate-pdf.outputs.total }}
+      critical:
+        description: "Critical-severity findings"
+        value: ${{ jobs.generate-pdf.outputs.critical }}
+      high:
+        description: "High-severity findings"
+        value: ${{ jobs.generate-pdf.outputs.high }}
+      medium:
+        description: "Medium-severity findings"
+        value: ${{ jobs.generate-pdf.outputs.medium }}
+      artifact:
+        description: "Name of the uploaded PDF artifact"
+        value: ${{ jobs.generate-pdf.outputs.artifact }}
+      resolved_sha:
+        description: "Commit SHA the reported CodeQL run actually analysed"
+        value: ${{ jobs.generate-pdf.outputs.resolved_sha }}
+      sha_matched:
+        description: "'true' when the CodeQL run analysed the requested SHA exactly"
+        value: ${{ jobs.generate-pdf.outputs.sha_matched }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
@@ -18,28 +63,91 @@ jobs:
     permissions:
       actions: read
       contents: read
+    outputs:
+      total: ${{ steps.counts.outputs.total }}
+      critical: ${{ steps.counts.outputs.critical }}
+      high: ${{ steps.counts.outputs.high }}
+      medium: ${{ steps.counts.outputs.medium }}
+      artifact: ${{ steps.names.outputs.pdf_artifact }}
+      resolved_sha: ${{ steps.set-run-id.outputs.resolved_sha }}
+      sha_matched: ${{ steps.set-run-id.outputs.sha_matched }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Get latest CodeQL run ID
-        if: ${{ github.event.inputs.run_id == '' }}
-        id: get-run-id
-        run: |
-          LATEST_RUN=$(gh run list --workflow=codeql.yml --status=success --limit=1 --json databaseId --jq '.[0].databaseId')
-          echo "run_id=$LATEST_RUN" >> $GITHUB_OUTPUT
+      - name: Resolve CodeQL run ID
+        id: set-run-id
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - name: Set run ID
-        id: set-run-id
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+          INPUT_SHA: ${{ inputs.sha }}
         run: |
-          if [ -n "${{ github.event.inputs.run_id }}" ]; then
-            echo "run_id=${{ github.event.inputs.run_id }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          # Explicit run id always wins.
+          if [ -n "${INPUT_RUN_ID}" ]; then
+            RUN_ID="${INPUT_RUN_ID}"
+            RESOLVED_SHA=$(gh run view "$RUN_ID" --json headSha --jq '.headSha' 2>/dev/null || echo "")
+            MATCHED="true"
+          elif [ -n "${INPUT_SHA}" ]; then
+            # Report on a SPECIFIC commit. Anything else would silently attach
+            # a report for different code to a release, which is worse than
+            # having no report at all — so a mismatch is surfaced loudly and
+            # exported for the caller to show.
+            RUN_ID=$(gh run list --workflow=codeql.yml --status=success --limit=50 \
+              --json databaseId,headSha \
+              --jq "[.[] | select(.headSha==\"${INPUT_SHA}\")] | .[0].databaseId // empty")
+            if [ -n "$RUN_ID" ]; then
+              RESOLVED_SHA="${INPUT_SHA}"
+              MATCHED="true"
+            else
+              echo "::warning::No successful CodeQL run found for ${INPUT_SHA}; falling back to the most recent successful run. The report will NOT describe the requested commit."
+              RUN_ID=$(gh run list --workflow=codeql.yml --status=success --limit=1 --json databaseId --jq '.[0].databaseId')
+              RESOLVED_SHA=$(gh run view "$RUN_ID" --json headSha --jq '.headSha' 2>/dev/null || echo "")
+              MATCHED="false"
+            fi
           else
-            echo "run_id=${{ steps.get-run-id.outputs.run_id }}" >> $GITHUB_OUTPUT
+            RUN_ID=$(gh run list --workflow=codeql.yml --status=success --limit=1 --json databaseId --jq '.[0].databaseId')
+            RESOLVED_SHA=$(gh run view "$RUN_ID" --json headSha --jq '.headSha' 2>/dev/null || echo "")
+            MATCHED="true"
           fi
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Could not resolve a successful CodeQL run to report on."
+            exit 1
+          fi
+
+          echo "::notice::Using CodeQL run $RUN_ID (sha ${RESOLVED_SHA:-unknown})"
+          {
+            echo "run_id=$RUN_ID"
+            echo "resolved_sha=$RESOLVED_SHA"
+            echo "sha_matched=$MATCHED"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Compute report labels
+        id: names
+        env:
+          INPUT_LABEL: ${{ inputs.label }}
+          RESOLVED_SHA: ${{ steps.set-run-id.outputs.resolved_sha }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA=$(echo "${RESOLVED_SHA}" | cut -c1-8)
+          if [ -n "${INPUT_LABEL}" ]; then
+            LABEL="${INPUT_LABEL}"
+            SUFFIX="-${INPUT_LABEL}"
+          elif [ -n "$SHORT_SHA" ]; then
+            LABEL="$SHORT_SHA"
+            SUFFIX="-$SHORT_SHA"
+          else
+            LABEL=""
+            SUFFIX=""
+          fi
+          {
+            echo "label=$LABEL"
+            echo "pdf_artifact=codeql-security-report${SUFFIX}"
+            echo "html_artifact=codeql-security-report-html${SUFFIX}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Download SARIF artifacts
         uses: dawidd6/action-download-artifact@v6
@@ -293,6 +401,8 @@ jobs:
               <div class="meta-info">
                   <p><strong>Generated:</strong> {{ timestamp }}</p>
                   <p><strong>Repository:</strong> {{ repo }}</p>
+                  {% if label %}<p><strong>Version:</strong> {{ label }}</p>{% endif %}
+                  {% if commit %}<p><strong>Commit analysed:</strong> <code>{{ commit }}</code></p>{% endif %}
                   <p><strong>Languages Analyzed:</strong> {{ languages|join(', ') }}</p>
                   <p><strong>Total Findings:</strong> {{ total_findings }}</p>
               </div>
@@ -372,6 +482,8 @@ jobs:
           html_content = html_template.render(
               timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC"),
               repo="${{ github.repository }}",
+              label="${{ steps.names.outputs.label }}",
+              commit="${{ steps.set-run-id.outputs.resolved_sha }}",
               languages=sorted(languages),
               total_findings=len(all_results),
               severity_counts=severity_counts,
@@ -382,6 +494,20 @@ jobs:
           # Write HTML file
           pathlib.Path("codeql-report.html").write_text(html_content, encoding="utf-8")
           print(f"Generated HTML report with {len(all_results)} findings")
+
+          # Totals for the workflow outputs, so callers can summarise without
+          # re-parsing the SARIF.
+          totals = defaultdict(int)
+          for r in all_results:
+              totals[r["severity"]] += 1
+          pathlib.Path("codeql-counts.json").write_text(json.dumps({
+              "total": len(all_results),
+              "critical": totals["Critical"],
+              "high": totals["High"],
+              "medium": totals["Medium"],
+              "low": totals["Low"],
+              "info": totals["Info"],
+          }), encoding="utf-8")
 
       - name: Convert HTML to PDF
         shell: python
@@ -409,28 +535,55 @@ jobs:
       - name: Verify PDF output
         run: ls -lh codeql-security-report.pdf
 
+      - name: Export finding counts
+        id: counts
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, pathlib
+          c = json.loads(pathlib.Path("codeql-counts.json").read_text())
+          for k in ("total", "critical", "high", "medium", "low", "info"):
+              print(f"{k}={c[k]}")
+          PY
+
       - name: Upload PDF Report
         uses: actions/upload-artifact@v6
         with:
-          name: codeql-security-report
+          name: ${{ steps.names.outputs.pdf_artifact }}
           path: codeql-security-report.pdf
           retention-days: 90
 
       - name: Upload HTML Report
         uses: actions/upload-artifact@v6
         with:
-          name: codeql-security-report-html
+          name: ${{ steps.names.outputs.html_artifact }}
           path: codeql-report.html
           retention-days: 90
 
       - name: Summary
         run: |
-          echo "## CodeQL PDF Report Generated ✅" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "📊 **Report Details:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Source Run ID: ${{ steps.set-run-id.outputs.run_id }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "📥 **Download:**" >> $GITHUB_STEP_SUMMARY
-          echo "- PDF report available in workflow artifacts" >> $GITHUB_STEP_SUMMARY
-          echo "- HTML report also available for preview" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## CodeQL PDF Report Generated ✅"
+            echo ""
+            echo "| Property | Value |"
+            echo "|---|---|"
+            echo "| Source Run ID | ${{ steps.set-run-id.outputs.run_id }} |"
+            echo "| Commit analysed | \`${{ steps.set-run-id.outputs.resolved_sha }}\` |"
+            echo "| Version label | ${{ steps.names.outputs.label || '(none)' }} |"
+            echo "| Generated | $(date -u '+%Y-%m-%d %H:%M:%S UTC') |"
+            echo ""
+            echo "| Severity | Count |"
+            echo "|---|---:|"
+            echo "| Critical | ${{ steps.counts.outputs.critical }} |"
+            echo "| High | ${{ steps.counts.outputs.high }} |"
+            echo "| Medium | ${{ steps.counts.outputs.medium }} |"
+            echo "| Low | ${{ steps.counts.outputs.low }} |"
+            echo "| Info | ${{ steps.counts.outputs.info }} |"
+            echo "| **Total** | **${{ steps.counts.outputs.total }}** |"
+            echo ""
+            echo "📥 PDF and HTML are available in this run's artifacts."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ steps.set-run-id.outputs.sha_matched }}" != "true" ]; then
+            echo "> ⚠️ **The requested commit had no successful CodeQL run.** This report describes \`${{ steps.set-run-id.outputs.resolved_sha }}\` instead — do not attach it to a release as-is." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/zap-report.yml
+++ b/.github/workflows/zap-report.yml
@@ -1,0 +1,470 @@
+name: "Generate ZAP Security Report"
+
+# OWASP ZAP baseline scan against a stack booted inside the runner, rendered to
+# PDF for release evidence. Callable from mirror-to-production.yml so every
+# production sync can carry a scan of exactly the code being shipped.
+#
+# WHAT IS SCANNED, AND WHY THOSE TWO TARGETS
+#   * the frontend built in PRODUCTION mode (frontend/Dockerfile -> next start)
+#     — this is the configuration that actually ships. The dev server emits a
+#     deliberately relaxed CSP (unsafe-eval/unsafe-inline for Turbopack HMR),
+#     so scanning it produces Mediums that cannot occur in production and
+#     mislead anyone reading the report.
+#   * the backend API — scanned on the dev stack, which means DEBUG differs
+#     from production. Called out in the report rather than papered over.
+#
+# WHAT THIS IS NOT
+#   A baseline scan is PASSIVE: it sends no attack payloads, so it does not
+#   cover SQLi/XSS/injection. It is also UNAUTHENTICATED, so it only reaches
+#   public pages — the backend crawl bottoms out at a handful of URLs. Both
+#   limits are printed into the report so a green result is not mistaken for
+#   "the application was tested and is clean".
+#   For the authenticated active scan see security/zap/ (needs a throwaway
+#   database; not run here).
+
+on:
+  workflow_dispatch:
+    inputs:
+      label:
+        description: "Label shown in the report header and appended to artifact names (e.g. v1.2.3)"
+        required: false
+        type: string
+      spider_minutes:
+        description: "Minutes to spend crawling each target"
+        required: false
+        type: string
+        default: "5"
+
+  workflow_call:
+    inputs:
+      label:
+        required: false
+        type: string
+      spider_minutes:
+        required: false
+        type: string
+        default: "5"
+      ref:
+        description: "Commit/ref to check out and scan"
+        required: false
+        type: string
+    outputs:
+      high:
+        description: "High-risk alerts across both targets"
+        value: ${{ jobs.zap-scan.outputs.high }}
+      medium:
+        description: "Medium-risk alerts across both targets"
+        value: ${{ jobs.zap-scan.outputs.medium }}
+      low:
+        description: "Low-risk alerts across both targets"
+        value: ${{ jobs.zap-scan.outputs.low }}
+      artifact:
+        description: "Name of the uploaded report artifact"
+        value: ${{ jobs.zap-scan.outputs.artifact }}
+      scanned_sha:
+        description: "Commit SHA that was actually scanned"
+        value: ${{ jobs.zap-scan.outputs.scanned_sha }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  zap-scan:
+    name: ZAP baseline scan
+    runs-on: ubuntu-latest
+    # Stack build + two 5-minute crawls; generous ceiling so a slow image
+    # build cannot leave the job hanging for the default 6 hours.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    outputs:
+      high: ${{ steps.counts.outputs.high }}
+      medium: ${{ steps.counts.outputs.medium }}
+      low: ${{ steps.counts.outputs.low }}
+      artifact: ${{ steps.names.outputs.artifact }}
+      scanned_sha: ${{ steps.names.outputs.sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Compute report labels
+        id: names
+        env:
+          INPUT_LABEL: ${{ inputs.label }}
+        run: |
+          set -euo pipefail
+          SHA=$(git rev-parse HEAD)
+          SHORT_SHA=$(echo "$SHA" | cut -c1-8)
+          if [ -n "${INPUT_LABEL}" ]; then
+            LABEL="${INPUT_LABEL}"
+            SUFFIX="-${INPUT_LABEL}"
+          else
+            LABEL="$SHORT_SHA"
+            SUFFIX="-$SHORT_SHA"
+          fi
+          {
+            echo "sha=$SHA"
+            echo "short_sha=$SHORT_SHA"
+            echo "label=$LABEL"
+            echo "artifact=zap-security-report${SUFFIX}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Bring up docker-compose.dev.yml
+        # Same best-effort bringup as ci.yml's E2E smoke lane: the compose file
+        # mixes private GHCR images with `build:` directives, so a pull can fail
+        # and `up --build` then rebuilds locally. Readiness — not the pull —
+        # decides the outcome, and the guard below fails hard.
+        continue-on-error: true
+        run: |
+          docker compose -f docker-compose.dev.yml pull --quiet 2>&1 | tail -5 || true
+          docker compose -f docker-compose.dev.yml up -d --build 2>&1 | tail -50 || true
+          echo "Waiting for backend (/health) and frontend (:3000)..."
+          ready=0
+          for i in $(seq 1 90); do
+            if curl -fsS http://localhost:8000/health > /dev/null 2>&1 \
+               && curl -fsS http://localhost:3000 > /dev/null 2>&1; then
+              echo "Services up after $((i * 2))s"
+              ready=1
+              break
+            fi
+            sleep 2
+          done
+          if [ "$ready" -ne 1 ]; then
+            echo "::warning title=zap-report::Services did not become ready; the guard step will fail the job."
+            docker compose -f docker-compose.dev.yml ps || true
+            docker compose -f docker-compose.dev.yml logs --tail=100 || true
+          fi
+          echo "READY=$ready" >> "$GITHUB_ENV"
+
+      - name: Fail-on-not-ready guard
+        if: env.READY != '1'
+        run: |
+          echo "::error title=zap-report::Compose stack failed to become ready; refusing to publish a scan of a half-booted app."
+          exit 1
+
+      - name: Migrate + seed inside backend container
+        # /health returns 200 as soon as FastAPI starts — it does not check the
+        # schema. Without this the crawler hits endpoints that 500 on a missing
+        # `users` table, which shows up as spurious findings.
+        run: |
+          docker compose -f docker-compose.dev.yml exec -T backend alembic upgrade head
+          docker compose -f docker-compose.dev.yml exec -T backend python -m app.seed || echo "seed completed"
+
+      - name: Build and start production-mode frontend
+        run: |
+          set -euo pipefail
+          docker build -t scholarship-frontend-zap:prod -f frontend/Dockerfile frontend/
+          docker run -d --name zap-prod-frontend --network host \
+            -e NODE_ENV=production -e PORT=3100 \
+            -e NEXT_PUBLIC_API_URL=http://localhost:8000 \
+            scholarship-frontend-zap:prod
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:3100/ > /dev/null 2>&1; then
+              echo "Production frontend up after $((i * 3))s"
+              break
+            fi
+            sleep 3
+          done
+          curl -fsS -o /dev/null http://localhost:3100/ || {
+            echo "::error::Production frontend did not start"
+            docker logs zap-prod-frontend --tail 100 || true
+            exit 1
+          }
+          # Record the CSP actually served, so the report can show that the
+          # production policy (nonce + strict-dynamic) is what was scanned.
+          curl -sI http://localhost:3100/ | grep -i '^content-security-policy:' > /tmp/prod-csp.txt || true
+
+      - name: Prepare report directory
+        run: |
+          mkdir -p zap-out
+          # The ZAP image runs as uid 1000; the mounted dir must be writable
+          # by it or every report write fails at the very end of the scan.
+          chmod 777 zap-out
+
+      - name: ZAP baseline scan - production frontend
+        run: |
+          set -euo pipefail
+          # -a alpha passive rules, -j AJAX spider (required for a Next.js SPA),
+          # -m crawl minutes. Exit code is intentionally tolerated: zap-baseline
+          # returns non-zero when WARNs are present, which is the normal case and
+          # is not a reason to fail a reporting job.
+          docker run --rm --network host \
+            -v "$(pwd)/zap-out:/zap/wrk/:rw" \
+            ghcr.io/zaproxy/zaproxy:stable \
+            zap-baseline.py -t http://localhost:3100 \
+              -r zap-frontend-prod-report.html \
+              -J zap-frontend-prod-report.json \
+              -w zap-frontend-prod-report.md \
+              -a -j -m "${{ inputs.spider_minutes || '5' }}" || true
+          test -f zap-out/zap-frontend-prod-report.json
+
+      - name: ZAP baseline scan - backend API
+        run: |
+          set -euo pipefail
+          # No -j: the API serves no HTML, so the AJAX spider has nothing to do.
+          docker run --rm --network host \
+            -v "$(pwd)/zap-out:/zap/wrk/:rw" \
+            ghcr.io/zaproxy/zaproxy:stable \
+            zap-baseline.py -t http://localhost:8000 \
+              -r zap-backend-report.html \
+              -J zap-backend-report.json \
+              -w zap-backend-report.md \
+              -a -m "${{ inputs.spider_minutes || '5' }}" || true
+          test -f zap-out/zap-backend-report.json
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install jinja2 weasyprint
+
+      - name: Install CJK fonts
+        # This report is written in Traditional Chinese. Without a CJK font
+        # WeasyPrint lays the text out with no glyphs — the PDF renders and the
+        # job goes green, but every Chinese heading and the entire limitations
+        # section come out blank. Verified: with only fonts-dejavu-core, none of
+        # "正式環境組態 / 後端 API / 掃描限制" survive into the PDF text layer.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq fonts-noto-cjk
+
+      - name: Build summary report
+        id: counts
+        env:
+          LABEL: ${{ steps.names.outputs.label }}
+          COMMIT: ${{ steps.names.outputs.sha }}
+          REPO: ${{ github.repository }}
+        shell: python
+        run: |
+          import json, os, pathlib, collections
+          from datetime import datetime, timezone
+          from jinja2 import Template
+
+          OUT = pathlib.Path("zap-out")
+          TARGETS = [
+              ("正式環境組態前端 (production build)", "zap-frontend-prod-report.json",
+               "http://localhost:3100", "next start，與正式環境相同的 build"),
+              ("後端 API", "zap-backend-report.json",
+               "http://localhost:8000", "開發堆疊（DEBUG 與正式環境不同）"),
+          ]
+
+          RISKS = ["High", "Medium", "Low", "Informational"]
+          per_target = []
+          totals = collections.Counter()
+
+          for title, filename, url, note in TARGETS:
+              path = OUT / filename
+              counts = collections.Counter()
+              alerts = []
+              if path.exists():
+                  data = json.loads(path.read_text(encoding="utf-8"))
+                  for site in data.get("site", []):
+                      for alert in site.get("alerts", []):
+                          # riskdesc looks like "Medium (High)" -> risk, confidence
+                          risk = alert.get("riskdesc", "Informational").split(" ")[0]
+                          counts[risk] += 1
+                          totals[risk] += 1
+                          alerts.append({
+                              "name": alert.get("name", "?"),
+                              "risk": risk,
+                              "confidence": alert.get("riskdesc", ""),
+                              "count": alert.get("count", "0"),
+                              "desc": (alert.get("desc") or "").strip(),
+                          })
+              order = {r: i for i, r in enumerate(RISKS)}
+              alerts.sort(key=lambda a: order.get(a["risk"], 99))
+              per_target.append({
+                  "title": title, "url": url, "note": note,
+                  "counts": counts, "alerts": alerts,
+                  "total": sum(counts.values()),
+                  "missing": not path.exists(),
+              })
+
+          csp = ""
+          csp_file = pathlib.Path("/tmp/prod-csp.txt")
+          if csp_file.exists():
+              csp = csp_file.read_text(encoding="utf-8").strip()
+
+          template = Template('''
+          <!DOCTYPE html>
+          <html><head><meta charset="utf-8"><title>OWASP ZAP Baseline Report</title>
+          <style>
+            /* Noto CJK first: the report body is Traditional Chinese and a
+               Latin-only font silently drops every glyph. */
+            body { font-family: 'Noto Sans CJK TC', 'Noto Sans CJK SC', 'DejaVu Sans', sans-serif;
+                   margin: 36px; line-height: 1.55; color: #333; }
+            h1 { color: #2c3e50; border-bottom: 3px solid #3498db; padding-bottom: 8px; }
+            h2 { color: #34495e; margin-top: 28px; border-left: 4px solid #3498db; padding-left: 10px; }
+            .meta { background: #ecf0f1; padding: 14px; border-radius: 5px; margin: 18px 0; }
+            table { width: 100%; border-collapse: collapse; margin: 14px 0; }
+            th, td { border: 1px solid #bdc3c7; padding: 8px; text-align: left; font-size: 0.95em; }
+            th { background: #34495e; color: #fff; }
+            tr:nth-child(even) { background: #f8f9fa; }
+            .num { text-align: right; }
+            .r-High { color: #c0392b; font-weight: bold; }
+            .r-Medium { color: #d35400; font-weight: bold; }
+            .r-Low { color: #2980b9; }
+            .r-Informational { color: #7f8c8d; }
+            .limits { background: #fff8e6; border-left: 4px solid #f39c12; padding: 12px 16px; margin: 18px 0; }
+            code { background: #ecf0f1; padding: 2px 5px; border-radius: 3px; word-break: break-all; }
+            .foot { margin-top: 40px; padding-top: 14px; border-top: 1px solid #bdc3c7;
+                    text-align: center; color: #7f8c8d; font-size: 0.9em; }
+          </style></head><body>
+            <h1>OWASP ZAP 弱點掃描報告（Baseline）</h1>
+            <div class="meta">
+              <p><strong>Repository:</strong> {{ repo }}</p>
+              {% if label %}<p><strong>Version:</strong> {{ label }}</p>{% endif %}
+              <p><strong>Commit:</strong> <code>{{ commit }}</code></p>
+              <p><strong>Generated:</strong> {{ timestamp }}</p>
+              <p><strong>Tool:</strong> OWASP ZAP (ghcr.io/zaproxy/zaproxy:stable)</p>
+              <p><strong>Mode:</strong> Baseline — 被動掃描 + AJAX Spider，<strong>不發送攻擊 payload</strong></p>
+            </div>
+
+            <h2>總覽</h2>
+            <table>
+              <tr><th>受測對象</th><th class="num">High</th><th class="num">Medium</th>
+                  <th class="num">Low</th><th class="num">Info</th><th class="num">合計</th></tr>
+              {% for t in targets %}
+              <tr>
+                <td><strong>{{ t.title }}</strong><br><code>{{ t.url }}</code><br>
+                    <span style="color:#7f8c8d">{{ t.note }}</span></td>
+                <td class="num r-High">{{ t.counts['High'] or 0 }}</td>
+                <td class="num r-Medium">{{ t.counts['Medium'] or 0 }}</td>
+                <td class="num r-Low">{{ t.counts['Low'] or 0 }}</td>
+                <td class="num r-Informational">{{ t.counts['Informational'] or 0 }}</td>
+                <td class="num"><strong>{{ t.total }}</strong></td>
+              </tr>
+              {% endfor %}
+            </table>
+
+            {% if csp %}
+            <h2>正式環境組態實測 CSP</h2>
+            <p><code>{{ csp }}</code></p>
+            {% endif %}
+
+            {% for t in targets %}
+            <h2>{{ t.title }}</h2>
+            {% if t.missing %}
+              <p><strong>此目標沒有產出報告檔</strong>（掃描可能失敗）。</p>
+            {% elif t.alerts %}
+            <table>
+              <tr><th>告警</th><th>風險（信心）</th><th class="num">實例數</th></tr>
+              {% for a in t.alerts %}
+              <tr><td>{{ a.name }}</td>
+                  <td class="r-{{ a.risk }}">{{ a.confidence }}</td>
+                  <td class="num">{{ a.count }}</td></tr>
+              {% endfor %}
+            </table>
+            {% else %}
+              <p>無任何告警。</p>
+            {% endif %}
+            {% endfor %}
+
+            <h2>掃描限制（請與報告一併閱讀）</h2>
+            <div class="limits">
+              <ol>
+                <li><strong>被動掃描</strong>：未發送攻擊 payload，<strong>不涵蓋</strong> SQL Injection、
+                    XSS、指令注入等主動測試項目。</li>
+                <li><strong>未認證</strong>：僅涵蓋公開頁面。登入後的管理／學院／教授功能未被爬取；
+                    後端 API 需 Bearer token，故僅掃到少數公開路徑。</li>
+                <li><strong>未經 nginx</strong>：直連容器，未經正式環境的反向代理，
+                    因此安全標頭類告警不代表正式環境實際組態。</li>
+                <li><strong>後端為開發堆疊</strong>：DEBUG 等設定與正式環境不同。</li>
+                <li><strong>爬取不具決定性</strong>：AJAX Spider 每次涵蓋的 URL 集合略有差異，
+                    比較兩次掃描應以「告警類型」而非「筆數」為準。</li>
+              </ol>
+              <p style="margin-bottom:0"><strong>因此「0 findings」代表的是「被動掃描未發現」，
+              而不是「已完整測試且安全」。</strong>需要涵蓋認證後範圍或主動攻擊測試時，
+              請執行 <code>security/zap/</code> 的 authenticated active scan（需可拋棄的測試資料庫）。</p>
+            </div>
+
+            <div class="foot">Generated by OWASP ZAP via GitHub Actions</div>
+          </body></html>
+          ''')
+
+          html = template.render(
+              repo=os.environ.get("REPO", ""),
+              label=os.environ.get("LABEL", ""),
+              commit=os.environ.get("COMMIT", ""),
+              timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+              targets=per_target,
+              csp=csp,
+          )
+          pathlib.Path("zap-out/zap-summary.html").write_text(html, encoding="utf-8")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"high={totals['High']}\n")
+              fh.write(f"medium={totals['Medium']}\n")
+              fh.write(f"low={totals['Low']}\n")
+              fh.write(f"info={totals['Informational']}\n")
+              fh.write(f"total={sum(totals.values())}\n")
+
+          print("Totals:", dict(totals))
+
+      - name: Convert summary to PDF
+        run: |
+          python - <<'PY'
+          from weasyprint import HTML, CSS
+          from weasyprint.text.fonts import FontConfiguration
+          fc = FontConfiguration()
+          css = CSS(string='@page { size: A4; margin: 14mm; }', font_config=fc)
+          HTML('zap-out/zap-summary.html').write_pdf(
+              'zap-out/zap-security-report.pdf', stylesheets=[css], font_config=fc)
+          print("PDF generated")
+          PY
+          ls -lh zap-out/zap-security-report.pdf
+
+      - name: Upload ZAP report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.names.outputs.artifact }}
+          path: |
+            zap-out/zap-security-report.pdf
+            zap-out/zap-summary.html
+            zap-out/*.html
+            zap-out/*.json
+            zap-out/*.md
+          retention-days: 90
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## OWASP ZAP Baseline Report ✅"
+            echo ""
+            echo "| Property | Value |"
+            echo "|---|---|"
+            echo "| Commit scanned | \`${{ steps.names.outputs.sha }}\` |"
+            echo "| Version label | ${{ steps.names.outputs.label }} |"
+            echo ""
+            echo "| Risk | Count |"
+            echo "|---|---:|"
+            echo "| High | ${{ steps.counts.outputs.high }} |"
+            echo "| Medium | ${{ steps.counts.outputs.medium }} |"
+            echo "| Low | ${{ steps.counts.outputs.low }} |"
+            echo "| Informational | ${{ steps.counts.outputs.info }} |"
+            echo ""
+            echo "Passive scan only — no attack payloads, unauthenticated. A clean result means"
+            echo "\"nothing found passively\", not \"tested and secure\". See the PDF for the full"
+            echo "limitations section."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.dev.yml logs backend frontend --tail=200 || true
+          docker logs zap-prod-frontend --tail=100 || true
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker rm -f zap-prod-frontend || true
+          docker compose -f docker-compose.dev.yml down -v || true


### PR DESCRIPTION
每次 production sync 自動產生**該版本 commit** 的 ZAP 與 CodeQL 報告，並把摘要留言到 production PR 上。

由 `security_reports` input 控制（預設開啟）。

## 三個檔案在做什麼

| 檔案 | 變更 |
|---|---|
| `.github/workflows/zap-report.yml` | **新增**：可重用的 ZAP baseline 掃描 + PDF |
| `.github/workflows/sarif-to-pdf.yml` | 加上 `workflow_call`，可指定 **SHA** 而非只有「最新」，並輸出統計數字 |
| `.github/workflows/mirror-to-production.yml` | 新 input、並行呼叫兩個掃描、把摘要留言到 production PR |

## ZAP 掃哪兩個目標，為什麼

- **正式環境組態的前端**（`frontend/Dockerfile` → `next start` on `:3100`）
  開發模式的 CSP 是為了 Turbopack HMR **刻意放寬**的（`unsafe-eval` / `unsafe-inline`），
  掃它只會產生**正式環境不可能出現**的 Medium 告警，反而誤導讀報告的人。
- **後端 API**（`:8000`）—— 跑在開發堆疊上，`DEBUG` 與正式環境不同，這點**寫在報告裡**而不是含糊帶過。

PDF 用 **weasyprint**，與 `sarif-to-pdf.yml` 既有的工具鏈相同（不需要瀏覽器）。
已用實際的 ZAP HTML 驗證過：12 頁、文字層完整。

## 幾個刻意的設計取捨

**掃描不阻擋發布。** 兩個掃描與 `sync-to-production` **並行**，且刻意**不被 `needs` 依賴**。
掃描要跑數十分鐘，拿它擋住 mirror 只會讓發布變慢而不會更安全 —— 這些報告是給人看的佐證，不是 merge gate。

**但失敗不會靜默。** `attach-security-reports` 用 `always()`，掃描失敗或被略過時會在留言中**明確標示**：

```
| OWASP ZAP (baseline) | ❌ 未產出（`failure`）| 請查看 workflow run |
| CodeQL               | ⏭️ 已略過 | 本次未執行 |
```

沉默會被讀成「掃過了而且沒問題」，那是唯一絕對不能不小心暗示的結論。

**CodeQL 對不上該 commit 時會警告。** 原本的 workflow 只會拿「最新一次成功的 run」。
用在 release 上，那等於可能把**別的程式碼**的報告貼到這個版本上 —— 比沒有報告更糟。
現在會先找該 SHA 的 run，找不到才退回最新一次，同時輸出 `sha_matched=false` 並在留言中標明：

```
> ⚠️ CodeQL 報告並非本 commit：找不到 `abc123` 的成功 CodeQL run，
> 報告內容對應的是 `999888`。合併前請確認差異。
```

**報告以 commit SHA 命名，不是版本號。** 版本號是在 `sync-to-production` 內部算出來的，
並行的掃描 job 拿不到。SHA 不會有歧義，版本號則出現在 PR 留言裡。
（若要讓檔名帶版本號，就得把版本計算拆成前置 job —— 那一步要 `git fetch prod-repo --tags` 與 GH_PAT，
牽動既有流程較多，這次沒動。）

## 兩件實測出來、而不是假設的事

**1. 只有拉丁字型時，中文報告會印出空白。**
weasyprint 在缺 CJK 字型時**仍然會產出 PDF、job 仍然是綠的**，但每個中文標題與整段「掃描限制」
在文字層裡完全不存在。實測：只裝 `fonts-dejavu-core` 時，
`正式環境組態` / `後端 API` / `掃描限制` **一個都取不出來**；裝上 `fonts-noto-cjk` 後全部正常。
已明確安裝該字型並把 Noto CJK 放在 font stack 最前面。

**2. 摘要產生器是用真實 ZAP JSON 跑過的**，不是紙上推導。
拿前一次掃描的報告當輸入，算出 High 0 / Medium 0 / Low 7 / Info 14 ——
與來源報告逐一相符（prod 前端 5 Low + 9 Info、後端 2 Low + 5 Info）。

## 報告會自己講清楚它不涵蓋什麼

ZAP baseline 是**被動**掃描：不送攻擊 payload、未認證，因此**不涵蓋 SQLi / XSS / 指令注入**，
也不涵蓋登入後的管理／學院／教授功能。PDF 內有完整的限制章節，並直接寫明：

> **「0 findings」代表「被動掃描未發現」，而不是「已完整測試且安全」。**

認證後的主動掃描見 `security/zap/`（需可拋棄的測試資料庫；隨 #1290 進入 main）。

## 不會污染 production repo

mirror 在安裝 production 模板前會**整個刪掉 `.github/workflows/`**，
所以 `zap-report.yml` 不會被同步過去（它依賴 `docker-compose.dev.yml`，而 production 拿不到那個檔案）。

## 測試計畫

- [x] `actionlint` 三個 workflow 皆乾淨（repo 內其餘既有告警與本 PR 無關）
- [x] YAML 可解析；兩個 workflow 的 inline Python 皆通過 `ast.parse`
- [x] reusable workflow 的 inputs／outputs 契約與呼叫端逐一對上
- [x] ZAP 摘要產生器對真實 ZAP JSON 實跑，數字與來源報告相符
- [x] PDF 實際產出並驗證文字層（含中文）：3 頁，`v1.2.3` / `e79d8f33` / 中文標題皆可取出
- [x] PR 留言腳本三種情境模擬：兩者成功、ZAP 失敗 + CodeQL SHA 不符、兩者略過
- [ ] **端對端實跑**：需要實際 dispatch 一次 mirror 才能驗證 runner 上的
      stack bringup、prod image build 與 artifact 上傳。建議先用
      `security_reports = false` 跑一次確認既有流程無回歸，再開啟跑一次完整的

## 給 reviewer 的注意事項

- 這會讓每次 sync 多花約 **20–35 分鐘**的 runner 時間（stack bringup + prod image build + 兩次 5 分鐘爬取）。
  因為是並行且不阻擋發布，mirror 本身的完成時間不受影響。`spider_minutes` 可調。
- `attach-security-reports` 用 `secrets.GH_PAT` 到 **production repo** 留言，
  需要該 token 具備 production repo 的 PR 留言權限（與既有建立 PR 的權限相同）。

Related: #1280, #1290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjWMHqES2xjo6WRAMraXKc
