### PR TITLE
feat(prod-workflows): two-stage gated deploy (test → production)

### DIFF
--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -47,13 +47,23 @@ warning: here-document at line 10 delimited by end-of-file (wanted `FOOTER_EOF')
 | `bootstrap-ap-runner.sh` 🅾️ | **兩台空 VM 的步驟 0** — 把 bare AP VM 變成可跑 action 的 self-hosted runner | 在 AP VM 手動執行一次 | **必要(前置)** |
 | `setting-env.yml` | 在 AP VM 裝 Docker、SSH 到 DB VM 裝 Docker+傳 image、建部署目錄 | runner 就緒後手動觸發 | **必要** |
 | `auto-tag-on-merge.yml` ⭐ | 自動建立 Git tag 和 Release | PR merge 到 main | **必要** |
-| `deploy.yml` | 部署應用程式到 production | Push to main / 手動觸發 | **必要** |
+| `deploy.yml` | **兩階段部署編排**：先 test AP VM、通過後才 production AP VM，兩階段各需一位 reviewer 核准 | Push to main / 手動觸發 | **必要** |
+| `deploy-stack.yml` | `deploy.yml` 兩個階段共用的 reusable workflow（實際的部署腳本本體） | 由 `deploy.yml` 呼叫，不單獨觸發 | **必要**（與 deploy.yml 成對） |
 | `health-check.yml` | 監控應用程式健康狀態 | 每 15 分鐘 / 手動觸發 | 選用 |
 | `backup.yml` | 備份資料庫和檔案 | 每日 2AM UTC / 手動觸發 | 選用 |
 
 ### 🅾️ 步驟 0：bare VM 的 bootstrap（雞生蛋問題）
 
-所有 workflow 都 `runs-on: [self-hosted, linux]`。**空的 AP VM 上沒有 runner,任何 action 都跑不了** —— 必須先手動把 runner 裝起來。`bootstrap-ap-runner.sh` 就是這一步:裝 Docker + 把 GitHub Actions runner 註冊成 systemd service。
+所有 workflow 都跑在 self-hosted runner 上,而且是**兩台** AP VM:test 與 production。兩台都會註冊成 `[self-hosted, linux]`,因此**必須**再加上 stage label 才分得開:
+
+| VM | labels | 由誰使用 |
+|----|--------|----------|
+| test AP VM | `[self-hosted, linux, test]` | `deploy.yml` 的 test 階段、`setting-env.yml`(stage=test) |
+| production AP VM | `[self-hosted, linux, production]` | `deploy.yml` 的 production 階段、`backup.yml`、`health-check.yml`、`setting-env.yml`(stage=production) |
+
+**沒有 stage label 的 runner 收不到任何 job**(workflow 指定的是三個 label 的組合);label 貼錯則會把 production 的部署跑到 test VM 上。
+
+**空的 AP VM 上沒有 runner,任何 action 都跑不了** —— 必須先手動把 runner 裝起來。`bootstrap-ap-runner.sh` 就是這一步:裝 Docker + 把 GitHub Actions runner 註冊成 systemd service。**每台 VM 各跑一次,`--stage` 帶對應的值**。
 
 > 此 `.sh` **只存在於 dev repo 的本目錄**(mirror 只帶可執行的 `.yml` 過去,且空 VM 本來也收不到)。操作者直接從這裡複製到 AP VM 執行。
 
@@ -63,7 +73,10 @@ gh api -X POST repos/<OWNER>/<PROD_REPO>/actions/runners/registration-token --jq
 
 # 2) 把本目錄的 bootstrap-ap-runner.sh 複製到 AP VM,然後:
 chmod +x bootstrap-ap-runner.sh
-./bootstrap-ap-runner.sh --repo-url https://github.com/<OWNER>/<PROD_REPO> --token <TOKEN>
+# test AP VM:
+./bootstrap-ap-runner.sh --repo-url https://github.com/<OWNER>/<PROD_REPO> --token <TOKEN> --stage test
+# production AP VM(另外再取一次 token):
+./bootstrap-ap-runner.sh --repo-url https://github.com/<OWNER>/<PROD_REPO> --token <TOKEN> --stage production
 ```
 
 腳本特性:`set -euo pipefail` + ERR trap(失敗會印出**確切失敗行號與指令**)、全程輸出同時寫入 `/tmp/bootstrap-ap-runner-*.log`、可重複執行(idempotent)。跑完 AP VM 就能跑 action;DB VM **不需要** runner(`setting-env.yml` 透過 SSH 操作它)。
@@ -133,8 +146,13 @@ cd scholarship-production
 mkdir -p .github/workflows
 
 # Copy optional workflows
+# deploy.yml 與 deploy-stack.yml 必須成對複製 —— deploy.yml 用
+# `uses: ./.github/workflows/deploy-stack.yml` 呼叫後者，少一個就無法解析。
 cp /path/to/development-repo/.github/production-workflows-examples/deploy.yml \
    .github/workflows/deploy.yml
+
+cp /path/to/development-repo/.github/production-workflows-examples/deploy-stack.yml \
+   .github/workflows/deploy-stack.yml
 
 cp /path/to/development-repo/.github/production-workflows-examples/health-check.yml \
    .github/workflows/health-check.yml
@@ -148,16 +166,38 @@ cp /path/to/development-repo/.github/production-workflows-examples/backup.yml \
 在 production repository 設定以下 secrets（Settings → Secrets and variables → Actions）：
 
 > 沒有任何 workflow 使用 SSH。deploy.yml / backup.yml / health-check.yml 都跑在
-> production AP VM 上的 self-hosted runner（labels `[self-hosted, linux]`），
+> AP VM 上的 self-hosted runner（labels `[self-hosted, linux, <stage>]`），
 > 直接操作本機 docker 與 DB VM 的 5432 埠。GitHub-hosted runner 連不到校內 VM。
+>
+> ⚠️ **test 與 production 用的是不同的 env variable / secret**。作法是把值放進
+> GitHub **Environments**（`test` 與 `production`），而不是全部放在 repository 層。
+> Repository 層的 secret 是 **production 的值**（backup.yml / health-check.yml 這類
+> 排程 workflow 沒有 `environment:`，仍從這裡取值）；`test` environment 則把每一個
+> 值覆寫成測試環境的。**沒有被 test environment 覆寫的 secret 會自動 fallback 到
+> repository 層 = production 的值**，所以 `test` environment 必須把下表的 secret
+> 全部各自設一份。deploy-stack.yml 的 "Assert stage identity" 步驟就是用來擋這個
+> 漏設的（詳見 SECRETS-SETUP-GUIDE.md § Environments）。
 
 #### Repository Variables（Settings → Variables → Actions）
 
 | Variable | 必填 | 說明 |
 |----------|------|------|
-| `IMAGE_OWNER` | ✅ | 發布映像檔的 GHCR namespace，也就是**開發 repo 的 owner**（例：`anud18`）。production repo 不建置映像檔，只取用開發流程已經發布、staging 驗過的那一份。 |
-| `PRODUCTION_URL` | ✅ | 例：`https://ss.aa.nycu.edu.tw` |
-| `ENV_FILE` | — | AP VM 上既有 `.env` 的絕對路徑（安裝手冊 5.1，例：`/home/<user>/.env`）。**設了就用它**，GitHub 完全不存這些值。留空則由 deploy.yml 依下方 secrets 產生 `~/scholarship-production/.env`（權限 600）。 |
+| `IMAGE_OWNER` | ✅ | 發布映像檔的 GHCR namespace，也就是**開發 repo 的 owner**（例：`anud18`）。production repo 不建置映像檔，只取用開發流程已經發布、staging 驗過的那一份。兩個 stage 共用。 |
+
+#### Environment Variables（Settings → Environments → `test` / `production` → Variables）
+
+以下每一項都要在 **兩個 environment 各設一份**（值不同）：
+
+| Variable | 必填 | `test` 範例 | `production` 範例 |
+|----------|------|-------------|-------------------|
+| `DEPLOY_STAGE` | ✅ | `test` | `production` | 
+| `EXPECT_DOMAIN` | test 必填 | `ss-test.aa.nycu.edu.tw` | `ss.aa.nycu.edu.tw` |
+| `EXPECT_DB_HOST` | test 必填 | test DB VM 的位址 | production DB VM 的位址 |
+| `DEPLOY_URL` | ✅ | `https://ss-test.aa.nycu.edu.tw` | `https://ss.aa.nycu.edu.tw` |
+| `SSL_CERT_DIR` | — | 該台 VM 上憑證目錄的絕對路徑 | 同左 |
+| `ENV_FILE` | — | 該台 VM 上既有 `.env` 的絕對路徑（安裝手冊 5.1）。**設了就用它**，GitHub 完全不存這些值。留空則由 deploy-stack.yml 依下方 secrets 產生 `~/scholarship-<stage>/.env`（權限 600）。 | 同左 |
+
+`DEPLOY_STAGE` / `EXPECT_DOMAIN` / `EXPECT_DB_HOST` 是防呆用的：deploy 一開始就會比對「這個 environment 宣告自己是哪個 stage」與「secret 解析出來的 DOMAIN / DB_HOST」，對不上就直接失敗，避免 test 部署因為漏設 secret 而打到 production 的資料庫。
 | `SSL_CERT_DIR` | — | TLS 憑證資料夾的絕對路徑（例：`/home/<user>/ssl`）。留空則用 repo `nginx/ssl/prod`。兩種 `ENV_FILE` 模式下都以這個變數優先。資料夾內需有 `fullchain.pem`、`privkey.pem`、`chain.pem`。 |
 
 #### 部署相關 (deploy.yml)
@@ -253,8 +293,8 @@ CUTOFF_DATE=$(date -d '90 days ago' +%Y%m%d)  # 改為 90 天
 ### Self-hosted Runner
 
 部署與維運 workflow 都跑在 AP VM 上的 self-hosted runner，不使用 SSH 金鑰。
-安裝方式見安裝手冊第 6 節；註冊時 labels 需包含 `self-hosted` 與 `linux`，
-並以 service 方式常駐：
+安裝方式見安裝手冊第 6 節；註冊時 labels 需包含 `self-hosted`、`linux`，
+**以及該台 VM 的 stage label（`test` 或 `production`）**，並以 service 方式常駐：
 
 ```bash
 sudo ./svc.sh install
@@ -299,12 +339,16 @@ runner 使用者需要 passwordless sudo（deploy.yml 與 backup.yml 都會用�
 
 ### Deploy Workflow
 
-- [ ] Docker Hub 憑證已設定
-- [ ] SSH key 已添加到 production server
-- [ ] Server 有足夠的磁碟空間
-- [ ] Docker Compose 檔案正確配置
-- [ ] 測試 SSH 連線成功
-- [ ] 煙霧測試 URL 正確
+- [ ] `deploy.yml` 與 `deploy-stack.yml` 都已複製到 prod repo
+- [ ] test AP VM 的 runner labels 含 `test`；production AP VM 含 `production`
+- [ ] GitHub Environments `test` 與 `production` 都已建立
+- [ ] 兩個 environment 都設了 **Required reviewers（1 人）**
+- [ ] `test` environment 已把所有 secret 各設一份（沒設的會 fallback 到 production 的值）
+- [ ] 兩個 environment 的 `DEPLOY_STAGE` / `EXPECT_DOMAIN` / `EXPECT_DB_HOST` 已設定
+- [ ] `SECRET_KEY`、`PII_ENCRYPTION_KEYS` 兩邊不同
+- [ ] Repository variable `IMAGE_OWNER` 已設定
+- [ ] 兩台 VM 都有 TLS 憑證（`fullchain.pem` / `privkey.pem` / `chain.pem`）
+- [ ] 兩台 VM 都有足夠的磁碟空間，且 runner 使用者有 passwordless sudo
 
 ### Health Check Workflow
 
@@ -326,15 +370,19 @@ runner 使用者需要 passwordless sudo（deploy.yml 與 backup.yml 都會用�
 ### 手動測試部署
 
 ```bash
-# In production repo
-gh workflow run deploy.yml
+# In production repo；建議帶明確 tag，兩個 stage 才會部署到同一份 image
+gh workflow run deploy.yml -f tag=v1.2.3
 
-# Monitor progress
+# Monitor progress（會先停在 test 階段等核准）
 gh run watch
 
 # Check logs
 gh run view --log
 ```
+
+run 會停兩次：先是 `test` 環境的 "Review deployments"，reviewer 按下
+**Approve and deploy** 後才跑 test AP VM；test 全綠後再停一次等 `production`
+的核准。任一階段被拒絕（Reject），後面的階段就不會執行。
 
 ### 測試健康檢查
 

--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -47,7 +47,7 @@ warning: here-document at line 10 delimited by end-of-file (wanted `FOOTER_EOF')
 | `bootstrap-ap-runner.sh` 🅾️ | **兩台空 VM 的步驟 0** — 把 bare AP VM 變成可跑 action 的 self-hosted runner | 在 AP VM 手動執行一次 | **必要(前置)** |
 | `setting-env.yml` | 在 AP VM 裝 Docker、SSH 到 DB VM 裝 Docker+傳 image、建部署目錄 | runner 就緒後手動觸發 | **必要** |
 | `auto-tag-on-merge.yml` ⭐ | 自動建立 Git tag 和 Release | PR merge 到 main | **必要** |
-| `deploy.yml` | **兩階段部署編排**：先 test AP VM、通過後才 production AP VM，兩階段各需一位 reviewer 核准 | Push to main / 手動觸發 | **必要** |
+| `deploy.yml` | **兩階段部署編排**：一律先 test AP VM 再 production AP VM，兩階段各需一位 reviewer 核准（test 失敗不否決 production，由 reviewer 判斷） | Push to main / 手動觸發 | **必要** |
 | `deploy-stack.yml` | `deploy.yml` 兩個階段共用的 reusable workflow（實際的部署腳本本體） | 由 `deploy.yml` 呼叫，不單獨觸發 | **必要**（與 deploy.yml 成對） |
 | `health-check.yml` | 監控應用程式健康狀態 | 每 15 分鐘 / 手動觸發 | 選用 |
 | `backup.yml` | 備份資料庫和檔案 | 每日 2AM UTC / 手動觸發 | 選用 |
@@ -191,9 +191,9 @@ cp /path/to/development-repo/.github/production-workflows-examples/backup.yml \
 | Variable | 必填 | `test` 範例 | `production` 範例 |
 |----------|------|-------------|-------------------|
 | `DEPLOY_STAGE` | ✅ | `test` | `production` | 
-| `EXPECT_DOMAIN` | test 必填 | `ss-test.aa.nycu.edu.tw` | `ss.aa.nycu.edu.tw` |
+| `EXPECT_DOMAIN` | test 必填 | 測試站網域 | 正式站網域 |
 | `EXPECT_DB_HOST` | test 必填 | test DB VM 的位址 | production DB VM 的位址 |
-| `DEPLOY_URL` | ✅ | `https://ss-test.aa.nycu.edu.tw` | `https://ss.aa.nycu.edu.tw` |
+| `DEPLOY_URL` | ✅ | `https://<測試站網域>` | `https://<正式站網域>` |
 | `SSL_CERT_DIR` | — | 該台 VM 上憑證目錄的絕對路徑 | 同左 |
 | `ENV_FILE` | — | 該台 VM 上既有 `.env` 的絕對路徑（安裝手冊 5.1）。**設了就用它**，GitHub 完全不存這些值。留空則由 deploy-stack.yml 依下方 secrets 產生 `~/scholarship-<stage>/.env`（權限 600）。 | 同左 |
 
@@ -210,17 +210,17 @@ deploy 時會直接驗證該檔案（缺 key、`portal.test`、`ss-test`、`測�
 
 | Secret Name | Description | Example |
 |-------------|-------------|---------|
-| `DOMAIN` | 對外網域 | `ss.aa.nycu.edu.tw` |
+| `DOMAIN` | 對外網域 | `<正式站網域>` |
 | `SECRET_KEY` | JWT signing key（≥ 32 字元，且必須與 staging 不同） | `openssl rand -hex 32` |
-| `CORS_ORIGINS` | 允許的前端來源 | `https://ss.aa.nycu.edu.tw` |
+| `CORS_ORIGINS` | 允許的前端來源 | `https://<正式站網域>` |
 | `DB_HOST` / `DB_PORT` / `DB_USER` / `DB_PASSWORD` / `DB_NAME` | DB VM 的 PostgreSQL 連線資訊 | `10.x.x.x` / `5432` / … |
 | `REDIS_PASSWORD` | Redis 密碼（prod compose 強制要求） | `openssl rand -base64 24` |
 | `MINIO_HOST` / `MINIO_PORT` / `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` / `MINIO_BUCKET_NAME` / `MINIO_SECURE` | 物件儲存 | `10.x.x.x` / `9000` / … |
 | `PII_ENCRYPTION_KEYS` / `PII_ENCRYPTION_ACTIVE_VERSION` | PII 加密金鑰 JSON | `{"v1":"<key>"}` / `v1` |
-| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASSWORD` | 寄信設定 | `smtp-prod2.nycu.edu.tw` / `587` |
-| `EMAIL_FROM` / `EMAIL_FROM_NAME` | 寄件者（不可含 `ss-test` 或 `測試`） | `noreply@aa.nycu.edu.tw` |
-| `PORTAL_JWT_SERVER_URL` | Portal SSO（不可指向 `portal.test`） | `https://portal.nycu.edu.tw/jwt/portal` |
-| `NEXT_PUBLIC_NYCU_PORTAL_URL` | 前端 Portal 連結 | `https://portal.nycu.edu.tw` |
+| `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASSWORD` | 寄信設定 | `smtp.<校內網域>` / `587` |
+| `EMAIL_FROM` / `EMAIL_FROM_NAME` | 寄件者（不可含 `FORBIDDEN_MARKERS` 列出的字串） | `noreply@<校內網域>` |
+| `PORTAL_JWT_SERVER_URL` | Portal SSO（不可含 `FORBIDDEN_MARKERS` 列出的字串） | `https://portal.<校內網域>/jwt/portal` |
+| `NEXT_PUBLIC_NYCU_PORTAL_URL` | 前端 Portal 連結 | `https://portal.<校內網域>` |
 | `STUDENT_API_BASE_URL` | 學籍 API（不可是 localhost/mock） | `http://<ip>/api/SoAA` |
 | `SUPER_ADMIN_NYCU_ID` | 可升級為 super_admin 的職編 | `E00001` |
 
@@ -381,8 +381,10 @@ gh run view --log
 ```
 
 run 會停兩次：先是 `test` 環境的 "Review deployments"，reviewer 按下
-**Approve and deploy** 後才跑 test AP VM；test 全綠後再停一次等 `production`
-的核准。任一階段被拒絕（Reject），後面的階段就不會執行。
+**Approve and deploy** 後才跑 test AP VM；test 跑完再停一次等 `production` 的核准。
+
+test **失敗**時 production 仍然會要求核准 —— reviewer 看得到 test 的失敗結果，
+再決定放行或 Reject。要停下整條 promotion 就按 Reject。
 
 ### 測試健康檢查
 

--- a/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
+++ b/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
@@ -15,6 +15,7 @@ The `setting-env.yml` workflow now **focuses on system prerequisites and Docker 
 
 ## 📋 Table of Contents
 
+- [Environments：兩階段部署與核准閘門](#environments兩階段部署與核准閘門) ⭐ **先讀這個**
 - [Quick Start](#quick-start)
 - [Required Secrets](#required-secrets)
   - [Database VM SSH Access](#database-vm-ssh-access-secrets) ⭐ **Required for Docker setup**
@@ -29,6 +30,117 @@ The `setting-env.yml` workflow now **focuses on system prerequisites and Docker 
 - [Security Best Practices](#security-best-practices)
 - [Validation](#validating-secrets)
 - [Troubleshooting](#troubleshooting)
+
+---
+
+## Environments：兩階段部署與核准閘門
+
+`deploy.yml` 不再直接部署 production。它是一條**兩階段的 promotion pipeline**：
+
+```
+resolve-images ──▶ deploy-test ────────▶ deploy-production
+ (ubuntu-latest)   runner: [self-hosted,   runner: [self-hosted,
+                            linux, test]            linux, production]
+                   environment: test      environment: production
+                   🔒 需 1 位 reviewer 核准  🔒 需 1 位 reviewer 核准
+```
+
+- 同一個 GHCR image 先上 **test AP VM**，跑完 migration + health + smoke 全綠，
+  才輪到 **production AP VM**；`needs: deploy-test` 讓這個順序是結構性的，
+  test 失敗或被拒絕，production 那個 job 根本不會開始。
+- 兩階段共用同一份腳本（`deploy-stack.yml`），差別只有 **runner label** 與
+  **GitHub Environment**。test 因此是 production 的彩排，不是另一套流程。
+
+### 1. 建立兩個 Environment 並設定 reviewer（核准閘門）
+
+**這一步是 YAML 做不到的**：`environment:` 這個 key 本身不會擋任何東西，
+真正的核准規則在 repo 設定裡。沒設 reviewer 的話，兩個階段都會無人值守直接跑完。
+
+Settings → Environments → New environment，建立 `test` 與 `production`，各自：
+
+1. 勾選 **Required reviewers**，加入 **1 位** 有權限的成員（需求：一名 user 同意）。
+2. （建議）**Deployment branches**：限制成 `main`。
+3. （建議）取消勾選 "Allow administrators to bypass configured protection rules"，
+   否則 admin 可以略過核准。
+
+或用 CLI：
+
+```bash
+# <OWNER>/<PROD_REPO> 換成 production repo；<REVIEWER_USER_ID> 是數字 user id
+# （取得方式：gh api users/<LOGIN> --jq .id）
+for ENV in test production; do
+  gh api -X PUT "repos/<OWNER>/<PROD_REPO>/environments/$ENV" \
+    -F "wait_timer=0" \
+    -F "reviewers[][type]=User" -F "reviewers[][id]=<REVIEWER_USER_ID>" \
+    -F "deployment_branch_policy[protected_branches]=true" \
+    -F "deployment_branch_policy[custom_branch_policies]=false"
+done
+```
+
+核准流程：run 開始後停在 "Review deployments"，指定的 reviewer 在 Actions 頁面
+按 **Approve and deploy** 才會繼續。test 核准 → 跑完 → production 再要一次核准。
+
+`setting-env.yml` 也掛了同樣的 environment（它會改機器、寫 `.env`），
+所以它也要先被核准；`backup.yml` / `health-check.yml` 是排程執行、只讀或只寫備份，
+**刻意不掛** environment —— 掛了會卡在等人核准，排程等於失效。
+
+### 2. test 與 production 用不同的 env variable
+
+值放在 **Environment secrets / variables**，不是 repository 層：
+
+| 放在哪 | 內容 | 誰讀得到 |
+|--------|------|----------|
+| Repository secrets | **production 的值** | 所有 workflow（含沒掛 environment 的 `backup.yml`、`health-check.yml`） |
+| Environment `production` | 可留空，fallback 到 repository 層 | `deploy.yml` 的 production 階段、`setting-env.yml`(production) |
+| Environment `test` | **測試環境的值，下面清單要全部各設一份** | `deploy.yml` 的 test 階段、`setting-env.yml`(test) |
+
+> ⚠️ **fallback 陷阱**：environment 沒定義的 secret 會自動往上抓 repository 層的值。
+> 也就是說 `test` environment 少設一個 `DB_HOST`，test 部署就會連上 **production 的
+> 資料庫**，而且不會有任何錯誤訊息。
+
+`test` environment 必須各自設定的 secret（值與 production 不同）：
+
+```
+DOMAIN  SECRET_KEY  CORS_ORIGINS
+DB_HOST  DB_PORT  DB_USER  DB_PASSWORD  DB_NAME
+REDIS_PASSWORD
+MINIO_HOST  MINIO_PORT  MINIO_ACCESS_KEY  MINIO_SECRET_KEY  MINIO_BUCKET_NAME  MINIO_SECURE
+PII_ENCRYPTION_KEYS  PII_ENCRYPTION_ACTIVE_VERSION
+SMTP_HOST  SMTP_PORT  SMTP_USER  SMTP_PASSWORD  EMAIL_FROM  EMAIL_FROM_NAME
+PORTAL_JWT_SERVER_URL  STUDENT_API_BASE_URL  NEXT_PUBLIC_NYCU_PORTAL_URL
+SUPER_ADMIN_NYCU_ID
+```
+
+`SECRET_KEY` 與 `PII_ENCRYPTION_KEYS` **絕對不要兩邊共用**：共用的 `SECRET_KEY`
+等於 test 簽出來的 token 可以拿去打 production；共用的 PII 金鑰則讓測試資料庫
+的備份足以解開正式個資。
+
+環境變數（Variables，不是 secret）：
+
+| Variable | `test` | `production` | 作用 |
+|----------|--------|--------------|------|
+| `DEPLOY_STAGE` | `test` | `production` | 防呆：environment 自報身分，對不上就拒絕部署 |
+| `EXPECT_DOMAIN` | 測試網域 | 正式網域 | 防呆：比對 `secrets.DOMAIN`，抓漏設的 fallback |
+| `EXPECT_DB_HOST` | 測試 DB 位址 | 正式 DB 位址 | 防呆：比對 `secrets.DB_HOST` |
+| `DEPLOY_URL` | `https://ss-test.aa.nycu.edu.tw` | `https://ss.aa.nycu.edu.tw` | Environment 頁面顯示的連結 |
+| `SSL_CERT_DIR` | 選填 | 選填 | 該台 VM 上的憑證目錄 |
+| `ENV_FILE` | 選填 | 選填 | 該台 VM 上 operator 自管的 `.env` 路徑 |
+
+`DEPLOY_STAGE` / `EXPECT_DOMAIN` / `EXPECT_DB_HOST` 在 test 是**必填**：
+deploy 的第一個步驟（Assert stage identity，跑在 checkout 之前）會比對它們，
+一旦 `test` environment 漏設 secret 而 fallback 到 production 的值，這一步就會
+直接失敗，還沒碰到任何 container。
+
+### 3. 兩台 runner 的 label
+
+| VM | labels | bootstrap 指令 |
+|----|--------|----------------|
+| test AP VM | `self-hosted,linux,test` | `./bootstrap-ap-runner.sh --repo-url … --token … --stage test` |
+| production AP VM | `self-hosted,linux,production` | `./bootstrap-ap-runner.sh --repo-url … --token … --stage production` |
+
+兩台都會有 `self-hosted` 與 `linux`，**stage label 是唯一能分辨的依據**。
+`bootstrap-ap-runner.sh --stage` 是必填參數，且會擋掉「`--labels` 沒有含 stage label」
+這種註冊完卻永遠收不到 job 的情況。
 
 ---
 

--- a/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
+++ b/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
@@ -45,9 +45,12 @@ resolve-images ──▶ deploy-test ────────▶ deploy-producti
                    🔒 需 1 位 reviewer 核准  🔒 需 1 位 reviewer 核准
 ```
 
-- 同一個 GHCR image 先上 **test AP VM**，跑完 migration + health + smoke 全綠，
-  才輪到 **production AP VM**；`needs: deploy-test` 讓這個順序是結構性的，
-  test 失敗或被拒絕，production 那個 job 根本不會開始。
+- 同一個 GHCR image 一律先上 **test AP VM**，跑完 migration + health + smoke，
+  才輪到 **production AP VM**。順序是結構性的（`needs: deploy-test`）。
+- **但 test 失敗不會否決 production**：production 段仍然會跳出自己的核准要求，
+  reviewer 看著 test 的結果自行判斷要不要放行。test tier 有它自己會壞的理由
+  （它的 DB、憑證、portal），那些不該卡住 production 的 hotfix。真正會否決的只有
+  `resolve-images` —— 沒解析出 tag 就沒東西可部署。
 - 兩階段共用同一份腳本（`deploy-stack.yml`），差別只有 **runner label** 與
   **GitHub Environment**。test 因此是 production 的彩排，不是另一套流程。
 
@@ -122,9 +125,13 @@ SUPER_ADMIN_NYCU_ID
 | `DEPLOY_STAGE` | `test` | `production` | 防呆：environment 自報身分，對不上就拒絕部署 |
 | `EXPECT_DOMAIN` | 測試網域 | 正式網域 | 防呆：比對 `secrets.DOMAIN`，抓漏設的 fallback |
 | `EXPECT_DB_HOST` | 測試 DB 位址 | 正式 DB 位址 | 防呆：比對 `secrets.DB_HOST` |
-| `DEPLOY_URL` | `https://ss-test.aa.nycu.edu.tw` | `https://ss.aa.nycu.edu.tw` | Environment 頁面顯示的連結 |
+| `DEPLOY_URL` | `https://<測試站網域>` | `https://<正式站網域>` | Environment 頁面顯示的連結 |
 | `SSL_CERT_DIR` | 選填 | 選填 | 該台 VM 上的憑證目錄 |
 | `ENV_FILE` | 選填 | 選填 | 該台 VM 上 operator 自管的 `.env` 路徑 |
+| `FORBIDDEN_MARKERS` | 選填（設在 repository 層即可） | 同左 | 空白分隔的字串清單，只會出現在非正式值裡（測試網域、測試寄件者……）。production 段只要有任一 secret 命中就拒絕部署；不設就跳過這項檢查 |
+
+`FORBIDDEN_MARKERS` 取代了以前寫死在 workflow 裡的站台字串（測試網域、`測試` 寄件者
+名稱等）—— 這份模板會被 mirror 進 production repo，不該帶著站台自己的主機名。
 
 `DEPLOY_STAGE` / `EXPECT_DOMAIN` / `EXPECT_DB_HOST` 在 test 是**必填**：
 deploy 的第一個步驟（Assert stage identity，跑在 checkout 之前）會比對它們，
@@ -175,7 +182,7 @@ These secrets configure the connection from AP VM to the PostgreSQL database on 
 
 | Secret Name | Description | Example Value | Required |
 |-------------|-------------|---------------|----------|
-| `DB_HOST` | Database VM hostname or IP address | `10.0.1.100` or `db.internal.nycu.edu.tw` | ✅ Yes |
+| `DB_HOST` | Database VM hostname or IP address | `10.x.x.x` or `db.internal.<your-domain>` | ✅ Yes |
 | `DB_PORT` | PostgreSQL port | `5432` | ⚠️ Optional (default: 5432) |
 | `DB_USER` | PostgreSQL username | `scholarship_user` or `scholar` | ✅ Yes |
 | `DB_PASSWORD` | PostgreSQL password | `SecureP@ssw0rd123456` | ✅ Yes |
@@ -379,7 +386,7 @@ These secrets configure the connection from AP VM to MinIO object storage on DB 
 
 | Secret Name | Description | Example Value | Required |
 |-------------|-------------|---------------|----------|
-| `MINIO_HOST` | MinIO VM hostname or IP | `10.0.1.100` or `minio.internal.nycu.edu.tw` | ✅ Yes |
+| `MINIO_HOST` | MinIO VM hostname or IP | `10.x.x.x` or `minio.internal.<your-domain>` | ✅ Yes |
 | `MINIO_PORT` | MinIO API port | `9000` | ⚠️ Optional (default: 9000) |
 | `MINIO_ROOT_USER` | MinIO admin username | `minioadmin` | ✅ Yes |
 | `MINIO_ROOT_PASSWORD` | MinIO admin password | `MinIO@Secure2024!` | ✅ Yes |
@@ -474,11 +481,11 @@ These secrets configure SMTP for sending system emails (notifications, password 
 
 | Secret Name | Description | Example Value | Required |
 |-------------|-------------|---------------|----------|
-| `SMTP_HOST` | SMTP server hostname | `smtp.nycu.edu.tw` or `smtp.gmail.com` | ✅ Yes |
+| `SMTP_HOST` | SMTP server hostname | `smtp.<your-domain>` or `smtp.gmail.com` | ✅ Yes |
 | `SMTP_PORT` | SMTP server port | `587` (TLS) or `465` (SSL) | ⚠️ Optional (default: 587) |
-| `SMTP_USER` | SMTP authentication username | `scholarship@nycu.edu.tw` | ✅ Yes |
+| `SMTP_USER` | SMTP authentication username | `scholarship@<your-domain>` | ✅ Yes |
 | `SMTP_PASSWORD` | SMTP authentication password | `EmailP@ss2024!` | ✅ Yes |
-| `EMAIL_FROM` | "From" email address | `scholarship@nycu.edu.tw` | ✅ Yes |
+| `EMAIL_FROM` | "From" email address | `scholarship@<your-domain>` | ✅ Yes |
 | `EMAIL_FROM_NAME` | "From" display name | `NYCU Scholarship System` | ⚠️ Optional |
 
 **Common SMTP Providers:**
@@ -487,7 +494,7 @@ These secrets configure SMTP for sending system emails (notifications, password 
 |----------|-----------|-----------|-------|
 | Gmail | `smtp.gmail.com` | `587` | Requires App Password (not account password) |
 | Office 365 | `smtp.office365.com` | `587` | - |
-| NYCU Mail | `smtp.nycu.edu.tw` | `587` | Contact IT for credentials |
+| 校內 Mail | `smtp.<your-domain>` | `587` | Contact IT for credentials |
 
 **For Gmail:**
 1. Enable 2-Factor Authentication on your Google account
@@ -497,7 +504,7 @@ These secrets configure SMTP for sending system emails (notifications, password 
 **Testing SMTP:**
 ```bash
 # Test SMTP connection with openssl
-openssl s_client -starttls smtp -connect smtp.nycu.edu.tw:587
+openssl s_client -starttls smtp -connect smtp.<your-domain>:587
 ```
 
 ---
@@ -510,7 +517,7 @@ These secrets configure Portal SSO integration for user authentication.
 
 | Secret Name | Description | Example Value | Required |
 |-------------|-------------|---------------|----------|
-| `PORTAL_JWT_SERVER_URL` | Portal SSO JWT verification endpoint | `https://portal.nycu.edu.tw/api/auth` | ✅ Yes |
+| `PORTAL_JWT_SERVER_URL` | Portal SSO JWT verification endpoint | `https://portal.<your-domain>/api/auth` | ✅ Yes |
 
 **How to obtain:**
 - Contact NYCU IT Services for Portal SSO endpoint URL
@@ -531,7 +538,7 @@ These secrets configure integration with NYCU Student Information System (SIS) A
 
 | Secret Name | Description | Example Value | Required |
 |-------------|-------------|---------------|----------|
-| `STUDENT_API_BASE_URL` | Student API base URL | `https://api.sis.nycu.edu.tw` | ✅ Yes |
+| `STUDENT_API_BASE_URL` | Student API base URL | `https://api.sis.<your-domain>` | ✅ Yes |
 
 > The student API no longer requires authentication; `STUDENT_API_ACCOUNT` and `STUDENT_API_HMAC_KEY` are no longer used.
 
@@ -560,8 +567,8 @@ These secrets configure general application settings.
 
 | Secret Name | Description | Example Value | Required |
 |-------------|-------------|---------------|----------|
-| `DOMAIN` | Production domain name | `ss.aa.nycu.edu.tw` | ✅ Yes |
-| `CORS_ORIGINS` | Allowed CORS origins (comma-separated) | `https://ss.aa.nycu.edu.tw` | ✅ Yes |
+| `DOMAIN` | Production domain name | `<your-production-domain>` | ✅ Yes |
+| `CORS_ORIGINS` | Allowed CORS origins (comma-separated) | `https://<production-domain>` | ✅ Yes |
 
 **DOMAIN:**
 - Must match DNS A record pointing to AP VM
@@ -573,7 +580,7 @@ These secrets configure general application settings.
 **CORS_ORIGINS:**
 - List of allowed origins for Cross-Origin Resource Sharing
 - Format: Comma-separated URLs (no trailing slash)
-- Example: `https://ss.aa.nycu.edu.tw,https://scholarship.nycu.edu.tw`
+- Example: `https://<production-domain>,https://<alt-domain>`
 - ⚠️ In production, never use `*` (allow all origins)
 
 ---
@@ -638,22 +645,22 @@ gh secret set SECRET_KEY  # Will prompt
 gh secret set REDIS_PASSWORD  # Will prompt
 
 # Email secrets
-gh secret set SMTP_HOST -b "smtp.nycu.edu.tw"
+gh secret set SMTP_HOST -b "smtp.<your-domain>"
 gh secret set SMTP_PORT -b "587"
-gh secret set SMTP_USER -b "scholarship@nycu.edu.tw"
+gh secret set SMTP_USER -b "scholarship@<your-domain>"
 gh secret set SMTP_PASSWORD  # Will prompt
-gh secret set EMAIL_FROM -b "scholarship@nycu.edu.tw"
+gh secret set EMAIL_FROM -b "scholarship@<your-domain>"
 gh secret set EMAIL_FROM_NAME -b "NYCU Scholarship System"
 
 # SSO secrets
-gh secret set PORTAL_JWT_SERVER_URL -b "https://portal.nycu.edu.tw/api/auth"
+gh secret set PORTAL_JWT_SERVER_URL -b "https://portal.<your-domain>/api/auth"
 
 # Student API secrets
-gh secret set STUDENT_API_BASE_URL -b "https://api.sis.nycu.edu.tw"
+gh secret set STUDENT_API_BASE_URL -b "https://api.sis.<your-domain>"
 
 # General configuration
-gh secret set DOMAIN -b "ss.aa.nycu.edu.tw"
-gh secret set CORS_ORIGINS -b "https://ss.aa.nycu.edu.tw"
+gh secret set DOMAIN -b "<production-domain>"
+gh secret set CORS_ORIGINS -b "https://<production-domain>"
 
 echo "✅ All secrets configured!"
 echo "Verify with: gh secret list"
@@ -840,10 +847,10 @@ docker compose exec postgres psql -U postgres -c "ALTER USER scholarship_user PA
 **Solution:**
 ```bash
 # Correct format (include protocol)
-gh secret set PORTAL_JWT_SERVER_URL -b "https://portal.nycu.edu.tw/api/auth"
+gh secret set PORTAL_JWT_SERVER_URL -b "https://portal.<your-domain>/api/auth"
 
-# ❌ Wrong: portal.nycu.edu.tw/api/auth
-# ✅ Right: https://portal.nycu.edu.tw/api/auth
+# ❌ Wrong: portal.<your-domain>/api/auth
+# ✅ Right: https://portal.<your-domain>/api/auth
 ```
 
 ---

--- a/.github/production-workflows-examples/backup.yml
+++ b/.github/production-workflows-examples/backup.yml
@@ -21,7 +21,12 @@
 # see the manifest written by the verify job.
 #
 # Prerequisites:
-#   - Self-hosted runner on the production AP VM, labels [self-hosted, linux].
+#   - Self-hosted runner on the production AP VM, labels
+#     [self-hosted, linux, production]. The `production` label is mandatory:
+#     the test AP VM answers to [self-hosted, linux] too, and a backup that
+#     landed there would dump the TEST database under a production filename.
+#     Scheduled, so deliberately NOT behind the `production` environment's
+#     approval gate — a nightly backup that waits for a reviewer never runs.
 #   - Secrets: DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME.
 #   - Passwordless sudo for the runner user (already required by deploy.yml).
 
@@ -60,7 +65,7 @@ permissions: {}
 jobs:
   backup-database:
     name: Backup PostgreSQL Database
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, production]
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.backup_type == 'full' ||
@@ -144,7 +149,7 @@ jobs:
 
   backup-files:
     name: Backup Application Files
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, production]
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.backup_type == 'full' ||
@@ -192,7 +197,7 @@ jobs:
 
   verify-backups:
     name: Verify & Report Backups
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, production]
     needs: [backup-database, backup-files]
     if: always()
 

--- a/.github/production-workflows-examples/bootstrap-ap-runner.sh
+++ b/.github/production-workflows-examples/bootstrap-ap-runner.sh
@@ -25,9 +25,18 @@
 #        ./bootstrap-ap-runner.sh \
 #            --repo-url https://github.com/<OWNER>/<PROD_REPO> \
 #            --token    <REGISTRATION_TOKEN>
-#      Optional: --labels "self-hosted,linux"  (default)
+#            --stage    test|production
+#      Optional: --labels "self-hosted,linux,<stage>"  (default, derived from --stage)
 #                --runner-version 2.319.1       (default: latest at write time)
-#                --name <runner-name>           (default: <hostname>-ap)
+#                --name <runner-name>           (default: <hostname>-ap-<stage>)
+#
+#   --stage IS MANDATORY. There are two AP VMs and both register as
+#   [self-hosted, linux]; the stage label is the ONLY thing that tells the
+#   workflows apart. deploy.yml targets ["self-hosted","linux","test"] and
+#   ["self-hosted","linux","production"] explicitly — a runner without its
+#   stage label is invisible to them, and a runner with the WRONG one will
+#   happily accept a production deploy on the test VM. Run this script once
+#   per VM with the matching --stage.
 #
 # GUARANTEES:
 #   - set -euo pipefail + an ERR trap that prints the failing line — a failure
@@ -58,14 +67,16 @@ trap 'on_err "$LINENO"' ERR
 # ── args ─────────────────────────────────────────────────────────────────
 REPO_URL=""
 REG_TOKEN=""
-LABELS="self-hosted,linux"
+STAGE=""
+LABELS=""
 RUNNER_VERSION="2.319.1"
-RUNNER_NAME="$(hostname)-ap"
+RUNNER_NAME=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --repo-url)        REPO_URL="$2"; shift 2 ;;
     --token)           REG_TOKEN="$2"; shift 2 ;;
+    --stage)           STAGE="$2"; shift 2 ;;
     --labels)          LABELS="$2"; shift 2 ;;
     --runner-version)  RUNNER_VERSION="$2"; shift 2 ;;
     --name)            RUNNER_NAME="$2"; shift 2 ;;
@@ -76,6 +87,24 @@ done
 
 [ -n "$REPO_URL" ]  || die "--repo-url is required (https://github.com/<OWNER>/<PROD_REPO>)"
 [ -n "$REG_TOKEN" ] || die "--token is required (runner registration token, expires ~1h)"
+case "$STAGE" in
+  test|production) : ;;
+  "") die "--stage is required (test|production). The workflows select the VM by its stage label; a runner without one gets no jobs." ;;
+  *)  die "--stage must be 'test' or 'production' (got: $STAGE)" ;;
+esac
+
+# Derived AFTER the stage is known, so both default to the right thing while
+# an explicit --labels/--name still wins.
+: "${LABELS:=self-hosted,linux,$STAGE}"
+: "${RUNNER_NAME:=$(hostname)-ap-$STAGE}"
+
+# An explicit --labels that drops the stage label registers a runner no
+# workflow will ever dispatch to — catch it here, not after a silent hour of
+# "queued" jobs.
+case ",$LABELS," in
+  *",$STAGE,"*) : ;;
+  *) die "--labels ($LABELS) does not contain the stage label '$STAGE' — deploy.yml would never dispatch to this runner." ;;
+esac
 
 RUN_USER="$(id -un)"
 [ "$RUN_USER" != "root" ] || die "Run as a normal sudo-capable user, NOT root — the GitHub runner refuses to run as root."
@@ -83,6 +112,7 @@ RUN_USER="$(id -un)"
 log "Bootstrap plan"
 echo "   AP VM user      : $RUN_USER"
 echo "   Repo URL        : $REPO_URL"
+echo "   Stage           : $STAGE"
 echo "   Runner name     : $RUNNER_NAME"
 echo "   Runner labels   : $LABELS"
 echo "   Runner version  : $RUNNER_VERSION"

--- a/.github/production-workflows-examples/deploy-stack.yml
+++ b/.github/production-workflows-examples/deploy-stack.yml
@@ -1,0 +1,651 @@
+# Reusable deployment stage — the body of the two-stage promotion pipeline.
+# Copy this file to the PRIVATE production repository at
+# .github/workflows/deploy-stack.yml (deploy.yml calls it twice).
+#
+# ONE definition, TWO stages. deploy.yml promotes the same GHCR image first to
+# the TEST AP VM and then, only if that succeeded, to the PRODUCTION AP VM:
+#
+#     resolve-images ──▶ deploy (stage: test)       ──▶ deploy (stage: production)
+#                        runner [self-hosted,linux,test]  runner [self-hosted,linux,production]
+#                        environment: test                environment: production
+#                        ▲ 1 reviewer must approve        ▲ 1 reviewer must approve
+#
+# The stage is selected entirely by inputs, so the two runs are bit-identical
+# in behaviour and differ ONLY in (a) which runner they land on and (b) which
+# GitHub Environment supplies the secrets/variables. That is the point: the
+# test stage is a rehearsal of the production stage, not a different script.
+#
+# WHY GitHub Environments carry the config
+# ----------------------------------------
+# `environment:` does three things at once here, and all three are required:
+#   1. Required reviewers  → the manual approval gate (configured in repo
+#      Settings → Environments, NOT in YAML — see SECRETS-SETUP-GUIDE.md).
+#   2. Environment secrets → the TEST stage resolves the TEST database, portal,
+#      SMTP relay and PII keys; the PRODUCTION stage resolves the real ones.
+#   3. Environment variables → per-stage URL, ENV_FILE, SSL_CERT_DIR.
+#
+# ⚠️  INHERITANCE TRAP: a secret that the `test` environment does NOT define
+# falls back to the REPOSITORY-level secret — i.e. to the PRODUCTION value.
+# A test deploy could then quietly write to the production database. The
+# "Assert stage identity" step below is the guard: each environment must
+# declare DEPLOY_STAGE, EXPECT_DOMAIN and EXPECT_DB_HOST, and the resolved
+# secrets are checked against them before anything is touched.
+
+name: Deploy stack (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      stage:
+        description: 'test | production — selects the GitHub Environment and the guard set'
+        required: true
+        type: string
+      runner_labels:
+        description: 'JSON array of runner labels, e.g. ''["self-hosted","linux","test"]'''
+        required: true
+        type: string
+      tag:
+        description: 'Upstream image tag to deploy (already verified by resolve-images)'
+        required: true
+        type: string
+      deploy_dir:
+        description: 'Deploy directory on the AP VM. Defaults to ~/scholarship-<stage>.'
+        required: false
+        type: string
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  deploy:
+    name: Deploy to ${{ inputs.stage }}
+    # Labels are resolved from the caller so ONE definition can target both VMs.
+    # Both VMs answer to [self-hosted, linux]; the stage label is what makes the
+    # targeting deterministic. Never drop it — without it a job would land on
+    # whichever of the two runners happened to be idle.
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    # The approval gate. GitHub blocks the job here, before the runner is even
+    # picked up, until a required reviewer approves the run.
+    environment:
+      name: ${{ inputs.stage }}
+      url: ${{ vars.DEPLOY_URL }}
+    # Job-level permissions REPLACE the workflow-level block, so contents: read
+    # must be restated alongside the packages elevation.
+    permissions:
+      contents: read # actions/checkout
+      packages: read # docker/login-action + docker pull (GITHUB_TOKEN fallback when GH_PAT is unset)
+
+    # DELIBERATELY MINIMAL. Everything compose interpolates comes from an env
+    # file (see "Resolve environment file"), NOT from the job environment:
+    # compose gives shell variables precedence over --env-file, so exporting
+    # the same keys here would silently shadow an operator-managed .env — and
+    # an unset GitHub secret exports as an EMPTY string, which shadows the
+    # file's value with "" rather than falling back to it.
+    #
+    # Only workflow-authoritative values live here. Both are always non-empty
+    # (IMAGE_OWNER is validated in resolve-images), so overriding is intended:
+    # the workflow decides which image was pulled and therefore which runs.
+    env:
+      TAG: ${{ inputs.tag }}
+      IMAGE_OWNER: ${{ vars.IMAGE_OWNER }}
+      STAGE: ${{ inputs.stage }}
+
+    steps:
+      # ── Gate 0: is this environment really the environment we think it is? ──
+      # Runs FIRST, before checkout, before any container is touched. Catches
+      # the inheritance trap described in the header: an environment that was
+      # never created, or created without its own secrets, resolves to the
+      # repository-level (production) values and would otherwise deploy the
+      # test stage straight onto production infrastructure.
+      - name: Assert stage identity
+        env:
+          DEPLOY_STAGE: ${{ vars.DEPLOY_STAGE }}
+          EXPECT_DOMAIN: ${{ vars.EXPECT_DOMAIN }}
+          EXPECT_DB_HOST: ${{ vars.EXPECT_DB_HOST }}
+          ENV_FILE_VAR: ${{ vars.ENV_FILE }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+        run: |
+          fail=0
+          err() { echo "::error::$1"; fail=1; }
+
+          if [ "${DEPLOY_STAGE}" != "${STAGE}" ]; then
+            err "Environment '${STAGE}' declares DEPLOY_STAGE='${DEPLOY_STAGE}' (expected '${STAGE}')."
+            echo "::error::Create the '${STAGE}' environment (Settings → Environments) and set the"
+            echo "::error::variable DEPLOY_STAGE=${STAGE}. Without it, this job would silently run"
+            echo "::error::against repository-level (production) secrets."
+          fi
+
+          # EXPECT_* are mandatory for test (that is the stage that can do
+          # damage by inheriting) and advisory for production.
+          if [ -z "${EXPECT_DOMAIN}" ] || [ -z "${EXPECT_DB_HOST}" ]; then
+            if [ "${STAGE}" = "test" ]; then
+              err "The 'test' environment must define EXPECT_DOMAIN and EXPECT_DB_HOST."
+              echo "::error::They pin which host this stage is allowed to touch, so an"
+              echo "::error::un-overridden secret cannot point the test deploy at production."
+            else
+              echo "::warning::EXPECT_DOMAIN / EXPECT_DB_HOST not set for '${STAGE}' — skipping the target check."
+            fi
+          elif [ -n "${ENV_FILE_VAR}" ]; then
+            # ENV_FILE mode: the values live on the VM, and secrets.DOMAIN /
+            # secrets.DB_HOST are legitimately unset. The same comparison is
+            # made against the file itself in "Resolve environment file".
+            echo "::notice::ENV_FILE mode — target check deferred to the resolved env file."
+          else
+            [ "${DOMAIN}" = "${EXPECT_DOMAIN}" ] || \
+              err "DOMAIN resolved to '${DOMAIN}' but the '${STAGE}' environment expects '${EXPECT_DOMAIN}'."
+            [ "${DB_HOST}" = "${EXPECT_DB_HOST}" ] || \
+              err "DB_HOST resolved to a host other than the one '${STAGE}' expects (EXPECT_DB_HOST)."
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Refusing to deploy — see SECRETS-SETUP-GUIDE.md § Environments."
+            exit 1
+          fi
+          echo "✅ Stage identity confirmed: ${STAGE} → ${DOMAIN:-${EXPECT_DOMAIN:-(from env file)}}"
+
+      # ── Gate 1: fail fast on misconfigured secrets BEFORE touching anything ─
+      # Closes go-live blockers P3/P4/P7/P8: config.py ships staging/dev defaults
+      # (portal.test auth, localhost student API, "(測試)" mail sender), so a
+      # missing secret would not crash — it would silently run against the wrong
+      # infrastructure. The backend boot guard (#936) is the second line of
+      # defense; this is the first.
+      #
+      # The presence/shape checks apply to BOTH stages. The "must not look like
+      # staging" checks apply to the production stage only — on the test stage
+      # those values are *supposed* to be the test ones.
+      - name: Validate secrets
+        # Only meaningful when the stack is configured from GitHub Secrets.
+        # With ENV_FILE set, the values live on the AP VM and are validated
+        # there by the "Resolve environment file" step instead.
+        if: vars.ENV_FILE == ''
+        env:
+          DOMAIN: ${{ secrets.DOMAIN }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          MINIO_HOST: ${{ secrets.MINIO_HOST }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PORTAL_JWT_SERVER_URL: ${{ secrets.PORTAL_JWT_SERVER_URL }}
+          STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
+          SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
+        run: |
+          fail=0
+          err() { echo "::error::$1"; fail=1; }
+
+          [ -n "$DOMAIN" ] || err "DOMAIN is not set"
+          [ -n "$DB_HOST" ] || err "DB_HOST is not set"
+          [ -n "$DB_PASSWORD" ] || err "DB_PASSWORD is not set"
+          [ -n "$REDIS_PASSWORD" ] || err "REDIS_PASSWORD is not set"
+          [ -n "$MINIO_HOST" ] || err "MINIO_HOST is not set"
+          [ -n "$MINIO_ACCESS_KEY" ] || err "MINIO_ACCESS_KEY is not set"
+          [ -n "$MINIO_SECRET_KEY" ] || err "MINIO_SECRET_KEY is not set"
+          [ -n "$SUPER_ADMIN_NYCU_ID" ] || err "SUPER_ADMIN_NYCU_ID is not set (no one could elevate to super_admin)"
+          [ -n "$SMTP_HOST" ] || err "SMTP_HOST is not set (would default to the staging relay)"
+
+          # Every stage gets its own key — a shared SECRET_KEY would let a token
+          # minted on test authenticate against production.
+          [ "${#SECRET_KEY}" -ge 32 ] || err "SECRET_KEY must be >= 32 chars (and MUST differ per stage)"
+
+          # P4: PII keys — missing keys hard-fail the encrypt migration / first
+          # PII read; malformed JSON fails at boot. Catch both here.
+          if [ -z "$PII_ENCRYPTION_KEYS" ]; then
+            err "PII_ENCRYPTION_KEYS is not set. Generate a key per docs/architecture/pii-encryption.md then set '{\"v1\":\"<KEY>\"}'"
+          elif ! echo "$PII_ENCRYPTION_KEYS" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
+            err "PII_ENCRYPTION_KEYS is not valid JSON"
+          fi
+
+          case "$PORTAL_JWT_SERVER_URL" in
+            "") err "PORTAL_JWT_SERVER_URL is not set (config.py would default to portal.test)" ;;
+            https://*) : ;;
+            *) err "PORTAL_JWT_SERVER_URL must be https://" ;;
+          esac
+          [ -n "$STUDENT_API_BASE_URL" ] || err "STUDENT_API_BASE_URL is not set (would default to the localhost mock; verification fails SILENTLY)"
+          [ -n "$EMAIL_FROM" ] || err "EMAIL_FROM is not set"
+          [ -n "$EMAIL_FROM_NAME" ] || err "EMAIL_FROM_NAME is not set"
+
+          if [ "${STAGE}" = "production" ]; then
+            # P3: production must never authenticate against the staging portal.
+            case "$PORTAL_JWT_SERVER_URL" in
+              *portal.test*) err "PORTAL_JWT_SERVER_URL points at portal.test (staging) — set the production Portal endpoint" ;;
+            esac
+            # P8: student API must be the real campus API (no longer uses HMAC auth).
+            case "$STUDENT_API_BASE_URL" in
+              *localhost*|*127.0.0.1*|*mock*) err "STUDENT_API_BASE_URL looks like a mock/localhost endpoint: $STUDENT_API_BASE_URL" ;;
+            esac
+            # P7: real applicants must not receive '(測試)' mail from ss-test.
+            case "$EMAIL_FROM" in *ss-test*) err "EMAIL_FROM still uses the staging address: $EMAIL_FROM" ;; esac
+            case "$EMAIL_FROM_NAME" in *測試*) err "EMAIL_FROM_NAME still contains 測試: $EMAIL_FROM_NAME" ;; esac
+          else
+            # Mirror image of the production guards: on test, a value that looks
+            # like the real thing means an environment secret was not overridden.
+            case "$EMAIL_FROM" in
+              *ss-test*|*test*) : ;;
+              *) echo "::warning::EMAIL_FROM ('$EMAIL_FROM') carries no test marker — real applicants could be mailed from the test stack." ;;
+            esac
+          fi
+
+          [ "$fail" -eq 0 ] || exit 1
+          echo "✅ All ${STAGE} secrets validated"
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve deploy directory
+        env:
+          DEPLOY_DIR_INPUT: ${{ inputs.deploy_dir }}
+        run: |
+          DIR="${DEPLOY_DIR_INPUT}"
+          [ -n "$DIR" ] || DIR="$HOME/scholarship-${STAGE}"
+          mkdir -p "$DIR"
+          echo "DEPLOY_DIR=${DIR}" >> "$GITHUB_ENV"
+          echo "Deploy directory: ${DIR}"
+
+      # Authenticate against the UPSTREAM namespace. GITHUB_TOKEN is scoped to
+      # this repository and cannot read another owner's packages, so a PAT with
+      # read:packages is required whenever those packages are private.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Pull images
+        run: |
+          docker pull ${{ env.REGISTRY }}/${IMAGE_OWNER}/scholarship-system-backend:${TAG}
+          docker pull ${{ env.REGISTRY }}/${IMAGE_OWNER}/scholarship-system-frontend:${TAG}
+
+      - name: Prepare deployment files
+        run: |
+          mkdir -p "${DEPLOY_DIR}/logs/nginx"
+          cp docker-compose.prod.yml "${DEPLOY_DIR}/docker-compose.yml"
+          # Merge (not replace): a certificate directory placed under
+          # <deploy dir>/nginx/ssl/prod by the operator must survive, since the
+          # repo ships nginx configs but no keys.
+          if [ -d nginx ]; then cp -r nginx "${DEPLOY_DIR}/"; fi
+          # Everything below is copied as the runner user and therefore owned by
+          # it, so a plain rm is enough to replace it. sudo -n is only a fallback
+          # for hosts that ran an earlier, broken version of this workflow and
+          # were left with root-owned leftovers; -n so a VM WITHOUT passwordless
+          # sudo fails immediately with the message below instead of blocking on
+          # a password prompt no one can answer.
+          replace_dir() {
+            rm -rf "${DEPLOY_DIR}/$1" 2>/dev/null && return 0
+            sudo -n rm -rf "${DEPLOY_DIR}/$1" 2>/dev/null && return 0
+            echo "::error::Cannot replace ${DEPLOY_DIR}/$1 — it is owned by root"
+            echo "::error::from an earlier deploy and this runner has no passwordless sudo."
+            echo "::error::Clear it once on the VM: sudo rm -rf ${DEPLOY_DIR}/$1"
+            return 1
+          }
+          if [ -d monitoring ]; then
+            replace_dir monitoring
+            cp -r monitoring "${DEPLOY_DIR}/"
+          fi
+          # scripts/logrotate.conf is bind-mounted as the logrotate service's
+          # config. This copy was missing, so Docker materialised the mount
+          # source as a root-owned DIRECTORY and logrotate rotated nothing
+          # ("Handling 0 logs", exit 0) while the container stayed Up — the
+          # nginx access log grew unbounded with no signal anything was wrong.
+          # No chown here: logrotate ignores configs it does not own, so the
+          # container makes its own root-owned copy (docker-compose.prod.yml).
+          if [ -d scripts ]; then
+            replace_dir scripts
+            cp -r scripts "${DEPLOY_DIR}/"
+          fi
+
+      # Two supported ways to configure the stack, chosen by the ENV_FILE
+      # environment variable (set it per GitHub Environment, so test and
+      # production can use different modes and different paths):
+      #
+      #   ENV_FILE set   — an operator-managed .env already on the VM
+      #                    (install manual section 5.1: `touch ~/.env`). Nothing
+      #                    is written; GitHub never holds these values.
+      #   ENV_FILE unset — generated here from the environment's secrets into
+      #                    the deploy directory, mode 600. This is the default.
+      #
+      # Either way compose is invoked with --env-file, so there is exactly one
+      # source of truth for interpolation.
+      - name: Resolve environment file
+        env:
+          ENV_FILE_VAR: ${{ vars.ENV_FILE }}
+          SSL_CERT_DIR_VAR: ${{ vars.SSL_CERT_DIR }}
+          EXPECT_DOMAIN: ${{ vars.EXPECT_DOMAIN }}
+          EXPECT_DB_HOST: ${{ vars.EXPECT_DB_HOST }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+          MINIO_HOST: ${{ secrets.MINIO_HOST }}
+          MINIO_PORT: ${{ secrets.MINIO_PORT }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          # Secret name stays MINIO_BUCKET_NAME; compose interpolates
+          # ${MINIO_BUCKET} — the env name config.py actually binds.
+          MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
+          MINIO_SECURE: ${{ secrets.MINIO_SECURE }}
+          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
+          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
+          PORTAL_JWT_SERVER_URL: ${{ secrets.PORTAL_JWT_SERVER_URL }}
+          STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
+          SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
+          NEXT_PUBLIC_NYCU_PORTAL_URL: ${{ secrets.NEXT_PUBLIC_NYCU_PORTAL_URL }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${ENV_FILE_VAR}" ]; then
+            ENV_FILE="${ENV_FILE_VAR}"
+            echo "Using operator-managed env file: ${ENV_FILE}"
+            [ -f "${ENV_FILE}" ] || {
+              echo "::error::ENV_FILE points at ${ENV_FILE}, which does not exist on this runner."
+              echo "::error::Create it (see install manual section 5.1) or clear the ENV_FILE variable"
+              echo "::error::on the '${STAGE}' environment to fall back to generating it from secrets."
+              exit 1
+            }
+            [ -r "${ENV_FILE}" ] || { echo "::error::${ENV_FILE} is not readable by the runner user."; exit 1; }
+
+            # Fail now on anything compose cannot default, instead of booting a
+            # backend that silently falls back to config.py's dev values.
+            missing=""
+            for k in DOMAIN SECRET_KEY DB_HOST DB_PORT DB_USER DB_PASSWORD DB_NAME \
+                     REDIS_PASSWORD MINIO_HOST MINIO_ACCESS_KEY MINIO_SECRET_KEY \
+                     PII_ENCRYPTION_KEYS SMTP_HOST EMAIL_FROM EMAIL_FROM_NAME \
+                     PORTAL_JWT_SERVER_URL STUDENT_API_BASE_URL SUPER_ADMIN_NYCU_ID \
+                     NEXT_PUBLIC_NYCU_PORTAL_URL CORS_ORIGINS; do
+              grep -qE "^[[:space:]]*${k}=" "${ENV_FILE}" || missing="${missing} ${k}"
+            done
+            [ -z "${missing}" ] || { echo "::error::${ENV_FILE} is missing required keys:${missing}"; exit 1; }
+
+            # Same guards the "Validate secrets" step applies to GitHub Secrets.
+            # They live here too because in ENV_FILE mode that step has nothing
+            # to inspect — config.py ships staging defaults, so a wrong value
+            # would not crash, it would quietly run against the wrong backend.
+            v() { sed -n "s/^[[:space:]]*$1=//p" "${ENV_FILE}" | tail -1; }
+            fail=0
+            err() { echo "::error::$1"; fail=1; }
+
+            SK="$(v SECRET_KEY)"
+            [ "${#SK}" -ge 32 ] || err "SECRET_KEY must be >= 32 chars (and MUST differ per stage)"
+
+            printf '%s' "$(v PII_ENCRYPTION_KEYS)" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1 \
+              || err "PII_ENCRYPTION_KEYS is not valid JSON"
+
+            case "$(v PORTAL_JWT_SERVER_URL)" in
+              https://*) : ;;
+              *) err "PORTAL_JWT_SERVER_URL must be https://" ;;
+            esac
+
+            # The env file is the source of truth in this mode, so re-check the
+            # stage target against it too — an operator .env copied from the
+            # production VM to the test VM is exactly the mistake to catch.
+            if [ -n "${EXPECT_DOMAIN}" ] && [ "$(v DOMAIN)" != "${EXPECT_DOMAIN}" ]; then
+              err "${ENV_FILE} sets DOMAIN=$(v DOMAIN) but the '${STAGE}' environment expects ${EXPECT_DOMAIN}"
+            fi
+            if [ -n "${EXPECT_DB_HOST}" ] && [ "$(v DB_HOST)" != "${EXPECT_DB_HOST}" ]; then
+              err "${ENV_FILE} points DB_HOST at a host other than the one '${STAGE}' expects (EXPECT_DB_HOST)"
+            fi
+
+            if [ "${STAGE}" = "production" ]; then
+              case "$(v PORTAL_JWT_SERVER_URL)" in
+                *portal.test*) err "PORTAL_JWT_SERVER_URL points at portal.test (staging)" ;;
+              esac
+              case "$(v STUDENT_API_BASE_URL)" in
+                *localhost*|*127.0.0.1*|*mock*) err "STUDENT_API_BASE_URL looks like a mock/localhost endpoint" ;;
+              esac
+              case "$(v EMAIL_FROM)" in *ss-test*) err "EMAIL_FROM still uses the staging address" ;; esac
+              case "$(v EMAIL_FROM_NAME)" in *測試*) err "EMAIL_FROM_NAME still contains 測試" ;; esac
+            fi
+
+            [ "$fail" -eq 0 ] || exit 1
+            echo "✅ All required keys present and validated"
+          else
+            ENV_FILE="${DEPLOY_DIR}/.env"
+            echo "Generating ${ENV_FILE} from the '${STAGE}' environment's secrets"
+            umask 077
+            {
+              echo "# Generated by deploy-stack.yml (stage: ${STAGE}) — do not edit; changes are overwritten."
+              echo "DOMAIN=${DOMAIN}"
+              echo "SECRET_KEY=${SECRET_KEY}"
+              echo "CORS_ORIGINS=${CORS_ORIGINS}"
+              echo "DB_HOST=${DB_HOST}"
+              echo "DB_PORT=${DB_PORT}"
+              echo "DB_USER=${DB_USER}"
+              echo "DB_PASSWORD=${DB_PASSWORD}"
+              echo "DB_NAME=${DB_NAME}"
+              echo "REDIS_PASSWORD=${REDIS_PASSWORD}"
+              echo "MINIO_HOST=${MINIO_HOST}"
+              echo "MINIO_PORT=${MINIO_PORT}"
+              echo "MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}"
+              echo "MINIO_SECRET_KEY=${MINIO_SECRET_KEY}"
+              echo "MINIO_BUCKET=${MINIO_BUCKET_NAME}"
+              echo "MINIO_SECURE=${MINIO_SECURE}"
+              echo "PII_ENCRYPTION_KEYS=${PII_ENCRYPTION_KEYS}"
+              echo "PII_ENCRYPTION_ACTIVE_VERSION=${PII_ENCRYPTION_ACTIVE_VERSION}"
+              echo "SMTP_HOST=${SMTP_HOST}"
+              echo "SMTP_PORT=${SMTP_PORT}"
+              echo "SMTP_USER=${SMTP_USER}"
+              echo "SMTP_PASSWORD=${SMTP_PASSWORD}"
+              echo "EMAIL_FROM=${EMAIL_FROM}"
+              echo "EMAIL_FROM_NAME=${EMAIL_FROM_NAME}"
+              echo "PORTAL_SSO_ENABLED=true"
+              echo "PORTAL_JWT_SERVER_URL=${PORTAL_JWT_SERVER_URL}"
+              echo "PORTAL_TEST_MODE=false"
+              echo "STUDENT_API_ENABLED=true"
+              echo "STUDENT_API_BASE_URL=${STUDENT_API_BASE_URL}"
+              echo "SUPER_ADMIN_NYCU_ID=${SUPER_ADMIN_NYCU_ID}"
+              echo "NEXT_PUBLIC_NYCU_PORTAL_URL=${NEXT_PUBLIC_NYCU_PORTAL_URL}"
+              [ -n "${SSL_CERT_DIR_VAR}" ] && echo "SSL_CERT_DIR=${SSL_CERT_DIR_VAR}"
+            } > "${ENV_FILE}"
+            chmod 600 "${ENV_FILE}"
+            echo "✅ Wrote $(grep -c '=' "${ENV_FILE}") entries (mode 600)"
+          fi
+
+          echo "ENV_FILE=${ENV_FILE}" >> "$GITHUB_ENV"
+
+          # Read back the values later steps need. Taking DOMAIN from the
+          # resolved file (rather than from secrets) keeps both modes identical.
+          envget() { sed -n "s/^[[:space:]]*$1=//p" "${ENV_FILE}" | tail -1; }
+          echo "DOMAIN=$(envget DOMAIN)" >> "$GITHUB_ENV"
+
+          # Certificate location precedence: the SSL_CERT_DIR environment
+          # variable wins in BOTH modes (it describes where the operator put
+          # the certificate on this host, not a secret), then the env file,
+          # then compose's ./nginx/ssl/prod default.
+          CERT_DIR="${SSL_CERT_DIR_VAR:-$(envget SSL_CERT_DIR)}"
+          echo "CERT_DIR=${CERT_DIR}" >> "$GITHUB_ENV"
+          # Export to compose ONLY when non-empty: an exported empty string
+          # would shadow the env file's value instead of deferring to it.
+          if [ -n "${CERT_DIR}" ]; then
+            echo "SSL_CERT_DIR=${CERT_DIR}" >> "$GITHUB_ENV"
+            echo "Certificate directory (SSL_CERT_DIR): ${CERT_DIR}"
+          else
+            echo "Certificate directory: compose default (./nginx/ssl/prod)"
+          fi
+
+      - name: Verify TLS certificates are present
+        run: |
+          cd "${DEPLOY_DIR}"
+          CERT_DIR="${CERT_DIR:-./nginx/ssl/prod}"
+          echo "Certificate directory: $CERT_DIR"
+          missing=0
+          # nginx.prod.conf references all three; a missing file puts nginx in
+          # a crash loop and the deploy would only fail later, at `nginx -t`,
+          # with a far less obvious message.
+          for f in fullchain.pem privkey.pem chain.pem; do
+            if [ -f "${CERT_DIR}/${f}" ]; then
+              echo "  ✅ ${f}"
+            else
+              echo "::error::Missing certificate file: ${CERT_DIR}/${f}"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || {
+            echo "::error::Place the TLS certificate in ${CERT_DIR}, or set the"
+            echo "::error::SSL_CERT_DIR variable on the '${STAGE}' environment to an absolute"
+            echo "::error::path on this VM (e.g. /home/<user>/ssl) so private keys stay out of git."
+            exit 1
+          }
+
+      - name: Start new containers
+        run: |
+          cd "${DEPLOY_DIR}"
+          # --env-file is the single source of interpolation values; TAG and
+          # IMAGE_OWNER come from the job env and intentionally take precedence.
+          docker compose --env-file "${ENV_FILE}" down || true
+
+          # scholarship_prod_network is declared external so it keeps a stable,
+          # unprefixed name the monitoring stack can join — compose never
+          # creates an external network, so it has to exist before `up`.
+          #
+          # Order matters: this runs AFTER `down`. Revisions before the external
+          # switch declared the network inline, so it exists under the compose
+          # project prefix holding this very subnet, and creating the new one
+          # first fails with "Pool overlaps with other one on this address
+          # space". `down` detaches the containers; removing the legacy network
+          # then frees the address space. Both lines are no-ops once migrated.
+          docker network rm "$(basename "${DEPLOY_DIR}")_scholarship_prod_network" 2>/dev/null || true
+          docker network inspect scholarship_prod_network >/dev/null 2>&1 || \
+            docker network create --subnet 172.24.0.0/16 scholarship_prod_network
+
+          docker compose --env-file "${ENV_FILE}" up -d
+
+      - name: Validate and reload nginx config
+        run: |
+          # Config is bind-mounted read-only; `compose up -d` does not reload
+          # nginx when only the file contents change. Validate first — never
+          # leave a broken config running.
+          if docker exec scholarship_nginx_prod nginx -t; then
+            docker exec scholarship_nginx_prod nginx -s reload
+            echo "✅ nginx config validated and reloaded"
+          else
+            echo "::error::nginx config test failed — keeping previously-loaded config"
+            exit 1
+          fi
+
+      - name: Run database migrations
+        run: |
+          # NO error swallowing: a half-applied migration with a green deploy
+          # is the worst possible state (and /health does not verify schema).
+          docker exec scholarship_backend_prod alembic upgrade head
+          docker exec scholarship_backend_prod alembic current
+
+      - name: Seed baseline
+        run: |
+          # --prod creates ONLY admin/lookup/settings/email templates — never
+          # test users. Idempotent. Must succeed (no '|| echo' swallowing).
+          docker exec scholarship_backend_prod python -m app.seed --prod
+
+      - name: Health check
+        run: |
+          # Backend has no published port (expose-only) — check from inside the
+          # container, then end-to-end through nginx.
+          max_retries=10
+          retry_count=0
+          until docker exec scholarship_backend_prod curl -fsS http://localhost:8000/health >/dev/null 2>&1 || [ $retry_count -eq $max_retries ]; do
+            echo "Backend not ready yet... ($retry_count/$max_retries)"
+            sleep 5
+            retry_count=$((retry_count + 1))
+          done
+          if [ $retry_count -eq $max_retries ]; then
+            echo "::error::Backend health check failed"
+            docker logs --tail 100 scholarship_backend_prod
+            exit 1
+          fi
+          echo "✅ Backend healthy"
+
+          retry_count=0
+          until curl -fsk https://localhost/health >/dev/null 2>&1 || [ $retry_count -eq $max_retries ]; do
+            echo "nginx→backend not ready yet... ($retry_count/$max_retries)"
+            sleep 5
+            retry_count=$((retry_count + 1))
+          done
+          if [ $retry_count -eq $max_retries ]; then
+            echo "::error::End-to-end health check via nginx failed"
+            docker logs --tail 50 scholarship_nginx_prod
+            exit 1
+          fi
+          echo "✅ nginx → backend healthy"
+
+      - name: Smoke tests
+        run: |
+          curl -fsk "https://localhost/health" -H "Host: ${DOMAIN}" >/dev/null || exit 1
+          # /api/v1/docs is intentionally disabled when ENVIRONMENT=production
+          # (backend/app/main.py), and docker-compose.prod.yml hardcodes that on
+          # BOTH stages — smoke-test a real mounted API route instead.
+          curl -fsk "https://localhost/api/v1/scholarships" -H "Host: ${DOMAIN}" >/dev/null || exit 1
+          # Frontend through nginx
+          code=$(curl -sk -o /dev/null -w '%{http_code}' "https://localhost/" -H "Host: ${DOMAIN}")
+          [ "$code" = "200" ] || { echo "::error::Frontend returned $code"; exit 1; }
+          echo "✅ Smoke tests passed"
+
+      - name: Record successful deployment tag
+        if: success()
+        run: |
+          echo "${TAG}" > "${DEPLOY_DIR}/last-good-tag"
+          echo "Saved last-good tag: ${TAG}"
+
+      - name: Rollback to last-good deployment
+        if: failure()
+        run: |
+          cd "${DEPLOY_DIR}"
+          # Resolve step may itself have failed, leaving ENV_FILE unset.
+          ENV_FILE="${ENV_FILE:-${DEPLOY_DIR}/.env}"
+          if [ ! -f "${ENV_FILE}" ]; then
+            echo "::error::No usable env file (${ENV_FILE}) — cannot roll back automatically."
+            exit 1
+          fi
+          # last-good-tag is written ONLY by the success path above, so it
+          # always names a tag that actually passed health + smoke checks.
+          if [ -f last-good-tag ]; then
+            PREV_TAG=$(cat last-good-tag)
+            if [ "$PREV_TAG" = "$TAG" ]; then
+              echo "::error::last-good tag is '${PREV_TAG}', identical to the tag that just failed."
+              echo "::error::This happens when deploying the mutable 'latest' tag — rolling back"
+              echo "::error::would re-pull the same image. Redeploy an explicit older tag instead."
+              exit 1
+            fi
+            echo "::warning::Deploy of ${TAG} failed — rolling back to ${PREV_TAG}"
+            TAG=$PREV_TAG docker compose --env-file "${ENV_FILE}" up -d
+            sleep 15
+            if docker exec scholarship_backend_prod curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+              echo "::notice::Rollback to ${PREV_TAG} succeeded."
+            else
+              echo "::error::Rollback health check ALSO failed — manual intervention required."
+              echo "::error::If a migration was applied, evaluate 'alembic downgrade' or restore the latest backup (see DR runbook)."
+            fi
+          else
+            echo "::warning::No last-good-tag — cannot auto-rollback."
+          fi
+
+      - name: Deployment summary
+        if: success()
+        env:
+          DEPLOY_URL: ${{ vars.DEPLOY_URL }}
+        run: |
+          {
+            echo "## ✅ ${STAGE} deployment successful"
+            echo ""
+            echo "**Stage**: ${STAGE}"
+            echo "**Version**: ${TAG}"
+            echo "**URL**: ${DEPLOY_URL}"
+            echo "**Directory**: ${DEPLOY_DIR}"
+            echo "**Migrations**: $(docker exec scholarship_backend_prod alembic current 2>/dev/null | tail -1)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/production-workflows-examples/deploy-stack.yml
+++ b/.github/production-workflows-examples/deploy-stack.yml
@@ -146,9 +146,9 @@ jobs:
           echo "✅ Stage identity confirmed: ${STAGE} → ${DOMAIN:-${EXPECT_DOMAIN:-(from env file)}}"
 
       # ── Gate 1: fail fast on misconfigured secrets BEFORE touching anything ─
-      # Closes go-live blockers P3/P4/P7/P8: config.py ships staging/dev defaults
-      # (portal.test auth, localhost student API, "(測試)" mail sender), so a
-      # missing secret would not crash — it would silently run against the wrong
+      # Closes go-live blockers P3/P4/P7/P8: config.py ships staging/dev
+      # defaults for auth, the student API and the mail sender, so a missing
+      # secret would not crash — it would silently run against the wrong
       # infrastructure. The backend boot guard (#936) is the second line of
       # defense; this is the first.
       #
@@ -176,6 +176,7 @@ jobs:
           EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
           EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
           SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
+          FORBIDDEN_MARKERS: ${{ vars.FORBIDDEN_MARKERS }}
         run: |
           fail=0
           err() { echo "::error::$1"; fail=1; }
@@ -188,7 +189,7 @@ jobs:
           [ -n "$MINIO_ACCESS_KEY" ] || err "MINIO_ACCESS_KEY is not set"
           [ -n "$MINIO_SECRET_KEY" ] || err "MINIO_SECRET_KEY is not set"
           [ -n "$SUPER_ADMIN_NYCU_ID" ] || err "SUPER_ADMIN_NYCU_ID is not set (no one could elevate to super_admin)"
-          [ -n "$SMTP_HOST" ] || err "SMTP_HOST is not set (would default to the staging relay)"
+          [ -n "$SMTP_HOST" ] || err "SMTP_HOST is not set (would default to the test relay)"
 
           # Every stage gets its own key — a shared SECRET_KEY would let a token
           # minted on test authenticate against production.
@@ -203,7 +204,7 @@ jobs:
           fi
 
           case "$PORTAL_JWT_SERVER_URL" in
-            "") err "PORTAL_JWT_SERVER_URL is not set (config.py would default to portal.test)" ;;
+            "") err "PORTAL_JWT_SERVER_URL is not set (config.py would default to the test portal)" ;;
             https://*) : ;;
             *) err "PORTAL_JWT_SERVER_URL must be https://" ;;
           esac
@@ -212,24 +213,29 @@ jobs:
           [ -n "$EMAIL_FROM_NAME" ] || err "EMAIL_FROM_NAME is not set"
 
           if [ "${STAGE}" = "production" ]; then
-            # P3: production must never authenticate against the staging portal.
-            case "$PORTAL_JWT_SERVER_URL" in
-              *portal.test*) err "PORTAL_JWT_SERVER_URL points at portal.test (staging) — set the production Portal endpoint" ;;
-            esac
-            # P8: student API must be the real campus API (no longer uses HMAC auth).
+            # P8: student API must be the real campus API, never the mock.
+            # These markers are generic, so they stay in the template.
             case "$STUDENT_API_BASE_URL" in
               *localhost*|*127.0.0.1*|*mock*) err "STUDENT_API_BASE_URL looks like a mock/localhost endpoint: $STUDENT_API_BASE_URL" ;;
             esac
-            # P7: real applicants must not receive '(測試)' mail from ss-test.
-            case "$EMAIL_FROM" in *ss-test*) err "EMAIL_FROM still uses the staging address: $EMAIL_FROM" ;; esac
-            case "$EMAIL_FROM_NAME" in *測試*) err "EMAIL_FROM_NAME still contains 測試: $EMAIL_FROM_NAME" ;; esac
-          else
-            # Mirror image of the production guards: on test, a value that looks
-            # like the real thing means an environment secret was not overridden.
-            case "$EMAIL_FROM" in
-              *ss-test*|*test*) : ;;
-              *) echo "::warning::EMAIL_FROM ('$EMAIL_FROM') carries no test marker — real applicants could be mailed from the test stack." ;;
-            esac
+
+            # P3/P7: production must not authenticate against the test portal
+            # or mail real applicants from the test sender. The strings that
+            # identify THIS deployment's test tier are site-specific, so they
+            # come from the FORBIDDEN_MARKERS variable rather than being
+            # hardcoded here — this template is mirrored into a repository that
+            # should not carry the site's hostnames.
+            if [ -n "${FORBIDDEN_MARKERS}" ]; then
+              for m in ${FORBIDDEN_MARKERS}; do
+                case "$PORTAL_JWT_SERVER_URL" in *"$m"*) err "PORTAL_JWT_SERVER_URL matches the non-production marker '$m'" ;; esac
+                case "$EMAIL_FROM"            in *"$m"*) err "EMAIL_FROM matches the non-production marker '$m'" ;; esac
+                case "$EMAIL_FROM_NAME"       in *"$m"*) err "EMAIL_FROM_NAME matches the non-production marker '$m'" ;; esac
+                case "$STUDENT_API_BASE_URL"  in *"$m"*) err "STUDENT_API_BASE_URL matches the non-production marker '$m'" ;; esac
+              done
+            else
+              echo "::warning::FORBIDDEN_MARKERS is not set — skipping the 'production must not use test endpoints' check."
+              echo "::warning::Set it to a space-separated list of substrings that only ever appear in test values."
+            fi
           fi
 
           [ "$fail" -eq 0 ] || exit 1
@@ -319,6 +325,7 @@ jobs:
           SSL_CERT_DIR_VAR: ${{ vars.SSL_CERT_DIR }}
           EXPECT_DOMAIN: ${{ vars.EXPECT_DOMAIN }}
           EXPECT_DB_HOST: ${{ vars.EXPECT_DB_HOST }}
+          FORBIDDEN_MARKERS: ${{ vars.FORBIDDEN_MARKERS }}
           DOMAIN: ${{ secrets.DOMAIN }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
@@ -404,14 +411,16 @@ jobs:
             fi
 
             if [ "${STAGE}" = "production" ]; then
-              case "$(v PORTAL_JWT_SERVER_URL)" in
-                *portal.test*) err "PORTAL_JWT_SERVER_URL points at portal.test (staging)" ;;
-              esac
               case "$(v STUDENT_API_BASE_URL)" in
                 *localhost*|*127.0.0.1*|*mock*) err "STUDENT_API_BASE_URL looks like a mock/localhost endpoint" ;;
               esac
-              case "$(v EMAIL_FROM)" in *ss-test*) err "EMAIL_FROM still uses the staging address" ;; esac
-              case "$(v EMAIL_FROM_NAME)" in *測試*) err "EMAIL_FROM_NAME still contains 測試" ;; esac
+              # Site-specific markers come from the FORBIDDEN_MARKERS variable,
+              # not from this file — see the same check in "Validate secrets".
+              for m in ${FORBIDDEN_MARKERS}; do
+                for k in PORTAL_JWT_SERVER_URL EMAIL_FROM EMAIL_FROM_NAME STUDENT_API_BASE_URL; do
+                  case "$(v $k)" in *"$m"*) err "$k matches the non-production marker '$m'" ;; esac
+                done
+              done
             fi
 
             [ "$fail" -eq 0 ] || exit 1

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -10,11 +10,16 @@
 #                      env: test          env: production
 #                      🔒 1 approval      🔒 1 approval
 #
-# Nothing reaches the production VM that has not first been deployed to, and
-# verified on, the test VM by the very same script (deploy-stack.yml) — the
-# stage differs only in which runner it lands on and which GitHub Environment
-# supplies its secrets. `needs: deploy-test` makes that ordering structural: a
-# failed or rejected test stage means the production job never starts.
+# Every image is deployed to, and exercised on, the test VM first by the very
+# same script (deploy-stack.yml) — the stage differs only in which runner it
+# lands on and which GitHub Environment supplies its secrets.
+#
+# The ordering is structural (`needs: deploy-test`), but it is NOT a veto: if
+# the test stage fails, production still asks for its approval and a reviewer
+# may take it through. That is deliberate — the test tier can fail for reasons
+# that say nothing about production (its own DB, certificate or portal), and
+# those must not be able to block a hotfix. What the reviewer gets is the test
+# result in front of them, not a machine deciding for them.
 #
 # The approval gate is a GitHub *Environment protection rule*, not YAML. It has
 # to be configured once, in the production repository:
@@ -45,11 +50,16 @@
 #       DEPLOY_STAGE   = test | production   (stage-identity guard, required)
 #       EXPECT_DOMAIN  = the domain this stage may touch (required on test)
 #       EXPECT_DB_HOST = the DB host this stage may touch (required on test)
-#       DEPLOY_URL     = https://ss-test.aa.nycu.edu.tw | https://ss.aa.nycu.edu.tw
+#       DEPLOY_URL     = that stage's site URL (shown on the Environments page)
 #       SSL_CERT_DIR   = optional; absolute path to the TLS certificate
 #                        directory on that VM (e.g. /home/<user>/ssl).
 #                        Defaults to ./nginx/ssl/prod in the deploy directory.
 #       ENV_FILE       = optional; path to an operator-managed .env on that VM.
+#       FORBIDDEN_MARKERS = optional (repo-level is fine); space-separated
+#                        substrings that only ever appear in non-production
+#                        values (test hostnames, test mail sender, ...). The
+#                        production stage refuses to deploy if a secret
+#                        contains one. Unset = that check is skipped.
 #   - secrets.GH_PAT with read:packages, if the upstream packages are private.
 #   - docker-compose.prod-db.yml stack already running on each stage's DB VM.
 
@@ -164,10 +174,26 @@ jobs:
       contents: read
       packages: read
 
-  # ── Stage 2: PRODUCTION AP VM — only reachable through a green test stage ──
+  # ── Stage 2: PRODUCTION AP VM — runs after test, gated on its own reviewer ─
   deploy-production:
     name: Deploy to production
     needs: [resolve-images, deploy-test]
+    # ORDERED, BUT NOT BLOCKED BY THE TEST RESULT.
+    #
+    # `needs` still makes production wait for the rehearsal to finish, so the
+    # two stages never deploy at once and the reviewer sees the test outcome
+    # before deciding. What it deliberately does NOT do is veto: a red test
+    # stage does not cancel production. The test tier has its own ways to fail
+    # (its DB down, its certificate expired, its portal unreachable) and none
+    # of those should be able to hold a production hotfix hostage.
+    #
+    # The judgement moves to the human at the approval gate — they can read the
+    # failed test job and then approve, or reject and stop the promotion.
+    #
+    # `!cancelled()` keeps a cancelled run from carrying on regardless, and the
+    # resolve-images guard is what actually can veto: without a resolved tag
+    # there is nothing to deploy.
+    if: ${{ !cancelled() && needs.resolve-images.result == 'success' }}
     uses: ./.github/workflows/deploy-stack.yml
     with:
       stage: production

--- a/.github/production-workflows-examples/deploy.yml
+++ b/.github/production-workflows-examples/deploy.yml
@@ -1,30 +1,57 @@
 # Production Deployment Workflow (issue #74 / go-live blocker P5)
 # Copy this file to the PRIVATE production repository at .github/workflows/deploy.yml
+# (it calls deploy-stack.yml, which must be copied alongside it).
 #
-# Modeled on the PROVEN staging deploy job (dev repo deploy-pipeline.yml
-# deploy-staging) instead of the previous SSH-based template, which was
-# unusable: ubuntu-latest runner (cannot reach campus VMs), no migration/seed,
-# no nginx validation, placeholder smoke URLs, and a `git checkout HEAD~1`
-# "rollback" that would have desynced the working tree from the images.
+# TWO-STAGE PROMOTION WITH A HUMAN GATE ON EACH STAGE
+# ---------------------------------------------------
+#   resolve-images ──▶ deploy-test ──▶ deploy-production
+#   (ubuntu-latest)    [self-hosted,      [self-hosted,
+#                       linux, test]       linux, production]
+#                      env: test          env: production
+#                      🔒 1 approval      🔒 1 approval
+#
+# Nothing reaches the production VM that has not first been deployed to, and
+# verified on, the test VM by the very same script (deploy-stack.yml) — the
+# stage differs only in which runner it lands on and which GitHub Environment
+# supplies its secrets. `needs: deploy-test` makes that ordering structural: a
+# failed or rejected test stage means the production job never starts.
+#
+# The approval gate is a GitHub *Environment protection rule*, not YAML. It has
+# to be configured once, in the production repository:
+#
+#   Settings → Environments → `test`        → Required reviewers: 1 person
+#   Settings → Environments → `production`  → Required reviewers: 1 person
+#
+# Without that configuration these jobs run unattended — the `environment:` key
+# alone gates nothing. See SECRETS-SETUP-GUIDE.md § Environments.
 #
 # This repository does NOT build images. The development repository's pipeline
-# publishes them to GHCR once; production promotes that exact artifact, so what
-# runs in production is bit-identical to what staging verified.
+# publishes them to GHCR once; both stages promote that exact artifact, so what
+# runs in production is bit-identical to what the test stage verified.
 #
 # Prerequisites (one-time, see SECRETS-SETUP-GUIDE.md):
-#   - A self-hosted runner registered on the production AP VM with labels
-#     [self-hosted, linux] (same pattern as setting-env.yml).
-#   - GitHub `production` environment with required reviewers (blocker P6).
+#   - TWO self-hosted runners, one per VM, distinguished by a stage label:
+#       test AP VM        → labels [self-hosted, linux, test]
+#       production AP VM  → labels [self-hosted, linux, production]
+#     The stage label is mandatory. Both VMs answer to [self-hosted, linux], so
+#     without it a job lands on whichever runner is idle.
+#   - GitHub Environments `test` and `production`, each with 1 required
+#     reviewer and each holding its OWN secrets/variables (they are different
+#     databases, portals, mail relays and PII keys — see the guide).
 #   - Repository variables:
-#       PRODUCTION_URL = https://ss.aa.nycu.edu.tw
-#       IMAGE_OWNER    = GHCR namespace publishing the images (the dev repo's
-#                        owner, e.g. anud18) — required.
+#       IMAGE_OWNER = GHCR namespace publishing the images (the dev repo's
+#                     owner, e.g. anud18) — required, shared by both stages.
+#   - Per-environment variables (set on `test` AND on `production`):
+#       DEPLOY_STAGE   = test | production   (stage-identity guard, required)
+#       EXPECT_DOMAIN  = the domain this stage may touch (required on test)
+#       EXPECT_DB_HOST = the DB host this stage may touch (required on test)
+#       DEPLOY_URL     = https://ss-test.aa.nycu.edu.tw | https://ss.aa.nycu.edu.tw
 #       SSL_CERT_DIR   = optional; absolute path to the TLS certificate
-#                        directory on the AP VM (e.g. /home/<user>/ssl).
+#                        directory on that VM (e.g. /home/<user>/ssl).
 #                        Defaults to ./nginx/ssl/prod in the deploy directory.
+#       ENV_FILE       = optional; path to an operator-managed .env on that VM.
 #   - secrets.GH_PAT with read:packages, if the upstream packages are private.
-#   - All secrets listed in the validate-secrets job below.
-#   - docker-compose.prod-db.yml stack already running on the DB VM.
+#   - docker-compose.prod-db.yml stack already running on each stage's DB VM.
 
 name: Deploy to Production
 
@@ -43,7 +70,9 @@ on:
         type: string
 
 concurrency:
-  group: production-deploy
+  # Covers the whole promotion, not just the production stage: two overlapping
+  # runs would otherwise race to deploy different tags onto the same VMs.
+  group: deploy-promotion
   cancel-in-progress: false
 
 # Least privilege: nothing in this workflow writes via GITHUB_TOKEN. Jobs that
@@ -51,101 +80,18 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  REGISTRY: ghcr.io
-
 jobs:
-  # ── Gate 0: fail fast on misconfigured secrets BEFORE touching anything ──
-  # Closes go-live blockers P3/P4/P7/P8: config.py ships staging/dev defaults
-  # (portal.test auth, localhost student API, "(測試)" mail sender), so a
-  # missing secret would not crash — it would silently run production against
-  # test infrastructure. The backend boot guard (#936) is the second line of
-  # defense; this is the first.
-  validate-secrets:
-    name: Validate Production Secrets
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate
-        # Only meaningful when the stack is configured from GitHub Secrets.
-        # With ENV_FILE set, the values live on the AP VM and are validated
-        # there by the deploy job's "Resolve environment file" step instead.
-        if: vars.ENV_FILE == ''
-        env:
-          DOMAIN: ${{ secrets.DOMAIN }}
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-          MINIO_HOST: ${{ secrets.MINIO_HOST }}
-          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
-          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
-          PORTAL_JWT_SERVER_URL: ${{ secrets.PORTAL_JWT_SERVER_URL }}
-          STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
-          SMTP_HOST: ${{ secrets.SMTP_HOST }}
-          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
-          EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
-          SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
-        run: |
-          fail=0
-          err() { echo "::error::$1"; fail=1; }
-
-          [ -n "$DOMAIN" ] || err "DOMAIN is not set"
-          [ -n "$DB_HOST" ] || err "DB_HOST is not set"
-          [ -n "$DB_PASSWORD" ] || err "DB_PASSWORD is not set"
-          [ -n "$REDIS_PASSWORD" ] || err "REDIS_PASSWORD is not set"
-          [ -n "$MINIO_HOST" ] || err "MINIO_HOST is not set"
-          [ -n "$MINIO_ACCESS_KEY" ] || err "MINIO_ACCESS_KEY is not set"
-          [ -n "$MINIO_SECRET_KEY" ] || err "MINIO_SECRET_KEY is not set"
-          [ -n "$SUPER_ADMIN_NYCU_ID" ] || err "SUPER_ADMIN_NYCU_ID is not set (no one could elevate to super_admin)"
-
-          [ "${#SECRET_KEY}" -ge 32 ] || err "SECRET_KEY must be >= 32 chars (and MUST differ from staging)"
-
-          # P4: PII keys — missing keys hard-fail the encrypt migration / first
-          # PII read; malformed JSON fails at boot. Catch both here.
-          if [ -z "$PII_ENCRYPTION_KEYS" ]; then
-            err "PII_ENCRYPTION_KEYS is not set. Generate a key per docs/architecture/pii-encryption.md then set '{\"v1\":\"<KEY>\"}'"
-          elif ! echo "$PII_ENCRYPTION_KEYS" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
-            err "PII_ENCRYPTION_KEYS is not valid JSON"
-          fi
-
-          # P3: production must never authenticate against the staging portal.
-          case "$PORTAL_JWT_SERVER_URL" in
-            "") err "PORTAL_JWT_SERVER_URL is not set (config.py would default to portal.test — STAGING auth)" ;;
-            *portal.test*) err "PORTAL_JWT_SERVER_URL points at portal.test (staging) — set the production Portal endpoint" ;;
-            https://*) : ;;
-            *) err "PORTAL_JWT_SERVER_URL must be https://" ;;
-          esac
-
-          # P8: student API must be the real campus API (no longer uses HMAC auth).
-          case "$STUDENT_API_BASE_URL" in
-            "") err "STUDENT_API_BASE_URL is not set (would default to the localhost mock; verification fails SILENTLY)" ;;
-            *localhost*|*127.0.0.1*|*mock*) err "STUDENT_API_BASE_URL looks like a mock/localhost endpoint: $STUDENT_API_BASE_URL" ;;
-          esac
-
-          # P7: real applicants must not receive '(測試)' mail from ss-test.
-          [ -n "$SMTP_HOST" ] || err "SMTP_HOST is not set (would default to the staging relay)"
-          case "$EMAIL_FROM" in
-            "") err "EMAIL_FROM is not set (would default to ss-test.aa@nycu.edu.tw)" ;;
-            *ss-test*) err "EMAIL_FROM still uses the staging address: $EMAIL_FROM" ;;
-          esac
-          case "$EMAIL_FROM_NAME" in
-            "") err "EMAIL_FROM_NAME is not set (would default to '(測試)獎學金申請與審核系統')" ;;
-            *測試*) err "EMAIL_FROM_NAME still contains 測試: $EMAIL_FROM_NAME" ;;
-          esac
-
-          [ "$fail" -eq 0 ] || exit 1
-          echo "✅ All production secrets validated"
-
   # ── Gate 1: the requested images must already exist upstream ──────────────
   # This repository does NOT build. Images are produced once by the development
   # repository's pipeline and promoted here unchanged, so what production runs
-  # is bit-identical to what was tested on staging — rebuilding from mirrored
-  # source would produce a different artifact from the one that was verified.
+  # is bit-identical to what was tested — rebuilding from mirrored source would
+  # produce a different artifact from the one that was verified.
+  #
+  # Runs BEFORE the approval gates on purpose: a reviewer should never be asked
+  # to approve a deploy of a tag that does not exist.
   resolve-images:
     name: Resolve Upstream Images
     runs-on: ubuntu-latest
-    needs: validate-secrets
     permissions:
       packages: read # ghcr.io login + docker manifest inspect (GITHUB_TOKEN fallback when GH_PAT is unset)
     outputs:
@@ -172,10 +118,10 @@ jobs:
 
           # `latest` follows the dev repo's main branch. Pin an immutable tag
           # (e.g. main-<sha> or a release version) for a reproducible deploy —
-          # with `latest`, the rollback path below can only re-pull `latest`,
-          # which is the same moving image.
+          # with `latest`, the two stages could resolve DIFFERENT images and the
+          # test stage would stop being evidence about the production one.
           VERSION="${REQUESTED_TAG:-latest}"
-          [ "$VERSION" = "latest" ] && echo "::warning::Deploying the mutable 'latest' tag — pin a tag for a reproducible, rollback-able deploy."
+          [ "$VERSION" = "latest" ] && echo "::warning::Deploying the mutable 'latest' tag — pin a tag so test and production promote the same image."
 
           echo "Resolving ghcr.io/${IMAGE_OWNER}/scholarship-system-{backend,frontend}:${VERSION}"
           echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
@@ -201,415 +147,36 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Deploying version: $VERSION"
 
-  deploy:
-    name: Deploy to Production
-    # The runner lives ON the production AP VM (campus network) — GitHub-hosted
-    # runners cannot reach it. Register with: [self-hosted, linux].
-    runs-on: [self-hosted, linux]
-    needs: [validate-secrets, resolve-images]
-    # Job-level permissions REPLACE the workflow-level block, so contents: read
-    # must be restated alongside the packages elevation.
+  # ── Stage 1: TEST AP VM — waits for a reviewer, then rehearses the deploy ──
+  deploy-test:
+    name: Deploy to test
+    needs: resolve-images
+    uses: ./.github/workflows/deploy-stack.yml
+    with:
+      stage: test
+      runner_labels: '["self-hosted","linux","test"]'
+      tag: ${{ needs.resolve-images.outputs.version }}
+    # The called workflow reads secrets from the `test` ENVIRONMENT, which
+    # overrides the repository-level (production) values. `inherit` is what
+    # passes GH_PAT and the rest down; the environment scoping happens inside.
+    secrets: inherit
     permissions:
-      contents: read # actions/checkout
-      packages: read # docker/login-action + docker pull (GITHUB_TOKEN fallback when GH_PAT is unset)
-    environment:
-      name: production
-      url: ${{ vars.PRODUCTION_URL }}
+      contents: read
+      packages: read
 
-    # DELIBERATELY MINIMAL. Everything compose interpolates comes from an env
-    # file (see "Resolve environment file"), NOT from the job environment:
-    # compose gives shell variables precedence over --env-file, so exporting
-    # the same keys here would silently shadow an operator-managed .env — and
-    # an unset GitHub secret exports as an EMPTY string, which shadows the
-    # file's value with "" rather than falling back to it.
-    #
-    # Only workflow-authoritative values live here. Both are always non-empty
-    # (IMAGE_OWNER is validated in resolve-images), so overriding is intended:
-    # the workflow decides which image was pulled and therefore which runs.
-    env:
-      TAG: ${{ needs.resolve-images.outputs.version }}
-      IMAGE_OWNER: ${{ vars.IMAGE_OWNER }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      # Authenticate against the UPSTREAM namespace. GITHUB_TOKEN is scoped to
-      # this repository and cannot read another owner's packages, so a PAT with
-      # read:packages is required whenever those packages are private.
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
-
-      - name: Pull images
-        run: |
-          docker pull ${{ env.REGISTRY }}/${IMAGE_OWNER}/scholarship-system-backend:${TAG}
-          docker pull ${{ env.REGISTRY }}/${IMAGE_OWNER}/scholarship-system-frontend:${TAG}
-
-      - name: Prepare deployment files
-        run: |
-          mkdir -p ~/scholarship-production/logs/nginx
-          cp docker-compose.prod.yml ~/scholarship-production/docker-compose.yml
-          # Merge (not replace): a certificate directory placed under
-          # ~/scholarship-production/nginx/ssl/prod by the operator must
-          # survive, since the repo ships nginx configs but no keys.
-          if [ -d nginx ]; then cp -r nginx ~/scholarship-production/; fi
-          # Everything below is copied as the runner user and therefore owned by
-          # it, so a plain rm is enough to replace it. sudo -n is only a fallback
-          # for hosts that ran an earlier, broken version of this workflow and
-          # were left with root-owned leftovers; -n so a VM WITHOUT passwordless
-          # sudo fails immediately with the message below instead of blocking on
-          # a password prompt no one can answer.
-          replace_dir() {
-            rm -rf "$HOME/scholarship-production/$1" 2>/dev/null && return 0
-            sudo -n rm -rf "$HOME/scholarship-production/$1" 2>/dev/null && return 0
-            echo "::error::Cannot replace ~/scholarship-production/$1 — it is owned by root"
-            echo "::error::from an earlier deploy and this runner has no passwordless sudo."
-            echo "::error::Clear it once on the AP VM: sudo rm -rf ~/scholarship-production/$1"
-            return 1
-          }
-          if [ -d monitoring ]; then
-            replace_dir monitoring
-            cp -r monitoring ~/scholarship-production/
-          fi
-          # scripts/logrotate.conf is bind-mounted as the logrotate service's
-          # config. This copy was missing, so Docker materialised the mount
-          # source as a root-owned DIRECTORY and logrotate rotated nothing
-          # ("Handling 0 logs", exit 0) while the container stayed Up — the
-          # nginx access log grew unbounded with no signal anything was wrong.
-          # No chown here: logrotate ignores configs it does not own, so the
-          # container makes its own root-owned copy (docker-compose.prod.yml).
-          if [ -d scripts ]; then
-            replace_dir scripts
-            cp -r scripts ~/scholarship-production/
-          fi
-
-      # Two supported ways to configure the stack, chosen by the ENV_FILE
-      # repository variable:
-      #
-      #   ENV_FILE set   — an operator-managed .env already on the AP VM
-      #                    (install manual section 5.1: `touch ~/.env`). Nothing
-      #                    is written; GitHub never holds these values.
-      #   ENV_FILE unset — generated here from GitHub Secrets into the deploy
-      #                    directory, mode 600. This is the default.
-      #
-      # Either way compose is invoked with --env-file, so there is exactly one
-      # source of truth for interpolation.
-      - name: Resolve environment file
-        env:
-          ENV_FILE_VAR: ${{ vars.ENV_FILE }}
-          SSL_CERT_DIR_VAR: ${{ vars.SSL_CERT_DIR }}
-          DOMAIN: ${{ secrets.DOMAIN }}
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          CORS_ORIGINS: ${{ secrets.CORS_ORIGINS }}
-          DB_HOST: ${{ secrets.DB_HOST }}
-          DB_PORT: ${{ secrets.DB_PORT }}
-          DB_USER: ${{ secrets.DB_USER }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          DB_NAME: ${{ secrets.DB_NAME }}
-          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-          MINIO_HOST: ${{ secrets.MINIO_HOST }}
-          MINIO_PORT: ${{ secrets.MINIO_PORT }}
-          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
-          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
-          # Secret name stays MINIO_BUCKET_NAME; compose interpolates
-          # ${MINIO_BUCKET} — the env name config.py actually binds.
-          MINIO_BUCKET_NAME: ${{ secrets.MINIO_BUCKET_NAME }}
-          MINIO_SECURE: ${{ secrets.MINIO_SECURE }}
-          PII_ENCRYPTION_KEYS: ${{ secrets.PII_ENCRYPTION_KEYS }}
-          PII_ENCRYPTION_ACTIVE_VERSION: ${{ secrets.PII_ENCRYPTION_ACTIVE_VERSION }}
-          SMTP_HOST: ${{ secrets.SMTP_HOST }}
-          SMTP_PORT: ${{ secrets.SMTP_PORT }}
-          SMTP_USER: ${{ secrets.SMTP_USER }}
-          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
-          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
-          EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
-          PORTAL_JWT_SERVER_URL: ${{ secrets.PORTAL_JWT_SERVER_URL }}
-          STUDENT_API_BASE_URL: ${{ secrets.STUDENT_API_BASE_URL }}
-          SUPER_ADMIN_NYCU_ID: ${{ secrets.SUPER_ADMIN_NYCU_ID }}
-          NEXT_PUBLIC_NYCU_PORTAL_URL: ${{ secrets.NEXT_PUBLIC_NYCU_PORTAL_URL }}
-        run: |
-          set -euo pipefail
-
-          if [ -n "${ENV_FILE_VAR}" ]; then
-            ENV_FILE="${ENV_FILE_VAR}"
-            echo "Using operator-managed env file: ${ENV_FILE}"
-            [ -f "${ENV_FILE}" ] || {
-              echo "::error::ENV_FILE points at ${ENV_FILE}, which does not exist on this runner."
-              echo "::error::Create it (see install manual section 5.1) or clear the ENV_FILE variable"
-              echo "::error::to fall back to generating it from GitHub Secrets."
-              exit 1
-            }
-            [ -r "${ENV_FILE}" ] || { echo "::error::${ENV_FILE} is not readable by the runner user."; exit 1; }
-
-            # Fail now on anything compose cannot default, instead of booting a
-            # backend that silently falls back to config.py's dev values.
-            missing=""
-            for k in DOMAIN SECRET_KEY DB_HOST DB_PORT DB_USER DB_PASSWORD DB_NAME \
-                     REDIS_PASSWORD MINIO_HOST MINIO_ACCESS_KEY MINIO_SECRET_KEY \
-                     PII_ENCRYPTION_KEYS SMTP_HOST EMAIL_FROM EMAIL_FROM_NAME \
-                     PORTAL_JWT_SERVER_URL STUDENT_API_BASE_URL SUPER_ADMIN_NYCU_ID \
-                     NEXT_PUBLIC_NYCU_PORTAL_URL CORS_ORIGINS; do
-              grep -qE "^[[:space:]]*${k}=" "${ENV_FILE}" || missing="${missing} ${k}"
-            done
-            [ -z "${missing}" ] || { echo "::error::${ENV_FILE} is missing required keys:${missing}"; exit 1; }
-
-            # Same production guards the validate-secrets job applies to
-            # GitHub Secrets. They live here too because in ENV_FILE mode that
-            # job has nothing to inspect — config.py ships staging defaults, so
-            # a wrong value would not crash, it would quietly run production
-            # against test infrastructure.
-            v() { sed -n "s/^[[:space:]]*$1=//p" "${ENV_FILE}" | tail -1; }
-            fail=0
-            err() { echo "::error::$1"; fail=1; }
-
-            SK="$(v SECRET_KEY)"
-            [ "${#SK}" -ge 32 ] || err "SECRET_KEY must be >= 32 chars (and MUST differ from staging)"
-
-            printf '%s' "$(v PII_ENCRYPTION_KEYS)" | python3 -c 'import json,sys; json.load(sys.stdin)' >/dev/null 2>&1 \
-              || err "PII_ENCRYPTION_KEYS is not valid JSON"
-
-            case "$(v PORTAL_JWT_SERVER_URL)" in
-              *portal.test*) err "PORTAL_JWT_SERVER_URL points at portal.test (staging)" ;;
-              https://*) : ;;
-              *) err "PORTAL_JWT_SERVER_URL must be https://" ;;
-            esac
-            case "$(v STUDENT_API_BASE_URL)" in
-              *localhost*|*127.0.0.1*|*mock*) err "STUDENT_API_BASE_URL looks like a mock/localhost endpoint" ;;
-            esac
-            case "$(v EMAIL_FROM)" in *ss-test*) err "EMAIL_FROM still uses the staging address" ;; esac
-            case "$(v EMAIL_FROM_NAME)" in *測試*) err "EMAIL_FROM_NAME still contains 測試" ;; esac
-
-            [ "$fail" -eq 0 ] || exit 1
-            echo "✅ All required keys present and validated"
-          else
-            ENV_FILE="$HOME/scholarship-production/.env"
-            echo "Generating ${ENV_FILE} from GitHub Secrets"
-            umask 077
-            {
-              echo "# Generated by deploy.yml — do not edit; changes are overwritten."
-              echo "DOMAIN=${DOMAIN}"
-              echo "SECRET_KEY=${SECRET_KEY}"
-              echo "CORS_ORIGINS=${CORS_ORIGINS}"
-              echo "DB_HOST=${DB_HOST}"
-              echo "DB_PORT=${DB_PORT}"
-              echo "DB_USER=${DB_USER}"
-              echo "DB_PASSWORD=${DB_PASSWORD}"
-              echo "DB_NAME=${DB_NAME}"
-              echo "REDIS_PASSWORD=${REDIS_PASSWORD}"
-              echo "MINIO_HOST=${MINIO_HOST}"
-              echo "MINIO_PORT=${MINIO_PORT}"
-              echo "MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}"
-              echo "MINIO_SECRET_KEY=${MINIO_SECRET_KEY}"
-              echo "MINIO_BUCKET=${MINIO_BUCKET_NAME}"
-              echo "MINIO_SECURE=${MINIO_SECURE}"
-              echo "PII_ENCRYPTION_KEYS=${PII_ENCRYPTION_KEYS}"
-              echo "PII_ENCRYPTION_ACTIVE_VERSION=${PII_ENCRYPTION_ACTIVE_VERSION}"
-              echo "SMTP_HOST=${SMTP_HOST}"
-              echo "SMTP_PORT=${SMTP_PORT}"
-              echo "SMTP_USER=${SMTP_USER}"
-              echo "SMTP_PASSWORD=${SMTP_PASSWORD}"
-              echo "EMAIL_FROM=${EMAIL_FROM}"
-              echo "EMAIL_FROM_NAME=${EMAIL_FROM_NAME}"
-              echo "PORTAL_SSO_ENABLED=true"
-              echo "PORTAL_JWT_SERVER_URL=${PORTAL_JWT_SERVER_URL}"
-              echo "PORTAL_TEST_MODE=false"
-              echo "STUDENT_API_ENABLED=true"
-              echo "STUDENT_API_BASE_URL=${STUDENT_API_BASE_URL}"
-              echo "SUPER_ADMIN_NYCU_ID=${SUPER_ADMIN_NYCU_ID}"
-              echo "NEXT_PUBLIC_NYCU_PORTAL_URL=${NEXT_PUBLIC_NYCU_PORTAL_URL}"
-              [ -n "${SSL_CERT_DIR_VAR}" ] && echo "SSL_CERT_DIR=${SSL_CERT_DIR_VAR}"
-            } > "${ENV_FILE}"
-            chmod 600 "${ENV_FILE}"
-            echo "✅ Wrote $(grep -c '=' "${ENV_FILE}") entries (mode 600)"
-          fi
-
-          echo "ENV_FILE=${ENV_FILE}" >> "$GITHUB_ENV"
-
-          # Read back the values later steps need. Taking DOMAIN from the
-          # resolved file (rather than from secrets) keeps both modes identical.
-          envget() { sed -n "s/^[[:space:]]*$1=//p" "${ENV_FILE}" | tail -1; }
-          echo "DOMAIN=$(envget DOMAIN)" >> "$GITHUB_ENV"
-
-          # Certificate location precedence: the SSL_CERT_DIR repository
-          # variable wins in BOTH modes (it describes where the operator put
-          # the certificate on this host, not a secret), then the env file,
-          # then compose's ./nginx/ssl/prod default.
-          CERT_DIR="${SSL_CERT_DIR_VAR:-$(envget SSL_CERT_DIR)}"
-          echo "CERT_DIR=${CERT_DIR}" >> "$GITHUB_ENV"
-          # Export to compose ONLY when non-empty: an exported empty string
-          # would shadow the env file's value instead of deferring to it.
-          if [ -n "${CERT_DIR}" ]; then
-            echo "SSL_CERT_DIR=${CERT_DIR}" >> "$GITHUB_ENV"
-            echo "Certificate directory (SSL_CERT_DIR): ${CERT_DIR}"
-          else
-            echo "Certificate directory: compose default (./nginx/ssl/prod)"
-          fi
-
-      - name: Verify TLS certificates are present
-        run: |
-          cd ~/scholarship-production
-          CERT_DIR="${CERT_DIR:-./nginx/ssl/prod}"
-          echo "Certificate directory: $CERT_DIR"
-          missing=0
-          # nginx.prod.conf references all three; a missing file puts nginx in
-          # a crash loop and the deploy would only fail later, at `nginx -t`,
-          # with a far less obvious message.
-          for f in fullchain.pem privkey.pem chain.pem; do
-            if [ -f "${CERT_DIR}/${f}" ]; then
-              echo "  ✅ ${f}"
-            else
-              echo "::error::Missing certificate file: ${CERT_DIR}/${f}"
-              missing=1
-            fi
-          done
-          [ "$missing" -eq 0 ] || {
-            echo "::error::Place the TLS certificate in ${CERT_DIR}, or set the"
-            echo "::error::repository variable SSL_CERT_DIR to an absolute path on the AP VM"
-            echo "::error::(e.g. /home/<user>/ssl) so private keys stay out of git."
-            exit 1
-          }
-
-      - name: Start new containers
-        run: |
-          cd ~/scholarship-production
-          # --env-file is the single source of interpolation values; TAG and
-          # IMAGE_OWNER come from the job env and intentionally take precedence.
-          docker compose --env-file "${ENV_FILE}" down || true
-
-          # scholarship_prod_network is declared external so it keeps a stable,
-          # unprefixed name the monitoring stack can join — compose never
-          # creates an external network, so it has to exist before `up`.
-          #
-          # Order matters: this runs AFTER `down`. Revisions before the external
-          # switch declared the network inline, so it exists under the compose
-          # project prefix holding this very subnet, and creating the new one
-          # first fails with "Pool overlaps with other one on this address
-          # space". `down` detaches the containers; removing the legacy network
-          # then frees the address space. Both lines are no-ops once migrated.
-          docker network rm scholarship-production_scholarship_prod_network 2>/dev/null || true
-          docker network inspect scholarship_prod_network >/dev/null 2>&1 || \
-            docker network create --subnet 172.24.0.0/16 scholarship_prod_network
-
-          docker compose --env-file "${ENV_FILE}" up -d
-
-      - name: Validate and reload nginx config
-        run: |
-          # Config is bind-mounted read-only; `compose up -d` does not reload
-          # nginx when only the file contents change. Validate first — never
-          # leave a broken config running.
-          if docker exec scholarship_nginx_prod nginx -t; then
-            docker exec scholarship_nginx_prod nginx -s reload
-            echo "✅ nginx config validated and reloaded"
-          else
-            echo "::error::nginx config test failed — keeping previously-loaded config"
-            exit 1
-          fi
-
-      - name: Run database migrations
-        run: |
-          # NO error swallowing: a half-applied migration with a green deploy
-          # is the worst possible state (and /health does not verify schema).
-          docker exec scholarship_backend_prod alembic upgrade head
-          docker exec scholarship_backend_prod alembic current
-
-      - name: Seed production baseline
-        run: |
-          # --prod creates ONLY admin/lookup/settings/email templates — never
-          # test users. Idempotent. Must succeed (no '|| echo' swallowing).
-          docker exec scholarship_backend_prod python -m app.seed --prod
-
-      - name: Health check
-        run: |
-          # Backend has no published port in production (expose-only) —
-          # check from inside the container, then end-to-end through nginx.
-          max_retries=10
-          retry_count=0
-          until docker exec scholarship_backend_prod curl -fsS http://localhost:8000/health >/dev/null 2>&1 || [ $retry_count -eq $max_retries ]; do
-            echo "Backend not ready yet... ($retry_count/$max_retries)"
-            sleep 5
-            retry_count=$((retry_count + 1))
-          done
-          if [ $retry_count -eq $max_retries ]; then
-            echo "::error::Backend health check failed"
-            docker logs --tail 100 scholarship_backend_prod
-            exit 1
-          fi
-          echo "✅ Backend healthy"
-
-          retry_count=0
-          until curl -fsk https://localhost/health >/dev/null 2>&1 || [ $retry_count -eq $max_retries ]; do
-            echo "nginx→backend not ready yet... ($retry_count/$max_retries)"
-            sleep 5
-            retry_count=$((retry_count + 1))
-          done
-          if [ $retry_count -eq $max_retries ]; then
-            echo "::error::End-to-end health check via nginx failed"
-            docker logs --tail 50 scholarship_nginx_prod
-            exit 1
-          fi
-          echo "✅ nginx → backend healthy"
-
-      - name: Smoke tests
-        run: |
-          curl -fsk "https://localhost/health" -H "Host: ${DOMAIN}" >/dev/null || exit 1
-          # /api/v1/docs is intentionally disabled when ENVIRONMENT=production
-          # (backend/app/main.py) — smoke-test a real mounted API route instead.
-          curl -fsk "https://localhost/api/v1/scholarships" -H "Host: ${DOMAIN}" >/dev/null || exit 1
-          # Frontend through nginx
-          code=$(curl -sk -o /dev/null -w '%{http_code}' "https://localhost/" -H "Host: ${DOMAIN}")
-          [ "$code" = "200" ] || { echo "::error::Frontend returned $code"; exit 1; }
-          echo "✅ Smoke tests passed"
-
-      - name: Record successful deployment tag
-        if: success()
-        run: |
-          echo "${TAG}" > ~/scholarship-production/last-good-tag
-          echo "Saved last-good tag: ${TAG}"
-
-      - name: Rollback to last-good deployment
-        if: failure()
-        run: |
-          cd ~/scholarship-production
-          # Resolve step may itself have failed, leaving ENV_FILE unset.
-          ENV_FILE="${ENV_FILE:-$HOME/scholarship-production/.env}"
-          if [ ! -f "${ENV_FILE}" ]; then
-            echo "::error::No usable env file (${ENV_FILE}) — cannot roll back automatically."
-            exit 1
-          fi
-          # last-good-tag is written ONLY by the success path above, so it
-          # always names a tag that actually passed health + smoke checks.
-          if [ -f last-good-tag ]; then
-            PREV_TAG=$(cat last-good-tag)
-            if [ "$PREV_TAG" = "$TAG" ]; then
-              echo "::error::last-good tag is '${PREV_TAG}', identical to the tag that just failed."
-              echo "::error::This happens when deploying the mutable 'latest' tag — rolling back"
-              echo "::error::would re-pull the same image. Redeploy an explicit older tag instead."
-              exit 1
-            fi
-            echo "::warning::Deploy of ${TAG} failed — rolling back to ${PREV_TAG}"
-            TAG=$PREV_TAG docker compose --env-file "${ENV_FILE}" up -d
-            sleep 15
-            if docker exec scholarship_backend_prod curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
-              echo "::notice::Rollback to ${PREV_TAG} succeeded."
-            else
-              echo "::error::Rollback health check ALSO failed — manual intervention required."
-              echo "::error::If a migration was applied, evaluate 'alembic downgrade' or restore the latest backup (see DR runbook)."
-            fi
-          else
-            echo "::warning::No last-good-tag — cannot auto-rollback."
-          fi
-
-      - name: Deployment summary
-        if: success()
-        run: |
-          {
-            echo "## ✅ Production Deployment Successful"
-            echo ""
-            echo "**Version**: ${TAG}"
-            echo "**URL**: ${{ vars.PRODUCTION_URL }}"
-            echo "**Migrations**: $(docker exec scholarship_backend_prod alembic current 2>/dev/null | tail -1)"
-          } >> "$GITHUB_STEP_SUMMARY"
+  # ── Stage 2: PRODUCTION AP VM — only reachable through a green test stage ──
+  deploy-production:
+    name: Deploy to production
+    needs: [resolve-images, deploy-test]
+    uses: ./.github/workflows/deploy-stack.yml
+    with:
+      stage: production
+      runner_labels: '["self-hosted","linux","production"]'
+      # Deliberately the SAME resolved tag the test stage deployed — not a
+      # re-resolution — so the artifact that was verified is the artifact that
+      # ships.
+      tag: ${{ needs.resolve-images.outputs.version }}
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: read

--- a/.github/production-workflows-examples/health-check.yml
+++ b/.github/production-workflows-examples/health-check.yml
@@ -10,7 +10,11 @@
 #
 # Prerequisites:
 #   - The self-hosted runner registered on the production AP VM, labels
-#     [self-hosted, linux] (same runner deploy.yml uses).
+#     [self-hosted, linux, production] (the same runner deploy.yml's production
+#     stage uses). The `production` label is mandatory — the test AP VM also
+#     answers to [self-hosted, linux], and probes that landed there would
+#     report on the wrong stack. Scheduled, so deliberately NOT behind the
+#     `production` environment's approval gate: it only reads.
 #   - Secrets: DOMAIN, REDIS_PASSWORD (already required by deploy.yml).
 
 name: Production Health Check
@@ -26,7 +30,7 @@ jobs:
     # The runner lives ON the production AP VM, so every probe below is a
     # direct localhost/container check — the most direct signal of service
     # availability, with no VPN or SSH hop to fail independently.
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, production]
     permissions:
       issues: write
       contents: read

--- a/.github/production-workflows-examples/setting-env.yml
+++ b/.github/production-workflows-examples/setting-env.yml
@@ -7,7 +7,18 @@
 # - Creates necessary directory structure with correct permissions
 # - Generates .env files from GitHub Secrets
 #
-# GitHub Runner: Runs on self-hosted runner installed on AP VM
+# GitHub Runner: Runs on the self-hosted runner installed on the selected
+# stage's AP VM. There are TWO such VMs and both answer to [self-hosted, linux],
+# so the `stage` input picks the runner by its stage label — never leave it to
+# chance, or a "setup" run can reconfigure the wrong machine.
+#
+# Approval: this workflow writes .env files and installs packages on the VM, so
+# the production stage runs under the `production` GitHub Environment and is
+# blocked until a required reviewer approves it. The test stage is gated the
+# same way by the `test` environment. Configure the reviewers once in
+# Settings → Environments (see SECRETS-SETUP-GUIDE.md § Environments) — the
+# `environment:` key alone gates nothing.
+#
 # Reference: See installation manual Section 3 (Docker) and Section 6 (GitHub Runner)
 
 name: Setup Production Environment
@@ -15,6 +26,14 @@ name: Setup Production Environment
 on:
   workflow_dispatch:
     inputs:
+      stage:
+        description: 'Which AP VM to configure'
+        required: true
+        type: choice
+        options:
+          - test
+          - production
+        default: 'test'
       action:
         description: 'Action to perform'
         required: true
@@ -31,8 +50,14 @@ permissions:
 
 jobs:
   setup-environment:
-    name: ${{ github.event.inputs.action == 'validate' && 'Validate Environment' || github.event.inputs.action == 'setup' && 'Setup Environment' || 'Full Check & Setup' }}
-    runs-on: [self-hosted, linux]
+    name: ${{ inputs.stage }} — ${{ github.event.inputs.action == 'validate' && 'Validate Environment' || github.event.inputs.action == 'setup' && 'Setup Environment' || 'Full Check & Setup' }}
+    # Stage label appended to the shared [self-hosted, linux] pair so the job
+    # is pinned to exactly one VM.
+    runs-on: ${{ fromJSON(format('["self-hosted","linux","{0}"]', inputs.stage)) }}
+    # The approval gate, and the source of this stage's secrets: the `test`
+    # environment supplies the test database/portal/SMTP values, `production`
+    # the real ones. Both require a reviewer before the job starts.
+    environment: ${{ inputs.stage }}
     # Bounded so a hung SSH/sudo prompt or an offline runner doesn't wait
     # forever. If the job sits queued, the AP VM runner service is likely down
     # — SSH in and run: sudo systemctl status actions.runner.*

--- a/.github/workflows/mirror-to-production.yml
+++ b/.github/workflows/mirror-to-production.yml
@@ -625,7 +625,10 @@ jobs:
           # scanners). Operators read those guides in the DEV repo's
           # .github/production-workflows-examples/ — they already have access
           # there since they dispatch this mirror.
-          for f in deploy.yml health-check.yml backup.yml auto-tag-on-merge.yml setting-env.yml; do
+          # deploy-stack.yml is the reusable stage body deploy.yml calls with
+          # `uses: ./.github/workflows/deploy-stack.yml` — shipping deploy.yml
+          # without it leaves the prod repo with an unresolvable workflow.
+          for f in deploy.yml deploy-stack.yml health-check.yml backup.yml auto-tag-on-merge.yml setting-env.yml; do
             src="/tmp/prod-workflow-templates/$f"
             [ -f "$src" ] || continue
             dest=".github/workflows/$f"


### PR DESCRIPTION
## 為什麼

production repo 的 `deploy.yml` 過去直接部署到 production AP VM：沒有事前彩排，也沒有任何人工關卡。這個 PR 讓同一份 image 一律先上 test AP VM，再輪到 production，而且兩段各需一位 reviewer 核准。

```
resolve-images ──▶ deploy-test ────────▶ deploy-production
 (ubuntu-latest)   [self-hosted,           [self-hosted,
                    linux, test]            linux, production]
                   environment: test       environment: production
                   🔒 1 reviewer           🔒 1 reviewer
```

**順序是結構性的，但 test 失敗不否決 production。** `needs: deploy-test` 讓 production 等彩排跑完、讓 reviewer 看得到結果再決定；test 紅了，production 仍然會跳出自己的核准要求。理由是 test tier 有它自己會壞的理由（它的 DB、憑證、portal），那些不該卡住 production 的 hotfix —— 判斷交給核准的人，按 Reject 就停。唯一的硬否決是 `resolve-images`：沒解析出 tag 就沒東西可部署。

## 怎麼做

- **`deploy-stack.yml`（新增）** — 部署本體抽成 reusable workflow，以 `stage` / `runner_labels` / `tag` 參數化。一份腳本兩段共用，差別只有落在哪台 runner、以及哪個 GitHub Environment 供給設定。
- **`deploy.yml`** — 改成編排層，兩段各呼叫一次。production 用的是 test 驗過的同一個 tag，不重新解析。
- **env variable 隔離** — job 綁上 `environment:` 之後，`secrets.*` / `vars.*` 都由該 environment 解析，test 與 production 因此拿到各自的資料庫、portal、SMTP 與 PII 金鑰。
- **fallback 防呆** — environment 沒定義的 secret 會靜默落回 repository 層（＝production 的值）。`Assert stage identity` 在 checkout 之前比對 `DEPLOY_STAGE`、`EXPECT_DOMAIN`、`EXPECT_DB_HOST`，test 段必填，對不上就拒絕部署。
- **不再寫死站台字串** — 以前 workflow 裡直接比對測試站的網域／寄件者來判斷「production 是不是還指著測試環境」。這份模板會 mirror 進 production repo，不該帶站台主機名，改由 `FORBIDDEN_MARKERS` 變數提供（空白分隔；不設就跳過該檢查並發 warning）。`localhost` / `127.0.0.1` / `mock` 這類通用標記留在模板裡。
- **文件清理** — `README.md`、`SECRETS-SETUP-GUIDE.md` 的範例表格與 `gh secret set` 片段原本寫著真實網域、信件中繼、portal 與 student API 位址，全部改為佔位符。
- **runner label 全面釘死** — 兩台 AP VM 都答應 `[self-hosted, linux]`，不加 stage label 的話 job 會落在剛好閒著的那台。`setting-env.yml` 加了 stage 輸入與同樣的核准閘門；`backup.yml`、`health-check.yml` 釘到 production 但**刻意不加**核准（排程工作卡在等人核准等於沒在跑）。
- **`bootstrap-ap-runner.sh`** — `--stage` 改為必填，並擋掉「`--labels` 沒含 stage label」這種註冊完永遠收不到 job 的情況。
- **`mirror-to-production.yml`** — 安裝清單補上 `deploy-stack.yml`，否則 mirror 過去的 `deploy.yml` 會找不到它呼叫的 workflow。

## 部署前必做（YAML 做不到的部分）

在 production repo：

1. Settings → Environments 建立 `test` 與 `production`，各設 **Required reviewers = 1**。`environment:` 這個 key 本身不擋任何東西。
2. `test` environment 逐項設定自己的 secret —— 漏設的會靜默落回 production 的值。
3. 兩個 environment 都設 `DEPLOY_STAGE` / `EXPECT_DOMAIN` / `EXPECT_DB_HOST` / `DEPLOY_URL`；`FORBIDDEN_MARKERS` 設在 repository 層即可。
4. 兩台 VM 各跑一次 `bootstrap-ap-runner.sh --stage test|production`。

細節見 `SECRETS-SETUP-GUIDE.md` 的 Environments 章節。

## 驗證

在 `anud18/naass-prod-test` 用真實 self-hosted runner 實跑：

| 驗證項目 | 結果 |
|---|---|
| 每段各一道核准 | ✅ 兩段都停在 `waiting`，runner 尚未分配 |
| runner label 路由 | ✅ 兩段都落到對應 label |
| 兩段各自的 env variable | ✅ `~/scholarship-test` + `.env.stage-test` vs `~/scholarship-production` + `.env.prod-test` |
| 完整部署鏈 | ✅ 憑證 → 拉 image → 起容器 → nginx `-t`+reload → migration → seed → health → smoke → last-good-tag |
| rollback 分支 | ✅ 失敗時觸發並正確判定無 last-good-tag；成功時 skipped |

**兩點驗證落差，尚未實測：**

1. 「test 失敗 → production 仍要求核准」這個新行為是在驗證跑完之後才改的。實測當時 test 失敗那次，production 是 **skipped**（舊語意）。新的 `if:` 條件只有 YAML 層面驗過。
2. 測試用 `ENV_FILE` 模式，而兩個 stage 的 `.env` 是互相複製、指向同一顆 DB。因此證明的是「路徑與解析確實分流」，不是「值不同時會正確分流」。後者要等 test environment 真的指向另一套後端，或改用 GitHub Secrets 模式（清掉 `ENV_FILE`，`Validate secrets` 才會啟動）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4CxXHiWfBXFcJSA7gADut
