### PR TITLE
fix: 指導教授不在系統內時申請不會被指派到教授；教授審核通知寄到兩個信箱（重提 #1323 + review 修正）

### DIFF
--- a/backend/alembic/versions/advisor_backfill_idx_001.py
+++ b/backend/alembic/versions/advisor_backfill_idx_001.py
@@ -30,6 +30,9 @@ and deleted_at IS NULL. Three exclusions, all deliberate:
   land in the professor's 待審核 bucket — which has no status gate — while the
   review endpoint refuses them, stranding the row with a permanent 403.
 - Soft-deleted rows are never resurfaced.
+- Configurations without a professor stage, or whose professor review window
+  has closed, are skipped: the badge would count such a row while the list
+  hides it, or the review endpoint would 403 it forever.
 """
 
 from typing import Sequence, Union
@@ -50,19 +53,45 @@ USER_PROFILES_INDEX = "ix_user_profiles_advisor_nycu_id"
 # Kept in sync with PROFESSOR_ACTIONABLE_APPLICATION_STATUSES (app/models/enums.py).
 ACTIONABLE_STATUSES = ("submitted", "under_review")
 
+# The config predicate mirrors application_builder.backfill_professor_assignments:
+# only claim on a configuration that HAS a professor stage for that application
+# kind and whose professor review window has not closed (NULL bounds = no gate,
+# exactly as ApplicationService.can_professor_submit_review treats them).
 BACKFILL_SQL = """
     UPDATE applications AS a
     SET professor_id = u.id
     FROM user_profiles AS p
     JOIN users AS u
       ON u.nycu_id = p.advisor_nycu_id
-     AND u.role = 'professor'
+     AND u.role = 'professor',
+    scholarship_configurations AS c
     WHERE a.user_id = p.user_id
+      AND c.id = a.scholarship_configuration_id
       AND a.professor_id IS NULL
       AND a.deleted_at IS NULL
       AND p.advisor_nycu_id IS NOT NULL
       AND p.advisor_nycu_id <> ''
       AND a.status::text IN :statuses
+      AND (
+            (
+                a.is_renewal IS FALSE
+                AND c.requires_professor_recommendation IS TRUE
+                AND (
+                    c.application_start_date IS NULL
+                    OR c.professor_review_end IS NULL
+                    OR c.professor_review_end >= NOW()
+                )
+            )
+            OR (
+                a.is_renewal IS TRUE
+                AND c.renewal_requires_professor_review IS TRUE
+                AND (
+                    c.renewal_professor_review_start IS NULL
+                    OR c.renewal_professor_review_end IS NULL
+                    OR c.renewal_professor_review_end >= NOW()
+                )
+            )
+      )
 """
 
 
@@ -75,7 +104,7 @@ def upgrade() -> None:
     inspector = sa.inspect(bind)
     tables = set(inspector.get_table_names())
 
-    if {"applications", "user_profiles", "users"} <= tables:
+    if {"applications", "user_profiles", "users", "scholarship_configurations"} <= tables:
         result = bind.execute(
             sa.text(BACKFILL_SQL).bindparams(sa.bindparam("statuses", expanding=True)),
             {"statuses": list(ACTIONABLE_STATUSES)},

--- a/backend/alembic/versions/advisor_backfill_idx_001.py
+++ b/backend/alembic/versions/advisor_backfill_idx_001.py
@@ -21,10 +21,15 @@ load. This migration:
    auto-index foreign keys).
 
 The row filter mirrors application_builder.backfill_professor_assignments:
-statuses from REVIEWABLE_APPLICATION_STATUSES (app/models/enums.py) and
-deleted_at IS NULL. Drafts are deliberately excluded — they get their professor
-at submission time from the profile as it reads then — and soft-deleted rows are
-never resurfaced.
+statuses from PROFESSOR_ACTIONABLE_APPLICATION_STATUSES (app/models/enums.py)
+and deleted_at IS NULL. Three exclusions, all deliberate:
+
+- Drafts get their professor at submission time from the profile as it reads
+  then.
+- Already-decided applications (approved / partial_approved / rejected) would
+  land in the professor's 待審核 bucket — which has no status gate — while the
+  review endpoint refuses them, stranding the row with a permanent 403.
+- Soft-deleted rows are never resurfaced.
 """
 
 from typing import Sequence, Union
@@ -42,8 +47,8 @@ depends_on: Union[str, Sequence[str], None] = None
 APPLICATIONS_INDEX = "ix_applications_professor_id"
 USER_PROFILES_INDEX = "ix_user_profiles_advisor_nycu_id"
 
-# Kept in sync with REVIEWABLE_APPLICATION_STATUSES (app/models/enums.py).
-REVIEWABLE_STATUSES = ("submitted", "under_review", "approved", "partial_approved", "rejected")
+# Kept in sync with PROFESSOR_ACTIONABLE_APPLICATION_STATUSES (app/models/enums.py).
+ACTIONABLE_STATUSES = ("submitted", "under_review")
 
 BACKFILL_SQL = """
     UPDATE applications AS a
@@ -73,7 +78,7 @@ def upgrade() -> None:
     if {"applications", "user_profiles", "users"} <= tables:
         result = bind.execute(
             sa.text(BACKFILL_SQL).bindparams(sa.bindparam("statuses", expanding=True)),
-            {"statuses": list(REVIEWABLE_STATUSES)},
+            {"statuses": list(ACTIONABLE_STATUSES)},
         )
         print(f"[advisor_backfill_idx_001] assigned advisor to {result.rowcount} orphaned application(s)")
 

--- a/backend/alembic/versions/advisor_backfill_idx_001.py
+++ b/backend/alembic/versions/advisor_backfill_idx_001.py
@@ -1,0 +1,99 @@
+"""Index the advisor-match columns and backfill orphaned professor assignments
+
+Revision ID: advisor_backfill_idx_001
+Revises: email_timing_three_triggers_001
+Create Date: 2026-08-17 00:00:00.000000
+
+A submitted application only gets `professor_id` when the advisor the student
+named in `user_profiles.advisor_nycu_id` ALREADY exists as a role=professor
+User (application_builder.assign_professor_from_profile). Applications naming an
+advisor who had not yet signed in were stored with professor_id NULL and never
+reached any review queue.
+
+The code fix claims those rows on professor login and on every professor queue
+load. This migration:
+
+1. Backfills the rows that are already orphaned, so they surface immediately
+   instead of waiting for their advisor's next login.
+2. Adds the two indexes that lookup path needs — `user_profiles.advisor_nycu_id`
+   (new hot column) and `applications.professor_id` (already filtered by every
+   professor queue / stats query, never indexed because PostgreSQL does not
+   auto-index foreign keys).
+
+The row filter mirrors application_builder.backfill_professor_assignments:
+statuses from REVIEWABLE_APPLICATION_STATUSES (app/models/enums.py) and
+deleted_at IS NULL. Drafts are deliberately excluded — they get their professor
+at submission time from the profile as it reads then — and soft-deleted rows are
+never resurfaced.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "advisor_backfill_idx_001"
+down_revision: Union[str, None] = "email_timing_three_triggers_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+APPLICATIONS_INDEX = "ix_applications_professor_id"
+USER_PROFILES_INDEX = "ix_user_profiles_advisor_nycu_id"
+
+# Kept in sync with REVIEWABLE_APPLICATION_STATUSES (app/models/enums.py).
+REVIEWABLE_STATUSES = ("submitted", "under_review", "approved", "partial_approved", "rejected")
+
+BACKFILL_SQL = """
+    UPDATE applications AS a
+    SET professor_id = u.id
+    FROM user_profiles AS p
+    JOIN users AS u
+      ON u.nycu_id = p.advisor_nycu_id
+     AND u.role = 'professor'
+    WHERE a.user_id = p.user_id
+      AND a.professor_id IS NULL
+      AND a.deleted_at IS NULL
+      AND p.advisor_nycu_id IS NOT NULL
+      AND p.advisor_nycu_id <> ''
+      AND a.status::text IN :statuses
+"""
+
+
+def _index_names(inspector, table: str) -> set:
+    return {idx["name"] for idx in inspector.get_indexes(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    if {"applications", "user_profiles", "users"} <= tables:
+        result = bind.execute(
+            sa.text(BACKFILL_SQL).bindparams(sa.bindparam("statuses", expanding=True)),
+            {"statuses": list(REVIEWABLE_STATUSES)},
+        )
+        print(f"[advisor_backfill_idx_001] assigned advisor to {result.rowcount} orphaned application(s)")
+
+    if "applications" in tables and APPLICATIONS_INDEX not in _index_names(inspector, "applications"):
+        op.create_index(APPLICATIONS_INDEX, "applications", ["professor_id"])
+
+    if "user_profiles" in tables and USER_PROFILES_INDEX not in _index_names(inspector, "user_profiles"):
+        op.create_index(USER_PROFILES_INDEX, "user_profiles", ["advisor_nycu_id"])
+
+
+def downgrade() -> None:
+    # Only the indexes are reversible. The backfilled professor_id values are
+    # indistinguishable from assignments made at submission time, so clearing
+    # them would destroy correct data — they are intentionally left in place.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+
+    if "user_profiles" in tables and USER_PROFILES_INDEX in _index_names(inspector, "user_profiles"):
+        op.drop_index(USER_PROFILES_INDEX, table_name="user_profiles")
+
+    if "applications" in tables and APPLICATIONS_INDEX in _index_names(inspector, "applications"):
+        op.drop_index(APPLICATIONS_INDEX, table_name="applications")

--- a/backend/alembic/versions/professor_notify_both_emails_001.py
+++ b/backend/alembic/versions/professor_notify_both_emails_001.py
@@ -1,0 +1,105 @@
+"""Notify the advisor at BOTH the account email and the profile advisor_email
+
+Revision ID: professor_notify_both_emails_001
+Revises: advisor_backfill_idx_001
+Create Date: 2026-08-24 00:00:00.000000
+
+The 教授審核通知 rule (trigger point 1, professor side) resolved its recipient
+with ``COALESCE(users.email, user_profiles.advisor_email)``: the SSO account
+email of ``applications.professor_id`` if the professor had an account,
+otherwise the address the student typed into their profile. The two are
+populated independently and can disagree, and whichever lost the COALESCE was
+silently never mailed.
+
+The rule now notifies both (UNION folds them when identical). The seed only
+inserts rules whose *name* is missing, so every existing install keeps the old
+query until this migration rewrites it.
+
+Content is snapshotted verbatim rather than imported from
+app.db.seed_scholarship_configs so that a later edit to the seed cannot
+retroactively change what this migration did.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "professor_notify_both_emails_001"
+down_revision: Union[str, None] = "advisor_backfill_idx_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TEMPLATE_KEY = "professor_review_notification"
+TRIGGER_EVENT = "application_submitted"
+
+# Kept in sync with PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY
+# (app/db/seed_scholarship_configs.py).
+NEW_CONDITION_QUERY = """
+                SELECT email FROM (
+                    SELECT u.email
+                    FROM applications a
+                    JOIN users u ON u.id = a.professor_id
+                    WHERE a.id = {application_id}
+                    AND u.email IS NOT NULL
+                    AND u.email != ''
+
+                    UNION
+
+                    SELECT up.advisor_email
+                    FROM applications a
+                    JOIN user_profiles up ON up.user_id = a.user_id
+                    WHERE a.id = {application_id}
+                    AND up.advisor_email IS NOT NULL
+                    AND up.advisor_email != ''
+                ) emails
+                WHERE email IS NOT NULL
+            """
+
+NEW_DESCRIPTION = "當申請提交後，通知指導教授有新申請待審核（系統帳號信箱與學生填寫的指導教授信箱皆寄送）"
+
+# What the seed shipped before this revision — restored on downgrade.
+OLD_CONDITION_QUERY = """
+                SELECT COALESCE(u.email, up.advisor_email) AS email
+                FROM applications a
+                LEFT JOIN users u ON u.id = a.professor_id
+                LEFT JOIN user_profiles up ON up.user_id = a.user_id
+                WHERE a.id = {application_id}
+                AND COALESCE(u.email, up.advisor_email) IS NOT NULL
+                AND COALESCE(u.email, up.advisor_email) != ''
+            """
+
+OLD_DESCRIPTION = "當申請提交後，通知指導教授有新申請待審核"
+
+
+def _set_rule(condition_query: str, description: str) -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "email_automation_rules" not in inspector.get_table_names():
+        return
+
+    result = bind.execute(
+        sa.text(
+            "UPDATE email_automation_rules "
+            "SET condition_query = :condition_query, description = :description "
+            "WHERE template_key = :template_key "
+            "AND CAST(trigger_event AS TEXT) = :trigger_event"
+        ),
+        {
+            "condition_query": condition_query,
+            "description": description,
+            "template_key": TEMPLATE_KEY,
+            "trigger_event": TRIGGER_EVENT,
+        },
+    )
+    print(f"[professor_notify_both_emails_001] rewrote {result.rowcount} '{TEMPLATE_KEY}' rule(s)")
+
+
+def upgrade() -> None:
+    _set_rule(NEW_CONDITION_QUERY, NEW_DESCRIPTION)
+
+
+def downgrade() -> None:
+    _set_rule(OLD_CONDITION_QUERY, OLD_DESCRIPTION)

--- a/backend/alembic/versions/professor_notify_both_emails_001.py
+++ b/backend/alembic/versions/professor_notify_both_emails_001.py
@@ -60,9 +60,16 @@ NEW_CONDITION_QUERY = """
                     SELECT up.advisor_email
                     FROM applications a
                     JOIN user_profiles up ON up.user_id = a.user_id
+                    LEFT JOIN users u ON u.id = a.professor_id
                     WHERE a.id = {application_id}
                     AND up.advisor_email IS NOT NULL
                     AND up.advisor_email != ''
+                    AND (
+                        u.id IS NULL
+                        OR up.advisor_nycu_id IS NULL
+                        OR up.advisor_nycu_id = ''
+                        OR up.advisor_nycu_id = u.nycu_id
+                    )
                 ) emails
                 WHERE email IS NOT NULL
             """

--- a/backend/alembic/versions/professor_notify_both_emails_001.py
+++ b/backend/alembic/versions/professor_notify_both_emails_001.py
@@ -15,12 +15,21 @@ The rule now notifies both (UNION folds them when identical). The seed only
 inserts rules whose *name* is missing, so every existing install keeps the old
 query until this migration rewrites it.
 
+Only rows still carrying a query this project shipped are rewritten — the
+seed's COALESCE text or the older 24f4d6ba449b advisor_email-only text,
+compared whitespace-insensitively. `condition_query` is admin-editable
+(PUT /email-automation/rules/{id}) and (template_key, trigger_event) is not
+unique, so an unconditional UPDATE would flatten a customised recipient
+query (or a second, admin-created rule on the same template) with no
+pre-image to recover from. Customised rows are left untouched and logged.
+
 Content is snapshotted verbatim rather than imported from
 app.db.seed_scholarship_configs so that a later edit to the seed cannot
 retroactively change what this migration did.
 """
 
-from typing import Sequence, Union
+import re
+from typing import Iterable, Sequence, Union
 
 import sqlalchemy as sa
 
@@ -73,33 +82,63 @@ OLD_CONDITION_QUERY = """
 
 OLD_DESCRIPTION = "當申請提交後，通知指導教授有新申請待審核"
 
+# What 24f4d6ba449b wrote before the seed's COALESCE version existed — an
+# install that never re-seeded still carries this text.
+LEGACY_CONDITION_QUERY = """
+            SELECT user_profiles.advisor_email as email
+            FROM applications
+            JOIN user_profiles ON applications.user_id = user_profiles.user_id
+            WHERE applications.id = {application_id}
+            AND user_profiles.advisor_email IS NOT NULL
+            AND user_profiles.advisor_email != ''
+"""
 
-def _set_rule(condition_query: str, description: str) -> None:
+
+def _normalize(sql) -> str:
+    return re.sub(r"\s+", " ", sql or "").strip()
+
+
+def _rewrite_shipped_rules(expected: Iterable[str], condition_query: str, description: str) -> None:
+    """Rewrite the professor rule(s) whose query is one of *expected*; skip the rest."""
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     if "email_automation_rules" not in inspector.get_table_names():
         return
 
-    result = bind.execute(
+    rows = bind.execute(
         sa.text(
-            "UPDATE email_automation_rules "
-            "SET condition_query = :condition_query, description = :description "
+            "SELECT id, condition_query FROM email_automation_rules "
             "WHERE template_key = :template_key "
             "AND CAST(trigger_event AS TEXT) = :trigger_event"
         ),
-        {
-            "condition_query": condition_query,
-            "description": description,
-            "template_key": TEMPLATE_KEY,
-            "trigger_event": TRIGGER_EVENT,
-        },
-    )
-    print(f"[professor_notify_both_emails_001] rewrote {result.rowcount} '{TEMPLATE_KEY}' rule(s)")
+        {"template_key": TEMPLATE_KEY, "trigger_event": TRIGGER_EVENT},
+    ).fetchall()
+
+    expected_normalized = {_normalize(q) for q in expected}
+    rewritten = 0
+    for row in rows:
+        if _normalize(row.condition_query) not in expected_normalized:
+            print(
+                f"[professor_notify_both_emails_001] rule id={row.id} carries a customised "
+                f"condition_query; left untouched"
+            )
+            continue
+        bind.execute(
+            sa.text(
+                "UPDATE email_automation_rules "
+                "SET condition_query = :condition_query, description = :description "
+                "WHERE id = :id"
+            ),
+            {"condition_query": condition_query, "description": description, "id": row.id},
+        )
+        rewritten += 1
+    print(f"[professor_notify_both_emails_001] rewrote {rewritten} of {len(rows)} '{TEMPLATE_KEY}' rule(s)")
 
 
 def upgrade() -> None:
-    _set_rule(NEW_CONDITION_QUERY, NEW_DESCRIPTION)
+    _rewrite_shipped_rules((OLD_CONDITION_QUERY, LEGACY_CONDITION_QUERY), NEW_CONDITION_QUERY, NEW_DESCRIPTION)
 
 
 def downgrade() -> None:
-    _set_rule(OLD_CONDITION_QUERY, OLD_DESCRIPTION)
+    # Only rows this revision wrote are reverted; a customised row stays as is.
+    _rewrite_shipped_rules((NEW_CONDITION_QUERY,), OLD_CONDITION_QUERY, OLD_DESCRIPTION)

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -55,6 +55,38 @@ COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY = """
                 AND u.email != ''
             """
 
+# --- 教授審核通知 -------------------------------------------------------------
+# Trigger point 1, professor side. The advisor is reachable through TWO
+# addresses that are populated independently and can disagree:
+#   - users.email            — the professor's SSO account, via applications.professor_id
+#                              (NULL until the professor has an account, see
+#                              application_builder.assign_professor_from_profile)
+#   - user_profiles.advisor_email — typed by the student (profile form / batch import)
+# Both are notified; the UNION folds them when they are the same address.
+# Picking one over the other (the old COALESCE) silently dropped the other
+# channel, e.g. a professor whose account email differs from what the student
+# wrote never heard about the application through the address they actually read.
+PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY = """
+                SELECT email FROM (
+                    SELECT u.email
+                    FROM applications a
+                    JOIN users u ON u.id = a.professor_id
+                    WHERE a.id = {application_id}
+                    AND u.email IS NOT NULL
+                    AND u.email != ''
+
+                    UNION
+
+                    SELECT up.advisor_email
+                    FROM applications a
+                    JOIN user_profiles up ON up.user_id = a.user_id
+                    WHERE a.id = {application_id}
+                    AND up.advisor_email IS NOT NULL
+                    AND up.advisor_email != ''
+                ) emails
+                WHERE email IS NOT NULL
+            """
+
 
 async def seed_scholarship_configurations(session: AsyncSession) -> None:
     """Initialize scholarship configurations with quota and workflow settings"""
@@ -1112,20 +1144,12 @@ async def seed_email_automation_rules(session: AsyncSession) -> None:
         },
         {
             "name": "教授審核通知",
-            "description": "當申請提交後，通知指導教授有新申請待審核",
+            "description": "當申請提交後，通知指導教授有新申請待審核（系統帳號信箱與學生填寫的指導教授信箱皆寄送）",
             "trigger_event": TriggerEvent.application_submitted,
             "template_key": "professor_review_notification",
             "delay_hours": 0,
             "is_active": True,
-            "condition_query": """
-                SELECT COALESCE(u.email, up.advisor_email) AS email
-                FROM applications a
-                LEFT JOIN users u ON u.id = a.professor_id
-                LEFT JOIN user_profiles up ON up.user_id = a.user_id
-                WHERE a.id = {application_id}
-                AND COALESCE(u.email, up.advisor_email) IS NOT NULL
-                AND COALESCE(u.email, up.advisor_email) != ''
-            """,
+            "condition_query": PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY,
         },
         {
             "name": "學院排名送出通知",

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -66,6 +66,13 @@ COLLEGE_RANKING_SUBMITTED_CONDITION_QUERY = """
 # Picking one over the other (the old COALESCE) silently dropped the other
 # channel, e.g. a professor whose account email differs from what the student
 # wrote never heard about the application through the address they actually read.
+#
+# The profile address is skipped in exactly one case: the profile names a
+# DIFFERENT professor (advisor_nycu_id set and != the assigned professor's
+# nycu_id). professor_id is pinned at first submission and survives a
+# returned→resubmit cycle, so a student who changes advisor before resubmitting
+# would otherwise mail the new advisor a review link that 403s for them.
+# A blank advisor_nycu_id is not evidence of a different person, so it still mails.
 PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY = """
                 SELECT email FROM (
                     SELECT u.email
@@ -80,9 +87,16 @@ PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY = """
                     SELECT up.advisor_email
                     FROM applications a
                     JOIN user_profiles up ON up.user_id = a.user_id
+                    LEFT JOIN users u ON u.id = a.professor_id
                     WHERE a.id = {application_id}
                     AND up.advisor_email IS NOT NULL
                     AND up.advisor_email != ''
+                    AND (
+                        u.id IS NULL
+                        OR up.advisor_nycu_id IS NULL
+                        OR up.advisor_nycu_id = ''
+                        OR up.advisor_nycu_id = u.nycu_id
+                    )
                 ) emails
                 WHERE email IS NOT NULL
             """

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -142,7 +142,9 @@ class Application(Base):
     agree_terms = Column(Boolean, default=False)
 
     # 審核相關
-    professor_id = Column(Integer, ForeignKey("users.id"))  # 指導教授
+    # Indexed: every professor review-queue / stats query filters on it, and the
+    # advisor backfill scans for the NULL rows.
+    professor_id = Column(Integer, ForeignKey("users.id"), index=True)  # 指導教授
     reviewer_id = Column(Integer, ForeignKey("users.id"))  # 審核者
     final_approver_id = Column(Integer, ForeignKey("users.id"))  # 最終核准者
 

--- a/backend/app/models/enums.py
+++ b/backend/app/models/enums.py
@@ -55,6 +55,19 @@ REVIEWABLE_APPLICATION_STATUSES = [
 ]
 
 
+# The strict subset of the above on which a professor can still ACT — the
+# statuses `can_professor_submit_review` accepts. The listing set above is
+# deliberately wider (it also surfaces decided applications for reference), so
+# anything that grants or counts pending professor work must use this set
+# instead: the professor queue's 待審核 bucket is "assigned to me and I have not
+# reviewed", with no status gate, so a decided application that lands in it can
+# never be cleared — submitting a review on it is rejected.
+PROFESSOR_ACTIONABLE_APPLICATION_STATUSES = [
+    ApplicationStatus.submitted.value,  # 已送出
+    ApplicationStatus.under_review.value,  # 審批中
+]
+
+
 # ── Apply-flow visibility sets ───────────────────────────────────────
 # Partition every ApplicationStatus value into three buckets that decide
 # whether a scholarship is shown in the STUDENT APPLY FLOW.

--- a/backend/app/models/user_profile.py
+++ b/backend/app/models/user_profile.py
@@ -27,7 +27,10 @@ class UserProfile(Base):
     # Advisor information (simplified)
     advisor_name = Column(String(100))  # Professor name
     advisor_email = Column(String(100))
-    advisor_nycu_id = Column(String(20))  # NYCU ID of the advisor
+    # Indexed: the professor-side advisor fallback resolves advisees by this
+    # column on every professor login and review-queue load
+    # (application_builder.backfill_professor_assignments).
+    advisor_nycu_id = Column(String(20), index=True)  # NYCU ID of the advisor
 
     # Personal preferences and notes
     preferred_language = Column(String(10), default="zh-TW")  # zh-TW, en-US

--- a/backend/app/services/application_builder.py
+++ b/backend/app/services/application_builder.py
@@ -10,12 +10,13 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import ValidationError
+from app.models.application import Application
 from app.models.application_sequence import ApplicationSequence
-from app.models.enums import ApplicationStatus, ReviewStage
+from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, ApplicationStatus, ReviewStage
 from app.models.user import User, UserRole
 from app.models.user_profile import UserProfile
 from app.utils.i18n import ScholarshipI18n
@@ -164,3 +165,74 @@ async def assign_professor_from_profile(
             getattr(application, "app_id", "?"),
         )
     return professor
+
+
+async def backfill_professor_assignments(db: AsyncSession, professor: Optional[User]) -> int:
+    """Claim applications left unassigned because this professor had no account yet.
+
+    :func:`assign_professor_from_profile` runs at submission time and can only
+    match an advisor who ALREADY exists as a ``role=professor`` User. When a
+    student names an advisor who has never signed in, the application is stored
+    with ``professor_id IS NULL`` and never reaches anybody's review queue.
+
+    This repairs those rows the moment the advisor does get an account. It is
+    idempotent (already-assigned rows are excluded by ``professor_id IS NULL``),
+    so it is safe to run on every professor login and on every professor queue
+    load — see the two call sites:
+
+    - :meth:`PortalSSOService.process_portal_login` — first SSO login / any
+      later login, right after the account is created or its role is updated.
+    - :meth:`ApplicationService.get_professor_applications_paginated` and
+      :meth:`ApplicationService.get_professor_review_stats` — fallback for
+      professor accounts created outside the SSO path (admin-created,
+      pre-authorized) and for advisors named AFTER the professor's first login.
+
+    Assignment (rather than a read-only ``advisor_nycu_id`` join in the queue
+    query) is deliberate: every downstream authorization check — opening the
+    application, submitting a review, updating it — compares
+    ``application.professor_id`` against the caller. A row merely *shown* in the
+    queue without being assigned would 403 on the very next click.
+
+    Only :data:`REVIEWABLE_APPLICATION_STATUSES` rows are claimed. Drafts are
+    excluded on purpose: they get their professor at submission time from the
+    profile as it reads *then*, so pre-assigning one would pin a stale advisor
+    if the student edits their profile before submitting.
+
+    Returns the number of applications claimed.
+    """
+    if professor is None or not professor.id or not professor.nycu_id:
+        return 0
+
+    # Compare against enum AND its .value: a SQLite-loaded (or hand-built) User
+    # can carry the raw string, and a bare `!= UserRole.professor` would then
+    # silently skip a real professor.
+    if professor.role not in (UserRole.professor, UserRole.professor.value):
+        return 0
+
+    advisee_user_ids = select(UserProfile.user_id).where(UserProfile.advisor_nycu_id == professor.nycu_id)
+
+    # synchronize_session=False: both call sites run this before loading any
+    # Application into the session, so there is nothing in the identity map to
+    # go stale, and skipping the sync avoids an extra round trip.
+    stmt = (
+        update(Application)
+        .where(
+            Application.professor_id.is_(None),
+            Application.deleted_at.is_(None),  # never resurface a soft-deleted application
+            Application.status.in_(REVIEWABLE_APPLICATION_STATUSES),
+            Application.user_id.in_(advisee_user_ids),
+        )
+        .values(professor_id=professor.id)
+        .execution_options(synchronize_session=False)
+    )
+    result = await db.execute(stmt)
+    claimed = result.rowcount or 0
+
+    if claimed:
+        logger.info(
+            "Backfilled %s unassigned application(s) to professor %s (nycu_id=%s)",
+            claimed,
+            professor.id,
+            professor.nycu_id,
+        )
+    return claimed

--- a/backend/app/services/application_builder.py
+++ b/backend/app/services/application_builder.py
@@ -10,13 +10,14 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import and_, select, update
+from sqlalchemy import and_, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import ValidationError
 from app.models.application import Application
 from app.models.application_sequence import ApplicationSequence
 from app.models.enums import PROFESSOR_ACTIONABLE_APPLICATION_STATUSES, ApplicationStatus, ReviewStage
+from app.models.scholarship import ScholarshipConfiguration
 from app.models.user import User, UserRole
 from app.models.user_profile import UserProfile
 from app.utils.i18n import ScholarshipI18n
@@ -193,17 +194,29 @@ async def backfill_professor_assignments(db: AsyncSession, professor: Optional[U
     ``application.professor_id`` against the caller. A row merely *shown* in the
     queue without being assigned would 403 on the very next click.
 
-    Only :data:`PROFESSOR_ACTIONABLE_APPLICATION_STATUSES` rows are claimed —
-    NOT the wider listing set. Two exclusions matter:
+    Only rows the professor can still ACT on are claimed. The queue's 待審核
+    bucket is "assigned to me and I have not reviewed" with no further gate,
+    while ``can_professor_submit_review`` refuses anything outside its status
+    and time window — so every row claimed here that the review endpoint would
+    refuse is a row parked in 待審核 forever with a 403 on every attempt to
+    clear it. Four exclusions, all deliberate:
 
     - Drafts: they get their professor at submission time from the profile as it
       reads *then*, so pre-assigning one would pin a stale advisor if the
       student edits their profile before submitting.
-    - Already-decided applications (approved / partial_approved / rejected):
-      the queue's 待審核 bucket is "assigned to me and I have not reviewed",
-      with no status gate, while ``can_professor_submit_review`` refuses any
-      status outside submitted/under_review. Claiming a decided row would park
-      it in 待審核 forever with a 403 on every attempt to clear it.
+    - Already-decided applications (approved / partial_approved / rejected) —
+      :data:`PROFESSOR_ACTIONABLE_APPLICATION_STATUSES`, not the wider listing
+      set.
+    - Configurations without a professor stage (``requires_professor_recommendation``
+      for initial applications, ``renewal_requires_professor_review`` for
+      renewals — the same predicate the professor queue filters on). The
+      dashboard badge does NOT apply that filter, so a claimed row on such a
+      configuration would count as 1 待審核 that the list never shows.
+    - Configurations whose professor review window has already closed. The
+      window ``can_professor_submit_review`` enforces is application_start_date →
+      professor_review_end (renewal_professor_review_start/_end for renewals),
+      skipped when either bound is NULL; a future start is fine, the row simply
+      becomes actionable later.
 
     Returns the number of applications claimed.
     """
@@ -218,6 +231,29 @@ async def backfill_professor_assignments(db: AsyncSession, professor: Optional[U
 
     advisee_user_ids = select(UserProfile.user_id).where(UserProfile.advisor_nycu_id == professor.nycu_id)
 
+    # Configurations on which an application of each kind is professor-actionable:
+    # the workflow has a professor stage and its review window has not closed.
+    # Mirrors the professor queue's config predicate
+    # (ApplicationService.get_professor_applications_paginated) plus the time
+    # gate of ApplicationService.can_professor_submit_review.
+    now = datetime.now(timezone.utc)
+    initial_actionable_configs = select(ScholarshipConfiguration.id).where(
+        ScholarshipConfiguration.requires_professor_recommendation.is_(True),
+        or_(
+            ScholarshipConfiguration.application_start_date.is_(None),
+            ScholarshipConfiguration.professor_review_end.is_(None),
+            ScholarshipConfiguration.professor_review_end >= now,
+        ),
+    )
+    renewal_actionable_configs = select(ScholarshipConfiguration.id).where(
+        ScholarshipConfiguration.renewal_requires_professor_review.is_(True),
+        or_(
+            ScholarshipConfiguration.renewal_professor_review_start.is_(None),
+            ScholarshipConfiguration.renewal_professor_review_end.is_(None),
+            ScholarshipConfiguration.renewal_professor_review_end >= now,
+        ),
+    )
+
     # synchronize_session=False: both call sites run this before loading any
     # Application into the session, so there is nothing in the identity map to
     # go stale, and skipping the sync avoids an extra round trip.
@@ -228,6 +264,16 @@ async def backfill_professor_assignments(db: AsyncSession, professor: Optional[U
             Application.deleted_at.is_(None),  # never resurface a soft-deleted application
             Application.status.in_(PROFESSOR_ACTIONABLE_APPLICATION_STATUSES),
             Application.user_id.in_(advisee_user_ids),
+            or_(
+                and_(
+                    Application.is_renewal.is_(False),
+                    Application.scholarship_configuration_id.in_(initial_actionable_configs),
+                ),
+                and_(
+                    Application.is_renewal.is_(True),
+                    Application.scholarship_configuration_id.in_(renewal_actionable_configs),
+                ),
+            ),
         )
         .values(professor_id=professor.id)
         .execution_options(synchronize_session=False)

--- a/backend/app/services/application_builder.py
+++ b/backend/app/services/application_builder.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.exceptions import ValidationError
 from app.models.application import Application
 from app.models.application_sequence import ApplicationSequence
-from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, ApplicationStatus, ReviewStage
+from app.models.enums import PROFESSOR_ACTIONABLE_APPLICATION_STATUSES, ApplicationStatus, ReviewStage
 from app.models.user import User, UserRole
 from app.models.user_profile import UserProfile
 from app.utils.i18n import ScholarshipI18n
@@ -193,10 +193,17 @@ async def backfill_professor_assignments(db: AsyncSession, professor: Optional[U
     ``application.professor_id`` against the caller. A row merely *shown* in the
     queue without being assigned would 403 on the very next click.
 
-    Only :data:`REVIEWABLE_APPLICATION_STATUSES` rows are claimed. Drafts are
-    excluded on purpose: they get their professor at submission time from the
-    profile as it reads *then*, so pre-assigning one would pin a stale advisor
-    if the student edits their profile before submitting.
+    Only :data:`PROFESSOR_ACTIONABLE_APPLICATION_STATUSES` rows are claimed —
+    NOT the wider listing set. Two exclusions matter:
+
+    - Drafts: they get their professor at submission time from the profile as it
+      reads *then*, so pre-assigning one would pin a stale advisor if the
+      student edits their profile before submitting.
+    - Already-decided applications (approved / partial_approved / rejected):
+      the queue's 待審核 bucket is "assigned to me and I have not reviewed",
+      with no status gate, while ``can_professor_submit_review`` refuses any
+      status outside submitted/under_review. Claiming a decided row would park
+      it in 待審核 forever with a 403 on every attempt to clear it.
 
     Returns the number of applications claimed.
     """
@@ -219,7 +226,7 @@ async def backfill_professor_assignments(db: AsyncSession, professor: Optional[U
         .where(
             Application.professor_id.is_(None),
             Application.deleted_at.is_(None),  # never resurface a soft-deleted application
-            Application.status.in_(REVIEWABLE_APPLICATION_STATUSES),
+            Application.status.in_(PROFESSOR_ACTIONABLE_APPLICATION_STATUSES),
             Application.user_id.in_(advisee_user_ids),
         )
         .values(professor_id=professor.id)

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -34,6 +34,7 @@ from app.schemas.application import (
     ApplicationUpdate,
     StudentDataSchema,
 )
+from app.services.application_builder import backfill_professor_assignments
 from app.services.eligibility_service import EligibilityService
 from app.services.email_automation_service import email_automation_service
 from app.services.email_service import EmailService
@@ -2446,6 +2447,32 @@ class ApplicationService:
         return document_type_names.get(file_type, file_type)
 
     # Professor Review Methods
+    async def _claim_unassigned_advisee_applications(self, professor_id: int) -> int:
+        """Fallback advisor match for the professor-facing queries.
+
+        A submitted application only carries ``professor_id`` when the named
+        advisor already had an account at submission time; otherwise the row is
+        orphaned. :func:`backfill_professor_assignments` normally repairs it on
+        the professor's SSO login, but that hook cannot cover every route into a
+        professor account (admin-created / pre-authorized accounts) nor advisees
+        who named the professor after that login. Running the same idempotent
+        claim here makes the queue and the dashboard badge self-healing.
+
+        Never raises: a failed repair must not take down the queue the professor
+        came to read. The rollback keeps the session usable for the caller's own
+        query — the claim is simply retried on the next request.
+        """
+        try:
+            professor = await self.db.get(User, professor_id)
+            claimed = await backfill_professor_assignments(self.db, professor)
+            if claimed:
+                await self.db.commit()
+            return claimed
+        except Exception:
+            logger.exception("Advisor fallback backfill failed for professor %s", professor_id)
+            await self.db.rollback()
+            return 0
+
     @staticmethod
     def _professor_reviewed(professor_id: int):
         """Correlated predicate: this professor authored an ApplicationReview for the row.
@@ -2469,6 +2496,11 @@ class ApplicationService:
         pass ``page``/``size`` for explicit pagination.
         """
         try:
+            # Fallback advisor match: adopt any application whose student named
+            # this professor as advisor but that was submitted before they had
+            # an account. Runs first so the query below sees the claimed rows.
+            await self._claim_unassigned_advisee_applications(professor_id)
+
             # Build base query with ALL required filters (consistent with what will be returned)
             base_query = (
                 select(Application)
@@ -2758,6 +2790,10 @@ class ApplicationService:
           surfacing it here would require a join on
           ScholarshipConfiguration.professor_review_end_date)
         """
+        # Same fallback advisor match as the queue — otherwise the dashboard
+        # badge would keep under-counting until the professor opens the list.
+        await self._claim_unassigned_advisee_applications(professor_id)
+
         pending_query = select(sa_func.count(Application.id)).where(
             Application.professor_id == professor_id,
             Application.status.in_(

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -20,7 +20,12 @@ from app.core.metrics import scholarship_applications_total
 from app.core.schema_validation import serialize_value
 from app.models.audit_log import AuditAction, AuditLog
 from app.models.application import Application, ApplicationStatus
-from app.models.enums import REVIEWABLE_APPLICATION_STATUSES, ReviewStage, Semester
+from app.models.enums import (
+    PROFESSOR_ACTIONABLE_APPLICATION_STATUSES,
+    REVIEWABLE_APPLICATION_STATUSES,
+    ReviewStage,
+    Semester,
+)
 from app.models.review import ApplicationReview, ApplicationReviewItem
 from app.models.scholarship import ScholarshipConfiguration, ScholarshipType, SubTypeSelectionMode
 from app.models.user import User, UserRole
@@ -2458,16 +2463,20 @@ class ApplicationService:
         who named the professor after that login. Running the same idempotent
         claim here makes the queue and the dashboard badge self-healing.
 
+        Does NOT commit: the claim joins the caller's transaction and is
+        persisted by the request-scoped session (``get_db``), so the commit
+        boundary stays with the request instead of being owned by a read helper.
+        The caller's own query runs afterwards in that same transaction and
+        therefore sees the claimed rows.
+
         Never raises: a failed repair must not take down the queue the professor
-        came to read. The rollback keeps the session usable for the caller's own
-        query — the claim is simply retried on the next request.
+        came to read. Both callers invoke this as their FIRST statement, so the
+        rollback discards nothing but the failed UPDATE and leaves the session
+        usable — the claim is simply retried on the next request.
         """
         try:
             professor = await self.db.get(User, professor_id)
-            claimed = await backfill_professor_assignments(self.db, professor)
-            if claimed:
-                await self.db.commit()
-            return claimed
+            return await backfill_professor_assignments(self.db, professor)
         except Exception:
             logger.exception("Advisor fallback backfill failed for professor %s", professor_id)
             await self.db.rollback()
@@ -2796,12 +2805,7 @@ class ApplicationService:
 
         pending_query = select(sa_func.count(Application.id)).where(
             Application.professor_id == professor_id,
-            Application.status.in_(
-                [
-                    ApplicationStatus.submitted.value,
-                    ApplicationStatus.under_review.value,
-                ]
-            ),
+            Application.status.in_(PROFESSOR_ACTIONABLE_APPLICATION_STATUSES),
             ~self._professor_reviewed(professor_id),
         )
 

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2470,16 +2470,20 @@ class ApplicationService:
         therefore sees the claimed rows.
 
         Never raises: a failed repair must not take down the queue the professor
-        came to read. Both callers invoke this as their FIRST statement, so the
-        rollback discards nothing but the failed UPDATE and leaves the session
-        usable — the claim is simply retried on the next request.
+        came to read. The claim runs inside a SAVEPOINT so a failure rolls back
+        only the failed UPDATE — the claim is simply retried on the next request.
+        A session-level ``rollback()`` is NOT an option here: it expires every
+        loaded object (``expire_on_commit=False`` governs commit only), including
+        the ``current_user`` FastAPI loaded in this same request-scoped session,
+        and the endpoint's next ``current_user.id`` would raise MissingGreenlet
+        and turn into the HTTP 500 this helper exists to prevent.
         """
         try:
-            professor = await self.db.get(User, professor_id)
-            return await backfill_professor_assignments(self.db, professor)
+            async with self.db.begin_nested():
+                professor = await self.db.get(User, professor_id)
+                return await backfill_professor_assignments(self.db, professor)
         except Exception:
             logger.exception("Advisor fallback backfill failed for professor %s", professor_id)
-            await self.db.rollback()
             return 0
 
     @staticmethod

--- a/backend/app/services/email_automation_service.py
+++ b/backend/app/services/email_automation_service.py
@@ -71,6 +71,32 @@ def bind_placeholders(sql: str, context: Dict[str, Any]) -> str:
     return "".join(result)
 
 
+def dedupe_recipient_rows(rows: List[Any]) -> List[Dict[str, Any]]:
+    """Collapse a recipient query's rows to one entry per address.
+
+    Addresses are compared case-insensitively and whitespace-trimmed; the first
+    spelling seen is the one mailed. The shipped rules UNION addresses that are
+    populated independently (the SIS ``com_email`` vs the SSO ``users.email``
+    for students; the SSO account email vs the student-typed
+    ``user_profiles.advisor_email`` for professors), and SQL UNION only folds
+    byte-identical strings — ``Prof@nycu.edu.tw`` and ``prof@nycu.edu.tw`` would
+    otherwise produce two scheduled_emails rows, two renderer round-trips and
+    two copies in the same inbox. Empty / NULL cells are dropped.
+    """
+    seen: set = set()
+    recipients: List[Dict[str, Any]] = []
+    for row in rows:
+        if not row or not row[0]:
+            continue
+        email = str(row[0]).strip()
+        key = email.lower()
+        if not email or key in seen:
+            continue
+        seen.add(key)
+        recipients.append({"email": email})
+    return recipients
+
+
 class EmailAutomationService:
     """Service for handling automated email sending based on triggers"""
 
@@ -208,7 +234,7 @@ class EmailAutomationService:
 
         rows = await self._execute_read_only(db, parameterized_query, context)
 
-        recipients = [{"email": row[0]} for row in rows if row]
+        recipients = dedupe_recipient_rows(rows)
         logger.info(f"✓ Found {len(recipients)} recipients for rule {rule.template_key}")
         return recipients
 

--- a/backend/app/services/portal_sso_service.py
+++ b/backend/app/services/portal_sso_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.exceptions import AuthenticationError
 from app.models.user import EmployeeStatus, User, UserRole, UserType
+from app.services.application_builder import backfill_professor_assignments
 from app.services.auth_service import AuthService
 from app.services.student_service import StudentService
 
@@ -237,6 +238,19 @@ class PortalSSOService:
         # Update last login time
         user.last_login_at = datetime.now(timezone.utc)
         await self.db.commit()
+
+        # 教授帳號建立（或角色更新為教授）後，回補帳號存在之前就送出的申請：
+        # 學生填了 advisor_nycu_id，但提交當下查無此教授，professor_id 留 NULL。
+        # 非教授角色由 helper 自行擋掉，這裡不重複判斷。
+        # Best-effort — 回補失敗絕不能擋住登入，所以吞掉例外並回到乾淨的 session。
+        try:
+            claimed = await backfill_professor_assignments(self.db, user)
+            if claimed:
+                await self.db.commit()
+                logger.info(f"Assigned {claimed} pending application(s) to professor {nycu_id} on login")
+        except Exception:
+            await self.db.rollback()
+            logger.exception(f"Professor application backfill failed for {nycu_id}; login continues")
 
         # Generate system tokens with debug data
         logger.info(f"🔍 Creating tokens with debug data - Portal: {bool(portal_data)}, Student: {bool(student_data)}")

--- a/backend/app/services/portal_sso_service.py
+++ b/backend/app/services/portal_sso_service.py
@@ -242,14 +242,19 @@ class PortalSSOService:
         # 教授帳號建立（或角色更新為教授）後，回補帳號存在之前就送出的申請：
         # 學生填了 advisor_nycu_id，但提交當下查無此教授，professor_id 留 NULL。
         # 非教授角色由 helper 自行擋掉，這裡不重複判斷。
-        # Best-effort — 回補失敗絕不能擋住登入，所以吞掉例外並回到乾淨的 session。
+        # Best-effort — 回補失敗絕不能擋住登入。The claim runs inside a SAVEPOINT:
+        # a failure rolls back only the savepoint. A session-level rollback()
+        # would expire EVERY loaded object (expire_on_commit=False does not
+        # apply to rollback), and the `user` read by create_tokens() below would
+        # then need a lazy refresh → MissingGreenlet → HTTP 400, i.e. the repair
+        # would be the thing that blocks the login.
         try:
-            claimed = await backfill_professor_assignments(self.db, user)
+            async with self.db.begin_nested():
+                claimed = await backfill_professor_assignments(self.db, user)
             if claimed:
                 await self.db.commit()
                 logger.info(f"Assigned {claimed} pending application(s) to professor {nycu_id} on login")
         except Exception:
-            await self.db.rollback()
             logger.exception(f"Professor application backfill failed for {nycu_id}; login continues")
 
         # Generate system tokens with debug data

--- a/backend/app/tests/test_advisor_backfill.py
+++ b/backend/app/tests/test_advisor_backfill.py
@@ -55,7 +55,19 @@ async def _seed_student_with_advisor(db: AsyncSession, *, nycu_id: str, advisor_
     return student
 
 
-async def _seed_config(db: AsyncSession, *, suffix: str, requires_prof: bool = True) -> ScholarshipConfiguration:
+_OPEN_WINDOW_END = datetime(2030, 1, 1, tzinfo=timezone.utc)
+_CLOSED_WINDOW_END = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+async def _seed_config(
+    db: AsyncSession,
+    *,
+    suffix: str,
+    requires_prof: bool = True,
+    professor_review_end: Optional[datetime] = _OPEN_WINDOW_END,
+    renewal_requires_prof: bool = False,
+    renewal_professor_review_end: Optional[datetime] = _OPEN_WINDOW_END,
+) -> ScholarshipConfiguration:
     st = ScholarshipType(code=f"backfill_{suffix}", name=f"Backfill type {suffix}", status="active")
     db.add(st)
     await db.commit()
@@ -69,9 +81,12 @@ async def _seed_config(db: AsyncSession, *, suffix: str, requires_prof: bool = T
         application_start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
         application_end_date=datetime(2030, 1, 1, tzinfo=timezone.utc),
         professor_review_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
-        professor_review_end=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        professor_review_end=professor_review_end,
         requires_professor_recommendation=requires_prof,
         requires_college_review=False,
+        renewal_requires_professor_review=renewal_requires_prof,
+        renewal_professor_review_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        renewal_professor_review_end=renewal_professor_review_end,
         amount=0,
         is_active=True,
     )
@@ -89,6 +104,7 @@ async def _seed_app(
     suffix: str,
     status: str = ApplicationStatus.submitted.value,
     professor_id: Optional[int] = None,
+    is_renewal: bool = False,
 ) -> Application:
     app = Application(
         app_id=f"APP-BACKFILL-{suffix}",
@@ -98,6 +114,7 @@ async def _seed_app(
         academic_year=114,
         sub_type_selection_mode="single",
         status=status,
+        is_renewal=is_renewal,
         professor_id=professor_id,
     )
     db.add(app)
@@ -258,6 +275,81 @@ async def test_no_op_for_non_professor_users(db: AsyncSession):
     assert await backfill_professor_assignments(db, admin) == 0
     assert await backfill_professor_assignments(db, None) == 0
     assert await _professor_id_of(db, app) is None
+
+
+# --- actionability gates: config must have a professor stage, window open ----
+
+
+@pytest.mark.asyncio
+async def test_skips_configs_without_a_professor_stage(db: AsyncSession):
+    """The queue filters on requires_professor_recommendation but the badge
+    does not — claiming here would show 1 待審核 that the list never lists."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_nostage", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="nostage", requires_prof=False)
+    app = await _seed_app(db, student=student, config=cfg, suffix="nostage")
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    assert await backfill_professor_assignments(db, professor) == 0
+    assert await _professor_id_of(db, app) is None
+
+    service = ApplicationService(db)
+    applications, total = await service.get_professor_applications_paginated(professor_id=professor.id)
+    stats = await service.get_professor_review_stats(professor.id)
+    assert (total, applications) == (0, [])
+    assert stats["pending_reviews"] == 0  # badge and list agree
+
+
+@pytest.mark.asyncio
+async def test_skips_closed_professor_review_window(db: AsyncSession):
+    """Same stranding as a decided status, via the time gate: the review
+    endpoint would 403 such a row forever."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_closed", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="closed", professor_review_end=_CLOSED_WINDOW_END)
+    app = await _seed_app(db, student=student, config=cfg, suffix="closed")
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    assert await backfill_professor_assignments(db, professor) == 0
+    assert await _professor_id_of(db, app) is None
+
+
+@pytest.mark.asyncio
+async def test_claims_when_review_window_is_not_configured(db: AsyncSession):
+    """NULL bounds mean no time gate (can_professor_submit_review skips it)."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_nowin", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="nowin", professor_review_end=None)
+    app = await _seed_app(db, student=student, config=cfg, suffix="nowin")
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    assert await backfill_professor_assignments(db, professor) == 1
+    assert await _professor_id_of(db, app) == professor.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("renewal_requires_prof", "renewal_window_end", "expected_claimed"),
+    [
+        (True, _OPEN_WINDOW_END, 1),
+        (True, _CLOSED_WINDOW_END, 0),
+        (False, _OPEN_WINDOW_END, 0),
+    ],
+)
+async def test_renewals_follow_the_renewal_flags(
+    db: AsyncSession, renewal_requires_prof: bool, renewal_window_end: datetime, expected_claimed: int
+):
+    """A renewal is gated by the renewal-specific admin flag and window, not
+    the initial-application ones (which are all open here)."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_renew", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(
+        db,
+        suffix="renew",
+        renewal_requires_prof=renewal_requires_prof,
+        renewal_professor_review_end=renewal_window_end,
+    )
+    app = await _seed_app(db, student=student, config=cfg, suffix="renew", is_renewal=True)
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    assert await backfill_professor_assignments(db, professor) == expected_claimed
+    assert (await _professor_id_of(db, app) == professor.id) is bool(expected_claimed)
 
 
 # --- professor-facing queries (fallback advisor match) -----------------------

--- a/backend/app/tests/test_advisor_backfill.py
+++ b/backend/app/tests/test_advisor_backfill.py
@@ -1,0 +1,307 @@
+"""Advisor backfill: applications submitted before the advisor had an account.
+
+`assign_professor_from_profile` runs at submission time and can only match an
+advisor who already exists as a role=professor User. A student naming an advisor
+who has never signed in produced an application with `professor_id IS NULL` that
+reached nobody's review queue and stayed invisible until an admin noticed it.
+
+Contract pinned here:
+
+- `backfill_professor_assignments` claims exactly the orphaned, reviewable rows
+  of THIS professor's advisees — never drafts, never someone else's advisees,
+  never an application that already has a professor.
+- It is a no-op for non-professor users (and safe on None).
+- The professor review queue and the dashboard stats both apply the same claim,
+  so an orphaned application surfaces on the professor's next load even when the
+  account was created outside the SSO hook.
+- Portal SSO login runs the claim for professor accounts.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application import Application, ApplicationStatus
+from app.models.scholarship import ScholarshipConfiguration, ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.models.user_profile import UserProfile
+from app.services.application_builder import backfill_professor_assignments
+from app.services.application_service import ApplicationService
+
+PROF_NYCU_ID = "P900001"
+
+
+async def _seed_user(db: AsyncSession, *, role: UserRole, nycu_id: str) -> User:
+    user = User(
+        nycu_id=nycu_id,
+        name=f"User {nycu_id}",
+        email=f"{nycu_id}@u.edu",
+        user_type=UserType.student if role == UserRole.student else UserType.employee,
+        role=role,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _seed_student_with_advisor(db: AsyncSession, *, nycu_id: str, advisor_nycu_id: Optional[str]) -> User:
+    student = await _seed_user(db, role=UserRole.student, nycu_id=nycu_id)
+    db.add(UserProfile(user_id=student.id, advisor_nycu_id=advisor_nycu_id))
+    await db.commit()
+    return student
+
+
+async def _seed_config(db: AsyncSession, *, suffix: str, requires_prof: bool = True) -> ScholarshipConfiguration:
+    st = ScholarshipType(code=f"backfill_{suffix}", name=f"Backfill type {suffix}", status="active")
+    db.add(st)
+    await db.commit()
+    await db.refresh(st)
+
+    cfg = ScholarshipConfiguration(
+        scholarship_type_id=st.id,
+        config_code=f"backfill_cfg_{suffix}",
+        config_name=f"Backfill cfg {suffix}",
+        academic_year=114,
+        application_start_date=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        application_end_date=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        professor_review_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        professor_review_end=datetime(2030, 1, 1, tzinfo=timezone.utc),
+        requires_professor_recommendation=requires_prof,
+        requires_college_review=False,
+        amount=0,
+        is_active=True,
+    )
+    db.add(cfg)
+    await db.commit()
+    await db.refresh(cfg)
+    return cfg
+
+
+async def _seed_app(
+    db: AsyncSession,
+    *,
+    student: User,
+    config: ScholarshipConfiguration,
+    suffix: str,
+    status: str = ApplicationStatus.submitted.value,
+    professor_id: Optional[int] = None,
+) -> Application:
+    app = Application(
+        app_id=f"APP-BACKFILL-{suffix}",
+        user_id=student.id,
+        scholarship_type_id=config.scholarship_type_id,
+        scholarship_configuration_id=config.id,
+        academic_year=114,
+        sub_type_selection_mode="single",
+        status=status,
+        professor_id=professor_id,
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+    return app
+
+
+async def _professor_id_of(db: AsyncSession, application: Application) -> Optional[int]:
+    """Read professor_id straight from the DB — the bulk UPDATE runs with
+    synchronize_session=False, so the in-session object may be stale."""
+    result = await db.execute(select(Application.professor_id).where(Application.id == application.id))
+    return result.scalar_one()
+
+
+# --- backfill_professor_assignments -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_claims_orphaned_application_of_advisee(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_claim", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="claim")
+    app = await _seed_app(db, student=student, config=cfg, suffix="claim")
+
+    # The professor account appears only now — after the application was filed.
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 1
+    assert await _professor_id_of(db, app) == professor.id
+
+
+@pytest.mark.asyncio
+async def test_skips_drafts(db: AsyncSession):
+    """A draft gets its professor at submission time from the profile as it
+    reads then — claiming it early would pin a stale advisor."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_draft", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="draft")
+    draft = await _seed_app(db, student=student, config=cfg, suffix="draft", status=ApplicationStatus.draft.value)
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 0
+    assert await _professor_id_of(db, draft) is None
+
+
+@pytest.mark.asyncio
+async def test_skips_soft_deleted_applications(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_deleted", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="deleted")
+    app = await _seed_app(db, student=student, config=cfg, suffix="deleted")
+    app.deleted_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 0
+    assert await _professor_id_of(db, app) is None
+
+
+@pytest.mark.asyncio
+async def test_never_overwrites_an_existing_assignment(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_taken", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="taken")
+    other_prof = await _seed_user(db, role=UserRole.professor, nycu_id="P900999")
+    app = await _seed_app(db, student=student, config=cfg, suffix="taken", professor_id=other_prof.id)
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 0
+    assert await _professor_id_of(db, app) == other_prof.id
+
+
+@pytest.mark.asyncio
+async def test_ignores_applications_of_other_advisees(db: AsyncSession):
+    mine = await _seed_student_with_advisor(db, nycu_id="stu_mine", advisor_nycu_id=PROF_NYCU_ID)
+    theirs = await _seed_student_with_advisor(db, nycu_id="stu_theirs", advisor_nycu_id="P900888")
+    no_advisor = await _seed_student_with_advisor(db, nycu_id="stu_none", advisor_nycu_id=None)
+    cfg = await _seed_config(db, suffix="scope")
+
+    mine_app = await _seed_app(db, student=mine, config=cfg, suffix="mine")
+    theirs_app = await _seed_app(db, student=theirs, config=cfg, suffix="theirs")
+    orphan_app = await _seed_app(db, student=no_advisor, config=cfg, suffix="none")
+
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 1
+    assert await _professor_id_of(db, mine_app) == professor.id
+    assert await _professor_id_of(db, theirs_app) is None
+    assert await _professor_id_of(db, orphan_app) is None
+
+
+@pytest.mark.asyncio
+async def test_accepts_raw_string_role(db: AsyncSession):
+    """`role` reaches this helper as the enum member from a DB load but as a raw
+    string from hand-built Users — both must count as a professor."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_strrole", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="strrole")
+    app = await _seed_app(db, student=student, config=cfg, suffix="strrole")
+
+    # No refresh() — that would replace the raw string with the enum member and
+    # the test would stop covering what it is here to cover.
+    professor = User(nycu_id=PROF_NYCU_ID, name="字串角色", user_type="employee", role="professor")
+    db.add(professor)
+    await db.commit()
+    assert professor.role == "professor"
+
+    assert await backfill_professor_assignments(db, professor) == 1
+    await db.commit()
+    assert await _professor_id_of(db, app) == professor.id
+
+
+@pytest.mark.asyncio
+async def test_no_op_for_non_professor_users(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_nonprof", advisor_nycu_id="ADMIN01")
+    cfg = await _seed_config(db, suffix="nonprof")
+    app = await _seed_app(db, student=student, config=cfg, suffix="nonprof")
+
+    # Same nycu_id the student named, but the account is not a professor.
+    admin = await _seed_user(db, role=UserRole.admin, nycu_id="ADMIN01")
+
+    assert await backfill_professor_assignments(db, admin) == 0
+    assert await backfill_professor_assignments(db, None) == 0
+    assert await _professor_id_of(db, app) is None
+
+
+# --- professor-facing queries (fallback advisor match) -----------------------
+
+
+@pytest.mark.asyncio
+async def test_review_queue_surfaces_previously_orphaned_application(db: AsyncSession):
+    """The reported bug: student submits, advisor has no account, application
+    never appears for the professor. Opening the queue must now surface it."""
+    student = await _seed_student_with_advisor(db, nycu_id="stu_queue", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="queue")
+    app = await _seed_app(db, student=student, config=cfg, suffix="queue")
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    service = ApplicationService(db)
+    applications, total = await service.get_professor_applications_paginated(professor_id=professor.id)
+
+    assert total == 1
+    assert [a.app_id for a in applications] == [app.app_id]
+    assert await _professor_id_of(db, app) == professor.id
+
+
+@pytest.mark.asyncio
+async def test_review_stats_count_previously_orphaned_application(db: AsyncSession):
+    student = await _seed_student_with_advisor(db, nycu_id="stu_stats", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="stats")
+    await _seed_app(db, student=student, config=cfg, suffix="stats")
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    service = ApplicationService(db)
+    stats = await service.get_professor_review_stats(professor.id)
+
+    assert stats["pending_reviews"] == 1
+
+
+# --- Portal SSO login hook ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_portal_sso_login_claims_pending_applications(db: AsyncSession, monkeypatch):
+    """First SSO login creates the professor account — and adopts the
+    applications that were waiting for it."""
+    from app.services.portal_sso_service import PortalSSOService
+
+    student = await _seed_student_with_advisor(db, nycu_id="stu_sso", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="sso")
+    app = await _seed_app(db, student=student, config=cfg, suffix="sso")
+
+    service = PortalSSOService(db)
+
+    async def _fake_verify(_token: str) -> dict:
+        return {
+            "txtID": PROF_NYCU_ID,
+            "nycuID": PROF_NYCU_ID,
+            "txtName": "王教授",
+            "mail": "prof@nycu.edu.tw",
+            "dept": "資訊工程學系",
+            "deptCode": "5743",
+            "userType": "employee",
+            "employeestatus": "在職",
+        }
+
+    async def _fake_student_status(_nycu_id: str):
+        return False, None
+
+    monkeypatch.setattr(service, "verify_portal_token", _fake_verify)
+    monkeypatch.setattr(service, "_verify_student_status", _fake_student_status)
+
+    await service.process_portal_login("irrelevant-token")
+
+    professor = (await db.execute(select(User).where(User.nycu_id == PROF_NYCU_ID))).scalar_one()
+    assert professor.role == UserRole.professor
+    assert await _professor_id_of(db, app) == professor.id

--- a/backend/app/tests/test_advisor_backfill.py
+++ b/backend/app/tests/test_advisor_backfill.py
@@ -331,3 +331,77 @@ async def test_portal_sso_login_claims_pending_applications(db: AsyncSession, mo
     professor = (await db.execute(select(User).where(User.nycu_id == PROF_NYCU_ID))).scalar_one()
     assert professor.role == UserRole.professor
     assert await _professor_id_of(db, app) == professor.id
+
+
+# --- best-effort contract: a failing claim must not take the caller down ----
+#
+# The claim's failure must roll back ONLY the claim. A session-level rollback()
+# expires every loaded ORM object (expire_on_commit=False governs commit only),
+# and the caller's next attribute read on `user` / `current_user` then needs a
+# lazy refresh → MissingGreenlet under AsyncSession → HTTP 400/500 in exactly
+# the situation the best-effort handlers exist to absorb.
+
+
+async def _failing_backfill(db: AsyncSession, _professor):
+    """Stand-in for a claim that dies mid-transaction (timeout, deadlock...)."""
+    from sqlalchemy import text
+
+    await db.execute(text("UPDATE no_such_table SET x = 1"))
+
+
+@pytest.mark.asyncio
+async def test_failed_claim_does_not_break_the_review_queue(db: AsyncSession, monkeypatch):
+    import app.services.application_service as application_service_module
+
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+    student = await _seed_student_with_advisor(db, nycu_id="stu_qfail", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix="qfail")
+    assigned = await _seed_app(db, student=student, config=cfg, suffix="qfail", professor_id=professor.id)
+    # What the endpoint holds: the current_user loaded in this same session.
+    current_user = await db.get(User, professor.id)
+
+    monkeypatch.setattr(application_service_module, "backfill_professor_assignments", _failing_backfill)
+
+    service = ApplicationService(db)
+    applications, total = await service.get_professor_applications_paginated(professor_id=professor.id)
+    stats = await service.get_professor_review_stats(professor.id)
+
+    assert [a.app_id for a in applications] == [assigned.app_id]
+    assert total == 1
+    assert stats["pending_reviews"] == 1
+    # The endpoint logs / serialises current_user after the call — must not raise.
+    assert (current_user.id, current_user.nycu_id) == (professor.id, PROF_NYCU_ID)
+
+
+@pytest.mark.asyncio
+async def test_failed_claim_does_not_block_portal_sso_login(db: AsyncSession, monkeypatch):
+    import app.services.portal_sso_service as portal_sso_module
+    from app.services.portal_sso_service import PortalSSOService
+
+    monkeypatch.setattr(portal_sso_module, "backfill_professor_assignments", _failing_backfill)
+
+    service = PortalSSOService(db)
+
+    async def _fake_verify(_token: str) -> dict:
+        return {
+            "txtID": PROF_NYCU_ID,
+            "nycuID": PROF_NYCU_ID,
+            "txtName": "王教授",
+            "mail": "prof@nycu.edu.tw",
+            "dept": "資訊工程學系",
+            "deptCode": "5743",
+            "userType": "employee",
+            "employeestatus": "在職",
+        }
+
+    async def _fake_student_status(_nycu_id: str):
+        return False, None
+
+    monkeypatch.setattr(service, "verify_portal_token", _fake_verify)
+    monkeypatch.setattr(service, "_verify_student_status", _fake_student_status)
+
+    result = await service.process_portal_login("irrelevant-token")
+
+    assert result["access_token"]
+    professor = (await db.execute(select(User).where(User.nycu_id == PROF_NYCU_ID))).scalar_one()
+    assert professor.role == UserRole.professor

--- a/backend/app/tests/test_advisor_backfill.py
+++ b/backend/app/tests/test_advisor_backfill.py
@@ -148,6 +148,32 @@ async def test_skips_drafts(db: AsyncSession):
     assert await _professor_id_of(db, draft) is None
 
 
+@pytest.mark.parametrize(
+    "status",
+    [
+        ApplicationStatus.approved.value,
+        ApplicationStatus.partial_approved.value,
+        ApplicationStatus.rejected.value,
+    ],
+)
+@pytest.mark.asyncio
+async def test_skips_already_decided_applications(db: AsyncSession, status: str):
+    """A decided application would land in the professor's 待審核 bucket — which
+    filters on "not reviewed by me", not on status — while the review endpoint
+    refuses anything outside submitted/under_review. Claiming it would strand
+    the row there with a permanent 403."""
+    student = await _seed_student_with_advisor(db, nycu_id=f"stu_{status}", advisor_nycu_id=PROF_NYCU_ID)
+    cfg = await _seed_config(db, suffix=status)
+    app = await _seed_app(db, student=student, config=cfg, suffix=status, status=status)
+    professor = await _seed_user(db, role=UserRole.professor, nycu_id=PROF_NYCU_ID)
+
+    claimed = await backfill_professor_assignments(db, professor)
+    await db.commit()
+
+    assert claimed == 0
+    assert await _professor_id_of(db, app) is None
+
+
 @pytest.mark.asyncio
 async def test_skips_soft_deleted_applications(db: AsyncSession):
     student = await _seed_student_with_advisor(db, nycu_id="stu_deleted", advisor_nycu_id=PROF_NYCU_ID)

--- a/backend/app/tests/test_email_automation_service_unit.py
+++ b/backend/app/tests/test_email_automation_service_unit.py
@@ -402,3 +402,35 @@ async def test_process_single_rule_schedules_when_delay_set(monkeypatch):
     assert scheduled["recipient"] == "person@example.com"
     assert scheduled["email_category"] == EmailCategory.application_student
     assert before <= scheduled["scheduled_for"] <= after + timedelta(hours=3, minutes=1)
+
+
+def test_dedupe_recipient_rows_is_case_insensitive_and_drops_blanks():
+    from app.services.email_automation_service import dedupe_recipient_rows
+
+    rows = [
+        ("Prof@nycu.edu.tw",),
+        ("prof@nycu.edu.tw",),  # same inbox, different case → folded
+        ("  prof@nycu.edu.tw  ",),  # whitespace → folded
+        ("other@nycu.edu.tw",),
+        (None,),
+        ("",),
+        None,
+    ]
+
+    assert dedupe_recipient_rows(rows) == [{"email": "Prof@nycu.edu.tw"}, {"email": "other@nycu.edu.tw"}]
+
+
+@pytest.mark.asyncio
+async def test_get_recipients_folds_case_variants_of_the_same_address(monkeypatch):
+    service = EmailAutomationService()
+    rule = EmailAutomationRule(
+        id=1,
+        template_key="professor_review_notification",
+        trigger_event="submit",
+        condition_query="SELECT email FROM users WHERE id = {application_id}",
+    )
+    db = StubAsyncSession(results=[("Prof@nycu.edu.tw",), ("prof@nycu.edu.tw",)])
+
+    recipients = await service._get_recipients(db, rule, {"application_id": 1})
+
+    assert recipients == [{"email": "Prof@nycu.edu.tw"}]

--- a/backend/app/tests/test_professor_review_notification_recipients.py
+++ b/backend/app/tests/test_professor_review_notification_recipients.py
@@ -1,0 +1,145 @@
+"""Trigger point 1, professor side: 教授審核通知 reaches BOTH advisor addresses.
+
+An advisor is reachable through two independently-populated addresses:
+
+- ``users.email`` of ``applications.professor_id`` — the professor's SSO account,
+  assigned at submission only when the professor already has an account.
+- ``user_profiles.advisor_email`` — typed by the student (profile form / batch
+  import).
+
+They can disagree, and the previous ``COALESCE`` silently dropped whichever
+lost. Contract pinned here: the shipped condition_query resolves to the union
+of both, folds them when identical, and still works when either side is
+missing.
+"""
+
+from typing import Optional
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.sql_read_only_guard import assert_read_only_select
+from app.db.seed_scholarship_configs import PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY
+from app.models.application import Application, ApplicationStatus
+from app.models.email_management import EmailAutomationRule, TriggerEvent
+from app.models.scholarship import ScholarshipType
+from app.models.user import User, UserRole, UserType
+from app.models.user_profile import UserProfile
+from app.services.email_automation_service import email_automation_service
+
+ACCOUNT_EMAIL = "prof.account@nycu.edu.tw"
+PROFILE_EMAIL = "prof.typed-by-student@gmail.com"
+
+
+async def _seed_user(db: AsyncSession, *, nycu_id: str, role: UserRole, email: Optional[str]) -> User:
+    user = User(
+        nycu_id=nycu_id,
+        name=nycu_id,
+        email=email,
+        user_type=UserType.student if role == UserRole.student else UserType.employee,
+        role=role,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def _seed_application(
+    db: AsyncSession,
+    *,
+    suffix: str,
+    advisor_email: Optional[str],
+    professor: Optional[User],
+) -> Application:
+    student = await _seed_user(db, nycu_id=f"stu_{suffix}", role=UserRole.student, email=f"stu_{suffix}@u.edu")
+    db.add(UserProfile(user_id=student.id, advisor_email=advisor_email))
+
+    scholarship_type = ScholarshipType(code=f"prof_notify_{suffix}", name=f"Prof notify {suffix}", status="active")
+    db.add(scholarship_type)
+    await db.commit()
+    await db.refresh(scholarship_type)
+
+    application = Application(
+        app_id=f"APP-PROFNOTIFY-{suffix}",
+        user_id=student.id,
+        scholarship_type_id=scholarship_type.id,
+        academic_year=114,
+        sub_type_selection_mode="single",
+        status=ApplicationStatus.submitted.value,
+        professor_id=professor.id if professor else None,
+    )
+    db.add(application)
+    await db.commit()
+    await db.refresh(application)
+    return application
+
+
+def _rule() -> EmailAutomationRule:
+    return EmailAutomationRule(
+        name="教授審核通知",
+        trigger_event=TriggerEvent.application_submitted,
+        template_key="professor_review_notification",
+        condition_query=PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY,
+        delay_hours=0,
+        is_active=True,
+    )
+
+
+async def _recipients(db: AsyncSession, application: Application) -> list[str]:
+    rows = await email_automation_service._get_recipients(db, _rule(), {"application_id": application.id})
+    return sorted(r["email"] for r in rows)
+
+
+def test_shipped_query_passes_the_read_only_guard():
+    assert_read_only_select(PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY)
+
+
+@pytest.mark.asyncio
+async def test_both_addresses_are_notified_when_they_differ(db: AsyncSession):
+    professor = await _seed_user(db, nycu_id="prof_both", role=UserRole.professor, email=ACCOUNT_EMAIL)
+    application = await _seed_application(db, suffix="both", advisor_email=PROFILE_EMAIL, professor=professor)
+
+    assert await _recipients(db, application) == sorted([ACCOUNT_EMAIL, PROFILE_EMAIL])
+
+
+@pytest.mark.asyncio
+async def test_identical_addresses_are_folded_into_one_send(db: AsyncSession):
+    professor = await _seed_user(db, nycu_id="prof_same", role=UserRole.professor, email=ACCOUNT_EMAIL)
+    application = await _seed_application(db, suffix="same", advisor_email=ACCOUNT_EMAIL, professor=professor)
+
+    assert await _recipients(db, application) == [ACCOUNT_EMAIL]
+
+
+@pytest.mark.asyncio
+async def test_profile_email_alone_when_professor_has_no_account(db: AsyncSession):
+    """The PR #1323 scenario: advisor named before they ever signed in."""
+    application = await _seed_application(db, suffix="noacct", advisor_email=PROFILE_EMAIL, professor=None)
+
+    assert await _recipients(db, application) == [PROFILE_EMAIL]
+
+
+@pytest.mark.asyncio
+async def test_account_email_alone_when_profile_has_no_advisor_email(db: AsyncSession):
+    professor = await _seed_user(db, nycu_id="prof_only", role=UserRole.professor, email=ACCOUNT_EMAIL)
+    application = await _seed_application(db, suffix="acctonly", advisor_email=None, professor=professor)
+
+    assert await _recipients(db, application) == [ACCOUNT_EMAIL]
+
+
+@pytest.mark.asyncio
+async def test_blank_addresses_are_skipped(db: AsyncSession):
+    professor = await _seed_user(db, nycu_id="prof_blank", role=UserRole.professor, email="")
+    application = await _seed_application(db, suffix="blank", advisor_email="", professor=professor)
+
+    assert await _recipients(db, application) == []
+
+
+@pytest.mark.asyncio
+async def test_other_applications_do_not_leak_in(db: AsyncSession):
+    professor = await _seed_user(db, nycu_id="prof_a", role=UserRole.professor, email=ACCOUNT_EMAIL)
+    other_prof = await _seed_user(db, nycu_id="prof_b", role=UserRole.professor, email="other@nycu.edu.tw")
+    target = await _seed_application(db, suffix="target", advisor_email=PROFILE_EMAIL, professor=professor)
+    await _seed_application(db, suffix="other", advisor_email="other.typed@gmail.com", professor=other_prof)
+
+    assert await _recipients(db, target) == sorted([ACCOUNT_EMAIL, PROFILE_EMAIL])

--- a/backend/app/tests/test_professor_review_notification_recipients.py
+++ b/backend/app/tests/test_professor_review_notification_recipients.py
@@ -51,9 +51,10 @@ async def _seed_application(
     suffix: str,
     advisor_email: Optional[str],
     professor: Optional[User],
+    advisor_nycu_id: Optional[str] = None,
 ) -> Application:
     student = await _seed_user(db, nycu_id=f"stu_{suffix}", role=UserRole.student, email=f"stu_{suffix}@u.edu")
-    db.add(UserProfile(user_id=student.id, advisor_email=advisor_email))
+    db.add(UserProfile(user_id=student.id, advisor_email=advisor_email, advisor_nycu_id=advisor_nycu_id))
 
     scholarship_type = ScholarshipType(code=f"prof_notify_{suffix}", name=f"Prof notify {suffix}", status="active")
     db.add(scholarship_type)
@@ -143,3 +144,28 @@ async def test_other_applications_do_not_leak_in(db: AsyncSession):
     await _seed_application(db, suffix="other", advisor_email="other.typed@gmail.com", professor=other_prof)
 
     assert await _recipients(db, target) == sorted([ACCOUNT_EMAIL, PROFILE_EMAIL])
+
+
+@pytest.mark.asyncio
+async def test_profile_naming_the_assigned_professor_mails_both_addresses(db: AsyncSession):
+    """Same person, two inboxes: the normal case the UNION exists for."""
+    professor = await _seed_user(db, nycu_id="prof_named", role=UserRole.professor, email=ACCOUNT_EMAIL)
+    application = await _seed_application(
+        db, suffix="named", advisor_email=PROFILE_EMAIL, professor=professor, advisor_nycu_id=professor.nycu_id
+    )
+
+    assert await _recipients(db, application) == sorted([ACCOUNT_EMAIL, PROFILE_EMAIL])
+
+
+@pytest.mark.asyncio
+async def test_profile_naming_a_different_professor_is_not_mailed(db: AsyncSession):
+    """returned→resubmit after an advisor change: professor_id still points at
+    the original reviewer, so the newly named advisor must not get a review
+    link that would 403 for them."""
+    original = await _seed_user(db, nycu_id="prof_orig", role=UserRole.professor, email=ACCOUNT_EMAIL)
+    await _seed_user(db, nycu_id="prof_new", role=UserRole.professor, email="new.prof@nycu.edu.tw")
+    application = await _seed_application(
+        db, suffix="changed", advisor_email="new.prof@gmail.com", professor=original, advisor_nycu_id="prof_new"
+    )
+
+    assert await _recipients(db, application) == [ACCOUNT_EMAIL]

--- a/backend/app/tests/test_sql_read_only_guard.py
+++ b/backend/app/tests/test_sql_read_only_guard.py
@@ -14,6 +14,7 @@ from app.core.sql_read_only_guard import (
     assert_read_only_select,
     mask_literals,
 )
+from app.db.seed_scholarship_configs import PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY
 
 # The two condition_query strings that actually ship (db/seed_scholarship_configs.py).
 SEEDED_STUDENT_QUERY = """
@@ -36,15 +37,9 @@ SEEDED_STUDENT_QUERY = """
     WHERE email IS NOT NULL
 """
 
-SEEDED_PROFESSOR_QUERY = """
-    SELECT COALESCE(u.email, up.advisor_email) AS email
-    FROM applications a
-    LEFT JOIN users u ON u.id = a.professor_id
-    LEFT JOIN user_profiles up ON up.user_id = a.user_id
-    WHERE a.id = {application_id}
-    AND COALESCE(u.email, up.advisor_email) IS NOT NULL
-    AND COALESCE(u.email, up.advisor_email) != ''
-"""
+# The professor rule is imported from the seed so this test always checks the
+# query that actually ships (see test_professor_review_notification_recipients).
+SEEDED_PROFESSOR_QUERY = PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
重新提交 #1323（已於 #1337 revert），並加上 `/code-review high` 的修正與「教授通知信寄到兩個信箱」的需求。共 8 個 commit：#1323 原本的 2 個 + 6 個新的。

## 原始問題（#1323）

學生提交申請時，若填寫的指導教授**還沒有系統帳號**，`assign_professor_from_profile` 查無 `role=professor` 的 User，`professor_id` 留 NULL——申請不會出現在任何教授的待審清單，教授之後登入也永遠看不到。

**修法**：共用 helper `backfill_professor_assignments`（`application_builder.py`）以 `UserProfile.advisor_nycu_id ↔ User.nycu_id` 認領孤兒申請，冪等（`WHERE professor_id IS NULL`），在教授 SSO 登入後及教授清單／儀表板查詢時執行。Migration `advisor_backfill_idx_001` 一次性回補現有孤兒並建立 `applications.professor_id`、`user_profiles.advisor_nycu_id` 索引。

## 新增：教授審核通知寄到兩個信箱

`教授審核通知` 規則原本用 `COALESCE(users.email, user_profiles.advisor_email)`——有帳號就只寄帳號信箱，學生填的指導教授信箱被丟掉。改成 `UNION` 兩者皆寄（相同地址自動合併）。

- seed 抽成常數 `PROFESSOR_REVIEW_NOTIFICATION_CONDITION_QUERY`
- Migration `professor_notify_both_emails_001` 改寫既有安裝的規則列（seed 只補「名稱不存在」的規則）；**只改寫仍是出貨文字**（seed 的 COALESCE 版或更早 `24f4d6ba449b` 的版本）的列，admin 客製過的略過並 log；downgrade 同理
- 審核者仍由 `professor_id`（來自學生填的工號）決定，`advisor_email` 純粹是投遞地址。僅在 profile 的 `advisor_nycu_id` **明確指向另一位教授**時（退回後換指導教授再送出的情境）不寄 profile 信箱，避免對方收到點了就 403 的審查連結

## Code review 修正（`/code-review high`）

| 發現 | 修法 |
|---|---|
| best-effort handler 用 `session.rollback()`，會 expire 已載入的 `user`/`current_user` → `MissingGreenlet` → SSO 登入 400、教授清單 500（已以測試重現） | 改用 `begin_nested()` SAVEPOINT，失敗只回滾 claim |
| 回補沒有 config 閘門：清單查詢過濾 `requires_professor_recommendation` 但 badge 不過濾 → 永遠清不掉的待審核數字；也讓教授能對沒有教授審查階段的獎學金送審 | runtime helper 與 migration SQL 皆只認領「config 有教授審查階段」的申請（續領看 renewal flag） |
| 回補沒有時間閘門：審查期已結束的 `submitted` 孤兒被認領後，送審永遠 403 | 同上，審查期已結束（`professor_review_end < now`）不認領；NULL 邊界不設限，與 `can_professor_submit_review` 一致 |
| `UNION` 只對位元組相同去重，`Prof@` vs `prof@` 寄兩封 | `_get_recipients` 以 trim+lower 去重，所有規則受惠 |

刻意未處理（既有、超出範圍）：所有 employee/staff 預設 `role=professor` 的 SSO 政策；`can_professor_submit_review` 非續領分支未檢查 `requires_professor_review_for`。

## 注意

`advisor_backfill_idx_001` 的回補 SQL 在這個 PR 裡被修改（加上 config／時間閘門）。#1323 曾短暫合併後 revert；若有任何環境在那段期間已跑過這支 migration，閘門不會回溯套用到已認領的列。

## 驗證

- 後端全套 **5284 passed, 2 skipped**（含新增 25 個測試：回補閘門 4 組、失敗路徑 2、通知收件人 9、去重 2）
- black + flake8（`B904,B014`）通過；`alembic heads` 單一 head
- 兩支 migration 在 dev DB 的 `pg_dump` 複本上跑 upgrade → downgrade → upgrade：回補以 4 組 fixture 驗證（有階段+開窗、續領 flag 認領；無階段、已關窗不動）；規則改寫以客製列 + legacy 列驗證（改 2 跳 1，downgrade 對稱）
- 新的規則查詢在真實 Postgres 上對實際申請執行正常

## Test plan

- [ ] 學生填寫系統中不存在的 `advisor_nycu_id` 送出 → `professor_id` 為 NULL
- [ ] 該教授首次 SSO 登入 → 申請出現在待審核清單，badge +1，可開啟並送出推薦
- [ ] 不需教授審查的獎學金、或審查期已結束的孤兒申請 → 不被認領，badge 與清單一致為 0
- [ ] 學生送出申請 → 教授的帳號信箱與 profile 填的信箱各收到一封（相同地址只一封）
- [ ] 退回後學生改填另一位教授再送出 → 只有原審核教授收到信
