### PR TITLE
fix: eliminate medium+ ZAP findings from input-validation gaps

### DIFF
--- a/backend/app/api/v1/endpoints/admin/system_settings.py
+++ b/backend/app/api/v1/endpoints/admin/system_settings.py
@@ -22,7 +22,9 @@ router = APIRouter()
 
 @router.get("/system-setting")
 async def get_system_setting(
-    key: str = Query(..., description="Setting key"),
+    # Capped at the system_settings.key column width: a miss echoes the key
+    # straight back through SystemSettingSchema, which enforces the same limit.
+    key: str = Query(..., max_length=100, description="Setting key"),
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -107,8 +107,12 @@ class Settings(BaseSettings):
     pii_encryption_keys: str = ""
     pii_encryption_active_version: str = "v1"
 
-    # Mock SSO for development
-    enable_mock_sso: bool = True
+    # Mock SSO for development. Defaults to OFF so that dropping the env var
+    # fails safe: this flag alone gates /mock-sso/* and /auth/dev-profiles/*,
+    # which mint arbitrary accounts (including admins) without credentials.
+    # Every environment that wants it sets ENABLE_MOCK_SSO=true explicitly
+    # (docker-compose.dev.yml, docker-compose.staging-e2e.yml, write_dev_env.sh).
+    enable_mock_sso: bool = False
     mock_sso_domain: str = "dev.university.edu"
 
     # Portal SSO Configuration

--- a/backend/app/core/db_errors.py
+++ b/backend/app/core/db_errors.py
@@ -1,0 +1,64 @@
+"""Classification of database errors that are really *invalid input*.
+
+PostgreSQL class-22 errors ("data exception": value too long for a VARCHAR,
+unparseable enum label, numeric overflow, bad date literal) are raised when a
+request carries a value the column cannot represent. Those are client errors,
+not server faults, so they must surface as 422 rather than 500.
+
+The async path makes this non-obvious: SQLAlchemy's asyncpg dialect wraps the
+driver exception in its own ``Error`` class, so the raised object is a plain
+``DBAPIError`` and NOT ``sqlalchemy.exc.DataError`` the way psycopg2 (sync
+path) produces. The real ``asyncpg.exceptions.DataError`` sits further down the
+``__cause__`` chain, which is why this walks it instead of a single isinstance.
+"""
+
+from sqlalchemy.exc import DataError, DBAPIError, IntegrityError
+
+try:  # pragma: no cover - asyncpg is always installed in the app image
+    from asyncpg.exceptions import DataError as AsyncpgDataError
+    from asyncpg.exceptions import IntegrityConstraintViolationError as AsyncpgIntegrityError
+except ImportError:  # pragma: no cover
+    AsyncpgDataError = None
+    AsyncpgIntegrityError = None
+
+# Guard against a self-referential or pathologically long __cause__ chain.
+_MAX_CAUSE_DEPTH = 10
+
+
+def _driver_error_matches(exc: BaseException, driver_error_type) -> bool:
+    """Walk the ``__cause__`` chain under a DBAPIError looking for a driver error."""
+    if not isinstance(exc, DBAPIError) or driver_error_type is None:
+        return False
+
+    current = exc.orig
+    for _ in range(_MAX_CAUSE_DEPTH):
+        if current is None:
+            return False
+        if isinstance(current, driver_error_type):
+            return True
+        current = getattr(current, "__cause__", None)
+
+    return False
+
+
+def is_invalid_input_error(exc: BaseException) -> bool:
+    """True when ``exc`` is a PostgreSQL data exception caused by request input."""
+    # Sync path (psycopg2): SQLAlchemy classifies it correctly on its own.
+    if isinstance(exc, DataError):
+        return True
+    # Async path (asyncpg): unwrap the dialect's wrapper to find the driver error.
+    return _driver_error_matches(exc, AsyncpgDataError)
+
+
+def is_constraint_violation_error(exc: BaseException) -> bool:
+    """True when ``exc`` is a PostgreSQL integrity-constraint violation.
+
+    Class-23 errors (unique, foreign key, check, not-null) mean the request
+    conflicts with data that already exists or with a declared invariant — a
+    409, not a server fault. The full traceback is still logged before this is
+    consulted, so a genuine server-side bug that trips a constraint stays
+    diagnosable in the logs.
+    """
+    if isinstance(exc, IntegrityError):
+        return True
+    return _driver_error_matches(exc, AsyncpgIntegrityError)

--- a/backend/app/core/db_errors.py
+++ b/backend/app/core/db_errors.py
@@ -1,64 +1,76 @@
-"""Classification of database errors that are really *invalid input*.
+"""Classification of database errors by PostgreSQL SQLSTATE.
 
-PostgreSQL class-22 errors ("data exception": value too long for a VARCHAR,
-unparseable enum label, numeric overflow, bad date literal) are raised when a
-request carries a value the column cannot represent. Those are client errors,
-not server faults, so they must surface as 422 rather than 500.
+Some database errors are really *invalid input*: a value too long for a VARCHAR,
+an unparseable enum label, a numeric overflow. Those are client errors and must
+surface as 422 rather than 500. A unique or foreign-key violation is a 409.
 
-The async path makes this non-obvious: SQLAlchemy's asyncpg dialect wraps the
-driver exception in its own ``Error`` class, so the raised object is a plain
-``DBAPIError`` and NOT ``sqlalchemy.exc.DataError`` the way psycopg2 (sync
-path) produces. The real ``asyncpg.exceptions.DataError`` sits further down the
-``__cause__`` chain, which is why this walks it instead of a single isinstance.
+Classification is by SQLSTATE rather than by exception class because the two
+drivers disagree on shape:
+
+* **asyncpg** — SQLAlchemy's dialect wraps the driver exception in its own
+  ``Error`` class, so what is raised is a plain ``DBAPIError``, NOT
+  ``sqlalchemy.exc.DataError``; the real ``asyncpg.exceptions`` object sits
+  further down the ``__cause__`` chain and carries ``.sqlstate``.
+* **psycopg2** (sync path) — SQLAlchemy classifies it correctly, and the driver
+  error carries the same code as ``.pgcode``.
+
+Matching the exact codes also keeps the mapping narrow. Deliberately excluded:
+
+* ``23502`` not-null and ``23514`` check violations — a service that forgets to
+  populate a ``nullable=False`` column is a server bug, and answering 409 would
+  both lie to the client and hide it from 5xx alerting.
+* ``22012`` division-by-zero and the rest of class 22 — server-side arithmetic,
+  not request payload.
 """
 
-from sqlalchemy.exc import DataError, DBAPIError, IntegrityError
+from sqlalchemy.exc import DBAPIError
 
-try:  # pragma: no cover - asyncpg is always installed in the app image
-    from asyncpg.exceptions import DataError as AsyncpgDataError
-    from asyncpg.exceptions import IntegrityConstraintViolationError as AsyncpgIntegrityError
-except ImportError:  # pragma: no cover
-    AsyncpgDataError = None
-    AsyncpgIntegrityError = None
+# Class 22 (data exception), limited to "this value cannot be represented".
+INVALID_INPUT_SQLSTATES = frozenset(
+    {
+        "22001",  # string_data_right_truncation — value longer than the column
+        "22003",  # numeric_value_out_of_range
+        "22007",  # invalid_datetime_format
+        "22008",  # datetime_field_overflow
+        "22P02",  # invalid_text_representation — e.g. unknown enum label
+    }
+)
+
+# Class 23 (integrity constraint violation), limited to genuine conflicts.
+CONFLICT_SQLSTATES = frozenset(
+    {
+        "23503",  # foreign_key_violation
+        "23505",  # unique_violation
+    }
+)
 
 # Guard against a self-referential or pathologically long __cause__ chain.
 _MAX_CAUSE_DEPTH = 10
 
 
-def _driver_error_matches(exc: BaseException, driver_error_type) -> bool:
-    """Walk the ``__cause__`` chain under a DBAPIError looking for a driver error."""
-    if not isinstance(exc, DBAPIError) or driver_error_type is None:
-        return False
+def sqlstate_of(exc: BaseException) -> str | None:
+    """Return the PostgreSQL SQLSTATE behind a SQLAlchemy ``DBAPIError``, if any."""
+    if not isinstance(exc, DBAPIError):
+        return None
 
     current = exc.orig
     for _ in range(_MAX_CAUSE_DEPTH):
         if current is None:
-            return False
-        if isinstance(current, driver_error_type):
-            return True
+            return None
+        # asyncpg exposes .sqlstate; psycopg2 exposes the same code as .pgcode.
+        code = getattr(current, "sqlstate", None) or getattr(current, "pgcode", None)
+        if code:
+            return str(code)
         current = getattr(current, "__cause__", None)
 
-    return False
+    return None
 
 
 def is_invalid_input_error(exc: BaseException) -> bool:
-    """True when ``exc`` is a PostgreSQL data exception caused by request input."""
-    # Sync path (psycopg2): SQLAlchemy classifies it correctly on its own.
-    if isinstance(exc, DataError):
-        return True
-    # Async path (asyncpg): unwrap the dialect's wrapper to find the driver error.
-    return _driver_error_matches(exc, AsyncpgDataError)
+    """True when ``exc`` means the request carried an unrepresentable value."""
+    return sqlstate_of(exc) in INVALID_INPUT_SQLSTATES
 
 
 def is_constraint_violation_error(exc: BaseException) -> bool:
-    """True when ``exc`` is a PostgreSQL integrity-constraint violation.
-
-    Class-23 errors (unique, foreign key, check, not-null) mean the request
-    conflicts with data that already exists or with a declared invariant — a
-    409, not a server fault. The full traceback is still logged before this is
-    consulted, so a genuine server-side bug that trips a constraint stays
-    diagnosable in the logs.
-    """
-    if isinstance(exc, IntegrityError):
-        return True
-    return _driver_error_matches(exc, AsyncpgIntegrityError)
+    """True when ``exc`` means the request conflicts with existing data."""
+    return sqlstate_of(exc) in CONFLICT_SQLSTATES

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,6 +20,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.api.v1.api import api_router
 from app.core.config import settings
 from app.core.database_health import check_database_health
+from app.core.db_errors import is_constraint_violation_error, is_invalid_input_error
 from app.core.exceptions import ScholarshipException, scholarship_exception_handler
 from app.core.security import require_admin
 from app.models.user import User
@@ -284,6 +285,32 @@ async def general_exception_handler(request: Request, exc: Exception):  # pylint
             content={
                 "success": False,
                 "message": "Service temporarily unavailable - database connection issue",
+                "trace_id": trace_id,
+            },
+        )
+
+    # A PostgreSQL data exception means the request carried a value the column
+    # cannot store (over-length string, unknown enum label, numeric overflow).
+    # That is a client error; answering 500 both misreports it and trips
+    # vulnerability scanners looking for crash-on-payload behaviour.
+    if is_invalid_input_error(exc):
+        return JSONResponse(
+            status_code=422,
+            content={
+                "success": False,
+                "message": "Invalid request parameters. Please check your input and try again.",
+                "trace_id": trace_id,
+            },
+        )
+
+    # Likewise a unique/foreign-key/check violation: the request conflicts with
+    # existing data rather than crashing the server.
+    if is_constraint_violation_error(exc):
+        return JSONResponse(
+            status_code=409,
+            content={
+                "success": False,
+                "message": "The request conflicts with existing data.",
                 "trace_id": trace_id,
             },
         )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -20,7 +20,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.api.v1.api import api_router
 from app.core.config import settings
 from app.core.database_health import check_database_health
-from app.core.db_errors import is_constraint_violation_error, is_invalid_input_error
+from app.core.db_errors import is_constraint_violation_error, is_invalid_input_error, sqlstate_of
 from app.core.exceptions import ScholarshipException, scholarship_exception_handler
 from app.core.security import require_admin
 from app.models.user import User
@@ -261,6 +261,84 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         )
 
 
+@app.exception_handler(DBAPIError)
+async def dbapi_exception_handler(request: Request, exc: DBAPIError):
+    """Map database driver errors to the status code they actually describe.
+
+    Registered on DBAPIError rather than folded into the generic ``Exception``
+    handler on purpose. Starlette wires the ``Exception`` handler into
+    ``ServerErrorMiddleware``, which sits OUTSIDE the middleware stack and
+    re-raises after sending its response — so a 422 returned from there would
+    still be counted as a 500 by MetricsMiddleware and still escape the ASGI
+    app. Handlers for concrete classes are dispatched by ``ExceptionMiddleware``
+    *inside* the stack, which keeps metrics, logs and the response in agreement.
+    """
+    db_logger = logging.getLogger(__name__)
+    trace_id = getattr(request.state, "trace_id", "unknown")
+    sqlstate = sqlstate_of(exc)
+
+    def _log(level: int, outcome: str) -> None:
+        db_logger.log(
+            level,
+            "Database error -> %s - Trace ID: %s, Path: %s, Method: %s, SQLSTATE: %s, Exception: %s",
+            outcome,
+            trace_id,
+            request.url.path,
+            request.method,
+            sqlstate,
+            type(exc).__name__,
+            exc_info=True,
+        )
+
+    # A client error, but keep the traceback: a backend defect can land here too
+    # (e.g. a service writing a wrong-case enum label). WARNING rather than ERROR
+    # so a 4xx does not page anyone while staying diagnosable.
+    if is_invalid_input_error(exc):
+        _log(logging.WARNING, "422 invalid input")
+        return JSONResponse(
+            status_code=422,
+            content={
+                "success": False,
+                "message": "Invalid request parameters. Please check your input and try again.",
+                "trace_id": trace_id,
+            },
+        )
+
+    if is_constraint_violation_error(exc):
+        _log(logging.WARNING, "409 conflict")
+        return JSONResponse(
+            status_code=409,
+            content={
+                "success": False,
+                "message": "The request conflicts with existing data.",
+                "trace_id": trace_id,
+            },
+        )
+
+    if isinstance(exc, OperationalError):
+        _log(logging.ERROR, "503 unavailable")
+        return JSONResponse(
+            status_code=503,
+            content={
+                "success": False,
+                "message": "Service temporarily unavailable - database connection issue",
+                "trace_id": trace_id,
+            },
+        )
+
+    # Anything else (a not-null/check violation, bad SQL, a programming error)
+    # is a server fault and must stay a 500 so it keeps showing up in alerting.
+    _log(logging.ERROR, "500 unhandled")
+    return JSONResponse(
+        status_code=500,
+        content={
+            "success": False,
+            "message": "Internal server error",
+            "trace_id": trace_id,
+        },
+    )
+
+
 @app.exception_handler(Exception)
 async def general_exception_handler(request: Request, exc: Exception):  # pylint: disable=broad-exception-caught
     """Handle unexpected exceptions"""
@@ -285,32 +363,6 @@ async def general_exception_handler(request: Request, exc: Exception):  # pylint
             content={
                 "success": False,
                 "message": "Service temporarily unavailable - database connection issue",
-                "trace_id": trace_id,
-            },
-        )
-
-    # A PostgreSQL data exception means the request carried a value the column
-    # cannot store (over-length string, unknown enum label, numeric overflow).
-    # That is a client error; answering 500 both misreports it and trips
-    # vulnerability scanners looking for crash-on-payload behaviour.
-    if is_invalid_input_error(exc):
-        return JSONResponse(
-            status_code=422,
-            content={
-                "success": False,
-                "message": "Invalid request parameters. Please check your input and try again.",
-                "trace_id": trace_id,
-            },
-        )
-
-    # Likewise a unique/foreign-key/check violation: the request conflicts with
-    # existing data rather than crashing the server.
-    if is_constraint_violation_error(exc):
-        return JSONResponse(
-            status_code=409,
-            content={
-                "success": False,
-                "message": "The request conflicts with existing data.",
                 "trace_id": trace_id,
             },
         )

--- a/backend/app/schemas/application_field.py
+++ b/backend/app/schemas/application_field.py
@@ -13,14 +13,16 @@ from app.models.application_field import FieldType
 class ApplicationFieldBase(BaseModel):
     """Base schema for application field"""
 
-    scholarship_type: str = Field(..., description="Scholarship type")
-    field_name: str = Field(..., description="Field name (English)")
-    field_label: str = Field(..., description="Field label (Chinese)")
-    field_label_en: Optional[str] = Field(None, description="Field label (English)")
-    field_type: str = Field(default=FieldType.TEXT.value, description="Field type")
+    # max_length mirrors the application_fields column widths — without it an
+    # over-length value reaches Postgres and fails there instead of at the boundary.
+    scholarship_type: str = Field(..., max_length=50, description="Scholarship type")
+    field_name: str = Field(..., max_length=100, description="Field name (English)")
+    field_label: str = Field(..., max_length=200, description="Field label (Chinese)")
+    field_label_en: Optional[str] = Field(None, max_length=200, description="Field label (English)")
+    field_type: str = Field(default=FieldType.TEXT.value, max_length=20, description="Field type")
     is_required: bool = Field(default=False, description="Is field required")
-    placeholder: Optional[str] = Field(None, description="Placeholder text")
-    placeholder_en: Optional[str] = Field(None, description="Placeholder text (English)")
+    placeholder: Optional[str] = Field(None, max_length=500, description="Placeholder text")
+    placeholder_en: Optional[str] = Field(None, max_length=500, description="Placeholder text (English)")
     max_length: Optional[int] = Field(None, description="Maximum length")
     min_value: Optional[float] = Field(None, description="Minimum value")
     max_value: Optional[float] = Field(None, description="Maximum value")
@@ -60,12 +62,12 @@ class ApplicationFieldCreate(ApplicationFieldBase):
 class ApplicationFieldUpdate(BaseModel):
     """Schema for updating application field"""
 
-    field_label: Optional[str] = None
-    field_label_en: Optional[str] = None
-    field_type: Optional[str] = None
+    field_label: Optional[str] = Field(None, max_length=200)
+    field_label_en: Optional[str] = Field(None, max_length=200)
+    field_type: Optional[str] = Field(None, max_length=20)
     is_required: Optional[bool] = None
-    placeholder: Optional[str] = None
-    placeholder_en: Optional[str] = None
+    placeholder: Optional[str] = Field(None, max_length=500)
+    placeholder_en: Optional[str] = Field(None, max_length=500)
     max_length: Optional[int] = None
     min_value: Optional[float] = None
     max_value: Optional[float] = None

--- a/backend/app/schemas/application_field.py
+++ b/backend/app/schemas/application_field.py
@@ -111,22 +111,24 @@ class ApplicationFieldResponse(ApplicationFieldBase):
 class ApplicationDocumentBase(BaseModel):
     """Base schema for application document"""
 
-    scholarship_type: str = Field(..., description="Scholarship type")
-    document_name: str = Field(..., description="Document name")
-    document_name_en: Optional[str] = Field(None, description="Document name (English)")
+    # max_length mirrors the application_documents column widths (description,
+    # description_en and upload_instructions* are Text, so they stay uncapped).
+    scholarship_type: str = Field(..., max_length=50, description="Scholarship type")
+    document_name: str = Field(..., max_length=200, description="Document name")
+    document_name_en: Optional[str] = Field(None, max_length=200, description="Document name (English)")
     description: Optional[str] = Field(None, description="Document description")
     description_en: Optional[str] = Field(None, description="Document description (English)")
     is_required: bool = Field(default=True, description="Is document required")
     display_in_list: bool = Field(default=True, description="Show in scholarship-list document boxes")
     requires_upload: bool = Field(default=True, description="Student must upload this document in step 3")
     accepted_file_types: List[str] = Field(default=["PDF"], description="Accepted file types")
-    max_file_size: str = Field(default="5MB", description="Maximum file size")
+    max_file_size: str = Field(default="5MB", max_length=20, description="Maximum file size")
     max_file_count: int = Field(default=1, description="Maximum file count")
     display_order: int = Field(default=0, description="Display order")
     is_active: bool = Field(default=True, description="Is document active")
     upload_instructions: Optional[str] = Field(None, description="Upload instructions")
     upload_instructions_en: Optional[str] = Field(None, description="Upload instructions (English)")
-    example_file_url: Optional[str] = Field(None, description="Example file MinIO object name")
+    example_file_url: Optional[str] = Field(None, max_length=500, description="Example file MinIO object name")
     validation_rules: Optional[Dict[str, Any]] = Field(None, description="Validation rules")
 
 
@@ -139,21 +141,21 @@ class ApplicationDocumentCreate(ApplicationDocumentBase):
 class ApplicationDocumentUpdate(BaseModel):
     """Schema for updating application document"""
 
-    document_name: Optional[str] = None
-    document_name_en: Optional[str] = None
+    document_name: Optional[str] = Field(None, max_length=200)
+    document_name_en: Optional[str] = Field(None, max_length=200)
     description: Optional[str] = None
     description_en: Optional[str] = None
     is_required: Optional[bool] = None
     display_in_list: Optional[bool] = None
     requires_upload: Optional[bool] = None
     accepted_file_types: Optional[List[str]] = None
-    max_file_size: Optional[str] = None
+    max_file_size: Optional[str] = Field(None, max_length=20)
     max_file_count: Optional[int] = None
     display_order: Optional[int] = None
     is_active: Optional[bool] = None
     upload_instructions: Optional[str] = None
     upload_instructions_en: Optional[str] = None
-    example_file_url: Optional[str] = None
+    example_file_url: Optional[str] = Field(None, max_length=500)
     validation_rules: Optional[Dict[str, Any]] = None
 
 

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -71,7 +71,8 @@ class ErrorResponse(BaseModel):
 class SystemSettingSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    key: str
+    # key mirrors system_settings.key (String(100)); value is a Text column.
+    key: str = Field(..., max_length=100)
     value: str
 
 

--- a/backend/app/tests/test_developer_profiles.py
+++ b/backend/app/tests/test_developer_profiles.py
@@ -13,10 +13,19 @@ from app.main import app
 from app.models.user import UserRole
 from app.services.developer_profile_service import DeveloperProfile, DeveloperProfileManager, DeveloperProfileService
 
-# Enable mock SSO for testing
-settings.enable_mock_sso = True
-
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def enable_mock_sso(monkeypatch):
+    """Every endpoint in this module is gated on enable_mock_sso.
+
+    Set it per-test instead of assigning to the global settings at import time:
+    that leaked into every module collected afterwards, so test_mock_sso.py
+    silently inherited the flag and its own missing precondition went unnoticed
+    until CI's smoke lane (which does not collect this module) failed.
+    """
+    monkeypatch.setattr(settings, "enable_mock_sso", True)
 
 
 class TestDeveloperProfileService:

--- a/backend/app/tests/test_input_validation_hardening.py
+++ b/backend/app/tests/test_input_validation_hardening.py
@@ -3,7 +3,9 @@
 Covers the three changes that removed the Medium/High findings of the
 2026-08-11 authenticated active scan:
 
-1. PostgreSQL data exceptions surface as 422, not 500 (``is_invalid_input_error``).
+1. Database errors are classified by SQLSTATE, so an unrepresentable value
+   surfaces as 422 and a genuine conflict as 409 — while a broken server-side
+   invariant (not-null, check, division-by-zero) stays a 500.
 2. String schemas cap length at the DB column width, so over-length payloads are
    rejected at the boundary instead of by Postgres.
 3. Mock SSO defaults to OFF, so dropping the env var cannot expose the
@@ -12,18 +14,26 @@ Covers the three changes that removed the Medium/High findings of the
 
 import pytest
 from pydantic import ValidationError
-from sqlalchemy.exc import DataError, DBAPIError, IntegrityError, OperationalError
+from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError
 
-from app.core.db_errors import is_constraint_violation_error, is_invalid_input_error
-from app.schemas.application_field import ApplicationFieldCreate
+from app.core.db_errors import is_constraint_violation_error, is_invalid_input_error, sqlstate_of
+from app.schemas.application_field import ApplicationDocumentCreate, ApplicationFieldCreate
 from app.schemas.common import SystemSettingSchema
 
 
-def _asyncpg_data_error(message: str):
-    """Build the driver exception asyncpg would raise for a class-22 error."""
-    from asyncpg.exceptions import StringDataRightTruncationError
+class _Psycopg2Error(Exception):
+    """psycopg2 exposes the SQLSTATE as .pgcode; asyncpg as .sqlstate."""
 
-    return StringDataRightTruncationError(message)
+    def __init__(self, pgcode: str):
+        super().__init__(f"psycopg2 error {pgcode}")
+        self.pgcode = pgcode
+
+
+def _asyncpg_error(name: str):
+    """Build the driver exception asyncpg would raise, by class name."""
+    import asyncpg.exceptions
+
+    return getattr(asyncpg.exceptions, name)("driver error")
 
 
 def _dbapi_error(orig: BaseException) -> DBAPIError:
@@ -31,59 +41,99 @@ def _dbapi_error(orig: BaseException) -> DBAPIError:
     return DBAPIError("SELECT 1", {}, orig)
 
 
-class TestIsInvalidInputError:
-    def test_sync_data_error_is_invalid_input(self):
-        """psycopg2 path: SQLAlchemy already classifies it as DataError."""
-        exc = DataError("INSERT ...", {}, Exception("value too long"))
-        assert is_invalid_input_error(exc) is True
+def _wrapped(orig: BaseException) -> DBAPIError:
+    """asyncpg path: the driver error hides one level down, under the wrapper."""
+    wrapper = Exception("dialect wrapper")
+    wrapper.__cause__ = orig
+    return _dbapi_error(wrapper)
 
-    def test_asyncpg_data_error_through_cause_chain(self):
-        """asyncpg path: the driver error hides behind the dialect wrapper."""
-        driver_error = _asyncpg_data_error("value too long for type character varying(100)")
-        wrapper = Exception("dialect wrapper")
-        wrapper.__cause__ = driver_error
-        assert is_invalid_input_error(_dbapi_error(wrapper)) is True
 
-    def test_asyncpg_data_error_as_direct_orig(self):
-        driver_error = _asyncpg_data_error('invalid input value for enum semester: "semester"')
-        assert is_invalid_input_error(_dbapi_error(driver_error)) is True
+class TestSqlstateExtraction:
+    def test_reads_sqlstate_from_asyncpg_through_cause_chain(self):
+        assert sqlstate_of(_wrapped(_asyncpg_error("StringDataRightTruncationError"))) == "22001"
 
-    def test_connection_failure_is_not_invalid_input(self):
-        """Operational problems must keep their 503, not become a 422."""
-        exc = OperationalError("SELECT 1", {}, Exception("connection refused"))
-        assert is_invalid_input_error(exc) is False
+    def test_reads_sqlstate_from_direct_orig(self):
+        assert sqlstate_of(_dbapi_error(_asyncpg_error("UniqueViolationError"))) == "23505"
 
-    def test_unrelated_exception_is_not_invalid_input(self):
-        assert is_invalid_input_error(ValueError("boom")) is False
+    def test_reads_pgcode_from_psycopg2(self):
+        assert sqlstate_of(_dbapi_error(_Psycopg2Error("22001"))) == "22001"
+
+    def test_non_dbapi_exception_has_no_sqlstate(self):
+        assert sqlstate_of(ValueError("boom")) is None
 
     def test_self_referential_cause_chain_terminates(self):
         """A cyclic __cause__ must not hang the handler."""
         looping = Exception("loop")
         looping.__cause__ = looping
-        assert is_invalid_input_error(_dbapi_error(looping)) is False
+        assert sqlstate_of(_dbapi_error(looping)) is None
+
+
+class TestIsInvalidInputError:
+    @pytest.mark.parametrize(
+        "driver_error_name",
+        [
+            "StringDataRightTruncationError",  # 22001 — value longer than the column
+            "InvalidTextRepresentationError",  # 22P02 — unknown enum label
+            "NumericValueOutOfRangeError",  # 22003
+            "InvalidDatetimeFormatError",  # 22007
+        ],
+    )
+    def test_unrepresentable_value_is_invalid_input(self, driver_error_name):
+        assert is_invalid_input_error(_wrapped(_asyncpg_error(driver_error_name))) is True
+
+    def test_psycopg2_truncation_is_invalid_input(self):
+        assert is_invalid_input_error(_dbapi_error(_Psycopg2Error("22001"))) is True
+
+    def test_division_by_zero_stays_a_server_error(self):
+        """Server-side arithmetic is not the client's fault — must remain a 500."""
+        assert is_invalid_input_error(_wrapped(_asyncpg_error("DivisionByZeroError"))) is False
+
+    def test_connection_failure_is_not_invalid_input(self):
+        """Operational problems must keep their 503, not become a 422."""
+        exc = OperationalError("SELECT 1", {}, _Psycopg2Error("08006"))
+        assert is_invalid_input_error(exc) is False
+
+    def test_unrelated_exception_is_not_invalid_input(self):
+        assert is_invalid_input_error(ValueError("boom")) is False
 
 
 class TestIsConstraintViolationError:
-    def test_sync_integrity_error_is_constraint_violation(self):
-        exc = IntegrityError("INSERT ...", {}, Exception("duplicate key value"))
+    @pytest.mark.parametrize(
+        "driver_error_name",
+        [
+            "UniqueViolationError",  # 23505
+            "ForeignKeyViolationError",  # 23503
+        ],
+    )
+    def test_genuine_conflict_is_a_constraint_violation(self, driver_error_name):
+        assert is_constraint_violation_error(_wrapped(_asyncpg_error(driver_error_name))) is True
+
+    def test_psycopg2_unique_violation_is_a_constraint_violation(self):
+        exc = IntegrityError("INSERT ...", {}, _Psycopg2Error("23505"))
         assert is_constraint_violation_error(exc) is True
 
-    def test_asyncpg_unique_violation_through_cause_chain(self):
-        from asyncpg.exceptions import UniqueViolationError
-
-        driver_error = UniqueViolationError("duplicate key value violates unique constraint")
-        wrapper = Exception("dialect wrapper")
-        wrapper.__cause__ = driver_error
-        assert is_constraint_violation_error(_dbapi_error(wrapper)) is True
+    @pytest.mark.parametrize(
+        "driver_error_name",
+        [
+            "NotNullViolationError",  # 23502
+            "CheckViolationError",  # 23514
+        ],
+    )
+    def test_broken_invariant_stays_a_server_error(self, driver_error_name):
+        """A service that omits a NOT NULL column is a backend bug, not a conflict:
+        answering 409 would lie to the client and hide it from 5xx alerting."""
+        exc = _wrapped(_asyncpg_error(driver_error_name))
+        assert is_constraint_violation_error(exc) is False
+        assert is_invalid_input_error(exc) is False
 
     def test_data_error_is_not_a_constraint_violation(self):
         """The two classes must stay disjoint so each keeps its own status code."""
-        exc = _dbapi_error(_asyncpg_data_error("value too long"))
+        exc = _wrapped(_asyncpg_error("StringDataRightTruncationError"))
         assert is_constraint_violation_error(exc) is False
         assert is_invalid_input_error(exc) is True
 
     def test_connection_failure_is_not_a_constraint_violation(self):
-        exc = OperationalError("SELECT 1", {}, Exception("connection refused"))
+        exc = OperationalError("SELECT 1", {}, _Psycopg2Error("08006"))
         assert is_constraint_violation_error(exc) is False
 
 
@@ -123,6 +173,19 @@ class TestSchemaLengthCaps:
         """value is a Text column — long content must still be allowed."""
         setting = SystemSettingSchema(key="k", value="v" * 5000)
         assert len(setting.value) == 5000
+
+    def test_document_name_over_column_width_is_rejected(self):
+        """The document schemas share the router the field schemas were capped in."""
+        with pytest.raises(ValidationError):
+            ApplicationDocumentCreate(scholarship_type="phd_nstc", document_name="d" * 201)
+
+    def test_document_description_is_unbounded_text(self):
+        doc = ApplicationDocumentCreate(
+            scholarship_type="phd_nstc",
+            document_name="成績單",
+            description="x" * 5000,
+        )
+        assert len(doc.description) == 5000
 
 
 class TestSystemSettingKeyQueryCap:

--- a/backend/app/tests/test_input_validation_hardening.py
+++ b/backend/app/tests/test_input_validation_hardening.py
@@ -1,0 +1,134 @@
+"""Regression tests for the ZAP-driven input-validation hardening.
+
+Covers the three changes that removed the Medium/High findings of the
+2026-08-11 authenticated active scan:
+
+1. PostgreSQL data exceptions surface as 422, not 500 (``is_invalid_input_error``).
+2. String schemas cap length at the DB column width, so over-length payloads are
+   rejected at the boundary instead of by Postgres.
+3. Mock SSO defaults to OFF, so dropping the env var cannot expose the
+   credential-free account-minting endpoints.
+"""
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.exc import DataError, DBAPIError, IntegrityError, OperationalError
+
+from app.core.db_errors import is_constraint_violation_error, is_invalid_input_error
+from app.schemas.application_field import ApplicationFieldCreate
+from app.schemas.common import SystemSettingSchema
+
+
+def _asyncpg_data_error(message: str):
+    """Build the driver exception asyncpg would raise for a class-22 error."""
+    from asyncpg.exceptions import StringDataRightTruncationError
+
+    return StringDataRightTruncationError(message)
+
+
+def _dbapi_error(orig: BaseException) -> DBAPIError:
+    """Wrap a driver exception the way SQLAlchemy's asyncpg dialect does."""
+    return DBAPIError("SELECT 1", {}, orig)
+
+
+class TestIsInvalidInputError:
+    def test_sync_data_error_is_invalid_input(self):
+        """psycopg2 path: SQLAlchemy already classifies it as DataError."""
+        exc = DataError("INSERT ...", {}, Exception("value too long"))
+        assert is_invalid_input_error(exc) is True
+
+    def test_asyncpg_data_error_through_cause_chain(self):
+        """asyncpg path: the driver error hides behind the dialect wrapper."""
+        driver_error = _asyncpg_data_error("value too long for type character varying(100)")
+        wrapper = Exception("dialect wrapper")
+        wrapper.__cause__ = driver_error
+        assert is_invalid_input_error(_dbapi_error(wrapper)) is True
+
+    def test_asyncpg_data_error_as_direct_orig(self):
+        driver_error = _asyncpg_data_error('invalid input value for enum semester: "semester"')
+        assert is_invalid_input_error(_dbapi_error(driver_error)) is True
+
+    def test_connection_failure_is_not_invalid_input(self):
+        """Operational problems must keep their 503, not become a 422."""
+        exc = OperationalError("SELECT 1", {}, Exception("connection refused"))
+        assert is_invalid_input_error(exc) is False
+
+    def test_unrelated_exception_is_not_invalid_input(self):
+        assert is_invalid_input_error(ValueError("boom")) is False
+
+    def test_self_referential_cause_chain_terminates(self):
+        """A cyclic __cause__ must not hang the handler."""
+        looping = Exception("loop")
+        looping.__cause__ = looping
+        assert is_invalid_input_error(_dbapi_error(looping)) is False
+
+
+class TestIsConstraintViolationError:
+    def test_sync_integrity_error_is_constraint_violation(self):
+        exc = IntegrityError("INSERT ...", {}, Exception("duplicate key value"))
+        assert is_constraint_violation_error(exc) is True
+
+    def test_asyncpg_unique_violation_through_cause_chain(self):
+        from asyncpg.exceptions import UniqueViolationError
+
+        driver_error = UniqueViolationError("duplicate key value violates unique constraint")
+        wrapper = Exception("dialect wrapper")
+        wrapper.__cause__ = driver_error
+        assert is_constraint_violation_error(_dbapi_error(wrapper)) is True
+
+    def test_data_error_is_not_a_constraint_violation(self):
+        """The two classes must stay disjoint so each keeps its own status code."""
+        exc = _dbapi_error(_asyncpg_data_error("value too long"))
+        assert is_constraint_violation_error(exc) is False
+        assert is_invalid_input_error(exc) is True
+
+    def test_connection_failure_is_not_a_constraint_violation(self):
+        exc = OperationalError("SELECT 1", {}, Exception("connection refused"))
+        assert is_constraint_violation_error(exc) is False
+
+
+class TestSchemaLengthCaps:
+    """ZAP's format-string payload is ~250 chars; these columns are 50-200."""
+
+    def test_field_name_over_column_width_is_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ApplicationFieldCreate(
+                scholarship_type="phd_nstc",
+                field_name="x" * 101,
+                field_label="label",
+            )
+        assert "field_name" in str(exc_info.value)
+
+    def test_scholarship_type_over_column_width_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ApplicationFieldCreate(
+                scholarship_type="x" * 51,
+                field_name="zap",
+                field_label="label",
+            )
+
+    def test_values_within_column_width_are_accepted(self):
+        field = ApplicationFieldCreate(
+            scholarship_type="x" * 50,
+            field_name="y" * 100,
+            field_label="z" * 200,
+        )
+        assert field.field_name == "y" * 100
+
+    def test_system_setting_key_over_column_width_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SystemSettingSchema(key="k" * 101, value="v")
+
+    def test_system_setting_value_is_unbounded_text(self):
+        """value is a Text column — long content must still be allowed."""
+        setting = SystemSettingSchema(key="k", value="v" * 5000)
+        assert len(setting.value) == 5000
+
+
+class TestMockSsoDefault:
+    def test_mock_sso_defaults_to_disabled(self, monkeypatch):
+        """Dropping ENABLE_MOCK_SSO must disable, not enable, the dev endpoints."""
+        monkeypatch.delenv("ENABLE_MOCK_SSO", raising=False)
+        from app.core.config import Settings
+
+        assert Settings(_env_file=None).enable_mock_sso is False

--- a/backend/app/tests/test_input_validation_hardening.py
+++ b/backend/app/tests/test_input_validation_hardening.py
@@ -156,9 +156,13 @@ class TestSystemSettingKeyQueryCap:
 
 
 class TestMockSsoDefault:
-    def test_mock_sso_defaults_to_disabled(self, monkeypatch):
-        """Dropping ENABLE_MOCK_SSO must disable, not enable, the dev endpoints."""
-        monkeypatch.delenv("ENABLE_MOCK_SSO", raising=False)
+    def test_mock_sso_defaults_to_disabled(self):
+        """Dropping ENABLE_MOCK_SSO must disable, not enable, the dev endpoints.
+
+        Asserts the declared default rather than instantiating Settings, which
+        would need the whole required-env set and is sensitive to whatever the
+        preceding test left in os.environ.
+        """
         from app.core.config import Settings
 
-        assert Settings(_env_file=None).enable_mock_sso is False
+        assert Settings.model_fields["enable_mock_sso"].default is False

--- a/backend/app/tests/test_input_validation_hardening.py
+++ b/backend/app/tests/test_input_validation_hardening.py
@@ -125,6 +125,36 @@ class TestSchemaLengthCaps:
         assert len(setting.value) == 5000
 
 
+class TestSystemSettingKeyQueryCap:
+    """GET /admin/system-setting echoes a missing key back through
+    SystemSettingSchema, so the query param must be capped at the same width or
+    response construction raises inside the handler and answers 500."""
+
+    async def _get(self, key: str) -> int:
+        from httpx import ASGITransport, AsyncClient
+
+        from app.core.security import require_admin
+        from app.db.deps import get_db
+        from app.main import app
+
+        async def _no_db():
+            yield None
+
+        app.dependency_overrides[get_db] = _no_db
+        app.dependency_overrides[require_admin] = lambda: None
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.get("/api/v1/admin/system-setting", params={"key": key})
+            return response.status_code
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_over_length_key_is_rejected_before_the_handler(self):
+        assert await self._get("k" * 101) == 422
+
+
 class TestMockSsoDefault:
     def test_mock_sso_defaults_to_disabled(self, monkeypatch):
         """Dropping ENABLE_MOCK_SSO must disable, not enable, the dev endpoints."""

--- a/backend/app/tests/test_mock_sso.py
+++ b/backend/app/tests/test_mock_sso.py
@@ -13,6 +13,15 @@ from app.models.user import User, UserRole, UserType
 class TestMockSSO:
     """Test mock SSO functionality"""
 
+    @pytest.fixture(autouse=True)
+    def enable_mock_sso(self, monkeypatch):
+        """The /mock-sso/* endpoints 404 unless this flag is on, and it defaults
+        to off so a dropped env var fails safe. State the precondition here
+        rather than inheriting it from the ambient environment."""
+        from app.core import config
+
+        monkeypatch.setattr(config.settings, "enable_mock_sso", True)
+
     @pytest.fixture
     async def student001(self, db: AsyncSession) -> User:
         """Seed student001 user required by smoke SSO tests.


### PR DESCRIPTION
## 背景

2026-08-11 對 `main` @ `09adc4c7` 跑了一次認證後的 ZAP **active scan**（483 URLs，27 分鐘，admin JWT），結果 **2 High + 1 Medium**。目標：**部署到 production 的環境不得掃出 medium 以上的漏洞**。

三個 medium+ findings 全部收斂到兩個根因。

## Medium — "Format String Error" ×7

不是 format string 漏洞。ZAP 的 payload 長約 250 字元，超過目標 VARCHAR 欄位寬度，因此值一路送到 Postgres 才炸 `StringDataRightTruncationError`，未處理 → 500。掃描器把「打 payload 就 500」判讀為 crash-on-payload。

- 在 boundary 就擋掉：`ApplicationFieldBase` / `ApplicationFieldUpdate` / `SystemSettingSchema` 的字串欄位加上與 DB 欄位等寬的 `max_length`。
- 新增 `app/core/db_errors.py`：**依 SQLSTATE** 分類資料庫錯誤,註冊在 `DBAPIError` 的 exception handler 上。
  - **422** — `22001` 字串超長、`22003` 數值溢位、`22007`/`22008` 日期時間、`22P02` 無效 enum label。
  - **409** — `23503` FK、`23505` unique。
  - 其餘一律留 **500**：`23502` not-null 與 `23514` check 是後端自己壞掉的 invariant(service 忘記填 NOT NULL 欄位),回 409 等於對 client 說謊又把 bug 從 5xx 監控藏起來;`22012` division-by-zero 是後端算術,不是使用者輸入。

  用 SQLSTATE 而不是 exception class,是因為兩種 driver 形狀不同:asyncpg 這條路 SQLAlchemy 的 dialect 會把 driver exception 包一層,拋出來的是單純的 `DBAPIError`(不是 `sqlalchemy.exc.DataError`),真正帶 `.sqlstate` 的物件藏在 `__cause__` 鏈裡;psycopg2 則是同一組碼放在 `.pgcode`。取代碼可以同時涵蓋兩者,也讓匹配範圍精準。

  **handler 掛的位置很重要**:Starlette 把 `Exception` handler 接在 `ServerErrorMiddleware` — 它在 middleware stack **外面**,而且送出 response 之後會 re-raise。掛在那裡的話 client 看到 422,但 `MetricsMiddleware` 仍然記 500、log 仍然說 unhandled exception、exception 仍然逃出 ASGI app。改註冊在具體的 `DBAPIError` 上,由 stack **內**的 `ExceptionMiddleware` 派送,metrics / log / response 三者才一致。實測確認 `http_errors_total` 記的是 `422`/`409`,且 `Exception in ASGI application` 歸零。

  被映射成 4xx 的情況以 **WARNING + traceback** 記錄:萬一是後端造成的(例如 service 寫入大小寫錯誤的 enum label)仍然查得到,又不會讓 4xx 去 page 人。

## High ×2 — "Remote OS Command Injection" 與 "Path Traversal"，兩個都是 false positive

`/auth/dev-profiles/{developer_id}` 會把 path segment 轉成 title case 回填到產生的 profile 名稱，所以 payload `get-help` 變成 `"Prof. Get-Help"`，剛好命中 rule 90020 偵測 PowerShell 輸出的 regex。

不過這組 endpoint 會**在沒有任何憑證的情況下產生任意帳號（含 admin）**，而唯一的開關是 `enable_mock_sso` — 它的預設值是 `True`。

- 把 `enable_mock_sso` 預設改為 `False`，讓漏設 env var 時是 fail-safe。所有需要它的環境本來就都明確設定了 `ENABLE_MOCK_SSO`（`docker-compose.dev.yml`、`docker-compose.staging-e2e.yml`、`scripts/write_dev_env.sh`）；staging / prod 本來就是 `"false"`。

## 驗證

用**同一份 automation plan**、對 **production 設定**的目標（`ENVIRONMENT=production`、`DEBUG=false`、`ENABLE_MOCK_SSO=false`）跑完整 active scan，資料庫是 `scholarship_db` 的 `pg_dump` clone，覆蓋率一致（483 URLs、27m20s）：

| Risk | main @ 09adc4c7 | 本 PR（prod 設定） |
|---|---|---|
| High — Remote OS Command Injection | 5 | **0** |
| High — Path Traversal | 2 | **0** |
| Medium — Format String Error | 7 | **0** |

`{"pass": 56, "warn": 5, "fail": 0}` — **0 High、0 Medium**。

驗證過程本身抓到兩件事，都已處理：

1. **第一次驗證掃描更糟（多了一個 High: SQL Injection）** — 是我的掃描環境設錯，不是 regression。`ENVIRONMENT=production` 不允許推導 dev 的 deterministic PII key，於是每個碰到 `std_pid` 的 endpoint 都 `PIICryptoError` → 對**任何**輸入（包含合法輸入）都 500，ZAP 把它在 `John Doe'(` payload 上看到的 500 判成 SQL injection。
2. **一個我自己造成的 regression** — `GET /admin/system-setting` 在查不到 key 時會把 key 原封回填進 `SystemSettingSchema`，於是新加的 `max_length=100` 在 handler 內部拋 ValidationError → 500。已修（query param 一併設上限）。

## Code review 後續修正

`/code-review high` 在上面的實作裡找到 4 個缺陷,都已修(commit `f91ecd6a`):

1. **422/409 掛在錯的 handler 上**(MEDIUM)— 見上面 handler 位置的說明。
2. **class-23 base 抓太寬**(MEDIUM)— not-null / check violation 會變成 409。改為只匹配 23503/23505。
3. **class-22 抓太寬**(LOW)— 含 22012 division-by-zero 等後端算術。改為只匹配可代表「這個值存不進去」的 5 個碼。
4. **同 router 的 document schemas 沒設上限**(LOW)— `POST /application-fields/documents` 的 `document_name` 等欄位仍會打到 Postgres 才炸。已補 `ApplicationDocument*` 的 `max_length`。

因為映射範圍收窄,**第三次**重跑 production 設定的完整 active scan 確認沒有回退:`{"pass": 56, "warn": 5, "fail": 0}`,仍是 **0 High、0 Medium**(`zap-reports/verify-fix-prod3/`)。殘留的 3 個 500 與收窄前完全相同,都是沒有注入 payload 的一般請求。

## CI 修正

`Backend Tests (smoke)` 一開始是紅的:`test_mock_sso.py` 兩個測試拿到 404。根因不只是預設值 —

`test_developer_profiles.py:17` 在 **import 時**就直接改全域 `settings.enable_mock_sso = True`,污染會外溢到之後才被 collect 的每個模組,所以 `test_mock_sso.py` 從來沒宣告自己的前提條件,只是靠 collection 順序搭便車。CI 的 smoke lane 跑固定檔案清單 — 有 `test_mock_sso.py`、沒有 `test_developer_profiles.py` — 預設值一翻就爆。

兩邊都改成 autouse monkeypatch fixture,各自宣告需要的狀態,也不再跨模組外溢。

## Test plan

- [x] 新增 `app/tests/test_input_validation_hardening.py`(29 tests)：SQLSTATE 擷取與分類(asyncpg 與 psycopg2 兩條路徑、cyclic `__cause__`、operational error 不被誤判、not-null/check/division-by-zero 必須留 500)、schema 長度上限、system-setting query 上限、mock-SSO 預設值。
- [x] 後端全套測試:**5237 passed, 4 skipped, 3 failed**。3 個 failure 是 `TestDevEndpointsDebugGate`，在 `main` @ `09adc4c7` 上一模一樣會失敗（本機容器 `DEBUG=true`，debug gate 是開的 → 200 而非 403），與本 PR 無關。
- [x] `black --check --line-length=120` 通過；`flake8 --select=B904,B014` 通過。
- [x] CI 不設 `ENABLE_MOCK_SSO`,所以在該旗標關閉下驗證三種組合:`test_mock_sso.py` 單獨(6 passed)、`test_developer_profiles.py` 單獨(22 passed)、兩者加新測試一起(45 passed)。
- [x] CI 全綠:**26 pass / 0 fail**。
- [x] production 設定下重跑完整 ZAP active scan 兩次(收窄映射前後):皆為 0 High、0 Medium。

沒有動 OpenAPI 的型別輸出，所以不需要重新產生 `schema.d.ts`（`maxLength` 是 validation keyword，`openapi-typescript` 仍然輸出 `string`）。

## 沒有處理的部分（Low，超出「medium 以上」範圍）

- 3 個殘留的 500：`POST notifications/admin/create-test-notifications`、`POST payment-rosters/10/dry-run`、`PUT scholarship-configurations/matrix-quota`。三個都是沒有注入 payload 的一般請求（`param=''`、`attack=''`），因此不會重新觸發 payload-based rules。既有問題，值得另開一次 input-validation 清理。
- 後端沒有全域 `X-Content-Type-Options: nosniff`（frontend 的 `middleware.ts` 有設）。
- 公告內容未做 sanitize 就儲存；目前 UI 不會以 HTML 渲染，所以無法利用，但如果之後拿去組 HTML email 就有影響。

掃描報告與逐項分析在 `zap-reports/verify-fix-prod2/` 與 `zap-reports/verify-fix-prod3/`(未納入 commit)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjWMHqES2xjo6WRAMraXKc
