### PR TITLE
fix: 指導教授不在系統內時，申請不會被指派到教授

### DIFF
--- a/backend/alembic/versions/advisor_backfill_idx_001.py
+++ b/backend/alembic/versions/advisor_backfill_idx_001.py
@@ -21,10 +21,15 @@ load. This migration:
    auto-index foreign keys).
 
 The row filter mirrors application_builder.backfill_professor_assignments:
-statuses from REVIEWABLE_APPLICATION_STATUSES (app/models/enums.py) and
-deleted_at IS NULL. Drafts are deliberately excluded — they get their professor
-at submission time from the profile as it reads then — and soft-deleted rows are
-never resurfaced.
+statuses from PROFESSOR_ACTIONABLE_APPLICATION_STATUSES (app/models/enums.py)
+and deleted_at IS NULL. Three exclusions, all deliberate:
+
+- Drafts get their professor at submission time from the profile as it reads
+  then.
+- Already-decided applications (approved / partial_approved / rejected) would
+  land in the professor's 待審核 bucket — which has no status gate — while the
+  review endpoint refuses them, stranding the row with a permanent 403.
+- Soft-deleted rows are never resurfaced.
 """
 
 from typing import Sequence, Union
@@ -42,8 +47,8 @@ depends_on: Union[str, Sequence[str], None] = None
 APPLICATIONS_INDEX = "ix_applications_professor_id"
 USER_PROFILES_INDEX = "ix_user_profiles_advisor_nycu_id"
 
-# Kept in sync with REVIEWABLE_APPLICATION_STATUSES (app/models/enums.py).
-REVIEWABLE_STATUSES = ("submitted", "under_review", "approved", "partial_approved", "rejected")
+# Kept in sync with PROFESSOR_ACTIONABLE_APPLICATION_STATUSES (app/models/enums.py).
+ACTIONABLE_STATUSES = ("submitted", "under_review")
 
 BACKFILL_SQL = """
     UPDATE applications AS a
@@ -73,7 +78,7 @@ def upgrade() -> None:
     if {"applications", "user_profiles", "users"} <= tables:
         result = bind.execute(
             sa.text(BACKFILL_SQL).bindparams(sa.bindparam("statuses", expanding=True)),
-            {"statuses": list(REVIEWABLE_STATUSES)},
+            {"statuses": list(ACTIONABLE_STATUSES)},
         )
         print(f"[advisor_backfill_idx_001] assigned advisor to {result.rowcount} orphaned application(s)")
 

--- a/backend/alembic/versions/advisor_backfill_idx_001.py
+++ b/backend/alembic/versions/advisor_backfill_idx_001.py
@@ -1,0 +1,99 @@
+"""Index the advisor-match columns and backfill orphaned professor assignments
+
+Revision ID: advisor_backfill_idx_001
+Revises: email_timing_three_triggers_001
+Create Date: 2026-08-17 00:00:00.000000
+
+A submitted application only gets `professor_id` when the advisor the student
+named in `user_profiles.advisor_nycu_id` ALREADY exists as a role=professor
+User (application_builder.assign_professor_from_profile). Applications naming an
+advisor who had not yet signed in were stored with professor_id NULL and never
+reached any review queue.
+
+The code fix claims those rows on professor login and on every professor queue
+load. This migration:
+
+1. Backfills the rows that are already orphaned, so they surface immediately
+   instead of waiting for their advisor's next login.
+2. Adds the two indexes that lookup path needs — `user_profiles.advisor_nycu_id`
+   (new hot column) and `applications.professor_id` (already filtered by every
+   professor queue / stats query, never indexed because PostgreSQL does not
+   auto-index foreign keys).
+
+The row filter mirrors application_builder.backfill_professor_assignments:
+statuses from REVIEWABLE_APPLICATION_STATUSES (app/models/enums.py) and
+deleted_at IS NULL. Drafts are deliberately excluded — they get their professor
+at submission time from the profile as it reads then — and soft-deleted rows are
+never resurfaced.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "advisor_backfill_idx_001"
+down_revision: Union[str, None] = "email_timing_three_triggers_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+APPLICATIONS_INDEX = "ix_applications_professor_id"
+USER_PROFILES_INDEX = "ix_user_profiles_advisor_nycu_id"
+
+# Kept in sync with REVIEWABLE_APPLICATION_STATUSES (app/models/enums.py).
+REVIEWABLE_STATUSES = ("submitted", "under_review", "approved", "partial_approved", "rejected")
+
+BACKFILL_SQL = """
+    UPDATE applications AS a
+    SET professor_id = u.id
+    FROM user_profiles AS p
+    JOIN users AS u
+      ON u.nycu_id = p.advisor_nycu_id
+     AND u.role = 'professor'
+    WHERE a.user_id = p.user_id
+      AND a.professor_id IS NULL
+      AND a.deleted_at IS NULL
+      AND p.advisor_nycu_id IS NOT NULL
+      AND p.advisor_nycu_id <> ''
+      AND a.status::text IN :statuses
+"""
+
+
+def _index_names(inspector, table: str) -> set:
+    return {idx["name"] for idx in inspector.get_indexes(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    if {"applications", "user_profiles", "users"} <= tables:
+        result = bind.execute(
+            sa.text(BACKFILL_SQL).bindparams(sa.bindparam("statuses", expanding=True)),
+            {"statuses": list(REVIEWABLE_STATUSES)},
+        )
+        print(f"[advisor_backfill_idx_001] assigned advisor to {result.rowcount} orphaned application(s)")
+
+    if "applications" in tables and APPLICATIONS_INDEX not in _index_names(inspector, "applications"):
+        op.create_index(APPLICATIONS_INDEX, "applications", ["professor_id"])
+
+    if "user_profiles" in tables and USER_PROFILES_INDEX not in _index_names(inspector, "user_profiles"):
+        op.create_index(USER_PROFILES_INDEX, "user_profiles", ["advisor_nycu_id"])
+
+
+def downgrade() -> None:
+    # Only the indexes are reversible. The backfilled professor_id values are
+    # indistinguishable from assignments made at submission time, so clearing
+    # them would destroy correct data — they are intentionally left in place.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    if "user_profiles" in tables and USER_PROFILES_INDEX in _index_names(inspector, "user_profiles"):
+        op.drop_index(USER_PROFILES_INDEX, table_name="user_profiles")
+
+    if "applications" in tables and APPLICATIONS_INDEX in _index_names(inspector, "applications"):
+        op.drop_index(APPLICATIONS_INDEX, table_name="applications")

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -142,7 +142,9 @@ class Application(Base):
     agree_terms = Column(Boolean, default=False)
 
     # 審核相關
-    professor_id = Column(Integer, ForeignKey("users.id"))  # 指導教授
+    # Indexed: every professor review-queue / stats query filters on it, and the
+    # advisor backfill scans for the NULL rows.
+    professor_id = Column(Integer, ForeignKey("users.id"), index=True)  # 指導教授
     reviewer_id = Column(Integer, ForeignKey("users.id"))  # 審核者
     final_approver_id = Column(Integer, ForeignKey("users.id"))  # 最終核准者
 

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -55,6 +55,19 @@ REVIEWABLE_APPLICATION_STATUSES = [
 ]
 
 
+# The strict subset of the above on which a professor can still ACT — the
+# statuses `can_professor_submit_review` accepts. The listing set above is
+# deliberately wider (it also surfaces decided applications for reference), so
+# anything that grants or counts pending professor work must use this set
+# instead: the professor queue's 待審核 bucket is "assigned to me and I have not
+# reviewed", with no status gate, so a decided application that lands in it can
+# never be cleared — submitting a review on it is rejected.
+PROFESSOR_ACTIONABLE_APPLICATION_STATUSES = [
+    ApplicationStatus.submitted.value,  # 已送出
+    ApplicationStatus.under_review.value,  # 審批中
+]
+
+
 # ── Apply-flow visibility sets ───────────────────────────────────────
 # Partition every ApplicationStatus value into three buckets that decide
 # whether a scholarship is shown in the STUDENT APPLY FLOW.

--- a/backend/app/models/user_profile.py
+++ b/backend/app/models/user_profile.py
@@ -27,7 +27,10 @@ class UserProfile(Base):
     # Advisor information (simplified)
     advisor_name = Column(String(100))  # Professor name
     advisor_email = Column(String(100))
-    advisor_nycu_id = Column(String(20))  # NYCU ID of the advisor
+    # Indexed: the professor-side advisor fallback resolves advisees by this
+    # column on every professor login and review-queue load
+    # (application_builder.backfill_professor_assignments).
+    advisor_nycu_id = Column(String(20), index=True)  # NYCU ID of the advisor
 
     # Personal preferences and notes
     preferred_language = Column(String(10), default="zh-TW")  # zh-TW, en-US

--- a/backend/app/services/application_builder.py
+++ b/backend/app/services/application_builder.py
@@ -10,12 +10,13 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import ValidationError
+from app.models.application import Application
 from app.models.application_sequence import ApplicationSequence
-from app.models.enums import ApplicationStatus, ReviewStage
+from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, ApplicationStatus, ReviewStage
 from app.models.user import User, UserRole
 from app.models.user_profile import UserProfile
 from app.utils.i18n import ScholarshipI18n
@@ -164,3 +165,74 @@ async def assign_professor_from_profile(
             getattr(application, "app_id", "?"),
         )
     return professor
+
+
+async def backfill_professor_assignments(db: AsyncSession, professor: Optional[User]) -> int:
+    """Claim applications left unassigned because this professor had no account yet.
+
+    :func:`assign_professor_from_profile` runs at submission time and can only
+    match an advisor who ALREADY exists as a ``role=professor`` User. When a
+    student names an advisor who has never signed in, the application is stored
+    with ``professor_id IS NULL`` and never reaches anybody's review queue.
+
+    This repairs those rows the moment the advisor does get an account. It is
+    idempotent (already-assigned rows are excluded by ``professor_id IS NULL``),
+    so it is safe to run on every professor login and on every professor queue
+    load — see the two call sites:
+
+    - :meth:`PortalSSOService.process_portal_login` — first SSO login / any
+      later login, right after the account is created or its role is updated.
+    - :meth:`ApplicationService.get_professor_applications_paginated` and
+      :meth:`ApplicationService.get_professor_review_stats` — fallback for
+      professor accounts created outside the SSO path (admin-created,
+      pre-authorized) and for advisors named AFTER the professor's first login.
+
+    Assignment (rather than a read-only ``advisor_nycu_id`` join in the queue
+    query) is deliberate: every downstream authorization check — opening the
+    application, submitting a review, updating it — compares
+    ``application.professor_id`` against the caller. A row merely *shown* in the
+    queue without being assigned would 403 on the very next click.
+
+    Only :data:`REVIEWABLE_APPLICATION_STATUSES` rows are claimed. Drafts are
+    excluded on purpose: they get their professor at submission time from the
+    profile as it reads *then*, so pre-assigning one would pin a stale advisor
+    if the student edits their profile before submitting.
+
+    Returns the number of applications claimed.
+    """
+    if professor is None or not professor.id or not professor.nycu_id:
+        return 0
+
+    # Compare against enum AND its .value: a SQLite-loaded (or hand-built) User
+    # can carry the raw string, and a bare `!= UserRole.professor` would then
+    # silently skip a real professor.
+    if professor.role not in (UserRole.professor, UserRole.professor.value):
+        return 0
+
+    advisee_user_ids = select(UserProfile.user_id).where(UserProfile.advisor_nycu_id == professor.nycu_id)
+
+    # synchronize_session=False: both call sites run this before loading any
+    # Application into the session, so there is nothing in the identity map to
+    # go stale, and skipping the sync avoids an extra round trip.
+    stmt = (
+        update(Application)
+        .where(
+            Application.professor_id.is_(None),
+            Application.deleted_at.is_(None),  # never resurface a soft-deleted application
+            Application.status.in_(REVIEWABLE_APPLICATION_STATUSES),
+            Application.user_id.in_(advisee_user_ids),
+        )
+        .values(professor_id=professor.id)
+        .execution_options(synchronize_session=False)
+    )
+    result = await db.execute(stmt)
+    claimed = result.rowcount or 0
+
+    if claimed:
+        logger.info(
+            "Backfilled %s unassigned application(s) to professor %s (nycu_id=%s)",
+            claimed,
+            professor.id,
+            professor.nycu_id,
+        )
+    return claimed

--- a/backend/app/services/application_builder.py
+++ b/backend/app/services/application_builder.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.exceptions import ValidationError
 from app.models.application import Application
 from app.models.application_sequence import ApplicationSequence
-from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, ApplicationStatus, ReviewStage
+from app.models.enums import PROFESSOR_ACTIONABLE_APPLICATION_STATUSES, ApplicationStatus, ReviewStage
 from app.models.user import User, UserRole
 from app.models.user_profile import UserProfile
 from app.utils.i18n import ScholarshipI18n
@@ -193,10 +193,17 @@ async def backfill_professor_assignments(db: AsyncSession, professor: Optional[U
     ``application.professor_id`` against the caller. A row merely *shown* in the
     queue without being assigned would 403 on the very next click.
 
-    Only :data:`REVIEWABLE_APPLICATION_STATUSES` rows are claimed. Drafts are
-    excluded on purpose: they get their professor at submission time from the
-    profile as it reads *then*, so pre-assigning one would pin a stale advisor
-    if the student edits their profile before submitting.
+    Only :data:`PROFESSOR_ACTIONABLE_APPLICATION_STATUSES` rows are claimed —
+    NOT the wider listing set. Two exclusions matter:
+
+    - Drafts: they get their professor at submission time from the profile as it
+      reads *then*, so pre-assigning one would pin a stale advisor if the
+      student edits their profile before submitting.
+    - Already-decided applications (approved / partial_approved / rejected):
+      the queue's 待審核 bucket is "assigned to me and I have not reviewed",
+      with no status gate, while ``can_professor_submit_review`` refuses any
+      status outside submitted/under_review. Claiming a decided row would park
+      it in 待審核 forever with a 403 on every attempt to clear it.
 
     Returns the number of applications claimed.
     """
@@ -219,7 +226,7 @@ async def backfill_professor_assignments(db: AsyncSession, professor: Optional[U
         .where(
             Application.professor_id.is_(None),
             Application.deleted_at.is_(None),  # never resurface a soft-deleted application
-            Application.status.in_(REVIEWABLE_APPLICATION_STATUSES),
+            Application.status.in_(PROFESSOR_ACTIONABLE_APPLICATION_STATUSES),
             Application.user_id.in_(advisee_user_ids),
         )
         .values(professor_id=professor.id)

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -34,6 +34,7 @@ from app.schemas.application import (
     ApplicationUpdate,
     StudentDataSchema,
 )
+from app.services.application_builder import backfill_professor_assignments
 from app.services.eligibility_service import EligibilityService
 from app.services.email_automation_service import email_automation_service
 from app.services.email_service import EmailService
@@ -2446,6 +2447,32 @@ class ApplicationService:
         return document_type_names.get(file_type, file_type)
 
     # Professor Review Methods
+    async def _claim_unassigned_advisee_applications(self, professor_id: int) -> int:
+        """Fallback advisor match for the professor-facing queries.
+
+        A submitted application only carries ``professor_id`` when the named
+        advisor already had an account at submission time; otherwise the row is
+        orphaned. :func:`backfill_professor_assignments` normally repairs it on
+        the professor's SSO login, but that hook cannot cover every route into a
+        professor account (admin-created / pre-authorized accounts) nor advisees
+        who named the professor after that login. Running the same idempotent
+        claim here makes the queue and the dashboard badge self-healing.
+
+        Never raises: a failed repair must not take down the queue the professor
+        came to read. The rollback keeps the session usable for the caller's own
+        query — the claim is simply retried on the next request.
+        """
+        try:
+            professor = await self.db.get(User, professor_id)
+            claimed = await backfill_professor_assignments(self.db, professor)
+            if claimed:
+                await self.db.commit()
+            return claimed
+        except Exception:
+            logger.exception("Advisor fallback backfill failed for professor %s", professor_id)
+            await self.db.rollback()
+            return 0
+
     @staticmethod
     def _professor_reviewed(professor_id: int):
         """Correlated predicate: this professor authored an ApplicationReview for the row.
@@ -2469,6 +2496,11 @@ class ApplicationService:
         pass ``page``/``size`` for explicit pagination.
         """
         try:
+            # Fallback advisor match: adopt any application whose student named
+            # this professor as advisor but that was submitted before they had
+            # an account. Runs first so the query below sees the claimed rows.
+            await self._claim_unassigned_advisee_applications(professor_id)
+
             # Build base query with ALL required filters (consistent with what will be returned)
             base_query = (
                 select(Application)
@@ -2758,6 +2790,10 @@ class ApplicationService:
           surfacing it here would require a join on
           ScholarshipConfiguration.professor_review_end_date)
         """
+        # Same fallback advisor match as the queue — otherwise the dashboard
+        # badge would keep under-counting until the professor opens the list.
+        await self._claim_unassigned_advisee_applications(professor_id)
+
         pending_query = select(sa_func.count(Application.id)).where(
             Application.professor_id == professor_id,
             Application.status.in_(

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -20,7 +20,12 @@ from app.core.metrics import scholarship_applications_total
 from app.core.schema_validation import serialize_value
 from app.models.audit_log import AuditAction, AuditLog
 from app.models.application import Application, ApplicationStatus
-from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, ReviewStage, Semester
+from app.models.enums import (
+    PROFESSOR_ACTIONABLE_APPLICATION_STATUSES,
+    REVIEWABLE_APPLICATION_STATUSES,
+    ReviewStage,
+    Semester,
+)
 from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
 from app.models.user import User, UserRole
@@ -2458,16 +2463,20 @@ class ApplicationService:
         who named the professor after that login. Running the same idempotent
         claim here makes the queue and the dashboard badge self-healing.
 
+        Does NOT commit: the claim joins the caller's transaction and is
+        persisted by the request-scoped session (``get_db``), so the commit
+        boundary stays with the request instead of being owned by a read helper.
+        The caller's own query runs afterwards in that same transaction and
+        therefore sees the claimed rows.
+
         Never raises: a failed repair must not take down the queue the professor
-        came to read. The rollback keeps the session usable for the caller's own
-        query — the claim is simply retried on the next request.
+        came to read. Both callers invoke this as their FIRST statement, so the
+        rollback discards nothing but the failed UPDATE and leaves the session
+        usable — the claim is simply retried on the next request.
         """
         try:
             professor = await self.db.get(User, professor_id)
-            claimed = await backfill_professor_assignments(self.db, professor)
-            if claimed:
-                await self.db.commit()
-            return claimed
+            return await backfill_professor_assignments(self.db, professor)
         except Exception:
             logger.exception("Advisor fallback backfill failed for professor %s", professor_id)
             await self.db.rollback()
@@ -2796,12 +2805,7 @@ class ApplicationService:
 
         pending_query = select(sa_func.count(Application.id)).where(
             Application.professor_id == professor_id,
-            Application.status.in_(
-                [
-                    ApplicationStatus.submitted.value,
-                    ApplicationStatus.under_review.value,
-                ]
-            ),
+            Application.status.in_(PROFESSOR_ACTIONABLE_APPLICATION_STATUSES),
             ~self._professor_reviewed(professor_id),
         )
 

--- a/backend/app/services/portal_sso_service.py
+++ b/backend/app/services/portal_sso_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.exceptions import AuthenticationError
 from app.models.user import EmployeeStatus, User, UserRole, UserType
+from app.services.application_builder import backfill_professor_assignments
 from app.services.auth_service import AuthService
 from app.services.student_service import StudentService
 
@@ -237,6 +238,19 @@ class PortalSSOService:
         # Update last login time
         user.last_login_at = datetime.now(timezone.utc)
         await self.db.commit()
+
+        # 教授帳號建立（或角色更新為教授）後，回補帳號存在之前就送出的申請：
+        # 學生填了 advisor_nycu_id，但提交當下查無此教授，professor_id 留 NULL。
+        # 非教授角色由 helper 自行擋掉，這裡不重複判斷。
+        # Best-effort — 回補失敗絕不能擋住登入，所以吞掉例外並回到乾淨的 session。
+        try:
+            claimed = await backfill_professor_assignments(self.db, user)
+            if claimed:
+                await self.db.commit()
+                logger.info(f"Assigned {claimed} pending application(s) to professor {nycu_id} on login")
+        except Exception:
+            await self.db.rollback()
+            logger.exception(f"Professor application backfill failed for {nycu_id}; login continues")
 
         # Generate system tokens with debug data
         logger.info(f"🔍 Creating tokens with debug data - Portal: {bool(portal_data)}, Student: {bool(student_data)}")

--- a/backend/app/tests/test_advisor_backfill.py
+++ b/backend/app/tests/test_advisor_backfill.py
@@ -1,0 +1,307 @@
+"""Advisor backfill: applications submitted before the advisor had an account.
+
+`assign_professor_from_profile` runs at submission time and can only match an
+advisor who already exists as a role=professor User. A student naming an advisor
+who has never signed in produced an application with `professor_id IS NULL` that
+reached nobody's review queue and stayed invisible until an admin noticed it.
+
+Contract pinned here:
+
+- `backfill_professor_assignments` claims exactly the orphaned, reviewable rows
+  of THIS professor's advisees — never drafts, never someone else's advisees,
+  never an application that already has a professor.
+- It is a no-op for non-professor users (and safe on None).
+- The professor review queue and the dashboard stats both apply the same claim,
+  so an orphaned application surfaces on the professor's next load even when the
+  account was created outside the SSO hook.
+- Portal SSO login runs the claim for professor accounts.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application, ApplicationStatus
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.models.user_profile import UserProfile
+from app.services.application_builder import backfill_professor_assignments
+from app.services.application_service import ApplicationService
+
+PROF_NYCU_ID = "P900001"
+
+
+async def _seed_user(db: AsyncSession, *, role: UserRole, nycu_id: str) -> User:
+    user = User(
+        nycu_id=nycu_id,
+        name=f"User {nycu_id}",
+        email=f"{nycu_id}@u.edu",
+        user_type=UserType.student if role == UserRole.student else UserType.employee,
+        role=role,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _seed_student_with_advisor(db: AsyncSession, *, nycu_id: str, advisor_nycu_id: Optional[str]) -> User:
+    student = await _seed_user(db, role=UserRole.student, nycu_id=nycu_id)
+    db.add(UserProfile(user_id=student.id, advisor_nycu_id=advisor_nycu_id))
+    await db.commit()
+    return student
+
+
+async def _seed_config(db: AsyncSession, *, suffix: str, requires_prof: bool = True) -> ScholarshipConfiguration:
+    st = ScholarshipType(code=f"backfill_{suffix}", name=f"Backfill type {suffix}", status="active")
+    db.add(st)
+    await db.commit()
+    await db.refresh(st)
+
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=st.id,
+        config_code=f"backfill_cfg_{suffix}",
+        config_name=f"Backfill cfg {suffix}",
+        academic_year=114,
+        application_start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        application_end_date=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        professor_review_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        professor_review_end=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        requires_professor_recommendation=requires_prof,
+        requires_college_review=False,
+        amount=0,
+        is_active=True,
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+    return cfg
+
+
+async def _seed_app(
+    db: AsyncSession,
+    *,
+    student: User,
+    config: ScholarshipConfiguration,
+    suffix: str,
+    status: str = ApplicationStatus.submitted.value,
+    professor_id: Optional[int] = None,
+) -> Application:
+    app = Application(
+        app_id=f"APP-BACKFILL-{suffix}",
+        user_id=student.id,
+        scholarship_type_id=config.scholarship_type_id,
+        scholarship_configuration_id=config.id,
+        academic_year=114,
+        sub_type_selection_mode="single",
+        status=status,
+        professor_id=professor_id,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+async def _professor_id_of(db: AsyncSession, application: Application) -> Optional[int]:
+    """Read professor_id straight from the DB — the bulk UPDATE runs with
+    synchronize_session=False, so the in-session object may be stale."""
+    result = await db.execute(select(Application.professor_id).where(Application.id == application.id))
+    return result.scalar_one()
+
+
+# --- backfill_professor_assignments -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_claims_orphaned_application_of_advisee(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_claim", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="claim")
+    app = await _seed_app(db, student=student, config=cfg, suffix="claim")
+
+    # The professor account appears only now — after the application was filed.
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 1
+    assert await _professor_id_of(db, app) == professor.id
+
+
+@pytest.mark.asyncio
+async def test_skips_drafts(db: AsyncSession):
+    """A draft gets its professor at submission time from the profile as it
+    reads then — claiming it early would pin a stale advisor."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_draft", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="draft")
+    draft = await _seed_app(db, student=student, config=cfg, suffix="draft", status=ApplicationStatus.draft.value)
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 0
+    assert await _professor_id_of(db, draft) is None
+
+
+@pytest.mark.asyncio
+async def test_skips_soft_deleted_applications(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_deleted", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="deleted")
+    app = await _seed_app(db, student=student, config=cfg, suffix="deleted")
+    app.deleted_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 0
+    assert await _professor_id_of(db, app) is None
+
+
+@pytest.mark.asyncio
+async def test_never_overwrites_an_existing_assignment(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_taken", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="taken")
+    other_prof = await _seed_user(db, role=UserRole.professor, nycu_id="P900999")
+    app = await _seed_app(db, student=student, config=cfg, suffix="taken", professor_id=other_prof.id)
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 0
+    assert await _professor_id_of(db, app) == other_prof.id
+
+
+@pytest.mark.asyncio
+async def test_ignores_applications_of_other_advisees(db: AsyncSession):
+    mine = await _seed_student_with_advisor(db, nycu_id="stu_mine", advisor_nycu_id=PROF_NYCU_ID)
+    theirs = await _seed_student_with_advisor(db, nycu_id="stu_theirs", advisor_nycu_id="P900888")
+    no_advisor = await _seed_student_with_advisor(db, nycu_id="stu_none", advisor_nycu_id=None)
+    cfg = await _seed_config(db, suffix="scope")
+
+    mine_app = await _seed_app(db, student=mine, config=cfg, suffix="mine")
+    theirs_app = await _seed_app(db, student=theirs, config=cfg, suffix="theirs")
+    orphan_app = await _seed_app(db, student=no_advisor, config=cfg, suffix="none")
+
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 1
+    assert await _professor_id_of(db, mine_app) == professor.id
+    assert await _professor_id_of(db, theirs_app) is None
+    assert await _professor_id_of(db, orphan_app) is None
+
+
+@pytest.mark.asyncio
+async def test_accepts_raw_string_role(db: AsyncSession):
+    """`role` reaches this helper as the enum member from a DB load but as a raw
+    string from hand-built Users — both must count as a professor."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_strrole", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="strrole")
+    app = await _seed_app(db, student=student, config=cfg, suffix="strrole")
+
+    # No refresh() — that would replace the raw string with the enum member and
+    # the test would stop covering what it is here to cover.
+    professor = User(nycu_id=PROF_NYCU_ID, name="字串角色", user_type="employee", role="professor")
+    db.add(professor)
+    await db.commit()
+    assert professor.role == "professor"
+
+    assert await backfill_professor_assignments(db, professor) == 1
+    await db.commit()
+    assert await _professor_id_of(db, app) == professor.id
+
+
+@pytest.mark.asyncio
+async def test_no_op_for_non_professor_users(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_nonprof", advisor_nycu_id="ADMIN01")
+    cfg = await _seed_config(db, suffix="nonprof")
+    app = await _seed_app(db, student=student, config=cfg, suffix="nonprof")
+
+    # Same nycu_id the student named, but the account is not a professor.
+    admin = await _seed_user(db, role=UserRole.admin, nycu_id="ADMIN01")
+
+    assert await backfill_professor_assignments(db, admin) == 0
+    assert await backfill_professor_assignments(db, None) == 0
+    assert await _professor_id_of(db, app) is None
+
+
+# --- professor-facing queries (fallback advisor match) -----------------------
+
+
+@pytest.mark.asyncio
+async def test_review_queue_surfaces_previously_orphaned_application(db: AsyncSession):
+    """The reported bug: student submits, advisor has no account, application
+    never appears for the professor. Opening the queue must now surface it."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_queue", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="queue")
+    app = await _seed_app(db, student=student, config=cfg, suffix="queue")
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    service = ApplicationService(db)
+    applications, total = await service.get_professor_applications_paginated(professor_id=professor.id)
+
+    assert total == 1
+    assert [a.app_id for a in applications] == [app.app_id]
+    assert await _professor_id_of(db, app) == professor.id
+
+
+@pytest.mark.asyncio
+async def test_review_stats_count_previously_orphaned_application(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_stats", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="stats")
+    await _seed_app(db, student=student, config=cfg, suffix="stats")
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    service = ApplicationService(db)
+    stats = await service.get_professor_review_stats(professor.id)
+
+    assert stats["pending_reviews"] == 1
+
+
+# --- Portal SSO login hook ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_portal_sso_login_claims_pending_applications(db: AsyncSession, monkeypatch):
+    """First SSO login creates the professor account — and adopts the
+    applications that were waiting for it."""
+    from app.services.portal_sso_service import PortalSSOService
+
+    student = await _seed_student_with_advisor(db, nycu_id="stu_sso", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="sso")
+    app = await _seed_app(db, student=student, config=cfg, suffix="sso")
+
+    service = PortalSSOService(db)
+
+    async def _fake_verify(_token: str) -> dict:
+        return {
+            "txtID": PROF_NYCU_ID,
+            "nycuID": PROF_NYCU_ID,
+            "txtName": "王教授",
+            "mail": "prof@nycu.edu.tw",
+            "dept": "資訊工程學系",
+            "deptCode": "5743",
+            "userType": "employee",
+            "employeestatus": "在職",
+        }
+
+    async def _fake_student_status(_nycu_id: str):
+        return False, None
+
+    monkeypatch.setattr(service, "verify_portal_token", _fake_verify)
+    monkeypatch.setattr(service, "_verify_student_status", _fake_student_status)
+
+    await service.process_portal_login("irrelevant-token")
+
+    professor = (await db.execute(select(User).where(User.nycu_id == PROF_NYCU_ID))).scalar_one()
+    assert professor.role == UserRole.professor
+    assert await _professor_id_of(db, app) == professor.id

--- a/backend/app/tests/test_advisor_backfill.py
+++ b/backend/app/tests/test_advisor_backfill.py
@@ -148,6 +148,32 @@ async def test_skips_drafts(db: AsyncSession):
     assert await _professor_id_of(db, draft) is None
 
 
+@pytest.mark.parametrize(
+    "status",
+    [
+        ApplicationStatus.approved.value,
+        ApplicationStatus.partial_approved.value,
+        ApplicationStatus.rejected.value,
+    ],
+)
+@pytest.mark.asyncio
+async def test_skips_already_decided_applications(db: AsyncSession, status: str):
+    """A decided application would land in the professor's 待審核 bucket — which
+    filters on "not reviewed by me", not on status — while the review endpoint
+    refuses anything outside submitted/under_review. Claiming it would strand
+    the row there with a permanent 403."""
+    student = await _seed_student_with_advisor(db, nycu_id=f"stu_{status}", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix=status)
+    app = await _seed_app(db, student=student, config=cfg, suffix=status, status=status)
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 0
+    assert await _professor_id_of(db, app) is None
+
+
 @pytest.mark.asyncio
 async def test_skips_soft_deleted_applications(db: AsyncSession):
     student = await _seed_student_with_advisor(db, nycu_id="stu_deleted", advisor_nycu_id=PROF_NYCU_ID)


### PR DESCRIPTION
## 問題

學生提交獎學金申請時，如果填寫的指導教授**還沒有系統帳號**，該申請就不會被指派到任何教授。

`assign_professor_from_profile`（`application_builder.py:131`）在提交當下才查 `UserProfile.advisor_nycu_id` 對應的 `role=professor` User——查無此人就把 `professor_id` 留 NULL。這種申請不會出現在任何人的待審清單裡，只有管理員在「未指派教授」篩選中才看得到。教授之後就算登入了，也永遠看不到這筆申請。

（提交時寄給指導教授的通知信是直接用 profile 裡的 `advisor_email`，與帳號存在與否無關——所以教授會收到信、來登入，然後發現清單是空的。這個 PR 正是補上這一段。）

## 作法

新增共用 helper `backfill_professor_assignments`（`application_builder.py`），以 `UserProfile.advisor_nycu_id` ↔ `User.nycu_id` 比對，把孤兒申請認領回來。整個操作是冪等的（WHERE 帶 `professor_id IS NULL`），在兩個時機執行：

1. **教授 SSO 登入後**（`portal_sso_service.py`）— 帳號建立或角色更新為 professor 之後立即回補。這是本次回報情境的主要修法。Best-effort：回補失敗絕不擋登入。
2. **教授查詢清單／儀表板統計時**（`application_service.py`）— fallback，涵蓋非 SSO 途徑建立的教授帳號（管理員建立、預先授權），以及首次登入「之後」才被學生填上的情況。

### 為什麼是「指派」而不是查詢時 join 比對

所有下游權限檢查都是拿 `application.professor_id` 跟呼叫者比對（`reviews.py:79`、`can_professor_review_application`、`can_professor_submit_review`）。只在清單查詢裡 join `advisor_nycu_id`、卻不寫回 `professor_id`，教授會看得到、但點進去就 403。

### 認領範圍

只認領 `PROFESSOR_ACTIONABLE_APPLICATION_STATUSES`（`submitted` / `under_review`），三種排除都是刻意的：

- **草稿**：提交當下才依「當時的」profile 指派，提前指派會鎖住過期的指導教授。
- **已決議**（approved / partial_approved / rejected）：教授清單的「待審核」分頁條件是「指派給我且我尚未審查」，**沒有狀態閘門**，而 `can_professor_submit_review` 只收 submitted/under_review——認領已決議的申請會讓它永遠卡在待審核，且每次送審都 403。
- **軟刪除**：已刪除的申請不得復活。

本次也順手把 `PROFESSOR_ACTIONABLE_APPLICATION_STATUSES` 抽到 `enums.py`，放在 `REVIEWABLE_APPLICATION_STATUSES`（較寬的「清單顯示」集合）旁邊並註明兩者不可混用；儀表板 pending 計數原本就內聯這兩個值，一併改用共用常數。

## Migration `advisor_backfill_idx_001`

- 用同一組條件回補**現有**的孤兒申請，不必等教授下次登入。
- 建立兩個索引：`user_profiles.advisor_nycu_id`（本次新增的查詢熱點）與 `applications.professor_id`（每個教授查詢都在篩選它，但因 PostgreSQL 不會自動為 FK 建索引而一直沒有）。
- `downgrade()` 只還原索引；回補的 `professor_id` 與提交當下指派的值無法區分，清掉會破壞正確資料，故刻意保留（已於註解說明）。

## 驗證

- 新增 `backend/app/tests/test_advisor_backfill.py`（13 個測試）：認領 advisee 孤兒申請、跳過草稿／軟刪除／已決議（parametrized 三種）／他人 advisee／非教授指導者、不覆蓋既有指派、容忍 `role` 為原始字串，另含教授清單、儀表板統計與 `process_portal_login` 的端對端案例。
- **後端全套測試 5265 passed**。
- Migration 在 throwaway PostgreSQL 上從零跑到 head（單一 head），兩個索引確認建立，並以 5 筆 fixture 做 downgrade/upgrade 重放——只認領 submitted 那筆。
- 以 rollback 交易對**真實 dev 資料庫**乾跑：較寬的舊條件會誤認領 2 筆已 `approved` 的申請，收斂後為 0 筆。
- black + flake8（`B904,B014`）通過。

## Test plan

- [ ] 學生填寫一個系統中不存在的 `advisor_nycu_id`，送出申請 → `professor_id` 為 NULL
- [ ] 該教授首次 SSO 登入 → 申請出現在其「待審核」清單，儀表板 badge 同步 +1
- [ ] 教授點進該申請可正常開啟並送出推薦（不會 403）
- [ ] 已決議（approved／rejected）的孤兒申請不會出現在待審核
- [ ] 既有已指派申請的 `professor_id` 不受影響