### PR TITLE
fix(prod-db): pin network name so the monitoring stack can attach

### DIFF
--- a/docker-compose.prod-db.yml
+++ b/docker-compose.prod-db.yml
@@ -223,8 +223,18 @@ volumes:
       device: /opt/scholarship/minio/config
 
 networks:
+  # `name:` pins the real network name. Without it Compose prefixes the
+  # project name (naass_scholarship_prod_db_network), and
+  # docker-compose.prod-db-monitoring.yml — which joins this network as
+  # `external: true, name: scholarship_prod_db_network` — cannot find it, so
+  # the whole monitoring stack fails to start. Creating the bare-named network
+  # by hand does not help either: postgres would still sit on the prefixed one,
+  # and postgres-exporter resolves it by the service name `postgres`.
+  # docker-compose.staging-db.yml already pins its name the same way, and
+  # scripts/migrate_storage_to_rustfs.sh likewise defaults to the bare name.
   scholarship_prod_db_network:
     driver: bridge
+    name: scholarship_prod_db_network
     ipam:
       driver: default
       config:


### PR DESCRIPTION
## 問題

`docker-compose.prod-db-monitoring.yml` 以 `external: true` + `name: scholarship_prod_db_network` 參照這個網路，但 `docker-compose.prod-db.yml` 內嵌宣告時**沒有寫 `name:`**。Compose 會加上專案前綴，實際建出來的是 `<專案名>_scholarship_prod_db_network`，於是監控 stack 啟動時報 `network scholarship_prod_db_network not found`。

手動先建一個不帶前綴的同名網路也解決不了：postgres 仍然接在帶前綴的網路上，而 `postgres-exporter` 是透過服務名 `postgres` 連線的，兩者不同網路就解析不到——結果是 exporter 的 `up=1`（行程活著）但所有 `pg_*` 指標都不見。

## 為什麼改這一支，而不是改監控檔

- `docker-compose.staging-db.yml` 早就用同樣的方式釘住名稱（`name: scholarship_staging_db_network`）
- `scripts/migrate_storage_to_rustfs.sh` 也預設用不帶前綴的名稱（`NETWORK=scholarship_prod_db_network`）

不帶前綴的名稱本來就是既定約定，只有這個檔案漏掉。若反過來把監控檔改成非 external，它會自建一個獨立網路，`postgres-exporter` 依然連不到 postgres。

## 變更內容

```diff
 networks:
   scholarship_prod_db_network:
     driver: bridge
+    name: scholarship_prod_db_network
     ipam:
```

（另附一段註解說明原因，避免日後又被拿掉。）

## 驗證方式

在 staging 主機上用最小重現實測，兩組只差 `name:` 一行：

| 設定 | 實際網路名稱 | 另一個 compose 以 external 參照 |
|---|---|---|
| 無 `name:`（現況） | `nettesta_scholarship_prod_db_network` | ❌ 找不到 |
| 有 `name:`（本 PR） | `scholarship_prod_db_network` | ✅ 接得上，跨 stack DNS 解析成功 |

另外 `docker compose -f docker-compose.prod-db.yml config` 確認解析後的網路名稱為 `scholarship_prod_db_network`。

## 套用到已在跑的環境要注意

網路名稱改變會讓 Compose 視為不同網路，**容器會被重建**，DB 有短暫中斷，請挑維護時間：

```bash
docker compose -f docker-compose.prod-db-monitoring.yml down
docker compose --env-file .env -f docker-compose.prod-db.yml down

# 清掉舊的前綴網路，釋放 172.25.0.0/16 網段
docker network rm <專案名>_scholarship_prod_db_network

docker compose --env-file .env -f docker-compose.prod-db.yml up -d
docker compose --env-file .env -f docker-compose.prod-db-monitoring.yml up -d
docker network ls | grep scholarship_prod_db_network   # 應為不帶前綴
```

舊網路務必清掉，否則它會繼續占用 172.25.0.0/16。Volume 與 bind mount 不受影響，資料不會動到。

🤖 Generated with [Claude Code](https://claude.com/claude-code)