### PR TITLE
feat(prod-workflows): TLS certificate from GitHub secrets + per-stage monitoring deploy

### DIFF
--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -228,11 +228,9 @@ cp /path/to/development-repo/.github/production-workflows-examples/backup.yml \
 | `EXPECT_DOMAIN` | test 必填 | 測試站網域 | 正式站網域 |
 | `EXPECT_DB_HOST` | test 必填 | test DB VM 的位址 | production DB VM 的位址 |
 | `DEPLOY_URL` | ✅ | `https://<測試站網域>` | `https://<正式站網域>` |
-| `SSL_CERT_DIR` | — | 該台 VM 上憑證目錄的絕對路徑 | 同左 |
 | `ENV_FILE` | — | 該台 VM 上既有 `.env` 的絕對路徑（安裝手冊 5.1）。**設了就用它**，GitHub 完全不存這些值。留空則由 deploy-stack.yml 依下方 secrets 產生 `~/scholarship-<stage>/.env`（權限 600）。 | 同左 |
 
 `DEPLOY_STAGE` / `EXPECT_DOMAIN` / `EXPECT_DB_HOST` 是防呆用的：deploy 一開始就會比對「這個 environment 宣告自己是哪個 stage」與「secret 解析出來的 DOMAIN / DB_HOST」，對不上就直接失敗，避免 test 部署因為漏設 secret 而打到 production 的資料庫。
-| `SSL_CERT_DIR` | — | TLS 憑證資料夾的絕對路徑（例：`/home/<user>/ssl`）。留空則用 repo `nginx/ssl/prod`。兩種 `ENV_FILE` 模式下都以這個變數優先。資料夾內需有 `fullchain.pem`、`privkey.pem`、`chain.pem`。 |
 
 #### 部署相關 (deploy-stack.yml)
 

--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -53,6 +53,9 @@ warning: here-document at line 10 delimited by end-of-file (wanted `FOOTER_EOF')
 | `stop-test.yml` | **停掉 test AP VM** 的站台，需一位 reviewer 核准 | 只能手動觸發 | **必要** |
 | `stop-production.yml` | **停掉 production AP VM** 的站台（正式站會離線），需一位 reviewer 核准 | 只能手動觸發 | **必要** |
 | `stop-stack.yml` | 上面兩個 stop workflow 共用的 reusable workflow（實際的停機腳本本體） | 由兩個 stop workflow 呼叫，不單獨觸發 | **必要**（三個要一起複製） |
+| `deploy-monitoring-test.yml` | 在 **test AP VM** 起 Grafana/Loki/Prometheus（監控儀表板本體），需一位 reviewer 核准 | push to main 且動到 `monitoring/**` / 手動觸發 | **必要**（要看儀表板就必裝） |
+| `deploy-monitoring-production.yml` | 在 **production AP VM** 起 Grafana/Loki/Prometheus，需一位 reviewer 核准 | push to main 且動到 `monitoring/**` / 手動觸發 | **必要**（同上） |
+| `deploy-monitoring-stack.yml` | 上面兩個 monitoring workflow 共用的 reusable workflow（實際的部署腳本本體） | 由兩個 monitoring workflow 呼叫，不單獨觸發 | **必要**（三個要一起複製） |
 | `health-check.yml` | 監控應用程式健康狀態 | 每 15 分鐘 / 手動觸發 | 選用 |
 | `backup.yml` | 備份資料庫和檔案 | 每日 2AM UTC / 手動觸發 | 選用 |
 | `fortify-scan.yml` | Fortify SAST 掃描（Python + JS/TS + config），產出 `.fpr` 與 BIRT PDF 報告。掃描約 2.5 小時且獨佔共用 Fortify runner，故只在 push to main 觸發 | Push to main / 手動觸發 | 選用 |
@@ -174,6 +177,17 @@ cp /path/to/development-repo/.github/production-workflows-examples/stop-producti
 cp /path/to/development-repo/.github/production-workflows-examples/stop-stack.yml \
    .github/workflows/stop-stack.yml
 
+# monitoring 三件組同理：兩個 caller 都用
+# `uses: ./.github/workflows/deploy-monitoring-stack.yml`，少了它一樣無法解析。
+cp /path/to/development-repo/.github/production-workflows-examples/deploy-monitoring-test.yml \
+   .github/workflows/deploy-monitoring-test.yml
+
+cp /path/to/development-repo/.github/production-workflows-examples/deploy-monitoring-production.yml \
+   .github/workflows/deploy-monitoring-production.yml
+
+cp /path/to/development-repo/.github/production-workflows-examples/deploy-monitoring-stack.yml \
+   .github/workflows/deploy-monitoring-stack.yml
+
 cp /path/to/development-repo/.github/production-workflows-examples/health-check.yml \
    .github/workflows/health-check.yml
 
@@ -269,6 +283,51 @@ production 只是把同一份 artifact 拉下來跑，確保上線的東西跟 s
 #### 健康檢查 (health-check.yml)
 
 重用 `DOMAIN` 與 `REDIS_PASSWORD`；失敗時自動開 issue，恢復後自動關閉。
+
+#### 監控儀表板 (deploy-monitoring-stack.yml)
+
+`docker-compose.prod.yml` 只帶**採集端**（Alloy、node-exporter、cAdvisor、
+nginx-exporter、redis-exporter）。Alloy 把資料推到
+`http://monitoring_loki:3100` 與 `http://monitoring_prometheus:9090` —— 這是
+**docker DNS 名稱**，只有當 Grafana/Loki/Prometheus 也是同一台 VM 上的容器並掛在
+`scholarship_prod_network` 時才解析得到。在那之前 Alloy 會一路重試然後丟掉每一批
+資料（log 裡是 `no retries left, dropping data`），nginx 的
+`location ^~ /monitoring` 也沒有上游可打（502）。這組 workflow 就是負責把
+`monitoring/docker-compose.monitoring.yml` 起起來的那一步。
+
+**每個 stage 各有一份自己的監控堆疊**，跑在自己的 AP VM 上，不共用。
+
+| Secret（Environments → `test` / `production` → Secrets） | 必填 | 說明 |
+|---|---|---|
+| `GRAFANA_ADMIN_USER` | ✅ | Grafana 管理者帳號。正式站請勿用 `admin`。 |
+| `GRAFANA_ADMIN_PASSWORD` | ✅ | ≥ 12 字元。這個儀表板是從正式站網域對外開的，沒設好等於公開。 |
+| `GRAFANA_SECRET_KEY` | 建議 | Grafana 用它加密 `secureJsonData`（這裡就是 Loki 的 `X-Scope-OrgID` tenant header）。**要在第一次部署就設好**：對一個「已經存在、且是用別把 key（含 Grafana 內建預設 key，也就是沒設這個 secret 時用的那把）加密過」的 `grafana_data` volume 換 key，所有存起來的 secret 都會解成亂碼——provisioning 不會修好它（datasource 已存在就不會重寫 secure 欄位），畫面上只會看到 `Unable to connect with Loki`。真的撞到只有兩條路：把舊 key 換回來，或用 `reset_grafana_volume=true` 重建。`openssl rand -base64 32`，每個 stage 一把。 |
+| `GH_PAT` | 選用 | 只給「告警 → 開 GitHub issue」用（webhook-bridge）。沒設也能跑，只是告警只留在 Grafana 裡。 |
+
+| Variable | 必填 | 說明 |
+|---|---|---|
+| `GRAFANA_ROOT_URL` | — | 例 `https://<該 stage 網域>/monitoring`。留空時由 `EXPECT_DOMAIN` 推導；兩者都沒有就直接失敗（Grafana 在 sub-path 下必須知道自己的絕對網址，否則所有連結與登入導向都會指到錯的主機）。 |
+| `MONITORING_DIR` | — | 監控堆疊放在 VM 上的位置，預設 `/opt/scholarship/monitoring`。 |
+| `MONITORING_ALERT_REPO` | — | webhook-bridge 開 issue 的 repo，預設就是 production repo 自己。 |
+
+前置條件與注意事項：
+
+- **先跑過一次 `deploy-<stage>.yml`**。這組 workflow 需要 `scholarship_prod_network`
+  已存在（app stack 建的），最後一步的「透過 nginx 驗證 `/monitoring`」也需要 nginx 在跑。
+- **VM 上需要免密碼 sudo**，或事先把 `/opt/scholarship/monitoring` 與
+  `/opt/scholarship/secrets` 建好並 chown 給 runner 使用者。
+  `/opt/scholarship/secrets/gh_pat` 的路徑寫死在共用的 compose 檔裡（dev/prod 兩邊共用），
+  不能按 stage 搬家。
+- **⚠️ 防火牆**：共用的 compose 檔會把 Loki `3100` 與 Prometheus `9090`
+  publish 到 host（`0.0.0.0`），因為 DB VM 的 Alloy 要跨機推資料進來。**這兩個埠沒有任何
+  認證**，請用防火牆只開給該 stage 的 DB VM。
+- **DB VM 的採集端不在這組 workflow 範圍內**。`docker-compose.prod-db-monitoring.yml`
+  （alloy + node-exporter + postgres-exporter）要在 DB VM 上另外起，並把
+  `MONITORING_SERVER_URL` 指向該 stage 的 AP VM。
+- `reset_grafana_volume=true` 會**刪掉 `grafana_data`**：手動存的 dashboard、annotation、
+  告警靜音全部消失（provisioning 帶的內容會從檔案重建）。平時不要勾。
+- `stop-test.yml` / `stop-production.yml` **不會**停監控堆疊（不同的 compose project）。
+  站台停機期間 Grafana 仍會繼續跑，這是刻意的——正好用來看停機當下的狀況。
 
 ### 3. 自訂配置
 

--- a/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
+++ b/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
@@ -125,6 +125,7 @@ PII_ENCRYPTION_KEYS  PII_ENCRYPTION_ACTIVE_VERSION
 SMTP_HOST  SMTP_PORT  SMTP_USER  SMTP_PASSWORD  EMAIL_FROM  EMAIL_FROM_NAME
 PORTAL_JWT_SERVER_URL  STUDENT_API_BASE_URL  NEXT_PUBLIC_NYCU_PORTAL_URL
 SUPER_ADMIN_NYCU_ID
+SSL_FULLCHAIN_PEM  SSL_PRIVKEY_PEM  SSL_CHAIN_PEM
 ```
 
 `SECRET_KEY` 與 `PII_ENCRYPTION_KEYS` **絕對不要兩邊共用**：共用的 `SECRET_KEY`
@@ -139,7 +140,6 @@ SUPER_ADMIN_NYCU_ID
 | `EXPECT_DOMAIN` | 測試網域 | 正式網域 | 防呆：比對 `secrets.DOMAIN`，抓漏設的 fallback |
 | `EXPECT_DB_HOST` | 測試 DB 位址 | 正式 DB 位址 | 防呆：比對 `secrets.DB_HOST` |
 | `DEPLOY_URL` | `https://<測試站網域>` | `https://<正式站網域>` | Environment 頁面顯示的連結 |
-| `SSL_CERT_DIR` | 選填 | 選填 | 該台 VM 上的憑證目錄 |
 | `ENV_FILE` | 選填 | 選填 | 該台 VM 上 operator 自管的 `.env` 路徑 |
 | `FORBIDDEN_MARKERS` | 選填（設在 repository 層即可） | 同左 | 空白分隔的字串清單，只會出現在非正式值裡（測試網域、測試寄件者……）。production 段只要有任一 secret 命中就拒絕部署；不設就跳過這項檢查 |
 
@@ -450,6 +450,35 @@ openssl rand -base64 24
 - 🔐 `SECRET_KEY` is used for JWT token signing - **NEVER expose or reuse**
 - 🔐 If `SECRET_KEY` is compromised, all existing JWT tokens will be invalidated when changed
 - 🔐 Rotate `SECRET_KEY` every 90 days (will require all users to re-login)
+
+---
+
+### TLS certificate（必填，兩個 environment 各一份）
+
+`deploy-stack.yml` 每次部署都會把這三個 secret 寫成 AP VM 上
+`~/scholarship-<stage>/nginx/ssl/prod/{fullchain,privkey,chain}.pem`
+（privkey 600），nginx 容器再以唯讀方式掛到 `/etc/nginx/ssl`。
+**兩種 `ENV_FILE` 模式都一樣**：憑證不是 compose 變數，不放 `.env`。
+換憑證只要更新 secret 再重新部署，不必登入 VM。
+
+| Secret | Description | Required |
+|--------|-------------|----------|
+| `SSL_FULLCHAIN_PEM` | 站台憑證 + 中繼憑證（`fullchain.pem` 全文，`-----BEGIN CERTIFICATE-----` 開頭） | ✅ Yes |
+| `SSL_PRIVKEY_PEM` | 私鑰（`privkey.pem` 全文，PKCS#8 或 RSA/EC 皆可） | ✅ Yes |
+| `SSL_CHAIN_PEM` | 中繼憑證鏈（`chain.pem` 全文，供 OCSP stapling 的 `ssl_trusted_certificate`） | ✅ Yes |
+
+```bash
+# 直接用檔案內容設定；-e 指定 environment，test / production 各設一次
+gh secret set SSL_FULLCHAIN_PEM -e production < /path/to/fullchain.pem
+gh secret set SSL_PRIVKEY_PEM   -e production < /path/to/privkey.pem
+gh secret set SSL_CHAIN_PEM     -e production < /path/to/chain.pem
+```
+
+部署時會檢查：三個都有設、看起來是 PEM、私鑰與憑證配對、憑證尚未過期；
+任一項不符就在 `docker compose up` 之前失敗。
+
+> ⚠️ `test` environment **一定要**自己設這三個 secret —— 漏設會 fallback 到
+> repository 層的正式憑證，測試站就會拿著正式站的憑證起來。
 
 ---
 

--- a/.github/production-workflows-examples/deploy-monitoring-production.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-production.yml
@@ -1,0 +1,73 @@
+# PRODUCTION monitoring workflow — brings up Grafana/Loki/Prometheus on the
+# PRODUCTION AP VM.
+# Copy this file to the PRIVATE production repository at
+# .github/workflows/deploy-monitoring-production.yml (it calls
+# deploy-monitoring-stack.yml, which must be copied alongside it).
+#
+# ONE STAGE PER WORKFLOW, the same shape as deploy-production.yml. This workflow
+# touches the PRODUCTION AP VM only; deploy-monitoring-test.yml is its sibling.
+# The two are independent: a monitoring stack that fails to come up on test says
+# nothing about production, and must not block it.
+#
+#   deploy-production.yml             ──▶ the site      (app + collectors)
+#   deploy-monitoring-production.yml  ──▶ the dashboard (Grafana/Loki/Prometheus)
+#
+# ⚠️  THE GATE IS THE ONLY THING BETWEEN A PUSH AND PRODUCTION, and it matters
+# here for a reason of its own: this workflow writes the credentials of a
+# dashboard published on the production domain, and `reset_grafana_volume`
+# can destroy months of manually saved dashboards and annotations. Configure the
+# reviewer BEFORE this file goes live:
+#
+#   Settings → Environments → `production` → Required reviewers: 1 person
+#
+# The `environment:` key alone gates nothing. See SECRETS-SETUP-GUIDE.md.
+#
+# The push trigger is narrow on purpose: monitoring has no image to promote, so
+# a redeploy is only warranted when the mirrored commit actually changed
+# monitoring content. Every run costs a ~30 s Grafana restart (the site is never
+# touched).
+#
+# Prerequisites: those deploy-production.yml already needs, plus the
+# `production` environment secrets GRAFANA_ADMIN_USER / GRAFANA_ADMIN_PASSWORD.
+# See the header of deploy-monitoring-stack.yml for the full list, including the
+# firewall requirement for the Loki/Prometheus host ports.
+
+name: Deploy Monitoring to Production
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'monitoring/**'
+      - 'docker-compose.prod.yml'
+      - '.github/workflows/deploy-monitoring-production.yml'
+      - '.github/workflows/deploy-monitoring-stack.yml'
+  workflow_dispatch:
+    inputs:
+      reset_grafana_volume:
+        description: 'DESTRUCTIVE: wipe grafana_data first (loses manually saved dashboards, annotations and silences). Provisioned content is re-created.'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  # Scoped to production monitoring alone — see the note in
+  # deploy-monitoring-test.yml on why this is not shared with the app deploy.
+  group: deploy-monitoring-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-monitoring-production:
+    name: Deploy monitoring to production
+    uses: ./.github/workflows/deploy-monitoring-stack.yml
+    with:
+      stage: production
+      runner_labels: '["self-hosted","linux","production"]'
+      reset_grafana_volume: ${{ inputs.reset_grafana_volume || false }}
+    secrets: inherit
+    permissions:
+      contents: read

--- a/.github/production-workflows-examples/deploy-monitoring-stack.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-stack.yml
@@ -341,6 +341,16 @@ jobs:
             jq --arg env "${METRICS_ENV}" --argjson v "${STAMP}" '
               ((.templating.list[]? | select(.name == "environment") | .current)
                  |= {selected: true, text: $env, value: $env})
+              # Every OTHER query variable ships with a value saved from the
+              # staging server — `container: scholarship_backend_staging`, for
+              # one, while this deployment labels its containers
+              # `/scholarship_backend_prod`. A saved value is a property of the
+              # deployment it was saved on, and a stale one is not merely
+              # cosmetic: with it selected, the log panels query a stream that
+              # does not exist. Cleared, so Grafana resolves each from live data
+              # on load (every one of them has refresh enabled).
+              | ((.templating.list[]? | select(.type == "query" and .name != "environment") | .current)
+                 |= {})
               | .version = $v
             ' "$f" > "$tmp"
             mv "$tmp" "$f"

--- a/.github/production-workflows-examples/deploy-monitoring-stack.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-stack.yml
@@ -1,0 +1,699 @@
+# Reusable MONITORING stage — the body shared by BOTH monitoring workflows.
+# Copy this file to the PRIVATE production repository at
+# .github/workflows/deploy-monitoring-stack.yml.
+#
+# WHAT THIS DEPLOYS, AND WHY IT IS A SEPARATE WORKFLOW
+# ---------------------------------------------------
+# docker-compose.prod.yml — the file deploy-stack.yml brings up — ships only the
+# COLLECTORS: Grafana Alloy, node-exporter, cAdvisor, nginx-exporter and
+# redis-exporter. Nothing in it stores or displays anything. Alloy's config
+# (monitoring/config/alloy/prod-ap-vm.alloy) pushes to
+#
+#     http://monitoring_loki:3100/loki/api/v1/push
+#     http://monitoring_prometheus:9090/api/v1/write
+#
+# which are DOCKER DNS names, not hostnames — they only resolve if Loki and
+# Prometheus are containers on this same Docker host, attached to the app
+# network. Until that is true, Alloy retries and then drops every batch
+# ("no retries left, dropping data") and nginx's `location ^~ /monitoring`
+# proxy (nginx/nginx.prod.conf) has no upstream to reach, so the dashboard
+# 502s. This workflow is what makes those two names resolve: it brings up
+# monitoring/docker-compose.monitoring.yml — Grafana, Loki, Prometheus and the
+# webhook-bridge — on the AP VM and attaches them to scholarship_prod_network.
+#
+# It is deliberately NOT part of deploy-stack.yml:
+#   - The app stack is redeployed on every push to main; the monitoring stack
+#     changes only when monitoring/** changes, and restarting Grafana on every
+#     app deploy would drop ~30 s of dashboards for no reason.
+#   - Grafana holds STATE the app stack does not (grafana_data: manually saved
+#     dashboards, annotations, alert silences). It must be possible to redeploy
+#     the site without touching it — and to redeploy monitoring without
+#     restarting the site.
+#   - A failed monitoring deploy must never roll back or hold up the site.
+#
+# ONE definition, TWO callers — the same shape as deploy-stack.yml:
+#
+#     deploy-monitoring-test.yml ───────▶ this file (stage: test)
+#                                         runner [self-hosted,linux,test]
+#                                         environment: test  ▲ 1 reviewer
+#
+#     deploy-monitoring-production.yml ─▶ this file (stage: production)
+#                                         runner [self-hosted,linux,production]
+#                                         environment: production  ▲ 1 reviewer
+#
+# EACH STAGE GETS ITS OWN MONITORING STACK, on its own VM, reading its own
+# Docker socket. There is no cross-VM stack to share: the collectors reach the
+# store over Docker DNS, which does not leave the host. That also means the test
+# stage is a real rehearsal of the production one — same compose file, same
+# provisioning, same guards.
+#
+# NO IMAGES ARE PROMOTED HERE. Unlike deploy-stack.yml, this workflow deploys no
+# artifact built by the development repository: every image is a pinned upstream
+# one (grafana/grafana-enterprise, grafana/loki, prom/prometheus) except the
+# webhook-bridge, which is built from mirrored source on the VM. There is
+# therefore no `tag` input and no resolve-images gate.
+#
+# WHAT IT DOES NOT DO
+#   - The DB VM's collectors (docker-compose.prod-db-monitoring.yml: alloy,
+#     node-exporter, postgres-exporter) are NOT deployed from here. They need
+#     SSH from this runner to the DB VM; deploy them there, and point their
+#     MONITORING_SERVER_URL at this AP VM (see README § DB VM collectors).
+#   - It never touches the app stack's containers, beyond restarting Alloy so it
+#     re-resolves the Loki/Prometheus DNS names it failed on before this ran.
+#
+# Prerequisites (one-time, see SECRETS-SETUP-GUIDE.md § Monitoring):
+#   - The stage's app stack has been deployed at least once by deploy-stack.yml
+#     (this workflow needs scholarship_prod_network and, for the end-to-end
+#     dashboard check, the nginx container).
+#   - Environment secrets on the stage: GRAFANA_ADMIN_USER,
+#     GRAFANA_ADMIN_PASSWORD (both required), GRAFANA_SECRET_KEY (recommended),
+#     GH_PAT (optional — only for alert → GitHub issue delivery).
+#   - Environment variables on the stage: DEPLOY_STAGE (already required by
+#     deploy-stack.yml) and either GRAFANA_ROOT_URL or EXPECT_DOMAIN.
+#   - Passwordless sudo on the AP VM, OR /opt/scholarship/{monitoring,secrets}
+#     pre-created and owned by the runner user (see "Prepare monitoring
+#     directories"). The gh_pat mount path is hardcoded in the shared compose
+#     file, so it cannot be relocated per stage.
+#   - Host ports 3100 (Loki) and 9090 (Prometheus) are published by the shared
+#     compose file so the DB VM's Alloy can push to them. They carry NO
+#     authentication — firewall them to the DB VM only. See README § Firewall.
+
+name: Deploy monitoring stack (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      stage:
+        description: 'test | production — selects the GitHub Environment and the guard set'
+        required: true
+        type: string
+      runner_labels:
+        description: 'JSON array of runner labels, e.g. ''["self-hosted","linux","test"]'''
+        required: true
+        type: string
+      reset_grafana_volume:
+        description: 'DESTRUCTIVE: remove grafana_data before deploying (loses manually saved dashboards, annotations and silences). Provisioned dashboards/datasources/alerts are re-created from disk.'
+        required: false
+        type: boolean
+        default: false
+      monitoring_dir:
+        description: 'Directory on the AP VM holding the monitoring stack. Defaults to vars.MONITORING_DIR, then /opt/scholarship/monitoring.'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  deploy-monitoring:
+    name: Deploy monitoring to ${{ inputs.stage }}
+    # Labels come from the caller so ONE definition can target both VMs. Both
+    # answer to [self-hosted, linux]; the stage label is what makes the
+    # targeting deterministic — never drop it.
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    # The approval gate — the same one deploys pass through. GitHub blocks the
+    # job here, before the runner picks it up, until a reviewer approves.
+    environment:
+      name: ${{ inputs.stage }}
+      url: ${{ vars.DEPLOY_URL }}
+    permissions:
+      contents: read # actions/checkout
+
+    # DELIBERATELY MINIMAL, for the same reason as deploy-stack.yml: everything
+    # the monitoring compose file interpolates is exported inside the deploy
+    # step, where an unset value can be caught, rather than leaking into every
+    # step as an empty string.
+    env:
+      STAGE: ${{ inputs.stage }}
+      # Pinning the compose project name keeps the container and network names
+      # stable no matter which directory the stack is deployed from. The
+      # container names in the shared compose file are fixed (monitoring_*), but
+      # the compose-owned network name is derived from the project name, and the
+      # dev repo's equivalent workflow hardcodes `monitoring_monitoring_network`
+      # in a few places. Same project name, same names, everywhere.
+      COMPOSE_PROJECT_NAME: monitoring
+      # Both stage VMs run docker-compose.prod.yml, whose app network is
+      # `scholarship_prod_network` on BOTH — the stage is separated by VM, not by
+      # network name. The shared monitoring compose declares two external app
+      # networks (it was written for a host that served staging and production
+      # side by side); pointing both at the same name is supported by compose
+      # and attaches the container once. Verified on the test AP VM.
+      APP_NETWORK_NAME: scholarship_prod_network
+      PROD_APP_NETWORK_NAME: scholarship_prod_network
+
+    steps:
+      # ── Gate 1: is this environment really the environment we think it is? ──
+      # The inheritance trap from deploy-stack.yml's header applies here too: an
+      # environment that does not define its own secrets resolves to the
+      # repository-level (production) ones, and a "test" monitoring deploy would
+      # then publish the production Grafana under the production root URL.
+      - name: Assert stage identity
+        env:
+          DEPLOY_STAGE: ${{ vars.DEPLOY_STAGE }}
+          EXPECT_DOMAIN: ${{ vars.EXPECT_DOMAIN }}
+          GRAFANA_ROOT_URL: ${{ vars.GRAFANA_ROOT_URL }}
+        run: |
+          fail=0
+          err() { echo "::error::$1"; fail=1; }
+
+          if [ "${DEPLOY_STAGE}" != "${STAGE}" ]; then
+            err "Environment '${STAGE}' declares DEPLOY_STAGE='${DEPLOY_STAGE}' (expected '${STAGE}')."
+            echo "::error::Create the '${STAGE}' environment (Settings → Environments) and set the"
+            echo "::error::variable DEPLOY_STAGE=${STAGE}. Without it this job would run against"
+            echo "::error::repository-level (production) secrets."
+          fi
+
+          # Grafana serves from a sub-path and needs to know its own absolute
+          # URL, or every generated link (alert links, share URLs, the login
+          # redirect) points at the wrong host. Derive it from the stage's
+          # domain when GRAFANA_ROOT_URL is not set explicitly.
+          ROOT_URL="${GRAFANA_ROOT_URL}"
+          if [ -z "${ROOT_URL}" ]; then
+            [ -n "${EXPECT_DOMAIN}" ] || \
+              err "Set either GRAFANA_ROOT_URL or EXPECT_DOMAIN on the '${STAGE}' environment — Grafana cannot serve from /monitoring without its own absolute URL."
+            ROOT_URL="https://${EXPECT_DOMAIN}/monitoring"
+            echo "::notice::GRAFANA_ROOT_URL not set — derived '${ROOT_URL}' from EXPECT_DOMAIN."
+          fi
+
+          # A root URL pointing at the OTHER stage's domain is the mistake this
+          # catches: it survives every health check below and only shows up as
+          # broken links and a login loop for whoever opens the dashboard.
+          if [ -n "${EXPECT_DOMAIN}" ]; then
+            case "${ROOT_URL}" in
+              *"${EXPECT_DOMAIN}"*) : ;;
+              *) err "GRAFANA_ROOT_URL='${ROOT_URL}' does not contain the domain '${STAGE}' expects (EXPECT_DOMAIN=${EXPECT_DOMAIN})." ;;
+            esac
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Refusing to deploy — see SECRETS-SETUP-GUIDE.md § Monitoring."
+            exit 1
+          fi
+          echo "GRAFANA_ROOT_URL=${ROOT_URL}" >> "$GITHUB_ENV"
+          echo "✅ Stage identity confirmed: ${STAGE} → ${ROOT_URL}"
+
+      # ── Gate 2: fail fast on missing credentials BEFORE touching anything ───
+      # GF_SECURITY_ADMIN_USER / _PASSWORD are interpolated with no default. An
+      # empty password makes Grafana fall back to its built-in `admin` — an
+      # internet-reachable dashboard with a guessable login.
+      - name: Validate monitoring secrets
+        env:
+          GRAFANA_ADMIN_USER: ${{ secrets.GRAFANA_ADMIN_USER }}
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+          GRAFANA_SECRET_KEY: ${{ secrets.GRAFANA_SECRET_KEY }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          fail=0
+          err() { echo "::error::$1"; fail=1; }
+
+          [ -n "${GRAFANA_ADMIN_USER}" ] || err "GRAFANA_ADMIN_USER is not set on the '${STAGE}' environment"
+          [ -n "${GRAFANA_ADMIN_PASSWORD}" ] || err "GRAFANA_ADMIN_PASSWORD is not set on the '${STAGE}' environment"
+          [ "${#GRAFANA_ADMIN_PASSWORD}" -ge 12 ] || err "GRAFANA_ADMIN_PASSWORD must be >= 12 chars — this dashboard is reachable from the public site"
+
+          if [ "${STAGE}" = "production" ] && [ "${GRAFANA_ADMIN_USER}" = "admin" ]; then
+            # Not fatal: it is a real deployment's real choice. But the default
+            # username halves the work of a credential-stuffing attempt.
+            echo "::warning::GRAFANA_ADMIN_USER is 'admin' on production — prefer a non-default username."
+          fi
+
+          # Without a secret key Grafana generates one per container start, and
+          # every stored datasource password / alert secret encrypted with the
+          # previous key becomes undecryptable after a restart.
+          [ -n "${GRAFANA_SECRET_KEY}" ] || \
+            echo "::warning::GRAFANA_SECRET_KEY is not set — Grafana will use its built-in default key. Set a per-stage random value."
+
+          # Optional. The alert → GitHub issue path needs it; everything else
+          # (dashboards, datasources, alert evaluation) works without it.
+          [ -n "${GH_PAT}" ] || \
+            echo "::warning::GH_PAT is not set — alerts will still fire and show in Grafana, but the webhook-bridge cannot open GitHub issues."
+
+          [ "$fail" -eq 0 ] || exit 1
+          echo "✅ Monitoring secrets validated"
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Prepare monitoring directories
+        env:
+          MONITORING_DIR_INPUT: ${{ inputs.monitoring_dir }}
+          MONITORING_DIR_VAR: ${{ vars.MONITORING_DIR }}
+        run: |
+          set -euo pipefail
+
+          DIR="${MONITORING_DIR_INPUT:-${MONITORING_DIR_VAR:-/opt/scholarship/monitoring}}"
+
+          # Two paths matter and only one of them is relocatable:
+          #   $DIR                      — where this workflow puts the stack
+          #   /opt/scholarship/secrets  — hardcoded as the gh_pat bind-mount
+          #                               source in the SHARED compose file
+          #                               (monitoring/docker-compose.monitoring.yml,
+          #                               used by both repositories), so it
+          #                               cannot be moved per stage.
+          # Both live under /opt, which the runner user does not own. Try
+          # unprivileged first, fall back to `sudo -n` (never plain sudo — a VM
+          # without passwordless sudo must fail here with the message below
+          # instead of blocking forever on a password prompt no one can answer).
+          ensure_dir() {
+            mkdir -p "$1" 2>/dev/null && return 0
+            sudo -n mkdir -p "$1" 2>/dev/null || {
+              echo "::error::Cannot create $1 — this runner has no passwordless sudo."
+              echo "::error::Create it once on the VM, owned by the runner user:"
+              echo "::error::  sudo mkdir -p $1 && sudo chown -R \$USER:\$USER $1"
+              return 1
+            }
+            sudo -n chown -R "$USER:$USER" "$1" 2>/dev/null || true
+          }
+
+          ensure_dir "${DIR}"
+          [ -w "${DIR}" ] || sudo -n chown -R "$USER:$USER" "${DIR}" 2>/dev/null || {
+            echo "::error::${DIR} exists but is not writable by the runner user."
+            echo "::error::Fix once on the VM: sudo chown -R \$USER:\$USER ${DIR}"
+            exit 1
+          }
+
+          echo "MONITORING_DIR=${DIR}" >> "$GITHUB_ENV"
+          echo "Monitoring directory: ${DIR}"
+
+      - name: Deploy monitoring configuration
+        run: |
+          set -euo pipefail
+
+          # The provisioning tree is REPLACED, not merged. A plain `cp -r`
+          # leaves deleted files behind forever, and Grafana provisions whatever
+          # is on disk — a dashboard or alert rule removed from the repository
+          # months ago keeps being served, querying datasources that may no
+          # longer exist. (Observed on the test AP VM: a removed
+          # application-logs.json plus two .pre-rustfs/.removed backups were
+          # still being provisioned.) Everything under provisioning/ is
+          # repository-owned, so nothing local is lost.
+          PROV="${MONITORING_DIR}/config/grafana/provisioning"
+          if [ -d "${PROV}" ]; then
+            rm -rf "${PROV}" 2>/dev/null || sudo -n rm -rf "${PROV}" 2>/dev/null || {
+              echo "::error::Cannot replace ${PROV} — it is owned by another user"
+              echo "::error::and this runner has no passwordless sudo."
+              echo "::error::Clear it once on the VM: sudo rm -rf ${PROV}"
+              exit 1; }
+          fi
+
+          cp -r ./monitoring/* "${MONITORING_DIR}/"
+
+          # grafana.ini is always rewritten from the example so improvements to
+          # the example actually reach the VM. No secret is read from it —
+          # credentials arrive as GF_SECURITY_* environment variables in compose.
+          cp "${MONITORING_DIR}/config/grafana/grafana.ini.example" \
+             "${MONITORING_DIR}/config/grafana/grafana.ini"
+          echo "✅ Configuration written (grafana.ini regenerated from example)"
+
+      - name: Write the alert-dispatch PAT file
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          set -euo pipefail
+
+          # This file MUST exist as a file before `up`. Both Grafana and the
+          # webhook-bridge bind-mount it; when the source is missing Docker
+          # materialises it as a DIRECTORY, and from then on the mount fails
+          # in a way that reads like a Grafana bug.
+          SECRETS_DIR=/opt/scholarship/secrets
+          PAT_FILE="${SECRETS_DIR}/gh_pat"
+
+          sudo -n mkdir -p "${SECRETS_DIR}" 2>/dev/null || mkdir -p "${SECRETS_DIR}" || {
+            echo "::error::Cannot create ${SECRETS_DIR} (no passwordless sudo)."
+            echo "::error::Create it once on the VM: sudo mkdir -p ${SECRETS_DIR} && sudo chmod 700 ${SECRETS_DIR}"
+            exit 1
+          }
+          sudo -n chmod 700 "${SECRETS_DIR}" 2>/dev/null || true
+
+          # An empty PAT is written deliberately rather than skipped: the mount
+          # has to resolve to a file either way. The bridge reads it only when
+          # an alert fires, so an empty value costs a failed dispatch at alert
+          # time, not a failed deploy now (warned about in "Validate monitoring
+          # secrets").
+          printf '%s' "${GH_PAT}" | sudo -n tee "${PAT_FILE}" > /dev/null 2>&1 \
+            || printf '%s' "${GH_PAT}" > "${PAT_FILE}"
+
+          # Two containers with different UIDs read this (Grafana 472,
+          # webhook-bridge 1100). The file sits behind a 0700 root-owned
+          # directory that only bind mounts traverse, so 0444 on the file is not
+          # host-readable by other users.
+          sudo -n chown root:root "${PAT_FILE}" 2>/dev/null || true
+          sudo -n chmod 0444 "${PAT_FILE}" 2>/dev/null || chmod 0444 "${PAT_FILE}"
+          echo "✅ ${PAT_FILE} written ($([ -n "${GH_PAT}" ] && echo 'PAT present' || echo 'EMPTY — issue dispatch disabled'))"
+
+      - name: Pull and build monitoring images
+        run: |
+          set -euo pipefail
+          cd "${MONITORING_DIR}"
+          # `pull` fails outright on webhook-bridge (built locally, no registry),
+          # so pull only what has a registry and build the bridge from the
+          # mirrored source. --ignore-pull-failures keeps a transient registry
+          # hiccup from failing the deploy when the image is already local.
+          docker compose -f docker-compose.monitoring.yml pull \
+            --ignore-buildable --ignore-pull-failures || true
+          docker compose -f docker-compose.monitoring.yml build webhook-bridge
+
+      - name: Deploy monitoring stack
+        env:
+          GRAFANA_ADMIN_USER: ${{ secrets.GRAFANA_ADMIN_USER }}
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+          GRAFANA_SECRET_KEY: ${{ secrets.GRAFANA_SECRET_KEY }}
+          # Where the webhook-bridge opens alert issues. Defaults to THIS
+          # repository — the private one — because that is where whoever
+          # operates this deployment reads issues; the shared compose file's own
+          # default points at the development repository.
+          GH_REPO: ${{ vars.MONITORING_ALERT_REPO || github.repository }}
+          RESET_VOLUME: ${{ inputs.reset_grafana_volume }}
+        run: |
+          set -euo pipefail
+          cd "${MONITORING_DIR}"
+
+          # scholarship_prod_network is declared external in BOTH compose files,
+          # and compose never creates an external network. deploy-stack.yml
+          # creates it with this subnet; create it the same way here so
+          # whichever of the two runs first wins and the other simply finds it.
+          docker network inspect "${APP_NETWORK_NAME}" >/dev/null 2>&1 || \
+            docker network create --subnet 172.24.0.0/16 "${APP_NETWORK_NAME}"
+
+          if [ "${RESET_VOLUME}" = "true" ]; then
+            echo "::warning::reset_grafana_volume=true — removing grafana_data. Manually saved dashboards, annotations and silences are lost; provisioned content is re-created from disk."
+            docker compose -f docker-compose.monitoring.yml down -v
+          fi
+
+          docker compose -f docker-compose.monitoring.yml up -d
+
+      # Everything below reads Grafana through `docker exec`, not through a
+      # published port or a throwaway curl container: it needs no host port, no
+      # compose-network name, and works identically on both stages.
+      - name: Wait for Grafana
+        run: |
+          for i in $(seq 1 24); do
+            if docker exec monitoring_grafana wget --spider -q http://localhost:3000/api/health 2>/dev/null; then
+              echo "✅ Grafana answering after $((i*5))s"
+              exit 0
+            fi
+            echo "Waiting for Grafana... ($i/24)"
+            sleep 5
+          done
+          echo "::error::Grafana did not become healthy within 120s"
+          docker logs --tail 100 monitoring_grafana
+          exit 1
+
+      # GF_SECURITY_ADMIN_USER / _PASSWORD are applied ONLY when Grafana creates
+      # its database. On a volume that already exists — a hand-started stack, or
+      # any earlier deploy with different credentials — they are silently
+      # ignored, and every authenticated call below returns
+      #   401 … "no user found: user not found"
+      # which reads like a broken workflow rather than a stale volume. (Hit on
+      # the test AP VM: grafana_data held a single `admin` user from a manual
+      # deploy months earlier, so the declared login did not exist at all.)
+      #
+      # Reconcile before authenticating, and only when needed: the declared
+      # credentials are probed first, so a correctly provisioned stack — the
+      # normal case, and the only case on a fresh VM — is left untouched.
+      - name: Reconcile the Grafana admin account
+        env:
+          ADMIN_USER: ${{ secrets.GRAFANA_ADMIN_USER }}
+          ADMIN_PASS: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+        run: |
+          # 200 = these credentials work. Any authenticated endpoint would do;
+          # /api/org/users needs an org admin, which is what every later step
+          # needs too, so a 200 here proves the identity is usable.
+          probe() {
+            docker exec monitoring_grafana wget -qO- --server-response \
+              --header "Authorization: Basic $(printf '%s' "$1:${ADMIN_PASS}" | base64 -w0)" \
+              http://localhost:3000/api/org/users 2>&1 \
+              | awk '/^  HTTP/{c=$2} END{print c+0}'
+          }
+
+          if [ "$(probe "${ADMIN_USER}")" = "200" ]; then
+            echo "GRAFANA_API_USER=${ADMIN_USER}" >> "$GITHUB_ENV"
+            echo "✅ Declared admin credentials accepted"
+            exit 0
+          fi
+
+          echo "::warning::The declared GRAFANA_ADMIN_USER cannot authenticate — grafana_data predates this configuration. Reconciling."
+          # Operates directly on grafana.db and takes effect live (no restart).
+          # It resets the BUILT-IN admin user, whatever GF_SECURITY_ADMIN_USER
+          # says — which is precisely why the second probe below is needed.
+          docker exec monitoring_grafana grafana cli --homepath /usr/share/grafana \
+            admin reset-admin-password "${ADMIN_PASS}" 2>&1 | tail -2
+
+          if [ "$(probe "${ADMIN_USER}")" = "200" ]; then
+            echo "GRAFANA_API_USER=${ADMIN_USER}" >> "$GITHUB_ENV"
+            echo "✅ Password reset — declared credentials now accepted"
+            exit 0
+          fi
+
+          if [ "$(probe admin)" = "200" ]; then
+            # Deliberately NOT renaming or deleting the existing account: this
+            # workflow will not mutate an identity someone may be logging in
+            # with. The deploy proceeds under the login that exists, and says so.
+            echo "GRAFANA_API_USER=admin" >> "$GITHUB_ENV"
+            echo "::warning::This volume's only admin login is 'admin', not '${ADMIN_USER}'. Its password is now GRAFANA_ADMIN_PASSWORD and the deploy continues under it."
+            echo "::warning::To make '${ADMIN_USER}' the real admin login: create it in Grafana (Administration → Users), or re-run with reset_grafana_volume=true to rebuild from provisioning (DESTROYS manually saved dashboards)."
+            exit 0
+          fi
+
+          echo "::error::Cannot authenticate to Grafana as '${ADMIN_USER}' or as 'admin' even after a password reset."
+          echo "::error::Inspect the volume, or re-run with reset_grafana_volume=true to rebuild it from provisioning (DESTRUCTIVE)."
+          docker logs --tail 50 monitoring_grafana
+          exit 1
+
+      - name: Reload provisioning
+        env:
+          ADMIN_USER: ${{ env.GRAFANA_API_USER }}
+          ADMIN_PASS: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+        run: |
+          # The /api/admin/provisioning/*/reload endpoints work for datasources,
+          # alerting and plugins. Dashboards are the exception: Grafana compares
+          # the file's `version` field against the stored row and skips the
+          # update once they match, even when the panel queries changed. A
+          # container restart is the only reliable way to land in-place
+          # dashboard edits — ~30 s, and nothing else depends on Grafana.
+          AUTH_HDR="Authorization: Basic $(printf '%s' "${ADMIN_USER}:${ADMIN_PASS}" | base64 -w0)"
+          for path in datasources alerting plugins; do
+            STATUS=$(docker exec monitoring_grafana wget -qO- --server-response \
+              --header "$AUTH_HDR" --post-data '' \
+              "http://localhost:3000/api/admin/provisioning/${path}/reload" 2>&1 \
+              | awk '/^  HTTP/{code=$2} END{print code+0}')
+            case "$STATUS" in
+              200) echo "✅ reloaded ${path}" ;;
+              404) echo "(no ${path} reload endpoint on this Grafana version)" ;;
+              *)   echo "::warning::${path} reload returned ${STATUS}" ;;
+            esac
+          done
+
+          docker restart monitoring_grafana >/dev/null
+          for i in $(seq 1 24); do
+            docker exec monitoring_grafana wget --spider -q http://localhost:3000/api/health 2>/dev/null && break
+            sleep 5
+          done
+          docker exec monitoring_grafana wget --spider -q http://localhost:3000/api/health || {
+            echo "::error::Grafana did not come back after the provisioning restart"
+            docker logs --tail 100 monitoring_grafana
+            exit 1
+          }
+          echo "✅ Grafana back up after restart"
+
+      - name: Health check monitoring stack
+        env:
+          # Resolved by "Reconcile the Grafana admin account" — not read from
+          # secrets directly, because on a pre-existing volume the login that
+          # actually authenticates may not be the declared one.
+          ADMIN_USER: ${{ env.GRAFANA_API_USER }}
+          ADMIN_PASS: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          AUTH_HDR="Authorization: Basic $(printf '%s' "${ADMIN_USER}:${ADMIN_PASS}" | base64 -w0)"
+          # `|| true`: wget exits non-zero AND prints nothing on a 4xx, and a
+          # datasource health endpoint answering 400 is a result to report, not
+          # a reason to abort the step under `set -e`.
+          gf() { docker exec monitoring_grafana wget -qO- --header "$AUTH_HDR" "http://localhost:3000$1" 2>/dev/null || true; }
+
+          # 1. Container liveness. webhook-bridge is intentionally not in this
+          #    list: it is only in the alert delivery path, and a build/runtime
+          #    problem there must not fail a deploy that fixed dashboards.
+          for service in grafana prometheus loki; do
+            container="monitoring_${service}"
+            docker ps --filter "name=^/${container}$" --filter "status=running" --format '{{.Names}}' \
+              | grep -q "${container}" || {
+                echo "::error::${container} is not running"
+                docker logs --tail 50 "${container}" 2>&1 || true
+                exit 1; }
+          done
+          echo "✅ grafana, prometheus and loki are running"
+
+          # 2. Datasource health. An HTTP 200 from /api/health proves only that
+          #    Grafana is up — a datasource pointing at a dead URL fails
+          #    silently, one panel at a time, which is exactly the failure this
+          #    whole stack exists to prevent.
+          #
+          #    Only the datasources THIS stage reads are gating. The shared
+          #    provisioning ships one Loki datasource per tenant (prod, staging,
+          #    dev) because one Grafana used to serve several environments; on a
+          #    per-stage VM the other tenants are empty by design and must not
+          #    be able to fail the deploy.
+          REQUIRED_DS="prometheus-uid loki-prod-uid"
+          ds_fail=0
+          for uid in $(gf /api/datasources | jq -r '.[].uid'); do
+            STATUS=$(gf "/api/datasources/uid/${uid}/health" | jq -r '.status // "unreachable"')
+            case " ${REQUIRED_DS} " in
+              *" ${uid} "*)
+                if [ "$STATUS" = "OK" ]; then
+                  echo "  ✅ datasource ${uid}"
+                else
+                  echo "::error::Datasource ${uid} is not OK (status=${STATUS})"
+                  ds_fail=1
+                fi
+                ;;
+              *)
+                [ "$STATUS" = "OK" ] && echo "  ✅ datasource ${uid} (not gating)" \
+                  || echo "::warning::Datasource ${uid} is ${STATUS} — not gating on this stage."
+                ;;
+            esac
+          done
+
+          if [ "$ds_fail" -ne 0 ]; then
+            # Grafana answers a broken datasource with a generic "Unable to
+            # connect"; the actual reason is only in its own log.
+            echo "Grafana's own diagnosis:"
+            docker logs monitoring_grafana 2>&1 | grep -E 'logger=tsdb.*level=error' | tail -5
+            # The failure mode that costs the most time to identify. Grafana
+            # encrypts secureJsonData (here: the X-Scope-OrgID tenant header)
+            # with GF_SECURITY_SECRET_KEY. Setting or changing that secret
+            # against a volume encrypted under a DIFFERENT key — including
+            # Grafana's built-in default, which is what a stack started without
+            # the secret uses — decrypts every stored secret to garbage.
+            # Provisioning does not repair it: the datasource already exists, so
+            # its secure fields are never rewritten. Observed on the test AP VM,
+            # where it surfaced only as "Unable to connect with Loki".
+            if docker logs monitoring_grafana 2>&1 | grep -q 'invalid header field value'; then
+              echo "::error::'invalid header field value' means the stored tenant header cannot be decrypted:"
+              echo "::error::GRAFANA_SECRET_KEY does not match the key this grafana_data volume was encrypted with."
+              echo "::error::Either restore the previous key (a stack started WITHOUT the secret used Grafana's default),"
+              echo "::error::or re-run this workflow with reset_grafana_volume=true to rebuild the volume from provisioning."
+            fi
+            exit 1
+          fi
+
+          # 3. Provisioned dashboards and alert rules. The expected counts are
+          #    derived from the files that were just copied, not hardcoded, so
+          #    they cannot drift as monitoring/** grows.
+          EXPECT_DASH=$(find "${MONITORING_DIR}/config/grafana/provisioning/dashboards" -name '*.json' | wc -l)
+          GOT_DASH=$(gf '/api/search?type=dash-db' | jq 'length')
+          if [ "${GOT_DASH:-0}" -lt "${EXPECT_DASH}" ]; then
+            echo "::error::Expected ${EXPECT_DASH} provisioned dashboards, got ${GOT_DASH}"
+            docker logs monitoring_grafana 2>&1 | grep -E 'provisioning.dashboard.*level=error' | tail -20
+            exit 1
+          fi
+          echo "✅ ${GOT_DASH}/${EXPECT_DASH} dashboards provisioned"
+
+          EXPECT_RULES=$(cat "${MONITORING_DIR}"/config/grafana/provisioning/alerting/rules-*.yml \
+            | grep -c '^[[:space:]]*- uid:')
+          GOT_RULES=$(gf /api/v1/provisioning/alert-rules | jq 'length')
+          if [ "${GOT_RULES:-0}" -lt "${EXPECT_RULES}" ]; then
+            echo "::error::Expected ${EXPECT_RULES} provisioned alert rules, got ${GOT_RULES}"
+            docker logs monitoring_grafana 2>&1 | grep -E 'provisioning.alerting.*level=error' | tail -20
+            exit 1
+          fi
+          echo "✅ ${GOT_RULES}/${EXPECT_RULES} alert rules provisioned"
+
+      # The reason the app stack ships Alloy at all. Alloy resolves
+      # monitoring_loki / monitoring_prometheus once per push attempt and, on a
+      # host where they did not exist, has been dropping every batch. Restarting
+      # it here is what turns this deploy into live data.
+      - name: Restart Alloy so it re-resolves the store
+        run: |
+          ALLOY_CIDS=$(docker ps -q -f name=alloy)
+          if [ -n "$ALLOY_CIDS" ]; then
+            echo "Restarting Alloy: $ALLOY_CIDS"
+            docker restart $ALLOY_CIDS >/dev/null
+            echo "✅ Alloy restarted"
+          else
+            # `docker ps -q` exits 0 with empty output when nothing matches, so
+            # this has to test the output, not the exit code.
+            echo "::warning::No Alloy container on this VM — deploy the app stack (deploy-${STAGE}.yml) to start collecting."
+          fi
+
+      - name: Verify data is actually arriving
+        run: |
+          # Deploy honesty: a green stack that receives nothing looks identical
+          # to a working one on every check above. Give Alloy a scrape interval
+          # or two, then ask the store what it has.
+          sleep 45
+
+          fail=0
+
+          # Prometheus: remote-write from Alloy plus Prometheus's own scrapes.
+          UP=$(docker exec monitoring_prometheus wget -qO- \
+            'http://localhost:9090/api/v1/query?query=count(up)' \
+            | jq -r '.data.result[0].value[1] // "0"')
+          if [ "${UP%%.*}" -lt 1 ]; then
+            echo "::error::Prometheus knows no targets — Alloy is not writing metrics."
+            docker logs --tail 30 $(docker ps -q -f name=alloy | head -1) 2>&1 | tail -30 || true
+            fail=1
+          else
+            echo "✅ Prometheus has ${UP%%.*} up-series"
+          fi
+
+          # Loki, prod tenant. Alloy labels this stage's logs environment=prod
+          # and pushes with X-Scope-OrgID: prod (config/alloy/prod-ap-vm.alloy);
+          # an empty label set here means the push path is broken.
+          LABELS=$(docker exec monitoring_loki wget -qO- \
+            --header 'X-Scope-OrgID: prod' \
+            'http://localhost:3100/loki/api/v1/label/container/values' \
+            | jq -r '.data | length // 0')
+          if [ "${LABELS:-0}" -lt 1 ]; then
+            echo "::warning::Loki has no container labels for tenant 'prod' yet. Logs can lag a cold start; re-check the Application Logs dashboard in a few minutes."
+          else
+            echo "✅ Loki has logs from ${LABELS} containers (tenant: prod)"
+          fi
+
+          [ "$fail" -eq 0 ] || exit 1
+
+      - name: Verify the dashboard is reachable through nginx
+        run: |
+          # Grafana publishes NO host port — `location ^~ /monitoring` in
+          # nginx.prod.conf is the only way in. That block reaches
+          # monitoring_grafana:3000 over the app network, so this is the check
+          # that the network attachment actually worked end to end.
+          if ! docker ps --format '{{.Names}}' | grep -q '^scholarship_nginx_prod$'; then
+            echo "::warning::nginx is not running on this VM — cannot verify the /monitoring route. Deploy the app stack first."
+            exit 0
+          fi
+
+          CODE=$(curl -sk -o /dev/null -w '%{http_code}' https://localhost/monitoring/api/health || echo 000)
+          case "$CODE" in
+            200)
+              echo "✅ /monitoring/api/health returned 200 through nginx"
+              ;;
+            502|504)
+              echo "::error::nginx cannot reach Grafana (HTTP ${CODE}). The monitoring containers are up, so this is the app network attachment:"
+              echo "::error::  docker inspect monitoring_grafana --format '{{json .NetworkSettings.Networks}}'"
+              echo "::error::must list ${APP_NETWORK_NAME}."
+              exit 1
+              ;;
+            404)
+              echo "::error::nginx returned 404 for /monitoring — the running config predates the Grafana proxy block."
+              echo "::error::Redeploy the app stack (deploy-${STAGE}.yml) to install the current nginx.prod.conf."
+              exit 1
+              ;;
+            *)
+              echo "::error::/monitoring/api/health returned HTTP ${CODE}"
+              exit 1
+              ;;
+          esac
+
+      - name: Deployment summary
+        if: always()
+        run: |
+          {
+            echo "## Monitoring stack — ${STAGE}"
+            echo ""
+            echo "**Grafana URL**: ${GRAFANA_ROOT_URL:-unresolved}"
+            echo "**Directory**: ${MONITORING_DIR:-unresolved}"
+            echo "**App network**: ${APP_NETWORK_NAME}"
+            echo ""
+            echo "| Container | Image | Status |"
+            echo "|---|---|---|"
+            docker ps -a --filter 'name=monitoring_' \
+              --format '| {{.Names}} | {{.Image}} | {{.Status}} |' || true
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/production-workflows-examples/deploy-monitoring-stack.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-stack.yml
@@ -368,6 +368,28 @@ jobs:
 
           echo "✅ ${patched} dashboards retargeted to environment=${METRICS_ENV} (${retargeted_ds} also re-bound to ${LOKI_DS_UID})"
 
+          # Datasources are gated the same way, and the consequences are worse.
+          # Grafana's datasource provisioner applies a file only when its
+          # `version` exceeds the stored row, so on any VM that already has a
+          # grafana_data volume EVERY edit to datasources.yml is silently
+          # ignored — verified here by shipping cacheLevel: None and reading
+          # back `High` from the API after a restart. The same gate is why a
+          # rotated GRAFANA_SECRET_KEY leaves the encrypted tenant header
+          # unrepaired: provisioning never rewrites the secure fields of a
+          # datasource it decides is up to date.
+          #
+          # Stamping the version on every deploy makes provisioning declarative
+          # again: what the file says is what Grafana runs, and secure fields are
+          # re-encrypted with the key currently in use.
+          DS="${MONITORING_DIR}/config/grafana/provisioning/datasources"
+          for f in "${DS}"/*.yml; do
+            [ -f "$f" ] || continue
+            # Anchored on `version:` so the file-format key `apiVersion: 1` is
+            # left alone.
+            sed -i -E "s/^([[:space:]]*)version:[[:space:]]*[0-9]+[[:space:]]*$/\1version: ${STAMP}/" "$f"
+          done
+          echo "✅ datasource provisioning stamped version=${STAMP} so edits actually apply"
+
       - name: Write the alert-dispatch PAT file
         env:
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/production-workflows-examples/deploy-monitoring-stack.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-stack.yml
@@ -302,6 +302,62 @@ jobs:
              "${MONITORING_DIR}/config/grafana/grafana.ini"
           echo "✅ Configuration written (grafana.ini regenerated from example)"
 
+      # Without this every panel on every dashboard is empty, and the stack looks
+      # broken while it is in fact collecting perfectly.
+      #
+      # The dashboards are shared with the development repository, whose Grafana
+      # serves the staging monitoring server, so all eight ship with the
+      # `environment` template variable defaulting to `staging` and the log
+      # dashboard bound to the `loki-staging-uid` datasource. This VM's Alloy
+      # labels everything `environment="prod"` and pushes logs to Loki tenant
+      # `prod` (monitoring/config/alloy/prod-ap-vm.alloy), so those queries match
+      # nothing here. A viewer has to know to change a dropdown before seeing a
+      # single number — and concludes the deploy failed when they don't.
+      #
+      # Retarget at deploy time rather than in the repository: the correct value
+      # is a property of the DEPLOYMENT, and the same files have to keep working
+      # on the staging server.
+      - name: Retarget dashboards at this deployment
+        env:
+          # Both stages of this repository run docker-compose.prod.yml, which
+          # mounts prod-ap-vm.alloy on both — so the test stage's data is also
+          # labelled `prod`. What separates the stages is one Grafana per VM, not
+          # the label. Override per environment only if that ever changes.
+          METRICS_ENV: ${{ vars.METRICS_ENVIRONMENT || 'prod' }}
+          LOKI_DS_UID: ${{ vars.LOKI_DATASOURCE_UID || 'loki-prod-uid' }}
+        run: |
+          set -euo pipefail
+          DASH="${MONITORING_DIR}/config/grafana/provisioning/dashboards"
+
+          # Grafana's dashboard provisioner compares the file's `version` against
+          # the stored row and skips the import when they match — even though the
+          # queries changed. Stamping a monotonic version guarantees the retarget
+          # actually lands on a volume that already holds these dashboards.
+          STAMP=$(date +%s)
+
+          patched=0
+          while IFS= read -r f; do
+            tmp="${f}.retarget"
+            jq --arg env "${METRICS_ENV}" --argjson v "${STAMP}" '
+              ((.templating.list[]? | select(.name == "environment") | .current)
+                 |= {selected: true, text: $env, value: $env})
+              | .version = $v
+            ' "$f" > "$tmp"
+            mv "$tmp" "$f"
+            patched=$((patched + 1))
+          done < <(find "${DASH}" -name '*.json')
+
+          # The log dashboard names its datasource by uid. All three Loki
+          # datasources point at the same Loki and differ only by tenant header,
+          # so this is a one-token substitution.
+          retargeted_ds=$(grep -rl 'loki-staging-uid' "${DASH}" 2>/dev/null | wc -l)
+          if [ "${retargeted_ds}" -gt 0 ]; then
+            grep -rl 'loki-staging-uid' "${DASH}" \
+              | xargs sed -i "s/loki-staging-uid/${LOKI_DS_UID}/g"
+          fi
+
+          echo "✅ ${patched} dashboards retargeted to environment=${METRICS_ENV} (${retargeted_ds} also re-bound to ${LOKI_DS_UID})"
+
       - name: Write the alert-dispatch PAT file
         env:
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/production-workflows-examples/deploy-monitoring-test.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-test.yml
@@ -1,0 +1,77 @@
+# TEST monitoring workflow — brings up Grafana/Loki/Prometheus on the TEST AP VM.
+# Copy this file to the PRIVATE production repository at
+# .github/workflows/deploy-monitoring-test.yml (it calls
+# deploy-monitoring-stack.yml, which must be copied alongside it).
+#
+# ONE STAGE PER WORKFLOW, the same shape as deploy-test.yml. This workflow
+# touches the TEST AP VM only; deploy-monitoring-production.yml is its sibling.
+#
+#   deploy-test.yml             ──▶ the site        (app + collectors)
+#   deploy-monitoring-test.yml  ──▶ the dashboard   (Grafana/Loki/Prometheus)
+#
+# WHY THE TRIGGERS DIFFER FROM deploy-test.yml
+# --------------------------------------------
+# The app stack redeploys on every push to main. The monitoring stack has no
+# image to promote — it changes only when monitoring/** changes — and every
+# deploy costs a ~30 s Grafana restart. So this fires on a push ONLY when the
+# mirrored commit actually touched monitoring content, plus on manual dispatch.
+#
+# It still passes through the `test` environment's approval gate, because the
+# monitoring stack holds the credentials to a dashboard published on the public
+# site. Configure that gate once:
+#
+#   Settings → Environments → `test` → Required reviewers: 1 person
+#
+# The `environment:` key alone gates nothing. See SECRETS-SETUP-GUIDE.md.
+#
+# Prerequisites: those deploy-test.yml already needs, plus the `test`
+# environment secrets GRAFANA_ADMIN_USER / GRAFANA_ADMIN_PASSWORD. See the
+# header of deploy-monitoring-stack.yml for the full list.
+
+name: Deploy Monitoring to Test
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Everything the stack is built from. docker-compose.prod.yml is included
+      # because it owns the Alloy collector and the app network the monitoring
+      # containers attach to — a change there can require re-attaching them.
+      - 'monitoring/**'
+      - 'docker-compose.prod.yml'
+      - '.github/workflows/deploy-monitoring-test.yml'
+      - '.github/workflows/deploy-monitoring-stack.yml'
+  workflow_dispatch:
+    inputs:
+      reset_grafana_volume:
+        description: 'DESTRUCTIVE: wipe grafana_data first (loses manually saved dashboards, annotations and silences). Provisioned content is re-created.'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  # Scoped to test monitoring alone. NOT shared with deploy-test: a run waiting
+  # at the approval gate holds its group, and every merge to main leaves one
+  # pending — sharing would make a monitoring fix wait for an unrelated app
+  # deploy to be reviewed.
+  group: deploy-monitoring-test
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-monitoring-test:
+    name: Deploy monitoring to test
+    uses: ./.github/workflows/deploy-monitoring-stack.yml
+    with:
+      stage: test
+      runner_labels: '["self-hosted","linux","test"]'
+      reset_grafana_volume: ${{ inputs.reset_grafana_volume || false }}
+    # Reads secrets from the `test` ENVIRONMENT, which overrides the
+    # repository-level (production) values. The environment scoping happens
+    # inside the called workflow.
+    secrets: inherit
+    permissions:
+      contents: read

--- a/.github/production-workflows-examples/deploy-production.yml
+++ b/.github/production-workflows-examples/deploy-production.yml
@@ -55,15 +55,16 @@
 #       EXPECT_DOMAIN  = the domain this stage may touch (advisory here)
 #       EXPECT_DB_HOST = the DB host this stage may touch (advisory here)
 #       DEPLOY_URL     = the production site URL (shown on the Environments page)
-#       SSL_CERT_DIR   = optional; absolute path to the TLS certificate
-#                        directory on that VM (e.g. /home/<user>/ssl).
-#                        Defaults to ./nginx/ssl/prod in the deploy directory.
 #       ENV_FILE       = optional; path to an operator-managed .env on that VM.
 #       FORBIDDEN_MARKERS = optional (repo-level is fine); space-separated
 #                        substrings that only ever appear in non-production
 #                        values (test hostnames, test mail sender, ...). This
 #                        stage refuses to deploy if a secret contains one.
 #                        Unset = that check is skipped.
+#   - Secrets on the `production` environment (or repository level):
+#       SSL_FULLCHAIN_PEM / SSL_PRIVKEY_PEM / SSL_CHAIN_PEM = the TLS
+#                        certificate as PEM text; written to
+#                        <deploy dir>/nginx/ssl/prod on every deploy.
 #   - secrets.GH_PAT with read:packages, if the upstream packages are private.
 #   - docker-compose.prod-db.yml stack already running on the production DB VM.
 

--- a/.github/production-workflows-examples/deploy-stack.yml
+++ b/.github/production-workflows-examples/deploy-stack.yml
@@ -35,7 +35,9 @@
 #      Settings → Environments, NOT in YAML — see SECRETS-SETUP-GUIDE.md).
 #   2. Environment secrets → the TEST stage resolves the TEST database, portal,
 #      SMTP relay and PII keys; the PRODUCTION stage resolves the real ones.
-#   3. Environment variables → per-stage URL, ENV_FILE, SSL_CERT_DIR.
+#   3. Environment variables → per-stage URL, ENV_FILE. The TLS certificate
+#      is an environment SECRET too (SSL_FULLCHAIN_PEM / SSL_PRIVKEY_PEM /
+#      SSL_CHAIN_PEM), written to the deploy dir on every run.
 #
 # ⚠️  INHERITANCE TRAP: a secret that the `test` environment does NOT define
 # falls back to the REPOSITORY-level secret — i.e. to the PRODUCTION value.
@@ -359,9 +361,9 @@ jobs:
         run: |
           mkdir -p "${DEPLOY_DIR}/logs/nginx"
           cp docker-compose.prod.yml "${DEPLOY_DIR}/docker-compose.yml"
-          # Merge (not replace): a certificate directory placed under
-          # <deploy dir>/nginx/ssl/prod by the operator must survive, since the
-          # repo ships nginx configs but no keys.
+          # Merge (not replace): the repo ships nginx configs but no keys — the
+          # certificate under <deploy dir>/nginx/ssl/prod is written from
+          # secrets by the "Install TLS certificate" step below.
           if [ -d nginx ]; then cp -r nginx "${DEPLOY_DIR}/"; fi
           # Everything below is copied as the runner user and therefore owned by
           # it, so a plain rm is enough to replace it. sudo -n is only a fallback
@@ -408,7 +410,6 @@ jobs:
       - name: Resolve environment file
         env:
           ENV_FILE_VAR: ${{ vars.ENV_FILE }}
-          SSL_CERT_DIR_VAR: ${{ vars.SSL_CERT_DIR }}
           EXPECT_DOMAIN: ${{ vars.EXPECT_DOMAIN }}
           EXPECT_DB_HOST: ${{ vars.EXPECT_DB_HOST }}
           FORBIDDEN_MARKERS: ${{ vars.FORBIDDEN_MARKERS }}
@@ -547,7 +548,6 @@ jobs:
               echo "STUDENT_API_BASE_URL=${STUDENT_API_BASE_URL}"
               echo "SUPER_ADMIN_NYCU_ID=${SUPER_ADMIN_NYCU_ID}"
               echo "NEXT_PUBLIC_NYCU_PORTAL_URL=${NEXT_PUBLIC_NYCU_PORTAL_URL}"
-              [ -n "${SSL_CERT_DIR_VAR}" ] && echo "SSL_CERT_DIR=${SSL_CERT_DIR_VAR}"
             } > "${ENV_FILE}"
             chmod 600 "${ENV_FILE}"
             echo "✅ Wrote $(grep -c '=' "${ENV_FILE}") entries (mode 600)"
@@ -560,44 +560,96 @@ jobs:
           envget() { sed -n "s/^[[:space:]]*$1=//p" "${ENV_FILE}" | tail -1; }
           echo "DOMAIN=$(envget DOMAIN)" >> "$GITHUB_ENV"
 
-          # Certificate location precedence: the SSL_CERT_DIR environment
-          # variable wins in BOTH modes (it describes where the operator put
-          # the certificate on this host, not a secret), then the env file,
-          # then compose's ./nginx/ssl/prod default.
-          CERT_DIR="${SSL_CERT_DIR_VAR:-$(envget SSL_CERT_DIR)}"
-          echo "CERT_DIR=${CERT_DIR}" >> "$GITHUB_ENV"
-          # Export to compose ONLY when non-empty: an exported empty string
-          # would shadow the env file's value instead of deferring to it.
-          if [ -n "${CERT_DIR}" ]; then
-            echo "SSL_CERT_DIR=${CERT_DIR}" >> "$GITHUB_ENV"
-            echo "Certificate directory (SSL_CERT_DIR): ${CERT_DIR}"
-          else
-            echo "Certificate directory: compose default (./nginx/ssl/prod)"
-          fi
-
-      - name: Verify TLS certificates are present
+      # The TLS certificate comes from GitHub Secrets on the stage's
+      # environment, in BOTH ENV_FILE modes — a certificate is not a compose
+      # interpolation value, so it never belongs in .env. The three PEM files
+      # are (re)written on every deploy into <deploy dir>/nginx/ssl/prod, the
+      # directory docker-compose.prod.yml bind-mounts at /etc/nginx/ssl, so a
+      # renewed certificate ships by updating the secrets and redeploying —
+      # nothing has to be copied onto the VM by hand.
+      #
+      # nginx.prod.conf references all three files; a missing one puts nginx
+      # in a crash loop and the deploy would only fail later, at `nginx -t`,
+      # with a far less obvious message — so their presence and shape are
+      # checked here first.
+      - name: Install TLS certificate from secrets
+        env:
+          SSL_FULLCHAIN_PEM: ${{ secrets.SSL_FULLCHAIN_PEM }}
+          SSL_PRIVKEY_PEM: ${{ secrets.SSL_PRIVKEY_PEM }}
+          SSL_CHAIN_PEM: ${{ secrets.SSL_CHAIN_PEM }}
         run: |
-          cd "${DEPLOY_DIR}"
-          CERT_DIR="${CERT_DIR:-./nginx/ssl/prod}"
-          echo "Certificate directory: $CERT_DIR"
-          missing=0
-          # nginx.prod.conf references all three; a missing file puts nginx in
-          # a crash loop and the deploy would only fail later, at `nginx -t`,
-          # with a far less obvious message.
-          for f in fullchain.pem privkey.pem chain.pem; do
-            if [ -f "${CERT_DIR}/${f}" ]; then
-              echo "  ✅ ${f}"
-            else
-              echo "::error::Missing certificate file: ${CERT_DIR}/${f}"
-              missing=1
+          set -euo pipefail
+          CERT_DIR="${DEPLOY_DIR}/nginx/ssl/prod"
+          fail=0
+          err() { echo "::error::$1"; fail=1; }
+
+          # Presence + shape. `printf '%s'` (not echo) so a value that happens
+          # to start with "-n"/"-e" is not mangled, and so nothing is echoed
+          # to the log — the secret masking only protects the exact string.
+          check_pem() {
+            local name="$1" value="$2" pattern="$3"
+            if [ -z "${value}" ]; then
+              err "${name} is not set on the '${STAGE}' environment (paste the PEM file's full contents)"
+            elif ! printf '%s' "${value}" | grep -qE -- "${pattern}"; then
+              err "${name} does not look like a PEM block (expected a '${pattern}' line)"
             fi
-          done
-          [ "$missing" -eq 0 ] || {
-            echo "::error::Place the TLS certificate in ${CERT_DIR}, or set the"
-            echo "::error::SSL_CERT_DIR variable on the '${STAGE}' environment to an absolute"
-            echo "::error::path on this VM (e.g. /home/<user>/ssl) so private keys stay out of git."
+          }
+          check_pem SSL_FULLCHAIN_PEM "${SSL_FULLCHAIN_PEM}" '^-----BEGIN CERTIFICATE-----'
+          check_pem SSL_CHAIN_PEM     "${SSL_CHAIN_PEM}"     '^-----BEGIN CERTIFICATE-----'
+          # PKCS#8 ("BEGIN PRIVATE KEY") and PKCS#1/SEC1 ("BEGIN RSA/EC PRIVATE KEY")
+          check_pem SSL_PRIVKEY_PEM   "${SSL_PRIVKEY_PEM}"   '^-----BEGIN (RSA |EC )?PRIVATE KEY-----'
+          [ "$fail" -eq 0 ] || {
+            echo "::error::Set SSL_FULLCHAIN_PEM, SSL_PRIVKEY_PEM and SSL_CHAIN_PEM as secrets on the"
+            echo "::error::'${STAGE}' environment (see SECRETS-SETUP-GUIDE.md § TLS certificate)."
             exit 1
           }
+
+          # Write atomically-ish: into a temp dir first, then swap, so a failed
+          # write cannot leave nginx with a half-updated pair.
+          TMP_DIR="$(mktemp -d "${DEPLOY_DIR}/.ssl.XXXXXX")"
+          umask 077
+          # A trailing newline is appended in case the pasted secret lost it —
+          # OpenSSL's PEM parser wants the END line terminated.
+          printf '%s\n' "${SSL_FULLCHAIN_PEM}" > "${TMP_DIR}/fullchain.pem"
+          printf '%s\n' "${SSL_PRIVKEY_PEM}"   > "${TMP_DIR}/privkey.pem"
+          printf '%s\n' "${SSL_CHAIN_PEM}"     > "${TMP_DIR}/chain.pem"
+          # Public halves are world-readable (they are public); the key is
+          # 0600. nginx:alpine's master process runs as root and reads the
+          # bind mount fine regardless of the host uid that owns it.
+          chmod 644 "${TMP_DIR}/fullchain.pem" "${TMP_DIR}/chain.pem"
+          chmod 600 "${TMP_DIR}/privkey.pem"
+
+          # Semantic checks, when openssl is on the runner: parseable, the key
+          # matches the certificate, and it is not already expired. A mismatch
+          # here would otherwise surface as `nginx -t` failing after `up`.
+          if command -v openssl >/dev/null 2>&1; then
+            openssl x509 -noout -in "${TMP_DIR}/fullchain.pem" 2>/dev/null \
+              || err "SSL_FULLCHAIN_PEM is not a parseable X.509 certificate"
+            openssl pkey -noout -in "${TMP_DIR}/privkey.pem" 2>/dev/null \
+              || err "SSL_PRIVKEY_PEM is not a parseable private key"
+            if [ "$fail" -eq 0 ]; then
+              cert_pub="$(openssl x509 -noout -pubkey -in "${TMP_DIR}/fullchain.pem" | openssl sha256)"
+              key_pub="$(openssl pkey -pubout -in "${TMP_DIR}/privkey.pem" 2>/dev/null | openssl sha256)"
+              [ "${cert_pub}" = "${key_pub}" ] \
+                || err "SSL_PRIVKEY_PEM does not match SSL_FULLCHAIN_PEM (public keys differ)"
+              openssl x509 -noout -checkend 0 -in "${TMP_DIR}/fullchain.pem" >/dev/null \
+                || err "SSL_FULLCHAIN_PEM has already EXPIRED — renew it before deploying"
+              echo "Certificate: $(openssl x509 -noout -subject -enddate -in "${TMP_DIR}/fullchain.pem" | tr '\n' ' ')"
+            fi
+            [ "$fail" -eq 0 ] || { rm -rf "${TMP_DIR}"; exit 1; }
+          else
+            echo "::warning::openssl not found on this runner — skipping key/cert match check"
+          fi
+
+          umask 022
+          mkdir -p "$(dirname "${CERT_DIR}")"
+          rm -rf "${CERT_DIR}"
+          mv "${TMP_DIR}" "${CERT_DIR}"
+          chmod 755 "${CERT_DIR}"
+          for f in fullchain.pem privkey.pem chain.pem; do
+            echo "  ✅ ${f} ($(stat -c '%a %s bytes' "${CERT_DIR}/${f}"))"
+          done
+          echo "Certificate directory: ${CERT_DIR} → /etc/nginx/ssl"
 
       - name: Start new containers
         run: |

--- a/.github/production-workflows-examples/deploy-test.yml
+++ b/.github/production-workflows-examples/deploy-test.yml
@@ -47,10 +47,12 @@
 #       EXPECT_DOMAIN  = the domain this stage may touch (required)
 #       EXPECT_DB_HOST = the DB host this stage may touch (required)
 #       DEPLOY_URL     = the test site URL (shown on the Environments page)
-#       SSL_CERT_DIR   = optional; absolute path to the TLS certificate
-#                        directory on that VM (e.g. /home/<user>/ssl).
-#                        Defaults to ./nginx/ssl/prod in the deploy directory.
 #       ENV_FILE       = optional; path to an operator-managed .env on that VM.
+#   - Secrets on the `test` environment (MUST be set there — a missing one
+#     would fall back to the production certificate):
+#       SSL_FULLCHAIN_PEM / SSL_PRIVKEY_PEM / SSL_CHAIN_PEM = the test-site
+#                        TLS certificate as PEM text; written to
+#                        <deploy dir>/nginx/ssl/prod on every deploy.
 #   - secrets.GH_PAT with read:packages, if the upstream packages are private.
 #   - docker-compose.prod-db.yml stack already running on the test DB VM.
 

--- a/.github/production-workflows-examples/setting-env.yml
+++ b/.github/production-workflows-examples/setting-env.yml
@@ -1416,19 +1416,14 @@ jobs:
           sudo chown -R 999:999 /opt/scholarship/app/redis
           echo "   ✅ /opt/scholarship/app/redis/data ($(stat -c '%U:%G' /opt/scholarship/app/redis/data))"
 
-          # deploy-stack.yml hard-fails if these are absent, rather than letting
-          # nginx crash-loop on a missing certificate. The repo ships nginx
-          # configs but no keys — drop the certificate here, or set the
-          # SSL_CERT_DIR repository variable to a path outside the deploy dir.
+          # deploy-stack.yml writes fullchain.pem / privkey.pem / chain.pem
+          # here from the SSL_FULLCHAIN_PEM / SSL_PRIVKEY_PEM / SSL_CHAIN_PEM
+          # secrets on every deploy (and hard-fails if they are unset), so
+          # nothing needs to be placed here by hand. Files already present
+          # are simply overwritten by the next deploy.
           echo ""
           echo "🔐 TLS certificate directory: $DEPLOY_DIR/nginx/ssl/prod"
-          for f in fullchain.pem privkey.pem chain.pem; do
-            if [ -f "$DEPLOY_DIR/nginx/ssl/prod/$f" ]; then
-              echo "   ✅ $f"
-            else
-              echo "   ⚠️  missing $f — deployment will fail until it is placed here"
-            fi
-          done
+          echo "   (populated from the SSL_*_PEM secrets by deploy-stack.yml)"
 
           echo "   ✅ Created:"
           find "$DEPLOY_DIR" -maxdepth 2 -type d | sed 's/^/      /'

--- a/.github/production-workflows-examples/stop-stack.yml
+++ b/.github/production-workflows-examples/stop-stack.yml
@@ -173,10 +173,9 @@ jobs:
       # that IDENTIFIES a container is interpolated in docker-compose.prod.yml
       # (container_name is literal, the project name comes from the directory),
       # so a teardown without the env file still matches the right containers —
-      # but it prints a warning per unset variable and resolves path-bearing
-      # values (SSL_CERT_DIR) to their defaults, which is exactly the kind of
-      # noise that makes a stop log unreadable when someone re-reads it during
-      # an incident. Passing the deploy's own env file keeps stop and up
+      # but it prints a warning per unset variable, which is exactly the kind
+      # of noise that makes a stop log unreadable when someone re-reads it
+      # during an incident. Passing the deploy's own env file keeps stop and up
       # symmetric, and gives the target guard below something to check.
       - name: Resolve environment file
         env:

--- a/.github/workflows/mirror-to-production.yml
+++ b/.github/workflows/mirror-to-production.yml
@@ -631,7 +631,16 @@ jobs:
           # caller without it leaves the prod repo with an unresolvable workflow.
           # stop-test.yml / stop-production.yml / stop-stack.yml are the same
           # arrangement for taking a stage OFFLINE, and ship as their own trio.
-          for f in deploy-test.yml deploy-production.yml deploy-stack.yml stop-test.yml stop-production.yml stop-stack.yml health-check.yml backup.yml auto-tag-on-merge.yml setting-env.yml; do
+          # deploy-monitoring-{test,production,stack}.yml is a third trio, for
+          # the observability stack: docker-compose.prod.yml ships only the
+          # COLLECTORS (Alloy + exporters), which push to monitoring_loki /
+          # monitoring_prometheus — Docker DNS names that resolve only once
+          # monitoring/docker-compose.monitoring.yml is up on that same VM. That
+          # compose file is mirrored (see the docker-compose strip step, which
+          # exempts ./monitoring/), but nothing in the prod repo ever started it,
+          # so prod Alloy dropped every batch and nginx's /monitoring proxy had
+          # no upstream. These three workflows are what start it.
+          for f in deploy-test.yml deploy-production.yml deploy-stack.yml stop-test.yml stop-production.yml stop-stack.yml deploy-monitoring-test.yml deploy-monitoring-production.yml deploy-monitoring-stack.yml health-check.yml backup.yml auto-tag-on-merge.yml setting-env.yml; do
             src="/tmp/prod-workflow-templates/$f"
             [ -f "$src" ] || continue
             dest=".github/workflows/$f"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -171,12 +171,11 @@ services:
       - "443:443"
     volumes:
       - ./nginx/nginx.prod.conf:/etc/nginx/nginx.conf:ro
-      # Certificate directory. Defaults to the repo's own nginx/ssl/prod (which
-      # deploy.yml copies into the deploy dir), but can be pointed anywhere on
-      # the AP VM — e.g. SSL_CERT_DIR=/home/<user>/ssl per the install manual —
-      # so private keys never have to live in git. Must contain fullchain.pem,
-      # privkey.pem and chain.pem (nginx.prod.conf references all three).
-      - ${SSL_CERT_DIR:-./nginx/ssl/prod}:/etc/nginx/ssl:ro
+      # Certificate directory. deploy-stack.yml writes fullchain.pem,
+      # privkey.pem and chain.pem here from the GitHub Environment secrets
+      # (SSL_FULLCHAIN_PEM / SSL_PRIVKEY_PEM / SSL_CHAIN_PEM) on every deploy;
+      # nginx.prod.conf references all three. Keys never live in git.
+      - ./nginx/ssl/prod:/etc/nginx/ssl:ro
       - ./logs/nginx:/var/log/nginx
     depends_on:
       - backend

--- a/monitoring/config/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/config/grafana/provisioning/datasources/datasources.yml
@@ -19,8 +19,24 @@ datasources:
       httpMethod: POST
       timeInterval: 15s
       queryTimeout: 60s
-      # Cache settings for better performance
-      cacheLevel: High
+      # cacheLevel rounds the time range of METADATA queries (label and series
+      # lookups — i.e. every dashboard variable dropdown) to a coarse boundary so
+      # repeated lookups hit a cache. At `High` that boundary is one hour, and
+      # the rounded window ENDS at the last boundary rather than at now: on
+      # 2026-08-17 a freshly deployed stack asked for 11:00→12:00 while the clock
+      # said 12:52 and Prometheus had been up for 23 minutes. The response was an
+      # empty list, so every `environment` / `vm` / `instance` dropdown on every
+      # dashboard was empty, panels resolved to `environment=""`, and Loki
+      # rejected the resulting selector outright. The stack looked broken for up
+      # to an hour after each first deploy — exactly when someone is looking at
+      # it to confirm the deploy worked.
+      #
+      # `None` means dropdowns always reflect now. What that costs is a cache hit
+      # on label lookups for a handful of operators, which is nothing; what it
+      # buys is that a correct deployment never looks like a broken one.
+      cacheLevel: 'None'
+      # Unrelated to the above: this one applies to range queries in panels, and
+      # only ever extends an existing series, so it cannot hide fresh data.
       incrementalQuerying: true
       incrementalQueryOverlapWindow: 10m
       # Enable exemplars for tracing (if used in future)

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -171,7 +171,11 @@ services:
       - monitoring_network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q http://localhost:8080/healthz || exit 1"]
+      # 127.0.0.1, NOT localhost: uvicorn binds IPv4 only, while `localhost`
+      # inside this image resolves to ::1 first — so the probe connected to an
+      # address nothing listens on and the container reported `unhealthy`
+      # permanently, while /grafana was in fact serving requests the whole time.
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:8080/healthz || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

**TLS certificate from GitHub Secrets** (`b5b1a9da`)
- Drop the `SSL_CERT_DIR` variable and the operator-placed certificate directory.
- `deploy-stack.yml` gains an **Install TLS certificate from secrets** step: reads `SSL_FULLCHAIN_PEM` / `SSL_PRIVKEY_PEM` / `SSL_CHAIN_PEM` from the stage's GitHub Environment, validates them (present, PEM-shaped, key matches cert, not expired), and writes them to `<deploy dir>/nginx/ssl/prod` (privkey `600`) on every deploy — in **both** `ENV_FILE` modes.
- `docker-compose.prod.yml` mounts that fixed path; renewing a certificate is now "update the secrets, redeploy".
- Docs (`README.md`, `SECRETS-SETUP-GUIDE.md` § TLS certificate) and workflow headers updated; `setting-env.yml` / `stop-stack.yml` comments follow.

**Monitoring stack per stage** (`357d66fc` … `c189482d`)
- `deploy-monitoring-test.yml` / `deploy-monitoring-production.yml` / `deploy-monitoring-stack.yml` templates; dashboards retarget the deployment they run on; datasource/variable fixes.

## Verification (on `anud18/naass-prod-test`)
- Installed the templates on `main` and ran **Deploy to Test** end-to-end on the test AP VM: https://github.com/anud18/naass-prod-test/actions/runs/32222462973 ✅
- Step log shows the cert written from secrets, key/cert match verified, `nginx -t` OK; nginx mounts `~/scholarship-test/nginx/ssl/prod` and serves `CN=*.test.nycu.edu.tw` over HTTPS (200).
- Negative cases (missing secret, mismatched key) fail before `docker compose up`.

## Operator action after merge / mirror
- Set `SSL_FULLCHAIN_PEM`, `SSL_PRIVKEY_PEM`, `SSL_CHAIN_PEM` on **both** environments of the production repo (`gh secret set <NAME> -e <env> < file.pem`). `test` must set its own — otherwise it falls back to the production certificate.
- `SSL_CERT_DIR` variables can be deleted (now ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEisiNve3mjCWoRmsa4zXY