### PR TITLE
ci: add Fortify scan production workflow template (fix GitHub Actions command injection)

### DIFF
--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -51,6 +51,7 @@ warning: here-document at line 10 delimited by end-of-file (wanted `FOOTER_EOF')
 | `deploy-stack.yml` | `deploy.yml` 兩個階段共用的 reusable workflow（實際的部署腳本本體） | 由 `deploy.yml` 呼叫，不單獨觸發 | **必要**（與 deploy.yml 成對） |
 | `health-check.yml` | 監控應用程式健康狀態 | 每 15 分鐘 / 手動觸發 | 選用 |
 | `backup.yml` | 備份資料庫和檔案 | 每日 2AM UTC / 手動觸發 | 選用 |
+| `fortify-scan.yml` | Fortify SAST 掃描（Python + JS/TS + config），產出 `.fpr` 與 BIRT PDF 報告 | Push to main / PR to main / 手動觸發 | 選用 |
 
 ### 🅾️ 步驟 0：bare VM 的 bootstrap（雞生蛋問題）
 

--- a/.github/production-workflows-examples/fortify-scan.yml
+++ b/.github/production-workflows-examples/fortify-scan.yml
@@ -1,0 +1,155 @@
+---
+# Fortify SAST scan, for the production repository.
+#
+# Do not call the reusable NYCUITSC/fortifyscan workflow
+# (fortify-multi-language-scan.yml@main): its Python path never runs a Fortify
+# *translation*. It only wraps `pip install` in sourceanalyzer and relies on the
+# build tool to report source files, which pip does not do. With no root-level
+# requirements.txt (ours lives in backend/) it does not even do that, so
+# `sourceanalyzer -b <id> -scan` fails with "Unable to load build session with
+# ID" and no .fpr is produced. That workflow takes no inputs, so it cannot be
+# corrected from the caller side -- we run the scan inline here instead.
+#
+# Rulepacks are not selectable by flag: Fortify loads them from whichever
+# languages end up in the build session. Translating Python, JS/TS and the
+# config/content files into one session engages 9 of the 11 rulepacks on the
+# runner (Core/Extended Python, JavaScript, Configuration, Content, Cloud,
+# Universal).
+#
+# SQL is deliberately left out: Fortify's SQL front end only supports T-SQL and
+# PL/SQL, and this project is PostgreSQL, so the .sql files would only produce
+# parse noise. backend/db_*_backup.sql are generated dumps rather than source
+# anyway, and the data dump should not be shipped inside a scan artifact.
+#
+# Every ${{ }} value reaches PowerShell through `env:` rather than being
+# interpolated into the script body. Direct interpolation is what Fortify's own
+# "Command Injection: GitHub Actions" rule flags, and it was the single High
+# finding in the first scan of this file.
+#
+# Runtime: translation takes ~5 minutes, but the -scan dataflow analysis takes
+# ~2.5 hours on this codebase and holds the shared org Fortify runner for the
+# duration.
+#
+# Requires the self-hosted Windows Fortify runner (sourceanalyzer and
+# BIRTReportGenerator on PATH).
+
+name: Fortify Scan
+
+permissions:
+  contents: read
+  actions: read
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  fortify:
+    runs-on: [self-hosted, Windows, X64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Fortify SCA scan
+        shell: powershell
+        env:
+          PROJECT_NAME: ${{ github.event.repository.name }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $PROJECT_NAME = $env:PROJECT_NAME
+          $BUILD_ID = "${PROJECT_NAME}_build"
+
+          if ($env:EVENT_NAME -eq "pull_request") {
+              $SUFFIX = "PR_$($env:PR_NUMBER)"
+          } else {
+              $SUFFIX = "main"
+          }
+
+          $FPR_NAME = "${PROJECT_NAME}_${SUFFIX}.fpr"
+          $DEV_WORKBOOK_PDF = "${PROJECT_NAME}_${SUFFIX}_DeveloperWorkbook_BIRT.pdf"
+          $OWASP_2021_PDF = "${PROJECT_NAME}_${SUFFIX}_OWASP_Top10_2021_BIRT.pdf"
+
+          function Invoke-Translation {
+              param([string]$Label, [string[]]$ScaArgs)
+
+              Write-Host "::group::Translate $Label"
+              sourceanalyzer -b $BUILD_ID @ScaArgs
+              $code = $LASTEXITCODE
+              Write-Host "::endgroup::"
+              if ($code -ne 0) {
+                  Write-Error "$Label translation failed (exit $code)."
+                  exit 1
+              }
+          }
+
+          sourceanalyzer -b $BUILD_ID -clean
+
+          # Source-based scans throughout: no dependency install, which keeps
+          # the runner clean. Cross-package dataflow traces are shallower than a
+          # build-integrated scan, but the front ends parse the sources fine.
+          Invoke-Translation "python" @(
+              "-python-version", "3",
+              "-exclude", "backend/alembic/versions/**/*.py",
+              "backend/**/*.py"
+          )
+
+          # node_modules/.next are not committed, but a dirty runner workspace
+          # would otherwise pull tens of thousands of files into the session.
+          Invoke-Translation "javascript" @(
+              "-exclude", "**/node_modules/**/*",
+              "-exclude", "frontend/.next/**/*",
+              "-exclude", "frontend/coverage/**/*",
+              "frontend/**/*.js", "frontend/**/*.jsx",
+              "frontend/**/*.ts", "frontend/**/*.tsx"
+          )
+
+          Invoke-Translation "configuration/content" @(
+              "-exclude", "**/node_modules/**/*",
+              "-exclude", "frontend/.next/**/*",
+              "-exclude", "**/package-lock.json",
+              "**/*.yml", "**/*.yaml", "**/*.json",
+              "**/*.html", "nginx/**/*.conf"
+          )
+
+          # Fail loudly instead of letting -scan die on an empty build session.
+          $translated = sourceanalyzer -b $BUILD_ID -show-files
+          if (-not $translated) {
+              Write-Error "No files were translated into build session $BUILD_ID."
+              exit 1
+          }
+          Write-Host "Translated $($translated.Count) file(s)."
+
+          sourceanalyzer -b $BUILD_ID -scan -f $FPR_NAME
+          if ($LASTEXITCODE -ne 0) {
+              Write-Error "Fortify scan failed (exit $LASTEXITCODE)."
+              exit 1
+          }
+          if (-not (Test-Path $FPR_NAME)) {
+              Write-Error "Scan finished but $FPR_NAME was not produced."
+              exit 1
+          }
+
+          BIRTReportGenerator -template "Developer Workbook" `
+            -source $FPR_NAME -format PDF -output $DEV_WORKBOOK_PDF
+          BIRTReportGenerator -template "OWASP Top 10" `
+            -source $FPR_NAME -format PDF --Version "OWASP Top 10 2021" `
+            -output $OWASP_2021_PDF
+
+          "FPR_NAME=$FPR_NAME" >> $env:GITHUB_ENV
+          "DEV_WORKBOOK_PDF=$DEV_WORKBOOK_PDF" >> $env:GITHUB_ENV
+          "OWASP_2021_PDF=$OWASP_2021_PDF" >> $env:GITHUB_ENV
+
+      - name: Upload Fortify results
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.repository.name }}-${{ github.event_name }}-birt-reports
+          path: |
+            ${{ env.FPR_NAME }}
+            ${{ env.DEV_WORKBOOK_PDF }}
+            ${{ env.OWASP_2021_PDF }}


### PR DESCRIPTION
## Summary

在 `.github/production-workflows-examples/` 新增 `fortify-scan.yml`,讓 production repo (naass) 的 Fortify SAST 掃描經由 mirror 的正規通道安裝,而不是直接在 prod repo 手改。

這個 workflow 的內容已在 naass 端實測跑通(掃描成功、9 個 rulepack 載入、689 個檔案翻譯、產出 `.fpr` 與兩份 BIRT PDF),**但那次掃描回報了一個 High finding,指的正是 workflow 自己**:

```
Command Injection: GitHub Actions @ .github/workflows/fortify-scan.yml:49   (severity 5.0)
```

原因是 PowerShell 的 `run:` 區塊直接內插了 `${{ github.event.repository.name }}` / `${{ github.event_name }}` / `${{ github.event.number }}`。本 PR 的版本改成用 `env:` 傳值、在腳本內以 `$env:VAR` 取用,`run:` 區塊已無任何 `${{ }}`。

## 為什麼不用 reusable workflow

原本呼叫的 [NYCUITSC/fortifyscan](https://github.com/NYCUITSC/fortifyscan) `fortify-multi-language-scan.yml@main` 的 Python 路徑是壞的:它只把 `pip install` 包在 `sourceanalyzer` 底下,從來沒有真正做 translation。我們的 `requirements.txt` 在 `backend/` 而非 root,所以連那一步都跳過,接著 `sourceanalyzer -b <id> -scan` 直接失敗:

```
[error]: Unable to load build session with ID "naass_python_build".
FPR source file not found or not readable.
```

該 reusable workflow 沒有任何 inputs,caller 端無法調整,所以改成 inline 執行。(那個 repo 我只有讀取權限,無法直接修;它的 node 路徑有同樣的缺陷 —— 只跑 `npm install` 而沒 translate JS。)

## 掃描範圍

Rulepack 無法用參數指定,Fortify 是依 build session 內實際被 translate 的語言自動載入。本 workflow 把 Python、JS/TS、config/content 放進同一個 session,實測載入 **9 個 rulepack**:

Community Cloud / Community Universal / Core Cloud / Core JavaScript / Core Python / Core Universal / Extended Configuration / Extended Content / Extended JavaScript

**SQL 刻意排除**:Fortify 的 SQL front end 只支援 T-SQL 與 PL/SQL,本專案是 PostgreSQL,掃了只會產生 parse noise;而且 `backend/db_*_backup.sql` 是 dump 產物不是 source,data dump 也不該被打包進掃描 artifact。

## ⚠️ 執行成本

實測 naass 全量掃描:

| 階段 | 耗時 |
|------|------|
| translate python (263 files) | 58s |
| translate javascript (360 files) | 3m46s |
| translate configuration/content | 7s |
| **`-scan` dataflow 分析** | **2h37m** |
| BIRT 報告 | ~30s |

瓶頸在 `-scan` 而非 translation。這段期間會**獨佔 org 共用的 Windows Fortify runner (MISFORT404ORG)**,其他 repo 的 Fortify 掃描會排隊。目前保留 `pull_request` trigger,意即每個進 naass 的 production-sync PR 都會觸發一次 2.6 小時掃描 —— 若覺得成本太高,可以只留 `push: main`。

## 首次掃描結果(naass PR #42,43 個 finding)

| 嚴重度 | 類型 | 數量 |
|---|---|---|
| 5.0 High | Command Injection: GitHub Actions | 1 ← 本 PR 修掉 |
| 2.0 Low | Cross-Site Request Forgery | 40 |
| 2.0 Low | Password Management: Null Password | 2 |

40 個 CSRF 集中在 `frontend/lib/api/modules/*.ts`、`frontend/src/services/api/*.ts` 與部分 component / `app/api/v1/**/route.ts`;2 個 Null Password 在 `backend/app/core/config.py:53` 與 `backend/app/services/email_service.py:38`。這些都是既有程式碼的問題,不在本 PR 範圍,建議另開 issue 追。

## ⚠️ 與 naass PR #42 的相依關係

naass 目前有一個未合併的 [PR #42](https://github.com/NYCUITSC/naass/pull/42),內容是同一個 workflow 的**未修正版**(直接內插 `${{ }}`)。依照 mirror 的 drift 規則:

- prod repo **沒有**該檔案 → 從範本自動安裝 ✅
- prod repo 有、但比對不到任何歷史版範本 → **一律不覆寫**

所以如果先 merge naass #42,prod 端的檔案會被視為「prod 客製」,本 PR 的修正**永遠不會**經由 mirror 送達。建議**關閉 naass #42**,改由本 PR merge 後的 mirror 安裝。

## Test plan

- [ ] Merge 後 dispatch `mirror-to-production.yml`,確認 log 出現 `fortify-scan.yml` 被 install(而非 preserve)
- [ ] 確認 naass 的 `.github/workflows/fortify-scan.yml` 內容 `run:` 區塊無 `${{ }}`
- [ ] naass 端跑一次掃描,確認 Command Injection finding 消失、其餘 42 個 finding 不變
