### PR TITLE
fix(ui): rename system branding to PhD Scholarship System

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,9 +9,9 @@ import { getNonce } from "./NonceProvider";
 import { CspNonceProvider } from "@/components/providers/csp-nonce";
 
 export const metadata: Metadata = {
-  title: "獎學金申請與審核系統 | 國立陽明交通大學教務處",
+  title: "博士生獎學金申請暨審核系統 | 國立陽明交通大學教務處",
   description:
-    "國立陽明交通大學獎學金申請與審核系統，提供學生獎學金申請、教師推薦、行政審核等完整流程管理",
+    "國立陽明交通大學博士生獎學金申請暨審核系統，提供學生獎學金申請、教師推薦、行政審核等完整流程管理",
   keywords: "獎學金, 申請, 審核, 陽明交通大學, NYCU, 教務處",
   authors: [{ name: "國立陽明交通大學教務處" }],
   robots: "noindex, nofollow", // 系統內部使用

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -438,12 +438,12 @@ export default function ScholarshipManagementSystem() {
               <h1 className="text-4xl font-bold tracking-tight text-nycu-navy-800">
                 {user.role === "student"
                   ? t("system.title")
-                  : "獎學金申請與審核系統"}
+                  : "博士生獎學金申請暨審核系統"}
               </h1>
               <p className="text-lg text-nycu-navy-600 mt-1">
                 {user.role === "student"
                   ? t("system.subtitle")
-                  : "NYCU Admissions Scholarship System"}
+                  : "NYCU PhD Scholarship System"}
               </p>
               <p className="text-sm text-nycu-blue-600 font-medium mt-1">
                 國立陽明交通大學教務處 | NYCU Office of Academic Affairs

--- a/frontend/components/admin-dashboard.tsx
+++ b/frontend/components/admin-dashboard.tsx
@@ -96,7 +96,7 @@ export function AdminDashboard({
           <div>
             <h2 className="text-2xl font-bold mb-2">獎學金管理系統儀表板</h2>
             <p className="text-white/90">
-              歡迎使用陽明交通大學獎學金申請與審核系統，提升獎學金作業效率與透明度
+              歡迎使用陽明交通大學博士生獎學金申請暨審核系統，提升獎學金作業效率與透明度
             </p>
           </div>
         </div>

--- a/frontend/components/admin-management-interface.tsx
+++ b/frontend/components/admin-management-interface.tsx
@@ -3817,7 +3817,7 @@ export function AdminManagementInterface({
                                     <p className="mt-1">
                                       國立陽明交通大學教務處
                                     </p>
-                                    <p>獎學金申請與審核系統</p>
+                                    <p>博士生獎學金申請暨審核系統</p>
                                   </div>
                                 </div>
                               </div>

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -85,8 +85,8 @@ export function Footer({ locale = "zh" }: FooterProps) {
                   </p>
                   <p className="text-nycu-navy-600 text-sm">
                     {locale === "zh"
-                      ? "獎學金申請與審核系統"
-                      : "NYCU Admissions Scholarship System"}
+                      ? "博士生獎學金申請暨審核系統"
+                      : "NYCU PhD Scholarship System"}
                   </p>
                   <p className="text-nycu-navy-500 text-xs font-medium">
                     {locale === "zh" ? "版本 v1.0.0" : "Version v1.0.0"}

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -88,13 +88,13 @@ export function Header({
             <div className="hidden md:block border-l border-nycu-blue-200 pl-6">
               <h1 className="font-semibold text-lg text-nycu-navy-800">
                 {locale === "zh"
-                  ? "獎學金申請與審核系統"
-                  : "NYCU Admissions Scholarship System"}
+                  ? "博士生獎學金申請暨審核系統"
+                  : "NYCU PhD Scholarship System"}
               </h1>
               <p className="text-sm text-nycu-navy-600">
                 {locale === "zh"
-                  ? "NYCU Admissions Scholarship System"
-                  : "Admissions Scholarship Management"}
+                  ? "NYCU PhD Scholarship System"
+                  : "PhD Scholarship Management"}
               </p>
             </div>
 

--- a/frontend/components/sso-login-page.tsx
+++ b/frontend/components/sso-login-page.tsx
@@ -66,7 +66,7 @@ export function SSOLoginPage() {
             <GraduationCap className="h-8 w-8 text-white" />
           </div>
           <CardTitle className="text-2xl text-nycu-navy-800">登入系統</CardTitle>
-          <CardDescription>獎學金申請與審核系統</CardDescription>
+          <CardDescription>博士生獎學金申請暨審核系統</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">

--- a/frontend/emails/_components/Footer.tsx
+++ b/frontend/emails/_components/Footer.tsx
@@ -28,7 +28,7 @@ export const Footer = () => {
             lineHeight: '1.5',
           }}
         >
-          國立陽明交通大學 獎學金申請與審核系統
+          國立陽明交通大學 博士生獎學金申請暨審核系統
         </Text>
         <Text
           className="text-gray-600 text-xs m-0 mb-2"

--- a/frontend/emails/_components/Header.tsx
+++ b/frontend/emails/_components/Header.tsx
@@ -45,7 +45,7 @@ export const Header = () => {
           letterSpacing: '0.3px',
         }}
       >
-        獎學金申請與審核系統
+        博士生獎學金申請暨審核系統
       </Text>
       <Text
         className="text-blue-100 text-xs m-0 mt-1"
@@ -57,7 +57,7 @@ export const Header = () => {
           opacity: '0.9',
         }}
       >
-        NYCU Admissions Scholarship System
+        NYCU PhD Scholarship System
       </Text>
     </Section>
   );

--- a/frontend/lib/__tests__/i18n.test.ts
+++ b/frontend/lib/__tests__/i18n.test.ts
@@ -20,7 +20,7 @@ describe("getTranslation", () => {
   it("resolves a top-level key", () => {
     /** Single-level path returns the value directly. */
     const result = getTranslation("zh", "system.title");
-    expect(result).toBe("獎學金申請與審核系統");
+    expect(result).toBe("博士生獎學金申請暨審核系統");
   });
 
   it("resolves a nested dot-path", () => {

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -8,9 +8,9 @@ export const translations = {
   zh: {
     // 系統標題
     system: {
-      title: "獎學金申請與審核系統",
-      subtitle: "NYCU Admissions Scholarship System",
-      name: "NYCU Admissions Scholarship System",
+      title: "博士生獎學金申請暨審核系統",
+      subtitle: "NYCU PhD Scholarship System",
+      name: "NYCU PhD Scholarship System",
     },
 
     // 導航
@@ -522,9 +522,9 @@ export const translations = {
   en: {
     // System Title
     system: {
-      title: "NYCU Admissions Scholarship System",
-      subtitle: "獎學金申請與審核系統",
-      name: "NYCU Admissions Scholarship System",
+      title: "NYCU PhD Scholarship System",
+      subtitle: "博士生獎學金申請暨審核系統",
+      name: "NYCU PhD Scholarship System",
     },
 
     // Navigation


### PR DESCRIPTION
## Summary

The system currently serves PhD scholarships only, but its displayed name didn't reflect that. Renames the system's branding across the frontend:

- 獎學金申請與審核系統 → **博士生獎學金申請暨審核系統**
- NYCU Admissions Scholarship System → **NYCU PhD Scholarship System**
- Admissions Scholarship Management → PhD Scholarship Management (header en-locale subtitle, kept in sync with the renamed title)

## Where it shows up

- Header, footer, login page, admin dashboard welcome banner, admin email-preview signature
- Outbound scholarship email templates (`emails/_components/Header.tsx` / `Footer.tsx`)
- `lib/i18n.ts` (both zh and en translation blocks)
- Page `<title>` / meta description (`app/layout.tsx`), `app/page.tsx`
- Updated the pinned unit-test assertion in `lib/__tests__/i18n.test.ts`

## Test plan

- [x] `tsc --noEmit` — no type errors
- [x] Full Jest suites for every touched component (`i18n`, `admin-dashboard`, `admin-management-interface`, `footer`, `sso-login-page`) — 37/37 pass
- [x] Repo-wide grep confirms zero remaining occurrences of the old Chinese/English name under `frontend/`
- [ ] Visual smoke-check in a running dev environment (header/footer/login page render correctly at both locales)

🤖 Generated with [Claude Code](https://claude.com/claude-code)