### PR TITLE
fix: 縮短 nstc description migration 的 revision id（修 staging 部署失敗）

### DIFF
--- a/backend/alembic/versions/drop_nstc_subtype_desc_001.py
+++ b/backend/alembic/versions/drop_nstc_subtype_desc_001.py
@@ -1,6 +1,6 @@
 """clear the phd nstc sub-type description (it only restated its own name)
 
-Revision ID: drop_nstc_subtype_description_001
+Revision ID: drop_nstc_subtype_desc_001
 Revises: moe_1w_ay115_label_001
 Create Date: 2026-09-04 00:00:00.000000
 
@@ -22,13 +22,18 @@ deployed database.
 The UPDATE is scoped to the phd scholarship type: sub_type_code values are
 configuration-driven strings, not globally unique, so another scholarship
 type could legitimately define its own 'nstc' with a description worth keeping.
+
+The revision id is kept at 26 characters: alembic_version.version_num is
+VARCHAR(32), and the first cut of this migration used a 33-character id, which
+applied the UPDATE and then blew up writing the version row (staging rolled
+back cleanly). Existing ids in this repo top out at exactly 32.
 """
 
 from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "drop_nstc_subtype_description_001"
+revision: str = "drop_nstc_subtype_desc_001"
 down_revision: Union[str, Sequence[str], None] = "moe_1w_ay115_label_001"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
## 問題

#1364 併入後，`Deploy to Staging` 在 **Run database migrations** 這步失敗：

```
INFO  [alembic.runtime.migration] Running upgrade moe_1w_ay115_label_001 -> drop_nstc_subtype_description_001
sqlalchemy.exc.DataError: (psycopg2.errors.StringDataRightTruncation)
value too long for type character varying(32)
[SQL: UPDATE alembic_version SET version_num='drop_nstc_subtype_description_001'
      WHERE alembic_version.version_num = 'moe_1w_ay115_label_001']
```

`alembic_version.version_num` 是 `VARCHAR(32)`，而我在 #1364 取的 revision id `drop_nstc_subtype_description_001` 是 **33 字元**，剛好超出 1 個字。migration 的 UPDATE 本身跑得過，是接著寫版本號時炸掉。

倉庫既有的 revision id 最長剛好 32（`professor_notify_both_emails_001`、`college_ranking_college_code_001`⋯），所以這個上限是實際存在的、我踩過頭了。

**Staging 狀態**：workflow 已自動 rollback 到前一個 good tag，health check 通過，服務正常。失敗的 migration 在同一個 transaction 內，所以 nstc 那筆資料沒有被改到一半，`alembic_version` 仍停在 `moe_1w_ay115_label_001`。

## 修正

revision id 改成 `drop_nstc_subtype_desc_001`（26 字元），檔名一併更名，內容不變。

```
moe_1w_ay115_label_001 -> drop_nstc_subtype_desc_001 (head)
```

也在 migration docstring 裡記下這個 32 字元上限，避免之後再犯。

## 驗證

- [x] `alembic heads` → 單一 head `drop_nstc_subtype_desc_001`，chain 線性
- [x] 掃過 `backend/alembic/versions/*.py` 全部 revision id，確認沒有任何一支超過 32 字元
- [x] 確認 `alembic_version.version_num` 實際型別為 `character varying(32)`