### PR TITLE
Make production deploy, monitoring and Fortify workflows dispatch-only

### DIFF
--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -47,18 +47,18 @@ warning: here-document at line 10 delimited by end-of-file (wanted `FOOTER_EOF')
 | `bootstrap-ap-runner.sh` 🅾️ | **兩台空 VM 的步驟 0** — 把 bare AP VM 變成可跑 action 的 self-hosted runner | 在 AP VM 手動執行一次 | **必要(前置)** |
 | `setting-env.yml` | 在 AP VM 裝 Docker、SSH 到 DB VM 裝 Docker+傳 image、建部署目錄 | runner 就緒後手動觸發 | **必要** |
 | `auto-tag-on-merge.yml` ⭐ | 自動建立 Git tag 和 Release | PR merge 到 main | **必要** |
-| `deploy-test.yml` | 部署 **test AP VM**，需一位 reviewer 核准 | Push to main / 手動觸發 | **必要** |
-| `deploy-production.yml` | 部署 **production AP VM**，需一位 reviewer 核准 | Push to main / 手動觸發 | **必要** |
+| `deploy-test.yml` | 部署 **test AP VM**，需一位 reviewer 核准 | **只能手動觸發**（push to main 不會部署） | **必要** |
+| `deploy-production.yml` | 部署 **production AP VM**，需一位 reviewer 核准 | **只能手動觸發**（push to main 不會部署） | **必要** |
 | `deploy-stack.yml` | 上面兩個 workflow 共用的 reusable workflow（實際的部署腳本本體） | 由兩個 deploy workflow 呼叫，不單獨觸發 | **必要**（三個要一起複製） |
 | `stop-test.yml` | **停掉 test AP VM** 的站台，需一位 reviewer 核准 | 只能手動觸發 | **必要** |
 | `stop-production.yml` | **停掉 production AP VM** 的站台（正式站會離線），需一位 reviewer 核准 | 只能手動觸發 | **必要** |
 | `stop-stack.yml` | 上面兩個 stop workflow 共用的 reusable workflow（實際的停機腳本本體） | 由兩個 stop workflow 呼叫，不單獨觸發 | **必要**（三個要一起複製） |
-| `deploy-monitoring-test.yml` | 在 **test AP VM** 起 Grafana/Loki/Prometheus（監控儀表板本體），需一位 reviewer 核准 | push to main 且動到 `monitoring/**` / 手動觸發 | **必要**（要看儀表板就必裝） |
-| `deploy-monitoring-production.yml` | 在 **production AP VM** 起 Grafana/Loki/Prometheus，需一位 reviewer 核准 | push to main 且動到 `monitoring/**` / 手動觸發 | **必要**（同上） |
+| `deploy-monitoring-test.yml` | 在 **test AP VM** 起 Grafana/Loki/Prometheus（監控儀表板本體），需一位 reviewer 核准 | **只能手動觸發**（同步進 `monitoring/**` 的變更後自己跑） | **必要**（要看儀表板就必裝） |
+| `deploy-monitoring-production.yml` | 在 **production AP VM** 起 Grafana/Loki/Prometheus，需一位 reviewer 核准 | **只能手動觸發**（同上） | **必要**（同上） |
 | `deploy-monitoring-stack.yml` | 上面兩個 monitoring workflow 共用的 reusable workflow（實際的部署腳本本體） | 由兩個 monitoring workflow 呼叫，不單獨觸發 | **必要**（三個要一起複製） |
 | `health-check.yml` | 監控應用程式健康狀態 | 每 15 分鐘 / 手動觸發 | 選用 |
 | `backup.yml` | 備份資料庫和檔案 | 每日 2AM UTC / 手動觸發 | 選用 |
-| `fortify-scan.yml` | Fortify SAST 掃描（Python + JS/TS + config），產出 `.fpr` 與 BIRT PDF 報告。掃描約 2.5 小時且獨佔共用 Fortify runner，故只在 push to main 觸發 | Push to main / 手動觸發 | 選用 |
+| `fortify-scan.yml` | Fortify SAST 掃描（Python + JS/TS + config），產出 `.fpr` 與 BIRT PDF 報告。掃描約 2.5 小時且獨佔共用 Fortify runner，故**只能手動觸發**——要交報告時才跑，不隨 push/PR 啟動 | **只能手動觸發** | 選用 |
 
 ### 🅾️ 步驟 0：bare VM 的 bootstrap（雞生蛋問題）
 
@@ -310,6 +310,9 @@ nginx-exporter、redis-exporter）。Alloy 把資料推到
 
 前置條件與注意事項：
 
+- **只能手動 dispatch**。這兩個 caller 已移除 `push:` 觸發：mirror 同步進
+  `monitoring/**` 的變更後，自己跑 `gh workflow run deploy-monitoring-<stage>.yml`
+  才會重新部署（每次都會重啟 Grafana 約 30 秒，站台不受影響）。
 - **先跑過一次 `deploy-<stage>.yml`**。這組 workflow 需要 `scholarship_prod_network`
   已存在（app stack 建的），最後一步的「透過 nginx 驗證 `/monitoring`」也需要 nginx 在跑。
 - **VM 上需要免密碼 sudo**，或事先把 `/opt/scholarship/monitoring` 與
@@ -417,6 +420,7 @@ runner 使用者需要 passwordless sudo（deploy-stack.yml 與 backup.yml 都�
 ### Deploy Workflow
 
 - [ ] `deploy-test.yml`、`deploy-production.yml`、`deploy-stack.yml` 三個都已複製到 prod repo
+- [ ] 已知道 deploy **只能手動 dispatch**：merge 到 main 不會部署，release 要自己跑 `gh workflow run deploy-<stage>.yml -f tag=<tag>`
 - [ ] test AP VM 的 runner labels 含 `test`；production AP VM 含 `production`
 - [ ] GitHub Environments `test` 與 `production` 都已建立
 - [ ] 兩個 environment 都設了 **Required reviewers（1 人）**
@@ -432,7 +436,7 @@ runner 使用者需要 passwordless sudo（deploy-stack.yml 與 backup.yml 都�
 - [ ] `stop-test.yml`、`stop-production.yml`、`stop-stack.yml` 三個都已複製到 prod repo
 - [ ] 兩個 environment 的 **Required reviewers** 已設定（stop 與 deploy 共用同一道關卡）
 - [ ] 已知道恢復方式：`gh workflow run deploy-<stage>.yml -f tag=<tag>`
-- [ ] 已知道 stop **不會**阻止下一次 push to main 把站台開回來（需要持續離線時另外擋 merge / disable deploy workflow）
+- [ ] 已知道 stop **不會**阻止任何人 dispatch deploy 把站台開回來（push to main 本身已不會部署；需要持續離線時，在 Actions 頁把該 stage 的 deploy workflow disable 掉）
 
 ### Health Check Workflow
 
@@ -453,6 +457,10 @@ runner 使用者需要 passwordless sudo（deploy-stack.yml 與 backup.yml 都�
 
 ### 手動測試部署
 
+> ⚠️ **部署只能手動 dispatch**：`deploy-test.yml` / `deploy-production.yml` 都
+> 已移除 `push:` 觸發，merge 到 main（含 mirror 同步的 release PR）**不會**部署
+> 任何東西。要上線就自己跑下面的指令。
+
 ```bash
 # In production repo；建議帶明確 tag，兩個 workflow 才會部署到同一份 image
 gh workflow run deploy-test.yml -f tag=v1.2.3
@@ -465,16 +473,20 @@ gh run watch
 gh run view --log
 ```
 
-兩個 workflow 各自獨立：push to main 會同時觸發，各自停在自己 environment 的
+`tag` 留空會部署 GHCR 上當下的 `latest`，兩次 dispatch 各自解析、可能拿到不同
+image；要可重現就一定帶明確 tag。
+
+兩個 workflow 各自獨立：各自 dispatch、各自停在自己 environment 的
 "Review deployments" 等核准，reviewer 按下 **Approve and deploy** 才會跑到對應
 的 AP VM。
 
 **沒有誰否決誰**：test 失敗不會擋下 production，production 卡在核准也不會擋下
-test。順序完全由人決定 —— reviewer 可以先放行 test、看完結果再回來核准
-production，要停就按 Reject。
+test。順序完全由人決定 —— 先放行 test、看完結果再 dispatch production，要停就
+按 Reject 或乾脆不 dispatch。
 
-> ⚠️ `production` environment 的 required reviewer 是唯一擋在 push to main 與
-> 正式機之間的關卡（不再有前置的 test 階段），上線前務必先設好。
+> ⚠️ 現在擋在 merge 與正式機之間的有兩道，兩道都是人：① 有人手動 dispatch
+> `deploy-production.yml`；② `production` environment 的 required reviewer（不再
+> 有前置的 test 階段）。上線前務必先把 reviewer 設好。
 
 ### 停止站台（stop-test.yml / stop-production.yml）
 
@@ -499,10 +511,10 @@ gh workflow run stop-production.yml -f confirm=production -f mode=stop -f reason
 | 恢復 | `gh workflow run deploy-<stage>.yml -f tag=<tag>`，會照常跑 migration + health + smoke checks |
 
 > ⚠️ **stop 不等於 hold。** 這兩個 workflow 只是把「當下正在跑的」關掉，不會在
-> VM 上留下任何標記；`deploy-test.yml` / `deploy-production.yml` 仍然是 push to
-> main 觸發的，所以**下一次 merge 就會把站台重新部署開回來**。若該 stage 必須
-> 持續離線（維護時段、incident 處理中），就用擋 merge，或到 Actions 頁面暫時
-> disable 對應的 deploy workflow。
+> VM 上留下任何標記。merge 到 main 已經不會自動把站台開回來（deploy 已改成
+> 只能手動 dispatch），但**任何人 dispatch 一次 deploy 就會開回來**。若該 stage
+> 必須持續離線（維護時段、incident 處理中），除了公告之外，請到 Actions 頁面把
+> 對應的 deploy workflow 暫時 disable 掉。
 
 ### 測試健康檢查
 
@@ -602,7 +614,7 @@ for f in deploy-test.yml deploy-production.yml deploy-stack.yml; do
 done
 
 # 舊版單一檔 deploy.yml 已拆成上面兩個 caller —— prod repo 若還留著它，
-# 刪掉，否則 push to main 會多跑一條舊的 promotion。
+# 刪掉，否則它自己的 push to main 觸發還會多跑一條舊的 promotion。
 git rm -f .github/workflows/deploy.yml 2>/dev/null || true
 
 # Commit

--- a/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
+++ b/.github/production-workflows-examples/SECRETS-SETUP-GUIDE.md
@@ -35,16 +35,17 @@ The `setting-env.yml` workflow now **focuses on system prerequisites and Docker 
 
 ## Environments：兩個部署 workflow 與核准閘門
 
-部署拆成**兩個各自獨立的 workflow**，觸發條件相同（push to main）：
+部署拆成**兩個各自獨立的 workflow**，而且**都只能手動 dispatch**——兩者皆已移除
+`push:` 觸發，merge 到 main（含 mirror 同步的 release PR）不會部署任何東西：
 
 ```
-push to main ─┬─▶ deploy-test.yml ──────▶ deploy-stack.yml (stage: test)
-              │                            resolve-images ──▶ deploy
-              │                            (ubuntu-latest)    runner: [self-hosted, linux, test]
-              │                                               environment: test
-              │                                               🔒 需 1 位 reviewer 核准
-              │
-              └─▶ deploy-production.yml ▶ deploy-stack.yml (stage: production)
+gh workflow run deploy-test.yml ────────▶ deploy-stack.yml (stage: test)
+                                           resolve-images ──▶ deploy
+                                           (ubuntu-latest)    runner: [self-hosted, linux, test]
+                                                              environment: test
+                                                              🔒 需 1 位 reviewer 核准
+
+gh workflow run deploy-production.yml ──▶ deploy-stack.yml (stage: production)
                                            resolve-images ──▶ deploy
                                            (ubuntu-latest)    runner: [self-hosted, linux, production]
                                                               environment: production
@@ -54,16 +55,16 @@ push to main ─┬─▶ deploy-test.yml ──────▶ deploy-stack.yml
 - 兩者**互不等待、互不否決**：test 失敗不會擋下 production，production 卡在核准
   也不會擋下 test。test tier 有它自己會壞的理由（它的 DB、憑證、portal），那些
   不該卡住 production 的 hotfix。
-- **順序由人決定**：production 的 reviewer 在 Actions 頁面看得到同一個 push
-  觸發的 test run，可以先看結果再決定核准或 Reject。
+- **順序由人決定**：先 dispatch test、在 Actions 頁面看完結果，再決定要不要
+  dispatch production（或在核准頁按 Reject）。
 - 唯一會自動否決的是各自的 `resolve-images` —— 沒解析出 tag 就沒東西可部署。
 - 兩者共用同一份腳本（`deploy-stack.yml`），差別只有 **runner label** 與
   **GitHub Environment**。test 因此是 production 的彩排，不是另一套流程。
-- ⚠️ 因為 production 前面不再有 test 階段擋著，`production` environment 的
-  required reviewer 就是 push to main 與正式機之間**唯一**的關卡。
+- ⚠️ 擋在 merge 與正式機之間的有兩道，兩道都是人：**有人手動 dispatch** 與
+  `production` environment 的 **required reviewer**。前面不再有 test 階段自動擋著。
 
-> `latest`（不帶 tag 觸發）時兩個 workflow 各自解析一次，中間 tag 可能移動 ——
-> 要讓 test 真的能當 production 的證據，就用 `-f tag=<明確 tag>` 手動觸發兩者。
+> `tag` 留空時兩次 dispatch 各自解析一次 `latest`，中間 tag 可能移動 ——
+> 要讓 test 真的能當 production 的證據，兩邊都用 `-f tag=<明確 tag>`。
 
 ### 1. 建立兩個 Environment 並設定 reviewer（核准閘門）
 

--- a/.github/production-workflows-examples/deploy-monitoring-production.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-production.yml
@@ -22,10 +22,12 @@
 #
 # The `environment:` key alone gates nothing. See SECRETS-SETUP-GUIDE.md.
 #
-# The push trigger is narrow on purpose: monitoring has no image to promote, so
-# a redeploy is only warranted when the mirrored commit actually changed
-# monitoring content. Every run costs a ~30 s Grafana restart (the site is never
-# touched).
+# MANUAL DISPATCH ONLY. Nothing here fires on a push: monitoring has no image to
+# promote, so a redeploy is only warranted once someone has mirrored a change to
+# monitoring content and decided to ship it. Every run costs a ~30 s Grafana
+# restart (the site is never touched):
+#
+#   gh workflow run deploy-monitoring-production.yml
 #
 # Prerequisites: those deploy-production.yml already needs, plus the
 # `production` environment secrets GRAFANA_ADMIN_USER / GRAFANA_ADMIN_PASSWORD.
@@ -35,14 +37,9 @@
 name: Deploy Monitoring to Production
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'monitoring/**'
-      - 'docker-compose.prod.yml'
-      - '.github/workflows/deploy-monitoring-production.yml'
-      - '.github/workflows/deploy-monitoring-stack.yml'
+  # Dispatch only — see the header. Redeploy after a mirror sync brought in a
+  # change to monitoring/**, docker-compose.prod.yml, or either of these two
+  # workflow files.
   workflow_dispatch:
     inputs:
       reset_grafana_volume:

--- a/.github/production-workflows-examples/deploy-monitoring-stack.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-stack.yml
@@ -22,9 +22,9 @@
 # webhook-bridge — on the AP VM and attaches them to scholarship_prod_network.
 #
 # It is deliberately NOT part of deploy-stack.yml:
-#   - The app stack is redeployed on every push to main; the monitoring stack
-#     changes only when monitoring/** changes, and restarting Grafana on every
-#     app deploy would drop ~30 s of dashboards for no reason.
+#   - The app stack is redeployed on every release dispatch; the monitoring
+#     stack changes only when monitoring/** changes, and restarting Grafana on
+#     every app deploy would drop ~30 s of dashboards for no reason.
 #   - Grafana holds STATE the app stack does not (grafana_data: manually saved
 #     dashboards, annotations, alert silences). It must be possible to redeploy
 #     the site without touching it — and to redeploy monitoring without

--- a/.github/production-workflows-examples/deploy-monitoring-test.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-test.yml
@@ -9,12 +9,14 @@
 #   deploy-test.yml             ──▶ the site        (app + collectors)
 #   deploy-monitoring-test.yml  ──▶ the dashboard   (Grafana/Loki/Prometheus)
 #
-# WHY THE TRIGGERS DIFFER FROM deploy-test.yml
-# --------------------------------------------
-# The app stack redeploys on every push to main. The monitoring stack has no
-# image to promote — it changes only when monitoring/** changes — and every
-# deploy costs a ~30 s Grafana restart. So this fires on a push ONLY when the
-# mirrored commit actually touched monitoring content, plus on manual dispatch.
+# MANUAL DISPATCH ONLY
+# --------------------
+# Nothing here fires on a push. The monitoring stack has no image to promote —
+# it changes only when monitoring/** changes — and every deploy costs a ~30 s
+# Grafana restart, so a redeploy is a decision someone makes after mirroring
+# monitoring content, not something a sync triggers:
+#
+#   gh workflow run deploy-monitoring-test.yml
 #
 # It still passes through the `test` environment's approval gate, because the
 # monitoring stack holds the credentials to a dashboard published on the public
@@ -31,17 +33,11 @@
 name: Deploy Monitoring to Test
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      # Everything the stack is built from. docker-compose.prod.yml is included
-      # because it owns the Alloy collector and the app network the monitoring
-      # containers attach to — a change there can require re-attaching them.
-      - 'monitoring/**'
-      - 'docker-compose.prod.yml'
-      - '.github/workflows/deploy-monitoring-test.yml'
-      - '.github/workflows/deploy-monitoring-stack.yml'
+  # Dispatch only — see the header. Redeploy after a mirror sync brought in a
+  # change to any of the files the stack is built from:
+  #   monitoring/**, docker-compose.prod.yml (it owns the Alloy collector and
+  #   the app network the monitoring containers attach to), and these two
+  #   workflow files.
   workflow_dispatch:
     inputs:
       reset_grafana_volume:
@@ -52,9 +48,8 @@ on:
 
 concurrency:
   # Scoped to test monitoring alone. NOT shared with deploy-test: a run waiting
-  # at the approval gate holds its group, and every merge to main leaves one
-  # pending — sharing would make a monitoring fix wait for an unrelated app
-  # deploy to be reviewed.
+  # at the approval gate holds its group, so sharing would make a monitoring fix
+  # wait for an unrelated app deploy to be reviewed first.
   group: deploy-monitoring-test
   cancel-in-progress: false
 

--- a/.github/production-workflows-examples/deploy-production.yml
+++ b/.github/production-workflows-examples/deploy-production.yml
@@ -3,42 +3,42 @@
 # .github/workflows/deploy-production.yml (it calls deploy-stack.yml, which
 # must be copied alongside it).
 #
-# ONE STAGE PER WORKFLOW
-# ----------------------
+# ONE STAGE PER WORKFLOW, MANUAL DISPATCH ONLY
+# -------------------------------------------
 # This workflow deploys the PRODUCTION AP VM. Its sibling, deploy-test.yml,
-# deploys the test one. Both fire on the SAME trigger — a push to main — and
-# run INDEPENDENTLY: neither waits on nor vetoes the other.
+# deploys the test one. Neither has a `push:` trigger: a merge to main deploys
+# NOTHING by itself. Each tier is released by dispatching its own workflow, and
+# the two run INDEPENDENTLY — neither waits on nor vetoes the other.
 #
-#   push to main ─┬─▶ deploy-test.yml        → [self-hosted, linux, test]
-#                 │                            environment: test        🔒 1 approval
-#                 └─▶ deploy-production.yml  → [self-hosted, linux, production]
-#                                              environment: production  🔒 1 approval
+#   gh workflow run deploy-test.yml       → [self-hosted, linux, test]
+#                                           environment: test        🔒 1 approval
+#   gh workflow run deploy-production.yml → [self-hosted, linux, production]
+#                                           environment: production  🔒 1 approval
 #
 # Splitting them is deliberate. A red test tier says nothing about production
 # (its own DB, certificate or portal can fail on their own) and must not be
-# able to hold a hotfix hostage. What sequences the two is the human at this
-# workflow's approval gate: the test run is already visible in the Actions tab
-# when they decide, so they can read it and then approve — or reject and stop
-# the promotion here.
+# able to hold a hotfix hostage. What sequences the two is the human who
+# dispatches them: the test run is already visible in the Actions tab when they
+# decide, so they can read it and then dispatch production — or not.
 #
-# ⚠️  THE GATE IS THE ONLY THING BETWEEN A PUSH AND PRODUCTION. Because this
-# workflow no longer sits behind the test stage, the required reviewer on the
-# `production` environment is not a convenience — it is the control. Configure
-# it BEFORE this file goes live:
+# ⚠️  TWO THINGS STAND BETWEEN A MERGE AND PRODUCTION, and both are human. The
+# first is the dispatch itself — nothing here fires on a push, so a mirror sync
+# can no longer reach this VM on its own. The second is the required reviewer on
+# the `production` environment, which still gates the run once dispatched.
+# Configure it BEFORE this file goes live:
 #
 #   Settings → Environments → `production` → Required reviewers: 1 person
 #
 # The gate is a GitHub *Environment protection rule*, not YAML; without that
-# configuration this job runs unattended on every push to main — the
-# `environment:` key alone gates nothing. See SECRETS-SETUP-GUIDE.md
-# § Environments.
+# configuration a dispatched job runs unattended — the `environment:` key alone
+# gates nothing. See SECRETS-SETUP-GUIDE.md § Environments.
 #
 # This repository does NOT build images. The development repository's pipeline
 # publishes them to GHCR once; both workflows promote that exact artifact, so
 # what runs in production is bit-identical to what the test stage verified —
-# provided both were given the same explicit tag. With the default `latest`,
-# the two workflows resolve independently and can land on different images:
-# dispatch manually with a pinned tag whenever that matters.
+# provided both were given the same explicit tag. With `tag` left empty, the two
+# dispatches resolve `latest` independently and can land on different images:
+# pass a pinned tag whenever that matters.
 #
 # Prerequisites (one-time, see SECRETS-SETUP-GUIDE.md):
 #   - A self-hosted runner on the production AP VM, labelled
@@ -71,12 +71,10 @@
 name: Deploy to Production
 
 on:
-  # NOTE: a code push alone does not produce a new image here — pushing to main
-  # deploys whatever the upstream `latest` tag currently points at. For a
-  # reproducible release, dispatch manually with an explicit tag.
-  push:
-    branches:
-      - main
+  # Dispatch only. This repository builds no image — the deploy promotes an
+  # artifact the development repository already published to GHCR, so leaving
+  # `tag` empty deploys whatever `latest` points at RIGHT NOW. For a
+  # reproducible release, always pass the explicit tag the test stage verified.
   workflow_dispatch:
     inputs:
       tag:
@@ -86,8 +84,8 @@ on:
 
 concurrency:
   # Scoped to the production stage ONLY, so the test rehearsal never blocks a
-  # production deploy (and vice versa). Two overlapping production runs would
-  # race to deploy different tags onto one VM.
+  # production deploy (and vice versa). Two overlapping production dispatches
+  # would race to deploy different tags onto one VM.
   group: deploy-production
   cancel-in-progress: false
 

--- a/.github/production-workflows-examples/deploy-stack.yml
+++ b/.github/production-workflows-examples/deploy-stack.yml
@@ -2,8 +2,8 @@
 # Copy this file to the PRIVATE production repository at
 # .github/workflows/deploy-stack.yml.
 #
-# ONE definition, TWO callers. Each stage is its own workflow, and both fire on
-# the same trigger (push to main):
+# ONE definition, TWO callers. Each stage is its own workflow, and both are
+# started by MANUAL DISPATCH — nothing deploys on a push to main:
 #
 #     deploy-test.yml ────────▶ this file (stage: test)
 #                               resolve-images ──▶ deploy
@@ -20,8 +20,8 @@
 # The two workflows are INDEPENDENT: neither waits on nor vetoes the other.
 # That is deliberate — the test tier has its own ways to fail (its DB down, its
 # certificate expired, its portal unreachable) and none of those should hold a
-# production hotfix hostage. What sequences them is the human at each approval
-# gate, who can read the test run before approving production.
+# production hotfix hostage. What sequences them is the human who dispatches
+# them and approves at each gate, having read the test run first.
 #
 # The stage is selected entirely by inputs, so the two runs are bit-identical
 # in behaviour and differ ONLY in (a) which runner they land on and (b) which

--- a/.github/production-workflows-examples/deploy-test.yml
+++ b/.github/production-workflows-examples/deploy-test.yml
@@ -3,23 +3,29 @@
 # .github/workflows/deploy-test.yml (it calls deploy-stack.yml, which must be
 # copied alongside it).
 #
-# ONE STAGE PER WORKFLOW
-# ----------------------
+# ONE STAGE PER WORKFLOW, MANUAL DISPATCH ONLY
+# -------------------------------------------
 # This workflow deploys the TEST AP VM. Its sibling, deploy-production.yml,
-# deploys the production one. Both fire on the SAME trigger — a push to main —
-# and run INDEPENDENTLY: neither waits on nor vetoes the other.
+# deploys the production one. Neither has a `push:` trigger: a merge to main
+# deploys NOTHING by itself. Each tier is released by dispatching its own
+# workflow, and the two run INDEPENDENTLY — neither waits on nor vetoes the
+# other.
 #
-#   push to main ─┬─▶ deploy-test.yml        → [self-hosted, linux, test]
-#                 │                            environment: test        🔒 1 approval
-#                 └─▶ deploy-production.yml  → [self-hosted, linux, production]
-#                                              environment: production  🔒 1 approval
+#   gh workflow run deploy-test.yml       → [self-hosted, linux, test]
+#                                           environment: test        🔒 1 approval
+#   gh workflow run deploy-production.yml → [self-hosted, linux, production]
+#                                           environment: production  🔒 1 approval
 #
 # Splitting them is deliberate. A red test tier says nothing about production
 # (its own DB, certificate or portal can fail on their own) and must not be
 # able to hold a hotfix hostage; conversely a production deploy that is being
 # held at its gate must not stall the test rehearsal. What sequences the two is
-# the human at each approval gate, who can read the test run before approving
-# production — not a machine deciding for them.
+# the human who dispatches them and approves at each gate — they can read the
+# test run before dispatching production, rather than a machine deciding.
+#
+# Dropping the push trigger also removes the last way a mirror sync could reach
+# a VM on its own: mirroring updates main, and nothing more happens until
+# someone dispatches a deploy.
 #
 # The approval gate is a GitHub *Environment protection rule*, not YAML. It has
 # to be configured once, in the production repository:
@@ -59,12 +65,10 @@
 name: Deploy to Test
 
 on:
-  # NOTE: a code push alone does not produce a new image here — pushing to main
-  # deploys whatever the upstream `latest` tag currently points at. For a
-  # reproducible release, dispatch manually with an explicit tag.
-  push:
-    branches:
-      - main
+  # Dispatch only. This repository builds no image — the deploy promotes an
+  # artifact the development repository already published to GHCR, so leaving
+  # `tag` empty deploys whatever `latest` points at RIGHT NOW. For a
+  # reproducible release, always pass the explicit tag.
   workflow_dispatch:
     inputs:
       tag:
@@ -75,7 +79,7 @@ on:
 concurrency:
   # Scoped to the test stage ONLY, so a production deploy queued behind its
   # approval gate never blocks the test rehearsal (and vice versa). Two
-  # overlapping test runs would race to deploy different tags onto one VM.
+  # overlapping test dispatches would race to deploy different tags onto one VM.
   group: deploy-test
   cancel-in-progress: false
 

--- a/.github/production-workflows-examples/fortify-scan.yml
+++ b/.github/production-workflows-examples/fortify-scan.yml
@@ -28,8 +28,13 @@
 #
 # Runtime: translation takes ~5 minutes, but the -scan dataflow analysis takes
 # ~2.5 hours on this codebase and holds the shared org Fortify runner for the
-# duration. That is why this runs on pushes to main only -- a pull_request
-# trigger would spend 2.5 hours of the shared runner on every mirrored sync PR.
+# duration. That is why this is MANUAL DISPATCH ONLY: neither a push to main nor
+# a pull_request may start it. Every mirrored sync would otherwise spend 2.5
+# hours of the shared runner on a release nobody asked to scan -- the scan is
+# tied to a release decision, not to a commit, so a human starts it.
+#
+#   gh workflow run fortify-scan.yml            # scans the current main
+#   gh workflow run fortify-scan.yml --ref <branch|tag>
 #
 # Requires the self-hosted Windows Fortify runner (sourceanalyzer and
 # BIRTReportGenerator on PATH).
@@ -41,8 +46,9 @@ permissions:
   actions: read
 
 on:
-  push:
-    branches: ["main"]
+  # Dispatch only -- see the runtime note above. The ref chosen at dispatch time
+  # is what gets scanned; the artifact name is suffixed `main` regardless, since
+  # that is the branch a release is cut from.
   workflow_dispatch:
 
 jobs:

--- a/.github/production-workflows-examples/stop-production.yml
+++ b/.github/production-workflows-examples/stop-production.yml
@@ -13,11 +13,12 @@
 # the test one. There is no combined "stop everything" entry point on purpose:
 # a single dispatch must never be able to take both tiers down.
 #
-#   deploy-production.yml  ──▶ starts production  (push to main / dispatch)
+#   deploy-production.yml  ──▶ starts production  (dispatch ONLY)
 #   stop-production.yml    ──▶ stops  production  (dispatch ONLY)
 #
 # MANUAL DISPATCH ONLY. Nothing about a code push implies the site should go
-# offline, so there is no `push:` trigger here.
+# offline, so there is no `push:` trigger here — as of the dispatch-only
+# release flow, its sibling has none either.
 #
 # Two things gate this run, and both are deliberate:
 #   1. `confirm` — you must type `production`. workflow_dispatch remembers the
@@ -31,10 +32,11 @@
 #      § Environments.
 #
 # ⚠️  A STOP IS NOT A HOLD. This run stops what is currently up and leaves no
-# marker behind, so the NEXT PUSH TO MAIN redeploys and restarts production —
-# possibly mid-incident, before anyone decided it was safe. If production has
-# to stay down, hold the merges or disable deploy-production.yml in the Actions
-# tab for that window. To restore service deliberately:
+# marker behind. Merging to main no longer restarts production by itself, but
+# ANY DISPATCH OF deploy-production.yml does — possibly mid-incident, before
+# anyone decided it was safe. If production has to stay down, say so where the
+# operators look, and disable deploy-production.yml in the Actions tab for that
+# window. To restore service deliberately:
 #
 #   gh workflow run deploy-production.yml -f tag=v1.2.3
 #

--- a/.github/production-workflows-examples/stop-stack.yml
+++ b/.github/production-workflows-examples/stop-stack.yml
@@ -29,12 +29,13 @@
 # exactly the blast radius we want. Nothing here touches the database.
 #
 # A STOP IS NOT A HOLD. This workflow stops what is running right now, and
-# nothing more — it leaves no marker behind. deploy-test.yml and
-# deploy-production.yml still fire on every push to main, so the next merge
-# redeploys and restarts the stage. If the stage has to STAY down (a
-# maintenance window, an incident), keep it down the same way you would keep
-# any deploy from landing: hold the merge, or disable the deploy workflow in
-# the Actions tab for as long as it needs to stay off.
+# nothing more — it leaves no marker behind. Nothing restarts the stage on its
+# own (deploy-test.yml and deploy-production.yml are dispatch-only, so a merge
+# to main no longer redeploys), but equally nothing prevents someone from
+# dispatching a deploy during the window and bringing the stage straight back
+# up. If the stage has to STAY down (a maintenance window, an incident), say so
+# where the operators look — and, for a hard stop, disable the stage's deploy
+# workflow in the Actions tab for as long as it needs to stay off.
 #
 # Prerequisites — the same ones deploy-stack.yml already requires:
 #   - A self-hosted runner on the stage's AP VM, labelled
@@ -342,5 +343,5 @@ jobs:
             echo ""
             echo "It redeploys and verifies with the usual health and smoke checks."
             echo ""
-            echo "> ⚠️ Nothing holds ${STAGE} down: the next push to main redeploys and restarts it."
+            echo "> ⚠️ Nothing holds ${STAGE} down: a deploy dispatch restarts it at any time."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/production-workflows-examples/stop-test.yml
+++ b/.github/production-workflows-examples/stop-test.yml
@@ -8,11 +8,12 @@
 # production one. There is no combined "stop everything" entry point on
 # purpose: a single dispatch must never be able to take both tiers down.
 #
-#   deploy-test.yml  ──▶ starts the test stack   (push to main / dispatch)
+#   deploy-test.yml  ──▶ starts the test stack   (dispatch ONLY)
 #   stop-test.yml    ──▶ stops  the test stack   (dispatch ONLY)
 #
 # MANUAL DISPATCH ONLY. Nothing about a code push implies the site should go
-# offline, so there is no `push:` trigger here.
+# offline, so there is no `push:` trigger here — as of the dispatch-only release
+# flow, its sibling has none either.
 #
 # Two things gate this run, and both are deliberate:
 #   1. `confirm` — you must type `test`. workflow_dispatch remembers the last
@@ -25,9 +26,9 @@
 #      this runs unattended. See SECRETS-SETUP-GUIDE.md § Environments.
 #
 # A STOP IS NOT A HOLD. It stops what is running now and leaves no marker
-# behind, so the next push to main redeploys and restarts test. If it has to
-# stay down, hold the merge or disable deploy-test.yml in the Actions tab for
-# that window. To bring test back immediately:
+# behind: merging to main no longer restarts test, but any dispatch of
+# deploy-test.yml does. If it has to stay down, disable deploy-test.yml in the
+# Actions tab for that window. To bring test back immediately:
 #
 #   gh workflow run deploy-test.yml [-f tag=v1.2.3]
 #

--- a/.github/workflows/mirror-to-production.yml
+++ b/.github/workflows/mirror-to-production.yml
@@ -1106,6 +1106,16 @@ jobs:
           1. Review the Pull Request in the production repository
           2. Merge the PR (using squash merge) when ready to deploy
           3. **The version tag will be created automatically** after PR merge (requires auto-tag workflow in production repo)
+          4. **Merging deploys nothing.** The production repo's deploy workflows are
+             dispatch-only — run them yourself, in this order, approving at each
+             environment gate:
+             \`\`\`bash
+             gh workflow run deploy-test.yml       -f tag=<image tag>
+             gh workflow run deploy-production.yml -f tag=<same tag>
+             # only when monitoring/** changed in this sync:
+             gh workflow run deploy-monitoring-test.yml
+             gh workflow run deploy-monitoring-production.yml
+             \`\`\`
 
           ## 🏷️ Auto-Tagging Information
 


### PR DESCRIPTION
The production repo's release path fired on push to main: deploy-test.yml,
deploy-production.yml and (path-filtered) both monitoring callers all deployed
whenever a mirror sync landed, and fortify-scan.yml burned ~2.5 h of the shared
org Fortify runner on the same trigger.

Remove the push triggers so nothing in the production repo starts on a merge:

- deploy-test.yml / deploy-production.yml: workflow_dispatch only. A release is
  now two human acts per tier — the dispatch, then the environment reviewer.
- deploy-monitoring-test.yml / deploy-monitoring-production.yml: workflow_dispatch
  only; the paths filter becomes a note on when a redeploy is warranted.
- fortify-scan.yml: workflow_dispatch only, so the shared Fortify runner is held
  only when someone actually wants the report.

Approval gates are unchanged — the test/production environments keep their
required reviewers, and stop/setting-env still pass through the same gate.

Docs and cross-references updated to match: the reusable stack headers, both
stop workflows (a stop is still not a hold — a dispatch restores the stage),
README (workflow table, deploy/stop/monitoring sections, checklists),
SECRETS-SETUP-GUIDE architecture diagram, and the mirror workflow's run summary,
which now spells out the dispatch commands a release needs after the PR merges.

Note: fortify-scan.yml is not in the mirror's workflow-template sync list, so the
production repo's copy has to be updated by hand.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TzxiiTzrWWGKHChyi2YksY