### PR TITLE
fix: default MINIO_SECURE to false in the production compose

### DIFF
--- a/docker-compose.prod-db.yml
+++ b/docker-compose.prod-db.yml
@@ -51,11 +51,20 @@ services:
   # compose set a dead MINIO_BUCKET_NAME env, so the backend has been using
   # the config default "scholarship-files".
   #
-  # TLS gate: MinIO served TLS from minio_config/certs when present. RustFS
-  # reads certs from RUSTFS_TLS_PATH instead. If the prod backend really runs
-  # MINIO_SECURE=true against this host, provision /opt/scholarship/rustfs/certs
-  # and uncomment the two TLS lines below BEFORE cutover — do not drop the old
-  # minio_config volume until the cert story is replaced.
+  # TLS: NOT enabled, and the cutover has already happened. MinIO served TLS
+  # from minio_config/certs when present; RustFS reads certs from
+  # RUSTFS_TLS_PATH instead, and neither that nor the /certs mount below was
+  # ever turned on — so this store listens in CLEARTEXT. Confirmed by probing
+  # it from the backend container on both stages: https fails at the
+  # transport, http answers 403.
+  #
+  # docker-compose.prod.yml therefore defaults MINIO_SECURE to false. The two
+  # files must be changed together; changing either alone breaks storage.
+  #
+  # TO ENABLE TLS: provision /opt/scholarship/rustfs/certs, uncomment the two
+  # lines below, switch this service's healthcheck to https, and only then set
+  # MINIO_SECURE=true in the env file. Doing it in the other order reproduces
+  # run 33034953741 (`SSL: WRONG_VERSION_NUMBER` at "Seed baseline").
   minio:
     image: rustfs/rustfs:1.0.0-beta.8
     container_name: scholarship_rustfs_prod

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,7 +66,35 @@ services:
       # name with that same default so the bucket choice is explicit instead
       # of accidental (same bug fixed in docker-compose.dev.yml).
       MINIO_BUCKET: ${MINIO_BUCKET:-scholarship-files}
-      MINIO_SECURE: ${MINIO_SECURE:-true}
+      # Defaults FALSE: the store speaks plain HTTP and has since the RustFS
+      # cutover — docker-compose.prod-db.yml keeps RUSTFS_TLS_PATH and the
+      # /certs mount commented out, and its healthcheck is http://. Probed
+      # from inside the backend container on BOTH stages, https fails at the
+      # transport and http answers 403 (an unauthenticated S3 request — proof
+      # the store replied):
+      #   production 10.40.2.86:9000    http 403 / https FAIL
+      #   test       10.113.74.25:19000 http 403 / https FAIL
+      #
+      # This said ${MINIO_SECURE:-true} and that is what took production down.
+      # 正式機更新手冊 §4.4 tells operators to set MINIO_SECURE=true, so the
+      # env file said true, the backend built its client with secure=True
+      # (minio_service.py:59-62), and storage died with `SSL:
+      # WRONG_VERSION_NUMBER` — surfacing as a failed "Seed baseline" (run
+      # 33034953741) and latent for every roster upload after it.
+      #
+      # Production was the lone outlier: dev, staging and staging-e2e already
+      # say false.
+      #
+      # TO ENABLE TLS: provision /opt/scholarship/rustfs/certs, uncomment
+      # RUSTFS_TLS_PATH and the /certs mount in docker-compose.prod-db.yml,
+      # switch that healthcheck to https, and only then set MINIO_SECURE=true
+      # in the env file. Doing it in the other order reproduces the outage.
+      #
+      # Safe over cleartext: S3 SigV4 sends an HMAC signature, so
+      # MINIO_SECRET_KEY never goes on the wire. File BODIES do — roster
+      # spreadsheets carry student PII. That is the accepted trade for an
+      # internal-only link; revisit it if this ever crosses an untrusted hop.
+      MINIO_SECURE: ${MINIO_SECURE:-false}
       # PII Encryption keys (issue #73). JSON map of {version: base64url 32-byte key}.
       # Required in production. Populated by the KMS sidecar at deploy time.
       PII_ENCRYPTION_KEYS: ${PII_ENCRYPTION_KEYS}


### PR DESCRIPTION
## 問題

Production deploy 在 **Seed baseline** 失敗：

```
HTTPSConnectionPool(host='10.40.2.86', port=9000):
  (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER]')))
fastapi.exceptions.HTTPException: 500: MinIO bucket initialization failed
```

`WRONG_VERSION_NUMBER` = 一邊講 TLS、另一邊用明文回。

- **App 講 HTTPS**：`backend/app/services/minio_service.py:59-62` 用 `secure=settings.minio_secure`，而本檔 `:69` 預設 `${MINIO_SECURE:-true}`
- **Store 只講 HTTP**：`docker-compose.prod-db.yml` 的 `RUSTFS_TLS_PATH` 與 `/certs` mount 自 RustFS cutover 起就註解著，healthcheck 也是 `http://`

從 backend container 內部（真正的網路路徑）探測兩個 stage：

| stage | endpoint | http | https |
| --- | --- | --- | --- |
| production | `10.40.2.86:9000` | `403` | `FAIL` |
| test | `10.113.74.25:19000` | `403` | `FAIL` |

`403` 是未授權的 S3 請求 —— 代表 store 確實在該協定上回應了；https 兩邊都在 transport 層失敗。

**Production 是唯一的例外**：`docker-compose.dev.yml:111`、`docker-compose.staging.yml:48`、`docker-compose.staging-e2e.yml:132` 早就都是 `"false"`。

## 這不是只影響 seed

`seed_regulations_doc` 只是 seed 裡第一個碰 storage 的步驟，而且它在 setting 已存在時會 skip —— 所以只有「首次部署到該台 VM」才會踩到。**錯配一直存在**：任何一次造冊檔上傳都會撞同一個錯。

## 改動

```diff
-      MINIO_SECURE: ${MINIO_SECURE:-true}
+      MINIO_SECURE: ${MINIO_SECURE:-false}
```

這是**唯一的非註解改動**。其餘是把 `docker-compose.prod-db.yml` 的 TLS 註解改寫 —— 它原本寫的是「cutover **之前**要準備憑證」，但 cutover 早就做了、而且沒帶憑證，留著會誤導下一個人。現在改成陳述現況（store 走明文），並寫明兩個檔案必須一起改、以及改的順序。

保留 `${...:-}` 而非寫死字面值，日後仍可開 TLS：

| env | 解析結果 |
| --- | --- |
| `MINIO_SECURE=true` | `"true"` |
| 未設定 | `"false"` |

⚠️ 但**只能在 prod-db 那側真的提供 TLS 之後才可以設 true**：備妥 `/opt/scholarship/rustfs/certs`、取消註解 `RUSTFS_TLS_PATH` 與 `/certs` mount、healthcheck 改 `https://`，**最後**才設 `MINIO_SECURE=true`。順序顛倒就是重現這次的 outage。

## 安全取捨

走 cleartext 的實際暴露面：

- ✅ **`MINIO_SECRET_KEY` 不會上線** —— S3 SigV4 送的是 HMAC 簽章，不是 secret 本身
- ⚠️ **檔案內容會** —— 造冊 Excel 含學生個資
- ✅ **無 mixed-content / presigned URL 外洩** —— `get_presigned_url` 在 `api/` 層無任何呼叫者，所有下載都經 backend 串流（`files.py:176,310`），瀏覽器不直接連 store

這是內網專用連線的既有取捨，與 dev/staging 現況一致。若這條路徑日後會跨越不受信任的網段，需重新評估。

## Test plan

- [x] `docker compose config`：env 設 `true` → `"true"`；env 未設 → `"false"`
- [x] 兩個 compose 檔 YAML parse
- [x] 確認唯一的非註解改動就是那一行
- [x] **已在真實 production 驗證**：修正後 deploy 全綠 —— Seed baseline / Health check / Smoke tests 皆通過，`✓ Seeded 獎學金要點 system document (240290 bytes)` 確認檔案真的寫進 storage

## 為什麼兩個 repo 都要改

Production repo（NYCUITSC/naass）持有這個檔案的副本，同一行、同一個行號。只改那邊的話，下次 mirror 同步就會被這裡蓋回去。兩邊的改動內容完全相同。

對應 PR：NYCUITSC/naass#64

## 不在本 PR 範圍

同一次事故還有第二個獨立缺陷：`MINIO_SECRET_KEY` 與 `MINIO_ROOT_PASSWORD` 被各自獨立生成（安裝手冊在兩行各寫一次「請用 openssl rand 生成」，卻沒說兩者必須相同），導致 `SignatureDoesNotMatch`。那個已在 production 的環境檔就地修正，不涉及本 repo。手冊本身的修正待另開 PR（手冊只存在於 naass）。
