### PR TITLE
fix: monitoring deploy works on a production runner without passwordless sudo

### DIFF
--- a/.github/production-workflows-examples/README.md
+++ b/.github/production-workflows-examples/README.md
@@ -315,10 +315,11 @@ nginx-exporter、redis-exporter）。Alloy 把資料推到
   才會重新部署（每次都會重啟 Grafana 約 30 秒，站台不受影響）。
 - **先跑過一次 `deploy-<stage>.yml`**。這組 workflow 需要 `scholarship_prod_network`
   已存在（app stack 建的），最後一步的「透過 nginx 驗證 `/monitoring`」也需要 nginx 在跑。
-- **VM 上需要免密碼 sudo**，或事先把 `/opt/scholarship/monitoring` 與
-  `/opt/scholarship/secrets` 建好並 chown 給 runner 使用者。
-  `/opt/scholarship/secrets/gh_pat` 的路徑寫死在共用的 compose 檔裡（dev/prod 兩邊共用），
-  不能按 stage 搬家。
+- **不需要 root 權限**。偏好的位置是 `/opt/scholarship/{monitoring,secrets}`
+  （runner 有免密碼 sudo、或事先建好並 chown 給 runner 使用者時採用）；
+  兩者都不行時會自動退回 `$HOME/scholarship/{monitoring,secrets}`。
+  `gh_pat` 的掛載來源在共用的 compose 檔裡以
+  `${MONITORING_SECRETS_DIR:-/opt/scholarship/secrets}` 插值，由 workflow 匯出。
 - **⚠️ 防火牆**：共用的 compose 檔會把 Loki `3100` 與 Prometheus `9090`
   publish 到 host（`0.0.0.0`），因為 DB VM 的 Alloy 要跨機推資料進來。**這兩個埠沒有任何
   認證**，請用防火牆只開給該 stage 的 DB VM。

--- a/.github/production-workflows-examples/deploy-monitoring-stack.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-stack.yml
@@ -541,16 +541,26 @@ jobs:
               | awk '/^  HTTP/{c=$2} END{print c+0}'
           }
 
-          if [ "$(probe "${ADMIN_USER}")" = "200" ]; then
-            echo "GRAFANA_API_USER=${ADMIN_USER}" >> "$GITHUB_ENV"
-            echo "✅ Declared admin credentials accepted"
-            exit 0
-          fi
+          # /api/health answers before Grafana finishes serving the user table:
+          # right after an image upgrade the SQLite migrations hold the DB
+          # ("database is locked") while the declared login already 401s
+          # "user not found". Observed on the test AP VM — a probe 3 s after
+          # container start concluded the volume needed reconciling when it
+          # merely needed a few more seconds. Retry briefly before deciding.
+          for i in $(seq 1 7); do
+            if [ "$(probe "${ADMIN_USER}")" = "200" ]; then
+              echo "GRAFANA_API_USER=${ADMIN_USER}" >> "$GITHUB_ENV"
+              echo "✅ Declared admin credentials accepted"
+              exit 0
+            fi
+            [ "$i" -lt 7 ] && sleep 5
+          done
 
           echo "::warning::The declared GRAFANA_ADMIN_USER cannot authenticate — grafana_data predates this configuration. Reconciling."
           # Operates directly on grafana.db and takes effect live (no restart).
-          # It resets the BUILT-IN admin user, whatever GF_SECURITY_ADMIN_USER
-          # says — which is precisely why the second probe below is needed.
+          # It resets USER ID 1 — Grafana's initial admin, whatever its login
+          # is — not the declared GF_SECURITY_ADMIN_USER; that is precisely why
+          # the probes below have to hunt for the login that exists.
           docker exec monitoring_grafana grafana cli --homepath /usr/share/grafana \
             admin reset-admin-password "${ADMIN_PASS}" 2>&1 | tail -2
 
@@ -560,17 +570,35 @@ jobs:
             exit 0
           fi
 
-          if [ "$(probe admin)" = "200" ]; then
-            # Deliberately NOT renaming or deleting the existing account: this
-            # workflow will not mutate an identity someone may be logging in
-            # with. The deploy proceeds under the login that exists, and says so.
-            echo "GRAFANA_API_USER=admin" >> "$GITHUB_ENV"
-            echo "::warning::This volume's only admin login is 'admin', not '${ADMIN_USER}'. Its password is now GRAFANA_ADMIN_PASSWORD and the deploy continues under it."
-            echo "::warning::To make '${ADMIN_USER}' the real admin login: create it in Grafana (Administration → Users), or re-run with reset_grafana_volume=true to rebuild from provisioning (DESTROYS manually saved dashboards)."
-            exit 0
-          fi
+          # A volume created under GF_SECURITY_ADMIN_USER=<some old name> has
+          # NO 'admin' user at all — Grafana names the initial admin after the
+          # configured value. After a credential rotation neither the declared
+          # login nor 'admin' exists, and the only account the reset above
+          # touched is user id 1 under its old name. Ask the database who that
+          # is (read-only; sqlite3 is not in the Grafana image, so read the
+          # volume from a throwaway python container) and try that login too.
+          GRAFANA_DB_VOL=$(docker inspect monitoring_grafana \
+            --format '{{range .Mounts}}{{if eq .Destination "/var/lib/grafana"}}{{.Name}}{{end}}{{end}}')
+          ADMIN1_LOGIN=$(docker run --rm -v "${GRAFANA_DB_VOL}:/var/lib/grafana:ro" python:3.13-slim \
+            python -c "import sqlite3; print(sqlite3.connect('file:/var/lib/grafana/grafana.db?mode=ro', uri=True).execute('select login from \"user\" where id=1').fetchone()[0])" \
+            2>/dev/null || true)
 
-          echo "::error::Cannot authenticate to Grafana as '${ADMIN_USER}' or as 'admin' even after a password reset."
+          for candidate in admin "${ADMIN1_LOGIN}"; do
+            [ -n "${candidate}" ] || continue
+            [ "${candidate}" = "${ADMIN_USER}" ] && continue
+            if [ "$(probe "${candidate}")" = "200" ]; then
+              # Deliberately NOT renaming or deleting the existing account:
+              # this workflow will not mutate an identity someone may be
+              # logging in with. The deploy proceeds under the login that
+              # exists, and says so.
+              echo "GRAFANA_API_USER=${candidate}" >> "$GITHUB_ENV"
+              echo "::warning::This volume's admin login is '${candidate}', not '${ADMIN_USER}'. Its password is now GRAFANA_ADMIN_PASSWORD and the deploy continues under it."
+              echo "::warning::To make '${ADMIN_USER}' the real admin login: create it in Grafana (Administration → Users), or re-run with reset_grafana_volume=true to rebuild from provisioning (DESTROYS manually saved dashboards)."
+              exit 0
+            fi
+          done
+
+          echo "::error::Cannot authenticate to Grafana as '${ADMIN_USER}', 'admin'${ADMIN1_LOGIN:+, or '${ADMIN1_LOGIN}' (user id 1)} even after a password reset."
           echo "::error::Inspect the volume, or re-run with reset_grafana_volume=true to rebuild it from provisioning (DESTRUCTIVE)."
           docker logs --tail 50 monitoring_grafana
           exit 1

--- a/.github/production-workflows-examples/deploy-monitoring-stack.yml
+++ b/.github/production-workflows-examples/deploy-monitoring-stack.yml
@@ -70,10 +70,13 @@
 #     GH_PAT (optional — only for alert → GitHub issue delivery).
 #   - Environment variables on the stage: DEPLOY_STAGE (already required by
 #     deploy-stack.yml) and either GRAFANA_ROOT_URL or EXPECT_DOMAIN.
-#   - Passwordless sudo on the AP VM, OR /opt/scholarship/{monitoring,secrets}
-#     pre-created and owned by the runner user (see "Prepare monitoring
-#     directories"). The gh_pat mount path is hardcoded in the shared compose
-#     file, so it cannot be relocated per stage.
+#   - No root access is required. Preferred layout is
+#     /opt/scholarship/{monitoring,secrets} — used when the runner has
+#     passwordless sudo or the directories are pre-created and owned by the
+#     runner user. A fully unprivileged runner falls back to
+#     $HOME/scholarship/{monitoring,secrets}; the gh_pat mount source is
+#     interpolated into the shared compose file via MONITORING_SECRETS_DIR
+#     (see "Prepare monitoring directories").
 #   - Host ports 3100 (Loki) and 9090 (Prometheus) are published by the shared
 #     compose file so the DB VM's Alloy can push to them. They carry NO
 #     authentication — firewall them to the DB VM only. See README § Firewall.
@@ -238,39 +241,62 @@ jobs:
         run: |
           set -euo pipefail
 
-          DIR="${MONITORING_DIR_INPUT:-${MONITORING_DIR_VAR:-/opt/scholarship/monitoring}}"
-
-          # Two paths matter and only one of them is relocatable:
-          #   $DIR                      — where this workflow puts the stack
-          #   /opt/scholarship/secrets  — hardcoded as the gh_pat bind-mount
-          #                               source in the SHARED compose file
-          #                               (monitoring/docker-compose.monitoring.yml,
-          #                               used by both repositories), so it
-          #                               cannot be moved per stage.
-          # Both live under /opt, which the runner user does not own. Try
-          # unprivileged first, fall back to `sudo -n` (never plain sudo — a VM
-          # without passwordless sudo must fail here with the message below
-          # instead of blocking forever on a password prompt no one can answer).
+          # Two directories matter, and BOTH are relocatable:
+          #   monitoring dir — where this workflow puts the stack.
+          #   secrets dir    — the gh_pat bind-mount source. The SHARED compose
+          #                    file (monitoring/docker-compose.monitoring.yml,
+          #                    used by both repositories) interpolates it as
+          #                    ${MONITORING_SECRETS_DIR:-/opt/scholarship/secrets},
+          #                    and $GITHUB_ENV below keeps the value exported
+          #                    for every later `docker compose` call.
+          # The preferred defaults live under /opt, which the runner user does
+          # not own. Try unprivileged first, fall back to `sudo -n` (never plain
+          # sudo — a VM without passwordless sudo must not block forever on a
+          # password prompt no one can answer), and when neither works fall back
+          # to the runner's HOME: an unprivileged runner must still be able to
+          # install the stack.
           ensure_dir() {
-            mkdir -p "$1" 2>/dev/null && return 0
-            sudo -n mkdir -p "$1" 2>/dev/null || {
-              echo "::error::Cannot create $1 — this runner has no passwordless sudo."
-              echo "::error::Create it once on the VM, owned by the runner user:"
-              echo "::error::  sudo mkdir -p $1 && sudo chown -R \$USER:\$USER $1"
-              return 1
-            }
-            sudo -n chown -R "$USER:$USER" "$1" 2>/dev/null || true
+            mkdir -p "$1" 2>/dev/null || sudo -n mkdir -p "$1" 2>/dev/null || return 1
+            [ -w "$1" ] || sudo -n chown -R "$USER:$USER" "$1" 2>/dev/null || true
+            [ -w "$1" ]
           }
 
-          ensure_dir "${DIR}"
-          [ -w "${DIR}" ] || sudo -n chown -R "$USER:$USER" "${DIR}" 2>/dev/null || {
-            echo "::error::${DIR} exists but is not writable by the runner user."
-            echo "::error::Fix once on the VM: sudo chown -R \$USER:\$USER ${DIR}"
-            exit 1
-          }
+          DIR="${MONITORING_DIR_INPUT:-${MONITORING_DIR_VAR:-}}"
+          if [ -n "${DIR}" ]; then
+            # Explicitly configured — never silently relocate it.
+            ensure_dir "${DIR}" || {
+              echo "::error::Cannot create or write ${DIR} (set via the monitoring_dir input or vars.MONITORING_DIR)."
+              echo "::error::Fix once on the VM: sudo mkdir -p ${DIR} && sudo chown -R \$USER:\$USER ${DIR}"
+              exit 1
+            }
+          elif ensure_dir /opt/scholarship/monitoring; then
+            DIR=/opt/scholarship/monitoring
+          else
+            DIR="${HOME}/scholarship/monitoring"
+            echo "::notice::/opt/scholarship/monitoring is not writable and this runner has no passwordless sudo — installing to ${DIR} instead."
+            ensure_dir "${DIR}" || { echo "::error::Cannot create ${DIR} either."; exit 1; }
+          fi
+
+          # Same fallback for the secrets dir. When sudo works it stays
+          # root-owned 0700 (the runner never reads it back — the PAT write
+          # goes through `sudo -n tee`); without sudo it is runner-owned 0700,
+          # which shields it from other unprivileged users just the same.
+          SECRETS_DIR=/opt/scholarship/secrets
+          if sudo -n mkdir -p "${SECRETS_DIR}" 2>/dev/null; then
+            sudo -n chmod 700 "${SECRETS_DIR}" 2>/dev/null || true
+          elif mkdir -p "${SECRETS_DIR}" 2>/dev/null && [ -w "${SECRETS_DIR}" ]; then
+            chmod 700 "${SECRETS_DIR}"
+          else
+            SECRETS_DIR="${HOME}/scholarship/secrets"
+            echo "::notice::/opt/scholarship/secrets is not writable and this runner has no passwordless sudo — using ${SECRETS_DIR} instead."
+            mkdir -p "${SECRETS_DIR}"
+            chmod 700 "${SECRETS_DIR}"
+          fi
 
           echo "MONITORING_DIR=${DIR}" >> "$GITHUB_ENV"
+          echo "MONITORING_SECRETS_DIR=${SECRETS_DIR}" >> "$GITHUB_ENV"
           echo "Monitoring directory: ${DIR}"
+          echo "Secrets directory:    ${SECRETS_DIR}"
 
       - name: Deploy monitoring configuration
         run: |
@@ -400,28 +426,32 @@ jobs:
           # webhook-bridge bind-mount it; when the source is missing Docker
           # materialises it as a DIRECTORY, and from then on the mount fails
           # in a way that reads like a Grafana bug.
-          SECRETS_DIR=/opt/scholarship/secrets
-          PAT_FILE="${SECRETS_DIR}/gh_pat"
-
-          sudo -n mkdir -p "${SECRETS_DIR}" 2>/dev/null || mkdir -p "${SECRETS_DIR}" || {
-            echo "::error::Cannot create ${SECRETS_DIR} (no passwordless sudo)."
-            echo "::error::Create it once on the VM: sudo mkdir -p ${SECRETS_DIR} && sudo chmod 700 ${SECRETS_DIR}"
-            exit 1
-          }
-          sudo -n chmod 700 "${SECRETS_DIR}" 2>/dev/null || true
+          #
+          # The directory itself was resolved and created by "Prepare
+          # monitoring directories" — /opt/scholarship/secrets when the runner
+          # can, the runner's HOME when it cannot — and the shared compose file
+          # mounts ${MONITORING_SECRETS_DIR:-/opt/scholarship/secrets}/gh_pat.
+          PAT_FILE="${MONITORING_SECRETS_DIR}/gh_pat"
 
           # An empty PAT is written deliberately rather than skipped: the mount
           # has to resolve to a file either way. The bridge reads it only when
           # an alert fires, so an empty value costs a failed dispatch at alert
           # time, not a failed deploy now (warned about in "Validate monitoring
           # secrets").
-          printf '%s' "${GH_PAT}" | sudo -n tee "${PAT_FILE}" > /dev/null 2>&1 \
-            || printf '%s' "${GH_PAT}" > "${PAT_FILE}"
+          if ! printf '%s' "${GH_PAT}" | sudo -n tee "${PAT_FILE}" > /dev/null 2>&1; then
+            # A previous run left the file 0444: its owner may delete it, but
+            # not open it for writing — recreate instead of overwriting.
+            rm -f "${PAT_FILE}" 2>/dev/null || true
+            printf '%s' "${GH_PAT}" > "${PAT_FILE}" || {
+              echo "::error::Cannot write ${PAT_FILE} — no passwordless sudo and the path is not writable."
+              exit 1
+            }
+          fi
 
           # Two containers with different UIDs read this (Grafana 472,
-          # webhook-bridge 1100). The file sits behind a 0700 root-owned
-          # directory that only bind mounts traverse, so 0444 on the file is not
-          # host-readable by other users.
+          # webhook-bridge 1100). The file sits behind a 0700 directory that
+          # only bind mounts traverse, so 0444 on the file is not host-readable
+          # by other unprivileged users.
           sudo -n chown root:root "${PAT_FILE}" 2>/dev/null || true
           sudo -n chmod 0444 "${PAT_FILE}" 2>/dev/null || chmod 0444 "${PAT_FILE}"
           echo "✅ ${PAT_FILE} written ($([ -n "${GH_PAT}" ] && echo 'PAT present' || echo 'EMPTY — issue dispatch disabled'))"

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -41,7 +41,10 @@ services:
       - grafana_data:/var/lib/grafana
       - ./config/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./config/grafana/grafana.ini:/etc/grafana/grafana.ini:ro
-      - /opt/scholarship/secrets/gh_pat:/etc/grafana/secrets/gh_pat:ro
+      # Host path interpolated so a runner without root can relocate the
+      # secrets dir (see the production deploy-monitoring-stack.yml workflow);
+      # the default preserves the staging layout.
+      - ${MONITORING_SECRETS_DIR:-/opt/scholarship/secrets}/gh_pat:/etc/grafana/secrets/gh_pat:ro
     networks:
       - monitoring_network
       - app_network
@@ -166,7 +169,7 @@ services:
       GH_EVENT_TYPE: ${GH_EVENT_TYPE:-monitoring-alert}
       GH_PAT_FILE: /etc/webhook-bridge/gh_pat
     volumes:
-      - /opt/scholarship/secrets/gh_pat:/etc/webhook-bridge/gh_pat:ro
+      - ${MONITORING_SECRETS_DIR:-/opt/scholarship/secrets}/gh_pat:/etc/webhook-bridge/gh_pat:ro
     networks:
       - monitoring_network
     restart: unless-stopped


### PR DESCRIPTION
## Problem

The production monitoring deploy on NYCUITSC/naass ([run 32223343896](https://github.com/NYCUITSC/naass/actions/runs/32223343896)) hard-failed at **Prepare monitoring directories**:

```
Cannot create /opt/scholarship/monitoring — this runner has no passwordless sudo.
```

The runner user (`nycuaa`) doesn't own `/opt` and has no passwordless sudo, and `/opt/scholarship/secrets` (the `gh_pat` bind-mount source) was hardcoded in the shared compose file, so there was no way to install the stack unprivileged.

## Changes

**`.github/production-workflows-examples/deploy-monitoring-stack.yml`**
- *Prepare monitoring directories*: try `/opt/scholarship/{monitoring,secrets}` unprivileged, then `sudo -n`; when neither works, **fall back to `$HOME/scholarship/{monitoring,secrets}`** instead of failing. An explicitly configured `monitoring_dir` / `vars.MONITORING_DIR` still fails loudly rather than being silently relocated. The resolved secrets dir is exported as `MONITORING_SECRETS_DIR` for compose interpolation.
- *Write the alert-dispatch PAT file*: writes into the resolved secrets dir, recreates the 0444 file on re-runs (the owner can delete but not open it for writing), clear error when nothing is writable.
- *Reconcile the Grafana admin account* — two failure modes found while verifying end-to-end:
  - **Startup race**: `/api/health` answers before the user table is served (post-upgrade SQLite migrations hold the DB), so the declared login 401s "user not found" and the step concluded the volume needed reconciling. The initial probe now retries for up to 30s.
  - **Rotated admin login**: `grafana cli admin reset-admin-password` resets **user id 1**, whose login is whatever `GF_SECURITY_ADMIN_USER` said when the volume was first created — after a credential rotation neither the declared login nor `admin` exists, and the step dead-ended even though the reset worked. The step now reads user id 1's login from `grafana.db` (read-only, throwaway python container) and continues the deploy under it, with a warning.

**`monitoring/docker-compose.monitoring.yml`**
- The two `gh_pat` mount sources are now `${MONITORING_SECRETS_DIR:-/opt/scholarship/secrets}` — the default keeps the dev/staging deploy byte-identical in behavior (verified with `docker compose config`).

**`.github/production-workflows-examples/README.md`** — prerequisites updated (root access no longer required).

## Verification

- Container matrix over the extracted step scripts (ubuntu, non-root, no sudo binary): HOME fallback taken and stack dirs writable; 0444 PAT rewrite on re-run; pre-created runner-owned `/opt` still preferred; explicit unusable dir fails loudly; passwordless-sudo path unchanged (`/opt`, secrets root-owned 0700, PAT root 0444). All pass.
- End-to-end on the production rehearsal repo (anud18/naass-prod-test, dispatched from a branch with these exact files): [run 32707057205](https://github.com/anud18/naass-prod-test/actions/runs/32707057205) — **all 20 steps green**, including the reconcile recovering a volume whose admin login predated a credential rotation (`ss_admin`), data-arrival verification, and the nginx `/monitoring` route check. (Two earlier runs, 32706428781 / 32706742519, are what surfaced the reconcile race + rotated-login dead-end.)

## Rollout

Merge → dispatch `mirror-to-production.yml` (it auto-installs the workflow template and syncs `monitoring/**`) → `gh workflow run deploy-monitoring-production.yml` on naass. No VM preparation needed anymore; on naass the stack will land in `/home/nycuaa/scholarship/{monitoring,secrets}`.