### PR TITLE
fix: resolve AppScan staging findings (hidden dirs, headers, caching)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.models.user import User
 from app.core.metrics import CONTENT_TYPE_LATEST, generate_latest, set_app_info, update_db_pool_metrics
 from app.db.session import async_engine, sync_engine
 from app.middleware.metrics_middleware import MetricsMiddleware
+from app.middleware.security_headers_middleware import SecurityHeadersMiddleware
 
 # Import scheduler
 from app.services.roster_scheduler_service import init_scheduler, shutdown_scheduler
@@ -162,6 +163,10 @@ app.add_middleware(
 # Add Prometheus metrics middleware
 if settings.enable_metrics:
     app.add_middleware(MetricsMiddleware)
+
+# Cache-Control / CSP hardening on every response (AppScan 2026-08-13) — see
+# the module docstring for why this cannot live in nginx.
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Add schema validation middleware (development only)
 # Temporarily disabled due to logger scoping issue

--- a/backend/app/middleware/security_headers_middleware.py
+++ b/backend/app/middleware/security_headers_middleware.py
@@ -1,0 +1,53 @@
+"""
+Response-header hardening for every backend API response.
+
+Added for the 2026-08-13 AppScan staging findings:
+
+- "Cacheable SSL Page Found": authenticated JSON responses (e.g.
+  /api/v1/auth/me, /api/v1/payment-rosters) carried no Cache-Control header,
+  so browsers and shared caches were free to store per-user data. Every
+  response now defaults to ``no-store`` unless the endpoint set an explicit
+  Cache-Control of its own (a few file endpoints do).
+
+- Missing "Content-Security-Policy": API responses had no CSP at all. JSON
+  responses get the strict no-execution policy recommended for APIs. Non-JSON
+  responses (Swagger UI HTML in dev, streamed files) are left alone — the
+  interactive docs would break under ``default-src 'none'``, and file
+  responses that the frontend frames get their CSP from the Next.js proxy
+  layer instead.
+
+nginx cannot do either of these safely: ``add_header`` APPENDS, so a
+Cache-Control added there would coexist with (not replace) an endpoint's own
+value, and a server-level CSP would stack a second, conflicting policy onto
+the nonce-based CSP the frontend middleware emits for pages.
+"""
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+# Strict no-execution policy for machine-readable responses. frame-ancestors
+# 'none' also makes framing a raw API response impossible regardless of the
+# X-Frame-Options nginx adds.
+API_CONTENT_SECURITY_POLICY = "default-src 'none'; frame-ancestors 'none'"
+
+NO_STORE_CACHE_CONTROL = "no-store, no-cache, must-revalidate"
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Default every response to non-cacheable and give JSON a strict CSP."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+
+        # Endpoint-declared caching wins (e.g. photo/file endpoints that set
+        # their own private max-age); everything else must not be stored.
+        if "cache-control" not in response.headers:
+            response.headers["Cache-Control"] = NO_STORE_CACHE_CONTROL
+            response.headers["Pragma"] = "no-cache"
+
+        content_type = response.headers.get("content-type", "")
+        if content_type.startswith("application/json") and "content-security-policy" not in response.headers:
+            response.headers["Content-Security-Policy"] = API_CONTENT_SECURITY_POLICY
+
+        return response

--- a/backend/app/tests/test_security_headers_middleware.py
+++ b/backend/app/tests/test_security_headers_middleware.py
@@ -1,0 +1,61 @@
+"""SecurityHeadersMiddleware contract (AppScan 2026-08-13 staging findings).
+
+Every JSON response must be non-cacheable and carry the strict API CSP;
+endpoint-declared Cache-Control must win; non-JSON responses (docs HTML,
+files) must not receive the API CSP.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.responses import HTMLResponse, JSONResponse
+
+from app.middleware.security_headers_middleware import (
+    API_CONTENT_SECURITY_POLICY,
+    NO_STORE_CACHE_CONTROL,
+    SecurityHeadersMiddleware,
+)
+
+
+def _build_client() -> TestClient:
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/json")
+    async def json_endpoint():
+        return {"success": True, "message": "ok", "data": None}
+
+    @app.get("/cached-file")
+    async def cached_file_endpoint():
+        return JSONResponse(
+            content={"success": True},
+            headers={"Cache-Control": "private, max-age=3600"},
+        )
+
+    @app.get("/docs-like")
+    async def docs_like_endpoint():
+        return HTMLResponse("<html><body>docs</body></html>")
+
+    return TestClient(app)
+
+
+def test_json_response_defaults_to_no_store_with_api_csp():
+    response = _build_client().get("/json")
+
+    assert response.headers["Cache-Control"] == NO_STORE_CACHE_CONTROL
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Content-Security-Policy"] == API_CONTENT_SECURITY_POLICY
+
+
+def test_endpoint_declared_cache_control_wins():
+    response = _build_client().get("/cached-file")
+
+    assert response.headers["Cache-Control"] == "private, max-age=3600"
+    assert "Pragma" not in response.headers
+
+
+def test_html_response_gets_no_api_csp_but_still_no_store():
+    # Swagger UI (non-production only) must not be broken by default-src 'none'.
+    response = _build_client().get("/docs-like")
+
+    assert "Content-Security-Policy" not in response.headers
+    assert response.headers["Cache-Control"] == NO_STORE_CACHE_CONTROL

--- a/frontend/__tests__/security-headers-nginx-parity.test.ts
+++ b/frontend/__tests__/security-headers-nginx-parity.test.ts
@@ -18,6 +18,7 @@ import path from "path";
 
 import { middleware } from "@/middleware";
 import {
+  CROSS_ORIGIN_EMBEDDER_POLICY,
   CROSS_ORIGIN_OPENER_POLICY,
   CROSS_ORIGIN_RESOURCE_POLICY,
   PERMISSIONS_POLICY,
@@ -47,6 +48,7 @@ describe("nginx <-> middleware security-header parity (issue #1223 B)", () => {
     ["Permissions-Policy", PERMISSIONS_POLICY],
     ["Cross-Origin-Opener-Policy", CROSS_ORIGIN_OPENER_POLICY],
     ["Cross-Origin-Resource-Policy", CROSS_ORIGIN_RESOURCE_POLICY],
+    ["Cross-Origin-Embedder-Policy", CROSS_ORIGIN_EMBEDDER_POLICY],
   ] as const;
 
   describe.each(NGINX_CONFIGS)("%s", (relPath) => {
@@ -66,48 +68,123 @@ describe("nginx <-> middleware security-header parity (issue #1223 B)", () => {
      * nginx drops ALL inherited add_headers in any block that declares one of its
      * own. Both configs have a `/api/v1/preview` block and an `/api/email/` block
      * that re-declare X-Frame-Options SAMEORIGIN — each MUST also re-declare the
-     * three new headers or they silently vanish for exactly the routes that serve
-     * framed file/email previews.
+     * document-scoped headers or they silently vanish for exactly the routes that
+     * serve framed file/email previews. COEP is the sharpest of these: a
+     * require-corp parent page refuses to frame any response that does not
+     * itself declare COEP, so a missing re-declaration = blank preview iframes.
      */
-    it("re-declares all three in every block that re-declares X-Frame-Options SAMEORIGIN", () => {
+    it("re-declares the document-scoped headers in every block that re-declares X-Frame-Options SAMEORIGIN", () => {
       const sameOriginBlocks = conf.split("add_header X-Frame-Options SAMEORIGIN").length - 1;
+      const monitoringBlocks = conf.split("location ^~ /monitoring").length - 1;
+      const healthBlocks = conf.split("location /health").length - 1;
       expect(sameOriginBlocks).toBeGreaterThan(0);
+      expect(monitoringBlocks).toBe(1);
+      expect(healthBlocks).toBe(1);
 
+      // server level + each SAMEORIGIN block + /monitoring + /health
       for (const [header] of ["Permissions-Policy", "Cross-Origin-Opener-Policy"].map(
         (h) => [h] as const
       )) {
-        // one server-level declaration + one per SAMEORIGIN block
-        expect(declaredValues(conf, header)).toHaveLength(sameOriginBlocks + 1);
+        expect(declaredValues(conf, header)).toHaveLength(
+          1 + sameOriginBlocks + monitoringBlocks + healthBlocks
+        );
       }
+
+      // COEP is deliberately ABSENT from /monitoring: Grafana loads
+      // cross-origin no-cors images (gravatars, grafana.com panels) that an
+      // enforced require-corp would block, and it is the one document prefix
+      // where nginx's COEP is not deduplicated against the Next.js middleware.
+      expect(declaredValues(conf, "Cross-Origin-Embedder-Policy")).toHaveLength(
+        1 + sameOriginBlocks + healthBlocks
+      );
     });
 
     /**
      * Static-asset blocks declare their own Cache-Control, which drops every
      * inherited add_header — and frontend/middleware.ts's matcher EXCLUDES those
      * same paths (`_next/static`, `.js`/`.css`/image extensions). Without an
-     * explicit re-declaration they are covered by NEITHER layer.
+     * explicit re-declaration they are covered by NEITHER layer. The same holds
+     * for the bare `/pdf.worker.min.mjs` block.
      *
-     * Only CORP is required there: it is the header that governs no-cors
-     * SUBRESOURCE embedding. Permissions-Policy and COOP are document-scoped and
-     * inert on a JS/CSS response, so they are deliberately not repeated onto
-     * every cached asset.
+     * Each such block re-declares CORP (governs no-cors SUBRESOURCE embedding),
+     * HSTS and Referrer-Policy (AppScan 2026-08-13 flagged static chunks missing
+     * both). Permissions-Policy and COOP/COEP are document-scoped and inert on a
+     * JS/CSS response, so they are deliberately not repeated onto cached assets.
+     *
+     * The Cache-Control string is pinned to the SINGLE-declaration form — the
+     * old `expires 1y` + `"public, immutable"` pair emitted two Cache-Control
+     * headers on every asset (an AppScan unnecessary-header finding).
      */
-    it("re-declares CORP in every block that declares its own Cache-Control", () => {
-      const cacheControlBlocks = conf.split('add_header Cache-Control "public, immutable"').length - 1;
+    it("re-declares CORP/HSTS/Referrer-Policy in every subresource block", () => {
+      expect(conf).not.toContain('add_header Cache-Control "public, immutable"');
+      // Directive form only — comments explaining the removal may say "expires".
+      expect(conf).not.toMatch(/^\s*expires\s/m);
+      const cacheControlBlocks =
+        conf.split('add_header Cache-Control "public, max-age=31536000, immutable"').length - 1;
       expect(cacheControlBlocks).toBeGreaterThan(0);
 
       const sameOriginBlocks = conf.split("add_header X-Frame-Options SAMEORIGIN").length - 1;
-      expect(declaredValues(conf, "Cross-Origin-Resource-Policy")).toHaveLength(
-        1 + sameOriginBlocks + cacheControlBlocks
-      );
+      const workerBlocks = conf.split("location = /pdf.worker.min.mjs").length - 1;
+      const monitoringBlocks = conf.split("location ^~ /monitoring").length - 1;
+      const healthBlocks = conf.split("location /health").length - 1;
+      expect(workerBlocks).toBe(1);
+
+      const expected =
+        1 + sameOriginBlocks + cacheControlBlocks + workerBlocks + monitoringBlocks + healthBlocks;
+      expect(declaredValues(conf, "Cross-Origin-Resource-Policy")).toHaveLength(expected);
+      expect(declaredValues(conf, "Strict-Transport-Security")).toHaveLength(expected);
+      expect(declaredValues(conf, "Referrer-Policy")).toHaveLength(expected);
     });
 
-    it("does NOT set Cross-Origin-Embedder-Policy", () => {
-      // require-corp would break the same-origin /api/v1/preview iframes (the
-      // caveat raised in #1223) and buys nothing: no SharedArrayBuffer anywhere.
-      // Match the DIRECTIVE, not the bare name — the configs mention the header
-      // in a comment explaining precisely why it is absent.
-      expect(declaredValues(conf, "Cross-Origin-Embedder-Policy")).toHaveLength(0);
+    /**
+     * COOP/COEP/CORP are RFC 8941 sf-item headers: when nginx add_header
+     * APPENDS to the identical header the Next.js middleware already set, the
+     * duplicated value ("same-origin, same-origin") is a parse FAILURE that
+     * browsers treat as unsafe-none — crossOriginIsolated was observed false
+     * behind nginx. The upstream copy must therefore be hidden wherever nginx
+     * emits its own: once at server level, and re-declared in the pdf.worker
+     * block (whose own proxy_hide_header lines stop inheritance).
+     */
+    it("hides the upstream copy of every sf-item header nginx re-emits", () => {
+      for (const header of [
+        "Cross-Origin-Opener-Policy",
+        "Cross-Origin-Embedder-Policy",
+        "Cross-Origin-Resource-Policy",
+      ]) {
+        expect(conf.split(`proxy_hide_header ${header};`).length - 1).toBe(2);
+      }
+
+      // Next.js sets its own Cache-Control on every static path nginx caches
+      // (immutable for /_next/static, max-age=0 for /public) — each block that
+      // declares the immutable value must hide the upstream copy or the
+      // response carries two Cache-Control lines (the AppScan finding) with
+      // the upstream max-age=0 winning for /public assets.
+      const cacheControlBlocks =
+        conf.split('add_header Cache-Control "public, max-age=31536000, immutable"').length - 1;
+      expect(conf.split("proxy_hide_header Cache-Control;").length - 1).toBe(cacheControlBlocks);
+    });
+
+    it("pins HSTS to the preload form everywhere it is declared", () => {
+      const values = declaredValues(conf, "Strict-Transport-Security");
+      expect(values.length).toBeGreaterThan(0);
+      for (const value of values) {
+        expect(value).toBe("max-age=31536000; includeSubDomains; preload");
+      }
+    });
+
+    it("answers hidden-path probes with 404, never a 403 that confirms existence", () => {
+      // AppScan 2026-08-13: 55 "Hidden Directory Detected" findings — `deny all`
+      // (403) on dotfile paths reveals they exist. Both probe blocks must
+      // `return 404` and no location may use `deny all` outside /nginx_status.
+      expect(conf).toContain("location ~ /\\.");
+      const denyAlls = conf.split("deny all;").length - 1;
+      const statusBlocks = conf.split("location /nginx_status").length - 1;
+      expect(denyAlls).toBe(statusBlocks);
+    });
+
+    it("rejects rate-limited requests with 429, not the default 503", () => {
+      // AppScan files any 5xx as an "Application Error" (23 findings).
+      expect(conf).toContain("limit_req_status 429;");
     });
   });
 
@@ -123,16 +200,26 @@ describe("nginx <-> middleware security-header parity (issue #1223 B)", () => {
       "https://ss.test.nycu.edu.tw/api/v1/preview?fileId=1&type=pdf",
     ];
 
-    it.each(URLS)("%s carries all three headers with the shared values", (url) => {
+    it.each(URLS)("%s carries all four headers with the shared values", (url) => {
       const headers = middleware(mockRequest(url)).headers;
       expect(headers.get("Permissions-Policy")).toBe(PERMISSIONS_POLICY);
       expect(headers.get("Cross-Origin-Opener-Policy")).toBe(CROSS_ORIGIN_OPENER_POLICY);
       expect(headers.get("Cross-Origin-Resource-Policy")).toBe(CROSS_ORIGIN_RESOURCE_POLICY);
+      expect(headers.get("Cross-Origin-Embedder-Policy")).toBe(CROSS_ORIGIN_EMBEDDER_POLICY);
     });
 
-    it("does NOT emit Cross-Origin-Embedder-Policy", () => {
-      const headers = middleware(mockRequest("https://ss.test.nycu.edu.tw/student/apply")).headers;
-      expect(headers.get("Cross-Origin-Embedder-Policy")).toBeNull();
+    it("marks every /api response no-store, and leaves pages alone", () => {
+      // AppScan 2026-08-13 "Cacheable SSL Page Found": authenticated JSON/file
+      // responses must never be cacheable. Framed preview responses included —
+      // they are auth-gated documents, not static assets.
+      const api = middleware(
+        mockRequest("https://ss.test.nycu.edu.tw/api/v1/preview?fileId=1&type=pdf")
+      ).headers;
+      expect(api.get("Cache-Control")).toBe("no-store, no-cache, must-revalidate");
+      expect(api.get("Pragma")).toBe("no-cache");
+
+      const page = middleware(mockRequest("https://ss.test.nycu.edu.tw/student/apply")).headers;
+      expect(page.get("Cache-Control")).toBeNull();
     });
   });
 

--- a/frontend/app/api/v1/preview/footer-links/route.ts
+++ b/frontend/app/api/v1/preview/footer-links/route.ts
@@ -83,7 +83,9 @@ export async function GET(request: NextRequest) {
         // stream and reports a bogus "password protected" error.
         "Content-Length": fileBuffer.byteLength.toString(),
         "Accept-Ranges": "bytes",
-        "Cache-Control": "private, max-age=3600",
+        // no-store: authenticated document content must never land in a
+        // browser/shared cache (AppScan 2026-08-13 "Cacheable SSL Page Found")
+        "Cache-Control": "no-store, no-cache, must-revalidate",
         "X-Content-Type-Options": "nosniff",
         "Referrer-Policy": "no-referrer",
       },

--- a/frontend/app/api/v1/preview/supp-docs/route.ts
+++ b/frontend/app/api/v1/preview/supp-docs/route.ts
@@ -81,7 +81,9 @@ export async function GET(request: NextRequest) {
         "Content-Disposition": contentDisposition,
         "Content-Length": fileBuffer.byteLength.toString(),
         "Accept-Ranges": "bytes",
-        "Cache-Control": "private, max-age=3600",
+        // no-store: authenticated document content must never land in a
+        // browser/shared cache (AppScan 2026-08-13 "Cacheable SSL Page Found")
+        "Cache-Control": "no-store, no-cache, must-revalidate",
         "X-Content-Type-Options": "nosniff",
         "Referrer-Policy": "no-referrer",
       },

--- a/frontend/app/api/v1/preview/system-docs/route.ts
+++ b/frontend/app/api/v1/preview/system-docs/route.ts
@@ -79,7 +79,9 @@ export async function GET(request: NextRequest) {
         "Content-Disposition": contentDisposition,
         "Content-Length": fileBuffer.byteLength.toString(),
         "Accept-Ranges": "bytes",
-        "Cache-Control": "private, max-age=3600",
+        // no-store: authenticated document content must never land in a
+        // browser/shared cache (AppScan 2026-08-13 "Cacheable SSL Page Found")
+        "Cache-Control": "no-store, no-cache, must-revalidate",
         "X-Content-Type-Options": "nosniff",
         "Referrer-Policy": "no-referrer",
       },

--- a/frontend/lib/security-headers.ts
+++ b/frontend/lib/security-headers.ts
@@ -85,19 +85,20 @@ export const PERMISSIONS_POLICY = [
  * Severs `window.opener` between this app and cross-origin documents (XS-Leaks /
  * tabnabbing defence).
  *
- * `same-origin-allow-popups` rather than the stricter `same-origin` because
- * components/react-email-template-viewer.tsx opens `window.open("", "_blank")`
- * and then writes into `sourceWindow.document` — the admin "view email template
- * source" flow. Per spec an about:blank popup inherits its opener's COOP and
- * stays in the same browsing-context group, so `same-origin` *should* also work,
- * but `-allow-popups` makes that flow correct by construction while still
- * blocking every cross-origin document from retaining a handle on us.
+ * `same-origin` — tightened from `same-origin-allow-popups`, which the
+ * 2026-08-13 AppScan run filed as a MEDIUM finding. The one popup flow in the
+ * app still works: components/react-email-template-viewer.tsx opens
+ * `window.open("", "_blank")` and writes into `sourceWindow.document`, and per
+ * spec an about:blank popup inherits its opener's COOP and origin, so it stays
+ * in the same browsing-context group. No other code calls window.open or reads
+ * window.opener (verified 2026-08-13), so nothing relied on the -allow-popups
+ * carve-out.
  *
  * NYCU Portal SSO is unaffected either way: both legs are top-level redirects
  * (components/sso-login-page.tsx -> Portal form POST -> backend RedirectResponse
  * -> /auth/sso-callback?token=), never a popup with an opener callback.
  */
-export const CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups";
+export const CROSS_ORIGIN_OPENER_POLICY = "same-origin";
 
 /**
  * Blocks foreign origins from embedding our responses as no-cors subresources
@@ -106,13 +107,27 @@ export const CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups";
  * Safe for the file-preview chain: CORP governs no-cors SUBRESOURCE fetches, not
  * iframe navigations, so the same-origin `/api/v1/preview*` iframes are outside
  * its scope entirely.
- *
- * Cross-Origin-Embedder-Policy is deliberately NOT set — see the note in
- * middleware.ts. COEP `require-corp` would demand a CORP header on every
- * subresource the preview iframes pull, and buys nothing here because the app
- * uses no SharedArrayBuffer and never needs `crossOriginIsolated`.
  */
 export const CROSS_ORIGIN_RESOURCE_POLICY = "same-origin";
+
+/**
+ * Requires every resource this document embeds to be same-origin or to opt in
+ * via CORS/CORP — added for the 2026-08-13 AppScan MEDIUM finding (the header
+ * was previously omitted on purpose; see git history of this comment).
+ *
+ * Safe here because every embed in the app is same-origin, data: or blob:
+ * (the CSP already pins img-src/font-src/frame-src to exactly those sources)
+ * — nothing loads a cross-origin subresource that would now be blocked.
+ *
+ * THE SHARP EDGE IS NESTED DOCUMENTS: a `require-corp` parent refuses any
+ * iframe whose response does not itself declare COEP. That is why
+ * middleware.ts emits this header on every matched route — pages AND the
+ * framed `/api/v1/preview*` / `/api/email/*` responses — and why the nginx
+ * preview/email blocks re-declare it. Dropping it from a framed response
+ * breaks every file preview with a silent blank iframe; blob: iframes are
+ * fine (they inherit the creator document's policy container).
+ */
+export const CROSS_ORIGIN_EMBEDDER_POLICY = "require-corp";
 
 /**
  * CSP hashes for the two `<style>` elements sonner (the `<Toaster />` in

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import {
+  CROSS_ORIGIN_EMBEDDER_POLICY,
   CROSS_ORIGIN_OPENER_POLICY,
   CROSS_ORIGIN_RESOURCE_POLICY,
   PERMISSIONS_POLICY,
@@ -159,11 +160,20 @@ export function middleware(request: NextRequest) {
   response.headers.set("Permissions-Policy", PERMISSIONS_POLICY);
   response.headers.set("Cross-Origin-Opener-Policy", CROSS_ORIGIN_OPENER_POLICY);
   response.headers.set("Cross-Origin-Resource-Policy", CROSS_ORIGIN_RESOURCE_POLICY);
-  // Cross-Origin-Embedder-Policy is DELIBERATELY NOT SET. `require-corp` would
-  // demand a CORP header on every subresource the same-origin /api/v1/preview
-  // iframes pull, breaking file preview — the exact caveat raised in #1223 — and
-  // it buys nothing: nothing in this app uses SharedArrayBuffer or needs
-  // `crossOriginIsolated`. Do not add it without re-testing every preview route.
+  // COEP on EVERY matched route, framed proxies included: a require-corp parent
+  // page refuses any nested document that does not itself declare COEP, so the
+  // /api/v1/preview* and /api/email/* responses need this header just as much
+  // as the pages that frame them — see lib/security-headers.ts.
+  response.headers.set("Cross-Origin-Embedder-Policy", CROSS_ORIGIN_EMBEDDER_POLICY);
+
+  // AppScan 2026-08-13 "Cacheable SSL Page Found": every /api response carries
+  // authenticated, per-user data — forbid browsers and shared caches from
+  // storing any of it. Pages are deliberately NOT covered (Next.js manages its
+  // own page caching, and no page response was flagged).
+  if (pathname === "/api" || pathname.startsWith("/api/")) {
+    response.headers.set("Cache-Control", "no-store, no-cache, must-revalidate");
+    response.headers.set("Pragma", "no-cache");
+  }
 
   // Expose nonce to response headers for Nginx to read (if needed)
   response.headers.set("X-CSP-Nonce", nonce);

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -36,6 +36,11 @@ http {
     limit_req_zone $binary_remote_addr zone=frontend:10m rate=50r/s;
     limit_req_zone $binary_remote_addr zone=portal_sso:10m rate=10r/s;
 
+    # Rejected requests answer 429 Too Many Requests, not the default 503: a
+    # 5xx here is indistinguishable from a real outage, and the 2026-08-13
+    # AppScan run filed every rate-limited probe as an "Application Error".
+    limit_req_status 429;
+
     # Security settings
     server_tokens off;
 
@@ -114,11 +119,31 @@ http {
         # frontend/lib/security-headers.ts and re-declared in every location block
         # below that declares an add_header of its own — nginx drops ALL inherited
         # add_headers in any block that declares one.
-        # Cross-Origin-Embedder-Policy is deliberately absent: require-corp breaks
-        # the /api/v1/preview iframes and this app never needs crossOriginIsolated.
+        # COOP tightened from same-origin-allow-popups and COEP added per the
+        # 2026-08-13 AppScan medium findings — the two flows those values were
+        # protecting (the about:blank email-template-source popup, the
+        # /api/v1/preview iframes) both survive: an about:blank popup inherits
+        # its opener's COOP and stays in the browsing-context group, and every
+        # framable response now carries COEP itself (see the preview and
+        # /api/email/ blocks below), which is exactly what a require-corp
+        # parent demands of a nested document.
         add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
-        add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+
+        # The Next.js middleware emits byte-identical COOP/COEP/CORP (pinned by
+        # security-headers-nginx-parity.test.ts), and add_header APPENDS — so a
+        # proxied page would carry each header TWICE. These three are RFC 8941
+        # sf-item headers: a duplicated value ("same-origin, same-origin") is a
+        # PARSE FAILURE that browsers fall back to unsafe-none on — verified:
+        # crossOriginIsolated flips false behind nginx. Hide the upstream copy
+        # so exactly one line (nginx's) survives. Blocks that declare their own
+        # proxy_hide_header (e.g. /api/, pdf.worker) do NOT inherit these and
+        # must re-declare them if they proxy to the frontend.
+        proxy_hide_header Cross-Origin-Opener-Policy;
+        proxy_hide_header Cross-Origin-Embedder-Policy;
+        proxy_hide_header Cross-Origin-Resource-Policy;
 
         # Portal SSO endpoint (highest priority)
         location = /api/v1/auth/portal-sso/verify {
@@ -216,18 +241,23 @@ http {
             # with SAMEORIGIN so the server-level `X-Frame-Options DENY` is NOT
             # inherited — otherwise the browser refuses to frame the response
             # ("<host> refused to connect").
-            # NOTE: any add_header here drops ALL inherited add_headers, so all seven
+            # NOTE: any add_header here drops ALL inherited add_headers, so all eight
             # must be re-declared. Keep downloads/uploads OUT of /api/v1/preview* so
             # this framing relaxation never applies to a non-framed response.
             add_header X-Frame-Options SAMEORIGIN always;
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
             add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
-            add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
             # CORP governs no-cors SUBRESOURCE fetches, not iframe navigations, so
             # same-origin here does not affect framing of the preview response.
             add_header Cross-Origin-Resource-Policy "same-origin" always;
+            # These responses are FRAMED by pages that now carry COEP
+            # require-corp — a require-corp parent refuses any nested document
+            # that does not itself declare COEP, so dropping this line breaks
+            # every file preview ("refused to connect"-style blank iframe).
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # Next.js email render API
@@ -252,10 +282,12 @@ http {
             add_header X-Frame-Options SAMEORIGIN always;
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
             add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
-            add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
             add_header Cross-Origin-Resource-Policy "same-origin" always;
+            # Framed by COEP require-corp pages — see the preview block above.
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # Next.js UPLOAD proxies (POST, not framed). Any
@@ -288,6 +320,33 @@ http {
 
             # Allow up to 10MB document uploads (backend enforces the 10MB cap)
             client_max_body_size 11M;
+        }
+
+        # AppScan 2026-08-13 "Hidden Directory Detected" (55 findings): dotfile
+        # probes (/.git/, /.ssh/, /.env, …) must be indistinguishable from any
+        # other missing path — 404, never `deny all` (403), which confirms the
+        # path exists. Regex locations win by ORDER OF APPEARANCE, so this and
+        # the probe block below sit AFTER the preview/upload-proxy regexes those
+        # app routes must keep winning; /_next/static/ and /monitoring use ^~
+        # and are never regex-matched.
+        location ~ /\. {
+            return 404;
+        }
+
+        # Server-side-script and backup-file probes (noSuchFile.php,
+        # ~AppScan.aspx, /cgi-bin/*.aspx, *.env, …): nothing in this stack ever
+        # serves these extensions, so answer with nginx's own minimal 404
+        # instead of the Next.js 404 page — AppScan pattern-matches that page's
+        # /_next/... markup as 16+ "path disclosure" findings. The (?!/api/)
+        # guard keeps every real API route (whose responses are JSON, not
+        # pages) out of this block.
+        # Case-sensitive location (~) with a caseless (?i:...) extension group:
+        # under ~* the (?!/api/) guard itself went caseless, so /API/x.php
+        # escaped the block and reached the Next.js 404 page. Real API routes
+        # are lowercase-only (the /api/ prefix location is case-sensitive), so
+        # the guard must be too; the probed EXTENSIONS stay case-insensitive.
+        location ~ "^(?!/api/).*\.(?i:php|php3|php4|php5|phtml|thtml|shtml|stm|jsp|jspx|jhtml|asp|aspx|cfm|cgi|pl|plx|nsf|html|htm|env|git|svn|htaccess|htpasswd|bak|old|orig|inc|ini|log|sql|swp)$" {
+            return 404;
         }
 
         # Backend API routes (all other /api/ requests)
@@ -325,18 +384,62 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Request-ID $request_id;
 
-            # Static file caching
-            expires 1y;
-            add_header Cache-Control "public, immutable";
+            # Static file caching. A single Cache-Control declaration — the old
+            # `expires 1y` + add_header pair emitted TWO Cache-Control headers
+            # (expires appends its own max-age line), which AppScan filed as an
+            # unnecessary-header finding. Next.js sets its OWN Cache-Control on
+            # these responses too, so the upstream copy must be hidden or the
+            # response still carries two lines. No `always`: a 404 must not
+            # inherit a year-long immutable cache lifetime.
+            proxy_hide_header Cache-Control;
+            add_header Cache-Control "public, max-age=31536000, immutable";
             # Any add_header in a block drops ALL inherited ones, and
             # frontend/middleware.ts's matcher EXCLUDES these static paths — so
-            # without these two lines this response gets them from neither layer.
+            # without these lines this response gets them from neither layer.
             # CORP is the header that actually matters on a subresource (it is
-            # what stops a foreign origin embedding it); nosniff matters on JS/CSS.
+            # what stops a foreign origin embedding it); nosniff matters on JS/CSS;
+            # HSTS is host-scoped and belongs on EVERY response (AppScan flags
+            # each one it is missing from); Referrer-Policy likewise.
             # Permissions-Policy and COOP are document-scoped and inert here, so
             # they are deliberately NOT repeated onto every cached asset.
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        }
+
+        # Public folder static assets (icons, images, fonts) — root-level files
+        # from frontend/public/. MUST be a TOP-LEVEL location with its own
+        # proxy_pass: this used to be a regex nested inside `location /`, and
+        # proxy_pass is NOT inherited by nested locations, so the nested block
+        # had no content handler and every /public asset (both site favicons)
+        # 404'd out of nginx's default `root html`. Mirrors the staging shape.
+        # The (?!/api/) guard keeps API routes out; /_next/static/ (^~) and
+        # /monitoring (^~) are never regex-matched, and the dotfile/probe
+        # regexes above win by order of appearance.
+        location ~ "^(?!/api/).*\.(?i:js|css|svg|png|jpg|jpeg|ico|gif|webp|woff|woff2|ttf|eot)$" {
+            set $frontend_upstream frontend:3000;
+            proxy_pass http://$frontend_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Request-ID $request_id;
+
+            # SECURITY: Remove potentially sensitive headers
+            proxy_hide_header X-Powered-By;
+            proxy_hide_header Server;
+
+            # Static file caching — single Cache-Control, see /_next/static/.
+            # Upstream Next.js serves /public files with `public, max-age=0`;
+            # hide it so nginx's immutable value is the only one emitted.
+            proxy_hide_header Cache-Control;
+            add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         }
 
         # pdf.js worker for the regulations preview (react-pdf).
@@ -357,11 +460,21 @@ http {
             proxy_set_header X-Forwarded-Host $host;
             proxy_set_header X-Request-ID $request_id;
 
-            # SECURITY: Remove potentially sensitive headers
+            # SECURITY: Remove potentially sensitive headers. Declaring any
+            # proxy_hide_header here stops inheritance of the server-level
+            # trio, so the sf-item headers must be re-hidden explicitly — the
+            # middleware DOES run on this path (it is not matcher-excluded) and
+            # a duplicated CORP would parse-fail to no protection.
             proxy_hide_header X-Powered-By;
             proxy_hide_header Server;
+            proxy_hide_header Cross-Origin-Opener-Policy;
+            proxy_hide_header Cross-Origin-Embedder-Policy;
+            proxy_hide_header Cross-Origin-Resource-Policy;
 
-            add_header X-Content-Type-Options "nosniff";
+            add_header X-Content-Type-Options nosniff always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         }
 
         # Grafana monitoring dashboard (subpath serving)
@@ -396,6 +509,21 @@ http {
             proxy_buffering off;
             proxy_buffer_size 16k;
             proxy_buffers 8 16k;
+
+            # Grafana is a DOCUMENT served under this origin, so re-declare the
+            # document-scoped set — EXCEPT Cross-Origin-Embedder-Policy: with
+            # inherited COEP require-corp actually enforced here (Grafana sets
+            # none of its own), gravatar avatars and grafana.com panel images
+            # (cross-origin no-cors subresources) are blocked. Declaring any
+            # add_header drops all inherited ones, which is exactly how COEP is
+            # kept off this one prefix.
+            add_header X-Frame-Options DENY always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
         }
 
         # Frontend routes (all other requests)
@@ -417,31 +545,29 @@ http {
             proxy_set_header Connection 'upgrade';
             proxy_cache_bypass $http_upgrade;
 
-            # Cache static assets
-            location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-                expires 1y;
-                add_header Cache-Control "public, immutable";
-            # Any add_header in a block drops ALL inherited ones, and
-            # frontend/middleware.ts's matcher EXCLUDES these static paths — so
-            # without these two lines this response gets them from neither layer.
-            # CORP is the header that actually matters on a subresource (it is
-            # what stops a foreign origin embedding it); nosniff matters on JS/CSS.
-            # Permissions-Policy and COOP are document-scoped and inert here, so
-            # they are deliberately NOT repeated onto every cached asset.
-            add_header Cross-Origin-Resource-Policy "same-origin" always;
-            add_header X-Content-Type-Options nosniff always;
-
-                # SECURITY: Remove potentially sensitive headers
-                proxy_hide_header X-Powered-By;
-                proxy_hide_header Server;
-            }
+            # NOTE: static-asset caching lives in the TOP-LEVEL extension regex
+            # above — a regex nested here would have no proxy_pass (not
+            # inherited) and 404 every /public asset out of nginx's `root html`.
         }
 
-        # Health check endpoint
+        # Health check endpoint. `return` responses take their Content-Type
+        # from default_type (the old `add_header Content-Type` produced a
+        # SECOND Content-Type line next to the inherited octet-stream one) —
+        # and since that add_header dropped every inherited security header,
+        # scanners re-filed "Missing HSTS" on this standard probe path. The
+        # full set is re-declared explicitly.
         location /health {
             access_log off;
+            default_type text/plain;
+            add_header X-Frame-Options DENY always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
             return 200 "healthy\n";
-            add_header Content-Type text/plain;
         }
 
         # Nginx status endpoint for prometheus exporter
@@ -455,13 +581,5 @@ http {
             deny all;
         }
 
-        # Block common attack patterns
-        location ~ /\. {
-            deny all;
-        }
-
-        location ~* \.(env|git|svn|htaccess|htpasswd)$ {
-            deny all;
-        }
     }
 }

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -36,6 +36,14 @@ http {
     limit_req_zone $binary_remote_addr zone=frontend:10m rate=30r/s;
     limit_req_zone $binary_remote_addr zone=portal_sso:10m rate=5r/s;
 
+    # Rejected requests answer 429 Too Many Requests, not the default 503: a
+    # 5xx here is indistinguishable from a real outage, and the 2026-08-13
+    # AppScan run filed every rate-limited probe as an "Application Error".
+    limit_req_status 429;
+
+    # Hide the nginx version in the Server header and on built-in error pages
+    server_tokens off;
+
     # HTTP Server - Redirect to HTTPS
     server {
         listen 80;
@@ -94,16 +102,36 @@ http {
         add_header X-Frame-Options DENY always;
         add_header X-Content-Type-Options nosniff always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         # Issue #1223 section B. Values are mirrored VERBATIM from
         # frontend/lib/security-headers.ts and re-declared in every location block
         # below that declares an add_header of its own — nginx drops ALL inherited
         # add_headers in any block that declares one.
-        # Cross-Origin-Embedder-Policy is deliberately absent: require-corp breaks
-        # the /api/v1/preview iframes and this app never needs crossOriginIsolated.
+        # COOP tightened from same-origin-allow-popups and COEP added per the
+        # 2026-08-13 AppScan medium findings — the two flows those values were
+        # protecting (the about:blank email-template-source popup, the
+        # /api/v1/preview iframes) both survive: an about:blank popup inherits
+        # its opener's COOP and stays in the browsing-context group, and every
+        # framable response now carries COEP itself (see the preview and
+        # /api/email/ blocks below), which is exactly what a require-corp
+        # parent demands of a nested document.
         add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
-        add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Resource-Policy "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+
+        # The Next.js middleware emits byte-identical COOP/COEP/CORP (pinned by
+        # security-headers-nginx-parity.test.ts), and add_header APPENDS — so a
+        # proxied page would carry each header TWICE. These three are RFC 8941
+        # sf-item headers: a duplicated value ("same-origin, same-origin") is a
+        # PARSE FAILURE that browsers fall back to unsafe-none on — verified:
+        # crossOriginIsolated flips false behind nginx. Hide the upstream copy
+        # so exactly one line (nginx's) survives. Blocks that declare their own
+        # proxy_hide_header (e.g. /api/, pdf.worker) do NOT inherit these and
+        # must re-declare them if they proxy to the frontend.
+        proxy_hide_header Cross-Origin-Opener-Policy;
+        proxy_hide_header Cross-Origin-Embedder-Policy;
+        proxy_hide_header Cross-Origin-Resource-Policy;
 
         # Portal SSO endpoint (最高優先級)
         location = /api/v1/auth/portal-sso/verify {
@@ -202,18 +230,23 @@ http {
             # with SAMEORIGIN so the server-level `X-Frame-Options DENY` is NOT
             # inherited — otherwise the browser refuses to frame the response
             # ("<host> refused to connect").
-            # NOTE: any add_header here drops ALL inherited add_headers, so all seven
+            # NOTE: any add_header here drops ALL inherited add_headers, so all eight
             # must be re-declared. Keep downloads/uploads OUT of /api/v1/preview* so
             # this framing relaxation never applies to a non-framed response.
             add_header X-Frame-Options SAMEORIGIN always;
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
             add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
-            add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
             # CORP governs no-cors SUBRESOURCE fetches, not iframe navigations, so
             # same-origin here does not affect framing of the preview response.
             add_header Cross-Origin-Resource-Policy "same-origin" always;
+            # These responses are FRAMED by pages that now carry COEP
+            # require-corp — a require-corp parent refuses any nested document
+            # that does not itself declare COEP, so dropping this line breaks
+            # every file preview ("refused to connect"-style blank iframe).
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # Next.js email render API
@@ -237,10 +270,12 @@ http {
             add_header X-Frame-Options SAMEORIGIN always;
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
             add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
-            add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
             add_header Cross-Origin-Resource-Policy "same-origin" always;
+            # Framed by COEP require-corp pages — see the preview block above.
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # Next.js UPLOAD proxies (POST, not framed). Any
@@ -274,19 +309,39 @@ http {
             client_max_body_size 11M;
         }
 
-        # Backend API routes (其他所有 /api/ 請求)
-        location /api/ {
-            # Handle OPTIONS requests directly (CORS preflight)
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' '*' always;
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS, PATCH' always;
-                add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, Accept, Origin, User-Agent, DNT, Cache-Control, X-Mx-ReqToken, Keep-Alive, X-Requested-With, If-Modified-Since' always;
-                add_header 'Access-Control-Max-Age' 86400 always;
-                add_header 'Content-Type' 'text/plain charset=UTF-8' always;
-                add_header 'Content-Length' 0 always;
-                return 204;
-            }
+        # AppScan 2026-08-13 "Hidden Directory Detected" (55 findings): dotfile
+        # probes (/.git/, /.ssh/, /.env, …) must be indistinguishable from any
+        # other missing path — 404, never `deny all` (403), which confirms the
+        # path exists. Regex locations win by ORDER OF APPEARANCE, so this and
+        # the probe block below sit AFTER the preview/upload-proxy regexes those
+        # app routes must keep winning, and BEFORE the static-asset extension
+        # regex (otherwise /.git/x.png would be proxied to the frontend).
+        location ~ /\. {
+            return 404;
+        }
 
+        # Server-side-script and backup-file probes (noSuchFile.php,
+        # ~AppScan.aspx, /cgi-bin/*.aspx, *.env, …): nothing in this stack ever
+        # serves these extensions, so answer with nginx's own minimal 404
+        # instead of the Next.js 404 page — AppScan pattern-matches that page's
+        # /_next/... markup as 16+ "path disclosure" findings. The (?!/api/)
+        # guard keeps every real API route (whose responses are JSON, not
+        # pages) out of this block.
+        # Case-sensitive location (~) with a caseless (?i:...) extension group:
+        # under ~* the (?!/api/) guard itself went caseless, so /API/x.php
+        # escaped the block and reached the Next.js 404 page. Real API routes
+        # are lowercase-only (the /api/ prefix location is case-sensitive), so
+        # the guard must be too; the probed EXTENSIONS stay case-insensitive.
+        location ~ "^(?!/api/).*\.(?i:php|php3|php4|php5|phtml|thtml|shtml|stm|jsp|jspx|jhtml|asp|aspx|cfm|cgi|pl|plx|nsf|html|htm|env|git|svn|htaccess|htpasswd|bak|old|orig|inc|ini|log|sql|swp)$" {
+            return 404;
+        }
+
+        # Backend API routes (其他所有 /api/ 請求)
+        # No nginx-level OPTIONS short-circuit: FastAPI's CORSMiddleware answers
+        # preflights (prod has always worked this way). The removed `if` block
+        # replied 204 with `Access-Control-Allow-Origin: *` AND — because any
+        # add_header inside it drops every inherited one — no security headers.
+        location /api/ {
             limit_req zone=api burst=20 nodelay;
 
             set $backend_upstream backend:8000;
@@ -324,18 +379,28 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Request-ID $request_id;
 
-            # Static file caching
-            expires 1y;
-            add_header Cache-Control "public, immutable";
+            # Static file caching. A single Cache-Control declaration — the old
+            # `expires 1y` + add_header pair emitted TWO Cache-Control headers
+            # (expires appends its own max-age line), which AppScan filed as an
+            # unnecessary-header finding. Next.js sets its OWN Cache-Control on
+            # these responses too, so the upstream copy must be hidden or the
+            # response still carries two lines. No `always`: a 404 must not
+            # inherit a year-long immutable cache lifetime.
+            proxy_hide_header Cache-Control;
+            add_header Cache-Control "public, max-age=31536000, immutable";
             # Any add_header in a block drops ALL inherited ones, and
             # frontend/middleware.ts's matcher EXCLUDES these static paths — so
-            # without these two lines this response gets them from neither layer.
+            # without these lines this response gets them from neither layer.
             # CORP is the header that actually matters on a subresource (it is
-            # what stops a foreign origin embedding it); nosniff matters on JS/CSS.
+            # what stops a foreign origin embedding it); nosniff matters on JS/CSS;
+            # HSTS is host-scoped and belongs on EVERY response (AppScan flags
+            # each one it is missing from); Referrer-Policy likewise.
             # Permissions-Policy and COOP are document-scoped and inert here, so
             # they are deliberately NOT repeated onto every cached asset.
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         }
 
         # Grafana monitoring dashboard (subpath serving)
@@ -367,6 +432,21 @@ http {
             proxy_buffering off;
             proxy_buffer_size 16k;
             proxy_buffers 8 16k;
+
+            # Grafana is a DOCUMENT served under this origin, so re-declare the
+            # document-scoped set — EXCEPT Cross-Origin-Embedder-Policy: with
+            # inherited COEP require-corp actually enforced here (Grafana sets
+            # none of its own), gravatar avatars and grafana.com panel images
+            # (cross-origin no-cors subresources) are blocked. Declaring any
+            # add_header drops all inherited ones, which is exactly how COEP is
+            # kept off this one prefix.
+            add_header X-Frame-Options DENY always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
         }
 
         # Public folder static assets (icons, images, fonts, etc.)
@@ -383,19 +463,23 @@ http {
             proxy_hide_header X-Powered-By;
             proxy_hide_header Server;
 
-            # Static file caching
-            expires 1y;
-            add_header Cache-Control "public, immutable";
+            # Static file caching — single Cache-Control, see /_next/static/.
+            # Upstream Next.js serves /public files with `public, max-age=0`;
+            # hide it so nginx's immutable value is the only one emitted.
+            proxy_hide_header Cache-Control;
+            add_header Cache-Control "public, max-age=31536000, immutable";
             # Any add_header in a block drops ALL inherited ones, and
             # frontend/middleware.ts's matcher EXCLUDES these static paths — so
-            # without these two lines this response gets them from neither layer.
+            # without these lines this response gets them from neither layer.
             # CORP is the header that actually matters on a subresource (it is
-            # what stops a foreign origin embedding it); nosniff matters on JS/CSS.
+            # what stops a foreign origin embedding it); nosniff matters on JS/CSS;
+            # HSTS/Referrer-Policy are re-declared for scanner-clean coverage.
             # Permissions-Policy and COOP are document-scoped and inert here, so
             # they are deliberately NOT repeated onto every cached asset.
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header X-Content-Type-Options nosniff always;
-            add_header X-Content-Type-Options "nosniff";
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         }
 
         # pdf.js worker for the regulations preview (react-pdf).
@@ -415,11 +499,21 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Request-ID $request_id;
 
-            # SECURITY: Remove potentially sensitive headers
+            # SECURITY: Remove potentially sensitive headers. Declaring any
+            # proxy_hide_header here stops inheritance of the server-level
+            # trio, so the sf-item headers must be re-hidden explicitly — the
+            # middleware DOES run on this path (it is not matcher-excluded) and
+            # a duplicated CORP would parse-fail to no protection.
             proxy_hide_header X-Powered-By;
             proxy_hide_header Server;
+            proxy_hide_header Cross-Origin-Opener-Policy;
+            proxy_hide_header Cross-Origin-Embedder-Policy;
+            proxy_hide_header Cross-Origin-Resource-Policy;
 
-            add_header X-Content-Type-Options "nosniff";
+            add_header X-Content-Type-Options nosniff always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         }
 
         # Frontend routes (所有其他請求)
@@ -441,11 +535,24 @@ http {
             proxy_cache_bypass $http_upgrade;
         }
 
-        # Health check endpoint
+        # Health check endpoint. `return` responses take their Content-Type
+        # from default_type (the old `add_header Content-Type` produced a
+        # SECOND Content-Type line next to the inherited octet-stream one) —
+        # and since that add_header dropped every inherited security header,
+        # scanners re-filed "Missing HSTS" on this standard probe path. The
+        # full set is re-declared explicitly.
         location /health {
             access_log off;
+            default_type text/plain;
+            add_header X-Frame-Options DENY always;
+            add_header X-Content-Type-Options nosniff always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Permissions-Policy "accelerometer=(), autoplay=(), browsing-topics=(), camera=(), clipboard-read=(), clipboard-write=(self), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), hid=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), serial=(), usb=(), xr-spatial-tracking=()" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Resource-Policy "same-origin" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
             return 200 "healthy\n";
-            add_header Content-Type text/plain;
         }
 
         # Nginx status endpoint for prometheus exporter


### PR DESCRIPTION
## Summary

Fixes every actionable finding from the 2026-08-13 HCL AppScan scan of ss.test.nycu.edu.tw (2 medium / 85 low / 28 informational), applied to **both** `nginx.staging.conf` and `nginx.prod.conf` plus the frontend/backend header layers.

| AppScan finding class | Fix |
|---|---|
| **M** COEP missing / COOP insecure (2) | `Cross-Origin-Embedder-Policy: require-corp` + `Cross-Origin-Opener-Policy: same-origin` across nginx, Next.js middleware, and every framable proxy response (a require-corp parent refuses nested documents without COEP) |
| **L** Hidden Directory Detected (55) | dotfile probes (`/.git/`, `/.ssh/`, …) `return 404` — never a 403 that confirms existence |
| **L** Error-page path disclosure (21) | server-side-script/backup extension probes (`.php`, `.jsp`, `.aspx`, `.html`, …) answered by nginx's bare 404 instead of the Next.js 404 page; case-sensitive `(?!/api/)` guard so `/API/x.php` can't slip through |
| **L** Cacheable SSL Page (6) | new backend `SecurityHeadersMiddleware`: every response defaults to `no-store` + `Pragma: no-cache` (endpoint-declared caching wins); three preview proxies drop `private, max-age=3600` |
| **L** Missing CSP on API responses (1) | `default-src 'none'; frame-ancestors 'none'` on JSON responses only (Swagger docs HTML unaffected) |
| **L** Missing HSTS / Referrer-Policy on static chunks; duplicated Cache-Control (3) | full header set re-declared in every inheritance-dropping block; `expires 1y` removed and upstream Cache-Control hidden so exactly one `public, max-age=31536000, immutable` is emitted |
| **I** Application Error (23) | `limit_req_status 429` instead of the default 503 |

Accepted residuals (documented, not fixed): `Server: nginx` product name (removal needs the headers-more module), user's own email on `/api/v1/auth/me` + roster emails (functional data), email/path patterns inside JS bundles (build artifacts).

## Review-driven hardening (24-agent adversarial review, all empirically reproduced)

- **Duplicate COOP/COEP/CORP disabled all three**: nginx `add_header` APPENDS to the middleware's identical header, and a duplicated sf-item value parse-fails to `unsafe-none` (`crossOriginIsolated` was false behind nginx). Fixed with `proxy_hide_header` so exactly one line survives — without this the two medium findings were closed on paper only.
- **Pre-existing prod bug**: the static-asset regex nested inside `location /` had no `proxy_pass` (not inherited), so every `frontend/public/` asset — including both site favicons — 404'd in production. Promoted to a top-level location; `/icon.svg` verified 200.
- `/health` and the staging CORS-preflight branch dropped every security header (the latter also replied `Access-Control-Allow-Origin: *`) — headers re-declared / branch removed (FastAPI CORSMiddleware handles preflights, as prod always has).
- Grafana `/monitoring` keeps COEP off (cross-origin no-cors avatars/panel images) but regains the rest of the header set.

## Test plan

- [x] `nginx -t` passes on both configs (nginx:alpine)
- [x] Live harness: staged configs proxying the real dev stack — exactly one COOP/COEP/CORP per response, all probes (`/noSuchFile.php`, `/API/noSuchFile.PHP`, `/.git/`, `/.env`, `/cgi-bin/~AppScan.aspx`) return nginx's 146-byte 404, `/health` carries HSTS, `/_next/static` and `/icon.svg` emit a single immutable Cache-Control, `/api` responses carry single `no-store` + CSP
- [x] Browser (Playwright, real Chrome PDF viewer): with `crossOriginIsolated === true`, the `/api/v1/preview` PDF iframe renders, a blob: PDF iframe renders, and the about:blank email-template-source popup still works under COOP `same-origin`
- [x] `security-headers-nginx-parity.test.ts` 33/33 (now also pins the dedup hides, 404-not-403, 429, and per-block header counts)
- [x] Backend middleware tests 3/3; black + flake8 (B904,B014) clean; frontend `tsc --noEmit` clean
- [ ] After merge: propagate to **naass-prod-test** (the conf actually serving ss.test) and re-run AppScan
- [ ] Mirror to NYCUITSC/naass (manual dispatch) for production

## ⚠️ Deployment note

The scanned host does **not** run this repo's `nginx.staging.conf` — its response fingerprint (HSTS preload, dotfile 403, versionless Server header) matches the prod-style conf deployed from **naass-prod-test**. Merging here changes nothing on ss.test until the change is pushed there; a re-scan before that will show identical results.