### PR TITLE
fix: use Portal app ID 'ssaa' for production SSO login

### DIFF
--- a/frontend/components/sso-login-page.tsx
+++ b/frontend/components/sso-login-page.tsx
@@ -13,12 +13,12 @@ import { GraduationCap, ExternalLink, LogOut, AlertTriangle } from "lucide-react
 
 // NYCU Portal SSO entry for the current environment. The Portal maps the app ID
 // to our callback (/api/v1/auth/portal-sso/verify) and POSTs the SSO JWT there.
-// Production uses the "esas" ID assigned by the IT center ("scholarship" belongs
+// Production uses the "ssaa" ID assigned by the IT center ("scholarship" belongs
 // to another system on the production Portal); the test Portal still uses
 // "scholarship".
 const PRODUCTION_PORTAL = {
   url: "https://portal.nycu.edu.tw",
-  appId: "esas",
+  appId: "ssaa",
 } as const;
 const TEST_PORTAL = {
   url: "https://portal.test.nycu.edu.tw",


### PR DESCRIPTION
## Summary
- Follow-up to #1345. The IT center registered this system on the production NYCU Portal as **`ssaa`**, not `esas`.
- Verified against the Portal's own lookup API (`POST /portal/api/getLoginLink`): `esas` maps to 博學獎學金申請系統 → `https://aaapi.nycu.edu.tw/api/v1/loginbyportal` (302s back to the Portal home, i.e. "cannot connect"), while `ssaa` maps to our callback `https://ss.aa.nycu.edu.tw/api/v1/auth/portal-sso/verify`.
- Production login now redirects to `https://portal.nycu.edu.tw/#/redirect/ssaa`. Test/staging/localhost keep `portal.test.nycu.edu.tw/#/redirect/scholarship` (unchanged).

## Deploy note
Build-time change — rebuild and redeploy the frontend image.

## Test plan
- [ ] CI passes
- [ ] Production after deploy: SSO login → `portal.nycu.edu.tw/#/redirect/ssaa` → Portal POSTs to `/api/v1/auth/portal-sso/verify` → user lands on dashboard
- [ ] Test env login unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)