### PR TITLE
fix: use Portal app ID 'esas' for production SSO login

### DIFF
--- a/frontend/components/sso-login-page.tsx
+++ b/frontend/components/sso-login-page.tsx
@@ -11,21 +11,33 @@ import {
 import { Button } from "@/components/ui/button";
 import { GraduationCap, ExternalLink, LogOut, AlertTriangle } from "lucide-react";
 
-// Resolve the NYCU Portal base URL for the current environment.
-function getPortalUrl(): string {
-  let portalUrl = "https://portal.nycu.edu.tw"; // default production
-  if (typeof window !== "undefined") {
-    const hostname = window.location.hostname;
-    if (
-      hostname.includes("test") ||
-      hostname.includes("staging") ||
-      hostname.includes("localhost") ||
-      hostname === "140.113.7.148"
-    ) {
-      portalUrl = "https://portal.test.nycu.edu.tw";
-    }
-  }
-  return portalUrl;
+// NYCU Portal SSO entry for the current environment. The Portal maps the app ID
+// to our callback (/api/v1/auth/portal-sso/verify) and POSTs the SSO JWT there.
+// Production uses the "esas" ID assigned by the IT center ("scholarship" belongs
+// to another system on the production Portal); the test Portal still uses
+// "scholarship".
+const PRODUCTION_PORTAL = {
+  url: "https://portal.nycu.edu.tw",
+  appId: "esas",
+} as const;
+const TEST_PORTAL = {
+  url: "https://portal.test.nycu.edu.tw",
+  appId: "scholarship",
+} as const;
+
+function isTestEnvironment(): boolean {
+  if (typeof window === "undefined") return false;
+  const hostname = window.location.hostname;
+  return (
+    hostname.includes("test") ||
+    hostname.includes("staging") ||
+    hostname.includes("localhost") ||
+    hostname === "140.113.7.148"
+  );
+}
+
+function getPortalConfig() {
+  return isTestEnvironment() ? TEST_PORTAL : PRODUCTION_PORTAL;
 }
 
 export function SSOLoginPage() {
@@ -48,14 +60,15 @@ export function SSOLoginPage() {
 
   const handleSSOLogin = () => {
     // Redirect to NYCU Portal for SSO authentication
-    window.location.href = `${getPortalUrl()}/#/redirect/scholarship`;
+    const portal = getPortalConfig();
+    window.location.href = `${portal.url}/#/redirect/${portal.appId}`;
   };
 
   const handlePortalLogout = () => {
     // Open the NYCU Portal so the user can complete a full SSO logout there
     // (clicking the Portal's own LogOut clears the userToken cookie). We can't
     // do it for them: portal.test is a different host and exposes no logout URL.
-    window.open(getPortalUrl(), "_blank", "noopener,noreferrer");
+    window.open(getPortalConfig().url, "_blank", "noopener,noreferrer");
   };
 
   return (


### PR DESCRIPTION
## Summary
- The production NYCU Portal's `scholarship` app ID is registered to **another system**, so clicking SSO login on ss.aa.nycu.edu.tw sent users to the wrong callback and they never returned to this system.
- The IT center assigned `esas` for this system. The login page now redirects to `https://portal.nycu.edu.tw/#/redirect/esas` in production.
- **Only production changes.** Hostnames matching test/staging/localhost/140.113.7.148 still use `https://portal.test.nycu.edu.tw/#/redirect/scholarship`.
- Portal URL and app ID are now selected together from a single environment check (`PRODUCTION_PORTAL` / `TEST_PORTAL`) instead of the URL alone, so they can't drift apart.
- The value is baked into the frontend image, not an env var: the prebuilt image has no build-args, so a `NEXT_PUBLIC_*` runtime env would never reach the client bundle.

## Deploy note
Build-time change: the frontend image must be rebuilt and redeployed, not just restarted.

## Test plan
- [ ] CI typecheck/lint pass (not run locally: no `node_modules`, and `npx` is blocked by the existing `next@^15.5.21` override conflict)
- [ ] Test env: SSO login still goes to `portal.test.nycu.edu.tw/#/redirect/scholarship` and completes
- [ ] Production after deploy: SSO login goes to `portal.nycu.edu.tw/#/redirect/esas`, Portal POSTs to `/api/v1/auth/portal-sso/verify`, user lands on dashboard
- [ ] Portal logout button still opens the correct Portal host

🤖 Generated with [Claude Code](https://claude.com/claude-code)