### PR TITLE
feat(ci): 新增 security-report workflow — 報告直接發佈在 workflow run 上

### DIFF
--- a/.github/workflows/security-report.yml
+++ b/.github/workflows/security-report.yml
@@ -1,0 +1,267 @@
+name: "Security Report (ZAP + CodeQL)"
+
+# Produce the security report for a given version and publish it ON THIS
+# WORKFLOW RUN — artifacts to download plus a consolidated summary rendered on
+# the run page. Nothing is posted to a PR or an issue from here.
+#
+# Why this exists next to mirror-to-production.yml:
+#   The mirror generates the same two reports as a side effect of shipping, and
+#   comments them onto the production PR. That only helps if you happen to be
+#   releasing. This workflow lets you produce the report for ANY commit or tag,
+#   on demand or automatically when a release is published, and read it in one
+#   place without hunting through a release pipeline.
+#
+# It composes the two reusable workflows rather than re-implementing them, so
+# there is exactly one ZAP scan definition and one SARIF parser in the repo.
+# Reusable workflows execute as jobs of THIS run, so their artifacts land on
+# this run's page directly.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit SHA / branch / tag to report on (default: this branch)"
+        required: false
+        type: string
+      label:
+        description: "Version label for the report header, e.g. v1.2.3 (default: short SHA)"
+        required: false
+        type: string
+      reports:
+        description: "Which reports to generate"
+        required: false
+        type: choice
+        options:
+          - both
+          - zap-only
+          - codeql-only
+        default: both
+      spider_minutes:
+        description: "Minutes ZAP spends crawling each target"
+        required: false
+        type: string
+        default: "5"
+
+  release:
+    # Every published release gets a report without anyone remembering to ask.
+    types: [published]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+# Two of these at once would fight over the runner's :3000/:8000/:3100 ports
+# and produce two half-scanned reports. Queue them instead.
+concurrency:
+  group: security-report-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve target
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      ref: ${{ steps.target.outputs.ref }}
+      sha: ${{ steps.target.outputs.sha }}
+      label: ${{ steps.target.outputs.label }}
+      run_zap: ${{ steps.target.outputs.run_zap }}
+      run_codeql: ${{ steps.target.outputs.run_codeql }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          # A release event should report on the tag, not on the default branch.
+          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
+          fetch-depth: 0
+
+      - name: Determine ref, sha and label
+        id: target
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_LABEL: ${{ inputs.label }}
+          INPUT_REPORTS: ${{ inputs.reports }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          REF="${INPUT_REF:-${RELEASE_TAG:-${GITHUB_REF_NAME}}}"
+          SHA=$(git rev-parse HEAD)
+          SHORT_SHA=$(echo "$SHA" | cut -c1-8)
+
+          # Priority: explicit label > release tag > short sha.
+          LABEL="${INPUT_LABEL:-${RELEASE_TAG:-$SHORT_SHA}}"
+
+          # `reports` only exists on workflow_dispatch; a release run does both.
+          case "${INPUT_REPORTS:-both}" in
+            zap-only)    RUN_ZAP=true;  RUN_CODEQL=false ;;
+            codeql-only) RUN_ZAP=false; RUN_CODEQL=true  ;;
+            *)           RUN_ZAP=true;  RUN_CODEQL=true  ;;
+          esac
+
+          {
+            echo "ref=$REF"
+            echo "sha=$SHA"
+            echo "label=$LABEL"
+            echo "run_zap=$RUN_ZAP"
+            echo "run_codeql=$RUN_CODEQL"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::notice::Reporting on $LABEL ($SHA)"
+
+  zap:
+    name: ZAP baseline
+    needs: resolve
+    if: needs.resolve.outputs.run_zap == 'true'
+    uses: ./.github/workflows/zap-report.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      label: ${{ needs.resolve.outputs.label }}
+      spider_minutes: ${{ inputs.spider_minutes || '5' }}
+    permissions:
+      contents: read
+
+  codeql:
+    name: CodeQL PDF
+    needs: resolve
+    if: needs.resolve.outputs.run_codeql == 'true'
+    uses: ./.github/workflows/sarif-to-pdf.yml
+    with:
+      sha: ${{ needs.resolve.outputs.sha }}
+      label: ${{ needs.resolve.outputs.label }}
+    permissions:
+      actions: read
+      contents: read
+
+  publish:
+    name: Publish report to this run
+    runs-on: ubuntu-latest
+    needs: [resolve, zap, codeql]
+    # always(): a scan that failed or was skipped must still be stated on the
+    # run page. A missing section would read as "clean".
+    if: always() && needs.resolve.result == 'success'
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Download generated reports
+        uses: actions/download-artifact@v6
+        with:
+          # Both reusable workflows upload onto this same run, so their
+          # artifacts are already here — collect them into one directory to
+          # re-publish as a single bundle.
+          pattern: "*-security-report-*"
+          path: bundle
+          merge-multiple: false
+        continue-on-error: true
+
+      - name: Render run summary
+        env:
+          LABEL: ${{ needs.resolve.outputs.label }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+          REF: ${{ needs.resolve.outputs.ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ZAP_RESULT: ${{ needs.zap.result }}
+          ZAP_HIGH: ${{ needs.zap.outputs.high }}
+          ZAP_MEDIUM: ${{ needs.zap.outputs.medium }}
+          ZAP_LOW: ${{ needs.zap.outputs.low }}
+          ZAP_ARTIFACT: ${{ needs.zap.outputs.artifact }}
+
+          CODEQL_RESULT: ${{ needs.codeql.result }}
+          CODEQL_TOTAL: ${{ needs.codeql.outputs.total }}
+          CODEQL_CRITICAL: ${{ needs.codeql.outputs.critical }}
+          CODEQL_HIGH: ${{ needs.codeql.outputs.high }}
+          CODEQL_MEDIUM: ${{ needs.codeql.outputs.medium }}
+          CODEQL_ARTIFACT: ${{ needs.codeql.outputs.artifact }}
+          CODEQL_SHA_MATCHED: ${{ needs.codeql.outputs.sha_matched }}
+          CODEQL_RESOLVED_SHA: ${{ needs.codeql.outputs.resolved_sha }}
+        run: |
+          set -euo pipefail
+
+          status_cell() {  # $1 result
+            case "$1" in
+              success) echo "✅ 已產出" ;;
+              skipped) echo "⏭️ 未選擇" ;;
+              "")      echo "⏭️ 未執行" ;;
+              *)       echo "❌ 失敗（\`$1\`）" ;;
+            esac
+          }
+
+          {
+            echo "# 🔐 資安報告 — ${LABEL}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| 版本 | \`${LABEL}\` |"
+            echo "| 受測 commit | \`${SHA}\` |"
+            echo "| 來源 ref | \`${REF}\` |"
+            echo "| 產生時間 | $(date -u '+%Y-%m-%d %H:%M:%S UTC') |"
+            echo ""
+
+            echo "## 結果"
+            echo ""
+            echo "| 報告 | 狀態 | Critical | High | Medium | Low |"
+            echo "|---|---|---:|---:|---:|---:|"
+            echo "| OWASP ZAP (baseline) | $(status_cell "${ZAP_RESULT}") | – | ${ZAP_HIGH:-–} | ${ZAP_MEDIUM:-–} | ${ZAP_LOW:-–} |"
+            echo "| CodeQL | $(status_cell "${CODEQL_RESULT}") | ${CODEQL_CRITICAL:-–} | ${CODEQL_HIGH:-–} | ${CODEQL_MEDIUM:-–} | – |"
+            echo ""
+
+            if [ "${CODEQL_RESULT}" = "success" ]; then
+              echo "CodeQL findings 合計：**${CODEQL_TOTAL:-?}**"
+              echo ""
+            fi
+
+            if [ "${CODEQL_RESULT}" = "success" ] && [ "${CODEQL_SHA_MATCHED}" != "true" ]; then
+              echo "> ⚠️ **CodeQL 報告並非此 commit**：找不到 \`${SHA}\` 的成功 CodeQL run，"
+              echo "> 報告內容對應的是 \`${CODEQL_RESOLVED_SHA}\`。請勿直接當作本版本的佐證。"
+              echo ""
+            fi
+
+            if [ "${ZAP_RESULT}" != "success" ] && [ "${ZAP_RESULT}" != "skipped" ] && [ -n "${ZAP_RESULT}" ]; then
+              echo "> ❌ **ZAP 掃描失敗**，本次沒有 ZAP 報告。請查看 \`ZAP baseline\` job 的 log。"
+              echo ""
+            fi
+            if [ "${CODEQL_RESULT}" != "success" ] && [ "${CODEQL_RESULT}" != "skipped" ] && [ -n "${CODEQL_RESULT}" ]; then
+              echo "> ❌ **CodeQL 報告產生失敗**。請查看 \`CodeQL PDF\` job 的 log。"
+              echo ""
+            fi
+
+            echo "## 下載"
+            echo ""
+            echo "報告在**本次 workflow run 頁面下方的 Artifacts 區**（保留 90 天）："
+            echo ""
+            if [ "${ZAP_RESULT}" = "success" ]; then
+              echo "- \`${ZAP_ARTIFACT}\` — ZAP：PDF（繳交用）／HTML／JSON／MD"
+            fi
+            if [ "${CODEQL_RESULT}" = "success" ]; then
+              echo "- \`${CODEQL_ARTIFACT}\` — CodeQL：PDF"
+            fi
+            # Wording stays accurate when only one of the two ran.
+            echo "- \`security-report-${LABEL}\` — 以上已產出的報告打包在一起，一次下載"
+            echo ""
+            echo "[前往本次 run](${RUN_URL})"
+            echo ""
+
+            echo "## 判讀須知"
+            echo ""
+            echo "ZAP 為 **baseline（被動）** 掃描：**不送攻擊 payload、未認證**，"
+            echo "因此**不涵蓋** SQL Injection／XSS／指令注入，也不涵蓋登入後的管理、學院、教授功能。"
+            echo ""
+            echo "> **「0 findings」代表「被動掃描未發現」，不等於「已完整測試且安全」。**"
+            echo ""
+            echo "完整限制章節寫在 ZAP PDF 內。需要認證後的主動掃描（會送真實攻擊 payload，"
+            echo "必須在可拋棄的測試資料庫上執行）時，見 \`security/zap/\`。"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Bundle reports as a single artifact
+        # Convenience only: the individual artifacts above are the source of
+        # truth. Skipped when neither scan produced anything.
+        if: needs.zap.result == 'success' || needs.codeql.result == 'success'
+        uses: actions/upload-artifact@v6
+        with:
+          name: security-report-${{ needs.resolve.outputs.label }}
+          path: bundle
+          retention-days: 90
+          if-no-files-found: warn


### PR DESCRIPTION
新增 `.github/workflows/security-report.yml`：對**任意 commit 或 tag** 產生 ZAP + CodeQL 報告，
並把結果**發佈在該次 workflow run 上** —— run 頁面直接看得到摘要，Artifacts 區直接下載。
不會留言到任何 PR 或 issue。

> ⚠️ **這個 PR 疊在 #1298 之上**（base 是 `feat/release-security-reports`）。
> 它呼叫的兩個 reusable workflow（`zap-report.yml`、`sarif-to-pdf.yml` 的 `workflow_call`）
> 由 #1298 引入。**請先合併 #1298**，此 PR 的 base 會自動變成 `main`。

## 為什麼跟 mirror 分開

`mirror-to-production.yml`（#1298）是在**發版的過程中順帶**產生同樣兩份報告，並留言到 production PR。
那只有「剛好在發版」時才幫得上忙。

這個 workflow 讓你可以：

- 針對**任意 ref**（某個 commit、某個 tag、某個分支）產生報告
- **隨時手動**重跑，不必觸發整條發版流程
- 只跑其中一種（例如只要 CodeQL）
- 在**一個地方**把結果看完 —— 就是那次 run 的頁面

兩者共用同一組 reusable workflow，所以整個 repo 仍然只有**一份 ZAP 掃描定義**與**一份 SARIF parser**。

## 觸發方式

| 觸發 | 行為 |
|---|---|
| `workflow_dispatch` | 可指定 `ref`、版本 `label`、要跑哪些報告（both / zap-only / codeql-only）、ZAP 爬取分鐘數 |
| `release: published` | 每個 release 自動產生，不必有人記得去按。報告對象是**該 tag**，不是預設分支 |

## 報告放在哪

reusable workflow 是以**同一個 run 的 job** 執行，所以它們的 artifacts 直接落在這次 run 上：

- `zap-security-report-<label>` — PDF（繳交用）／HTML／JSON／MD
- `codeql-security-report-<label>` — PDF
- `security-report-<label>` — 上面已產出的打包成一份，一次下載

run 頁面的 summary 會長這樣：

```
# 🔐 資安報告 — v1.2.3

| 版本 | `v1.2.3` |
| 受測 commit | `e79d8f33aaaabbbb` |

## 結果
| 報告 | 狀態 | Critical | High | Medium | Low |
|---|---|---:|---:|---:|---:|
| OWASP ZAP (baseline) | ✅ 已產出 | – | 0 | 0 | 7 |
| CodeQL | ✅ 已產出 | 0 | 1 | 3 | – |
```

## 失敗不會被藏起來

摘要**如實呈現**每種結果，而不是省略：

| 情況 | 顯示 |
|---|---|
| 掃描失敗 | `❌ 失敗（failure）` + 指向該 job log 的提示 |
| 沒有選這項 | `⏭️ 未選擇` |
| CodeQL 對不上該 commit | ⚠️ 明確警告「請勿直接當作本版本的佐證」，並列出實際對應的 SHA |

少一個區塊會被讀成「掃過了而且沒問題」，那正是最不能不小心暗示的結論。

## 其他

- **`concurrency`**：兩次同時跑會搶 runner 上的 `:3000` / `:8000` / `:3100`，
  產生兩份各掃一半的報告。改成排隊而不是取消。
- **報告仍然自己講清楚限制**：ZAP baseline 是被動、未認證掃描，不涵蓋 SQLi／XSS／指令注入，
  也不涵蓋登入後功能。摘要與 PDF 都寫明「**0 findings 代表被動掃描未發現，不等於已完整測試且安全**」。

## 測試計畫

- [x] `actionlint` 乾淨
- [x] 傳給兩個 reusable workflow 的 inputs，逐一比對其 `workflow_call` 宣告 —— 無未知參數
- [x] 摘要讀取的每個 output，逐一比對其 `workflow_call` outputs —— 無缺漏
- [x] 摘要腳本實跑三種情境：兩者成功／ZAP 失敗 + CodeQL SHA 不符／只跑 CodeQL
- [ ] **端對端實跑**：需合併 #1298 後手動 dispatch 一次才能驗證
      runner 上的 stack bringup 與 artifact 上傳（與 #1298 相同的未驗證項）

## 給 reviewer

- 完整跑一次約 **20–35 分鐘**（stack bringup + production image build + 兩次 5 分鐘爬取）。
  `codeql-only` 只要幾分鐘。
- `release: published` 會讓每個 release 都吃到這段 runner 時間。若不想要，
  拿掉該 trigger 即可，`workflow_dispatch` 不受影響。

Related: #1280, #1290, #1298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjWMHqES2xjo6WRAMraXKc
