### PR TITLE
feat: 教育部博士生獎學金標籤加上 115學年度 與滾動式調整說明

### DIFF
--- a/backend/alembic/versions/moe_1w_ay115_label_001.py
+++ b/backend/alembic/versions/moe_1w_ay115_label_001.py
@@ -1,0 +1,62 @@
+"""prefix moe_1w sub-type label with 115學年度 and note the rolling adjustment
+
+Revision ID: moe_1w_ay115_label_001
+Revises: add_footer_link_section_001
+Create Date: 2026-09-04 00:00:00.000000
+
+The professor review screen renders the sub-type heading straight from
+scholarship_sub_type_configs.name (see
+ApplicationService.get_application_available_sub_types), and the seed only
+inserts when the row is missing, so a seed-side rename never reaches an
+existing DB. This migration rewrites the phd moe_1w row in place:
+
+- name:        115學年度教育部博士生獎學金 (指導教授配合款每月 $5000 元)
+- description: 每年配合款經費金額將配合教育部相關規定，採滾動式調整。
+
+The description carries the rolling-adjustment note rather than restating the
+name, because the professor review screen now shows it underneath the heading.
+downgrade() restores the wording shipped by update_moe_1w_label_001.
+
+The UPDATE is scoped to the phd scholarship type: sub_type_code values are
+configuration-driven strings, not globally unique, so another scholarship
+type could legitimately define its own 'moe_1w' with a different label.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "moe_1w_ay115_label_001"
+down_revision: Union[str, Sequence[str], None] = "add_footer_link_section_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE scholarship_sub_type_configs
+        SET
+            name = '115學年度教育部博士生獎學金 (指導教授配合款每月 $5000 元)',
+            name_en = 'AY115 MOE PHD Scholarship (Professor Match NT$5,000/month)',
+            description = '每年配合款經費金額將配合教育部相關規定，採滾動式調整。',
+            description_en = 'The annual matching fund amount is subject to rolling adjustment in accordance with MOE regulations.'
+        WHERE sub_type_code = 'moe_1w'
+          AND scholarship_type_id IN (
+              SELECT id FROM scholarship_types WHERE code = 'phd'
+          )
+        """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        UPDATE scholarship_sub_type_configs
+        SET
+            name = '教育部博士生獎學金 (指導教授配合款每月 $5000 元)',
+            name_en = 'MOE PHD Scholarship (Professor Match NT$5,000/month)',
+            description = '教育部博士生獎學金，指導教授配合款每月 $5000 元',
+            description_en = 'MOE PHD Scholarship with professor match of NT$5,000/month'
+        WHERE sub_type_code = 'moe_1w'
+          AND scholarship_type_id IN (
+              SELECT id FROM scholarship_types WHERE code = 'phd'
+          )
+        """)

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -901,10 +901,10 @@ async def seed_scholarship_sub_type_configs(session: AsyncSession) -> None:
                     {
                         "scholarship_type_id": scholarship.id,
                         "sub_type_code": "moe_1w",
-                        "name": "教育部博士生獎學金 (指導教授配合款每月 $5000 元)",
-                        "name_en": "MOE PHD Scholarship (Professor Match NT$5,000/month)",
-                        "description": "教育部博士生獎學金，指導教授配合款每月 $5000 元",
-                        "description_en": "MOE PHD Scholarship with professor match of NT$5,000/month",
+                        "name": "115學年度教育部博士生獎學金 (指導教授配合款每月 $5000 元)",
+                        "name_en": "AY115 MOE PHD Scholarship (Professor Match NT$5,000/month)",
+                        "description": "每年配合款經費金額將配合教育部相關規定，採滾動式調整。",
+                        "description_en": "The annual matching fund amount is subject to rolling adjustment in accordance with MOE regulations.",
                         "amount": None,  # 使用主獎學金金額
                         "display_order": 2,
                         "is_active": True,

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -2934,6 +2934,8 @@ class ApplicationService:
                 "value": c.sub_type_code,
                 "label": c.name,
                 "label_en": c.name_en or c.name,
+                "note": c.description,
+                "note_en": c.description_en or c.description,
                 "is_default": c.sub_type_code == "default",
             }
             for c in available

--- a/frontend/components/professor-review-component.tsx
+++ b/frontend/components/professor-review-component.tsx
@@ -83,6 +83,11 @@ interface SubTypeOption {
   value: string;
   label: string;
   label_en: string;
+  // Sub-type description from scholarship_sub_type_configs; carries notes the
+  // professor must see alongside the heading (e.g. the moe_1w matching-fund
+  // rolling adjustment). Absent for sub-types without a description.
+  note?: string | null;
+  note_en?: string | null;
   is_default: boolean;
 }
 
@@ -858,6 +863,11 @@ function ProfessorReviewComponentInner({
                             {subType.label_en && (
                               <p className="text-sm text-muted-foreground mb-2">
                                 {subType.label_en}
+                              </p>
+                            )}
+                            {subType.note && (
+                              <p className="text-sm text-muted-foreground mb-2">
+                                （{subType.note}）
                               </p>
                             )}
                           </div>

--- a/frontend/e2e/specs/student-subtype-label.spec.ts
+++ b/frontend/e2e/specs/student-subtype-label.spec.ts
@@ -1,14 +1,15 @@
 /**
  * E2E spec: the phd moe_1w sub-type card label reads
- * 「教育部博士生獎學金 (指導教授配合款每月 $5000 元)」.
+ * 「115學年度教育部博士生獎學金 (指導教授配合款每月 $5000 元)」.
  *
  * Why this exists: the student wizard (ScholarshipApplicationStep) renders
  * the 選擇申請項目 cards verbatim from `eligible_sub_types[].label`, which the
  * backend reads from scholarship_sub_type_configs.name. The label was renamed
  * from the stale 「指導教授配合款一萬」 wording, and because the seed only
  * INSERTs when the row is missing, deployed DBs kept the old name until
- * migration update_moe_1w_label_001 rewrote it in place. This spec pins both
- * layers so the wording can't silently regress:
+ * migration update_moe_1w_label_001 rewrote it in place; moe_1w_ay115_label_001
+ * later added the 115學年度 prefix the same way. This spec pins both layers so
+ * the wording can't silently regress:
  *
  *   (a) DB   — scholarship_sub_type_configs.name for (phd, moe_1w) is the
  *              new wording (the migration/seed actually landed), and
@@ -17,7 +18,7 @@
  *              eligible_sub_types, which is the string the wizard card shows.
  *
  * Pinned invariants:
- * - The zh label is exactly 教育部博士生獎學金 (指導教授配合款每月 $5000 元).
+ * - The zh label is exactly 115學年度教育部博士生獎學金 (指導教授配合款每月 $5000 元).
  * - Neither the stale 「一萬」 nor the interim 「每月五千」 wording survives
  *   anywhere in the phd sub-type labels served to students.
  */
@@ -31,7 +32,7 @@ import { captureDiagnostics } from "../helpers/diagnose";
 const STUDENT_ID = "stuphd001";
 const SCHOLARSHIP_CODE = "phd";
 const SUB_TYPE = "moe_1w";
-const EXPECTED_LABEL = "教育部博士生獎學金 (指導教授配合款每月 $5000 元)";
+const EXPECTED_LABEL = "115學年度教育部博士生獎學金 (指導教授配合款每月 $5000 元)";
 const STALE_WORDINGS = ["指導教授配合款一萬", "指導教授配合款每月五千"];
 
 interface EligibleSubType {

--- a/frontend/lib/api/modules/professor.ts
+++ b/frontend/lib/api/modules/professor.ts
@@ -149,6 +149,8 @@ export function createProfessorApi() {
           value: string;
           label: string;
           label_en: string;
+          note?: string | null;
+          note_en?: string | null;
           is_default: boolean;
         }>
       >

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -260,7 +260,7 @@ export const translations = {
     },
     rule_types: {
       nstc: "國科會博士生獎學金",
-      moe_1w: "教育部博士生獎學金 (指導教授配合款每月 $5000 元)",
+      moe_1w: "115學年度教育部博士生獎學金 (指導教授配合款每月 $5000 元)",
       moe_2w: "教育部博士生獎學金 (指導教授配合款兩萬)",
     },
     scholarship_sections: {
@@ -792,7 +792,7 @@ export const translations = {
     },
     rule_types: {
       nstc: "NSTC PhD Scholarship",
-      moe_1w: "MOE PhD Scholarship (Advisor Matching Fund - NT$5,000/month)",
+      moe_1w: "AY115 MOE PhD Scholarship (Advisor Matching Fund - NT$5,000/month)",
       moe_2w: "MOE PhD Scholarship (Advisor Matching Fund - 20K)",
     },
     scholarship_sections: {


### PR DESCRIPTION
## 需求

教授審核時看到的教育部獎學金文字：

- 現在：`教育部博士生獎學金 (指導教授配合款每月 $5000 元)`
- 改成：`115學年度教育部博士生獎學金 (指導教授配合款每月 $5000 元)`
  `（每年配合款經費金額將配合教育部相關規定，採滾動式調整。）`

## 作法

教授審核畫面的子類型標題不是讀前端 i18n，而是直接顯示資料庫的
`scholarship_sub_type_configs.name`（`ApplicationService.get_application_available_sub_types`
→ `professor-review-component.tsx`）。而 seed 只在資料列缺少時才 INSERT，
所以只改 seed 不會影響既有部署，必須加 migration。

文字拆成兩個既有欄位：

- **年度前綴放 `name`** — 標籤維持簡短，分發名單、college ranking、Excel 匯出標題等重用該名稱的地方不會被長句污染。
- **滾動式調整說明放 `description`** — sub-types API 新增回傳 `note` / `note_en`，教授審核畫面在標題下方以小字顯示。`description` 目前沒有其他前端畫面使用。

## 變更檔案

| 檔案 | 說明 |
| --- | --- |
| `backend/alembic/versions/moe_1w_ay115_label_001.py` | 新增 migration，就地改寫既有 phd `moe_1w` 資料列，限定 phd scholarship type，附 `downgrade()` |
| `backend/app/db/seed_scholarship_configs.py` | 新建資料庫的 seed 同步新文字 |
| `backend/app/services/application_service.py` | sub-types 回傳新增 `note` / `note_en` |
| `frontend/components/professor-review-component.tsx` | 標題下方顯示 note（有值才顯示） |
| `frontend/lib/api/modules/professor.ts` | 型別補上 `note` / `note_en` |
| `frontend/lib/i18n.ts` | zh / en `rule_types.moe_1w` 同步年度前綴 |
| `frontend/e2e/specs/student-subtype-label.spec.ts` | 更新釘住此字串的迴歸測試 |

## 測試

- [x] `alembic heads` → 單一 head `moe_1w_ay115_label_001`，無分支
- [x] `npx tsc --noEmit` 通過
- [x] backend pytest — CI 上 Backend Tests (unit / smoke / integration) 三個 shard 全綠（本機 shell 缺 `database_url` / `secret_key` / `minio_*` 而無法執行，改由 CI 覆蓋）
- [x] `student-subtype-label.spec.ts` 已對 dev stack 實跑通過（1 passed）
- [x] 實機以 Playwright 確認教授審核畫面與學生申請 wizard 的文字與換行（見留言中的截圖）
- [x] `alembic upgrade head` 在 CI 實際執行成功（rebase 後 down_revision 改指 `add_footer_link_section_001`，恢復單一 head）
- [ ] 窄欄（真正手機兩欄，約 175px）下的折行未驗證 — wizard 在 390px 本來就橫向溢出，需先修該版面問題

## 注意

`115學年度` 目前是寫死字串，下個學年度需要再開一次 migration。若要改成依設定檔的
`academic_year` 動態組出來，codebase 已有 `format_academic_period()` 與
`ScholarshipConfiguration.academic_year_label` 可用 — 可另開 issue 處理。

