### PR TITLE
feat: 底部政策連結（隱私權政策/使用條款/無障礙聲明/網站地圖）改為管理員可編輯

### DIFF
--- a/backend/alembic/versions/add_footer_link_section_001_add_section_to_footer_links.py
+++ b/backend/alembic/versions/add_footer_link_section_001_add_section_to_footer_links.py
@@ -1,0 +1,119 @@
+"""add section to footer_links (相關連結 vs 底部政策列)
+
+The footer's bottom bar (隱私權政策 / 使用條款 / 無障礙聲明 / 網站地圖) was
+hardcoded as four ``href="#"`` anchors. It now shares the admin-editable
+``footer_links`` table with 相關連結, split by a new ``section`` column.
+
+The four names are seeded as *hidden* ``policy`` rows so an admin only has to
+set a real URL (or replace with an upload) and toggle them visible; visitors
+never see the placeholder URL. Nothing is seeded when policy rows already
+exist.
+
+IMPORTANT: migration 59b65a4de996 runs ``Base.metadata.create_all()``, so on a
+fresh database the column already exists by the time this runs. Each step is
+guarded individually — an early ``return`` would skip the seed.
+
+Revision ID: add_footer_link_section_001
+Revises: professor_notify_both_emails_001
+Create Date: 2026-09-03
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "add_footer_link_section_001"
+down_revision = "professor_notify_both_emails_001"
+branch_labels = None
+depends_on = None
+
+_ENUM_NAME = "footerlinksection"
+_ENUM_VALUES = ("related", "policy")
+_INDEX_NAME = "ix_footer_links_section"
+
+# Hidden placeholders: the admin sets the real target before showing them.
+_PLACEHOLDER_URL = "https://www.nycu.edu.tw"
+_SEED_POLICY_LINKS = [
+    ("隱私權政策", "Privacy Policy", 0),
+    ("使用條款", "Terms of Use", 1),
+    ("無障礙聲明", "Accessibility", 2),
+    ("網站地圖", "Sitemap", 3),
+]
+
+_footer_links_table = sa.table(
+    "footer_links",
+    sa.column("title_zh", sa.String),
+    sa.column("title_en", sa.String),
+    sa.column("link_type", sa.String),
+    sa.column("section", sa.String),
+    sa.column("url", sa.String),
+    sa.column("sort_order", sa.Integer),
+    sa.column("is_active", sa.Boolean),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "footer_links" not in inspector.get_table_names():
+        # Table is created by add_footer_links_001; nothing to do on a DB
+        # that somehow lacks it.
+        return
+
+    # --- 1. Enum type -------------------------------------------------------
+    section_enum = postgresql.ENUM(*_ENUM_VALUES, name=_ENUM_NAME)
+    section_enum.create(bind, checkfirst=True)
+
+    # --- 2. Column ------------------------------------------------------------
+    columns = {c["name"] for c in inspector.get_columns("footer_links")}
+    if "section" not in columns:
+        op.add_column(
+            "footer_links",
+            sa.Column(
+                "section",
+                sa.Enum(*_ENUM_VALUES, name=_ENUM_NAME, create_type=False),
+                nullable=False,
+                server_default="related",
+            ),
+        )
+        inspector = sa.inspect(bind)
+
+    # --- 3. Index ---------------------------------------------------------------
+    indexes = {i["name"] for i in inspector.get_indexes("footer_links")}
+    if _INDEX_NAME not in indexes:
+        op.create_index(_INDEX_NAME, "footer_links", ["section"])
+
+    # --- 4. Seed the hidden policy placeholders (only when none exist) ----
+    has_policy = bind.execute(sa.text("SELECT 1 FROM footer_links WHERE section = 'policy' LIMIT 1")).scalar()
+    if not has_policy:
+        op.bulk_insert(
+            _footer_links_table,
+            [
+                {
+                    "title_zh": title_zh,
+                    "title_en": title_en,
+                    "link_type": "url",
+                    "section": "policy",
+                    "url": _PLACEHOLDER_URL,
+                    "sort_order": sort_order,
+                    "is_active": False,
+                }
+                for title_zh, title_en, sort_order in _SEED_POLICY_LINKS
+            ],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "footer_links" in inspector.get_table_names():
+        columns = {c["name"] for c in inspector.get_columns("footer_links")}
+        if "section" in columns:
+            op.execute(sa.text("DELETE FROM footer_links WHERE section = 'policy'"))
+            op.drop_index(_INDEX_NAME, table_name="footer_links", if_exists=True)
+            op.drop_column("footer_links", "section")
+
+    sa.Enum(name=_ENUM_NAME).drop(bind, checkfirst=True)

--- a/backend/app/api/v1/endpoints/footer_links.py
+++ b/backend/app/api/v1/endpoints/footer_links.py
@@ -1,6 +1,7 @@
-"""Admin-managed footer 相關連結 (Related Links).
+"""Admin-managed footer links.
 
-Each entry is either an external URL or an uploaded document (PDF / Office /
+Two blocks share this table, keyed by ``section``: the 相關連結 (Related
+Links) list and the bottom policy bar (隱私權政策 / 使用條款 / ...). Each entry is either an external URL or an uploaded document (PDF / Office /
 ODF) streamed back through this API — never a direct MinIO URL.
 """
 
@@ -23,7 +24,7 @@ from app.core.document_formats import (
 from app.core.path_security import validate_upload_file
 from app.core.security import get_current_user, require_admin
 from app.db.deps import get_db
-from app.models.footer_link import FooterLink, FooterLinkType
+from app.models.footer_link import FooterLink, FooterLinkSection, FooterLinkType
 from app.models.user import User
 from app.schemas.footer_link import (
     MAX_TITLE_LENGTH,
@@ -61,24 +62,32 @@ async def _get_link_or_404(db: AsyncSession, link_id: int) -> FooterLink:
     return link
 
 
-async def _next_sort_order(db: AsyncSession) -> int:
-    max_order = (await db.execute(select(func.max(FooterLink.sort_order)))).scalar()
+async def _next_sort_order(db: AsyncSession, section: FooterLinkSection) -> int:
+    """Sort orders are independent per section — each block is its own list."""
+    stmt = select(func.max(FooterLink.sort_order)).where(FooterLink.section == section)
+    max_order = (await db.execute(stmt)).scalar()
     return (max_order + 1) if max_order is not None else 0
 
 
 @router.get("")
 async def list_footer_links(
     include_inactive: bool = False,
+    section: Optional[FooterLinkSection] = None,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """List footer links ordered by sort_order then id.
+
+    ``section`` narrows to one block; omitted, both blocks are returned so the
+    footer needs a single request.
 
     Any authenticated user may read. ``include_inactive`` is honoured for
     admins only — a non-admin always gets the active (publicly shown) set,
     so a hidden link cannot leak through the query parameter.
     """
     stmt = select(FooterLink)
+    if section is not None:
+        stmt = stmt.where(FooterLink.section == section)
     if not (include_inactive and _is_admin(current_user)):
         stmt = stmt.where(FooterLink.is_active.is_(True))
     stmt = stmt.order_by(FooterLink.sort_order.asc(), FooterLink.id.asc())
@@ -103,9 +112,10 @@ async def create_footer_link(
         title_zh=payload.title_zh,
         title_en=payload.title_en,
         link_type=FooterLinkType.url,
+        section=payload.section,
         url=payload.url,
         is_active=payload.is_active,
-        sort_order=await _next_sort_order(db),
+        sort_order=await _next_sort_order(db, payload.section),
         created_by=current_user.id,
     )
     db.add(link)
@@ -127,6 +137,7 @@ async def upload_footer_link_file(
     file: UploadFile = File(...),
     title_zh: str = Form(...),
     title_en: Optional[str] = Form(None),
+    section: FooterLinkSection = Form(FooterLinkSection.related),
     current_user: User = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
@@ -170,12 +181,13 @@ async def upload_footer_link_file(
         title_zh=stripped_zh,
         title_en=stripped_en,
         link_type=FooterLinkType.file,
+        section=section,
         object_name=object_name,
         original_filename=file.filename or "",
         content_type=content_type,
         file_size=len(file_content),
         is_active=True,
-        sort_order=await _next_sort_order(db),
+        sort_order=await _next_sort_order(db, section),
         created_by=current_user.id,
     )
     db.add(link)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,7 +12,7 @@ from app.models.college_review import CollegeRanking, CollegeRankingItem, QuotaD
 from app.models.document_request import DocumentRequest, DocumentRequestStatus
 from app.models.email_management import EmailCategory, EmailHistory, EmailStatus, ScheduledEmail, ScheduleStatus
 from app.models.enums import ApplicationCycle, QuotaManagementMode, Semester, SubTypeSelectionMode
-from app.models.footer_link import FooterLink, FooterLinkType
+from app.models.footer_link import FooterLink, FooterLinkSection, FooterLinkType
 from app.models.notification import Notification, NotificationType
 from app.models.payment_roster import (
     PaymentRoster,
@@ -126,6 +126,7 @@ __all__ = [
     "SupplementaryDoc",
     # Footer 相關連結 models
     "FooterLink",
+    "FooterLinkSection",
     "FooterLinkType",
     # Imported received-months ledger
     "ReceivedMonthImport",

--- a/backend/app/models/footer_link.py
+++ b/backend/app/models/footer_link.py
@@ -36,8 +36,19 @@ class FooterLinkType(enum.Enum):
     file = "file"
 
 
+class FooterLinkSection(enum.Enum):
+    """Which footer block an entry is rendered in.
+
+    ``related`` is the 相關連結 (Related Links) list; ``policy`` is the small
+    bottom bar (隱私權政策 / 使用條款 / 無障礙聲明 / 網站地圖 ...).
+    """
+
+    related = "related"
+    policy = "policy"
+
+
 class FooterLink(Base):
-    """Admin-managed entry in the site footer's 相關連結 (Related Links) list.
+    """Admin-managed entry in one of the site footer's link blocks.
 
     Exactly one of the two payload shapes is populated, keyed by ``link_type``:
     an external ``url``, or an uploaded document (``object_name`` + metadata).
@@ -55,6 +66,13 @@ class FooterLink(Base):
         Enum(FooterLinkType, values_callable=lambda obj: [e.value for e in obj]),
         nullable=False,
         default=FooterLinkType.url,
+    )
+    section = Column(
+        Enum(FooterLinkSection, values_callable=lambda obj: [e.value for e in obj]),
+        nullable=False,
+        default=FooterLinkSection.related,
+        server_default=FooterLinkSection.related.value,
+        index=True,
     )
 
     # link_type == url

--- a/backend/app/schemas/footer_link.py
+++ b/backend/app/schemas/footer_link.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from app.models.footer_link import FooterLinkType
+from app.models.footer_link import FooterLinkSection, FooterLinkType
 
 MAX_TITLE_LENGTH = 200
 MAX_URL_LENGTH = 1000
@@ -47,6 +47,7 @@ class FooterLinkResponse(BaseModel):
     title_zh: str
     title_en: Optional[str] = None
     link_type: FooterLinkType
+    section: FooterLinkSection
     url: Optional[str] = None
     object_name: Optional[str] = None
     original_filename: Optional[str] = None
@@ -66,6 +67,7 @@ class FooterLinkCreate(BaseModel):
     title_zh: str = Field(..., min_length=1, max_length=MAX_TITLE_LENGTH)
     title_en: Optional[str] = Field(default=None, max_length=MAX_TITLE_LENGTH)
     url: str = Field(..., min_length=1, max_length=MAX_URL_LENGTH)
+    section: FooterLinkSection = FooterLinkSection.related
     is_active: bool = True
 
     @field_validator("title_zh")

--- a/backend/app/tests/test_footer_links.py
+++ b/backend/app/tests/test_footer_links.py
@@ -196,6 +196,62 @@ async def test_new_links_append_to_end_of_order(admin_client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_section_defaults_to_related_and_is_persisted(admin_client: AsyncClient):
+    related = await admin_client.post(
+        "/api/v1/footer-links", json={"title_zh": "教務處", "url": "https://a.nycu.edu.tw"}
+    )
+    policy = await admin_client.post(
+        "/api/v1/footer-links",
+        json={"title_zh": "隱私權政策", "url": "https://p.nycu.edu.tw", "section": "policy"},
+    )
+    assert related.json()["data"]["section"] == "related"
+    assert policy.json()["data"]["section"] == "policy"
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_section_and_returns_both_when_omitted(admin_client: AsyncClient):
+    await admin_client.post("/api/v1/footer-links", json={"title_zh": "教務處", "url": "https://a.nycu.edu.tw"})
+    await admin_client.post(
+        "/api/v1/footer-links",
+        json={"title_zh": "使用條款", "url": "https://t.nycu.edu.tw", "section": "policy"},
+    )
+
+    everything = await admin_client.get("/api/v1/footer-links")
+    assert {item["section"] for item in everything.json()["data"]} == {"related", "policy"}
+
+    only_policy = await admin_client.get("/api/v1/footer-links?section=policy")
+    assert [item["title_zh"] for item in only_policy.json()["data"]] == ["使用條款"]
+
+    bogus = await admin_client.get("/api/v1/footer-links?section=nope")
+    assert bogus.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_sort_order_is_independent_per_section(admin_client: AsyncClient):
+    """Each block is its own list: a new policy link starts at 0 even when
+    the related list already holds entries."""
+    await admin_client.post("/api/v1/footer-links", json={"title_zh": "A", "url": "https://a.nycu.edu.tw"})
+    await admin_client.post("/api/v1/footer-links", json={"title_zh": "B", "url": "https://b.nycu.edu.tw"})
+    policy = await admin_client.post(
+        "/api/v1/footer-links",
+        json={"title_zh": "隱私權政策", "url": "https://p.nycu.edu.tw", "section": "policy"},
+    )
+    assert policy.json()["data"]["sort_order"] == 0
+
+
+@pytest.mark.asyncio
+async def test_upload_accepts_section(admin_client: AsyncClient, fake_minio):
+    res = await admin_client.post(
+        "/api/v1/footer-links/upload",
+        data={"title_zh": "無障礙聲明", "section": "policy"},
+        files={"file": ("a11y.pdf", BytesIO(b"%PDF-1.4 test"), "application/pdf")},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["data"]["section"] == "policy"
+    assert res.json()["data"]["link_type"] == "file"
+
+
+@pytest.mark.asyncio
 async def test_inactive_link_hidden_from_students_and_visible_to_admin(db: AsyncSession, admin_client: AsyncClient):
     created = await admin_client.post(
         "/api/v1/footer-links", json={"title_zh": "草稿連結", "url": "https://draft.nycu.edu.tw"}

--- a/frontend/components/__tests__/footer.test.tsx
+++ b/frontend/components/__tests__/footer.test.tsx
@@ -23,6 +23,7 @@ function makeLink(overrides: Record<string, unknown> = {}) {
     title_zh: "陽明交大首頁",
     title_en: "NYCU Homepage",
     link_type: "url",
+    section: "related",
     url: "https://www.nycu.edu.tw",
     object_name: null,
     original_filename: null,
@@ -113,6 +114,47 @@ test("the 相關連結 section is hidden when every link is hidden", async () =>
 
   expect(await screen.findByText("國立陽明交通大學")).toBeInTheDocument();
   await waitFor(() => expect(screen.queryByText("相關連結")).toBeNull());
+});
+
+test("policy links render in the bottom bar and are hidden when empty", async () => {
+  listMock.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [
+      makeLink({ id: 1, title_zh: "教務處" }),
+      makeLink({
+        id: 2,
+        section: "policy",
+        title_zh: "隱私權政策",
+        title_en: "Privacy Policy",
+        url: "https://www.nycu.edu.tw/privacy",
+      }),
+    ],
+  });
+
+  render(<Footer locale="zh" />);
+
+  const policyNav = await screen.findByRole("navigation", { name: "政策連結" });
+  const policyLink = screen.getByRole("link", { name: "隱私權政策" });
+  expect(policyNav).toContainElement(policyLink);
+  expect(policyLink).toHaveAttribute("href", "https://www.nycu.edu.tw/privacy");
+  // Policy links never leak into 相關連結 and vice versa.
+  expect(policyNav).not.toContainElement(screen.getByRole("link", { name: "教務處" }));
+  // The old hardcoded placeholders are gone.
+  expect(screen.queryByRole("link", { name: "使用條款" })).toBeNull();
+});
+
+test("the policy bar is omitted when no policy link is visible", async () => {
+  listMock.mockResolvedValue({
+    success: true,
+    message: "OK",
+    data: [makeLink({ title_zh: "教務處" })],
+  });
+
+  render(<Footer locale="zh" />);
+
+  expect(await screen.findByRole("link", { name: "教務處" })).toBeInTheDocument();
+  expect(screen.queryByRole("navigation", { name: "政策連結" })).toBeNull();
 });
 
 test("refetches when the admin panel reports a change", async () => {

--- a/frontend/components/admin/footer-links/AddFooterLinkDialog.tsx
+++ b/frontend/components/admin/footer-links/AddFooterLinkDialog.tsx
@@ -16,7 +16,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import apiClient from "@/lib/api";
-import type { FooterLink } from "@/lib/api/modules/footer-links";
+import type {
+  FooterLink,
+  FooterLinkSection,
+} from "@/lib/api/modules/footer-links";
+import { FOOTER_SECTION_COPY } from "./sections";
 
 const ACCEPTED = ".pdf,.doc,.docx,.odt,.ods,.odp";
 const ACCEPTED_LABEL = "PDF · DOC · DOCX · ODF";
@@ -24,6 +28,7 @@ const MAX_SIZE_MB = 10;
 const MAX_TITLE_LENGTH = 200;
 
 interface Props {
+  section: FooterLinkSection;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCreated: (link: FooterLink) => void;
@@ -35,7 +40,13 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
 }
 
-export function AddFooterLinkDialog({ open, onOpenChange, onCreated }: Props) {
+export function AddFooterLinkDialog({
+  section,
+  open,
+  onOpenChange,
+  onCreated,
+}: Props) {
+  const copy = FOOTER_SECTION_COPY[section];
   const [mode, setMode] = useState<"url" | "file">("url");
   const [titleZh, setTitleZh] = useState("");
   const [titleEn, setTitleEn] = useState("");
@@ -97,9 +108,10 @@ export function AddFooterLinkDialog({ open, onOpenChange, onCreated }: Props) {
           title_zh: trimmedZh,
           title_en: trimmedEn || null,
           url: trimmedUrl,
+          section,
         });
         if (res.success && res.data) {
-          toast.success("已新增相關連結");
+          toast.success(`已新增${copy.title}`);
           onCreated(res.data);
           reset();
           onOpenChange(false);
@@ -123,10 +135,11 @@ export function AddFooterLinkDialog({ open, onOpenChange, onCreated }: Props) {
       const res = await apiClient.footerLinks.upload(
         file,
         trimmedZh,
+        section,
         trimmedEn || undefined
       );
       if (res.success && res.data) {
-        toast.success("已新增相關連結");
+        toast.success(`已新增${copy.title}`);
         onCreated(res.data);
         reset();
         onOpenChange(false);
@@ -152,32 +165,30 @@ export function AddFooterLinkDialog({ open, onOpenChange, onCreated }: Props) {
     >
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>新增相關連結</DialogTitle>
-          <DialogDescription>
-            新增後會顯示在網頁最下方的「相關連結」區塊。
-          </DialogDescription>
+          <DialogTitle>新增{copy.title}</DialogTitle>
+          <DialogDescription>{copy.addDialogDescription}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
           <div>
-            <Label htmlFor="footer-link-title-zh">名稱（中文）</Label>
+            <Label htmlFor={`footer-link-${section}-title-zh`}>名稱（中文）</Label>
             <Input
-              id="footer-link-title-zh"
+              id={`footer-link-${section}-title-zh`}
               value={titleZh}
               onChange={(e) => setTitleZh(e.target.value)}
-              placeholder="例如：獎學金申請指南"
+              placeholder={copy.titlePlaceholderZh}
               maxLength={MAX_TITLE_LENGTH}
               disabled={submitting}
             />
           </div>
 
           <div>
-            <Label htmlFor="footer-link-title-en">名稱（英文，選填）</Label>
+            <Label htmlFor={`footer-link-${section}-title-en`}>名稱（英文，選填）</Label>
             <Input
-              id="footer-link-title-en"
+              id={`footer-link-${section}-title-en`}
               value={titleEn}
               onChange={(e) => setTitleEn(e.target.value)}
-              placeholder="Scholarship Guide"
+              placeholder={copy.titlePlaceholderEn}
               maxLength={MAX_TITLE_LENGTH}
               disabled={submitting}
             />
@@ -200,9 +211,9 @@ export function AddFooterLinkDialog({ open, onOpenChange, onCreated }: Props) {
             </TabsList>
 
             <TabsContent value="url" className="mt-4">
-              <Label htmlFor="footer-link-url">網址</Label>
+              <Label htmlFor={`footer-link-${section}-url`}>網址</Label>
               <Input
-                id="footer-link-url"
+                id={`footer-link-${section}-url`}
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
                 placeholder="https://www.nycu.edu.tw"

--- a/frontend/components/admin/footer-links/FooterLinksPanel.tsx
+++ b/frontend/components/admin/footer-links/FooterLinksPanel.tsx
@@ -45,10 +45,12 @@ import {
   buildFooterLinkFileProxyUrl,
   notifyFooterLinksChanged,
   type FooterLink,
+  type FooterLinkSection,
 } from "@/lib/api/modules/footer-links";
 import { previewMimeType } from "@/lib/utils";
 import { FilePreviewDialog } from "@/components/file-preview-dialog";
 import { AddFooterLinkDialog } from "./AddFooterLinkDialog";
+import { FOOTER_SECTION_COPY } from "./sections";
 
 const MAX_TITLE_LENGTH = 200;
 
@@ -180,7 +182,13 @@ function SortableRow({
   );
 }
 
-export function FooterLinksPanel() {
+interface FooterLinksPanelProps {
+  /** Which footer block this panel manages. Each block is its own list. */
+  section: FooterLinkSection;
+}
+
+export function FooterLinksPanel({ section }: FooterLinksPanelProps) {
+  const copy = FOOTER_SECTION_COPY[section];
   const [links, setLinks] = useState<FooterLink[]>([]);
   const [loading, setLoading] = useState(true);
   const [reordering, setReordering] = useState(false);
@@ -201,13 +209,13 @@ export function FooterLinksPanel() {
   useEffect(() => {
     // include_inactive: admins manage hidden links too.
     apiClient.footerLinks
-      .list(true)
+      .list(true, section)
       .then((res) => {
         if (res.success && res.data) setLinks(res.data);
       })
-      .catch(() => toast.error("載入相關連結失敗"))
+      .catch(() => toast.error(`載入${copy.title}失敗`))
       .finally(() => setLoading(false));
-  }, []);
+  }, [section, copy.title]);
 
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
@@ -348,13 +356,14 @@ export function FooterLinksPanel() {
   };
 
   return (
-    <section className="rounded-xl border border-gray-200 bg-white p-5 mt-6">
+    <section
+      className="rounded-xl border border-gray-200 bg-white p-5 mt-6"
+      data-testid={`footer-links-panel-${section}`}
+    >
       <header className="flex items-center justify-between mb-4">
         <div>
-          <h3 className="font-semibold text-nycu-navy-900">相關連結</h3>
-          <p className="text-sm text-gray-500 mt-0.5">
-            顯示在網頁最下方的連結，可放外部網址或上傳檔案（PDF 等），並可拖曳排序。
-          </p>
+          <h3 className="font-semibold text-nycu-navy-900">{copy.title}</h3>
+          <p className="text-sm text-gray-500 mt-0.5">{copy.description}</p>
         </div>
         <Button onClick={() => setAddOpen(true)} size="sm">
           <Plus className="h-4 w-4 mr-1.5" /> 新增
@@ -366,9 +375,7 @@ export function FooterLinksPanel() {
           <Loader2 className="h-4 w-4 animate-spin" /> 載入中…
         </div>
       ) : links.length === 0 ? (
-        <p className="text-sm text-gray-500 py-4">
-          目前尚無相關連結，點擊「新增」建立。
-        </p>
+        <p className="text-sm text-gray-500 py-4">{copy.emptyHint}</p>
       ) : (
         <DndContext
           sensors={sensors}
@@ -397,6 +404,7 @@ export function FooterLinksPanel() {
       )}
 
       <AddFooterLinkDialog
+        section={section}
         open={addOpen}
         onOpenChange={setAddOpen}
         onCreated={(link) => {
@@ -409,7 +417,7 @@ export function FooterLinksPanel() {
         <Dialog open onOpenChange={(next) => !next && setEditingLink(null)}>
           <DialogContent className="max-w-md">
             <DialogHeader>
-              <DialogTitle>編輯相關連結</DialogTitle>
+              <DialogTitle>編輯{copy.title}</DialogTitle>
               <DialogDescription>
                 {editingLink.link_type === "file"
                   ? "檔案內容無法直接替換，如需更換請刪除後重新上傳。"
@@ -419,20 +427,20 @@ export function FooterLinksPanel() {
 
             <div className="space-y-4">
               <div>
-                <Label htmlFor="edit-footer-title-zh">名稱（中文）</Label>
+                <Label htmlFor={`edit-footer-${section}-title-zh`}>名稱（中文）</Label>
                 <Input
-                  id="edit-footer-title-zh"
+                  id={`edit-footer-${section}-title-zh`}
                   value={editTitleZh}
                   onChange={(e) => setEditTitleZh(e.target.value)}
                   maxLength={MAX_TITLE_LENGTH}
                 />
               </div>
               <div>
-                <Label htmlFor="edit-footer-title-en">
+                <Label htmlFor={`edit-footer-${section}-title-en`}>
                   名稱（英文，選填）
                 </Label>
                 <Input
-                  id="edit-footer-title-en"
+                  id={`edit-footer-${section}-title-en`}
                   value={editTitleEn}
                   onChange={(e) => setEditTitleEn(e.target.value)}
                   maxLength={MAX_TITLE_LENGTH}
@@ -440,9 +448,9 @@ export function FooterLinksPanel() {
               </div>
               {editingLink.link_type === "url" ? (
                 <div>
-                  <Label htmlFor="edit-footer-url">網址</Label>
+                  <Label htmlFor={`edit-footer-${section}-url`}>網址</Label>
                   <Input
-                    id="edit-footer-url"
+                    id={`edit-footer-${section}-url`}
                     value={editUrl}
                     onChange={(e) => setEditUrl(e.target.value)}
                     placeholder="https://www.nycu.edu.tw"

--- a/frontend/components/admin/footer-links/__tests__/FooterLinksPanel.test.tsx
+++ b/frontend/components/admin/footer-links/__tests__/FooterLinksPanel.test.tsx
@@ -45,6 +45,7 @@ function makeLink(overrides: Record<string, unknown> = {}) {
     title_zh: "陽明交大首頁",
     title_en: "NYCU Homepage",
     link_type: "url",
+    section: "related",
     url: "https://www.nycu.edu.tw",
     object_name: null,
     original_filename: null,
@@ -67,10 +68,20 @@ beforeEach(() => {
 test("requests inactive links so admins can manage hidden entries", async () => {
   api.list.mockResolvedValue({ success: true, message: "OK", data: [] });
 
-  render(<FooterLinksPanel />);
+  render(<FooterLinksPanel section="related" />);
 
-  await waitFor(() => expect(api.list).toHaveBeenCalledWith(true));
+  await waitFor(() => expect(api.list).toHaveBeenCalledWith(true, "related"));
   expect(await screen.findByText(/目前尚無相關連結/)).toBeInTheDocument();
+});
+
+test("the policy panel lists its own section and uses policy copy", async () => {
+  api.list.mockResolvedValue({ success: true, message: "OK", data: [] });
+
+  render(<FooterLinksPanel section="policy" />);
+
+  await waitFor(() => expect(api.list).toHaveBeenCalledWith(true, "policy"));
+  expect(await screen.findByText(/目前尚無政策連結/)).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "政策連結" })).toBeInTheDocument();
 });
 
 test("shows a 已隱藏 badge for inactive links", async () => {
@@ -80,7 +91,7 @@ test("shows a 已隱藏 badge for inactive links", async () => {
     data: [makeLink({ is_active: false })],
   });
 
-  render(<FooterLinksPanel />);
+  render(<FooterLinksPanel section="related" />);
 
   expect(await screen.findByText("已隱藏")).toBeInTheDocument();
 });
@@ -97,7 +108,7 @@ test("toggling visibility patches is_active", async () => {
     data: makeLink({ is_active: false }),
   });
 
-  render(<FooterLinksPanel />);
+  render(<FooterLinksPanel section="related" />);
 
   fireEvent.click(await screen.findByLabelText("隱藏"));
 
@@ -113,7 +124,7 @@ test("rejects a non-http URL before hitting the API", async () => {
     data: [makeLink()],
   });
 
-  render(<FooterLinksPanel />);
+  render(<FooterLinksPanel section="related" />);
 
   fireEvent.click(await screen.findByLabelText("編輯"));
 
@@ -147,7 +158,7 @@ test("file links expose a preview action and no URL field when edited", async ()
     ],
   });
 
-  render(<FooterLinksPanel />);
+  render(<FooterLinksPanel section="related" />);
 
   expect(await screen.findByLabelText("預覽")).toBeInTheDocument();
 
@@ -169,7 +180,7 @@ test("deleting a link removes the row and calls the API", async () => {
     data: { deleted: true },
   });
 
-  render(<FooterLinksPanel />);
+  render(<FooterLinksPanel section="related" />);
 
   fireEvent.click(await screen.findByLabelText("刪除"));
   fireEvent.click(await screen.findByText("刪除", { selector: "button" }));

--- a/frontend/components/admin/footer-links/sections.ts
+++ b/frontend/components/admin/footer-links/sections.ts
@@ -1,0 +1,32 @@
+import type { FooterLinkSection } from "@/lib/api/modules/footer-links";
+
+/** Admin-facing copy for each footer block managed by FooterLinksPanel. */
+export interface FooterSectionCopy {
+  title: string;
+  description: string;
+  emptyHint: string;
+  addDialogDescription: string;
+  titlePlaceholderZh: string;
+  titlePlaceholderEn: string;
+}
+
+export const FOOTER_SECTION_COPY: Record<FooterLinkSection, FooterSectionCopy> = {
+  related: {
+    title: "相關連結",
+    description:
+      "顯示在網頁最下方的連結，可放外部網址或上傳檔案（PDF 等），並可拖曳排序。",
+    emptyHint: "目前尚無相關連結，點擊「新增」建立。",
+    addDialogDescription: "新增後會顯示在網頁最下方的「相關連結」區塊。",
+    titlePlaceholderZh: "例如：獎學金申請指南",
+    titlePlaceholderEn: "Scholarship Guide",
+  },
+  policy: {
+    title: "政策連結",
+    description:
+      "顯示在網頁最下方版權列旁的小字連結（例如隱私權政策、使用條款、無障礙聲明、網站地圖），可放外部網址或上傳檔案，並可拖曳排序。預設項目為隱藏，請先設定正確網址再顯示。",
+    emptyHint: "目前尚無政策連結，點擊「新增」建立。",
+    addDialogDescription: "新增後會顯示在網頁最下方版權列旁的小字連結。",
+    titlePlaceholderZh: "例如：隱私權政策",
+    titlePlaceholderEn: "Privacy Policy",
+  },
+};

--- a/frontend/components/admin/system-docs/SystemDocsPanel.tsx
+++ b/frontend/components/admin/system-docs/SystemDocsPanel.tsx
@@ -455,7 +455,8 @@ export function SystemDocsPanel() {
 
       <ApplicationNoticesPanel />
 
-      <FooterLinksPanel />
+      <FooterLinksPanel section="related" />
+      <FooterLinksPanel section="policy" />
 
       <FilePreviewDialog
         isOpen={preview !== null}

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -12,6 +12,7 @@ import {
   FOOTER_LINKS_CHANGED_EVENT,
   footerLinkHref,
   footerLinkLabel,
+  splitFooterLinksBySection,
   type FooterLink,
 } from "@/lib/api/modules/footer-links";
 import { logger } from "@/lib/utils/logger";
@@ -23,14 +24,17 @@ interface FooterProps {
 export function Footer({ locale = "zh" }: FooterProps) {
   const currentYear = new Date().getFullYear();
 
-  // 相關連結 are admin-managed (系統管理 → 系統文件). A fetch failure must not
-  // break the rest of the footer, so the list just stays empty.
-  const [links, setLinks] = useState<FooterLink[]>([]);
+  // 相關連結 and the bottom policy bar are both admin-managed (系統管理 →
+  // 系統文件) and come back in one request. A fetch failure must not break
+  // the rest of the footer, so both lists just stay empty.
+  const [allLinks, setAllLinks] = useState<FooterLink[]>([]);
+  const { related: links, policy: policyLinks } =
+    splitFooterLinksBySection(allLinks);
 
   const loadLinks = useCallback(async (signal?: { cancelled: boolean }) => {
     try {
       const res = await apiClient.footerLinks.list();
-      if (!signal?.cancelled && res.success && res.data) setLinks(res.data);
+      if (!signal?.cancelled && res.success && res.data) setAllLinks(res.data);
     } catch (error) {
       logger.error("Failed to load footer links", error);
     }
@@ -167,20 +171,31 @@ export function Footer({ locale = "zh" }: FooterProps) {
             </p>
           </div>
 
-          <div className="flex gap-6 text-xs text-nycu-navy-500">
-            <a href="#" className="hover:text-nycu-blue-600 transition-colors">
-              {locale === "zh" ? "隱私權政策" : "Privacy Policy"}
-            </a>
-            <a href="#" className="hover:text-nycu-blue-600 transition-colors">
-              {locale === "zh" ? "使用條款" : "Terms of Use"}
-            </a>
-            <a href="#" className="hover:text-nycu-blue-600 transition-colors">
-              {locale === "zh" ? "無障礙聲明" : "Accessibility"}
-            </a>
-            <a href="#" className="hover:text-nycu-blue-600 transition-colors">
-              {locale === "zh" ? "網站地圖" : "Sitemap"}
-            </a>
-          </div>
+          {/* Policy bar (隱私權政策 / 使用條款 / ...) — admin-managed, same
+              table as 相關連結. Omitted entirely when empty. */}
+          {policyLinks.length > 0 && (
+            <nav
+              aria-label={locale === "zh" ? "政策連結" : "Policy links"}
+              className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-xs text-nycu-navy-500"
+            >
+              {policyLinks.map((link) => (
+                <a
+                  key={link.id}
+                  href={footerLinkHref(link)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={
+                    link.link_type === "file"
+                      ? link.original_filename ?? undefined
+                      : undefined
+                  }
+                  className="hover:text-nycu-blue-600 transition-colors"
+                >
+                  {footerLinkLabel(link, locale)}
+                </a>
+              ))}
+            </nav>
+          )}
         </div>
 
         {/* System Status */}

--- a/frontend/lib/api/generated/schema.d.ts
+++ b/frontend/lib/api/generated/schema.d.ts
@@ -7262,6 +7262,9 @@ export interface paths {
          * List Footer Links
          * @description List footer links ordered by sort_order then id.
          *
+         *     ``section`` narrows to one block; omitted, both blocks are returned so the
+         *     footer needs a single request.
+         *
          *     Any authenticated user may read. ``include_inactive`` is honoured for
          *     admins only — a non-admin always gets the active (publicly shown) set,
          *     so a hidden link cannot leak through the query parameter.
@@ -9141,6 +9144,8 @@ export interface components {
             title_zh: string;
             /** Title En */
             title_en?: string | null;
+            /** @default related */
+            section: components["schemas"]["FooterLinkSection"];
         };
         /** Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post */
         Body_upload_renewal_import_api_v1_college_review_renewal_import_upload_post: {
@@ -9763,6 +9768,8 @@ export interface components {
             title_en?: string | null;
             /** Url */
             url: string;
+            /** @default related */
+            section: components["schemas"]["FooterLinkSection"];
             /**
              * Is Active
              * @default true
@@ -9781,6 +9788,15 @@ export interface components {
             /** Items */
             items: components["schemas"]["FooterLinkReorderItem"][];
         };
+        /**
+         * FooterLinkSection
+         * @description Which footer block an entry is rendered in.
+         *
+         *     ``related`` is the 相關連結 (Related Links) list; ``policy`` is the small
+         *     bottom bar (隱私權政策 / 使用條款 / 無障礙聲明 / 網站地圖 ...).
+         * @enum {string}
+         */
+        FooterLinkSection: "related" | "policy";
         /**
          * FooterLinkUpdate
          * @description Partial update. ``url`` is only accepted for link_type == url rows,
@@ -23344,6 +23360,7 @@ export interface operations {
         parameters: {
             query?: {
                 include_inactive?: boolean;
+                section?: components["schemas"]["FooterLinkSection"] | null;
             };
             header?: never;
             path?: never;

--- a/frontend/lib/api/modules/footer-links.ts
+++ b/frontend/lib/api/modules/footer-links.ts
@@ -1,7 +1,9 @@
 /**
- * Footer Links API Module (相關連結)
+ * Footer Links API Module
  *
- * Admin-managed entries rendered in the site footer. Each link is either an
+ * Admin-managed entries rendered in the site footer, split into two blocks
+ * by `section`: 相關連結 (`related`) and the bottom policy bar (`policy`:
+ * 隱私權政策 / 使用條款 / ...). Each link is either an
  * external URL or an uploaded document (PDF / Office / ODF) streamed back
  * through the backend proxy — never a direct MinIO URL.
  */
@@ -10,12 +12,16 @@ import type { ApiResponse } from '../types';
 
 export type FooterLinkType = 'url' | 'file';
 
+/** Which footer block a link renders in. Mirrors backend FooterLinkSection. */
+export type FooterLinkSection = 'related' | 'policy';
+
 /** Footer link payload returned by the backend. */
 export type FooterLink = {
   id: number;
   title_zh: string;
   title_en: string | null;
   link_type: FooterLinkType;
+  section: FooterLinkSection;
   url: string | null;
   object_name: string | null;
   original_filename: string | null;
@@ -31,6 +37,7 @@ export type FooterLinkCreatePayload = {
   title_zh: string;
   title_en?: string | null;
   url: string;
+  section: FooterLinkSection;
   is_active?: boolean;
 };
 
@@ -40,6 +47,16 @@ export type FooterLinkUpdatePayload = {
   url?: string;
   is_active?: boolean;
 };
+
+/** Split one list response into its two footer blocks, preserving order. */
+export function splitFooterLinksBySection(
+  links: FooterLink[]
+): Record<FooterLinkSection, FooterLink[]> {
+  return {
+    related: links.filter((l) => l.section === 'related'),
+    policy: links.filter((l) => l.section === 'policy'),
+  };
+}
 
 /**
  * Broadcast name for "the footer link list changed".
@@ -111,12 +128,17 @@ export function createFooterLinksApi() {
   return {
     /**
      * List footer links. `includeInactive` is honoured for admins only —
-     * the backend always filters hidden links out for non-admins.
+     * the backend always filters hidden links out for non-admins. Omit
+     * `section` to get both blocks in one request.
      */
     list: async (
-      includeInactive = false
+      includeInactive = false,
+      section?: FooterLinkSection
     ): Promise<ApiResponse<FooterLink[]>> => {
-      const query = includeInactive ? '?include_inactive=true' : '';
+      const params = new URLSearchParams();
+      if (includeInactive) params.set('include_inactive', 'true');
+      if (section) params.set('section', section);
+      const query = params.toString() ? `?${params.toString()}` : '';
       const res = await fetch(`/api/v1/footer-links${query}`, {
         headers: { Authorization: `Bearer ${authToken()}` },
       });
@@ -139,11 +161,13 @@ export function createFooterLinksApi() {
     upload: async (
       file: File,
       titleZh: string,
+      section: FooterLinkSection,
       titleEn?: string
     ): Promise<ApiResponse<FooterLink>> => {
       const formData = new FormData();
       formData.append('file', file);
       formData.append('title_zh', titleZh);
+      formData.append('section', section);
       if (titleEn) formData.append('title_en', titleEn);
 
       const res = await fetch('/api/v1/footer-links/upload-proxy', {


### PR DESCRIPTION
## Summary

網頁底部的 隱私權政策 / 使用條款 / 無障礙聲明 / 網站地圖 原本是寫死的 `href="#"`。現在和「相關連結」一樣由管理員在 **系統管理 → 系統文件** 編輯：可新增（外部網址或上傳檔案）、修改、隱藏、刪除、拖曳排序。

### 做法
- `footer_links` 新增 `section` 欄位（`related` = 相關連結，`policy` = 底部政策列），兩區共用同一張表與同一組 API。
- 建立 / 上傳接受 `section`；列表可用 `?section=` 篩選（不帶則一次回傳兩區）；排序各區獨立。
- Migration 以 existence check 新增 enum / 欄位 / index，並將四個政策項目 **以隱藏狀態** 預設建立（網址為佔位），管理員設好正確網址再顯示，訪客不會看到佔位連結。
- `<Footer>` 一次抓取後依 section 分流；政策列改由 API 渲染，沒有可見項目時整列不顯示。
- `FooterLinksPanel` / `AddFooterLinkDialog` 增加 `section` prop 與各區文案；系統文件頁各渲染一個面板，表單 id 依 section 命名避免同頁衝突。
- `schema.d.ts` 以 CI 版本相依重新產生（純新增 17 行）。

## Test plan
- [x] backend `test_footer_links.py` 40 passed（新增 section 預設/篩選/各區排序/上傳）
- [x] black / flake8 B904,B014 通過
- [x] frontend jest footer + FooterLinksPanel 15 passed；tsc、eslint 無錯
- [x] dev DB 套用 migration，policy 四筆隱藏種子正確；`GET /footer-links?section=policy` 與不帶參數皆符合預期
- [ ] 手動：系統文件頁兩個面板分別新增/隱藏/排序後，頁尾即時更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFpimDM353q5RsirBkC825
