### PR TITLE
perf: slim backend (1.81GB→646MB) and frontend (265MB→188MB) docker images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,38 +1,63 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+# syntax=docker/dockerfile:1
 
-# Set environment variables
+# ---------------------------------------------------------------------------
+# Builder: resolves and installs Python dependencies into a self-contained
+# virtualenv at /opt/venv. Everything that is only needed to *build* wheels
+# (uv itself, gcc, libpq-dev, the apt lists) stays in this stage and never
+# reaches the runtime image.
+# ---------------------------------------------------------------------------
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
 
-# Set work directory
+# Build-only toolchain. Almost every dependency ships a manylinux wheel, but
+# gcc/libpq-dev are kept here as a safety net for any sdist fallback — they
+# cost nothing in the final image because this stage is discarded.
+RUN echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian-security bookworm-security main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends --allow-unauthenticated=false \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml /tmp/pyproject.toml
+
+# The venv is placed outside /app so the app bind-mount used by
+# docker-compose.dev.yml cannot shadow the installed packages.
+RUN uv venv --seed /opt/venv && \
+    VIRTUAL_ENV=/opt/venv uv pip install -r /tmp/pyproject.toml
+
+# ---------------------------------------------------------------------------
+# Runtime: plain python-slim plus the shared libraries the app actually dlopen's
+# at runtime (libmagic for python-magic, CJK fonts for reportlab, curl for the
+# healthcheck). No compiler, no uv, no -dev packages.
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:$PATH" \
+    VIRTUAL_ENV=/opt/venv
+
 WORKDIR /app
 
-# Install system dependencies
-# Security: Use trusted Debian repositories with package authentication
-# Allows automatic security updates while maintaining repository trust
+# Security: use trusted Debian repositories with package authentication.
 RUN echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian-security bookworm-security main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends --allow-unauthenticated=false \
     curl \
-    gcc \
-    postgresql-client \
-    tesseract-ocr \
-    tesseract-ocr-eng \
-    libpq-dev \
-    libmagic-dev \
+    libmagic1 \
     # CJK fonts for Chinese PDF generation (reportlab)
     fonts-wqy-zenhei \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --get-selections > /installed-packages.list
 
-# Copy project files
-COPY pyproject.toml .
-
-# Install Python dependencies using uv
-RUN uv pip install --system -r pyproject.toml
+COPY --from=builder /opt/venv /opt/venv
 
 # Copy application code
 COPY . .
@@ -46,9 +71,6 @@ COPY . .
 # no bind mount) finds them; dev compose still bind-mounts ./frontend/emails
 # at /react-email-templates and points REACT_EMAIL_TEMPLATES_DIR there.
 COPY --from=frontend_emails . /frontend/emails
-
-# Create uploads directory
-RUN mkdir -p uploads
 
 # Create non-root user for security
 RUN groupadd -r appuser -g 1000 && \

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -154,8 +154,6 @@ dependencies = [
     
     # File processing and OCR
     "pillow==12.3.0",
-    "opencv-python==4.12.0.88",
-    "pytesseract==0.3.10",
     "google-generativeai==0.8.3",
     "python-magic==0.4.27",
     

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,8 +44,6 @@ jinja2==3.1.6  # Security: Fixed sandbox escape vulnerability (GHSA-cpwx-vrp4-4p
 
 # File processing and OCR
 pillow==12.3.0  # Security: PYSEC-2026-2253..2257, PYSEC-2026-3451..3454, CVE-2026-54058/59198/59200/59204 (<12.3.0)
-opencv-python==4.12.0.88  # Updated for Python 3.13 compatibility
-pytesseract==0.3.10
 google-generativeai==0.8.3
 python-magic==0.4.27
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1-alpine AS base
+FROM oven/bun:1-alpine AS buildbase
 
 # Install Node.js for running Next.js (Bun for deps, Node for runtime)
 # Security: Pin exact package version and configure trusted repositories to prevent dependency confusion attacks
@@ -7,7 +7,7 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/main" > /etc/apk/repositor
     apk add --no-cache nodejs=22.23.2-r0
 
 # Install dependencies only when needed
-FROM base AS deps
+FROM buildbase AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 # Security: Pin exact package version and configure trusted repositories to prevent dependency confusion attacks
 RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/main" > /etc/apk/repositories && \
@@ -26,7 +26,7 @@ COPY scripts ./scripts
 RUN bun install --frozen-lockfile
 
 # Rebuild the source code only when needed
-FROM base AS builder
+FROM buildbase AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -38,20 +38,27 @@ ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN bun run build
 
-# Production image, copy all the files and run next
-FROM base AS runner
+# Production image, copy all the files and run next.
+# Deliberately NOT `FROM buildbase`: the runtime only ever executes
+# `node server.js`, so the ~90MB bun binary and its entrypoint have no
+# business in the shipped image. Alpine version must stay in lockstep with
+# oven/bun:1-alpine so the pinned nodejs package keeps resolving.
+FROM alpine:3.22 AS runner
+# Security: Pin exact package version and configure trusted repositories to prevent dependency confusion attacks
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/main" > /etc/apk/repositories && \
+    echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/community" >> /etc/apk/repositories && \
+    apk add --no-cache nodejs=22.23.2-r0
 WORKDIR /app
 
 ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
 # Set the correct permission for prerender cache
-RUN mkdir .next
-RUN chown nextjs:nodejs .next
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs && \
+    mkdir .next && \
+    chown nextjs:nodejs .next
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing


### PR DESCRIPTION
## Summary

Docker image 瘦身，行為零變更。

| Image | Before | After | 減少 |
|---|---|---|---|
| backend | **1.81 GB** | **646 MB** | **−64%** |
| frontend (runner) | **265 MB** | **188 MB** | **−29%** |

Before 是從 `main` 在同一台機器、同一份 build cache 重新 build 出來的，跟 After 是 apples-to-apples。

## What changed

### `backend/Dockerfile` — 拆成 builder / runtime 兩段

原本是單一 stage，整套 build 工具鏈都留在最終 image 裡：

- `uv` binary **50 MB**
- `gcc` 連帶 `/usr/lib/gcc` **79 MB**（整個 apt layer 349 MB）
- `libpq-dev`（`psycopg2-binary` 自帶 libpq，根本不需要）

現在 deps 裝進 builder stage 的 `/opt/venv`，再 copy 進乾淨的 `python:3.12-slim-bookworm`。`gcc` / `libpq-dev` 留在 builder 當 sdist fallback 的保險，不進最終 image。

其他 apt 調整：

- 移除 `tesseract-ocr` / `tesseract-ocr-eng`（~21 MB）— 全 repo 沒有任何地方 import `pytesseract`，OCR 走 `ocr_service.py` 的 Google Generative AI。
- 移除 `postgresql-client` — 這個容器沒用到；CI 與 `scripts/*.sh` 裡每一處 `psql` / `pg_isready` 打的都是 postgres 容器或 runner。
- `libmagic-dev` → `libmagic1`（runtime 只需要 .so，不需要 headers）。

保留 `curl`（HEALTHCHECK 用）和 `fonts-wqy-zenhei`（reportlab 中文 PDF 用）。

### backend 依賴 — 移除兩個沒人用的套件

- **`opencv-python`** — `cv2` 全 repo 零 import，裝起來佔 **179 MB**（`cv2` 80 MB + `opencv_python.libs` 99 MB）
- **`pytesseract`** — 同樣零 import

`pyproject.toml` 和 `requirements.txt` 兩邊都拿掉。

### `frontend/Dockerfile` — runner 不再帶 bun

runner stage 原本寫 `FROM base`，而 `base` 是 `oven/bun:1-alpine`。也就是說一個**只跑 `node server.js`** 的 production image 裡帶著 **88.6 MB 的 bun binary**。

改成 `FROM alpine:3.22` + 同一個 pin 住的 `nodejs=22.23.2-r0`。`deps` / `builder` 仍然用 bun，所以 `docker-compose.dev.yml` 的 `target: builder` 完全不受影響。

順手把 runner 裡 4 個 user / `.next` 的 `RUN` layer 併成 1 個。

## Test plan

全部實測過（非推論）：

**Backend**

- [x] Image build 成功
- [x] `pyproject.toml` 裡每一個宣告的依賴都能 import（fastapi / sqlalchemy / asyncpg / psycopg2 / pandas / openpyxl / reportlab / pypdf / PIL / magic / minio / redis / structlog / apscheduler / jwt / passlib / bcrypt / cryptography / httpx / aiosmtplib / jinja2 / prometheus_client / croniter / google.generativeai / uvicorn）
- [x] `from app.main import app` 成功
- [x] **接真 Postgres 15 + Redis 7**：`/health` 回 `{"status":"healthy","database":{"connection":true,"pool_info":{"size":10,...}}}`
- [x] Docker 內建 `HEALTHCHECK` 回報 `healthy`（證明 `curl` 還在且可用）
- [x] **`psycopg2` 與 `asyncpg` 都能實際連線 `SELECT version()`** — 這是移除 `libpq-dev` 後最關鍵的驗證
- [x] `python-magic` 正確辨識 PDF magic bytes（`libmagic1` 有效）
- [x] reportlab 用 `wqy-zenhei.ttc` 渲染中文（「獎學金申請彙整表」）成功產出 PDF
- [x] pandas + openpyxl 中文 xlsx 寫入／讀回正確（批次匯入路徑）

**Frontend**

- [x] `--target runner` build 成功
- [x] 容器啟動後 `/` 回 HTTP 200，log 無 error / warning
- [x] `--target builder`（dev compose 用的）仍可 build

**未跑**：專案的 pytest / jest。這個 PR 只動 Dockerfile 與兩個未被任何程式碼 import 的依賴，沒有碰任何 application code。

## 後續可考慮（本 PR 未做）

剩下 646 MB 裡，venv 佔 468 MB，其中 **`google-generativeai` 的傳遞依賴佔約 120 MB**（`googleapiclient` 100 MB，絕大部分是 `discovery_cache/documents/*.json`；再加 `grpc` 18 MB）。該套件已被 Google 標為 deprecated，改用 `google-genai` 可再砍約 120 MB，但需要改 `ocr_service.py` 且要有 API key 才能驗證，故不併入此 PR。
