### PR TITLE
Rename student portal tab labels

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -237,14 +237,14 @@ export default function ScholarshipManagementSystem() {
             className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
           >
             <FileText className="h-4 w-4" />
-            {locale === "zh" ? "學生申請" : "New Application"}
+            {locale === "zh" ? "獎學金申請" : "New Application"}
           </TabsTrigger>
           <TabsTrigger
             value="applications"
             className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:text-nycu-blue-700"
           >
             <BookOpen className="h-4 w-4" />
-            {locale === "zh" ? "我的申請" : "My Applications"}
+            {locale === "zh" ? "我的申請紀錄" : "My Applications"}
           </TabsTrigger>
         </TabsList>
       );

--- a/frontend/lib/__tests__/i18n.test.ts
+++ b/frontend/lib/__tests__/i18n.test.ts
@@ -26,7 +26,7 @@ describe("getTranslation", () => {
   it("resolves a nested dot-path", () => {
     /** Multi-level dotted key traverses the translation tree. */
     expect(getTranslation("zh", "nav.dashboard")).toBe("儀表板");
-    expect(getTranslation("zh", "nav.applications")).toBe("學生申請");
+    expect(getTranslation("zh", "nav.applications")).toBe("獎學金申請");
   });
 
   it("returns the key itself when the path doesn't resolve", () => {

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -16,7 +16,7 @@ export const translations = {
     // 導航
     nav: {
       dashboard: "儀表板",
-      applications: "學生申請",
+      applications: "獎學金申請",
       review: "審核管理",
       admin: "系統管理",
       profile: "個人資料",
@@ -178,7 +178,7 @@ export const translations = {
 
     // 學生入口網站
     portal: {
-      my_applications: "我的申請",
+      my_applications: "我的申請紀錄",
       new_application: "新增申請",
       application_records: "申請記錄",
       no_applications: "尚無申請記錄",
@@ -351,14 +351,14 @@ export const translations = {
       no_eligible_scholarships: "目前沒有符合資格的獎學金",
       no_eligible_scholarships_desc:
         "很抱歉，您目前沒有符合申請資格的獎學金。請稍後再試或聯繫獎學金辦公室。",
-      all_eligible_already_submitted: "您可申請的獎學金皆已送出，請至「我的申請」查看進度",
+      all_eligible_already_submitted: "您可申請的獎學金皆已送出，請至「我的申請紀錄」查看進度",
       application_period_ended: "獎學金申請時間已結束",
       eligible: "可申請",
       not_eligible: "不符合申請資格",
       loading_data: "正在載入資料...",
       loading_scholarship_info: "載入獎學金資訊...",
       application_success: "申請提交成功！",
-      application_success_with_progress: "申請提交成功！請在「我的申請」查看進度",
+      application_success_with_progress: "申請提交成功！請在「我的申請紀錄」查看進度",
       draft_saved: "草稿已保存，您可以繼續編輯",
       draft_updated: "草稿已更新",
       draft_deleted: "草稿已成功刪除",


### PR DESCRIPTION
## Summary
- Student page tab label `學生申請` → `獎學金申請`
- Student page tab label `我的申請` → `我的申請紀錄`
- Kept the i18n dict entries (`nav.applications`, `portal.my_applications`) and the two in-app messages that reference the "我的申請" tab by name in sync with the new label
- Updated the pinned i18n unit test expectation

## Test plan
- [x] `jest lib/__tests__/i18n.test.ts components/__tests__/enhanced-student-portal.test.tsx` — 20/20 pass
- [x] `eslint` on touched files — clean
- [ ] Visual check on localhost (not run this session — happy to do if requested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)