### PR TITLE
ci: run Fortify scan on push to main only

### DIFF
--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -51,7 +51,7 @@ warning: here-document at line 10 delimited by end-of-file (wanted `FOOTER_EOF')
 | `deploy-stack.yml` | `deploy.yml` 兩個階段共用的 reusable workflow（實際的部署腳本本體） | 由 `deploy.yml` 呼叫，不單獨觸發 | **必要**（與 deploy.yml 成對） |
 | `health-check.yml` | 監控應用程式健康狀態 | 每 15 分鐘 / 手動觸發 | 選用 |
 | `backup.yml` | 備份資料庫和檔案 | 每日 2AM UTC / 手動觸發 | 選用 |
-| `fortify-scan.yml` | Fortify SAST 掃描（Python + JS/TS + config），產出 `.fpr` 與 BIRT PDF 報告 | Push to main / PR to main / 手動觸發 | 選用 |
+| `fortify-scan.yml` | Fortify SAST 掃描（Python + JS/TS + config），產出 `.fpr` 與 BIRT PDF 報告。掃描約 2.5 小時且獨佔共用 Fortify runner，故只在 push to main 觸發 | Push to main / 手動觸發 | 選用 |
 
 ### 🅾️ 步驟 0：bare VM 的 bootstrap（雞生蛋問題）
 

--- a/.github/production-workflows-examples/fortify-scan.yml
+++ b/.github/production-workflows-examples/fortify-scan.yml
@@ -28,7 +28,8 @@
 #
 # Runtime: translation takes ~5 minutes, but the -scan dataflow analysis takes
 # ~2.5 hours on this codebase and holds the shared org Fortify runner for the
-# duration.
+# duration. That is why this runs on pushes to main only -- a pull_request
+# trigger would spend 2.5 hours of the shared runner on every mirrored sync PR.
 #
 # Requires the self-hosted Windows Fortify runner (sourceanalyzer and
 # BIRTReportGenerator on PATH).
@@ -41,8 +42,6 @@ permissions:
 
 on:
   push:
-    branches: ["main"]
-  pull_request:
     branches: ["main"]
   workflow_dispatch:
 
@@ -57,19 +56,13 @@ jobs:
         shell: powershell
         env:
           PROJECT_NAME: ${{ github.event.repository.name }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ github.event.number }}
         run: |
           $ErrorActionPreference = "Stop"
 
           $PROJECT_NAME = $env:PROJECT_NAME
           $BUILD_ID = "${PROJECT_NAME}_build"
 
-          if ($env:EVENT_NAME -eq "pull_request") {
-              $SUFFIX = "PR_$($env:PR_NUMBER)"
-          } else {
-              $SUFFIX = "main"
-          }
+          $SUFFIX = "main"
 
           $FPR_NAME = "${PROJECT_NAME}_${SUFFIX}.fpr"
           $DEV_WORKBOOK_PDF = "${PROJECT_NAME}_${SUFFIX}_DeveloperWorkbook_BIRT.pdf"


### PR DESCRIPTION
## Summary

`fortify-scan.yml` 範本的觸發條件改成**只有 push to main**（外加手動 `workflow_dispatch`），移除 `pull_request`。

## 為什麼

實測 naass 全量掃描的耗時分佈：

| 階段 | 耗時 |
|------|------|
| translate python / javascript / config | 共 ~5 分鐘 |
| **`-scan` dataflow 分析** | **2h37m** |

瓶頸在 `-scan`，而這段期間會獨佔 org 共用的 Windows Fortify runner (`MISFORT404ORG`)，其他 repo 的 Fortify 掃描全部排隊。保留 `pull_request` 的話，每一個進 prod repo 的 mirror sync PR 都會付出 2.6 小時的共用 runner 成本。

改成 push to main 後，掃描只在程式碼真正進入 main 時跑一次。

## 順帶清掉的 dead code

`pull_request` 拿掉後，FPR 命名裡的 `PR_<number>` 分支永遠不會被走到，因此一併移除，`EVENT_NAME` / `PR_NUMBER` 兩個 env 也不再需要：

```diff
-          if ($env:EVENT_NAME -eq "pull_request") {
-              $SUFFIX = "PR_$($env:PR_NUMBER)"
-          } else {
-              $SUFFIX = "main"
-          }
+          $SUFFIX = "main"
```

`run:` 區塊內仍維持 0 個 `${{ }}` 內插（#1305 修掉的 Command Injection 不會回歸）。

## Test plan

- [ ] Merge 後同步到 NYCUITSC/naass 的 `.github/workflows/fortify-scan.yml`，維持與範本逐字節相同（mirror drift 規則需要）
- [ ] 確認 naass 的 PR 不再觸發 Fortify Scan，push to main 仍會觸發