### PR TITLE
chore: add pw-in-pr command

### DIFF
--- a/.claude/commands/pw-in-pr.md
+++ b/.claude/commands/pw-in-pr.md
@@ -1,0 +1,5 @@
+---
+description: Use a subagent to Playwright-test your modification and attach results to the PR
+---
+
+use subagent to playwright your modification and attach in pr


### PR DESCRIPTION
## Summary
- Adds the `/pw-in-pr` slash command (previously only in the user's global `~/.claude/commands`) to the project's `.claude/commands/`, matching how `change-dev-env-worktree` and `init-dev-env` were added.
- Spawns a subagent to Playwright-test a modification and attach the results to the PR.

## Test plan
- [ ] Run `/pw-in-pr` in a session with a pending change and confirm it spawns a subagent and posts Playwright results to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)