### PR TITLE
fix: percent-encode Chinese filenames in Content-Disposition (example preview, whitelist export/template)

### DIFF
--- a/backend/app/api/v1/endpoints/application_fields.py
+++ b/backend/app/api/v1/endpoints/application_fields.py
@@ -6,6 +6,7 @@ import io
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, File, HTTPException, Path, UploadFile, status
 from fastapi.responses import StreamingResponse
@@ -398,40 +399,50 @@ async def get_document_example(
     if not document or not document.example_file_url:
         raise HTTPException(status_code=404, detail="範例文件不存在")
 
-    try:
-        from app.services.minio_service import minio_service
+    from app.services.minio_service import minio_service
 
+    response = None
+    try:
         # Download from MinIO
         response = minio_service.client.get_object(
             bucket_name=minio_service.default_bucket, object_name=document.example_file_url
         )
-
         file_content = response.read()
-
-        # Determine content type based on file extension
-        file_extension = document.example_file_url.rsplit(".", 1)[-1].lower()
-        content_type_map = {
-            "pdf": "application/pdf",
-            "doc": "application/msword",
-            "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            "jpg": "image/jpeg",
-            "jpeg": "image/jpeg",
-            "png": "image/png",
-        }
-        content_type = content_type_map.get(file_extension, "application/octet-stream")
-
-        # Return as streaming response
-        return StreamingResponse(
-            io.BytesIO(file_content),
-            media_type=content_type,
-            headers={
-                "Content-Disposition": f"inline; filename*=UTF-8''{document.document_name}_example.{file_extension}"
-            },
-        )
-
     except Exception as e:
         logger.exception("Failed to get example file")
         raise HTTPException(status_code=500, detail="範例文件讀取失敗") from e
+    finally:
+        if response is not None:
+            response.close()
+            response.release_conn()
+
+    # Determine content type based on file extension
+    file_extension = document.example_file_url.rsplit(".", 1)[-1].lower()
+    content_type_map = {
+        "pdf": "application/pdf",
+        "doc": "application/msword",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "png": "image/png",
+    }
+    content_type = content_type_map.get(file_extension, "application/octet-stream")
+
+    # HTTP headers are latin-1 only: document_name is usually Chinese, so it
+    # MUST be percent-encoded (RFC 5987) or Starlette raises UnicodeEncodeError
+    # while building the response.
+    encoded_name = quote(f"{document.document_name}_example.{file_extension}", safe="")
+
+    return StreamingResponse(
+        io.BytesIO(file_content),
+        media_type=content_type,
+        headers={
+            "Content-Disposition": f"inline; filename*=UTF-8''{encoded_name}",
+            # Content-Length is REQUIRED: without it the frontend PDF viewer
+            # cannot detect truncation and reports a false "password protected".
+            "Content-Length": str(len(file_content)),
+        },
+    )
 
 
 @router.delete("/documents/{document_id}/example")

--- a/backend/app/api/v1/endpoints/scholarship_configurations.py
+++ b/backend/app/api/v1/endpoints/scholarship_configurations.py
@@ -4,6 +4,7 @@ Clean, database-driven approach for dynamic scholarship configuration management
 """
 
 import logging
+from urllib.parse import quote
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
@@ -1910,7 +1911,9 @@ async def export_whitelist_excel(
     return StreamingResponse(
         excel_file,
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        headers={"Content-Disposition": f"attachment; filename*=UTF-8''{filename}"},
+        # HTTP headers are latin-1 only: the filename is Chinese, so it MUST be
+        # percent-encoded (RFC 5987) or Starlette raises UnicodeEncodeError.
+        headers={"Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename, safe='')}"},
     )
 
 
@@ -1945,5 +1948,7 @@ async def download_whitelist_template(
     return StreamingResponse(
         template_file,
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        headers={"Content-Disposition": f"attachment; filename*=UTF-8''{filename}"},
+        # HTTP headers are latin-1 only: the filename is Chinese, so it MUST be
+        # percent-encoded (RFC 5987) or Starlette raises UnicodeEncodeError.
+        headers={"Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename, safe='')}"},
     )

--- a/backend/app/tests/test_application_fields_endpoints.py
+++ b/backend/app/tests/test_application_fields_endpoints.py
@@ -470,6 +470,37 @@ class TestApplicationFieldsEndpoints:
         resp = await c.get(f"/api/v1/application-fields/documents/{doc.id}/example")
         assert resp.status_code == 404
 
+    @pytest.mark.asyncio
+    async def test_get_example_chinese_document_name_200(self, login, admin, monkeypatch):
+        """Regression: document_name is Chinese, and HTTP headers are latin-1.
+        Interpolating it raw into Content-Disposition made Starlette raise
+        UnicodeEncodeError -> 500 "範例文件讀取失敗" in production."""
+        from unittest.mock import MagicMock
+
+        from app.services.minio_service import minio_service
+
+        payload = b"%PDF-1.4 fake"
+        fake_obj = MagicMock()
+        fake_obj.read.return_value = payload
+        fake_client = MagicMock()
+        fake_client.get_object.return_value = fake_obj
+        monkeypatch.setattr(minio_service, "client", fake_client)
+
+        doc = await self._make_document(
+            scholarship_type="undergrad_exget_cn",
+            document_name="成績單",
+            example_file_url="examples/document_1_20260902.pdf",
+        )
+        c = login(admin)
+        resp = await c.get(f"/api/v1/application-fields/documents/{doc.id}/example")
+
+        assert resp.status_code == 200
+        assert resp.content == payload
+        assert resp.headers["content-type"] == "application/pdf"
+        assert resp.headers["content-length"] == str(len(payload))
+        assert resp.headers["content-disposition"] == "inline; filename*=UTF-8''%E6%88%90%E7%B8%BE%E5%96%AE_example.pdf"
+        fake_obj.release_conn.assert_called_once()
+
     # ------------------------------------------------------------------
     # DELETE /documents/{document_id}/example  (require_admin)
     # ------------------------------------------------------------------

--- a/backend/app/tests/test_scholarship_configuration_endpoints.py
+++ b/backend/app/tests/test_scholarship_configuration_endpoints.py
@@ -850,3 +850,52 @@ class TestScholarshipConfigurationQuotaImport:
         }
         resp = await authenticated_admin_client.post(BASE, json=payload)
         assert resp.status_code == 422
+
+
+class TestWhitelistExcelDownloadHeaders:
+    """Regression: both whitelist downloads build a Chinese filename, and HTTP
+    headers are latin-1. Interpolating it raw into Content-Disposition made
+    Starlette raise UnicodeEncodeError -> 500 on every click in the admin UI."""
+
+    WHITELIST_BASE = "/api/v1/scholarship-configurations"
+    XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+    async def _create_config(self, client: AsyncClient, payload: dict, code: str) -> int:
+        resp = await client.post(BASE, json={**payload, "config_code": code})
+        assert resp.status_code == 200, resp.text
+        return resp.json()["data"]["id"]
+
+    @pytest.mark.asyncio
+    async def test_export_whitelist_encodes_chinese_filename(
+        self, authenticated_admin_client: AsyncClient, valid_config_payload
+    ):
+        config_id = await self._create_config(authenticated_admin_client, valid_config_payload, "WL-EXPORT-113-1")
+
+        resp = await authenticated_admin_client.get(f"{self.WHITELIST_BASE}/{config_id}/whitelist/export")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == self.XLSX
+        disposition = resp.headers["content-disposition"]
+        assert disposition.startswith("attachment; filename*=UTF-8''")
+        assert disposition.isascii()
+        # "_申請白名單_" percent-encoded
+        assert "_%E7%94%B3%E8%AB%8B%E7%99%BD%E5%90%8D%E5%96%AE_" in disposition
+        assert resp.content[:2] == b"PK"  # xlsx is a zip container
+
+    @pytest.mark.asyncio
+    async def test_whitelist_template_encodes_chinese_filename(
+        self, authenticated_admin_client: AsyncClient, valid_config_payload
+    ):
+        config_id = await self._create_config(authenticated_admin_client, valid_config_payload, "WL-TEMPLATE-113-1")
+
+        resp = await authenticated_admin_client.get(f"{self.WHITELIST_BASE}/{config_id}/whitelist/template")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"] == self.XLSX
+        disposition = resp.headers["content-disposition"]
+        # "白名單匯入模板_" percent-encoded
+        assert disposition.startswith(
+            "attachment; filename*=UTF-8''%E7%99%BD%E5%90%8D%E5%96%AE%E5%8C%AF%E5%85%A5%E6%A8%A1%E6%9D%BF_"
+        )
+        assert disposition.isascii()
+        assert resp.content[:2] == b"PK"


### PR DESCRIPTION
## Summary

Two admin download endpoints put a raw Chinese filename into the `Content-Disposition` header. HTTP headers are latin-1, so Starlette raised `UnicodeEncodeError` while building the response and the request failed with a 500. Both are live in production today.

**Example-file preview** (`GET /application-fields/documents/{id}/example`, 審核管理 → 文件要求): every preview failed with `500 範例文件讀取失敗` and the log line `Failed to get example file`.

- Percent-encode the filename per RFC 5987 (`quote(..., safe="")`), matching the other download endpoints
- Add an explicit `Content-Length` on the `StreamingResponse` (the frontend PDF viewer relies on it)
- Close and `release_conn()` the MinIO response in a `finally`
- Narrow the `try` to the MinIO fetch so header/response building can no longer be mis-reported as a "read" failure

**Whitelist Excel export and import template** (`GET /scholarship-configurations/{id}/whitelist/export` and `/template`): the filenames always contain `申請白名單` / `白名單匯入模板`, so both admin buttons returned 500 on every click.

- Percent-encode the filename in both endpoints

## Test plan

- [x] `test_get_example_chinese_document_name_200` in `backend/app/tests/test_application_fields_endpoints.py` (mocks MinIO, Chinese `document_name`, asserts 200, body, content-type, content-length, encoded header, connection release)
- [x] `TestWhitelistExcelDownloadHeaders` in `backend/app/tests/test_scholarship_configuration_endpoints.py` (both downloads return 200 with an ASCII, percent-encoded header and a real xlsx body)
- [x] Both touched test files pass locally in the backend image (45 + 24 tests); black and flake8 B904/B014 clean
- [ ] CI green
- [ ] Production: open an example preview and click whitelist export / template download

## Follow-ups (not in this PR)

Tracked in a separate issue: `/scholarships/{type}/terms` serves `.doc/.docx` as `_terms.pdf` and never releases the MinIO response; the admin example preview dialog hard-codes `application/pdf`; a shared `content_disposition()` helper for the 23 hand-rolled sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBsVC8brm6zno3e86Vx7yf
