### PR TITLE
fix: 移除國科會子類型的重複說明文字

### DIFF
--- a/backend/alembic/versions/drop_nstc_subtype_description_001.py
+++ b/backend/alembic/versions/drop_nstc_subtype_description_001.py
@@ -1,0 +1,60 @@
+"""clear the phd nstc sub-type description (it only restated its own name)
+
+Revision ID: drop_nstc_subtype_description_001
+Revises: moe_1w_ay115_label_001
+Create Date: 2026-09-04 00:00:00.000000
+
+moe_1w_ay115_label_001 made scholarship_sub_type_configs.description visible:
+the professor review screen now renders it as a note under the sub-type
+heading. That surfaced a line on the nstc card which only restated that row's
+own name — "國科會博士生獎學金，適用於符合條件的博士生" under the heading
+"國科會博士生獎學金" — so reviewers were trained to skip the very position
+that carries the moe_1w matching-fund caveat.
+
+Clearing the column removes the line with no code change, because the review
+screen renders the note only when it is non-empty.
+
+This is a separate revision rather than an edit to moe_1w_ay115_label_001:
+that revision is already merged and may already be applied, and an applied
+migration is never re-run, so an in-place edit would silently skip every
+deployed database.
+
+The UPDATE is scoped to the phd scholarship type: sub_type_code values are
+configuration-driven strings, not globally unique, so another scholarship
+type could legitimately define its own 'nstc' with a description worth keeping.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "drop_nstc_subtype_description_001"
+down_revision: Union[str, Sequence[str], None] = "moe_1w_ay115_label_001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        UPDATE scholarship_sub_type_configs
+        SET
+            description = NULL,
+            description_en = NULL
+        WHERE sub_type_code = 'nstc'
+          AND scholarship_type_id IN (
+              SELECT id FROM scholarship_types WHERE code = 'phd'
+          )
+        """)
+
+
+def downgrade() -> None:
+    op.execute("""
+        UPDATE scholarship_sub_type_configs
+        SET
+            description = '國科會博士生獎學金，適用於符合條件的博士生',
+            description_en = 'NSTC PHD Scholarship for eligible PhD students'
+        WHERE sub_type_code = 'nstc'
+          AND scholarship_type_id IN (
+              SELECT id FROM scholarship_types WHERE code = 'phd'
+          )
+        """)

--- a/backend/app/db/seed_scholarship_configs.py
+++ b/backend/app/db/seed_scholarship_configs.py
@@ -890,8 +890,11 @@ async def seed_scholarship_sub_type_configs(session: AsyncSession) -> None:
                         "sub_type_code": "nstc",
                         "name": "國科會博士生獎學金",
                         "name_en": "NSTC PHD Scholarship",
-                        "description": "國科會博士生獎學金，適用於符合條件的博士生",
-                        "description_en": "NSTC PHD Scholarship for eligible PhD students",
+                        # Left empty on purpose: the professor review screen shows
+                        # description as a note under the heading, and this row's
+                        # description only restated its own name.
+                        "description": None,
+                        "description_en": None,
                         "amount": None,  # 使用主獎學金金額
                         "display_order": 1,
                         "is_active": True,


### PR DESCRIPTION
## 背景

取代 #1363 —— 該 PR 的 base 是 #1362 的 feature branch，但 #1362 在期間已經併入 `main`，於是 #1363 合併後只停在那支已合併的分支上，沒有進到 `main`。本 PR 直接對 `main`，內容等價。

#1362 讓教授審核畫面在子類型標題下方顯示 `scholarship_sub_type_configs.description`。副作用是國科會那張卡片也跟著多出一行：

> （國科會博士生獎學金，適用於符合條件的博士生）

這行等於把自己的標題再講一次，「適用於符合條件的博士生」也沒有實質資訊。兩張卡片樣式相同，會把 moe_1w 那行真正的但書（配合款金額逐年滾動調整，牽涉教授的實際負擔）稀釋成看起來可以略過的裝飾文字。

## 作法

清空 phd nstc 這筆的 `description` / `description_en`。元件本來就是 `{subType.note && …}` 有值才渲染，因此不需要改任何前端程式碼。

| 檔案 | 說明 |
| --- | --- |
| `backend/alembic/versions/drop_nstc_subtype_description_001.py` | 新 revision，把 phd nstc 的 description 設為 NULL，`downgrade()` 還原原文字 |
| `backend/app/db/seed_scholarship_configs.py` | nstc description 改成 `None`，並註明為何刻意留空 |

**為什麼另開 revision 而不是改 `moe_1w_ay115_label_001`**：#1363 原本是直接在那支 migration 裡補一段 UPDATE，當時它還沒合併所以沒問題。但它現在已經在 `main`、也可能已經套用到 staging/prod，而**已套用的 migration 不會重跑** —— 就地修改會讓所有既有資料庫被靜默略過，只有全新的資料庫才會生效。因此改成掛在其後的新 revision。

```
moe_1w_ay115_label_001 -> drop_nstc_subtype_description_001 (head)
```

## 驗證

以 Playwright 對 dev stack 實跑（application 15，帳號 `professor`）：

| 檢查 | 結果 |
| --- | --- |
| 國科會卡片不再出現說明行 | ✅ `（國科會博士生獎學金，適用於符合條件的博士生）` 已從 dialog 與整頁文字中消失；全形 `（` 在整個 dialog 只剩 1 個（moe_1w 那行） |
| 國科會卡片標題與英文行仍在 | ✅ `國科會博士生獎學金` / `NSTC PHD Scholarship` |
| moe_1w 卡片維持原樣 | ✅ 標題、英文行、`（每年配合款經費金額將配合教育部相關規定，採滾動式調整。）` 與前一輪 byte-identical |
| API 回傳 | ✅ `nstc → note: null, note_en: null`；moe_1w 不變 |
| 舊字樣 | ✅ `指導教授配合款一萬`、`指導教授配合款每月五千` 仍然不存在 |
| 版面 | ✅ 兩張卡片同寬 796px，高度 280px / 308px，差 28px 正好是少掉的那一行（20px line-height + 8px `mb-2`），其餘元素完全一致 |

卡片是垂直堆疊而非並排格線，28px 差異讀起來是「內容不同」而不是版面壞掉；較高的那張正好是真的多了一句話要說。

**Before（#1362 現況）**
![before](https://raw.githubusercontent.com/anud18/scholarship-system/pr-1362-verification-screenshots/screenshots/02-review-modal-subtypes.png)

**After（本 PR）**
![after](https://raw.githubusercontent.com/anud18/scholarship-system/pr-1362-verification-screenshots/screenshots/nstc-removed/01-review-modal-subtypes.png)

- [x] `alembic heads` → 單一 head `drop_nstc_subtype_description_001`，chain 線性
- [x] Playwright 實機確認教授審核畫面
- [x] API 回傳 `note: null`