### PR TITLE
fix: emit COOP/COEP on static-asset responses for per-URL scanner checks

### DIFF
--- a/frontend/__tests__/security-headers-nginx-parity.test.ts
+++ b/frontend/__tests__/security-headers-nginx-parity.test.ts
@@ -81,21 +81,12 @@ describe("nginx <-> middleware security-header parity (issue #1223 B)", () => {
       expect(monitoringBlocks).toBe(1);
       expect(healthBlocks).toBe(1);
 
-      // server level + each SAMEORIGIN block + /monitoring + /health
-      for (const [header] of ["Permissions-Policy", "Cross-Origin-Opener-Policy"].map(
-        (h) => [h] as const
-      )) {
-        expect(declaredValues(conf, header)).toHaveLength(
-          1 + sameOriginBlocks + monitoringBlocks + healthBlocks
-        );
-      }
-
-      // COEP is deliberately ABSENT from /monitoring: Grafana loads
-      // cross-origin no-cors images (gravatars, grafana.com panels) that an
-      // enforced require-corp would block, and it is the one document prefix
-      // where nginx's COEP is not deduplicated against the Next.js middleware.
-      expect(declaredValues(conf, "Cross-Origin-Embedder-Policy")).toHaveLength(
-        1 + sameOriginBlocks + healthBlocks
+      // server level + each SAMEORIGIN block + /monitoring + /health.
+      // Permissions-Policy stays document-only: AppScan never flagged it on
+      // asset URLs, unlike COOP/COEP (counted with the subresource blocks
+      // below, because the scanner's medium checks are per-URL presence tests).
+      expect(declaredValues(conf, "Permissions-Policy")).toHaveLength(
+        1 + sameOriginBlocks + monitoringBlocks + healthBlocks
       );
     });
 
@@ -134,6 +125,19 @@ describe("nginx <-> middleware security-header parity (issue #1223 B)", () => {
       expect(declaredValues(conf, "Cross-Origin-Resource-Policy")).toHaveLength(expected);
       expect(declaredValues(conf, "Strict-Transport-Security")).toHaveLength(expected);
       expect(declaredValues(conf, "Referrer-Policy")).toHaveLength(expected);
+
+      // COOP/COEP ride every asset block too — inert on subresources per spec,
+      // but AppScan's medium checks are per-URL presence tests, so a re-scan
+      // that samples /_next/static/... re-files the finding otherwise. On
+      // /pdf.worker.min.mjs COEP is load-bearing: a require-corp owner blocks
+      // dedicated-worker scripts whose response lacks a compatible COEP.
+      expect(declaredValues(conf, "Cross-Origin-Opener-Policy")).toHaveLength(expected);
+      // COEP is deliberately ABSENT from /monitoring only: Grafana loads
+      // cross-origin no-cors images (gravatars, grafana.com panels) that an
+      // enforced require-corp would block.
+      expect(declaredValues(conf, "Cross-Origin-Embedder-Policy")).toHaveLength(
+        expected - monitoringBlocks
+      );
     });
 
     /**

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -400,12 +400,17 @@ http {
             # what stops a foreign origin embedding it); nosniff matters on JS/CSS;
             # HSTS is host-scoped and belongs on EVERY response (AppScan flags
             # each one it is missing from); Referrer-Policy likewise.
-            # Permissions-Policy and COOP are document-scoped and inert here, so
-            # they are deliberately NOT repeated onto every cached asset.
+            # COOP/COEP are document-scoped and functionally inert on a JS/CSS
+            # subresource, but AppScan's medium checks are per-URL presence
+            # tests — a re-scan that samples a chunk URL re-files the finding —
+            # so both are repeated below. Permissions-Policy was never flagged
+            # on assets and stays document-only.
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # Public folder static assets (icons, images, fonts) — root-level files
@@ -440,6 +445,8 @@ http {
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # pdf.js worker for the regulations preview (react-pdf).
@@ -475,6 +482,13 @@ http {
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            # COEP here is NOT just scanner hygiene: this file is loaded via
+            # `new Worker()` (react-pdf), and a require-corp owner document
+            # requires the dedicated-worker SCRIPT response to carry a
+            # compatible COEP or the worker is blocked (pdf.js then falls back
+            # to its slow main-thread fake worker).
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # Grafana monitoring dashboard (subpath serving)

--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -395,12 +395,17 @@ http {
             # what stops a foreign origin embedding it); nosniff matters on JS/CSS;
             # HSTS is host-scoped and belongs on EVERY response (AppScan flags
             # each one it is missing from); Referrer-Policy likewise.
-            # Permissions-Policy and COOP are document-scoped and inert here, so
-            # they are deliberately NOT repeated onto every cached asset.
+            # COOP/COEP are document-scoped and functionally inert on a JS/CSS
+            # subresource, but AppScan's medium checks are per-URL presence
+            # tests — a re-scan that samples a chunk URL re-files the finding —
+            # so both are repeated below. Permissions-Policy was never flagged
+            # on assets and stays document-only.
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # Grafana monitoring dashboard (subpath serving)
@@ -474,12 +479,17 @@ http {
             # CORP is the header that actually matters on a subresource (it is
             # what stops a foreign origin embedding it); nosniff matters on JS/CSS;
             # HSTS/Referrer-Policy are re-declared for scanner-clean coverage.
-            # Permissions-Policy and COOP are document-scoped and inert here, so
-            # they are deliberately NOT repeated onto every cached asset.
+            # COOP/COEP are document-scoped and functionally inert on a JS/CSS
+            # subresource, but AppScan's medium checks are per-URL presence
+            # tests — a re-scan that samples a chunk URL re-files the finding —
+            # so both are repeated below. Permissions-Policy was never flagged
+            # on assets and stays document-only.
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header X-Content-Type-Options nosniff always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # pdf.js worker for the regulations preview (react-pdf).
@@ -514,6 +524,13 @@ http {
             add_header Cross-Origin-Resource-Policy "same-origin" always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+            add_header Cross-Origin-Opener-Policy "same-origin" always;
+            # COEP here is NOT just scanner hygiene: this file is loaded via
+            # `new Worker()` (react-pdf), and a require-corp owner document
+            # requires the dedicated-worker SCRIPT response to carry a
+            # compatible COEP or the worker is blocked (pdf.js then falls back
+            # to its slow main-thread fake worker).
+            add_header Cross-Origin-Embedder-Policy "require-corp" always;
         }
 
         # Frontend routes (所有其他請求)


### PR DESCRIPTION
## Summary

Follow-up to #1310, driven by a staging-machine re-test: AppScan's medium header checks are **per-URL presence tests**, so a re-scan that samples a `/_next/static/` chunk URL re-files the "Missing COOP/COEP" findings even though both headers are functionally inert on subresources (the document root already sends them correctly).

- Repeat `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: require-corp` in every static-asset block — `/_next/static/`, the public-asset extension regex, and `location = /pdf.worker.min.mjs` — in **both** `nginx.staging.conf` and `nginx.prod.conf`.
- On `/pdf.worker.min.mjs` the COEP is **load-bearing, not just scanner hygiene**: the file is loaded via `new Worker()` (react-pdf), and a require-corp owner document blocks a dedicated-worker script whose response lacks a compatible COEP — pdf.js would silently fall back to its slow main-thread fake worker.
- `/monitoring` (Grafana) remains the only prefix without COEP (cross-origin no-cors avatars/panel images).
- Parity test updated: COOP is now counted with the subresource blocks; COEP everywhere except `/monitoring`.

## Test plan

- [x] `nginx -t` passes on both configs (nginx:alpine)
- [x] Live harness (staged configs proxying the real dev stack, both configs): `/_next/static/...js`, `/icon.svg`, and `/pdf.worker.min.mjs` each carry **exactly one** COOP / COEP / CORP
- [x] `security-headers-nginx-parity.test.ts` 33/33
- [ ] After merge: propagate to naass-prod-test and re-run AppScan against ss.test