### PR TITLE
fix: 移除國科會子類型的重複說明文字

### DIFF
--- a/backend/alembic/versions/moe_1w_ay115_label_001.py
+++ b/backend/alembic/versions/moe_1w_ay115_label_001.py
@@ -15,7 +15,16 @@ existing DB. This migration rewrites the phd moe_1w row in place:
 
 The description carries the rolling-adjustment note rather than restating the
 name, because the professor review screen now shows it underneath the heading.
-downgrade() restores the wording shipped by update_moe_1w_label_001.
+
+For the same reason the sibling nstc description is cleared: it only restated
+that row's own name ("國科會博士生獎學金，適用於符合條件的博士生"), so once
+descriptions became visible it rendered as a tautological third line that
+trained reviewers to skip the very position carrying the moe_1w caveat. The
+review screen renders the note only when it is non-empty, so clearing the
+column removes the line with no code change.
+
+downgrade() restores the wording shipped by update_moe_1w_label_001 and the
+original nstc description.
 
 The UPDATE is scoped to the phd scholarship type: sub_type_code values are
 configuration-driven strings, not globally unique, so another scholarship
@@ -46,6 +55,17 @@ def upgrade() -> None:
           )
         """)
 
+    op.execute("""
+        UPDATE scholarship_sub_type_configs
+        SET
+            description = NULL,
+            description_en = NULL
+        WHERE sub_type_code = 'nstc'
+          AND scholarship_type_id IN (
+              SELECT id FROM scholarship_types WHERE code = 'phd'
+          )
+        """)
+
 
 def downgrade() -> None:
     op.execute("""
@@ -56,6 +76,17 @@ def downgrade() -> None:
             description = '教育部博士生獎學金，指導教授配合款每月 $5000 元',
             description_en = 'MOE PHD Scholarship with professor match of NT$5,000/month'
         WHERE sub_type_code = 'moe_1w'
+          AND scholarship_type_id IN (
+              SELECT id FROM scholarship_types WHERE code = 'phd'
+          )
+        """)
+
+    op.execute("""
+        UPDATE scholarship_sub_type_configs
+        SET
+            description = '國科會博士生獎學金，適用於符合條件的博士生',
+            description_en = 'NSTC PHD Scholarship for eligible PhD students'
+        WHERE sub_type_code = 'nstc'
           AND scholarship_type_id IN (
               SELECT id FROM scholarship_types WHERE code = 'phd'
           )

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -890,8 +890,11 @@ async def seed_scholarship_sub_type_configs(session: AsyncSession) -> None:
                         "sub_type_code": "nstc",
                         "name": "國科會博士生獎學金",
                         "name_en": "NSTC PHD Scholarship",
-                        "description": "國科會博士生獎學金，適用於符合條件的博士生",
-                        "description_en": "NSTC PHD Scholarship for eligible PhD students",
+                        # Left empty on purpose: the professor review screen shows
+                        # description as a note under the heading, and this row's
+                        # description only restated its own name.
+                        "description": None,
+                        "description_en": None,
                         "amount": None,  # 使用主獎學金金額
                         "display_order": 1,
                         "is_active": True,


### PR DESCRIPTION
## 背景

疊在 #1362 之上（base 是 `feat/moe-1w-ay115-label`，不是 `main`）——因為要改的 migration 是那個 PR 新增的檔案。#1362 併入後 GitHub 會自動把本 PR 的 base 改指 `main`。

#1362 讓教授審核畫面在子類型標題下方顯示 `scholarship_sub_type_configs.description`。副作用是國科會那張卡片也跟著多出一行：

> （國科會博士生獎學金，適用於符合條件的博士生）

這行等於把自己的標題再講一次，「適用於符合條件的博士生」也沒有實質資訊。兩張卡片用同樣的樣式，會把 moe_1w 那行真正的但書（配合款金額逐年滾動調整，牽涉教授的實際負擔）稀釋成看起來可以略過的裝飾文字。

## 作法

清空 phd nstc 這筆的 `description` / `description_en`。元件本來就是 `{subType.note && …}` 有值才渲染，所以不需要動任何前端程式碼。

- `backend/app/db/seed_scholarship_configs.py` — nstc 的 description 改成 `None`，並加註為何刻意留空
- `backend/alembic/versions/moe_1w_ay115_label_001.py` — 在既有 migration 補一段把 phd nstc 的 description 設為 NULL 的 UPDATE；`downgrade()` 一併還原原本文字

沿用 #1362 的 migration 而不另開一支，是因為它尚未合併，且兩者是同一個成因（description 從此可見）；分成兩個 revision 只會讓 chain 變長而沒有額外好處。

## 驗證

以 Playwright 對 dev stack 實跑（application 15，帳號 `professor`）：

| 檢查 | 結果 |
| --- | --- |
| 國科會卡片不再出現任何說明行 | ✅ `（國科會博士生獎學金，適用於符合條件的博士生）` 已從 dialog 完全消失 |
| 國科會卡片標題與英文行仍在 | ✅ `國科會博士生獎學金` / `NSTC PHD Scholarship` |
| moe_1w 卡片維持原樣 | ✅ 標題、英文行、`（每年配合款經費金額將配合教育部相關規定，採滾動式調整。）` 均在 |
| API 回傳 | ✅ `nstc → note: null`；`moe_1w → note: "每年配合款經費金額將配合教育部相關規定，採滾動式調整。"` |

**Before（#1362 現況）**
![before](https://raw.githubusercontent.com/anud18/scholarship-system/pr-1362-verification-screenshots/screenshots/02-review-modal-subtypes.png)

**After（本 PR）**
![after](https://raw.githubusercontent.com/anud18/scholarship-system/pr-1362-verification-screenshots/screenshots/nstc-removed/01-review-modal-subtypes.png)

- [x] `alembic heads` → 單一 head `moe_1w_ay115_label_001`
- [x] Playwright 實機確認教授審核畫面
- [x] API 回傳 `note: null`