### PR TITLE
fix: send scholarship config deadlines as UTC instants, not local wall-clock

### DIFF
--- a/frontend/components/__tests__/admin-configuration-management.test.tsx
+++ b/frontend/components/__tests__/admin-configuration-management.test.tsx
@@ -676,6 +676,47 @@ describe("AdminConfigurationManagement Component", () => {
     });
   });
 
+  it("sends datetime-local picker values to the API as absolute UTC instants", async () => {
+    // Regression: the raw picker value (browser-local wall clock, no offset)
+    // used to be sent as-is and stored as UTC, so 06:15 came back as 14:15.
+    const user = userEvent.setup();
+    render(
+      <AdminConfigurationManagement scholarshipTypes={mockScholarshipTypes} />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("PhD獎學金114學年度第一學期")
+      ).toBeInTheDocument();
+    });
+    await user.click(screen.getAllByTitle("編輯配置")[0]);
+    await waitFor(() => {
+      expect(screen.getByText("編輯獎學金配置")).toBeInTheDocument();
+    });
+
+    const localValue = "2026-08-24T06:15";
+    const endInput = document.getElementById(
+      "edit_application_end_date"
+    ) as HTMLInputElement;
+    fireEvent.change(endInput, { target: { value: localValue } });
+    expect(endInput.value).toBe(localValue);
+
+    await user.click(screen.getByRole("button", { name: "更新配置" }));
+
+    await waitFor(() => {
+      expect(mockApi.admin.updateScholarshipConfiguration).toHaveBeenCalled();
+    });
+    const [, payload] =
+      mockApi.admin.updateScholarshipConfiguration.mock.calls[0];
+
+    // Same instant as the local wall-clock value, expressed in UTC.
+    expect(payload.application_end_date).toBe(
+      new Date(localValue).toISOString()
+    );
+    // Untouched pickers are sent as null so the backend clears them.
+    expect(payload.application_start_date).toBeNull();
+  });
+
   it("should delete configuration successfully", async () => {
     mockApi.admin.deleteScholarshipConfiguration.mockResolvedValue({
       success: true,

--- a/frontend/components/admin-configuration-management.tsx
+++ b/frontend/components/admin-configuration-management.tsx
@@ -63,7 +63,51 @@ import { ConfigToggleSwitch } from "@/components/admin/config/ConfigToggleSwitch
 import { QuotaExcelButtons } from "@/components/admin/quota-import/QuotaExcelButtons";
 import { QuotaManagementMode, getQuotaManagementModeLabel } from "@/lib/enums";
 import { toast } from "sonner";
+import {
+  dateTimeLocalToIso,
+  formatDateTimeLocal,
+} from "@/lib/utils/datetime-local";
 const api = apiClient;
+
+/** Form fields bound to `datetime-local` pickers (browser-local wall clock). */
+const CONFIG_DATETIME_FIELDS = [
+  "renewal_application_start_date",
+  "renewal_application_end_date",
+  "application_start_date",
+  "application_end_date",
+  "renewal_professor_review_start",
+  "renewal_professor_review_end",
+  "renewal_college_review_start",
+  "renewal_college_review_end",
+  "professor_review_start",
+  "professor_review_end",
+  "college_review_start",
+  "college_review_end",
+  "review_deadline",
+  "effective_start_date",
+  "effective_end_date",
+] as const;
+
+type ConfigDateTimeField = (typeof CONFIG_DATETIME_FIELDS)[number];
+
+/**
+ * Convert every picker value in the form to an absolute UTC instant before it
+ * reaches the API. The backend reads a bare `YYYY-MM-DDTHH:mm` as UTC, which
+ * shifted every deadline by the viewer's UTC offset (+8h in Taiwan). Fields the
+ * form never touched are left out so their stored value is kept; a cleared
+ * picker is sent as null so the backend clears it.
+ */
+const serializeConfigDateTimes = (
+  data: Partial<ScholarshipConfigurationFormData>
+) => {
+  const converted: Partial<Record<ConfigDateTimeField, string | null>> = {};
+  for (const field of CONFIG_DATETIME_FIELDS) {
+    if (field in data) {
+      converted[field] = dateTimeLocalToIso(data[field]);
+    }
+  }
+  return { ...data, ...converted };
+};
 
 interface AdminConfigurationManagementProps {
   scholarshipTypes: ScholarshipType[];
@@ -352,16 +396,15 @@ export function AdminConfigurationManagement({
 
       // 根據 quota_management_mode 自動推導 has_quota_limit 和 has_college_quota
       const quotaMode = formData.quota_management_mode || "none";
-      const processedData = {
+      const processedData = serializeConfigDateTimes({
         ...formData,
         has_quota_limit: quotaMode !== "none",
         has_college_quota:
           quotaMode === "college_based" || quotaMode === "matrix_based",
-      };
+      });
 
-      const response = await api.admin.createScholarshipConfiguration(
-        processedData as ScholarshipConfigurationFormData
-      );
+      const response =
+        await api.admin.createScholarshipConfiguration(processedData);
       if (response.success) {
         setShowCreateDialog(false);
         setFormData({});
@@ -388,12 +431,12 @@ export function AdminConfigurationManagement({
 
       // 根據 quota_management_mode 自動推導 has_quota_limit 和 has_college_quota
       const quotaMode = formData.quota_management_mode || "none";
-      const processedData = {
+      const processedData = serializeConfigDateTimes({
         ...formData,
         has_quota_limit: quotaMode !== "none",
         has_college_quota:
           quotaMode === "college_based" || quotaMode === "matrix_based",
-      };
+      });
 
       const response = await api.admin.updateScholarshipConfiguration(
         selectedConfig.id,
@@ -638,30 +681,6 @@ export function AdminConfigurationManagement({
       return format(date, "yyyy年MM月dd日 HH:mm", { locale: zhTW });
     } catch (error) {
       return "無效日期";
-    }
-  };
-
-  // 格式化日期時間字符串為 datetime-local 輸入格式 (YYYY-MM-DDTHH:mm)
-  const formatDateTimeLocal = (dateString: string | null | undefined) => {
-    if (!dateString) return "";
-    try {
-      const date = new Date(dateString);
-      // 檢查日期是否有效
-      if (isNaN(date.getTime())) {
-        logger.warn("Invalid date string:", dateString);
-        return "";
-      }
-
-      // 使用本地時間
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, "0");
-      const day = String(date.getDate()).padStart(2, "0");
-      const hours = String(date.getHours()).padStart(2, "0");
-      const minutes = String(date.getMinutes()).padStart(2, "0");
-
-      return `${year}-${month}-${day}T${hours}:${minutes}`;
-    } catch (error) {
-      return "";
     }
   };
 

--- a/frontend/lib/utils/__tests__/datetime-local.test.ts
+++ b/frontend/lib/utils/__tests__/datetime-local.test.ts
@@ -1,0 +1,59 @@
+import {
+  dateTimeLocalToIso,
+  formatDateTimeLocal,
+} from "@/lib/utils/datetime-local";
+
+const MS_PER_MINUTE = 60_000;
+
+describe("dateTimeLocalToIso", () => {
+  it("returns null for empty input so the API clears the field", () => {
+    expect(dateTimeLocalToIso("")).toBeNull();
+    expect(dateTimeLocalToIso(null)).toBeNull();
+    expect(dateTimeLocalToIso(undefined)).toBeNull();
+  });
+
+  it("treats the picker value as local wall-clock time and emits a UTC instant", () => {
+    const local = "2026-08-24T06:15";
+    const iso = dateTimeLocalToIso(local);
+
+    // The wall-clock time shifted by this machine's UTC offset.
+    const offsetMinutes = new Date(local).getTimezoneOffset();
+    const expectedMs =
+      Date.UTC(2026, 7, 24, 6, 15) + offsetMinutes * MS_PER_MINUTE;
+
+    expect(iso).toMatch(/Z$/);
+    expect(new Date(iso as string).getTime()).toBe(expectedMs);
+  });
+
+  it("is idempotent for values that already carry an offset", () => {
+    const iso = "2026-08-23T22:15:00.000Z";
+    expect(dateTimeLocalToIso(iso)).toBe(iso);
+  });
+
+  it("rejects unparsable input instead of silently clearing the field", () => {
+    expect(() => dateTimeLocalToIso("not-a-date")).toThrow("無效的日期時間");
+  });
+});
+
+describe("formatDateTimeLocal", () => {
+  it("returns an empty string for empty or invalid input", () => {
+    expect(formatDateTimeLocal("")).toBe("");
+    expect(formatDateTimeLocal(null)).toBe("");
+    expect(formatDateTimeLocal(undefined)).toBe("");
+    expect(formatDateTimeLocal("garbage")).toBe("");
+  });
+
+  it("round-trips a picker value through the API representation unchanged", () => {
+    const local = "2026-08-24T06:15";
+    expect(formatDateTimeLocal(dateTimeLocalToIso(local))).toBe(local);
+  });
+
+  it("renders an offset-bearing API value in local wall-clock time", () => {
+    const iso = "2026-08-23T22:15:00+00:00";
+    const expected = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const expectedDate = `${expected.getFullYear()}-${pad(expected.getMonth() + 1)}-${pad(expected.getDate())}`;
+    const expectedTime = `${pad(expected.getHours())}:${pad(expected.getMinutes())}`;
+    expect(formatDateTimeLocal(iso)).toBe(`${expectedDate}T${expectedTime}`);
+  });
+});

--- a/frontend/lib/utils/datetime-local.ts
+++ b/frontend/lib/utils/datetime-local.ts
@@ -1,0 +1,47 @@
+import { logger } from "@/lib/utils/logger";
+
+/**
+ * Helpers for `<input type="datetime-local">`.
+ *
+ * The input works in the browser's local wall-clock time and carries no
+ * timezone. Its value must therefore be converted to an absolute instant
+ * (UTC ISO-8601) before it is sent to the API, and an API value must be
+ * converted back to local wall-clock time when it is loaded into the input.
+ * Sending the raw input value made the backend store it as UTC, shifting
+ * every deadline by the viewer's UTC offset (+8h in Taiwan).
+ */
+
+const pad2 = (value: number) => String(value).padStart(2, "0");
+
+/**
+ * Format an API datetime string as a `datetime-local` value
+ * (`YYYY-MM-DDTHH:mm`) in the browser's local time. Empty or invalid → "".
+ */
+export function formatDateTimeLocal(value: string | null | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    logger.warn("Invalid date string:", value);
+    return "";
+  }
+  const datePart = `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+  const timePart = `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+  return `${datePart}T${timePart}`;
+}
+
+/**
+ * Convert a `datetime-local` value (browser-local wall clock) to a UTC
+ * ISO-8601 instant for the API. Empty → null (clears the field).
+ * Values that already carry an offset keep their meaning, so the
+ * conversion is idempotent.
+ */
+export function dateTimeLocalToIso(
+  value: string | null | undefined
+): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`無效的日期時間：${value}`);
+  }
+  return date.toISOString();
+}


### PR DESCRIPTION
## Summary

**Bug:** 管理員 → 獎學金配置 → 設定截止時間, entering 8/24 上午 6:15 reloads as 下午 2:15 (an 8-hour shift). Every window field on the form was affected, not just 截止時間.

**Root cause:** the form's fifteen `datetime-local` pickers submitted their raw value (`2026-08-24T06:15`, browser-local wall clock, no offset). `parse_date_field` keeps such a string naive and the timezone-aware column stores it as UTC, so the value drifted by the viewer's UTC offset on read-back.

**Fix (frontend only):**
- New `frontend/lib/utils/datetime-local.ts`:
  - `dateTimeLocalToIso` — picker value → UTC ISO instant; `""` → `null` so a cleared picker still clears the stored date; idempotent for values that already carry an offset; throws on unparsable input instead of silently dropping a deadline.
  - `formatDateTimeLocal` — API value → picker value (shared; replaces the copy that lived inside the component).
- `admin-configuration-management.tsx`: both create and update handlers pass the form through `serializeConfigDateTimes`, which converts all fifteen date fields before the API call.
- No backend change: the parser already handles offset-bearing ISO strings, and the existing Playwright deadline spec sends ISO strings via the API.

## Test plan

- [x] 7 new unit tests for the round trip (`lib/utils/__tests__/datetime-local.test.ts`), timezone-independent.
- [x] 1 new component regression test: open 編輯配置, enter `2026-08-24T06:15` in 一般申請截止, submit, assert the payload carries the equivalent UTC instant and untouched pickers are sent as `null`.
- [x] Both suites green (30 tests), `tsc --noEmit` and eslint clean on the changed files.
- [ ] Manual: in the dev stack, edit a config, set 一般申請截止 to 8/24 06:15, save, reopen — it should still read 06:15 (previously 14:15).

Note: the component is not prettier-clean on `main`, so I did not run prettier over the whole file — the diff contains only the semantic edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTpG62aonv7VsgHysPi3Xh
