### PR TITLE
ci: capture container diagnostics when a production deploy fails

### DIFF
--- a/.github/production-workflows-examples/deploy-stack.yml
+++ b/.github/production-workflows-examples/deploy-stack.yml
@@ -743,6 +743,45 @@ jobs:
           [ "$code" = "200" ] || { echo "::error::Frontend returned $code"; exit 1; }
           echo "✅ Smoke tests passed"
 
+      # ── Post-mortem: capture WHY before rollback destroys the evidence ──────
+      # `docker compose up -d` aborts on an unhealthy depends_on dependency
+      # with only "container X is unhealthy" — no container output, no probe
+      # results (run 32696545808 failed exactly this blind). This step dumps
+      # each container's state (incl. OOMKilled — the AP VM is memory-tight),
+      # its healthcheck probe log (each probe's exit code and curl output,
+      # which compose swallows), and its recent logs. It MUST stay above the
+      # rollback step: rollback re-runs `compose up -d`, recreating the
+      # containers and deleting exactly these logs.
+      - name: Diagnose failed deploy
+        if: failure()
+        run: |
+          echo "::group::Container states"
+          docker ps -a --filter "name=scholarship_" \
+            --format 'table {{.Names}}\t{{.Status}}\t{{.RunningFor}}' || true
+          echo "::endgroup::"
+
+          for c in scholarship_backend_prod scholarship_frontend_prod \
+                   scholarship_nginx_prod scholarship_redis_prod; do
+            docker inspect "$c" >/dev/null 2>&1 || continue
+
+            echo "::group::${c} — state"
+            docker inspect --format 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} restarts={{.RestartCount}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}n/a{{end}}' "$c" || true
+            echo "::endgroup::"
+
+            echo "::group::${c} — healthcheck probes"
+            docker inspect --format '{{if .State.Health}}{{range .State.Health.Log}}[exit {{.ExitCode}}] {{.Output}}{{end}}{{else}}(no healthcheck){{end}}' "$c" || true
+            echo "::endgroup::"
+
+            echo "::group::${c} — last 200 log lines"
+            docker logs --tail 200 "$c" 2>&1 || true
+            echo "::endgroup::"
+          done
+
+          echo "::group::Host resources"
+          free -h || true
+          df -h || true
+          echo "::endgroup::"
+
       - name: Record successful deployment tag
         if: success()
         run: |


### PR DESCRIPTION
## Summary

The first production deploy on the production repo ([run 32696545808](https://github.com/NYCUITSC/naass/actions/runs/32696545808)) failed with only:

```
dependency failed to start: container scholarship_backend_prod is unhealthy
```

`docker compose up -d` aborts on an unhealthy `depends_on` dependency **before** the workflow's own "Health check" step (the only step that dumped `docker logs`) is ever reached, so the run recorded zero evidence of why the backend never answered `/health`. Note `/health` returns HTTP 200 even when the DB is degraded, so an unhealthy container means uvicorn never accepted connections at all (crash loop / boot hang / OOM) — all of which are only distinguishable from the container's own logs.

This adds a failure-only **Diagnose failed deploy** step to the `deploy-stack.yml` template, placed **before** the rollback step (rollback re-runs `compose up -d`, which recreates the containers and destroys exactly these logs). Per container it dumps:

- state: status, exit code, **OOMKilled** (the AP VM is memory-tight), restart count, health status
- the healthcheck probe log — each probe's exit code and curl output, which compose swallows
- the last 200 container log lines
- plus host `free -h` / `df -h`

## Propagation

The same change is pushed byte-identically to `NYCUITSC/naass`'s `.github/workflows/deploy-stack.yml` so the failed deploy can be re-dispatched for diagnosis immediately. Once this PR merges, the naass copy byte-matches this template revision, so the mirror's pristine-copy drift policy continues to auto-update it.

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [ ] Re-dispatch **Deploy to Production** on naass with tag `main-0c301a9` — the run should now print the backend container's state, healthcheck probes, and logs in the "Diagnose failed deploy" step